### PR TITLE
Lan discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket_cs"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "clap",
+ "hbb_common",
+]
+
+[[package]]
 name = "sodiumoxide"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,6 +2909,7 @@ dependencies = [
  "serde_derive",
  "serde_json 1.0.66",
  "sha2",
+ "socket_cs",
  "uuid",
  "whoami",
  "winapi 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = ["use_dasp"]
 whoami = "1.1"
 scrap = { path = "libs/scrap" }
 hbb_common = { path = "libs/hbb_common" }
+socket_cs = { path = "libs/socket_cs" }
 enigo = { path = "libs/enigo" }
 serde_derive = "1.0"
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ psutil = "3.2"
 android_logger = "0.9"
 
 [workspace]
-members = ["libs/scrap", "libs/hbb_common", "libs/enigo"]
+members = ["libs/scrap", "libs/hbb_common", "libs/enigo", "libs/socket_cs"]
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2020"

--- a/libs/hbb_common/build.rs
+++ b/libs/hbb_common/build.rs
@@ -2,7 +2,7 @@ fn main() {
     std::fs::create_dir_all("src/protos").unwrap();
     protobuf_codegen_pure::Codegen::new()
         .out_dir("src/protos")
-        .inputs(&["protos/rendezvous.proto", "protos/message.proto"])
+        .inputs(&["protos/rendezvous.proto", "protos/base_proto.proto", "protos/message.proto", "protos/discovery.proto"])
         .include("protos")
         .run()
         .expect("Codegen failed.");

--- a/libs/hbb_common/protos/base_proto.proto
+++ b/libs/hbb_common/protos/base_proto.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+package base;
+
+message DisplayInfo {
+  sint32 x = 1;
+  sint32 y = 2;
+  int32 width = 3;
+  int32 height = 4;
+  string name = 5;
+  bool online = 6;
+}
+
+message PeerInfo {
+  string username = 1;
+  string hostname = 2;
+  string platform = 3;
+  repeated DisplayInfo displays = 4;
+  int32 current_display = 5;
+  bool sas_enabled = 6;
+  string version = 7;
+}

--- a/libs/hbb_common/protos/discovery.proto
+++ b/libs/hbb_common/protos/discovery.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package discovery;
+
+import "base_proto.proto";
+
+message Discovery {
+  base.PeerInfo peer = 1;
+  /// response port for current listening port(udp for now)
+  int32 port = 2;
+}

--- a/libs/hbb_common/protos/discovery.proto
+++ b/libs/hbb_common/protos/discovery.proto
@@ -8,3 +8,8 @@ message Discovery {
   /// response port for current listening port(udp for now)
   int32 port = 2;
 }
+
+message DiscoveryBack {
+  string id = 1;
+  base.PeerInfo peer = 2;
+}

--- a/libs/hbb_common/protos/discovery.proto
+++ b/libs/hbb_common/protos/discovery.proto
@@ -4,9 +4,10 @@ package discovery;
 import "base_proto.proto";
 
 message Discovery {
-  base.PeerInfo peer = 1;
+  string id = 1;
+  base.PeerInfo peer = 2;
   /// response port for current listening port(udp for now)
-  int32 port = 2;
+  int32 port = 3;
 }
 
 message DiscoveryBack {

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package hbb;
 
+import "base_proto.proto";
+
 message VP9 {
   bytes data = 1;
   bool key = 2;
@@ -23,15 +25,6 @@ message VideoFrame {
     RGB rgb = 7;
     YUV yuv = 8;
   }
-}
-
-message DisplayInfo {
-  sint32 x = 1;
-  sint32 y = 2;
-  int32 width = 3;
-  int32 height = 4;
-  string name = 5;
-  bool online = 6;
 }
 
 message PortForward {
@@ -58,20 +51,10 @@ message LoginRequest {
 
 message ChatMessage { string text = 1; }
 
-message PeerInfo {
-  string username = 1;
-  string hostname = 2;
-  string platform = 3;
-  repeated DisplayInfo displays = 4;
-  int32 current_display = 5;
-  bool sas_enabled = 6;
-  string version = 7;
-}
-
 message LoginResponse {
   oneof union {
     string error = 1;
-    PeerInfo peer_info = 2;
+    base.PeerInfo peer_info = 2;
   }
 }
 

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -55,6 +55,8 @@ pub const RENDEZVOUS_SERVERS: &'static [&'static str] = &[
 pub const RENDEZVOUS_PORT: i32 = 21116;
 pub const RELAY_PORT: i32 = 21117;
 
+pub const SERVER_UDP_PORT: u16 = 21001; // udp
+
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct Config {
     #[serde(default)]

--- a/libs/hbb_common/src/lib.rs
+++ b/libs/hbb_common/src/lib.rs
@@ -1,4 +1,8 @@
 pub mod compress;
+#[path = "./protos/base_proto.rs"]
+pub mod base_proto;
+#[path = "./protos/discovery.rs"]
+pub mod discovery_proto;
 #[path = "./protos/message.rs"]
 pub mod message_proto;
 #[path = "./protos/rendezvous.rs"]

--- a/libs/socket_cs/Cargo.toml
+++ b/libs/socket_cs/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "socket_cs"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+hbb_common = { path = "../hbb_common" }
+async-trait = "0.1"
+
+
+[dev-dependencies]
+clap = "2.33"

--- a/libs/socket_cs/examples/discovery.rs
+++ b/libs/socket_cs/examples/discovery.rs
@@ -1,0 +1,88 @@
+use hbb_common::{
+    base_proto::PeerInfo,
+    discovery_proto::Discovery as DiscoveryProto,
+    env_logger::*,
+    log, protobuf,
+    tokio::{self, sync::Notify},
+};
+use socket_cs::{discovery::*, udp::*};
+use std::env;
+use std::sync::Arc;
+
+async fn lan_discover(port: u16, port_back: u16) {
+    let peer = PeerInfo {
+        username: "client username".to_owned(),
+        hostname: "client hostname".to_owned(),
+        ..Default::default()
+    };
+    let client = DiscoveryClient::create(DiscoveryProto {
+        peer: protobuf::MessageField::from_option(Some(peer)),
+        port: port_back as i32,
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    client.lan_discover(port).await.unwrap();
+}
+
+async fn listen_discovery_back(port: u16) {
+    fn proc_peer(peer: PeerInfo) {
+        log::info!(
+            "peer recived, username: {}, hostname: {}",
+            peer.username,
+            peer.hostname
+        );
+    }
+
+    let exit_notify = Notify::new();
+    let handlers = UdpHandlers::new().handle(
+        CMD_DISCOVERY_BACK.as_bytes().to_vec(),
+        Box::new(HandlerDiscoveryBack::new(proc_peer)),
+    );
+
+    let server = Server::new(port, Arc::new(exit_notify));
+    server.start(handlers).await.unwrap();
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+    }
+}
+
+async fn listen_discovery(port: u16) {
+    let peer = PeerInfo {
+        username: "server username".to_owned(),
+        hostname: "server hostname".to_owned(),
+        ..Default::default()
+    };
+
+    let exit_notify = Notify::new();
+    let handlers = UdpHandlers::new().handle(
+        CMD_DISCOVERY.as_bytes().to_vec(),
+        Box::new(HandlerDiscovery::new(peer)),
+    );
+
+    let server = Server::new(port, Arc::new(exit_notify));
+    server.start(handlers).await.unwrap();
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "trace"));
+
+    let args: Vec<String> = env::args().collect();
+
+    let port_back = 9801u16;
+    let server_port: u16 = 9802u16;
+
+    if args.len() == 1 {
+        lan_discover(server_port, port_back).await;
+    } else if args.len() == 2 {
+        listen_discovery_back(port_back).await;
+    } else {
+        listen_discovery(server_port).await;
+    }
+}

--- a/libs/socket_cs/examples/discovery.rs
+++ b/libs/socket_cs/examples/discovery.rs
@@ -14,6 +14,7 @@ async fn lan_discover(port: u16, port_back: u16) {
         ..Default::default()
     };
     let client = DiscoveryClient::create(DiscoveryProto {
+        id: "client id".to_owned(),
         peer: protobuf::MessageField::from_option(Some(peer)),
         port: port_back as i32,
         ..Default::default()

--- a/libs/socket_cs/src/discovery.rs
+++ b/libs/socket_cs/src/discovery.rs
@@ -1,0 +1,120 @@
+use super::udp::UdpRequest;
+use async_trait::async_trait;
+use hbb_common::{
+    base_proto::PeerInfo, discovery_proto::Discovery as DiscoveryProto, log,
+    protobuf::Message, tokio::net::UdpSocket, ResultType,
+};
+use std::net::SocketAddr;
+
+pub const CMD_DISCOVERY: &str = "discovery";
+pub const CMD_DISCOVERY_BACK: &str = "discovery_back";
+
+// TODO: make sure if UdpFramed is needed, or UdpSocket just works fine.
+pub struct DiscoveryClient {
+    socket: UdpSocket,
+    send_data: Vec<u8>,
+}
+
+fn make_send_data(cmd: &str, msg: &impl Message) -> ResultType<Vec<u8>> {
+    let info_bytes = msg.write_to_bytes()?;
+    let mut send_data = cmd.as_bytes().to_vec();
+    send_data.push(crate::CMD_TOKEN);
+    send_data.extend(info_bytes);
+    Ok(send_data)
+}
+
+impl DiscoveryClient {
+    pub async fn create(info: DiscoveryProto) -> ResultType<Self> {
+        let addr = "0.0.0.0:0";
+        let socket = UdpSocket::bind(addr).await?;
+        log::trace!("succeeded to bind {} for discovery client", addr);
+
+        socket.set_broadcast(true)?;
+        log::info!("Broadcast mode set to ON");
+
+        let send_data = make_send_data(CMD_DISCOVERY, &info)?;
+        Ok(Self {
+            socket,
+            send_data,
+        })
+    }
+
+    pub async fn lan_discover(&self, peer_port: u16) -> ResultType<()> {
+        let addr = SocketAddr::from(([255, 255, 255, 255], peer_port));
+        self.socket.send_to(&self.send_data, addr).await?;
+        Ok(())
+    }
+}
+
+pub struct HandlerDiscovery {
+    send_data: Vec<u8>,
+}
+
+impl HandlerDiscovery {
+    pub fn new(self_info: PeerInfo) -> Self {
+        let send_data = make_send_data(CMD_DISCOVERY_BACK, &self_info).unwrap();
+        Self { send_data }
+    }
+}
+
+#[async_trait]
+impl crate::Handler<UdpRequest> for HandlerDiscovery {
+    async fn call(&self, request: UdpRequest) -> ResultType<()> {
+        log::trace!("received discover query from {}", request.addr);
+
+        let discovery = DiscoveryProto::parse_from_bytes(&request.data)?;
+        let peer = discovery.peer.as_ref().take().unwrap();
+        log::debug!(
+            "received discovery query from {} {}",
+            peer.username,
+            peer.hostname
+        );
+
+        let addr = "0.0.0.0:0";
+        let socket = match UdpSocket::bind(addr).await {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("cannot bind socket? {}", e);
+                return Ok(());
+            }
+        };
+
+        let mut peer_addr = request.addr;
+        peer_addr.set_port(discovery.port as u16);
+
+        // let peer_addr = SocketAddr::from(([255, 255, 255, 255], discovery.port as u16));
+        // socket.set_broadcast(true).unwrap();
+        log::debug!("send self peer info to {}", peer_addr);
+
+        let send_len = self.send_data.len();
+        let mut cur_len = 0usize;
+        while cur_len < send_len {
+            let len = socket.send_to(&self.send_data[cur_len..], peer_addr).await?;
+            cur_len += len;
+        }
+        log::trace!("send self peer info to {} done", peer_addr);
+
+        Ok(())
+    }
+}
+
+pub struct HandlerDiscoveryBack {
+    proc: fn(peer_info: PeerInfo),
+}
+
+impl HandlerDiscoveryBack {
+    pub fn new(proc: fn(peer_info: PeerInfo)) -> Self {
+        Self { proc }
+    }
+}
+
+#[async_trait]
+impl crate::Handler<UdpRequest> for HandlerDiscoveryBack {
+    async fn call(&self, request: UdpRequest) -> ResultType<()> {
+        log::trace!("recved discover back from {}", request.addr);
+
+        let peer = PeerInfo::parse_from_bytes(&request.data)?;
+        (self.proc)(peer);
+        Ok(())
+    }
+}

--- a/libs/socket_cs/src/lib.rs
+++ b/libs/socket_cs/src/lib.rs
@@ -1,0 +1,12 @@
+use async_trait::async_trait;
+pub use hbb_common::ResultType;
+pub mod discovery;
+pub mod udp;
+
+const CMD_TOKEN: u8 = '\n' as u8;
+
+/// Use tower::Service may be better ?
+#[async_trait]
+pub trait Handler<Request>: Send + Sync {
+    async fn call(&self, request: Request) -> ResultType<()>;
+}

--- a/libs/socket_cs/src/udp.rs
+++ b/libs/socket_cs/src/udp.rs
@@ -64,7 +64,6 @@ impl Server {
                         break;
                     }
                     n = server.next() => {
-                        log::info!("received message");
                         let handlers = handlers.clone();
                         let rt = rt.clone();
                         match n {
@@ -76,24 +75,24 @@ impl Server {
                                             match handlers.get(&cmd) {
                                                 Some(h) => {
                                                     let request = UdpRequest {data: data[p+1..].to_vec(), addr};
-                                                    if let Err(e) = h.call(request).await {
-                                                        log::error!("handle {:?} failed, {}", cmd, e);
+                                                    if let Err(_e) = h.call(request).await {
+                                                        // log::error!("handle {:?} failed, {}", cmd, e);
                                                     }
                                                 }
                                                 None => {
-                                                    log::warn!("no handler for {:?}", &cmd);
+                                                    // log::warn!("no handler for {:?}", &cmd);
                                                 }
                                             }
                                         });
                                     }
                                     None => {
-                                        log::error!("failed to parse command token");
+                                        // log::error!("failed to parse command token");
                                     }
                                 }
 
                             }
-                            Some(Err(e)) => {
-                                log::error!("recv error: {}", e)
+                            Some(Err(_e)) => {
+                                // log::error!("recv error: {}", e)
                             }
                             None => {
                                 log::error!("should never reach here");
@@ -139,11 +138,12 @@ impl UdpHandlers {
     /// ```rust
     /// extern crate socket_cs;
     /// use socket_cs::{ResultType, udp::{UdpHandlers, UdpRequest}};
+    /// use async_trait::async_trait;
     ///
     /// struct SimpleHandler;
     ///
     /// #[async_trait]
-    /// impl crate::Handler<UdpRequest> for SimpleHandler {
+    /// impl socket_cs::Handler<UdpRequest> for SimpleHandler {
     ///     async fn call(&self, _: UdpRequest) -> ResultType<()> {
     ///         Ok(())
     ///     }

--- a/libs/socket_cs/src/udp.rs
+++ b/libs/socket_cs/src/udp.rs
@@ -1,0 +1,160 @@
+use async_trait::async_trait;
+use hbb_common::{
+    log,
+    tokio::{self, sync::Notify},
+    udp::FramedSocket,
+    ResultType,
+};
+use std::collections::HashMap;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+/// Simple udp server
+pub struct Server {
+    port: u16,
+    exit_notify: Arc<Notify>,
+}
+
+pub struct UdpRequest {
+    pub data: Vec<u8>,
+    pub addr: SocketAddr,
+}
+
+type UdpHandler = Box<dyn crate::Handler<UdpRequest>>;
+
+pub struct UdpFnHandler<F>(F);
+
+/// Handlers of udp server.
+/// After udp server received data. Command should be parsed.
+/// Handler will then be used to process data.
+pub struct UdpHandlers {
+    handlers: HashMap<Vec<u8>, UdpHandler>,
+}
+
+impl Server {
+    pub fn new(port: u16, exit_notify: Arc<Notify>) -> Self {
+        Self { port, exit_notify }
+    }
+
+    /// Start server with the handlers.
+    pub async fn start(&self, handlers: UdpHandlers) -> ResultType<()> {
+        let exit_notify = self.exit_notify.clone();
+
+        let addr = SocketAddr::from(([0, 0, 0, 0], self.port));
+        let mut server = FramedSocket::new(addr).await?;
+        log::trace!("succeeded to bind {} for discovery server", addr);
+
+        tokio::spawn(async move {
+            let handlers = Arc::new(handlers.handlers);
+            loop {
+                tokio::select! {
+                    _ = exit_notify.notified() => {
+                        log::debug!("exit server graceful");
+                        break;
+                    }
+                    n = server.next() => {
+                        log::info!("received message");
+                        let handlers = handlers.clone();
+                        match n {
+                            Some(Ok((data, addr))) => {
+                                match data.iter().position(|x| x == &crate::CMD_TOKEN) {
+                                    Some(p) => {
+                                        tokio::spawn(async move {
+                                            let cmd = data[0..p].to_vec();
+                                            match handlers.get(&cmd) {
+                                                Some(h) => {
+                                                    let request = UdpRequest {data: data[p+1..].to_vec(), addr};
+                                                    if let Err(e) = h.call(request).await {
+                                                        log::error!("handle {:?} failed, {}", cmd, e);
+                                                    }
+                                                }
+                                                None => {
+                                                    log::warn!("no handler for {:?}", &cmd);
+                                                }
+                                            }
+                                        });
+                                    }
+                                    None => {
+                                        log::error!("failed to parse command token");
+                                    }
+                                }
+
+                            }
+                            Some(Err(e)) => {
+                                log::error!("recv error: {}", e)
+                            }
+                            None => {
+                                log::error!("should never reach here");
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+}
+
+impl UdpHandlers {
+    pub fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+    /// Insert <cmd, handler> pair.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate socket_cs;
+    /// use socket_cs::{ResultType, udp::{UdpHandlers, UdpRequest}};
+    ///
+    /// struct SimpleHandler;
+    ///
+    /// #[async_trait]
+    /// impl crate::Handler<UdpRequest> for SimpleHandler {
+    ///     async fn call(&self, _: UdpRequest) -> ResultType<()> {
+    ///         Ok(())
+    ///     }
+    /// }
+    /// async fn simple_ignore(_: UdpRequest) -> ResultType<()> {
+    ///     Ok(())
+    /// }
+    /// let handlers = UdpHandlers::new();
+    ///
+    /// handlers
+    /// .handle(b"cmd".to_vec(), Box::new(SimpleHandler))
+    /// .handle(b"cmd2".to_vec(), simple_ignore.into());
+    ///
+    /// ```
+    ///
+    /// **Notice** Same cmd where override the previous one.
+    ///
+    pub fn handle(mut self, cmd: Vec<u8>, h: UdpHandler) -> Self {
+        self.handlers.insert(cmd, h);
+        self
+    }
+}
+
+/// TODO: more generice Request.
+#[async_trait]
+impl<F, Fut> crate::Handler<UdpRequest> for UdpFnHandler<F>
+where
+    Fut: Future<Output = ResultType<()>> + Send,
+    F: Fn(UdpRequest) -> Fut + Send + Sync,
+{
+    async fn call(&self, request: UdpRequest) -> ResultType<()> {
+        self.0(request).await
+    }
+}
+
+impl<F, Fut> From<F> for UdpHandler
+where
+    Fut: Future<Output = ResultType<()>> + Send,
+    F: Fn(UdpRequest) -> Fut + Send + Sync + 'static,
+{
+    fn from(f: F) -> Self {
+        Box::new(UdpFnHandler(f))
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,6 +10,7 @@ use hbb_common::{
     bail,
     config::{Config, PeerConfig, PeerInfoSerde, CONNECT_TIMEOUT, RELAY_PORT, RENDEZVOUS_TIMEOUT},
     log,
+    base_proto::*,
     message_proto::*,
     protobuf::Message as _,
     rendezvous_proto::*,

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -90,6 +90,7 @@ pub enum Data {
     ConfirmedKey(Option<(Vec<u8>, Vec<u8>)>),
     RawMessage(Vec<u8>),
     FS(FS),
+    SessionsUpdated,
     Test,
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -389,6 +389,22 @@ pub fn get_id() -> String {
     }
 }
 
+pub async fn get_id_async() -> String {
+    if let Ok(Some(v)) = get_config_async("id", 1_000).await {
+        // update salt also, so that next time reinstallation not causing first-time auto-login failure
+        if let Ok(Some(v2)) = get_config_async("salt", 1_000).await {
+            Config::set_salt(&v2);
+        }
+        if v != Config::get_id() {
+            Config::set_key_confirmed(false);
+            Config::set_id(&v);
+        }
+        v
+    } else {
+        Config::get_id()
+    }
+}
+
 pub fn get_password() -> String {
     if let Ok(Some(v)) = get_config("password") {
         Config::set_password(&v);

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,6 +7,7 @@ use hbb_common::{
     config::{Config, CONNECT_TIMEOUT, RELAY_PORT},
     log,
     message_proto::*,
+    base_proto::*,
     protobuf::{Message as _, ProtobufEnum},
     rendezvous_proto::*,
     sleep,

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,7 +28,7 @@ mod connection;
 pub mod input_service;
 mod service;
 mod video_service;
-mod udp;
+pub mod udp;
 
 use hbb_common::tcp::new_listener;
 

--- a/src/server/udp.rs
+++ b/src/server/udp.rs
@@ -29,7 +29,7 @@ pub mod discovery {
     use super::get_peer_info;
     use crate::ipc;
     use hbb_common::{
-        config::{Config, PeerConfig, PeerInfoSerde, SERVER_UDP_PORT},
+        config::{PeerConfig, PeerInfoSerde, SERVER_UDP_PORT},
         discovery_proto::{Discovery as DiscoveryProto, DiscoveryBack as DiscoveryBackProto},
         log, protobuf, tokio, ResultType,
     };
@@ -44,6 +44,9 @@ pub mod discovery {
         }
     }
 
+    /// process sicovery bakc(response)
+    /// 1. update current peers.
+    /// 2. notify index window to udpate recent sessions.
     fn process_discovery_back(info: DiscoveryBackProto) {
         let mut config = PeerConfig::load(info.id.as_str());
 
@@ -70,6 +73,7 @@ pub mod discovery {
         });
     }
 
+    /// launch lan discover when user click "discover" button.
     pub fn launch_lan_discover() {
         std::thread::spawn(move || {
             if let Err(e) = lan_discover() {
@@ -95,6 +99,7 @@ pub mod discovery {
     pub(super) async fn handle_discovery(handlers: UdpHandlers) -> UdpHandlers {
         let info = get_discovery_back_info().await;
         handlers
+            // handle discover request
             .handle(
                 CMD_DISCOVERY.as_bytes().to_vec(),
                 Box::new(HandlerDiscovery::new(
@@ -103,6 +108,7 @@ pub mod discovery {
                     info,
                 )),
             )
+            // handle discover back(response)
             .handle(
                 CMD_DISCOVERY_BACK.as_bytes().to_vec(),
                 Box::new(HandlerDiscoveryBack::new(process_discovery_back)),

--- a/src/server/udp.rs
+++ b/src/server/udp.rs
@@ -1,0 +1,105 @@
+/// udp server
+///
+/// eg. discovery
+///
+use hbb_common::{base_proto::PeerInfo, config::SERVER_UDP_PORT, ResultType};
+use socket_cs::udp::{Server, UdpHandlers};
+
+/// Simple copy from ../connections.rs#send_logon_response
+/// Should be merged into one function.
+fn get_peer_info() -> PeerInfo {
+    let username = crate::platform::get_active_username();
+    #[allow(unused_mut)]
+    let mut sas_enabled = false;
+    #[cfg(windows)]
+    if crate::platform::is_root() {
+        sas_enabled = true;
+    }
+    PeerInfo {
+        hostname: whoami::hostname(),
+        username,
+        platform: whoami::platform().to_string(),
+        version: crate::VERSION.to_owned(),
+        sas_enabled,
+        ..Default::default()
+    }
+}
+
+mod discovery {
+    use super::get_peer_info;
+    use crate::ipc;
+    use hbb_common::{
+        base_proto::PeerInfo,
+        config::{PeerConfig, PeerInfoSerde},
+        discovery_proto::{Discovery as DiscoveryProto, DiscoveryBack as DiscoveryBackProto},
+        log, protobuf,
+        tokio::runtime::Runtime,
+        ResultType,
+    };
+    use socket_cs::{discovery::*, udp::UdpHandlers};
+
+    fn get_discovery_back_info() -> DiscoveryBackProto {
+        let peer = get_peer_info();
+        DiscoveryBackProto {
+            id: ipc::get_id(),
+            peer: protobuf::MessageField::from_option(Some(peer)),
+            ..Default::default()
+        }
+    }
+
+    fn process_discovery_back(info: DiscoveryBackProto) {
+        let mut config = PeerConfig::load(info.id.as_str());
+
+        let peer = info.peer.as_ref().unwrap();
+        let serde = PeerInfoSerde {
+            username: peer.username.clone(),
+            hostname: peer.hostname.clone(),
+            platform: peer.platform.clone(),
+        };
+        config.info = serde;
+        config.store(info.id.as_str());
+
+        let rt = match Runtime::new() {
+            Ok(r) => r,
+            Err(e) => {
+                log::error!("Failed to notify index window, {}", e);
+                return;
+            }
+        };
+
+        async fn notify_index_window() -> ResultType<()> {
+            let ms_timeout = 1000;
+            let mut c = ipc::connect(ms_timeout, "_index").await?;
+            c.send(&ipc::Data::SessionsUpdated).await?;
+            Ok(())
+        }
+        rt.block_on(async move {
+            if let Err(e) = notify_index_window().await {
+                log::error!("Failed to notify index window, {}", e);
+            }
+        });
+    }
+
+    // pub(crate) fn lan_discover();
+
+    pub(super) fn handle_discovery(handlers: UdpHandlers) -> UdpHandlers {
+        let info = get_discovery_back_info();
+        handlers
+            .handle(
+                CMD_DISCOVERY.as_bytes().to_vec(),
+                Box::new(HandlerDiscovery::new(Some(|| true), info)),
+            )
+            .handle(
+                CMD_DISCOVERY_BACK.as_bytes().to_vec(),
+                Box::new(HandlerDiscoveryBack::new(process_discovery_back)),
+            )
+    }
+}
+
+pub(super) async fn start_udp_server() -> ResultType<Server> {
+    let handlers = discovery::handle_discovery(UdpHandlers::new());
+
+    let mut server = Server::create(SERVER_UDP_PORT)?;
+    server.start(handlers).await?;
+    Ok(server)
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -87,7 +87,7 @@ pub fn start(args: &mut [String]) {
         let cloned = childs.clone();
         std::thread::spawn(move || check_zombie(cloned));
         let cloned = childs.clone();
-        tokio::spawn(async move {start_ipc(cloned)});
+        std::thread::spawn(move || start_ipc(cloned));
         crate::common::check_software_update();
         frame.event_handler(UI::new(childs));
         frame.sciter_handler(UIHostHandler {});
@@ -567,6 +567,10 @@ impl UI {
     fn is_xfce(&self) -> bool {
         crate::platform::is_xfce()
     }
+
+    fn lan_discover(&self) {
+        crate::server::udp::discovery::launch_lan_discover();
+    }
 }
 
 impl sciter::EventHandler for UI {
@@ -615,6 +619,7 @@ impl sciter::EventHandler for UI {
         fn get_software_ext();
         fn open_url(String);
         fn create_shortcut(String);
+        fn lan_discover();
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -86,6 +86,8 @@ pub fn start(args: &mut [String]) {
         let childs: Childs = Default::default();
         let cloned = childs.clone();
         std::thread::spawn(move || check_zombie(cloned));
+        let cloned = childs.clone();
+        tokio::spawn(async move {start_ipc(cloned)});
         crate::common::check_software_update();
         frame.event_handler(UI::new(childs));
         frame.sciter_handler(UIHostHandler {});
@@ -642,6 +644,55 @@ pub fn check_zombie(childs: Childs) {
         drop(lock);
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
+}
+
+// TODO: Duplicated code.
+// Need more generic and better shutdown handler
+#[tokio::main(flavor = "current_thread")]
+async fn start_ipc(childs: Childs) {
+    match ipc::new_listener("_index").await {
+        Ok(mut incoming) => {
+            while let Some(result) = incoming.next().await {
+                match result {
+                    Ok(stream) => {
+                        let mut stream = ipc::Connection::new(stream);
+                        let childs = childs.clone();
+                        tokio::spawn(async move {
+                            loop {
+                                tokio::select! {
+                                    res = stream.next() => {
+                                        match res {
+                                            Err(err) => {
+                                                log::info!("cm ipc connection closed: {}", err);
+                                                break;
+                                            }
+                                            Ok(Some(data)) => {
+                                                match data {
+                                                    ipc::Data::SessionsUpdated => {
+                                                        childs.lock().unwrap().0 = true;
+                                                    }
+                                                    _ => {
+                                                    }
+                                                }
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    }
+                    Err(err) => {
+                        log::error!("Couldn't get index client: {:?}", err);
+                    }
+                }
+            }
+        }
+        Err(err) => {
+            log::error!("Failed to start index ipc server: {}", err);
+        }
+    }
+    std::process::exit(-1);
 }
 
 // notice: avoiding create ipc connection repeatedly,

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -51,10 +51,15 @@ class RecentSessions: Reactor.Component {
         sessions = sessions.map(this.getSession);
         return <div style="width: *">
             <div .recent-sessions-title>RECENT SESSIONS</div>
+            <button .button #discover>DISCOVER</button>
             <div .recent-sessions-content key={sessions.length}>
                 {sessions}
             </div>
         </div>;
+    }
+
+    event click $(button#discover) {
+        handler.lan_discover();
     }
 
     function getSession(s) {

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -51,7 +51,7 @@ class RecentSessions: Reactor.Component {
         sessions = sessions.map(this.getSession);
         return <div style="width: *">
             <div .recent-sessions-title>RECENT SESSIONS</div>
-            <button .button #discover>DISCOVER</button>
+            { false && <button .button #discover>DISCOVER</button>}
             <div .recent-sessions-content key={sessions.length}>
                 {sessions}
             </div>

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -7,6 +7,7 @@ use hbb_common::{
     allow_err,
     config::{self, Config, PeerConfig},
     fs, log,
+    base_proto::*,
     message_proto::*,
     protobuf::Message as _,
     rendezvous_proto::ConnType,


### PR DESCRIPTION
#Features

Simple Udp server and Lan discovery.

## Udp server

![simple_udp_server](https://user-images.githubusercontent.com/13586388/146804968-dd929b13-c64b-4788-9b0e-ec8993875aab.png)


File: libs\socket_cs\src\udp.rs.


## Lan discovery
One client send discovery message through boardcast.
The others reply their peer info(id, username, hostname).

It only provide a way to add peers automatically.
No connections will not be established.

