### PR TITLE
adjust #[warn(unreachable_code)] position

### DIFF
--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -274,8 +274,8 @@ impl Config {
         return "".into();
     }
 
+    #[allow(unreachable_code)]
     pub fn log_path() -> PathBuf {
-        #[allow(unreachable_code)]
         #[cfg(target_os = "macos")]
         {
             if let Some(path) = dirs_next::home_dir().as_mut() {


### PR DESCRIPTION
adjust #[warn(unreachable_code)] to the right position,so that make every _cargo check_ clean.