### PR TITLE
fix pre-login window behavior on macOS Big Sur or above

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[target.'cfg(target_os="macos")']
+rustflags = [
+    "-C", "link-args=-sectcreate __CGPreLoginApp __cgpreloginapp /dev/null",
+]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -904,12 +904,10 @@ async fn start_ipc(
     mut rx_to_cm: mpsc::UnboundedReceiver<ipc::Data>,
     tx_from_cm: mpsc::UnboundedSender<ipc::Data>,
 ) -> ResultType<()> {
-    loop {
-        if !crate::platform::is_prelogin() {
-            break;
-        }
-        sleep(1.).await;
+    if crate::platform::is_prelogin() {
+        return Ok(());
     }
+
     let mut stream = None;
     if let Ok(s) = crate::ipc::connect(1000, "_cm").await {
         stream = Some(s);


### PR DESCRIPTION
fix security problem caused server hang and unexpected input behavior at pre-login window when macOS version on Big Sur or above