### PR TITLE
Update Readme & Other Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,6 @@
 RustDesk welcomes contribution from everyone. Here are the guidelines if you are
 thinking of helping us:
 
-
 ## Contributions
 
 Contributions to RustDesk or its dependencies should be made in the form of GitHub
@@ -23,7 +22,7 @@ efforts from contributors on the same issue.
   master you may be asked to rebase your changes.
 
 - Commits should be as small as possible, while ensuring that each commit is
-  correct independently (i.e., each commit should compile and pass tests). 
+  correct independently (i.e., each commit should compile and pass tests).
 
 - Commits should be accompanied by a Developer Certificate of Origin
   (http://developercertificate.org) sign-off, which indicates that you (and
@@ -40,10 +39,8 @@ For specific git instructions, see [GitHub workflow 101](https://github.com/serv
 
 ## Conduct
 
-We follow the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct). 
-
+We follow the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).
 
 ## Communication
 
 RustDesk contributors frequent the [Discord](https://discord.gg/nDceKgxnkV).
-

--- a/README-DE.md
+++ b/README-DE.md
@@ -20,52 +20,58 @@ RustDesk heißt jegliche Mitarbeit willkommen. Schau dir [`CONTRIBUTING.md`](CON
 [**PROGRAMM DOWNLOAD**](https://github.com/rustdesk/rustdesk/releases)
 
 ## Kostenlose öffentliche Server
+
 Hier sind die Server die du kostenlos nutzen kannst, es kann sein das sich diese Liste immer mal wieder ändert. Falls du nicht in der Nähe einer dieser Server bist, kann es sein, dass deine Verbindung langsam sein wird.
 
-| Standort  | Serverart     | Spezifikationen    | Kommentare                               |
-| --------- | ------------- | ------------------ | ---------------------------------------- |
-| Seoul     | AWS lightsail | 1 VCPU / 0.5GB RAM |                                          |
-| Singapore | Vultr         | 1 VCPU / 1GB RAM   |                                          |
-| Dallas    | Vultr         | 1 VCPU / 1GB RAM   |                                          |
+| Standort  | Serverart     | Spezifikationen    | Kommentare |
+| --------- | ------------- | ------------------ | ---------- |
+| Seoul     | AWS lightsail | 1 VCPU / 0.5GB RAM |            |
+| Singapore | Vultr         | 1 VCPU / 1GB RAM   |            |
+| Dallas    | Vultr         | 1 VCPU / 1GB RAM   |            |
 
 ## Abhängigkeiten
 
 Die Desktop Versionen nutzen [Sciter](https://sciter.com/) für die Oberfläche, bitte lade die dynamische Sciter Bibliothek selbst herunter.
 
-[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) | 
+[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) |
 [Linux](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so) |
 [MacOS](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.osx/libsciter.dylib)
 
 ## Die groben Schritte zum Kompilieren
-* Bereite deine Rust Entwicklungsumgebung und C++ Entwicklungsumgebung vor
 
-* Installiere [vcpkg](https://github.com/microsoft/vcpkg) und füge die `VCPKG_ROOT` Systemumgebungsvariable hinzu
+- Bereite deine Rust Entwicklungsumgebung und C++ Entwicklungsumgebung vor
 
-   - Windows: `vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static`
-   - Linux/MacOS: `vcpkg install libvpx libyuv opus`
+- Installiere [vcpkg](https://github.com/microsoft/vcpkg) und füge die `VCPKG_ROOT` Systemumgebungsvariable hinzu
 
-* Nutze `cargo run`
+  - Windows: `vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static`
+  - Linux/MacOS: `vcpkg install libvpx libyuv opus`
+
+- Nutze `cargo run`
 
 ## Kompilieren auf Linux
 
 ### Ubuntu 18 (Debian 10)
+
 ```sh
 sudo apt install -y g++ gcc git curl wget nasm yasm libgtk-3-dev clang libxcb-randr0-dev libxdo-dev libxfixes-dev libxcb-shape0-dev libxcb-xfixes0-dev libasound2-dev libpulse-dev cmake
 ```
 
 ### Fedora 28 (CentOS 8)
+
 ```sh
 sudo yum -y install gcc-c++ git curl wget nasm yasm gcc gtk3-devel clang libxcb-devel libxdo-devel libXfixes-devel pulseaudio-libs-devel cmake alsa-lib-devel
 ```
 
 ### Arch (Manjaro)
+
 ```sh
 sudo pacman -Syu --needed unzip git cmake gcc curl wget yasm nasm zip make pkg-config clang gtk3 xdotool libxcb libxfixes alsa-lib pulseaudio
 ```
 
 ### vcpkg installieren
+
 ```sh
-git clone https://github.com/microsoft/vcpkg 
+git clone https://github.com/microsoft/vcpkg
 cd vcpkg
 git checkout 134505003bb46e20fbace51ccfb69243fbbc5f82
 cd ..
@@ -75,6 +81,7 @@ vcpkg/vcpkg install libvpx libyuv opus
 ```
 
 ### libvpx reparieren (Für Fedora)
+
 ```sh
 cd vcpkg/buildtrees/libvpx/src
 cd *
@@ -87,6 +94,7 @@ cd
 ```
 
 ### Kompilieren
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
@@ -109,6 +117,7 @@ docker build -t "rustdesk-builder" .
 ```
 
 Jedes Mal, wenn du das Programm Kompilieren musst, nutze diesen Befehl:
+
 ```sh
 docker run --rm -it -v $PWD:/home/user/rustdesk -v rustdesk-git-cache:/home/user/.cargo/git -v rustdesk-registry-cache:/home/user/.cargo/registry -e PUID="$(id -u)" -e PGID="$(id -g)" rustdesk-builder
 ```
@@ -128,6 +137,7 @@ target/release/rustdesk
 Bitte gehe sicher, dass du diese Befehle vom Stammverzeichnis vom RustDesk Repository nutzt, sonst kann es passieren, dass das Programm die Ressourcen nicht finden kann. Bitte bedenke auch, dass Unterbefehle von Cargo, wie z.B. `install` oder `run` aktuell noch nicht unterstützt werden, da sie das Programm innerhalb des Containers starten oder installieren würden, anstatt auf deinem eigentlichen System.
 
 ### Ändere Wayland zu X11 (Xorg)
+
 RustDesk unterstützt "Wayland" nicht. Siehe [hier](https://docs.fedoraproject.org/en-US/quick-docs/configuring-xorg-as-default-gnome-session/) um Xorg als Standard GNOME Session zu nutzen.
 
 ## Dateistruktur
@@ -142,6 +152,7 @@ RustDesk unterstützt "Wayland" nicht. Siehe [hier](https://docs.fedoraproject.o
 - **[src/platform](https://github.com/rustdesk/rustdesk/tree/master/src/platform)**: Plattformspezifischer Code
 
 ## Screenshots
+
 ![image](https://user-images.githubusercontent.com/71636191/113112362-ae4deb80-923b-11eb-957d-ff88daad4f06.png)
 
 ![image](https://user-images.githubusercontent.com/71636191/113112619-f705a480-923b-11eb-911d-97e984ef52b6.png)

--- a/README-ES.md
+++ b/README-ES.md
@@ -13,56 +13,63 @@ Chat with us: [Discord](https://discord.gg/nDceKgxnkV) | [Reddit](https://www.re
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/I2I04VU09)
 
-Otro software de escritorio remoto, escrito en Rust. Funciona de forma inmediata, sin necesidad de configuración. Tienes el control total de sus datos, sin preocupaciones sobre la seguridad. Puedes utilizar nuestro servidor de rendezvous/relay, [set up your own](https://rustdesk.com/blog/id-relay-set/), o [escribir tu propio servidor rendezvous/relay](https://github.com/rustdesk/rustdesk-server-demo). 
+Otro software de escritorio remoto, escrito en Rust. Funciona de forma inmediata, sin necesidad de configuración. Tienes el control total de sus datos, sin preocupaciones sobre la seguridad. Puedes utilizar nuestro servidor de rendezvous/relay, [set up your own](https://rustdesk.com/blog/id-relay-set/), o [escribir tu propio servidor rendezvous/relay](https://github.com/rustdesk/rustdesk-server-demo).
 
-RustDesk agradece la contribución de todo el mundo.  Ve [`CONTRIBUTING.md`](CONTRIBUTING.md) para ayuda inicial.
+RustDesk agradece la contribución de todo el mundo. Ve [`CONTRIBUTING.md`](CONTRIBUTING.md) para ayuda inicial.
 
 [**DESCARGA DE BINARIOS**](https://github.com/rustdesk/rustdesk/releases)
 
 ## Servidores gratis de uso público
+
 A continuación se muestran los servidores que está utilizando de forma gratuita, puede cambiar en algún momento. Si no estás cerca de uno de ellos, tu red puede ser lenta.
+
 - Seoul, AWS lightsail, 1 VCPU/0.5G RAM
 - Singapore, Vultr, 1 VCPU/1G RAM
 - Dallas, Vultr, 1 VCPU/1G RAM
 
 ## Dependencies
 
-La versión Desktop usa  [sciter](https://sciter.com/) para GUI, por favor bajate la librería sciter tu mismo..
+La versión Desktop usa [sciter](https://sciter.com/) para GUI, por favor bajate la librería sciter tu mismo..
 
-[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) | 
+[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) |
 [Linux](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so) |
 [macOS](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.osx/libsciter.dylib)
 
 ## Pasos para compilar desde el inicio
-* Prepara el entono de desarrollode Rust y el entorno de compilación de C++ y Rust.
 
-* Instala [vcpkg](https://github.com/microsoft/vcpkg), y configura la variable de entono `VCPKG_ROOT` correctamente. 
+- Prepara el entono de desarrollode Rust y el entorno de compilación de C++ y Rust.
 
-   - Windows: vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
-   - Linux/Osx: vcpkg install libvpx libyuv opus
-   
-* run `cargo run`
+- Instala [vcpkg](https://github.com/microsoft/vcpkg), y configura la variable de entono `VCPKG_ROOT` correctamente.
+
+  - Windows: vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
+  - Linux/Osx: vcpkg install libvpx libyuv opus
+
+- run `cargo run`
 
 ## Como compilar en linux
 
 ### Ubuntu 18 (Debian 10)
+
 ```sh
 sudo apt install -y g++ gcc git curl wget nasm yasm libgtk-3-dev clang libxcb-randr0-dev libxdo-dev libxfixes-dev libxcb-shape0-dev libxcb-xfixes0-dev libasound2-dev libpulse-dev cmake
 ```
 
 ### Fedora 28 (CentOS 8)
+
 ```sh
 sudo yum -y install gcc-c++ git curl wget nasm yasm gcc gtk3-devel clang libxcb-devel libxdo-devel libXfixes-devel pulseaudio-libs-devel cmake alsa-lib-devel
 ```
 
 ### Arch (Manjaro)
+
 ```sh
 sudo pacman -Syu --needed unzip git cmake gcc curl wget yasm nasm zip make pkg-config clang gtk3 xdotool libxcb libxfixes alsa-lib pulseaudio
 ```
 
 ### Install vcpkg
+
 ```sh
-git clone https://github.com/microsoft/vcpkg 
+git clone https://github.com/microsoft/vcpkg
 cd vcpkg
 git checkout 134505003bb46e20fbace51ccfb69243fbbc5f82
 cd ..
@@ -72,6 +79,7 @@ vcpkg/vcpkg install libvpx libyuv opus
 ```
 
 ### Soluciona libvpx (For Fedora)
+
 ```sh
 cd vcpkg/buildtrees/libvpx/src
 cd *
@@ -84,6 +92,7 @@ cd
 ```
 
 ### Compila
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
@@ -104,6 +113,7 @@ git clone https://github.com/rustdesk/rustdesk
 cd rustdesk
 docker build -t "rustdesk-builder" .
 ```
+
 Entonces, cada vez que necesites compilar una modificación, ejecuta el siguiente comando:
 
 ```sh
@@ -125,6 +135,7 @@ target/release/rustdesk
 Por favor, asegurate de que estás ejecutando estos comandos desde la raíz del repositorio de RustDesk, de lo contrario la aplicación puede ser incapaz de encontrar los recursos necesarios. También hay que tener en cuenta que otros subcomandos de carga como `install` o `run` no estan actualmente soportados via este metodo y podrían requerir ser instalados dentro del contenedor y no en el host.
 
 ### Cambia Wayland a X11 (Xorg)
+
 RustDesk no soporta Wayland. Comprueba [aquí](https://docs.fedoraproject.org/en-US/quick-docs/configuring-xorg-as-default-gnome-session/) para configurar Xorg en la sesión por defecto de GNOME.
 
 ## Estructura de archivos
@@ -139,6 +150,7 @@ RustDesk no soporta Wayland. Comprueba [aquí](https://docs.fedoraproject.org/en
 - **[src/platform](https://github.com/rustdesk/rustdesk/tree/master/src/platform)**: código específico de cada plataforma
 
 ## Captura de pantalla
+
 ![image](https://user-images.githubusercontent.com/71636191/113112362-ae4deb80-923b-11eb-957d-ff88daad4f06.png)
 
 ![image](https://user-images.githubusercontent.com/71636191/113112619-f705a480-923b-11eb-911d-97e984ef52b6.png)

--- a/README-FR.md
+++ b/README-FR.md
@@ -13,14 +13,16 @@ Chattez avec nous : [Discord](https://discord.gg/nDceKgxnkV) | [Reddit](https://
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/I2I04VU09)
 
-Encore un autre logiciel de bureau à distance, écrit en Rust. Fonctionne directement, aucune configuration n'est nécessaire. Vous avez le contrôle total de vos données, sans aucun souci de sécurité. Vous pouvez utiliser notre serveur de rendez-vous/relais, [configurer le vôtre](https://rustdesk.com/blog/id-relay-set/), ou [écrire votre propre serveur de rendez-vous/relais](https://github.com/rustdesk/rustdesk-server-demo). 
+Encore un autre logiciel de bureau à distance, écrit en Rust. Fonctionne directement, aucune configuration n'est nécessaire. Vous avez le contrôle total de vos données, sans aucun souci de sécurité. Vous pouvez utiliser notre serveur de rendez-vous/relais, [configurer le vôtre](https://rustdesk.com/blog/id-relay-set/), ou [écrire votre propre serveur de rendez-vous/relais](https://github.com/rustdesk/rustdesk-server-demo).
 
-RustDesk accueille les contributions de tout le monde.  Voir [`CONTRIBUTING.md`](CONTRIBUTING.md) pour plus d'informations.
+RustDesk accueille les contributions de tout le monde. Voir [`CONTRIBUTING.md`](CONTRIBUTING.md) pour plus d'informations.
 
 [**TÉLÉCHARGEMENT BINAIRE**](https://github.com/rustdesk/rustdesk/releases)
 
 ## Serveurs publics libres
+
 Ci-dessous se trouvent les serveurs que vous utilisez gratuitement, cela peut changer au fil du temps. Si vous n'êtes pas proche de l'un d'entre eux, votre réseau peut être lent.
+
 - Séoul, AWS lightsail, 1 VCPU/0.5G RAM
 - Singapour, Vultr, 1 VCPU/1G RAM
 - Dallas, Vultr, 1 VCPU/1G RAM
@@ -29,40 +31,45 @@ Ci-dessous se trouvent les serveurs que vous utilisez gratuitement, cela peut ch
 
 Les versions de bureau utilisent [sciter](https://sciter.com/) pour l'interface graphique, veuillez télécharger la bibliothèque dynamique sciter vous-même.
 
-[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) | 
+[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) |
 [Linux](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so)
 [macOS](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.osx/libsciter.dylib)
 
 ## Étapes brutes de la compilation/build
-* Préparez votre environnement de développement Rust et votre environnement de compilation C++.
 
-* Installez [vcpkg](https://github.com/microsoft/vcpkg), et définissez correctement la variable d'environnement `VCPKG_ROOT`.
+- Préparez votre environnement de développement Rust et votre environnement de compilation C++.
 
-   - Windows : vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
-   - Linux/Osx : vcpkg install libvpx libyuv opus
-   
-* Exécuter `cargo run`
+- Installez [vcpkg](https://github.com/microsoft/vcpkg), et définissez correctement la variable d'environnement `VCPKG_ROOT`.
+
+  - Windows : vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
+  - Linux/Osx : vcpkg install libvpx libyuv opus
+
+- Exécuter `cargo run`
 
 ## Comment compiler/build sous Linux
 
 ### Ubuntu 18 (Debian 10)
+
 ```sh
 sudo apt install -y g++ gcc git curl wget nasm yasm libgtk-3-dev clang libxcb-randr0-dev libxdo-dev libxfixes-dev libxcb-shape0-dev libxcb-xfixes0-dev libasound2-dev libpulse-dev cmake
 ```
 
 ### Fedora 28 (CentOS 8)
+
 ```sh
 sudo yum -y install gcc-c++ git curl wget nasm yasm gcc gtk3-devel clang libxcb-devel libxdo-devel libXfixes-devel pulseaudio-libs-devel cmake alsa-lib-devel
 ```
 
 ### Arch (Manjaro)
+
 ```sh
 sudo pacman -Syu --needed unzip git cmake gcc curl wget yasm nasm zip make pkg-config clang gtk3 xdotool libxcb libxfixes alsa-lib pulseaudio
 ```
 
 ### Installer vcpkg
+
 ```sh
-git clone https://github.com/microsoft/vcpkg 
+git clone https://github.com/microsoft/vcpkg
 cd vcpkg
 git checkout 134505003bb46e20fbace51ccfb69243fbbc5f82
 cd ..
@@ -72,6 +79,7 @@ vcpkg/vcpkg install libvpx libyuv opus
 ```
 
 ### Corriger libvpx (Pour Fedora)
+
 ```sh
 cd vcpkg/buildtrees/libvpx/src
 cd *
@@ -84,6 +92,7 @@ cd
 ```
 
 ### Construire
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
@@ -116,6 +125,7 @@ Notez que le premier build peut prendre plus de temps avant que les dépendances
 ```sh
 target/debug/rustdesk
 ```
+
 Ou, si vous exécutez un exécutable provenant d'une release :
 
 ```sh
@@ -125,6 +135,7 @@ target/release/rustdesk
 Veuillez vous assurer que vous exécutez ces commandes à partir de la racine du référentiel RustDesk, sinon l'application ne pourra pas trouver les ressources requises. Notez également que les autres sous-commandes de cargo telles que `install` ou `run` ne sont pas actuellement supportées par cette méthode car elles installeraient ou exécuteraient le programme à l'intérieur du conteneur au lieu de l'hôte.
 
 ### Changer Wayland en X11 (Xorg)
+
 RustDesk ne supporte pas Wayland. Lisez [cela](https://docs.fedoraproject.org/en-US/quick-docs/configuring-xorg-as-default-gnome-session/) pour configurer Xorg comme la session GNOME par défaut.
 
 ## Structure du projet
@@ -139,6 +150,7 @@ RustDesk ne supporte pas Wayland. Lisez [cela](https://docs.fedoraproject.org/en
 - **[src/platform](https://github.com/rustdesk/rustdesk/tree/master/src/platform)** : code spécifique à la plateforme
 
 ## Images
+
 ![image](https://user-images.githubusercontent.com/71636191/113112362-ae4deb80-923b-11eb-957d-ff88daad4f06.png)
 
 ![image](https://user-images.githubusercontent.com/71636191/113112619-f705a480-923b-11eb-911d-97e984ef52b6.png)

--- a/README-PL.md
+++ b/README-PL.md
@@ -13,58 +13,64 @@ Porozmawiaj z nami na: [Discord](https://discord.gg/nDceKgxnkV) | [Reddit](https
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/I2I04VU09)
 
-Kolejny program do zdalnego pulpitu, napisany w Rust. Działa od samego początku, nie wymaga konfiguracji. Masz pełną kontrolę nad swoimi danymi, bez obaw o bezpieczeństwo. Możesz skorzystać z naszego darmowego serwera publicznego , [skonfigurować własny](https://rustdesk.com/blog/id-relay-set/), lub [napisać własny serwer rendezvous/relay server](https://github.com/rustdesk/rustdesk-server-demo). 
+Kolejny program do zdalnego pulpitu, napisany w Rust. Działa od samego początku, nie wymaga konfiguracji. Masz pełną kontrolę nad swoimi danymi, bez obaw o bezpieczeństwo. Możesz skorzystać z naszego darmowego serwera publicznego , [skonfigurować własny](https://rustdesk.com/blog/id-relay-set/), lub [napisać własny serwer rendezvous/relay server](https://github.com/rustdesk/rustdesk-server-demo).
 
-RustDesk zaprasza do współpracy każdego.  Zobacz [`CONTRIBUTING.md`](CONTRIBUTING.md) pomoc w uruchomieniu programu.
+RustDesk zaprasza do współpracy każdego. Zobacz [`CONTRIBUTING.md`](CONTRIBUTING.md) pomoc w uruchomieniu programu.
 
 [**POBIERZ KOMPILACJE**](https://github.com/rustdesk/rustdesk/releases)
 
 ## Darmowe Serwery Publiczne
+
 Poniżej znajdują się serwery, z których można korzystać za darmo, może się to zmienić z upływem czasu. Jeśli nie znajdujesz się w pobliżu jednego z nich, Twoja prędkość połączenia może być niska.
-| Lokalizacja  | Dostawca        | Specyfikacja      |
+| Lokalizacja | Dostawca | Specyfikacja |
 | --------- | ------------- | ------------------ |
-| Seul     | AWS lightsail | 1 VCPU / 0.5GB RAM |
-| Singapur | Vultr         | 1 VCPU / 1GB RAM   |
-| Dallas    | Vultr         | 1 VCPU / 1GB RAM   |        |
+| Seul | AWS lightsail | 1 VCPU / 0.5GB RAM |
+| Singapur | Vultr | 1 VCPU / 1GB RAM |
+| Dallas | Vultr | 1 VCPU / 1GB RAM | |
 
 ## Zależności
 
 Wersje desktopowe używają [sciter](https://sciter.com/) dla GUI, proszę pobrać bibliotekę dynamiczną sciter samodzielnie.
 
-[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) | 
+[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) |
 [Linux](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so) |
 [MacOS](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.osx/libsciter.dylib)
 
 ## Podstawowe kroki do kompilacji.
-* Przygotuj środowisko programistyczne Rust i środowisko programowania C++
 
-* Zainstaluj [vcpkg](https://github.com/microsoft/vcpkg), i ustaw `VCPKG_ROOT` env zmienną prawidłowo
+- Przygotuj środowisko programistyczne Rust i środowisko programowania C++
 
-   - Windows: vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
-   - Linux/MacOS: vcpkg install libvpx libyuv opus
-   
-* uruchom `cargo run`
+- Zainstaluj [vcpkg](https://github.com/microsoft/vcpkg), i ustaw `VCPKG_ROOT` env zmienną prawidłowo
+
+  - Windows: vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
+  - Linux/MacOS: vcpkg install libvpx libyuv opus
+
+- uruchom `cargo run`
 
 ## Jak Kompilować na Linuxie
 
 ### Ubuntu 18 (Debian 10)
+
 ```sh
 sudo apt install -y g++ gcc git curl wget nasm yasm libgtk-3-dev clang libxcb-randr0-dev libxdo-dev libxfixes-dev libxcb-shape0-dev libxcb-xfixes0-dev libasound2-dev libpulse-dev cmake
 ```
 
 ### Fedora 28 (CentOS 8)
+
 ```sh
 sudo yum -y install gcc-c++ git curl wget nasm yasm gcc gtk3-devel clang libxcb-devel libxdo-devel libXfixes-devel pulseaudio-libs-devel cmake alsa-lib-devel
 ```
 
 ### Arch (Manjaro)
+
 ```sh
 sudo pacman -Syu --needed unzip git cmake gcc curl wget yasm nasm zip make pkg-config clang gtk3 xdotool libxcb libxfixes alsa-lib pulseaudio
 ```
 
 ### Zainstaluj vcpkg
+
 ```sh
-git clone https://github.com/microsoft/vcpkg 
+git clone https://github.com/microsoft/vcpkg
 cd vcpkg
 git checkout 134505003bb46e20fbace51ccfb69243fbbc5f82
 cd ..
@@ -74,6 +80,7 @@ vcpkg/vcpkg install libvpx libyuv opus
 ```
 
 ### Fix libvpx (For Fedora)
+
 ```sh
 cd vcpkg/buildtrees/libvpx/src
 cd *
@@ -86,6 +93,7 @@ cd
 ```
 
 ### Kompilacja
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
@@ -115,7 +123,6 @@ docker run --rm -it -v $PWD:/home/user/rustdesk -v rustdesk-git-cache:/home/user
 
 Zauważ, że pierwsza kompilacja może potrwać dłużej zanim zależności zostaną zbuforowane, kolejne będą szybsze. Dodatkowo, jeśli potrzebujesz określić inne argumenty dla polecenia budowania, możesz to zrobić na końcu komendy w miejscu `<OPTIONAL-ARGS>`. Na przykład, jeśli chciałbyś zbudować zoptymalizowaną wersję wydania, uruchomiłbyś powyższą komendę a następnie `---release`. Powstały plik wykonywalny będzie dostępny w folderze docelowym w twoim systemie, i może być uruchomiony z:
 
-
 ```sh
 target/debug/rustdesk
 ```
@@ -129,6 +136,7 @@ target/release/rustdesk
 Upewnij się, że uruchamiasz te polecenia z katalogu głównego repozytorium RustDesk, w przeciwnym razie aplikacja może nie być w stanie znaleźć wymaganych zasobów. Należy również pamiętać, że inne podpolecenia ładowania, takie jak `install` lub `run` nie są obecnie obsługiwane za pomocą tej metody, ponieważ instalowałyby lub uruchamiały program wewnątrz kontenera zamiast na hoście.
 
 ### Zmień Wayland na X11 (Xorg)
+
 RustDesk nie obsługuje Waylanda. Sprawdź [this](https://docs.fedoraproject.org/en-US/quick-docs/configuring-xorg-as-default-gnome-session/) by skonfigurować Xorg jako domyślną sesję GNOME.
 
 ## Struktura plików
@@ -143,6 +151,7 @@ RustDesk nie obsługuje Waylanda. Sprawdź [this](https://docs.fedoraproject.org
 - **[src/platform](https://github.com/rustdesk/rustdesk/tree/master/src/platform)**: specyficzny dla danej platformy kod
 
 ## Migawki(Snapshoty)
+
 ![image](https://user-images.githubusercontent.com/71636191/113112362-ae4deb80-923b-11eb-957d-ff88daad4f06.png)
 
 ![image](https://user-images.githubusercontent.com/71636191/113112619-f705a480-923b-11eb-911d-97e984ef52b6.png)

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -16,12 +16,14 @@ Chat with us: [知乎](https://www.zhihu.com/people/rustdesk) | [Discord](https:
 或者[自己设置](https://rustdesk.com/blog/id-relay-set/)，
 亦或者[开发您的版本](https://github.com/rustdesk/rustdesk-server-demo)。
 
-欢迎大家贡献代码，  请看 [`CONTRIBUTING.md`](CONTRIBUTING.md).
+欢迎大家贡献代码， 请看 [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 [**可执行程序下载**](https://github.com/rustdesk/rustdesk/releases)
 
 ## 免费公共服务器
+
 以下是您免费使用的服务器，它可能会随着时间的推移而变化。如果您不靠近其中之一，您的网络可能会很慢。
+
 - 首尔, AWS lightsail, 1 VCPU/0.5G RAM
 - 新加坡, Vultr, 1 VCPU/1G RAM
 - 达拉斯, Vultr, 1 VCPU/1G RAM
@@ -30,40 +32,45 @@ Chat with us: [知乎](https://www.zhihu.com/people/rustdesk) | [Discord](https:
 
 桌面版本界面使用[sciter](https://sciter.com/), 请自行下载。
 
-[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) | 
+[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) |
 [Linux](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so) |
 [macOS](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.osx/libsciter.dylib)
 
 ## 基本构建步骤
-* 请准备好Rust开发环境和C++编译环境
 
-* 安装[vcpkg](https://github.com/microsoft/vcpkg), 正确设置`VCPKG_ROOT`环境变量
+- 请准备好 Rust 开发环境和 C++编译环境
 
-   - Windows: vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
-   - Linux/Osx: vcpkg install libvpx libyuv opus
-   
-* 运行 `cargo run`
+- 安装[vcpkg](https://github.com/microsoft/vcpkg), 正确设置`VCPKG_ROOT`环境变量
 
-## 在Linux上编译
+  - Windows: vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
+  - Linux/Osx: vcpkg install libvpx libyuv opus
+
+- 运行 `cargo run`
+
+## 在 Linux 上编译
 
 ### Ubuntu 18 (Debian 10)
+
 ```sh
 sudo apt install -y g++ gcc git curl wget nasm yasm libgtk-3-dev clang libxcb-randr0-dev libxdo-dev libxfixes-dev libxcb-shape0-dev libxcb-xfixes0-dev libasound2-dev libpulse-dev cmake
 ```
 
 ### Fedora 28 (CentOS 8)
+
 ```sh
 sudo yum -y install gcc-c++ git curl wget nasm yasm gcc gtk3-devel clang libxcb-devel libxdo-devel libXfixes-devel pulseaudio-libs-devel cmake alsa-lib-devel
 ```
 
 ### Arch (Manjaro)
+
 ```sh
 sudo pacman -Syu --needed unzip git cmake gcc curl wget yasm nasm zip make pkg-config clang gtk3 xdotool libxcb libxfixes alsa-lib pulseaudio
 ```
 
-### 安装vcpkg
+### 安装 vcpkg
+
 ```sh
-git clone https://github.com/microsoft/vcpkg 
+git clone https://github.com/microsoft/vcpkg
 cd vcpkg
 git checkout 134505003bb46e20fbace51ccfb69243fbbc5f82
 cd ..
@@ -72,7 +79,8 @@ export VCPKG_ROOT=$HOME/vcpkg
 vcpkg/vcpkg install libvpx libyuv opus
 ```
 
-### 修复libvpx (仅仅针对Fedora)
+### 修复 libvpx (仅仅针对 Fedora)
+
 ```sh
 cd vcpkg/buildtrees/libvpx/src
 cd *
@@ -85,6 +93,7 @@ cd
 ```
 
 ### 构建
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
@@ -96,7 +105,7 @@ mv libsciter-gtk.so target/debug
 cargo run
 ```
 
-## 使用Docker编译
+## 使用 Docker 编译
 
 首先克隆存储库并构建 docker 容器：
 
@@ -107,37 +116,42 @@ docker build -t "rustdesk-builder" .
 ```
 
 针对国内网络访问问题，可以做以下几点优化：
-1. Dockerfile中修改系统的源到国内镜像
-    ```
-    在Dockerfile的RUN apt update之前插入两行：
 
-    RUN sed -i "s/deb.debian.org/mirrors.163.com/g" /etc/apt/sources.list
-    RUN sed -i "s/security.debian.org/mirrors.163.com/g" /etc/apt/sources.list
-     ```
-2. 修改容器系统中的cargo源，在`RUN ./rustup.sh -y`后插入下面代码：
-    ```
-    RUN echo '[source.crates-io]' > ~/.cargo/config \
-     && echo 'registry = "https://github.com/rust-lang/crates.io-index"'  >> ~/.cargo/config \
-     && echo '# 替换成你偏好的镜像源'  >> ~/.cargo/config \
-     && echo "replace-with = 'sjtu'"  >> ~/.cargo/config \
-     && echo '# 上海交通大学'   >> ~/.cargo/config \
-     && echo '[source.sjtu]'   >> ~/.cargo/config \
-     && echo 'registry = "https://mirrors.sjtug.sjtu.edu.cn/git/crates.io-index"'  >> ~/.cargo/config \
-     && echo '' >> ~/.cargo/config
-    ```
+1. Dockerfile 中修改系统的源到国内镜像
 
-2. Dockerfile中加入代理的env
-    ```
-    在User root后插入两行
-    
-    ENV http_proxy=http://host:port
-    ENV https_proxy=http://host:port
-    ```
+   ```
+   在Dockerfile的RUN apt update之前插入两行：
 
-3. docker build命令后面加上proxy参数
-    ```
-    docker build -t "rustdesk-builder" . --build-arg http_proxy=http://host:port --build-arg https_proxy=http://host:port
-    ```
+   RUN sed -i "s/deb.debian.org/mirrors.163.com/g" /etc/apt/sources.list
+   RUN sed -i "s/security.debian.org/mirrors.163.com/g" /etc/apt/sources.list
+   ```
+
+2. 修改容器系统中的 cargo 源，在`RUN ./rustup.sh -y`后插入下面代码：
+
+   ```
+   RUN echo '[source.crates-io]' > ~/.cargo/config \
+    && echo 'registry = "https://github.com/rust-lang/crates.io-index"'  >> ~/.cargo/config \
+    && echo '# 替换成你偏好的镜像源'  >> ~/.cargo/config \
+    && echo "replace-with = 'sjtu'"  >> ~/.cargo/config \
+    && echo '# 上海交通大学'   >> ~/.cargo/config \
+    && echo '[source.sjtu]'   >> ~/.cargo/config \
+    && echo 'registry = "https://mirrors.sjtug.sjtu.edu.cn/git/crates.io-index"'  >> ~/.cargo/config \
+    && echo '' >> ~/.cargo/config
+   ```
+
+3. Dockerfile 中加入代理的 env
+
+   ```
+   在User root后插入两行
+
+   ENV http_proxy=http://host:port
+   ENV https_proxy=http://host:port
+   ```
+
+4. docker build 命令后面加上 proxy 参数
+   ```
+   docker build -t "rustdesk-builder" . --build-arg http_proxy=http://host:port --build-arg https_proxy=http://host:port
+   ```
 
 然后，每次需要构建应用程序时，运行以下命令：
 
@@ -146,16 +160,19 @@ docker run --rm -it -v $PWD:/home/user/rustdesk -v rustdesk-git-cache:/home/user
 ```
 
 运行若遇到无权限问题，出现以下提示：
+
 ```
 usermod: user user is currently used by process 1
 groupmod: Permission denied.
 groupmod: cannot lock /etc/group; try again later.
 ```
-可以尝试把`-e PUID="$(id -u)" -e PGID="$(id -g)"`参数去掉。（出现这一问题的原因是容器中的entrypoint脚本中判定uid和gid与给定的环境变量不一致时会修改user的uid和gid重新运行，但是重新运行时取不到环境变量中的uid和gid了，会再次进入uid与gid与给定值不一致的逻辑分支）
+
+可以尝试把`-e PUID="$(id -u)" -e PGID="$(id -g)"`参数去掉。（出现这一问题的原因是容器中的 entrypoint 脚本中判定 uid 和 gid 与给定的环境变量不一致时会修改 user 的 uid 和 gid 重新运行，但是重新运行时取不到环境变量中的 uid 和 gid 了，会再次进入 uid 与 gid 与给定值不一致的逻辑分支）
 
 请注意，第一次构建可能需要比较长的时间，因为需要缓存依赖项（国内网络经常出现拉取失败，可多尝试几次），后续构建会更快。此外，如果您需要为构建命令指定不同的参数，
 您可以在命令末尾的 `<OPTIONAL-ARGS>` 位置执行此操作。例如，如果你想构建一个优化的发布版本，你可以在命令后跟 `---release`。
-将在target下产生可执行程序，请通过以下方式运行调试版本：
+将在 target 下产生可执行程序，请通过以下方式运行调试版本：
+
 ```sh
 target/debug/rustdesk
 ```
@@ -169,22 +186,24 @@ target/release/rustdesk
 请确保您从 RustDesk 存储库的根目录运行这些命令，否则应用程序可能无法找到所需的资源。另请注意，此方法当前不支持其他`Cargo`子命令，
 例如 `install` 或 `run`，因为运行在容器里，而不是宿主机上。
 
-### 把Wayland修改成X11 (Xorg)
-RustDesk暂时不支持Wayland，不过正在积极开发中.
-请查看[this](https://docs.fedoraproject.org/en-US/quick-docs/configuring-xorg-as-default-gnome-session/)配置X11.
+### 把 Wayland 修改成 X11 (Xorg)
+
+RustDesk 暂时不支持 Wayland，不过正在积极开发中.
+请查看[this](https://docs.fedoraproject.org/en-US/quick-docs/configuring-xorg-as-default-gnome-session/)配置 X11.
 
 ## 文件结构
 
-- **[libs/hbb_common](https://github.com/rustdesk/rustdesk/tree/master/libs/hbb_common)**: 视频编解码, 配置, tcp/udp封装, protobuf, 文件传输相关文件系统操作函数, 以及一些其他实用函数
+- **[libs/hbb_common](https://github.com/rustdesk/rustdesk/tree/master/libs/hbb_common)**: 视频编解码, 配置, tcp/udp 封装, protobuf, 文件传输相关文件系统操作函数, 以及一些其他实用函数
 - **[libs/scrap](https://github.com/rustdesk/rustdesk/tree/master/libs/scrap)**: 截屏
 - **[libs/enigo](https://github.com/rustdesk/rustdesk/tree/master/libs/enigo)**: 平台相关的鼠标键盘输入
 - **[src/ui](https://github.com/rustdesk/rustdesk/tree/master/src/ui)**: GUI
-- **[src/server](https://github.com/rustdesk/rustdesk/tree/master/src/server)**: 被控端服务，audio/clipboard/input/video服务, 已经连接实现
+- **[src/server](https://github.com/rustdesk/rustdesk/tree/master/src/server)**: 被控端服务，audio/clipboard/input/video 服务, 已经连接实现
 - **[src/client.rs](https://github.com/rustdesk/rustdesk/tree/master/src/client.rs)**: 控制端
-- **[src/rendezvous_mediator.rs](https://github.com/rustdesk/rustdesk/tree/master/src/rendezvous_mediator.rs)**: 与[rustdesk-server](https://github.com/rustdesk/rustdesk-server)保持UDP通讯, 等待远程连接（通过打洞直连或者中继）
+- **[src/rendezvous_mediator.rs](https://github.com/rustdesk/rustdesk/tree/master/src/rendezvous_mediator.rs)**: 与[rustdesk-server](https://github.com/rustdesk/rustdesk-server)保持 UDP 通讯, 等待远程连接（通过打洞直连或者中继）
 - **[src/platform](https://github.com/rustdesk/rustdesk/tree/master/src/platform)**: 平台服务相关代码
 
 ## 截图
+
 ![image](https://user-images.githubusercontent.com/71636191/113112362-ae4deb80-923b-11eb-957d-ff88daad4f06.png)
 
 ![image](https://user-images.githubusercontent.com/71636191/113112619-f705a480-923b-11eb-911d-97e984ef52b6.png)

--- a/README.md
+++ b/README.md
@@ -13,56 +13,62 @@ Chat with us: [Discord](https://discord.gg/nDceKgxnkV) | [Reddit](https://www.re
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/I2I04VU09)
 
-Yet another remote desktop software, written in Rust. Works out of the box, no configuration required. You have full control of your data, with no concerns about security. You can use our rendezvous/relay server, [set up your own](https://rustdesk.com/blog/id-relay-set/), or [write your own rendezvous/relay server](https://github.com/rustdesk/rustdesk-server-demo). 
+Yet another remote desktop software, written in Rust. Works out of the box, no configuration required. You have full control of your data, with no concerns about security. You can use our rendezvous/relay server, [set up your own](https://rustdesk.com/blog/id-relay-set/), or [write your own rendezvous/relay server](https://github.com/rustdesk/rustdesk-server-demo).
 
-RustDesk welcomes contribution from everyone.  See [`CONTRIBUTING.md`](CONTRIBUTING.md) for help getting started.
+RustDesk welcomes contribution from everyone. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for help getting started.
 
 [**BINARY DOWNLOAD**](https://github.com/rustdesk/rustdesk/releases)
 
 ## Free Public Servers
+
 Below are the servers you are using for free, it may change along the time. If you are not close to one of these, your network may be slow.
-| Location  | Vendor        | Specification      |
+| Location | Vendor | Specification |
 | --------- | ------------- | ------------------ |
-| Seoul     | AWS lightsail | 1 VCPU / 0.5GB RAM |
-| Singapore | Vultr         | 1 VCPU / 1GB RAM   |
-| Dallas    | Vultr         | 1 VCPU / 1GB RAM   |                                          |
+| Seoul | AWS lightsail | 1 VCPU / 0.5GB RAM |
+| Singapore | Vultr | 1 VCPU / 1GB RAM |
+| Dallas | Vultr | 1 VCPU / 1GB RAM | |
 
 ## Dependencies
 
 Desktop versions use [sciter](https://sciter.com/) for GUI, please download sciter dynamic library yourself.
 
-[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) | 
+[Windows](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll) |
 [Linux](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so) |
 [MacOS](https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.osx/libsciter.dylib)
 
 ## Raw steps to build
-* Prepare your Rust development env and C++ build env
 
-* Install [vcpkg](https://github.com/microsoft/vcpkg), and set `VCPKG_ROOT` env variable correctly
+- Prepare your Rust development env and C++ build env
 
-   - Windows: vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
-   - Linux/MacOS: vcpkg install libvpx libyuv opus
-   
-* run `cargo run`
+- Install [vcpkg](https://github.com/microsoft/vcpkg), and set `VCPKG_ROOT` env variable correctly
+
+  - Windows: vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
+  - Linux/MacOS: vcpkg install libvpx libyuv opus
+
+- run `cargo run`
 
 ## How to build on Linux
 
 ### Ubuntu 18 (Debian 10)
+
 ```sh
 sudo apt install -y g++ gcc git curl wget nasm yasm libgtk-3-dev clang libxcb-randr0-dev libxdo-dev libxfixes-dev libxcb-shape0-dev libxcb-xfixes0-dev libasound2-dev libpulse-dev cmake
 ```
 
 ### Fedora 28 (CentOS 8)
+
 ```sh
 sudo yum -y install gcc-c++ git curl wget nasm yasm gcc gtk3-devel clang libxcb-devel libxdo-devel libXfixes-devel pulseaudio-libs-devel cmake alsa-lib-devel
 ```
 
 ### Arch (Manjaro)
+
 ```sh
 sudo pacman -Syu --needed unzip git cmake gcc curl wget yasm nasm zip make pkg-config clang gtk3 xdotool libxcb libxfixes alsa-lib pulseaudio
 ```
 
 ### Install vcpkg
+
 ```sh
 git clone https://github.com/microsoft/vcpkg
 cd vcpkg
@@ -74,6 +80,7 @@ vcpkg/vcpkg install libvpx libyuv opus
 ```
 
 ### Fix libvpx (For Fedora)
+
 ```sh
 cd vcpkg/buildtrees/libvpx/src
 cd *
@@ -86,6 +93,7 @@ cd
 ```
 
 ### Build
+
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
@@ -128,6 +136,7 @@ target/release/rustdesk
 Please ensure that you are running these commands from the root of the RustDesk repository, otherwise the application may be unable to find the required resources. Also note that other cargo subcommands such as `install` or `run` are not currently supported via this method as they would install or run the program inside the container instead of the host.
 
 ### Change Wayland to X11 (Xorg)
+
 RustDesk does not support Wayland. Check [this](https://docs.fedoraproject.org/en-US/quick-docs/configuring-xorg-as-default-gnome-session/) to configuring Xorg as the default GNOME session.
 
 ## File Structure
@@ -142,6 +151,7 @@ RustDesk does not support Wayland. Check [this](https://docs.fedoraproject.org/e
 - **[src/platform](https://github.com/rustdesk/rustdesk/tree/master/src/platform)**: platform specific code
 
 ## Snapshot
+
 ![image](https://user-images.githubusercontent.com/71636191/113112362-ae4deb80-923b-11eb-957d-ff88daad4f06.png)
 
 ![image](https://user-images.githubusercontent.com/71636191/113112619-f705a480-923b-11eb-911d-97e984ef52b6.png)
@@ -149,4 +159,3 @@ RustDesk does not support Wayland. Check [this](https://docs.fedoraproject.org/e
 ![image](https://user-images.githubusercontent.com/71636191/113112857-3fbd5d80-923c-11eb-9836-768325faf906.png)
 
 ![image](https://user-images.githubusercontent.com/71636191/135385039-38fdbd72-379a-422d-b97f-33df71fb1cec.png)
-

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo pacman -Syu --needed unzip git cmake gcc curl wget yasm nasm zip make pkg-c
 
 ### Install vcpkg
 ```sh
-git clone https://github.com/microsoft/vcpkg 
+git clone https://github.com/microsoft/vcpkg
 cd vcpkg
 git checkout 134505003bb46e20fbace51ccfb69243fbbc5f82
 cd ..
@@ -94,7 +94,7 @@ cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so
 mv libsciter-gtk.so target/debug
-cargo run
+VCPKG_ROOT=$HOME/vcpkg cargo run
 ```
 
 ## How to build with Docker

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.1.x   | :white_check_mark: |
-| 1.x     | :white_check_mark:             |
-| Below 1.0   | :x: |
+| Version   | Supported          |
+| --------- | ------------------ |
+| 1.1.x     | :white_check_mark: |
+| 1.x       | :white_check_mark: |
+| Below 1.0 | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
- Remove extra space after `git clone` command

```sh
git clone https://github.com/microsoft/vcpkg
```

---

- Add `VCPKG_ROOT` env before `cargo run` command

```sh
VCPKG_ROOT=$HOME/vcpkg cargo run
```

This will make the next runs easier ( don't need to add the environment variable permanently )

---

Fix syntax problems in all Markdown files ( Security, Contributing, Readme, ... )