### PR TITLE
Fix audio sample exit when mute

### DIFF
--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -437,7 +437,8 @@ async fn start_pa() {
                                 device = x;
                             }
                             if device == "Mute" {
-                                break;
+                                log::info!("Switch mute mode, skip sample audio.");
+                                continue;
                             }
                             if !device.is_empty() {
                                 device = crate::platform::linux::get_pa_source_name(&device);


### PR DESCRIPTION
Issue:
Audio sample exit when switching mute mode in the index page.

Solution:
Do not exit when mute.

Expectation:
We can continue to sample audio after switching audio input from mute to the available device.
