### PR TITLE
Support builds via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian
+
+WORKDIR /
+RUN apt update -y && apt install -y g++ gcc git curl wget nasm yasm libgtk-3-dev clang libxcb-randr0-dev libxdo-dev libxfixes-dev libxcb-shape0-dev libxcb-xfixes0-dev libasound2-dev libpulse-dev cmake unzip zip sudo
+
+RUN git clone https://github.com/microsoft/vcpkg --branch 2020.11-1
+RUN /vcpkg/bootstrap-vcpkg.sh -disableMetrics
+RUN /vcpkg/vcpkg --disable-metrics install libvpx libyuv opus
+
+RUN groupadd -r user && useradd -r -g user user --home /home/user && mkdir -p /home/user && chown user /home/user
+WORKDIR /home/user
+RUN wget https://github.com/c-smile/sciter-sdk/raw/dc65744b66389cd5a0ff6bdb7c63a8b7b05a708b/bin.lnx/x64/libsciter-gtk.so
+USER user
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+RUN chmod +x rustup.sh
+RUN ./rustup.sh -y
+
+USER root
+COPY ./entrypoint /
+ENTRYPOINT ["/entrypoint"]

--- a/README.md
+++ b/README.md
@@ -44,22 +44,22 @@ Desktop versions use [sciter](https://sciter.com/) for GUI, please download scit
 ## How to build on Linux
 
 ### Ubuntu 18 (Debian 10)
-```
+```sh
 sudo apt install -y g++ gcc git curl wget nasm yasm libgtk-3-dev clang libxcb-randr0-dev libxdo-dev libxfixes-dev libxcb-shape0-dev libxcb-xfixes0-dev libasound2-dev libpulse-dev cmake
 ```
 
 ### Fedora 28 (CentOS 8)
-```
+```sh
 sudo yum -y install gcc-c++ git curl wget nasm yasm gcc gtk3-devel clang libxcb-devel libxdo-devel libXfixes-devel pulseaudio-libs-devel cmake alsa-lib-devel
 ```
 
 ### Arch (Manjaro)
-```
+```sh
 sudo pacman -Syu --needed unzip git cmake gcc curl wget yasm nasm zip make pkg-config clang gtk3 xdotool libxcb libxfixes alsa-lib pulseaudio
 ```
 
 ### Install vcpkg
-```
+```sh
 git clone https://github.com/microsoft/vcpkg --branch 2020.11-1
 vcpkg/bootstrap-vcpkg.sh
 export VCPKG_ROOT=$HOME/vcpkg
@@ -67,7 +67,7 @@ vcpkg/vcpkg install libvpx libyuv opus
 ```
 
 ### Fix libvpx (For Fedora)
-```
+```sh
 cd vcpkg/buildtrees/libvpx/src
 cd *
 ./configure
@@ -79,7 +79,7 @@ cd
 ```
 
 ### Build
-```
+```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
 git clone https://github.com/rustdesk/rustdesk
@@ -89,6 +89,36 @@ wget https://github.com/c-smile/sciter-sdk/raw/dc65744b66389cd5a0ff6bdb7c63a8b7b
 mv libsciter-gtk.so target/debug
 cargo run
 ```
+
+## How to build with Docker
+
+Begin by cloning the repository and building the docker container:
+
+```sh
+git clone https://github.com/rustdesk/rustdesk
+cd rustdesk
+docker build -t "rustdesk-builder" .
+```
+
+Then, each time you need to build the application, run the following command:
+
+```sh
+docker run --rm -it -v $PWD:/home/user/rustdesk -v rustdesk-git-cache:/home/user/.cargo/git -v rustdesk-registry-cache:/home/user/.cargo/registry -e PUID="$(id -u)" -e PGID="$(id -g)" rustdesk-builder
+```
+
+Note that the first build may take longer before dependencies are cached, subsequent builds will be faster. Additionally, if you need to specify different arguments to the build command, you may do so at the end of the command in the `<OPTIONAL-ARGS>` position. For instance, if you wanted to build an optimized release version, you would run the command above followed by `---release`. The resulting executable will be available in the target folder on your system, and can be run with:
+
+```sh
+target/debug/rustdesk
+```
+
+Or, if you're running a release executable:
+
+```sh
+target/release/rustdesk
+```
+
+Please ensure that you are running these commands from the root of the RustDesk repository, otherwise the application may be unable to find the required resources. Also note that other cargo subcommands such as `install` or `run` are not currently supported via this method as they would install or run the program inside the container instead of the host.
 
 ### Change Wayland to X11 (Xorg)
 RustDesk does not support Wayland. Check [this](https://docs.fedoraproject.org/en-US/quick-docs/configuring-xorg-as-default-gnome-session/) to configuring Xorg as the default GNOME session.

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+if [ "$(id -u)" != "${PUID:-1000}" ] || [ "$(id -g)" != "${PGID:-1000}" ]; then
+  usermod -o -u "${PUID:-1000}" user
+  groupmod -o -g "${PGID:-1000}" user
+  chown -R user /home/user
+  sudo -u user /entrypoint $@
+  exit 0
+fi
+
+cd $HOME/rustdesk
+. $HOME/.cargo/env
+
+argv=$@
+
+while test $# -gt 0; do
+  case "$1" in
+    --release)
+      mkdir -p target/release
+      test -f target/release/libsciter-gtk.so || cp $HOME/libsciter-gtk.so target/release/
+      release=1
+      shift
+      ;;
+    --target)
+      shift
+      if test $# -gt 0; then
+        rustup target add $1
+        shift
+      fi
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ -z $release ]; then
+  mkdir -p target/debug
+  test -f target/debug/libsciter-gtk.so || cp $HOME/libsciter-gtk.so target/debug/
+fi
+
+VCPKG_ROOT=/vcpkg cargo build $argv


### PR DESCRIPTION
This PR adds support and documenation for build via Docker. The entrypoint script ensures the permissions are set correctly on the mountpoint, and grabs any necessary targets. The one improvement that could be made is ensuring the necessary dependancies are present for different platforms, since most of the other platforms I tried (windows, macos, android) failed with libsodium-related errors, so that could use some work at some point.