### PR TITLE
Privacy mode win magnifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3558,6 +3558,7 @@ dependencies = [
  "gstreamer",
  "gstreamer-app",
  "gstreamer-video",
+ "lazy_static",
  "libc",
  "num_cpus",
  "quest",

--- a/libs/enigo/src/lib.rs
+++ b/libs/enigo/src/lib.rs
@@ -63,6 +63,8 @@ extern crate objc;
 mod win;
 #[cfg(target_os = "windows")]
 pub use win::Enigo;
+#[cfg(target_os = "windows")]
+pub use win::ENIGO_INPUT_EXTRA_VALUE;
 
 #[cfg(target_os = "macos")]
 mod macos;

--- a/libs/enigo/src/win/mod.rs
+++ b/libs/enigo/src/win/mod.rs
@@ -2,3 +2,4 @@ mod win_impl;
 
 pub mod keycodes;
 pub use self::win_impl::Enigo;
+pub use self::win_impl::ENIGO_INPUT_EXTRA_VALUE;

--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -1,7 +1,7 @@
 use winapi;
 
 use self::winapi::ctypes::c_int;
-use self::winapi::shared::{minwindef::*, windef::*};
+use self::winapi::shared::{basetsd::ULONG_PTR, minwindef::*, windef::*};
 use self::winapi::um::winbase::*;
 use self::winapi::um::winuser::*;
 
@@ -18,6 +18,9 @@ extern "system" {
 pub struct Enigo;
 static mut LAYOUT: HKL = std::ptr::null_mut();
 
+/// The dwExtraInfo value in keyboard and mouse structure that used in SendInput()
+pub const ENIGO_INPUT_EXTRA_VALUE: ULONG_PTR = 100;
+
 fn mouse_event(flags: u32, data: u32, dx: i32, dy: i32) -> DWORD {
     let mut input = INPUT {
         type_: INPUT_MOUSE,
@@ -28,7 +31,7 @@ fn mouse_event(flags: u32, data: u32, dx: i32, dy: i32) -> DWORD {
                 mouseData: data,
                 dwFlags: flags,
                 time: 0,
-                dwExtraInfo: 0,
+                dwExtraInfo: ENIGO_INPUT_EXTRA_VALUE,
             })
         },
     };
@@ -56,7 +59,7 @@ fn keybd_event(flags: u32, vk: u16, scan: u16) -> DWORD {
                 wScan: scan,
                 dwFlags: flags,
                 time: 0,
-                dwExtraInfo: 0,
+                dwExtraInfo: ENIGO_INPUT_EXTRA_VALUE,
             })
         },
     };

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -64,6 +64,10 @@ message LoginRequest {
 
 message ChatMessage { string text = 1; }
 
+message Features {
+  bool privacy_mode = 1;
+}
+
 message PeerInfo {
   string username = 1;
   string hostname = 2;
@@ -72,6 +76,7 @@ message PeerInfo {
   int32 current_display = 5;
   bool sas_enabled = 6;
   string version = 7;
+  Features features = 8;
 }
 
 message LoginResponse {

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -418,11 +418,6 @@ message OptionMessage {
   BoolOption enable_file_transfer = 9;
 }
 
-message OptionResponse {
-  OptionMessage opt = 1;
-  string error = 2;
-}
-
 message TestDelay {
   int64 time = 1;
   bool from_client = 2;
@@ -442,6 +437,44 @@ message AudioFormat {
 
 message AudioFrame { bytes data = 1; }
 
+message BackNotification {
+  // no need to consider block input by someone else
+  enum BlockInputState {
+    StateUnknown = 1;
+    OnSucceeded = 2;
+    OnFailed = 3;
+    OffSucceeded = 4;
+    OffFailed = 5;
+  }
+  enum PrivacyModeState {
+    StateUnknown = 1;
+    // Privacy mode on by someone else
+    OnByOther = 2;
+    // Privacy mode is not supported on the remote side
+    NotSupported = 3;
+    // Privacy mode on by self
+    OnSucceeded = 4;
+    // Privacy mode on by self, but denied
+    OnFailedDenied = 5;
+    // Some plugins are not found
+    OnFailedPlugin = 6;
+    // Privacy mode on by self, but failed
+    OnFailed = 7;
+    // Privacy mode off by self
+    OffSucceeded = 8;
+    // Ctrl + P
+    OffByPeer = 9;
+    // Privacy mode off by self, but failed
+    OffFailed = 10;
+    OffUnknown = 11;
+  }
+
+  oneof union {
+    PrivacyModeState privacy_mode_state = 1;
+    BlockInputState block_input_state = 2;
+  }
+}
+
 message Misc {
   oneof union {
     ChatMessage chat_message = 4;
@@ -451,8 +484,8 @@ message Misc {
     AudioFormat audio_format = 8;
     string close_reason = 9;
     bool refresh_video = 10;
-    OptionResponse option_response = 11;
     bool video_received = 12;
+    BackNotification back_notification = 13;
   }
 }
 

--- a/libs/scrap/Cargo.toml
+++ b/libs/scrap/Cargo.toml
@@ -17,6 +17,7 @@ block = "0.1"
 cfg-if = "1.0"
 libc = "0.2"
 num_cpus = "1.13"
+lazy_static = "1.4"
 
 [dependencies.winapi]
 version = "0.3"

--- a/libs/scrap/examples/capture_mag.rs
+++ b/libs/scrap/examples/capture_mag.rs
@@ -1,0 +1,105 @@
+extern crate repng;
+extern crate scrap;
+
+use std::fs::File;
+
+#[cfg(windows)]
+use scrap::CapturerMag;
+use scrap::{i420_to_rgb, Display};
+
+fn main() {
+    let n = Display::all().unwrap().len();
+    for i in 0..n {
+        #[cfg(windows)]
+        record(i);
+    }
+}
+
+fn get_display(i: usize) -> Display {
+    Display::all().unwrap().remove(i)
+}
+
+#[cfg(windows)]
+fn record(i: usize) {
+    for d in Display::all().unwrap() {
+        println!("{:?} {} {}", d.origin(), d.width(), d.height());
+    }
+
+    let display = get_display(i);
+    let (w, h) = (display.width(), display.height());
+
+    {
+        let mut capture_mag =
+            CapturerMag::new(display.origin(), display.width(), display.height(), false)
+                .expect("Couldn't begin capture.");
+        let wnd_cls = "";
+        let wnd_title = "RustDeskPrivacyWindow";
+        if false == capture_mag.exclude(wnd_cls, wnd_title).unwrap() {
+            println!("No window found for cls {} title {}", wnd_cls, wnd_title);
+        } else {
+            println!("Filter window for cls {} title {}", wnd_cls, wnd_title);
+        }
+
+        let frame = capture_mag.frame(0).unwrap();
+        println!("Capture data len: {}, Saving...", frame.len());
+
+        let mut bitflipped = Vec::with_capacity(w * h * 4);
+        let stride = frame.len() / h;
+
+        for y in 0..h {
+            for x in 0..w {
+                let i = stride * y + 4 * x;
+                bitflipped.extend_from_slice(&[frame[i + 2], frame[i + 1], frame[i], 255]);
+            }
+        }
+        // Save the image.
+        let name = format!("capture_mag_{}_1.png", i);
+        repng::encode(
+            File::create(name.clone()).unwrap(),
+            w as u32,
+            h as u32,
+            &bitflipped,
+        )
+        .unwrap();
+        println!("Image saved to `{}`.", name);
+    }
+
+    {
+        let mut capture_mag =
+            CapturerMag::new(display.origin(), display.width(), display.height(), true)
+                .expect("Couldn't begin capture.");
+        let wnd_cls = "";
+        let wnd_title = "RustDeskPrivacyWindow";
+        if false == capture_mag.exclude(wnd_cls, wnd_title).unwrap() {
+            println!("No window found for cls {} title {}", wnd_cls, wnd_title);
+        } else {
+            println!("Filter window for cls {} title {}", wnd_cls, wnd_title);
+        }
+
+        let buffer = capture_mag.frame(0).unwrap();
+        println!("Capture data len: {}, Saving...", buffer.len());
+
+        let mut frame = Default::default();
+        i420_to_rgb(w, h, &buffer, &mut frame);
+
+        let mut bitflipped = Vec::with_capacity(w * h * 4);
+        let stride = frame.len() / h;
+
+        for y in 0..h {
+            for x in 0..w {
+                let i = stride * y + 3 * x;
+                bitflipped.extend_from_slice(&[frame[i], frame[i + 1], frame[i + 2], 255]);
+            }
+        }
+        let name = format!("capture_mag_{}_2.png", i);
+        repng::encode(
+            File::create(name.clone()).unwrap(),
+            w as u32,
+            h as u32,
+            &bitflipped,
+        )
+        .unwrap();
+
+        println!("Image saved to `{}`.", name);
+    }
+}

--- a/libs/scrap/examples/capture_mag.rs
+++ b/libs/scrap/examples/capture_mag.rs
@@ -33,11 +33,11 @@ fn record(i: usize) {
             CapturerMag::new(display.origin(), display.width(), display.height(), false)
                 .expect("Couldn't begin capture.");
         let wnd_cls = "";
-        let wnd_title = "RustDeskPrivacyWindow";
-        if false == capture_mag.exclude(wnd_cls, wnd_title).unwrap() {
-            println!("No window found for cls {} title {}", wnd_cls, wnd_title);
+        let wnd_name = "RustDeskPrivacyWindow";
+        if false == capture_mag.exclude(wnd_cls, wnd_name).unwrap() {
+            println!("No window found for cls {} name {}", wnd_cls, wnd_name);
         } else {
-            println!("Filter window for cls {} title {}", wnd_cls, wnd_title);
+            println!("Filter window for cls {} name {}", wnd_cls, wnd_name);
         }
 
         let frame = capture_mag.frame(0).unwrap();

--- a/libs/scrap/examples/screenshot.rs
+++ b/libs/scrap/examples/screenshot.rs
@@ -46,8 +46,7 @@ fn record(i: usize) {
                 }
             }
         };
-
-        println!("Captured! Saving...");
+        println!("Captured data len: {}, Saving...", buffer.len());
 
         // Flip the BGRA image into a RGBA image.
 
@@ -96,8 +95,7 @@ fn record(i: usize) {
                 }
             }
         };
-
-        println!("Captured! Saving...");
+        println!("Captured data len: {}, Saving...", buffer.len());
 
         let mut frame = Default::default();
         i420_to_rgb(w, h, &buffer, &mut frame);

--- a/libs/scrap/src/common/dxgi.rs
+++ b/libs/scrap/src/common/dxgi.rs
@@ -128,8 +128,8 @@ impl CapturerMag {
             data: Vec::new(),
         })
     }
-    pub fn exclude(&mut self, cls: &str, title: &str) -> io::Result<bool> {
-        self.inner.exclude(cls, title)
+    pub fn exclude(&mut self, cls: &str, name: &str) -> io::Result<bool> {
+        self.inner.exclude(cls, name)
     }
     // ((x, y), w, h)
     pub fn get_rect(&self) -> ((i32, i32), usize, usize) {

--- a/libs/scrap/src/common/dxgi.rs
+++ b/libs/scrap/src/common/dxgi.rs
@@ -112,12 +112,22 @@ impl Display {
     }
 }
 
+pub struct CapturerMagInitializer {}
+
 pub struct CapturerMag {
     inner: dxgi::mag::CapturerMag,
     data: Vec<u8>,
 }
 
 impl CapturerMag {
+    pub fn init() -> io::Result<()> {
+        dxgi::mag::CapturerMag::init()
+    }
+
+    pub fn uninit() -> io::Result<()> {
+        dxgi::mag::CapturerMag::uninit()
+    }
+
     pub fn is_supported() -> bool {
         dxgi::mag::CapturerMag::is_supported()
     }

--- a/libs/scrap/src/common/dxgi.rs
+++ b/libs/scrap/src/common/dxgi.rs
@@ -112,22 +112,12 @@ impl Display {
     }
 }
 
-pub struct CapturerMagInitializer {}
-
 pub struct CapturerMag {
     inner: dxgi::mag::CapturerMag,
     data: Vec<u8>,
 }
 
 impl CapturerMag {
-    pub fn init() -> io::Result<()> {
-        dxgi::mag::CapturerMag::init()
-    }
-
-    pub fn uninit() -> io::Result<()> {
-        dxgi::mag::CapturerMag::uninit()
-    }
-
     pub fn is_supported() -> bool {
         dxgi::mag::CapturerMag::is_supported()
     }

--- a/libs/scrap/src/common/dxgi.rs
+++ b/libs/scrap/src/common/dxgi.rs
@@ -111,3 +111,32 @@ impl Display {
         self.origin() == (0, 0)
     }
 }
+
+pub struct CapturerMag {
+    inner: dxgi::mag::CapturerMag,
+    data: Vec<u8>,
+}
+
+impl CapturerMag {
+    pub fn is_supported() -> bool {
+        dxgi::mag::CapturerMag::is_supported()
+    }
+
+    pub fn new(origin: (i32, i32), width: usize, height: usize, use_yuv: bool) -> io::Result<Self> {
+        Ok(CapturerMag {
+            inner: dxgi::mag::CapturerMag::new(origin, width, height, use_yuv)?,
+            data: Vec::new(),
+        })
+    }
+    pub fn exclude(&mut self, cls: &str, title: &str) -> io::Result<bool> {
+        self.inner.exclude(cls, title)
+    }
+    // ((x, y), w, h)
+    pub fn get_rect(&self) -> ((i32, i32), usize, usize) {
+        self.inner.get_rect()
+    }
+    pub fn frame<'a>(&'a mut self, _timeout_ms: u32) -> io::Result<Frame<'a>> {
+        self.inner.frame(&mut self.data)?;
+        Ok(Frame(&self.data))
+    }
+}

--- a/libs/scrap/src/dxgi/mag.rs
+++ b/libs/scrap/src/dxgi/mag.rs
@@ -103,7 +103,6 @@ pub type MagSetImageScalingCallbackFunc = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Clone)]
 struct MagInterface {
-    init_succeeded: bool,
     lib_handle: HINSTANCE,
     pub mag_initialize_func: MagInitializeFunc,
     pub mag_uninitialize_func: MagUninitializeFunc,
@@ -115,7 +114,6 @@ struct MagInterface {
 impl MagInterface {
     fn new() -> Result<Self> {
         let mut s = MagInterface {
-            init_succeeded: false,
             lib_handle: NULL as _,
             mag_initialize_func: None,
             mag_uninitialize_func: None,
@@ -123,7 +121,7 @@ impl MagInterface {
             set_window_filter_list_func: None,
             set_image_scaling_callback_func: None,
         };
-        s.init_succeeded = false;
+
         unsafe {
             if GetSystemMetrics(SM_CMONITORS) != 1 {
                 // Do not try to use the magnifier in multi-screen setup (where the API
@@ -174,23 +172,6 @@ impl MagInterface {
                 s.lib_handle,
                 "MagSetImageScalingCallback",
             )?));
-
-            // MagInitialize
-            if let Some(init_func) = s.mag_initialize_func {
-                if FALSE == init_func() {
-                    return Err(Error::new(
-                        ErrorKind::Other,
-                        format!("Failed to MagInitialize, error: {}", GetLastError()),
-                    ));
-                } else {
-                    s.init_succeeded = true;
-                }
-            } else {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    "Unreachable, mag_initialize_func should not be none",
-                ));
-            }
         }
         Ok(s)
     }
@@ -212,24 +193,14 @@ impl MagInterface {
     }
 
     pub(super) fn uninit(&mut self) {
-        if self.init_succeeded {
-            if let Some(uninit_func) = self.mag_uninitialize_func {
-                unsafe {
-                    if FALSE == uninit_func() {
-                        println!("Failed MagUninitialize {}", GetLastError())
-                    }
+        if !self.lib_handle.is_null() {
+            unsafe {
+                if FALSE == FreeLibrary(self.lib_handle) {
+                    println!("Failed FreeLibrary {}", GetLastError())
                 }
             }
-            if !self.lib_handle.is_null() {
-                unsafe {
-                    if FALSE == FreeLibrary(self.lib_handle) {
-                        println!("Failed FreeLibrary {}", GetLastError())
-                    }
-                }
-                self.lib_handle = NULL as _;
-            }
+            self.lib_handle = NULL as _;
         }
-        self.init_succeeded = false;
     }
 }
 
@@ -265,6 +236,45 @@ impl Drop for CapturerMag {
 }
 
 impl CapturerMag {
+    pub(crate) fn init() -> Result<()> {
+        let mag_interface = MagInterface::new()?;
+        // MagInitialize
+        if let Some(init_func) = mag_interface.mag_initialize_func {
+            unsafe {
+                if FALSE == init_func() {
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        format!("Failed to MagInitialize, error: {}", GetLastError()),
+                    ));
+                }
+            }
+        } else {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Unreachable, mag_initialize_func should not be none",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn uninit() -> Result<()> {
+        let mag_interface = MagInterface::new()?;
+        // MagUninitialize
+        if let Some(uninit_func) = mag_interface.mag_uninitialize_func {
+            unsafe {
+                if FALSE == uninit_func() {
+                    println!("Failed MagUninitialize {}", GetLastError())
+                }
+            }
+        } else {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Unreachable, mag_uninitialize_func should not be none",
+            ));
+        }
+        Ok(())
+    }
+
     pub(crate) fn is_supported() -> bool {
         MagInterface::new().is_ok()
     }
@@ -445,7 +455,7 @@ impl CapturerMag {
                     return Err(Error::new(
                         ErrorKind::Other,
                         format!(
-                            "Failed MagSetWindowFilterList for cls {} name {}, err: {}",
+                            "Failed MagSetWindowFilterList for cls {} title {}, err: {}",
                             cls,
                             name,
                             GetLastError()

--- a/libs/scrap/src/dxgi/mag.rs
+++ b/libs/scrap/src/dxgi/mag.rs
@@ -417,14 +417,14 @@ impl CapturerMag {
         Ok(s)
     }
 
-    pub(crate) fn exclude(&mut self, cls: &str, title: &str) -> Result<bool> {
-        let title_c = CString::new(title).unwrap();
+    pub(crate) fn exclude(&mut self, cls: &str, name: &str) -> Result<bool> {
+        let name_c = CString::new(name).unwrap();
         unsafe {
             let mut hwnd = if cls.len() == 0 {
-                FindWindowExA(NULL as _, NULL as _, NULL as _, title_c.as_ptr())
+                FindWindowExA(NULL as _, NULL as _, NULL as _, name_c.as_ptr())
             } else {
-                let cls_c = CString::new(title).unwrap();
-                FindWindowExA(NULL as _, NULL as _, cls_c.as_ptr(), title_c.as_ptr())
+                let cls_c = CString::new(cls).unwrap();
+                FindWindowExA(NULL as _, NULL as _, cls_c.as_ptr(), name_c.as_ptr())
             };
 
             if hwnd.is_null() {
@@ -445,9 +445,9 @@ impl CapturerMag {
                     return Err(Error::new(
                         ErrorKind::Other,
                         format!(
-                            "Failed MagSetWindowFilterList for cls {} title {}, err: {}",
+                            "Failed MagSetWindowFilterList for cls {} name {}, err: {}",
                             cls,
-                            title,
+                            name,
                             GetLastError()
                         ),
                     ));

--- a/libs/scrap/src/dxgi/mag.rs
+++ b/libs/scrap/src/dxgi/mag.rs
@@ -1,0 +1,624 @@
+// logic from webrtc -- https://github.com/shiguredo/libwebrtc/blob/main/modules/desktop_capture/win/screen_capturer_win_magnifier.cc
+use lazy_static;
+use std::{
+    ffi::CString,
+    io::{Error, ErrorKind, Result},
+    mem::size_of,
+    sync::Mutex,
+};
+use winapi::{
+    shared::{
+        basetsd::SIZE_T,
+        guiddef::{IsEqualGUID, GUID},
+        minwindef::{BOOL, DWORD, FALSE, FARPROC, HINSTANCE, HMODULE, HRGN, TRUE, UINT},
+        ntdef::{LONG, NULL},
+        windef::{HWND, RECT},
+        winerror::ERROR_CLASS_ALREADY_EXISTS,
+    },
+    um::{
+        errhandlingapi::GetLastError,
+        libloaderapi::{FreeLibrary, GetModuleHandleExA, GetProcAddress, LoadLibraryExA},
+        winuser::*,
+    },
+};
+
+pub const MW_FILTERMODE_EXCLUDE: u32 = 0;
+pub const MW_FILTERMODE_INCLUDE: u32 = 1;
+pub const GET_MODULE_HANDLE_EX_FLAG_PIN: u32 = 1;
+pub const GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT: u32 = 2;
+pub const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: u32 = 4;
+pub const LOAD_LIBRARY_AS_DATAFILE: u32 = 2;
+pub const LOAD_WITH_ALTERED_SEARCH_PATH: u32 = 8;
+pub const LOAD_IGNORE_CODE_AUTHZ_LEVEL: u32 = 16;
+pub const LOAD_LIBRARY_AS_IMAGE_RESOURCE: u32 = 32;
+pub const LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE: u32 = 64;
+pub const LOAD_LIBRARY_REQUIRE_SIGNED_TARGET: u32 = 128;
+pub const LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR: u32 = 256;
+pub const LOAD_LIBRARY_SEARCH_APPLICATION_DIR: u32 = 512;
+pub const LOAD_LIBRARY_SEARCH_USER_DIRS: u32 = 1024;
+pub const LOAD_LIBRARY_SEARCH_SYSTEM32: u32 = 2048;
+pub const LOAD_LIBRARY_SEARCH_DEFAULT_DIRS: u32 = 4096;
+pub const LOAD_LIBRARY_SAFE_CURRENT_DIRS: u32 = 8192;
+pub const LOAD_LIBRARY_SEARCH_SYSTEM32_NO_FORWARDER: u32 = 16384;
+pub const LOAD_LIBRARY_OS_INTEGRITY_CONTINUITY: u32 = 32768;
+
+extern "C" {
+    pub static GUID_WICPixelFormat32bppRGBA: GUID;
+}
+
+lazy_static::lazy_static! {
+    static ref MAG_BUFFER: Mutex<(bool, Vec<u8>)> =  Default::default();
+}
+
+pub type REFWICPixelFormatGUID = *const GUID;
+pub type WICPixelFormatGUID = GUID;
+
+#[allow(non_snake_case)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct tagMAGIMAGEHEADER {
+    pub width: UINT,
+    pub height: UINT,
+    pub format: WICPixelFormatGUID,
+    pub stride: UINT,
+    pub offset: UINT,
+    pub cbSize: SIZE_T,
+}
+pub type MAGIMAGEHEADER = tagMAGIMAGEHEADER;
+pub type PMAGIMAGEHEADER = *mut tagMAGIMAGEHEADER;
+
+// Function types
+pub type MagImageScalingCallback = ::std::option::Option<
+    unsafe extern "C" fn(
+        hwnd: HWND,
+        srcdata: *mut ::std::os::raw::c_void,
+        srcheader: MAGIMAGEHEADER,
+        destdata: *mut ::std::os::raw::c_void,
+        destheader: MAGIMAGEHEADER,
+        unclipped: RECT,
+        clipped: RECT,
+        dirty: HRGN,
+    ) -> BOOL,
+>;
+
+extern "C" {
+    pub fn MagShowSystemCursor(fShowCursor: BOOL) -> BOOL;
+}
+pub type MagInitializeFunc = ::std::option::Option<unsafe extern "C" fn() -> BOOL>;
+pub type MagUninitializeFunc = ::std::option::Option<unsafe extern "C" fn() -> BOOL>;
+pub type MagSetWindowSourceFunc =
+    ::std::option::Option<unsafe extern "C" fn(hwnd: HWND, rect: RECT) -> BOOL>;
+pub type MagSetWindowFilterListFunc = ::std::option::Option<
+    unsafe extern "C" fn(
+        hwnd: HWND,
+        dwFilterMode: DWORD,
+        count: ::std::os::raw::c_int,
+        pHWND: *mut HWND,
+    ) -> BOOL,
+>;
+pub type MagSetImageScalingCallbackFunc = ::std::option::Option<
+    unsafe extern "C" fn(hwnd: HWND, callback: MagImageScalingCallback) -> BOOL,
+>;
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+struct MagInterface {
+    init_succeeded: bool,
+    lib_handle: HINSTANCE,
+    pub mag_initialize_func: MagInitializeFunc,
+    pub mag_uninitialize_func: MagUninitializeFunc,
+    pub set_window_source_func: MagSetWindowSourceFunc,
+    pub set_window_filter_list_func: MagSetWindowFilterListFunc,
+    pub set_image_scaling_callback_func: MagSetImageScalingCallbackFunc,
+}
+
+impl MagInterface {
+    fn new() -> Result<Self> {
+        let mut s = MagInterface {
+            init_succeeded: false,
+            lib_handle: NULL as _,
+            mag_initialize_func: None,
+            mag_uninitialize_func: None,
+            set_window_source_func: None,
+            set_window_filter_list_func: None,
+            set_image_scaling_callback_func: None,
+        };
+        s.init_succeeded = false;
+        unsafe {
+            if GetSystemMetrics(SM_CMONITORS) != 1 {
+                // Do not try to use the magnifier in multi-screen setup (where the API
+                // crashes sometimes).
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "Magnifier capturer cannot work on multi-screen system.",
+                ));
+            }
+
+            // load lib
+            let lib_file_name = "Magnification.dll";
+            let lib_file_name_c = CString::new(lib_file_name).unwrap();
+            s.lib_handle = LoadLibraryExA(
+                lib_file_name_c.as_ptr() as _,
+                NULL,
+                LOAD_WITH_ALTERED_SEARCH_PATH,
+            );
+            if s.lib_handle.is_null() {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    format!(
+                        "Failed to LoadLibraryExA {}, error: {}",
+                        lib_file_name,
+                        GetLastError()
+                    ),
+                ));
+            };
+
+            // load functions
+            s.mag_initialize_func = Some(std::mem::transmute(Self::load_func(
+                s.lib_handle,
+                "MagInitialize",
+            )?));
+            s.mag_uninitialize_func = Some(std::mem::transmute(Self::load_func(
+                s.lib_handle,
+                "MagUninitialize",
+            )?));
+            s.set_window_source_func = Some(std::mem::transmute(Self::load_func(
+                s.lib_handle,
+                "MagSetWindowSource",
+            )?));
+            s.set_window_filter_list_func = Some(std::mem::transmute(Self::load_func(
+                s.lib_handle,
+                "MagSetWindowFilterList",
+            )?));
+            s.set_image_scaling_callback_func = Some(std::mem::transmute(Self::load_func(
+                s.lib_handle,
+                "MagSetImageScalingCallback",
+            )?));
+
+            // MagInitialize
+            if let Some(init_func) = s.mag_initialize_func {
+                if FALSE == init_func() {
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        format!("Failed to MagInitialize, error: {}", GetLastError()),
+                    ));
+                } else {
+                    s.init_succeeded = true;
+                }
+            } else {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "Unreachable, mag_initialize_func should not be none",
+                ));
+            }
+        }
+        Ok(s)
+    }
+
+    unsafe fn load_func(lib_module: HMODULE, func_name: &str) -> Result<FARPROC> {
+        let func_name_c = CString::new(func_name).unwrap();
+        let func = GetProcAddress(lib_module, func_name_c.as_ptr() as _);
+        if func.is_null() {
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!(
+                    "Failed to GetProcAddress {}, error: {}",
+                    func_name,
+                    GetLastError()
+                ),
+            ));
+        }
+        Ok(func)
+    }
+
+    pub(super) fn uninit(&mut self) {
+        if self.init_succeeded {
+            if let Some(uninit_func) = self.mag_uninitialize_func {
+                unsafe {
+                    if FALSE == uninit_func() {
+                        println!("Failed MagUninitialize {}", GetLastError())
+                    }
+                }
+            }
+            if !self.lib_handle.is_null() {
+                unsafe {
+                    if FALSE == FreeLibrary(self.lib_handle) {
+                        println!("Failed FreeLibrary {}", GetLastError())
+                    }
+                }
+                self.lib_handle = NULL as _;
+            }
+        }
+        self.init_succeeded = false;
+    }
+}
+
+impl Drop for MagInterface {
+    fn drop(&mut self) {
+        self.uninit();
+    }
+}
+
+pub struct CapturerMag {
+    mag_interface: MagInterface,
+    host_window: HWND,
+    magnifier_window: HWND,
+
+    magnifier_host_class: CString,
+    host_window_name: CString,
+    magnifier_window_class: CString,
+    magnifier_window_name: CString,
+
+    rect: RECT,
+    width: usize,
+    height: usize,
+
+    use_yuv: bool,
+    data: Vec<u8>,
+}
+
+impl Drop for CapturerMag {
+    fn drop(&mut self) {
+        self.destroy_windows();
+        self.mag_interface.uninit();
+    }
+}
+
+impl CapturerMag {
+    pub(crate) fn is_supported() -> bool {
+        MagInterface::new().is_ok()
+    }
+
+    pub(crate) fn new(
+        origin: (i32, i32),
+        width: usize,
+        height: usize,
+        use_yuv: bool,
+    ) -> Result<Self> {
+        let mut s = Self {
+            mag_interface: MagInterface::new()?,
+            host_window: 0 as _,
+            magnifier_window: 0 as _,
+            magnifier_host_class: CString::new("ScreenCapturerWinMagnifierHost")?,
+            host_window_name: CString::new("MagnifierHost")?,
+            magnifier_window_class: CString::new("Magnifier")?,
+            magnifier_window_name: CString::new("MagnifierWindow")?,
+            rect: RECT {
+                left: origin.0 as _,
+                top: origin.1 as _,
+                right: origin.0 + width as LONG,
+                bottom: origin.1 + height as LONG,
+            },
+            width,
+            height,
+            use_yuv,
+            data: Vec::new(),
+        };
+
+        unsafe {
+            let mut instance = 0 as HMODULE;
+            if 0 == GetModuleHandleExA(
+                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                    | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                DefWindowProcA as _,
+                &mut instance as _,
+            ) {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    format!("Failed to GetModuleHandleExA, error: {}", GetLastError()),
+                ));
+            }
+
+            // Register the host window class. See the MSDN documentation of the
+            // Magnification API for more infomation.
+            let wcex = WNDCLASSEXA {
+                cbSize: size_of::<WNDCLASSEXA>() as _,
+                style: 0,
+                lpfnWndProc: Some(DefWindowProcA),
+                cbClsExtra: 0,
+                cbWndExtra: 0,
+                hInstance: instance,
+                hIcon: 0 as _,
+                hCursor: LoadCursorA(NULL as _, IDC_ARROW as _),
+                hbrBackground: 0 as _,
+                lpszClassName: s.magnifier_host_class.as_ptr() as _,
+                lpszMenuName: 0 as _,
+                hIconSm: 0 as _,
+            };
+
+            // Ignore the error which may happen when the class is already registered.
+            if 0 == RegisterClassExA(&wcex) {
+                let code = GetLastError();
+                if code != ERROR_CLASS_ALREADY_EXISTS {
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        format!("Failed to RegisterClassExA, error: {}", code),
+                    ));
+                }
+            }
+
+            // Create the host window.
+            s.host_window = CreateWindowExA(
+                WS_EX_LAYERED,
+                s.magnifier_host_class.as_ptr(),
+                s.host_window_name.as_ptr(),
+                WS_POPUP,
+                0,
+                0,
+                0,
+                0,
+                NULL as _,
+                NULL as _,
+                instance,
+                NULL,
+            );
+            if s.host_window.is_null() {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    format!(
+                        "Failed to CreateWindowExA host_window, error: {}",
+                        GetLastError()
+                    ),
+                ));
+            }
+
+            // Create the magnifier control.
+            s.magnifier_window = CreateWindowExA(
+                0,
+                s.magnifier_window_class.as_ptr(),
+                s.magnifier_window_name.as_ptr(),
+                WS_CHILD | WS_VISIBLE,
+                0,
+                0,
+                0,
+                0,
+                s.host_window,
+                NULL as _,
+                instance,
+                NULL,
+            );
+            if s.magnifier_window.is_null() {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    format!(
+                        "Failed CreateWindowA magnifier_window, error: {}",
+                        GetLastError()
+                    ),
+                ));
+            }
+
+            // Hide the host window.
+            let _ = ShowWindow(s.host_window, SW_HIDE);
+
+            // Set the scaling callback to receive captured image.
+            if let Some(set_callback_func) = s.mag_interface.set_image_scaling_callback_func {
+                if FALSE
+                    == set_callback_func(
+                        s.magnifier_window,
+                        Some(Self::on_gag_image_scaling_callback),
+                    )
+                {
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        format!(
+                            "Failed to MagSetImageScalingCallback, error: {}",
+                            GetLastError()
+                        ),
+                    ));
+                }
+            } else {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "Unreachable, set_image_scaling_callback_func should not be none",
+                ));
+            }
+        }
+
+        Ok(s)
+    }
+
+    pub(crate) fn exclude(&mut self, cls: &str, title: &str) -> Result<bool> {
+        let title_c = CString::new(title).unwrap();
+        unsafe {
+            let mut hwnd = if cls.len() == 0 {
+                FindWindowExA(NULL as _, NULL as _, NULL as _, title_c.as_ptr())
+            } else {
+                let cls_c = CString::new(title).unwrap();
+                FindWindowExA(NULL as _, NULL as _, cls_c.as_ptr(), title_c.as_ptr())
+            };
+
+            if hwnd.is_null() {
+                return Ok(false);
+            }
+
+            if let Some(set_window_filter_list_func) =
+                self.mag_interface.set_window_filter_list_func
+            {
+                if FALSE
+                    == set_window_filter_list_func(
+                        self.magnifier_window,
+                        MW_FILTERMODE_EXCLUDE,
+                        1,
+                        &mut hwnd,
+                    )
+                {
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        format!(
+                            "Failed MagSetWindowFilterList for cls {} title {}, err: {}",
+                            cls,
+                            title,
+                            GetLastError()
+                        ),
+                    ));
+                }
+            } else {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "Unreachable, MagSetWindowFilterList should not be none",
+                ));
+            }
+        }
+
+        Ok(true)
+    }
+
+    pub(crate) fn get_rect(&self) -> ((i32, i32), usize, usize) {
+        (
+            (self.rect.left as _, self.rect.top as _),
+            self.width as _,
+            self.height as _,
+        )
+    }
+
+    fn clear_data() {
+        let mut lock = MAG_BUFFER.lock().unwrap();
+        lock.0 = false;
+        lock.1.clear();
+    }
+
+    pub(crate) fn frame(&mut self, data: &mut Vec<u8>) -> Result<()> {
+        Self::clear_data();
+
+        unsafe {
+            let x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+            let y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+            let w = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+            let h = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+            self.rect = RECT {
+                left: x as _,
+                top: y as _,
+                right: (x + w) as _,
+                bottom: (y + h) as _,
+            };
+
+            if FALSE
+                == SetWindowPos(
+                    self.magnifier_window,
+                    HWND_TOP,
+                    self.rect.left,
+                    self.rect.top,
+                    self.rect.right,
+                    self.rect.bottom,
+                    0,
+                )
+            {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    format!(
+                        "Failed SetWindowPos (x, y, w , h) - ({}, {}, {}, {}), error {}",
+                        self.rect.left,
+                        self.rect.top,
+                        self.rect.right,
+                        self.rect.bottom,
+                        GetLastError()
+                    ),
+                ));
+            }
+
+            // on_gag_image_scaling_callback will be called and fill in the
+            // frame before set_window_source_func_ returns.
+            if let Some(set_window_source_func) = self.mag_interface.set_window_source_func {
+                if FALSE == set_window_source_func(self.magnifier_window, self.rect) {
+                    return Err(Error::new(
+                        ErrorKind::Other,
+                        format!("Failed to MagSetWindowSource, error: {}", GetLastError()),
+                    ));
+                }
+            } else {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "Unreachable, set_window_source_func should not be none",
+                ));
+            }
+        }
+
+        let mut lock = MAG_BUFFER.lock().unwrap();
+        if !lock.0 {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "No data captured by magnifier",
+            ));
+        }
+
+        if self.use_yuv {
+            self.data.resize(lock.1.len(), 0);
+            unsafe {
+                std::ptr::copy_nonoverlapping(&mut lock.1[0], &mut self.data[0], self.data.len());
+            }
+            crate::common::bgra_to_i420(
+                self.width as usize,
+                self.height as usize,
+                &self.data,
+                data,
+            );
+        } else {
+            data.resize(lock.1.len(), 0);
+            unsafe {
+                std::ptr::copy_nonoverlapping(&mut lock.1[0], &mut data[0], data.len());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn destroy_windows(&mut self) {
+        if !self.magnifier_window.is_null() {
+            unsafe {
+                if FALSE == DestroyWindow(self.magnifier_window) {
+                    //
+                    println!("Failed DestroyWindow magnifier window {}", GetLastError())
+                }
+            }
+        }
+        self.magnifier_window = NULL as _;
+
+        if !self.host_window.is_null() {
+            unsafe {
+                if FALSE == DestroyWindow(self.host_window) {
+                    //
+                    println!("Failed DestroyWindow host window {}", GetLastError())
+                }
+            }
+        }
+        self.host_window = NULL as _;
+    }
+
+    unsafe extern "C" fn on_gag_image_scaling_callback(
+        _hwnd: HWND,
+        srcdata: *mut ::std::os::raw::c_void,
+        srcheader: MAGIMAGEHEADER,
+        _destdata: *mut ::std::os::raw::c_void,
+        _destheader: MAGIMAGEHEADER,
+        _unclipped: RECT,
+        _clipped: RECT,
+        _dirty: HRGN,
+    ) -> BOOL {
+        Self::clear_data();
+
+        if !IsEqualGUID(&srcheader.format, &GUID_WICPixelFormat32bppRGBA) {
+            // log warning?
+            return FALSE;
+        }
+        let mut lock = MAG_BUFFER.lock().unwrap();
+        lock.1.resize(srcheader.cbSize, 0);
+        std::ptr::copy_nonoverlapping(srcdata as _, &mut lock.1[0], srcheader.cbSize);
+        lock.0 = true;
+        TRUE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test() {
+        let mut capture_mag = CapturerMag::new((0, 0), 1920, 1080, false).unwrap();
+        capture_mag.exclude("", "RustDeskPrivacyWindow").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1000 * 10));
+        let mut data = Vec::new();
+        capture_mag.frame(&mut data).unwrap();
+        println!("capture data len: {}", data.len());
+    }
+}

--- a/libs/scrap/src/dxgi/mod.rs
+++ b/libs/scrap/src/dxgi/mod.rs
@@ -1,6 +1,7 @@
 use std::{io, mem, ptr, slice};
 pub mod gdi;
 pub use gdi::CapturerGDI;
+pub mod mag;
 
 use winapi::{
     shared::{

--- a/src/client.rs
+++ b/src/client.rs
@@ -323,7 +323,11 @@ impl Client {
         Ok((conn, direct))
     }
 
-    async fn secure_connection(peer_id: &str, signed_id_pk: Vec<u8>, conn: &mut Stream) -> ResultType<()> {
+    async fn secure_connection(
+        peer_id: &str,
+        signed_id_pk: Vec<u8>,
+        conn: &mut Stream,
+    ) -> ResultType<()> {
         let rs_pk = get_rs_pk("OeVuKk5nlHiXp+APNn0Y3pC1Iwpwn44JGqrQCsWqmBw=");
         let mut sign_pk = None;
         if !signed_id_pk.is_empty() && rs_pk.is_some() {
@@ -664,6 +668,7 @@ pub struct LoginConfigHandler {
     config: PeerConfig,
     pub port_forward: (String, i32),
     pub version: i64,
+    features: Option<Features>,
 }
 
 impl Deref for LoginConfigHandler {
@@ -872,6 +877,14 @@ impl LoginConfigHandler {
         }
     }
 
+    pub fn is_privacy_mode_supported(&self) -> bool {
+        if let Some(features) = &self.features {
+            features.privacy_mode
+        } else {
+            false
+        }
+    }
+
     pub fn refresh() -> Message {
         let mut misc = Misc::new();
         misc.set_refresh_video(true);
@@ -944,6 +957,7 @@ impl LoginConfigHandler {
         if !pi.version.is_empty() {
             self.version = hbb_common::get_version_number(&pi.version);
         }
+        self.features = pi.features.into_option();
         let serde = PeerInfoSerde {
             username,
             hostname: pi.hostname.clone(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -746,11 +746,11 @@ impl LoginConfigHandler {
             })
             .into();
         } else if name == "privacy-mode" {
-            config.privacy_mode = !config.privacy_mode;
+            // try toggle privacy mode
             option.privacy_mode = (if config.privacy_mode {
-                BoolOption::Yes
-            } else {
                 BoolOption::No
+            } else {
+                BoolOption::Yes
             })
             .into();
         } else if name == "enable-file-transfer" {

--- a/src/common.rs
+++ b/src/common.rs
@@ -465,3 +465,14 @@ pub fn is_ip(id: &str) -> bool {
         .unwrap()
         .is_match(id)
 }
+
+#[inline]
+pub fn make_privacy_mode_msg(state: back_notification::PrivacyModeState) -> Message {
+    let mut misc = Misc::new();
+    let mut back_notification = BackNotification::new();
+    back_notification.set_privacy_mode_state(state);
+    misc.set_back_notification(back_notification);
+    let mut msg_out = Message::new();
+    msg_out.set_misc(misc);
+    msg_out
+}

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -19,6 +19,16 @@ use std::collections::HashMap;
 #[cfg(not(windows))]
 use std::{fs::File, io::prelude::*};
 
+// State with timestamp, because std::time::Instant cannot be serialized
+#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
+#[serde(tag = "t", content = "c")]
+pub enum PrivacyModeState {
+    OffSucceeded,
+    OffFailed,
+    OffByPeer,
+    OffUnknown,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "t", content = "c")]
 pub enum FS {
@@ -107,6 +117,7 @@ pub enum Data {
     SyncConfigToUserResp(bool),
     ClipbaordFile(ClipbaordFile),
     ClipboardFileEnabled(bool),
+    PrivacyModeState((i32, PrivacyModeState)),
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -273,7 +273,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Peer denied", "被控端拒绝"),
         ("Please install plugins", "请安装插件"),
         ("Peer exit", "被控端退出"),
-        ("Failed off", "退出失败"),
+        ("Failed to turn off", "退出失败"),
         ("Off Unknown", "退出"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -266,5 +266,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_version_audio_tip", "当前安卓版本不支持音频录制，请升级至安卓10或更高。"),
         ("android_start_service_tip", "点击 [启动服务] 或打开 [屏幕录制] 权限开启手机屏幕共享服务。"),
         ("Account", "账号"),
+        ("Failed", "失败"),
+        ("Succeeded", "成功"),
+        ("Someone turns on privacy mode, exit", "其他用户使用隐私模式，退出"),
+        ("Unsupported", "不支持"),
+        ("Peer denied", "被控端拒绝"),
+        ("Please install plugins", "请安装插件"),
+        ("Peer exit", "被控端退出"),
+        ("Failed off", "退出失败"),
+        ("Off Unknown", "退出"),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -273,7 +273,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Peer denied", "Peer verweigert"),
         ("Please install plugins", "Bitte installieren Sie Plugins"),
         ("Peer exit", "Peer-Ausgang"),
-        ("Failed off", "Ausschalten fehlgeschlagen"),
+        ("Failed to turn off", "Ausschalten fehlgeschlagen"),
         ("Turned off", "Ausgeschaltet"),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -266,5 +266,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_version_audio_tip", "Die aktuelle Android-Version unterstützt keine Audioaufnahme, bitte aktualisieren Sie auf Android 10 oder höher."),
         ("android_start_service_tip", "Tippen Sie auf [Dienst starten] oder ÖFFNEN Sie die Berechtigung [Bildschirmaufnahme], um den Bildschirmfreigabedienst zu starten."),
         ("Account", "Konto"),
+        ("Failed", "Gescheitert"),
+        ("Succeeded", "Erfolgreich"),
+        ("Someone turns on privacy mode, exit", "Jemand aktiviert den Datenschutzmodus, beenden"),
+        ("Unsupported", "Nicht unterstützt"),
+        ("Peer denied", "Peer verweigert"),
+        ("Please install plugins", "Bitte installieren Sie Plugins"),
+        ("Peer exit", "Peer-Ausgang"),
+        ("Failed off", "Ausschalten fehlgeschlagen"),
+        ("Turned off", "Ausgeschaltet"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -266,5 +266,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_version_audio_tip", "La version actuelle d'Android ne prend pas en charge la capture audio, veuillez passer à Android 10 ou supérieur."),
         ("android_start_service_tip", "Appuyez sur [Démarrer le service] ou sur l'autorisation OUVRIR [Capture d'écran] pour démarrer le service de partage d'écran."),
         ("Account", "Compte"),
+        ("Failed", "échouer"),
+        ("Succeeded", "Succès"),
+        ("Someone turns on privacy mode, exit", "Quelqu'un active le mode de confidentialité, quittez"),
+        ("Unsupported", "Non pris en charge"),
+        ("Peer denied", "Pair refusé"),
+        ("Please install plugins", "Veuillez installer les plugins"),
+        ("Peer exit", "Sortie des pairs"),
+        ("Failed off", "Échec de la désactivation"),
+        ("Turned off", "Éteindre"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -273,7 +273,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Peer denied", "Pair refusé"),
         ("Please install plugins", "Veuillez installer les plugins"),
         ("Peer exit", "Sortie des pairs"),
-        ("Failed off", "Échec de la désactivation"),
+        ("Failed to turn off", "Échec de la désactivation"),
         ("Turned off", "Éteindre"),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -273,7 +273,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Peer denied", "Pari negato"),
         ("Please install plugins", "Si prega di installare i plugin"),
         ("Peer exit", "Uscita tra pari"),
-        ("Failed off", "Impossibile spegnere"),
+        ("Failed to turn off", "Impossibile spegnere"),
         ("Turned off", "Spegni"),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -266,5 +266,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_version_audio_tip", "L'attuale versione di Android non supporta l'acquisizione audio, esegui l'upgrade ad Android 10 o versioni successive."),
         ("android_start_service_tip", "Toccare [Avvia servizio] o APRI l'autorizzazione [Cattura schermo] per avviare il servizio di condivisione dello schermo."),
         ("Account", "Account"),
+        ("Failed", "Fallito"),
+        ("Succeeded", "Successo"),
+        ("Someone turns on privacy mode, exit", "Qualcuno attiva la modalità privacy, esci"),
+        ("Unsupported", "Non supportato"),
+        ("Peer denied", "Pari negato"),
+        ("Please install plugins", "Si prega di installare i plugin"),
+        ("Peer exit", "Uscita tra pari"),
+        ("Failed off", "Impossibile spegnere"),
+        ("Turned off", "Spegni"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -273,7 +273,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Peer denied", "Par negado"),
         ("Please install plugins", "Por favor instale plugins"),
         ("Peer exit", "Saída de pares"),
-        ("Failed off", "Falha ao desligar"),
+        ("Failed to turn off", "Falha ao desligar"),
         ("Turned off", "Desligado"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -266,5 +266,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_version_audio_tip", "A versão atual do Android não suporta captura de áudio, por favor atualize para o Android 10 ou maior."),
         ("android_start_service_tip", "Toque [Iniciar Serviço] ou ABRA a permissão [Captura de Tela] para iniciar o serviço de compartilhamento de tela."),
         ("Account", "Conta"),
+        ("Failed", "Falhou"),
+        ("Succeeded", "Conseguiu"),
+        ("Someone turns on privacy mode, exit", "Alguém liga o modo de privacidade, saia"),
+        ("Unsupported", "Sem suporte"),
+        ("Peer denied", "Par negado"),
+        ("Please install plugins", "Por favor instale plugins"),
+        ("Peer exit", "Saída de pares"),
+        ("Failed off", "Falha ao desligar"),
+        ("Turned off", "Desligado"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -273,7 +273,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Peer denied", "Отказано в пире"),
         ("Please install plugins", "Пожалуйста, установите плагины"),
         ("Peer exit", "Одноранговый выход"),
-        ("Failed off", "Не удалось отключить"),
+        ("Failed to turn off", "Не удалось отключить"),
         ("Turned off", "Выключен"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -266,5 +266,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_version_audio_tip", "Текущая версия Android не поддерживает захват звука, обновите ее до Android 10 или выше."),
         ("android_start_service_tip", "Коснитесь [Запуск промежуточного сервера] или ОТКРЫТЬ разрешение [Скриншот], чтобы запустить службу демонстрации экрана."),
         ("Account", "Аккаунт"),
+        ("Failed", "Неуспешный"),
+        ("Succeeded", "Успешно"),
+        ("Someone turns on privacy mode, exit", "Кто-то включает режим конфиденциальности, выйдите"),
+        ("Unsupported", "Не поддерживается"),
+        ("Peer denied", "Отказано в пире"),
+        ("Please install plugins", "Пожалуйста, установите плагины"),
+        ("Peer exit", "Одноранговый выход"),
+        ("Failed off", "Не удалось отключить"),
+        ("Turned off", "Выключен"),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -273,7 +273,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Peer denied", ""),
         ("Please install plugins", ""),
         ("Peer exit", ""),
-        ("Failed off", ""),
+        ("Failed to turn off", ""),
         ("Turned off", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -266,5 +266,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_version_audio_tip", ""),
         ("android_start_service_tip", ""),
         ("Account", ""),
+        ("Failed", ""),
+        ("Succeeded", ""),
+        ("Someone turns on privacy mode, exit", ""),
+        ("Unsupported", ""),
+        ("Peer denied", ""),
+        ("Please install plugins", ""),
+        ("Peer exit", ""),
+        ("Failed off", ""),
+        ("Turned off", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -273,7 +273,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Peer denied", "被控端拒絕"),
         ("Please install plugins", "請安裝插件"),
         ("Peer exit", "被控端退出"),
-        ("Failed off", "退出失敗"),
+        ("Failed to turn off", "退出失敗"),
         ("Turned off", "退出"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -266,5 +266,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_version_audio_tip", "當前安卓版本不支持音頻錄製，請升級至安卓10或更高。"),
         ("android_start_service_tip", "點擊 [啟動服務] 或打開 [屏幕錄製] 權限開啟手機屏幕共享服務。"),
         ("Account", "帳戶"),
+        ("Failed", "失敗"),
+        ("Succeeded", "成功"),
+        ("Someone turns on privacy mode, exit", "其他用戶開啟隱私模式，退出"),
+        ("Unsupported", "不支持"),
+        ("Peer denied", "被控端拒絕"),
+        ("Please install plugins", "請安裝插件"),
+        ("Peer exit", "被控端退出"),
+        ("Failed off", "退出失敗"),
+        ("Turned off", "退出"),
     ].iter().cloned().collect();
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -5,10 +5,10 @@ use hbb_common::{
     config::{Config, APP_NAME},
     log, sleep, timeout, tokio,
 };
-use std::io::prelude::*;
 use std::{
     ffi::OsString,
-    io, mem,
+    io::{self, prelude::*},
+    mem,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -397,6 +397,7 @@ const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
 extern "C" {
     fn LaunchProcessWin(cmd: *const u16, session_id: DWORD, as_user: BOOL) -> HANDLE;
+    fn GetSessionUserTokenWin(lphUserToken: LPHANDLE, dwSessionId: DWORD, as_user: BOOL) -> BOOL;
     fn selectInputDesktop() -> BOOL;
     fn inputDesktopSelected() -> BOOL;
     fn handleMask(
@@ -1023,6 +1024,23 @@ pub fn toggle_blank_screen(v: bool) {
 pub fn block_input(v: bool) -> bool {
     let v = if v { TRUE } else { FALSE };
     unsafe { BlockInput(v) == TRUE }
+}
+
+pub fn get_user_token(session_id: u32, as_user: bool) -> HANDLE {
+    let mut token = NULL as HANDLE;
+    unsafe {
+        if FALSE
+            == GetSessionUserTokenWin(
+                &mut token as _,
+                session_id,
+                if as_user { TRUE } else { FALSE },
+            )
+        {
+            NULL as _
+        } else {
+            token
+        }
+    }
 }
 
 pub fn add_recent_document(path: &str) {

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -63,6 +63,10 @@ impl RendezvousMediator {
                 allow_err!(lan_discovery());
             });
         }
+        #[cfg(windows)]
+        std::thread::spawn(move || {
+            allow_err!(crate::ui::platform::win_privacy::start());
+        });
         loop {
             Config::reset_online();
             if Config::get_option("stop-service").is_empty() {

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -63,10 +63,6 @@ impl RendezvousMediator {
                 allow_err!(lan_discovery());
             });
         }
-        #[cfg(windows)]
-        std::thread::spawn(move || {
-            allow_err!(crate::ui::platform::win_privacy::start());
-        });
         loop {
             Config::reset_online();
             if Config::get_option("stop-service").is_empty() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -82,6 +82,15 @@ async fn accept_connection_(server: ServerPtr, socket: Stream, secure: bool) -> 
     Ok(())
 }
 
+async fn check_privacy_mode_on(stream: &mut Stream) -> ResultType<()> {
+    if video_service::get_privacy_mode_conn_id() > 0 {
+        let msg_out =
+            crate::common::make_privacy_mode_msg(back_notification::PrivacyModeState::OnByOther);
+        timeout(CONNECT_TIMEOUT, stream.send(&msg_out)).await??;
+    }
+    Ok(())
+}
+
 pub async fn create_tcp_connection(
     server: ServerPtr,
     stream: Stream,
@@ -89,6 +98,8 @@ pub async fn create_tcp_connection(
     secure: bool,
 ) -> ResultType<()> {
     let mut stream = stream;
+    check_privacy_mode_on(&mut stream).await?;
+
     let id = {
         let mut w = server.write().unwrap();
         w.id_count += 1;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -7,6 +7,7 @@ use hbb_common::{
     fs,
     futures::{SinkExt, StreamExt},
     message_proto::{option_message::BoolOption, permission_info::Permission},
+    protobuf::MessageField,
     sleep, timeout,
     tokio::{
         net::TcpStream,
@@ -569,6 +570,10 @@ impl Connection {
             platform: whoami::platform().to_string(),
             version: crate::VERSION.to_owned(),
             sas_enabled,
+            features: MessageField::some(Features {
+                privacy_mode: video_service::is_privacy_mode_supported(),
+                ..Default::default()
+            }),
             ..Default::default()
         };
         let mut sub_service = false;

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -143,6 +143,16 @@ impl<T: Subscriber + From<ConnInner>> ServiceTmpl<T> {
         }
     }
 
+    pub fn send_to_others(&self, msg: Message, id: i32) {
+        let msg = Arc::new(msg);
+        let mut lock = self.0.write().unwrap();
+        for (sid, s) in lock.subscribes.iter_mut() {
+            if *sid != id {
+                s.send(msg.clone());
+            }
+        }
+    }
+
     pub fn send_shared(&self, msg: Arc<Message>) {
         let mut lock = self.0.write().unwrap();
         for s in lock.subscribes.values_mut() {

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -49,59 +49,13 @@ lazy_static::lazy_static! {
     };
     static ref PRIVACY_MODE_CONN_ID: Mutex<i32> = Mutex::new(0);
     static ref IS_CAPTURER_MAGNIFIER_SUPPORTED: bool = is_capturer_mag_supported();
-    static ref MAG_INITIALIZER: Mutex<MagInitializer> = Mutex::new(MagInitializer::new());
-}
-
-struct MagInitializer {
-    is_succeeded: bool,
-}
-
-impl MagInitializer {
-    fn new() -> Self {
-        let mut m = MagInitializer {
-            is_succeeded: false,
-        };
-        #[cfg(windows)]
-        {
-            m.is_succeeded = if let Err(e) = scrap::CapturerMag::init() {
-                log::error!("Failed to initialize magnifier capturer, {}", e);
-                false
-            } else {
-                true
-            };
-        }
-        m
-    }
-
-    fn uninit(&mut self) -> ResultType<()> {
-        if self.is_succeeded {
-            #[cfg(windows)]
-            {
-                scrap::CapturerMag::uninit()?;
-            }
-        }
-        self.is_succeeded = false;
-        Ok(())
-    }
-}
-
-impl Drop for MagInitializer {
-    fn drop(&mut self) {
-        if let Err(e) = self.uninit() {
-            log::error!("Failed to uninitialize magnifier capturer, {}", e);
-        }
-    }
 }
 
 fn is_capturer_mag_supported() -> bool {
-    if !MAG_INITIALIZER.lock().unwrap().is_succeeded {
-        return false;
-    }
-
     #[cfg(windows)]
     return scrap::CapturerMag::is_supported();
     #[cfg(not(windows))]
-    return false;
+    false
 }
 
 pub fn notify_video_frame_feched(conn_id: i32, frame_tm: Option<Instant>) {

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -245,7 +245,7 @@ fn create_capturer(privacy_mode_id: i32, display: Display) -> ResultType<Box<dyn
                     let mut ok = false;
                     let check_begin = Instant::now();
                     while check_begin.elapsed().as_secs() < 5 {
-                        match c1.exclude("", PRIVACY_WINDOW_TITLE) {
+                        match c1.exclude("", PRIVACY_WINDOW_NAME) {
                             Ok(false) => {
                                 ok = false;
                                 std::thread::sleep(std::time::Duration::from_millis(500));
@@ -254,7 +254,7 @@ fn create_capturer(privacy_mode_id: i32, display: Display) -> ResultType<Box<dyn
                                 bail!(
                                     "Failed to exclude privacy window {} - {}, err: {}",
                                     "",
-                                    PRIVACY_WINDOW_TITLE,
+                                    PRIVACY_WINDOW_NAME,
                                     e
                                 );
                             }
@@ -268,7 +268,7 @@ fn create_capturer(privacy_mode_id: i32, display: Display) -> ResultType<Box<dyn
                         bail!(
                             "Failed to exclude privacy window {} - {} ",
                             "",
-                            PRIVACY_WINDOW_TITLE
+                            PRIVACY_WINDOW_NAME
                         );
                     }
                     c = Some(Box::new(c1));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,9 +3,9 @@ mod cm;
 mod inline;
 #[cfg(target_os = "macos")]
 mod macos;
+pub mod platform;
 mod remote;
-use crate::common::SOFTWARE_UPDATE_URL;
-use crate::ipc;
+use crate::{common::SOFTWARE_UPDATE_URL, ipc};
 use hbb_common::{
     allow_err,
     config::{self, Config, Fav, PeerConfig, APP_NAME, ICON},

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -370,6 +370,12 @@ async fn start_ipc(cm: ConnectionManager) {
     #[cfg(windows)]
     std::thread::spawn(move || start_clipboard_file(cm_clip, _rx_file));
 
+    #[cfg(windows)]
+    std::thread::spawn(move || {
+        log::info!("try create privacy mode window");
+        allow_err!(crate::ui::platform::win_privacy::start());
+    });
+
     match new_listener("_cm").await {
         Ok(mut incoming) => {
             while let Some(result) = incoming.next().await {

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -94,6 +94,7 @@ class Header: Reactor.Component {
         updateWindowToolbarPosition();
         var style = "flow:horizontal;";
         if (is_osx) style += "margin:*";
+        self.timer(1ms, updatePrivacyMode);
         self.timer(1ms, toggleMenuState);
         return <div style={style}>
             {is_osx || is_xfce ? "" : <span #fullscreen>{svg_fullscreen}</span>}
@@ -130,7 +131,7 @@ class Header: Reactor.Component {
                 {is_win && pi.platform == 'Windows' && file_enabled ? <li #enable-file-transfer .toggle-option><span>{svg_checkmark}</span>{translate('File transfer')}</li> : ""}
                 {keyboard_enabled && clipboard_enabled ? <li #disable-clipboard .toggle-option><span>{svg_checkmark}</span>{translate('Disable clipboard')}</li> : ""} 
                 {keyboard_enabled ? <li #lock-after-session-end .toggle-option><span>{svg_checkmark}</span>{translate('Lock after session end')}</li> : ""} 
-                {false && keyboard_enabled && pi.platform == "Windows" ? <li #privacy-mode .toggle-option><span>{svg_checkmark}</span>{translate('Privacy mode')}</li> : ""}
+                {keyboard_enabled && pi.platform == "Windows" ? <li #privacy-mode><span>{svg_checkmark}</span>{translate('Privacy mode')}</li> : ""}
             </menu>
         </popup>;
     }
@@ -257,6 +258,8 @@ class Header: Reactor.Component {
     event click $(menu#display-options>li) (_, me) {
         if (me.id == "custom") {
             handle_custom_image_quality();
+        } else if (me.id == "privacy-mode") {
+            handler.toggle_option(me.id);
         } else if (me.attributes.hasClass("toggle-option")) {
             handler.toggle_option(me.id);
             toggleMenuState();
@@ -299,17 +302,11 @@ function toggleMenuState() {
     for (var el in $$(menu#display-options>li)) {
         el.attributes.toggleClass("selected", values.indexOf(el.id) >= 0);
     }
-    for (var id in ["show-remote-cursor", "disable-audio", "enable-file-transfer", "disable-clipboard", "lock-after-session-end", "privacy-mode"]) {
+    for (var id in ["show-remote-cursor", "disable-audio", "enable-file-transfer", "disable-clipboard", "lock-after-session-end"]) {
         var el = self.select('#' + id);
         if (el) {
             var value = handler.get_toggle_option(id);
             el.attributes.toggleClass("selected", value);
-            if (id == "privacy-mode") {
-                var el = $(li#block-input);
-                if (el) {
-                    el.state.disabled = value;
-                }
-            }
         }
     }
 }
@@ -342,6 +339,31 @@ handler.updatePi = function(v) {
     header.update();
     if (is_port_forward) {
         view.windowState = View.WINDOW_MINIMIZED;
+    }
+}
+
+function updatePrivacyMode() {
+    var el = $(li#privacy-mode);
+    if (el) {
+        var value = handler.get_toggle_option("privacy-mode");
+        el.attributes.toggleClass("selected", value);
+        var el = $(li#block-input);
+        if (el) {
+            el.state.disabled = value;
+        }
+    }
+}
+handler.updatePrivacyMode = updatePrivacyMode;
+
+handler.updateBlockInputState = function(input_blocked) {
+    if (!input_blocked) {
+        handler.toggle_option("block-input");
+        input_blocked = true;
+        $(#block-input).text = translate("Unblock user input");
+    } else {
+        handler.toggle_option("unblock-input");
+        input_blocked = false;
+        $(#block-input).text = translate("Block user input");
     }
 }
 

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -259,7 +259,7 @@ class Header: Reactor.Component {
         if (me.id == "custom") {
             handle_custom_image_quality();
         } else if (me.id == "privacy-mode") {
-            handler.toggle_option(me.id);
+            togglePrivacyMode(me.id);
         } else if (me.attributes.hasClass("toggle-option")) {
             handler.toggle_option(me.id);
             toggleMenuState();
@@ -345,15 +345,30 @@ handler.updatePi = function(v) {
 function updatePrivacyMode() {
     var el = $(li#privacy-mode);
     if (el) {
-        var value = handler.get_toggle_option("privacy-mode");
-        el.attributes.toggleClass("selected", value);
-        var el = $(li#block-input);
-        if (el) {
-            el.state.disabled = value;
+        var supported = handler.is_privacy_mode_supported();
+        if (!supported) {
+            // el.attributes.toggleClass("line-through", true);
+            el.style["display"]="none";
+        } else {
+            var value = handler.get_toggle_option("privacy-mode");
+            el.attributes.toggleClass("selected", value);
+            var el = $(li#block-input);
+            if (el) {
+                el.state.disabled = value;
+            }
         }
     }
 }
 handler.updatePrivacyMode = updatePrivacyMode;
+
+function togglePrivacyMode(privacy_id) {
+    var supported = handler.is_privacy_mode_supported();
+    if (!supported) {
+        msgbox("nocancel", translate("Privacy mode"), translate("Unsupported"), function() { });
+    } else {
+        handler.toggle_option(privacy_id);
+    }
+}
 
 handler.updateBlockInputState = function(input_blocked) {
     if (!input_blocked) {

--- a/src/ui/platform.rs
+++ b/src/ui/platform.rs
@@ -1,0 +1,2 @@
+#[cfg(windows)]
+pub mod win_privacy;

--- a/src/ui/platform/win_privacy.rs
+++ b/src/ui/platform/win_privacy.rs
@@ -1,0 +1,532 @@
+use crate::ipc::{connect, Data, PrivacyModeState};
+use hbb_common::{allow_err, bail, lazy_static, log, tokio, ResultType};
+use std::{
+    ffi::CString,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+use winapi::{
+    ctypes::c_int,
+    shared::{
+        minwindef::{DWORD, FALSE, HMODULE, LOBYTE, LPARAM, LRESULT, UINT, WPARAM},
+        ntdef::{HANDLE, NULL},
+        windef::{HHOOK, HWND, POINT},
+    },
+    um::{
+        errhandlingapi::GetLastError,
+        handleapi::CloseHandle,
+        libloaderapi::{GetModuleHandleA, GetModuleHandleExA, GetProcAddress},
+        memoryapi::{VirtualAllocEx, WriteProcessMemory},
+        processthreadsapi::{
+            CreateProcessW, GetCurrentThreadId, QueueUserAPC, ResumeThread, PROCESS_INFORMATION,
+            STARTUPINFOW,
+        },
+        winbase::CREATE_SUSPENDED,
+        winnt::{MEM_COMMIT, PAGE_READWRITE},
+        winuser::*,
+    },
+};
+
+pub const PRIVACY_WINDOW_CLASS_NAME: &'static str = "RustDeskPrivacyWindowClass";
+pub const PRIVACY_WINDOW_NAME: &'static str = "RustDeskPrivacyWindow";
+pub const PRIVACY_WINDOW_TITLE: &'static str = "RustDeskPrivacyWindow";
+
+pub const MW_FILTERMODE_EXCLUDE: u32 = 0;
+pub const MW_FILTERMODE_INCLUDE: u32 = 1;
+pub const GET_MODULE_HANDLE_EX_FLAG_PIN: u32 = 1;
+pub const GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT: u32 = 2;
+pub const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: u32 = 4;
+pub const LOAD_LIBRARY_AS_DATAFILE: u32 = 2;
+pub const LOAD_WITH_ALTERED_SEARCH_PATH: u32 = 8;
+pub const LOAD_IGNORE_CODE_AUTHZ_LEVEL: u32 = 16;
+pub const LOAD_LIBRARY_AS_IMAGE_RESOURCE: u32 = 32;
+pub const LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE: u32 = 64;
+pub const LOAD_LIBRARY_REQUIRE_SIGNED_TARGET: u32 = 128;
+pub const LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR: u32 = 256;
+pub const LOAD_LIBRARY_SEARCH_APPLICATION_DIR: u32 = 512;
+pub const LOAD_LIBRARY_SEARCH_USER_DIRS: u32 = 1024;
+pub const LOAD_LIBRARY_SEARCH_SYSTEM32: u32 = 2048;
+pub const LOAD_LIBRARY_SEARCH_DEFAULT_DIRS: u32 = 4096;
+pub const LOAD_LIBRARY_SAFE_CURRENT_DIRS: u32 = 8192;
+pub const LOAD_LIBRARY_SEARCH_SYSTEM32_NO_FORWARDER: u32 = 16384;
+pub const LOAD_LIBRARY_OS_INTEGRITY_CONTINUITY: u32 = 32768;
+
+const WM_USER_EXIT_HOOK: u32 = WM_USER + 1;
+
+lazy_static::lazy_static! {
+    static ref NEED_NOTIFY: Mutex<bool> = Mutex::new(false);
+    static ref CONN_ID: Mutex<i32> = Mutex::new(0);
+    static ref PRIVACY_MODE_ID: Mutex<DWORD> = Mutex::new(0);
+}
+
+pub fn turn_on_privacy(conn_id: i32) -> ResultType<bool> {
+    let exe_file = std::env::current_exe()?;
+    if let Some(cur_dir) = exe_file.parent() {
+        if !cur_dir.join("WindowInjection.dll").exists() {
+            return Ok(false)
+        }
+    } else {
+        bail!("Invalid exe parent for {}", exe_file.to_string_lossy().as_ref());
+    }
+
+    let pre_conn_id = *CONN_ID.lock().unwrap();
+    if pre_conn_id == conn_id {
+        return Ok(true);
+    }
+    if pre_conn_id != 0 {
+        bail!("Privacy occupied by another one");
+    }
+
+    let hwnd = wait_find_privacy_hwnd(0)?;
+    if hwnd.is_null() {
+        bail!("No privacy window created");
+    }
+    privacy_hook::hook()?;
+    unsafe {
+        ShowWindow(hwnd as _, SW_SHOW);
+    }
+    *CONN_ID.lock().unwrap() = conn_id;
+    Ok(true)
+}
+
+pub fn turn_off_privacy(conn_id: i32, state: Option<PrivacyModeState>) -> ResultType<()> {
+    let pre_conn_id = *CONN_ID.lock().unwrap();
+    if pre_conn_id != 0 && conn_id != 0 && pre_conn_id != conn_id {
+        bail!("Failed to turn off privacy mode that belongs to someone else")
+    }
+
+    privacy_hook::unhook()?;
+
+    unsafe {
+        let hwnd = wait_find_privacy_hwnd(0)?;
+        if !hwnd.is_null() {
+            ShowWindow(hwnd, SW_HIDE);
+        }
+    }
+
+    if pre_conn_id != 0 {
+        if let Some(state) = state {
+            allow_err!(set_privacy_mode_state(pre_conn_id, state, 1_000));
+        }
+        *CONN_ID.lock().unwrap() = 0;
+    }
+
+    Ok(())
+}
+
+pub fn start() -> ResultType<()> {
+    let exe_file = std::env::current_exe()?;
+    if exe_file.parent().is_none() {
+        bail!("Cannot get parent of current exe file");
+    }
+    let cur_dir = exe_file.parent().unwrap();
+
+    let dll_file = cur_dir.join("WindowInjection.dll");
+    if !dll_file.exists() {
+        bail!(
+            "Failed to find required file {}",
+            dll_file.to_string_lossy().as_ref()
+        );
+    }
+
+    let hwnd = wait_find_privacy_hwnd(1_000)?;
+    if !hwnd.is_null() {
+        log::info!("Privacy window is already created");
+        return Ok(());
+    }
+
+    // let cmdline = cur_dir.join("MiniBroker.exe").to_string_lossy().to_string();
+    let cmdline = cur_dir
+        .join("C:/Windows/System32/RuntimeBroker.exe")
+        .to_string_lossy()
+        .to_string();
+
+    unsafe {
+        let mut cmd_utf16: Vec<u16> = cmdline.encode_utf16().collect();
+        cmd_utf16.push(0);
+
+        let mut start_info = STARTUPINFOW {
+            cb: 0,
+            lpReserved: NULL as _,
+            lpDesktop: NULL as _,
+            lpTitle: NULL as _,
+            dwX: 0,
+            dwY: 0,
+            dwXSize: 0,
+            dwYSize: 0,
+            dwXCountChars: 0,
+            dwYCountChars: 0,
+            dwFillAttribute: 0,
+            dwFlags: 0,
+            wShowWindow: 0,
+            cbReserved2: 0,
+            lpReserved2: NULL as _,
+            hStdInput: NULL as _,
+            hStdOutput: NULL as _,
+            hStdError: NULL as _,
+        };
+        let mut proc_info = PROCESS_INFORMATION {
+            hProcess: NULL as _,
+            hThread: NULL as _,
+            dwProcessId: 0,
+            dwThreadId: 0,
+        };
+
+        if 0 == CreateProcessW(
+            NULL as _,
+            cmd_utf16.as_ptr() as _,
+            NULL as _,
+            NULL as _,
+            FALSE,
+            CREATE_SUSPENDED,
+            NULL,
+            NULL as _,
+            &mut start_info,
+            &mut proc_info,
+        ) {
+            bail!(
+                "Failed to create privacy window process {}, code {}",
+                cmdline,
+                GetLastError()
+            );
+        };
+
+        inject_dll(
+            proc_info.hProcess,
+            proc_info.hThread,
+            dll_file.to_string_lossy().as_ref(),
+        )?;
+        if 0xffffffff == ResumeThread(proc_info.hThread) {
+            // CloseHandle
+            CloseHandle(proc_info.hThread);
+            CloseHandle(proc_info.hProcess);
+
+            bail!(
+                "Failed to create privacy window process, {}",
+                GetLastError()
+            );
+        }
+
+        let hwnd = wait_find_privacy_hwnd(1_000)?;
+        if hwnd.is_null() {
+            bail!("Failed to get hwnd after started");
+        }
+    }
+
+    Ok(())
+}
+
+unsafe fn inject_dll<'a>(hproc: HANDLE, hthread: HANDLE, dll_file: &'a str) -> ResultType<()> {
+    let mut dll_file_utf16: Vec<u16> = dll_file.encode_utf16().collect();
+    dll_file_utf16.push(0);
+
+    let buf = VirtualAllocEx(
+        hproc,
+        NULL as _,
+        dll_file_utf16.len() * 2,
+        MEM_COMMIT,
+        PAGE_READWRITE,
+    );
+    if buf.is_null() {
+        bail!("Failed VirtualAllocEx");
+    }
+
+    let mut written: usize = 0;
+    if 0 == WriteProcessMemory(
+        hproc,
+        buf,
+        dll_file_utf16.as_ptr() as _,
+        dll_file_utf16.len() * 2,
+        &mut written,
+    ) {
+        bail!("Failed WriteProcessMemory");
+    }
+
+    let kernel32_modulename = CString::new("kernel32")?;
+    let hmodule = GetModuleHandleA(kernel32_modulename.as_ptr() as _);
+    if hmodule.is_null() {
+        bail!("Failed GetModuleHandleA");
+    }
+
+    let load_librarya_name = CString::new("LoadLibraryW")?;
+    let load_librarya = GetProcAddress(hmodule, load_librarya_name.as_ptr() as _);
+    if load_librarya.is_null() {
+        bail!("Failed GetProcAddress of LoadLibraryW");
+    }
+
+    if 0 == QueueUserAPC(Some(std::mem::transmute(load_librarya)), hthread, buf as _) {
+        bail!("Failed QueueUserAPC");
+    }
+
+    Ok(())
+}
+
+fn wait_find_privacy_hwnd(msecs: u128) -> ResultType<HWND> {
+    let tm_begin = Instant::now();
+    let wndname = CString::new(PRIVACY_WINDOW_NAME)?;
+    loop {
+        unsafe {
+            let hwnd = FindWindowA(NULL as _, wndname.as_ptr() as _);
+            if !hwnd.is_null() {
+                return Ok(hwnd);
+            }
+        }
+
+        if msecs == 0 || tm_begin.elapsed().as_millis() > msecs {
+            return Ok(NULL as _);
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn set_privacy_mode_state(
+    conn_id: i32,
+    state: PrivacyModeState,
+    ms_timeout: u64,
+) -> ResultType<()> {
+    println!("set_privacy_mode_state begin");
+    let mut c = connect(ms_timeout, "_cm").await?;
+    println!("set_privacy_mode_state connect done");
+    c.send(&Data::PrivacyModeState((conn_id, state))).await
+}
+
+pub(super) mod privacy_hook {
+    use super::*;
+    use std::sync::mpsc::{channel, Sender};
+
+    fn do_hook(tx: Sender<String>) -> ResultType<(HHOOK, HHOOK)> {
+        let invalid_ret = (0 as HHOOK, 0 as HHOOK);
+
+        let mut privacy_mode_id = PRIVACY_MODE_ID.lock().unwrap();
+        if *privacy_mode_id != 0 {
+            // unreachable!
+            tx.send("Already hooked".to_owned())?;
+            return Ok(invalid_ret);
+        }
+
+        unsafe {
+            let mut hm_keyboard = 0 as HMODULE;
+            if 0 == GetModuleHandleExA(
+                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                    | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                DefWindowProcA as _,
+                &mut hm_keyboard as _,
+            ) {
+                tx.send(format!(
+                    "Failed to GetModuleHandleExA, error: {}",
+                    GetLastError()
+                ))?;
+                return Ok(invalid_ret);
+            }
+            let mut hm_mouse = 0 as HMODULE;
+            if 0 == GetModuleHandleExA(
+                GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                    | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                DefWindowProcA as _,
+                &mut hm_mouse as _,
+            ) {
+                tx.send(format!(
+                    "Failed to GetModuleHandleExA, error: {}",
+                    GetLastError()
+                ))?;
+                return Ok(invalid_ret);
+            }
+
+            let hook_keyboard = SetWindowsHookExA(
+                WH_KEYBOARD_LL,
+                Some(privacy_mode_hook_keyboard),
+                hm_keyboard,
+                0,
+            );
+            if hook_keyboard.is_null() {
+                tx.send(format!(" SetWindowsHookExA keyboard {}", GetLastError()))?;
+                return Ok(invalid_ret);
+            }
+
+            let hook_mouse =
+                SetWindowsHookExA(WH_MOUSE_LL, Some(privacy_mode_hook_mouse), hm_mouse, 0);
+            if hook_mouse.is_null() {
+                if FALSE == UnhookWindowsHookEx(hook_keyboard) {
+                    // Fatal error
+                    log::error!(" UnhookWindowsHookEx keyboard {}", GetLastError());
+                }
+                tx.send(format!(" SetWindowsHookExA mouse {}", GetLastError()))?;
+                return Ok(invalid_ret);
+            }
+
+            *privacy_mode_id = GetCurrentThreadId();
+            tx.send("".to_owned())?;
+            return Ok((hook_keyboard, hook_mouse));
+        }
+    }
+
+    pub fn hook() -> ResultType<()> {
+        let (tx, rx) = channel();
+        std::thread::spawn(move || {
+            let hook_keyboard;
+            let hook_mouse;
+            unsafe {
+                match do_hook(tx.clone()) {
+                    Ok(hooks) => {
+                        hook_keyboard = hooks.0;
+                        hook_mouse = hooks.1;
+                    }
+                    Err(e) => {
+                        // Fatal error
+                        tx.send(format!("Unexpected err when hook {}", e)).unwrap();
+                        return;
+                    }
+                }
+                if hook_keyboard.is_null() {
+                    return;
+                }
+
+                let mut msg = MSG {
+                    hwnd: NULL as _,
+                    message: 0 as _,
+                    wParam: 0 as _,
+                    lParam: 0 as _,
+                    time: 0 as _,
+                    pt: POINT {
+                        x: 0 as _,
+                        y: 0 as _,
+                    },
+                };
+                while FALSE != GetMessageA(&mut msg, NULL as _, 0, 0) {
+                    if msg.message == WM_USER_EXIT_HOOK {
+                        break;
+                    }
+
+                    TranslateMessage(&msg);
+                    DispatchMessageA(&msg);
+                }
+
+                if FALSE == UnhookWindowsHookEx(hook_keyboard as _) {
+                    // Fatal error
+                    log::error!("Failed UnhookWindowsHookEx keyboard {}", GetLastError());
+                }
+
+                if FALSE == UnhookWindowsHookEx(hook_mouse as _) {
+                    // Fatal error
+                    log::error!("Failed UnhookWindowsHookEx mouse {}", GetLastError());
+                }
+
+                *PRIVACY_MODE_ID.lock().unwrap() = 0;
+            }
+        });
+
+        match rx.recv() {
+            Ok(msg) => {
+                if msg == "" {
+                    Ok(())
+                } else {
+                    bail!(msg)
+                }
+            }
+            Err(e) => {
+                bail!("Failed to wait hook result {}", e)
+            }
+        }
+    }
+
+    pub fn unhook() -> ResultType<()> {
+        unsafe {
+            let privacy_mode_id = PRIVACY_MODE_ID.lock().unwrap();
+            if *privacy_mode_id != 0 {
+                if FALSE == PostThreadMessageA(*privacy_mode_id, WM_USER_EXIT_HOOK, 0, 0) {
+                    bail!("Failed to post message to exit hook, {}", GetLastError());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[no_mangle]
+    pub extern "system" fn privacy_mode_hook_keyboard(
+        code: c_int,
+        w_param: WPARAM,
+        l_param: LPARAM,
+    ) -> LRESULT {
+        if code < 0 {
+            unsafe {
+                return CallNextHookEx(NULL as _, code, w_param, l_param);
+            }
+        }
+
+        let ks = l_param as PKBDLLHOOKSTRUCT;
+        let w_param2 = w_param as UINT;
+
+        unsafe {
+            if (*ks).dwExtraInfo != enigo::ENIGO_INPUT_EXTRA_VALUE {
+                // Disable alt key. Alt + Tab will switch windows.
+                if (*ks).flags & LLKHF_ALTDOWN == LLKHF_ALTDOWN {
+                    return 1;
+                }
+
+                match w_param2 {
+                    WM_KEYDOWN => {
+                        // Disable all keys other than P and Ctrl.
+                        if ![80, 162, 163].contains(&(*ks).vkCode) {
+                            return 1;
+                        }
+
+                        // NOTE: GetKeyboardState may not work well...
+
+                        // Check if Ctrl + P is pressed
+                        let cltr_down = (GetKeyState(VK_CONTROL) as u16) & (0x8000 as u16) > 0;
+                        let key = LOBYTE((*ks).vkCode as _);
+                        if cltr_down && (key == 'p' as u8 || key == 'P' as u8) {
+                            // Ctrl + P is pressed, turn off privacy mode
+                            if let Err(e) =
+                                turn_off_privacy(0, Some(crate::ipc::PrivacyModeState::OffByPeer))
+                            {
+                                log::error!("Failed to off_privacy {}", e);
+                            }
+                        }
+                    }
+                    WM_KEYUP => {
+                        log::trace!("WM_KEYUP {}", (*ks).vkCode);
+                    }
+                    _ => {
+                        log::trace!("KEYBOARD OTHER {} {}", w_param2, (*ks).vkCode);
+                    }
+                }
+            }
+        }
+        unsafe { CallNextHookEx(NULL as _, code, w_param, l_param) }
+    }
+
+    #[no_mangle]
+    pub extern "system" fn privacy_mode_hook_mouse(
+        code: c_int,
+        w_param: WPARAM,
+        l_param: LPARAM,
+    ) -> LRESULT {
+        if code < 0 {
+            unsafe {
+                return CallNextHookEx(NULL as _, code, w_param, l_param);
+            }
+        }
+
+        let ms = l_param as PMOUSEHOOKSTRUCT;
+        unsafe {
+            if (*ms).dwExtraInfo != enigo::ENIGO_INPUT_EXTRA_VALUE {
+                return 1;
+            }
+        }
+        unsafe { CallNextHookEx(NULL as _, code, w_param, l_param) }
+    }
+}
+
+mod test {
+    #[test]
+    fn privacy_hook() {
+        //use super::*;
+
+        // privacy_hook::hook().unwrap();
+        // std::thread::sleep(std::time::Duration::from_millis(50));
+        // privacy_hook::unhook().unwrap();
+    }
+}

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -2009,7 +2009,7 @@ impl Remote {
             }
             back_notification::PrivacyModeState::OffFailed => {
                 self.handler
-                    .msgbox("custom-error", "Privacy mode", "Failed off");
+                    .msgbox("custom-error", "Privacy mode", "Failed to turn off");
             }
             back_notification::PrivacyModeState::OffUnknown => {
                 self.handler

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -208,6 +208,7 @@ impl sciter::EventHandler for Handler {
         fn save_custom_image_quality(i32, i32);
         fn refresh_video();
         fn get_toggle_option(String);
+        fn is_privacy_mode_supported();
         fn toggle_option(String);
         fn get_remember();
     }
@@ -499,6 +500,10 @@ impl Handler {
 
     fn get_toggle_option(&mut self, name: String) -> bool {
         self.lc.read().unwrap().get_toggle_option(&name)
+    }
+
+    fn is_privacy_mode_supported(&self) -> bool {
+        self.lc.read().unwrap().is_privacy_mode_supported()
     }
 
     fn refresh_video(&mut self) {
@@ -1964,8 +1969,11 @@ impl Remote {
     ) -> bool {
         match state {
             back_notification::PrivacyModeState::OnByOther => {
-                self.handler
-                    .msgbox("error", "Connecting...", "Someone turns on privacy mode, exit");
+                self.handler.msgbox(
+                    "error",
+                    "Connecting...",
+                    "Someone turns on privacy mode, exit",
+                );
                 return false;
             }
             back_notification::PrivacyModeState::NotSupported => {
@@ -1987,7 +1995,8 @@ impl Remote {
                 self.update_privacy_mode(false);
             }
             back_notification::PrivacyModeState::OnFailed => {
-                self.handler.msgbox("custom-error", "Privacy mode", "Failed");
+                self.handler
+                    .msgbox("custom-error", "Privacy mode", "Failed");
                 self.update_privacy_mode(false);
             }
             back_notification::PrivacyModeState::OffSucceeded => {
@@ -2003,7 +2012,8 @@ impl Remote {
                     .msgbox("custom-error", "Privacy mode", "Failed off");
             }
             back_notification::PrivacyModeState::OffUnknown => {
-                self.handler.msgbox("custom-error", "Privacy mode", "Turned off");
+                self.handler
+                    .msgbox("custom-error", "Privacy mode", "Turned off");
                 // log::error!("Privacy mode is turned off with unknown reason");
                 self.update_privacy_mode(false);
             }
@@ -2094,6 +2104,7 @@ impl Interface for Handler {
         } else if !self.is_port_forward() {
             if pi.displays.is_empty() {
                 self.lc.write().unwrap().handle_peer_info(username, pi);
+                self.call("updatePrivacyMode", &[]);
                 self.msgbox("error", "Remote Error", "No Display");
                 return;
             }
@@ -2128,6 +2139,7 @@ impl Interface for Handler {
             });
         }
         self.lc.write().unwrap().handle_peer_info(username, pi);
+        self.call("updatePrivacyMode", &[]);
         self.call("updatePi", &make_args!(pi_sciter));
         if self.is_file_transfer() {
             self.call2("closeSuccess", &make_args!());

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -474,7 +474,7 @@ impl Handler {
     }
 
     #[inline]
-    fn save_config(&self, config: PeerConfig) {
+    pub(super) fn save_config(&self, config: PeerConfig) {
         self.lc.write().unwrap().save_config(config);
     }
 
@@ -483,7 +483,7 @@ impl Handler {
     }
 
     #[inline]
-    fn load_config(&self) -> PeerConfig {
+    pub(super) fn load_config(&self) -> PeerConfig {
         load_config(&self.id)
     }
 
@@ -1879,9 +1879,10 @@ impl Remote {
                         self.handler.msgbox("error", "Connection Error", &c);
                         return false;
                     }
-                    Some(misc::Union::option_response(resp)) => {
-                        self.handler
-                            .msgbox("custom-error", "Option Error", &resp.error);
+                    Some(misc::Union::back_notification(notification)) => {
+                        if !self.handle_back_notification(notification).await {
+                            return false;
+                        }
                     }
                     _ => {}
                 },
@@ -1895,6 +1896,118 @@ impl Remote {
                 }
                 _ => {}
             }
+        }
+        true
+    }
+
+    async fn handle_back_notification(&mut self, notification: BackNotification) -> bool {
+        match notification.union {
+            Some(back_notification::Union::block_input_state(state)) => {
+                self.handle_back_msg_block_input(
+                    state.enum_value_or(back_notification::BlockInputState::StateUnknown),
+                )
+                .await;
+            }
+            Some(back_notification::Union::privacy_mode_state(state)) => {
+                if !self
+                    .handle_back_msg_privacy_mode(
+                        state.enum_value_or(back_notification::PrivacyModeState::StateUnknown),
+                    )
+                    .await
+                {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+        true
+    }
+
+    #[inline(always)]
+    fn update_block_input_state(&mut self, on: bool) {
+        self.handler.call("updateBlockInputState", &make_args!(on));
+    }
+
+    async fn handle_back_msg_block_input(&mut self, state: back_notification::BlockInputState) {
+        match state {
+            back_notification::BlockInputState::OnSucceeded => {
+                self.update_block_input_state(true);
+            }
+            back_notification::BlockInputState::OnFailed => {
+                self.handler
+                    .msgbox("custom-error", "Block user input", "Failed");
+                self.update_block_input_state(false);
+            }
+            back_notification::BlockInputState::OffSucceeded => {
+                self.update_block_input_state(false);
+            }
+            back_notification::BlockInputState::OffFailed => {
+                self.handler
+                    .msgbox("custom-error", "Unblock user input", "Failed");
+            }
+            _ => {}
+        }
+    }
+
+    #[inline(always)]
+    fn update_privacy_mode(&mut self, on: bool) {
+        let mut config = self.handler.load_config();
+        config.privacy_mode = on;
+        self.handler.save_config(config);
+
+        self.handler.call("updatePrivacyMode", &[]);
+    }
+
+    async fn handle_back_msg_privacy_mode(
+        &mut self,
+        state: back_notification::PrivacyModeState,
+    ) -> bool {
+        match state {
+            back_notification::PrivacyModeState::OnByOther => {
+                self.handler
+                    .msgbox("error", "Connecting...", "Someone turns on privacy mode, exit");
+                return false;
+            }
+            back_notification::PrivacyModeState::NotSupported => {
+                self.handler
+                    .msgbox("custom-error", "Privacy mode", "Unsupported");
+                self.update_privacy_mode(false);
+            }
+            back_notification::PrivacyModeState::OnSucceeded => {
+                self.update_privacy_mode(true);
+            }
+            back_notification::PrivacyModeState::OnFailedDenied => {
+                self.handler
+                    .msgbox("custom-error", "Privacy mode", "Peer denied");
+                self.update_privacy_mode(false);
+            }
+            back_notification::PrivacyModeState::OnFailedPlugin => {
+                self.handler
+                    .msgbox("custom-error", "Privacy mode", "Please install plugins");
+                self.update_privacy_mode(false);
+            }
+            back_notification::PrivacyModeState::OnFailed => {
+                self.handler.msgbox("custom-error", "Privacy mode", "Failed");
+                self.update_privacy_mode(false);
+            }
+            back_notification::PrivacyModeState::OffSucceeded => {
+                self.update_privacy_mode(false);
+            }
+            back_notification::PrivacyModeState::OffByPeer => {
+                self.handler
+                    .msgbox("custom-error", "Privacy mode", "Peer exit");
+                self.update_privacy_mode(false);
+            }
+            back_notification::PrivacyModeState::OffFailed => {
+                self.handler
+                    .msgbox("custom-error", "Privacy mode", "Failed off");
+            }
+            back_notification::PrivacyModeState::OffUnknown => {
+                self.handler.msgbox("custom-error", "Privacy mode", "Turned off");
+                // log::error!("Privacy mode is turned off with unknown reason");
+                self.update_privacy_mode(false);
+            }
+            _ => {}
         }
         true
     }

--- a/src/windows.cc
+++ b/src/windows.cc
@@ -52,23 +52,23 @@ DWORD GetLogonPid(DWORD dwSessionId, BOOL as_user)
     return dwLogonPid;
 }
 
-// if should try WTSQueryUserToken?
-// https://stackoverflow.com/questions/7285666/example-code-a-service-calls-createprocessasuser-i-want-the-process-to-run-in
-BOOL GetSessionUserTokenWin(OUT LPHANDLE lphUserToken, DWORD dwSessionId, BOOL as_user)
-{
-    BOOL bResult = FALSE;
-    DWORD Id = GetLogonPid(dwSessionId, as_user);
-    if (HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, Id))
-    {
-        bResult = OpenProcessToken(hProcess, TOKEN_ALL_ACCESS, lphUserToken);
-        CloseHandle(hProcess);
-    }
-    return bResult;
-}
-
 // START the app as system
 extern "C"
 {
+    // if should try WTSQueryUserToken?
+    // https://stackoverflow.com/questions/7285666/example-code-a-service-calls-createprocessasuser-i-want-the-process-to-run-in
+    BOOL GetSessionUserTokenWin(OUT LPHANDLE lphUserToken, DWORD dwSessionId, BOOL as_user)
+    {
+        BOOL bResult = FALSE;
+        DWORD Id = GetLogonPid(dwSessionId, as_user);
+        if (HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, Id))
+        {
+            bResult = OpenProcessToken(hProcess, TOKEN_ALL_ACCESS, lphUserToken);
+            CloseHandle(hProcess);
+        }
+        return bResult;
+    }
+
     HANDLE LaunchProcessWin(LPCWSTR cmd, DWORD dwSessionId, BOOL as_user)
     {
         HANDLE hProcess = NULL;

--- a/src/windows.cc
+++ b/src/windows.cc
@@ -373,20 +373,21 @@ extern "C"
         SHAddToRecentDocs(SHARD_PATHW, path);
     }
 
-    uint32_t get_active_user(PWSTR bufin, uint32_t nin)    
-    {    
-        uint32_t nout = 0;    
-        auto id = WTSGetActiveConsoleSessionId();    
-        PWSTR buf = NULL;    
-        DWORD n = 0;    
-        if (WTSQuerySessionInformationW(NULL, id, WTSUserName, &buf, &n))    
-        {    
-            if (buf) {    
-                nout = min(nin, n);    
-                memcpy(bufin, buf, nout);    
-                WTSFreeMemory(buf);    
-            }    
-        }    
-        return nout;    
-    }  
+    uint32_t get_active_user(PWSTR bufin, uint32_t nin)
+    {
+        uint32_t nout = 0;
+        auto id = WTSGetActiveConsoleSessionId();
+        PWSTR buf = NULL;
+        DWORD n = 0;
+        if (WTSQuerySessionInformationW(NULL, id, WTSUserName, &buf, &n))
+        {
+            if (buf)
+            {
+                nout = min(nin, n);
+                memcpy(bufin, buf, nout);
+                WTSFreeMemory(buf);
+            }
+        }
+        return nout;
+    }
 } // end of extern "C"


### PR DESCRIPTION
Implement a privacy mode method like ToDesk on windows OS.
  1. Draw a window in front of most windows.
  2. The controller side will not see the topmost window.
  3. Diable all user input other than "Ctrl + P", Ctrl + P will exit privacy mode.

Topmost window is implemented by using [DLL injection](https://github.com/fufesou/RustDeskTempTopMostWindow).
[WindowInjection.dll](https://github.com/fufesou/RustDeskTempTopMostWindow/releases/tag/v0.1) need to be downloaded and placed in the same directory of rustdesk.exe.
![image](https://user-images.githubusercontent.com/13586388/162626603-a1b339d9-1a6e-4c42-9e40-19ef221dffd9.png)

Privacy mode is an exclusive mode that will cause others' connections be removed.
![image](https://user-images.githubusercontent.com/13586388/162626743-83675a7b-1574-43b5-9180-e02cbae229a4.png)



**To improve:**
1. Uninstall will not remove WindowInjection.dll. Because it is occupied by RuntimeBroker.exe. The process may not be terminated when uninstall.
