### PR TITLE
remove remote conn id

### DIFF
--- a/libs/clipboard/src/cliprdr.h
+++ b/libs/clipboard/src/cliprdr.h
@@ -18,8 +18,7 @@ extern "C"
 
 /* Clipboard Messages */
 #define DEFINE_CLIPRDR_HEADER_COMMON() \
-    UINT32 serverConnID;               \
-    UINT32 remoteConnID;               \
+    UINT32 connID;                     \
     UINT16 msgType;                    \
     UINT16 msgFlags;                   \
     UINT32 dataLen
@@ -192,7 +191,7 @@ extern "C"
     typedef UINT (*pcCliprdrServerFileContentsResponse)(
         CliprdrClientContext *context, const CLIPRDR_FILE_CONTENTS_RESPONSE *fileContentsResponse);
 
-    typedef BOOL (*pcCheckEnabled)(UINT32 server_conn_id, UINT32 remote_conn_id);
+    typedef BOOL (*pcCheckEnabled)(UINT32 connID);
 
     // TODO: hide more members of clipboard context
     struct _cliprdr_client_context

--- a/libs/clipboard/src/cliprdr.rs
+++ b/libs/clipboard/src/cliprdr.rs
@@ -175,8 +175,7 @@ pub const FALSE: ::std::os::raw::c_int = 0;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_HEADER {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -201,8 +200,7 @@ pub type CLIPRDR_GENERAL_CAPABILITY_SET = _CLIPRDR_GENERAL_CAPABILITY_SET;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_CAPABILITIES {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -213,8 +211,7 @@ pub type CLIPRDR_CAPABILITIES = _CLIPRDR_CAPABILITIES;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_MONITOR_READY {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -223,8 +220,7 @@ pub type CLIPRDR_MONITOR_READY = _CLIPRDR_MONITOR_READY;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_TEMP_DIRECTORY {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -241,8 +237,7 @@ pub type CLIPRDR_FORMAT = _CLIPRDR_FORMAT;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_FORMAT_LIST {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -253,8 +248,7 @@ pub type CLIPRDR_FORMAT_LIST = _CLIPRDR_FORMAT_LIST;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_FORMAT_LIST_RESPONSE {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -263,8 +257,7 @@ pub type CLIPRDR_FORMAT_LIST_RESPONSE = _CLIPRDR_FORMAT_LIST_RESPONSE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_LOCK_CLIPBOARD_DATA {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -274,8 +267,7 @@ pub type CLIPRDR_LOCK_CLIPBOARD_DATA = _CLIPRDR_LOCK_CLIPBOARD_DATA;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_UNLOCK_CLIPBOARD_DATA {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -285,8 +277,7 @@ pub type CLIPRDR_UNLOCK_CLIPBOARD_DATA = _CLIPRDR_UNLOCK_CLIPBOARD_DATA;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_FORMAT_DATA_REQUEST {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -296,8 +287,7 @@ pub type CLIPRDR_FORMAT_DATA_REQUEST = _CLIPRDR_FORMAT_DATA_REQUEST;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_FORMAT_DATA_RESPONSE {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -307,8 +297,7 @@ pub type CLIPRDR_FORMAT_DATA_RESPONSE = _CLIPRDR_FORMAT_DATA_RESPONSE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_FILE_CONTENTS_REQUEST {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -325,8 +314,7 @@ pub type CLIPRDR_FILE_CONTENTS_REQUEST = _CLIPRDR_FILE_CONTENTS_REQUEST;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _CLIPRDR_FILE_CONTENTS_RESPONSE {
-    pub serverConnID: UINT32,
-    pub remoteConnID: UINT32,
+    pub connID: UINT32,
     pub msgType: UINT16,
     pub msgFlags: UINT16,
     pub dataLen: UINT32,
@@ -457,7 +445,7 @@ pub type pcCliprdrServerFileContentsResponse = ::std::option::Option<
     ) -> UINT,
 >;
 pub type pcCheckEnabled = ::std::option::Option<
-    unsafe extern "C" fn(server_conn_id: UINT32, remote_conn_id: UINT32) -> BOOL,
+    unsafe extern "C" fn(connID: UINT32) -> BOOL,
 >;
 
 // TODO: hide more members of clipboard context
@@ -498,8 +486,7 @@ extern "C" {
     pub(crate) fn uninit_cliprdr(context: *mut CliprdrClientContext) -> BOOL;
     pub(crate) fn empty_cliprdr(
         context: *mut CliprdrClientContext,
-        server_conn_id: UINT32,
-        remote_conn_id: UINT32,
+        connID: UINT32,
     ) -> BOOL;
 }
 

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -308,58 +308,50 @@ message FileDirCreate {
 
 // main logic from freeRDP
 message CliprdrMonitorReady {
-  int32 server_conn_id = 1;
-  int32 remote_conn_id = 2;
+  int32 conn_id = 1;
 }
 
 message CliprdrFormat {
-  int32 server_conn_id = 1;
-  int32 remote_conn_id = 2;
-  int32 id = 3;
-  string format = 4;
+  int32 conn_id = 1;
+  int32 id = 2;
+  string format = 3;
 }
 
 message CliprdrServerFormatList {
-  int32 server_conn_id = 1;
-  int32 remote_conn_id = 2;
-  repeated CliprdrFormat formats = 3;
+  int32 conn_id = 1;
+  repeated CliprdrFormat formats = 2;
 }
 
 message CliprdrServerFormatListResponse {
-  int32 server_conn_id = 1;
-  int32 remote_conn_id = 2;
-  int32 msg_flags = 3;
+  int32 conn_id = 1;
+  int32 msg_flags = 2;
 }
 
 message CliprdrServerFormatDataRequest {
-  int32 server_conn_id = 1;
-  int32 remote_conn_id = 2;
-  int32 requested_format_id = 3;
+  int32 conn_id = 1;
+  int32 requested_format_id = 2;
 }
 
 message CliprdrServerFormatDataResponse {
-  int32 server_conn_id = 1;
-  int32 remote_conn_id = 2;
-  int32 msg_flags = 3;
-  bytes format_data = 4;
+  int32 conn_id = 1;
+  int32 msg_flags = 2;
+  bytes format_data = 3;
 }
 
 message CliprdrFileContentsRequest {
-  int32 server_conn_id = 1;
-  int32 remote_conn_id = 2;
-  int32 stream_id = 3;
-	int32 list_index = 4;
-	int32 dw_flags = 5;
-	int32 n_position_low = 6;
-	int32 n_position_high = 7;
-	int32 cb_requested = 8;
-	bool have_clip_data_id = 9;
-	int32 clip_data_id = 10;
+  int32 conn_id = 1;
+  int32 stream_id = 2;
+	int32 list_index = 3;
+	int32 dw_flags = 4;
+	int32 n_position_low = 5;
+	int32 n_position_high = 6;
+	int32 cb_requested = 7;
+	bool have_clip_data_id = 8;
+	int32 clip_data_id = 9;
 }
 
 message CliprdrFileContentsResponse {
-  int32 server_conn_id = 1;
-  int32 remote_conn_id = 2;
+  int32 conn_id = 1;
   int32 msg_flags = 3;
   int32 stream_id = 4;
 	bytes requested_data = 5;

--- a/src/clipboard_file.rs
+++ b/src/clipboard_file.rs
@@ -4,15 +4,13 @@ use hbb_common::message_proto::*;
 pub fn clip_2_msg(clip: ClipbaordFile) -> Message {
     match clip {
         ClipbaordFile::ServerFormatList {
-            server_conn_id,
-            remote_conn_id,
+            conn_id,
             format_list,
         } => {
             let mut formats: Vec<CliprdrFormat> = Vec::new();
             for v in format_list.iter() {
                 formats.push(CliprdrFormat {
-                    server_conn_id: 0,
-                    remote_conn_id: 0,
+                    conn_id: 0,
                     id: v.0,
                     format: v.1.clone(),
                     ..Default::default()
@@ -21,8 +19,7 @@ pub fn clip_2_msg(clip: ClipbaordFile) -> Message {
             Message {
                 union: Some(message::Union::cliprdr(Cliprdr {
                     union: Some(cliprdr::Union::format_list(CliprdrServerFormatList {
-                        server_conn_id,
-                        remote_conn_id,
+                        conn_id,
                         formats,
                         ..Default::default()
                     })),
@@ -31,16 +28,11 @@ pub fn clip_2_msg(clip: ClipbaordFile) -> Message {
                 ..Default::default()
             }
         }
-        ClipbaordFile::ServerFormatListResponse {
-            server_conn_id,
-            remote_conn_id,
-            msg_flags,
-        } => Message {
+        ClipbaordFile::ServerFormatListResponse { conn_id, msg_flags } => Message {
             union: Some(message::Union::cliprdr(Cliprdr {
                 union: Some(cliprdr::Union::format_list_response(
                     CliprdrServerFormatListResponse {
-                        server_conn_id,
-                        remote_conn_id,
+                        conn_id,
                         msg_flags,
                         ..Default::default()
                     },
@@ -50,15 +42,13 @@ pub fn clip_2_msg(clip: ClipbaordFile) -> Message {
             ..Default::default()
         },
         ClipbaordFile::ServerFormatDataRequest {
-            server_conn_id,
-            remote_conn_id,
+            conn_id,
             requested_format_id,
         } => Message {
             union: Some(message::Union::cliprdr(Cliprdr {
                 union: Some(cliprdr::Union::format_data_request(
                     CliprdrServerFormatDataRequest {
-                        server_conn_id,
-                        remote_conn_id,
+                        conn_id,
                         requested_format_id,
                         ..Default::default()
                     },
@@ -68,16 +58,14 @@ pub fn clip_2_msg(clip: ClipbaordFile) -> Message {
             ..Default::default()
         },
         ClipbaordFile::ServerFormatDataResponse {
-            server_conn_id,
-            remote_conn_id,
+            conn_id,
             msg_flags,
             format_data,
         } => Message {
             union: Some(message::Union::cliprdr(Cliprdr {
                 union: Some(cliprdr::Union::format_data_response(
                     CliprdrServerFormatDataResponse {
-                        server_conn_id,
-                        remote_conn_id,
+                        conn_id,
                         msg_flags,
                         format_data,
                         ..Default::default()
@@ -88,8 +76,7 @@ pub fn clip_2_msg(clip: ClipbaordFile) -> Message {
             ..Default::default()
         },
         ClipbaordFile::FileContentsRequest {
-            server_conn_id,
-            remote_conn_id,
+            conn_id,
             stream_id,
             list_index,
             dw_flags,
@@ -102,8 +89,7 @@ pub fn clip_2_msg(clip: ClipbaordFile) -> Message {
             union: Some(message::Union::cliprdr(Cliprdr {
                 union: Some(cliprdr::Union::file_contents_request(
                     CliprdrFileContentsRequest {
-                        server_conn_id,
-                        remote_conn_id,
+                        conn_id,
                         stream_id,
                         list_index,
                         dw_flags,
@@ -120,8 +106,7 @@ pub fn clip_2_msg(clip: ClipbaordFile) -> Message {
             ..Default::default()
         },
         ClipbaordFile::FileContentsResponse {
-            server_conn_id,
-            remote_conn_id,
+            conn_id,
             msg_flags,
             stream_id,
             requested_data,
@@ -129,8 +114,7 @@ pub fn clip_2_msg(clip: ClipbaordFile) -> Message {
             union: Some(message::Union::cliprdr(Cliprdr {
                 union: Some(cliprdr::Union::file_contents_response(
                     CliprdrFileContentsResponse {
-                        server_conn_id,
-                        remote_conn_id,
+                        conn_id,
                         msg_flags,
                         stream_id,
                         requested_data,
@@ -152,37 +136,32 @@ pub fn msg_2_clip(msg: Cliprdr) -> Option<ClipbaordFile> {
                 format_list.push((v.id, v.format.clone()));
             }
             Some(ClipbaordFile::ServerFormatList {
-                server_conn_id: data.server_conn_id,
-                remote_conn_id: data.remote_conn_id,
+                conn_id: data.conn_id,
                 format_list,
             })
         }
         Some(cliprdr::Union::format_list_response(data)) => {
             Some(ClipbaordFile::ServerFormatListResponse {
-                server_conn_id: data.server_conn_id,
-                remote_conn_id: data.remote_conn_id,
+                conn_id: data.conn_id,
                 msg_flags: data.msg_flags,
             })
         }
         Some(cliprdr::Union::format_data_request(data)) => {
             Some(ClipbaordFile::ServerFormatDataRequest {
-                server_conn_id: data.server_conn_id,
-                remote_conn_id: data.remote_conn_id,
+                conn_id: data.conn_id,
                 requested_format_id: data.requested_format_id,
             })
         }
         Some(cliprdr::Union::format_data_response(data)) => {
             Some(ClipbaordFile::ServerFormatDataResponse {
-                server_conn_id: data.server_conn_id,
-                remote_conn_id: data.remote_conn_id,
+                conn_id: data.conn_id,
                 msg_flags: data.msg_flags,
                 format_data: data.format_data,
             })
         }
         Some(cliprdr::Union::file_contents_request(data)) => {
             Some(ClipbaordFile::FileContentsRequest {
-                server_conn_id: data.server_conn_id,
-                remote_conn_id: data.remote_conn_id,
+                conn_id: data.conn_id,
                 stream_id: data.stream_id,
                 list_index: data.list_index,
                 dw_flags: data.dw_flags,
@@ -195,8 +174,7 @@ pub fn msg_2_clip(msg: Cliprdr) -> Option<ClipbaordFile> {
         }
         Some(cliprdr::Union::file_contents_response(data)) => {
             Some(ClipbaordFile::FileContentsResponse {
-                server_conn_id: data.server_conn_id,
-                remote_conn_id: data.remote_conn_id,
+                conn_id: data.conn_id,
                 msg_flags: data.msg_flags,
                 stream_id: data.stream_id,
                 requested_data: data.requested_data,

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -1,8 +1,7 @@
 use crate::ipc::{self, new_listener, Connection, Data};
 #[cfg(windows)]
 use clipboard::{
-    create_cliprdr_context, empty_clipboard, get_rx_clip_client, server_clip_file,
-    set_conn_enabled, ConnID,
+    create_cliprdr_context, empty_clipboard, get_rx_clip_client, server_clip_file, set_conn_enabled,
 };
 use hbb_common::{
     allow_err,
@@ -514,7 +513,7 @@ async fn start_clipboard_file(
                 Some((conn_id, clip)) => {
                     cmd_inner_send(
                         &cm,
-                        conn_id.server_conn_id as i32,
+                        conn_id,
                         Data::ClipbaordFile(clip)
                     );
                 }
@@ -523,11 +522,7 @@ async fn start_clipboard_file(
                 }
             },
             server_msg = rx.recv() => match server_msg {
-                Some(ClipboardFileData::Clip((server_conn_id, clip))) => {
-                    let conn_id = ConnID {
-                        server_conn_id: server_conn_id as u32,
-                        remote_conn_id: 0,
-                    };
+                Some(ClipboardFileData::Clip((conn_id, clip))) => {
                     if let Some(ctx) = cliprdr_context.as_mut() {
                         server_clip_file(ctx, conn_id, clip);
                     }
@@ -548,10 +543,10 @@ async fn start_clipboard_file(
                             }
                         });
                     }
-                    set_conn_enabled(id, 0, enabled);
+                    set_conn_enabled(id, enabled);
                     if !enabled {
                         if let Some(ctx) = cliprdr_context.as_mut() {
-                            empty_clipboard(ctx, id, 0);
+                            empty_clipboard(ctx, id);
                         }
                     }
                 }


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

Remote unused "remote conn id", for connections on the remote side are managed by single process.