### PR TITLE
Fix WCHAR Path & Add Resources Integration Lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,7 @@ dependencies = [
  "serde_derive",
  "serde_json 1.0.79",
  "sha2",
+ "simple_rc",
  "sys-locale",
  "sysinfo",
  "systray",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,6 +3691,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 
 [[package]]
+name = "simple_rc"
+version = "0.1.0"
+dependencies = [
+ "confy",
+ "hbb_common",
+ "serde 1.0.136",
+ "serde_derive",
+ "walkdir",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "A remote control software."
 [features]
 inline = []
 cli = []
+with_rc = ["simple_rc"]
 use_samplerate = ["samplerate"]
 use_rubato = ["rubato"]
 use_dasp = ["dasp"]
@@ -98,6 +99,7 @@ winapi = { version = "0.3", features = [ "winnt" ] }
 [build-dependencies]
 cc = "1.0"
 hbb_common = { path = "libs/hbb_common" }
+simple_rc = { path = "libs/simple_rc", optional = true }
 
 [dev-dependencies]
 hound = "3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ rust-pulsectl = { git = "https://github.com/open-trade/pulsectl" }
 android_logger = "0.11"
 
 [workspace]
-members = ["libs/scrap", "libs/hbb_common", "libs/enigo", "libs/clipboard", "libs/virtual_display"]
+members = ["libs/scrap", "libs/hbb_common", "libs/enigo", "libs/clipboard", "libs/virtual_display", "libs/simple_rc"]
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2020"

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,20 @@ fn build_manifest() {
     }
 }
 
+#[cfg(all(windows, feature = "with_rc"))]
+fn build_rc_source() {
+    use simple_rc::{generate_with_conf, Config, ConfigItem};
+    generate_with_conf(&Config {
+        outfile: "src/rc.rs".to_owned(),
+        confs: vec![ConfigItem {
+            inc: "resources".to_owned(),
+            exc: vec![],
+            suppressed_front: "resources".to_owned(),
+        }],
+    })
+    .unwrap();
+}
+
 fn install_oboe() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     if target_os != "android" {
@@ -63,6 +77,8 @@ fn install_oboe() {
 }
 
 fn main() {
+    #[cfg(all(windows, feature = "with_rc"))]
+    build_rc_source();
     #[cfg(all(windows, feature = "inline"))]
     build_manifest();
     #[cfg(windows)]

--- a/libs/simple_rc/Cargo.toml
+++ b/libs/simple_rc/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "simple_rc"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde_derive = "1.0"
+serde = "1.0"
+walkdir = "2"
+confy = { git = "https://github.com/open-trade/confy" }
+hbb_common = { path = "../hbb_common" }

--- a/libs/simple_rc/examples/generate.rs
+++ b/libs/simple_rc/examples/generate.rs
@@ -1,0 +1,22 @@
+extern crate simple_rc;
+
+use simple_rc::*;
+
+fn main() {
+    {
+        const CONF_FILE: &str = "simple_rc.toml";
+        generate(CONF_FILE).unwrap();
+    }
+
+    {
+        generate_with_conf(&Config {
+            outfile: "src/rc.rs".to_owned(),
+            confs: vec![ConfigItem {
+                inc: "D:/projects/windows/RustDeskTempTopMostWindow/x64/Release/xxx".to_owned(),
+                exc: vec!["*.dll".to_owned(), "*.exe".to_owned()],
+                suppressed_front: "D:/projects/windows".to_owned(),
+            }],
+        })
+        .unwrap();
+    }
+}

--- a/libs/simple_rc/examples/generate.rs
+++ b/libs/simple_rc/examples/generate.rs
@@ -13,7 +13,8 @@ fn main() {
             outfile: "src/rc.rs".to_owned(),
             confs: vec![ConfigItem {
                 inc: "D:/projects/windows/RustDeskTempTopMostWindow/x64/Release/xxx".to_owned(),
-                exc: vec!["*.dll".to_owned(), "*.exe".to_owned()],
+                // exc: vec!["*.dll".to_owned(), "*.exe".to_owned()],
+                exc: vec![],
                 suppressed_front: "D:/projects/windows".to_owned(),
             }],
         })

--- a/libs/simple_rc/simple_rc.toml
+++ b/libs/simple_rc/simple_rc.toml
@@ -1,0 +1,6 @@
+outfile = "src/rc.rs"
+
+[[confs]]
+inc = "D:/projects/windows/RustDeskTempTopMostWindow/x64/Release/xxx"
+exc = ["*.dll", "*.exe"]
+suppressed_front = "D:/projects/windows"

--- a/libs/simple_rc/simple_rc.toml
+++ b/libs/simple_rc/simple_rc.toml
@@ -1,6 +1,12 @@
+# The output source file
 outfile = "src/rc.rs"
 
+# The resource config list.
 [[confs]]
+# The file or director to integrate.
 inc = "D:/projects/windows/RustDeskTempTopMostWindow/x64/Release/xxx"
+# The exclusions.
 exc = ["*.dll", "*.exe"]
+# The front path that will ignore for extracting.
+# The following config will make base output path to be "RustDeskTempTopMostWindow/x64/Release/xxx".
 suppressed_front = "D:/projects/windows"

--- a/libs/simple_rc/src/lib.rs
+++ b/libs/simple_rc/src/lib.rs
@@ -1,0 +1,187 @@
+use hbb_common::{bail, ResultType};
+use serde_derive::{Deserialize, Serialize};
+use std::{collections::HashMap, fs::File, io::prelude::*, path::Path};
+use walkdir::WalkDir;
+
+const CONF_FILE: &str = "simple_rc.toml";
+
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
+pub struct ConfigItem {
+    #[serde(default)]
+    pub inc: String,
+    #[serde(default)]
+    pub exc: Vec<String>,
+    #[serde(default)]
+    pub suppressed_front: String,
+}
+
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Config {
+    #[serde(default)]
+    confs: Vec<ConfigItem>,
+    #[serde(default)]
+    outfile: String,
+}
+
+pub fn get_outin_files<'a>(item: &'a ConfigItem) -> ResultType<HashMap<String, String>> {
+    let mut outin_filemap = HashMap::new();
+
+    for entry in WalkDir::new(&item.inc).follow_links(true) {
+        let path = entry?.into_path();
+        if path.is_file() {
+            let mut suppressed_front = item.suppressed_front.clone();
+            if !suppressed_front.is_empty() && suppressed_front.ends_with('/') {
+                suppressed_front.push('/');
+            }
+            let outpath = path.strip_prefix(Path::new(&suppressed_front))?;
+            let outfile = if outpath.is_absolute() {
+                match outpath
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .map(|f| f.to_string())
+                {
+                    None => {
+                        bail!("Failed to get filename of {}", outpath.display());
+                    }
+                    Some(s) => s,
+                }
+            } else {
+                match outpath.to_str() {
+                    None => {
+                        bail!("Failed to convert {} to string", outpath.display());
+                    }
+                    Some(s) => s.to_string(),
+                }
+            };
+            let infile = match path.canonicalize()?.to_str() {
+                None => {
+                    bail!("Failed to get file path of {}", path.display());
+                }
+                Some(s) => s.to_string(),
+            };
+            if let Some(_) = outin_filemap.insert(outfile.clone(), infile) {
+                bail!("outfile {} is set before", outfile);
+            }
+        }
+    }
+
+    Ok(outin_filemap)
+}
+
+pub fn generate<'a>(conf: &'a Config) -> ResultType<()> {
+    let mut outfile = File::create(&conf.outfile)?;
+
+    outfile.write(
+        br##"
+use hbb_common::{bail, ResultType};
+use std::{
+    fs::{self, File},
+    io::prelude::*,
+    path::Path,
+};
+
+"##,
+    )?;
+
+    outfile.write(b"pub fn extract_resources() -> ResultType<()> {\n")?;
+    outfile.write(b"    let mut resources: Vec<(&str, &[u8])> = Vec::new();\n")?;
+
+    let mut outin_files = HashMap::new();
+    for item in conf.confs.iter() {
+        for (o, i) in get_outin_files(item)?.into_iter() {
+            if let Some(_) = outin_files.insert(o.clone(), i) {
+                bail!("outfile {} is set before", o);
+            }
+        }
+    }
+
+    let mut count = 1;
+    for (o, i) in outin_files.iter() {
+        let mut infile = File::open(&i)?;
+        let mut buffer = Vec::<u8>::new();
+        infile.read_to_end(&mut buffer)?;
+
+        let var_outfile = format!("outfile_{}", count);
+        let var_outdata = format!("outdata_{}", count);
+
+        write!(outfile, "    let {} = \"{}\";\n", var_outfile, o)?;
+        write!(outfile, "    let {} = [\n        ", var_outdata)?;
+
+        let mut line_num = 20;
+        for v in buffer {
+            if line_num == 0 {
+                write!(outfile, "\n        ")?;
+                line_num = 20;
+            }
+            write!(outfile, "{:#04x}u8, ", v)?;
+            line_num -= 1;
+        }
+        write!(outfile, "\n    ];\n")?;
+
+        write!(
+            outfile,
+            "    resources.push(({}, &{}));\n",
+            var_outfile, var_outdata
+        )?;
+
+        count += 1;
+    }
+
+    outfile.write(b"    do_extract(resources)?;\n")?;
+    outfile.write(b"    Ok(())\n")?;
+    outfile.write(b"}\n")?;
+
+    outfile.write(
+        br##"
+fn do_extract(resources: Vec<(&str, &[u8])>) -> ResultType<()> {
+    for (outfile, data) in resources {
+        match Path::new(outfile).parent().and_then(|p| p.to_str()) {
+            None => {
+                bail!("Failed to get parent of {}", outfile);
+            }
+            Some(p) => {
+                fs::create_dir_all(p)?;
+                let mut of = File::create(outfile)?;
+                of.write_all(data)?;
+                of.flush()?;
+            }
+        }
+    }
+    Ok(())
+}
+"##,
+    )?;
+
+    outfile.flush()?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+
+    #[test]
+    fn test_generate() {
+        use super::*;
+        generate(&Config {
+            confs: vec![ConfigItem {
+                inc: "D:/aa.png".to_owned(),
+                exc: vec![],
+                suppressed_front: "".to_owned(),
+            }],
+            outfile: "src/aa.rs".to_owned(),
+        })
+        .unwrap();
+    }
+
+    // #[test]
+    // fn test_extract() {
+    //     use super::*;
+    //     aa::extract_resources().unwrap();
+    // }
+}

--- a/libs/virtual_display/src/lib.rs
+++ b/libs/virtual_display/src/lib.rs
@@ -2,7 +2,7 @@
 pub mod win10;
 
 use hbb_common::{bail, lazy_static, ResultType};
-use std::{ffi::CString, path::Path, sync::Mutex};
+use std::{path::Path, sync::Mutex};
 
 lazy_static::lazy_static! {
     // If device is uninstalled though "Device Manager" Window.
@@ -33,16 +33,18 @@ pub fn install_update_driver(_reboot_required: &mut bool) -> ResultType<()> {
         bail!("{} not exists", install_path)
     }
 
-    let _full_install_path = match abs_path.to_str() {
-        Some(p) => CString::new(p)?.into_raw(),
-        None => bail!("{} not exists", install_path),
-    };
+    let _full_install_path: Vec<u16> = abs_path
+        .to_string_lossy()
+        .as_ref()
+        .encode_utf16()
+        .chain(Some(0).into_iter())
+        .collect();
 
     #[cfg(windows)]
     unsafe {
         {
             let mut reboot_required_tmp = win10::idd::FALSE;
-            if win10::idd::InstallUpdate(_full_install_path, &mut reboot_required_tmp)
+            if win10::idd::InstallUpdate(_full_install_path.as_ptr() as _, &mut reboot_required_tmp)
                 == win10::idd::FALSE
             {
                 bail!("{}", win10::get_last_msg()?);
@@ -65,16 +67,18 @@ pub fn uninstall_driver(_reboot_required: &mut bool) -> ResultType<()> {
         bail!("{} not exists", install_path)
     }
 
-    let _full_install_path = match abs_path.to_str() {
-        Some(p) => CString::new(p)?.into_raw(),
-        None => bail!("{} not exists", install_path),
-    };
+    let _full_install_path: Vec<u16> = abs_path
+        .to_string_lossy()
+        .as_ref()
+        .encode_utf16()
+        .chain(Some(0).into_iter())
+        .collect();
 
     #[cfg(windows)]
     unsafe {
         {
             let mut reboot_required_tmp = win10::idd::FALSE;
-            if win10::idd::Uninstall(_full_install_path, &mut reboot_required_tmp)
+            if win10::idd::Uninstall(_full_install_path.as_ptr() as _, &mut reboot_required_tmp)
                 == win10::idd::FALSE
             {
                 bail!("{}", win10::get_last_msg()?);

--- a/libs/virtual_display/src/lib.rs
+++ b/libs/virtual_display/src/lib.rs
@@ -33,18 +33,24 @@ pub fn install_update_driver(_reboot_required: &mut bool) -> ResultType<()> {
         bail!("{} not exists", install_path)
     }
 
-    let _full_install_path: Vec<u16> = abs_path
-        .to_string_lossy()
-        .as_ref()
-        .encode_utf16()
-        .chain(Some(0).into_iter())
-        .collect();
-
     #[cfg(windows)]
     unsafe {
         {
+            // Device must be created before install driver.
+            // https://github.com/fufesou/RustDeskIddDriver/issues/1
+            if let Err(e) = create_device() {
+                bail!("{}", e);
+            }
+
+            let full_install_path: Vec<u16> = abs_path
+                .to_string_lossy()
+                .as_ref()
+                .encode_utf16()
+                .chain(Some(0).into_iter())
+                .collect();
+
             let mut reboot_required_tmp = win10::idd::FALSE;
-            if win10::idd::InstallUpdate(_full_install_path.as_ptr() as _, &mut reboot_required_tmp)
+            if win10::idd::InstallUpdate(full_install_path.as_ptr() as _, &mut reboot_required_tmp)
                 == win10::idd::FALSE
             {
                 bail!("{}", win10::get_last_msg()?);
@@ -67,18 +73,18 @@ pub fn uninstall_driver(_reboot_required: &mut bool) -> ResultType<()> {
         bail!("{} not exists", install_path)
     }
 
-    let _full_install_path: Vec<u16> = abs_path
-        .to_string_lossy()
-        .as_ref()
-        .encode_utf16()
-        .chain(Some(0).into_iter())
-        .collect();
-
     #[cfg(windows)]
     unsafe {
         {
+            let full_install_path: Vec<u16> = abs_path
+                .to_string_lossy()
+                .as_ref()
+                .encode_utf16()
+                .chain(Some(0).into_iter())
+                .collect();
+
             let mut reboot_required_tmp = win10::idd::FALSE;
-            if win10::idd::Uninstall(_full_install_path.as_ptr() as _, &mut reboot_required_tmp)
+            if win10::idd::Uninstall(full_install_path.as_ptr() as _, &mut reboot_required_tmp)
                 == win10::idd::FALSE
             {
                 bail!("{}", win10::get_last_msg()?);

--- a/libs/virtual_display/src/win10/IddController.c
+++ b/libs/virtual_display/src/win10/IddController.c
@@ -64,14 +64,14 @@ const char* GetLastMsg()
     return g_lastMsg;
 }
 
-BOOL InstallUpdate(LPCTSTR fullInfPath, PBOOL rebootRequired)
+BOOL InstallUpdate(LPCWSTR fullInfPath, PBOOL rebootRequired)
 {
     SetLastMsg("Sucess");
 
-    // UpdateDriverForPlugAndPlayDevices may return FALSE while driver was successfully installed...
-    if (FALSE == UpdateDriverForPlugAndPlayDevices(
+    // UpdateDriverForPlugAndPlayDevicesW may return FALSE while driver was successfully installed...
+    if (FALSE == UpdateDriverForPlugAndPlayDevicesW(
         NULL,
-        _T("RustDeskIddDriver"),    // match hardware id in the inf file
+        L"RustDeskIddDriver",    // match hardware id in the inf file
         fullInfPath,
         INSTALLFLAG_FORCE
             // | INSTALLFLAG_NONINTERACTIVE  // INSTALLFLAG_NONINTERACTIVE may cause error 0xe0000247
@@ -82,7 +82,7 @@ BOOL InstallUpdate(LPCTSTR fullInfPath, PBOOL rebootRequired)
         DWORD error = GetLastError();
         if (error != 0)
         {
-            SetLastMsg("UpdateDriverForPlugAndPlayDevices failed, last error 0x%x\n", error);
+            SetLastMsg("UpdateDriverForPlugAndPlayDevicesW failed, last error 0x%x\n", error);
             if (g_printMsg)
             {
                 printf(g_lastMsg);
@@ -94,11 +94,11 @@ BOOL InstallUpdate(LPCTSTR fullInfPath, PBOOL rebootRequired)
     return TRUE;
 }
 
-BOOL Uninstall(LPCTSTR fullInfPath, PBOOL rebootRequired)
+BOOL Uninstall(LPCWSTR fullInfPath, PBOOL rebootRequired)
 {
     SetLastMsg("Sucess");
 
-    if (FALSE == DiUninstallDriver(
+    if (FALSE == DiUninstallDriverW(
         NULL,
         fullInfPath,
         0,
@@ -108,7 +108,7 @@ BOOL Uninstall(LPCTSTR fullInfPath, PBOOL rebootRequired)
         DWORD error = GetLastError();
         if (error != 0)
         {
-            SetLastMsg("DiUninstallDriver failed, last error 0x%x\n", error);
+            SetLastMsg("DiUninstallDriverW failed, last error 0x%x\n", error);
             if (g_printMsg)
             {
                 printf(g_lastMsg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,6 @@ mod lang;
 
 #[cfg(windows)]
 pub mod clipboard_file;
+
+#[cfg(all(windows, feature = "with_rc"))]
+pub mod rc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,10 @@ fn main() {
                 hbb_common::allow_err!(platform::uninstall_me());
                 hbb_common::allow_err!(platform::install_me("desktopicon startmenu",));
                 return;
+            } else if args[0] == "--extract" {
+                #[cfg(feature = "with_rc")]
+                hbb_common::allow_err!(crate::rc::extract_resources(&args[1]));
+                return;
             }
         }
         if args[0] == "--remove" {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -755,7 +755,7 @@ pub fn get_install_info() -> (String, String, String, String) {
 }
 
 pub fn update_me() -> ResultType<()> {
-    let (_, _, _, exe) = get_install_info();
+    let (_, path, _, exe) = get_install_info();
     let src_exe = std::env::current_exe()?.to_str().unwrap_or("").to_owned();
     let cmds = format!(
         "
@@ -763,10 +763,12 @@ pub fn update_me() -> ResultType<()> {
         sc stop {app_name}
         taskkill /F /IM {app_name}.exe
         copy /Y \"{src_exe}\" \"{exe}\"
+        \"{src_exe}\" --extract \"{path}\"
         sc start {app_name}
     ",
         src_exe = src_exe,
         exe = exe,
+        path = path,
         app_name = APP_NAME,
     );
     std::thread::sleep(std::time::Duration::from_millis(1000));

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -890,6 +890,7 @@ copy /Y \"{tmp_path}\\Uninstall {app_name}.lnk\" \"{start_menu}\\\"
 chcp 65001
 md \"{path}\"
 copy /Y \"{src_exe}\" \"{exe}\"
+\"{src_exe}\" --extract \"{path}\"
 reg add {subkey} /f
 reg add {subkey} /f /v DisplayIcon /t REG_SZ /d \"{exe}\"
 reg add {subkey} /f /v DisplayName /t REG_SZ /d \"{app_name}\"

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -1,0 +1,38 @@
+use hbb_common::{bail, ResultType};
+use std::{
+    fs::{self, File},
+    io::prelude::*,
+    path::Path,
+};
+
+#[allow(dead_code)]
+pub fn extract_resources(root_path: &str) -> ResultType<()> {
+    let mut resources: Vec<(&str, &[u8])> = Vec::new();
+    resources.push((outfile_4, &outdata_4));
+    do_extract(root_path, resources)?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn do_extract(root_path: &str, resources: Vec<(&str, &[u8])>) -> ResultType<()> {
+    let mut root_path = root_path.replace("\\", "/");
+    if !root_path.ends_with('/') {
+        root_path.push('/');
+    }
+    let root_path = Path::new(&root_path);
+    for (outfile, data) in resources {
+        let outfile_path = root_path.join(outfile);
+        match outfile_path.parent().and_then(|p| p.to_str()) {
+            None => {
+                bail!("Failed to get parent of {}", outfile_path.display());
+            }
+            Some(p) => {
+                fs::create_dir_all(p)?;
+                let mut of = File::create(outfile_path)?;
+                of.write_all(data)?;
+                of.flush()?;
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
OS: Win10

1. Fixed: IDD driver use utf-8 path.
2. Add: simple_rc. Integrate kinds of files. Reading resources to a resource file. Then extract the resources to a target path.

```
# 
# The output source file
outfile = "src/rc.rs"

# The resource config list.
[[confs]]
# The file or director to integrate.
inc = "D:/projects/windows/RustDeskTempTopMostWindow/x64/Release/xxx"
# The exclusions.
exc = ["*.dll", "*.exe"]
# The front path that will ignore for extracting.
# The following config will make base output path to be "RustDeskTempTopMostWindow/x64/Release/xxx".
suppressed_front = "D:/projects/windows"
```