### PR TITLE
Fix audio switch on linux

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -515,7 +515,7 @@ pub fn set_option(key: &str, value: &str) {
     set_options(options).ok();
 }
 
-pub fn restart_autdio_input() {
+pub fn restart_autdio_service() {
     crate::audio_service::restart();
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -515,6 +515,10 @@ pub fn set_option(key: &str, value: &str) {
     set_options(options).ok();
 }
 
+pub fn restart_autdio_input() {
+    crate::audio_service::restart();
+}
+
 #[tokio::main(flavor = "current_thread")]
 pub async fn set_options(value: HashMap<String, String>) -> ResultType<()> {
     let mut c = connect(1000, "").await?;

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -63,7 +63,7 @@ mod pa_impl {
                 .await
         );
         let zero_audio_frame: Vec<f32> = vec![0.; AUDIO_DATA_SIZE_U8 / 4];
-        while sp.ok() {
+        while sp.ok() && !RESTARTING.load(Ordering::SeqCst) {
             sp.snapshot(|sps| {
                 sps.send(create_format_msg(crate::platform::linux::PA_SAMPLE_RATE, 2));
                 Ok(())

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -14,9 +14,11 @@
 
 use super::*;
 use magnum_opus::{Application::*, Channels::*, Encoder};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 pub const NAME: &'static str = "audio";
 pub const AUDIO_DATA_SIZE_U8: usize = 960 * 4; // 10ms in 48000 stereo
+static RESTARTING: AtomicBool = AtomicBool::new(false);
 
 #[cfg(not(target_os = "linux"))]
 pub fn new() -> GenericService {
@@ -32,12 +34,21 @@ pub fn new() -> GenericService {
     sp
 }
 
+pub fn restart() {
+    log::info!("restart the audio service, freezing now...");
+    if RESTARTING.load(Ordering::SeqCst) {
+        return;
+    }
+    RESTARTING.store(true, Ordering::SeqCst);
+}
+
 #[cfg(target_os = "linux")]
 mod pa_impl {
     use super::*;
     #[tokio::main(flavor = "current_thread")]
     pub async fn run(sp: GenericService) -> ResultType<()> {
         hbb_common::sleep(0.1).await; // one moment to wait for _pa ipc
+        RESTARTING.store(false, Ordering::SeqCst);
         let mut stream = crate::ipc::connect(1000, "_pa").await?;
         unsafe {
             AUDIO_ZERO_COUNT = 0;
@@ -61,7 +72,7 @@ mod pa_impl {
                 if data.len() == 0 {
                     send_f32(&zero_audio_frame, &mut encoder, &sp);
                     continue;
-                } 
+                }
                 if data.len() != AUDIO_DATA_SIZE_U8 {
                     continue;
                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -364,6 +364,10 @@ impl UI {
         }
     }
 
+    fn refresh_audio_input(&self) {
+        ipc::restart_autdio_input();
+    }
+
     fn install_path(&mut self) -> String {
         #[cfg(windows)]
         return crate::platform::windows::get_install_info().1;
@@ -701,6 +705,7 @@ impl sciter::EventHandler for UI {
         fn create_shortcut(String);
         fn discover();
         fn get_lan_peers();
+        fn refresh_audio_input();
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -365,7 +365,7 @@ impl UI {
     }
 
     fn refresh_audio_input(&self) {
-        ipc::restart_autdio_input();
+        ipc::restart_autdio_service();
     }
 
     fn install_path(&mut self) -> String {

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -131,6 +131,7 @@ class AudioInputs: Reactor.Component {
         if (v == this.get_value()) return;
         if (v == this.get_default()) v = "";
         handler.set_option("audio-input", v);
+        handler.refresh_audio_input();
         this.toggleMenuState();
     }
 }


### PR DESCRIPTION
Issue: 
Switch audio input list failed on Linux.

Solution:
Fix it by restarting the audio service after switching audio input.

Expectation:
All remote clients can receive the new audio device after switching audio input.