### PR TITLE
Fix WCHAR Path & Add Resources Integration Lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,6 +3366,7 @@ dependencies = [
  "serde_derive",
  "serde_json 1.0.79",
  "sha2",
+ "simple_rc",
  "sys-locale",
  "sysinfo",
  "systray",
@@ -3627,6 +3628,17 @@ name = "signature"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+
+[[package]]
+name = "simple_rc"
+version = "0.1.0"
+dependencies = [
+ "confy",
+ "hbb_common",
+ "serde 1.0.136",
+ "serde_derive",
+ "walkdir",
+]
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "A remote control software."
 [features]
 inline = []
 cli = []
+with_rc = ["simple_rc"]
 use_samplerate = ["samplerate"]
 use_rubato = ["rubato"]
 use_dasp = ["dasp"]
@@ -83,7 +84,7 @@ rust-pulsectl = { git = "https://github.com/open-trade/pulsectl" }
 android_logger = "0.11"
 
 [workspace]
-members = ["libs/scrap", "libs/hbb_common", "libs/enigo", "libs/clipboard", "libs/virtual_display"]
+members = ["libs/scrap", "libs/hbb_common", "libs/enigo", "libs/clipboard", "libs/virtual_display", "libs/simple_rc"]
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2020"
@@ -97,6 +98,7 @@ winapi = { version = "0.3", features = [ "winnt" ] }
 [build-dependencies]
 cc = "1.0"
 hbb_common = { path = "libs/hbb_common" }
+simple_rc = { path = "libs/simple_rc", optional = true }
 
 [dev-dependencies]
 hound = "3.4"

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,20 @@ fn build_manifest() {
     }
 }
 
+#[cfg(all(windows, feature = "with_rc"))]
+fn build_rc_source() {
+    use simple_rc::{generate_with_conf, Config, ConfigItem};
+    generate_with_conf(&Config {
+        outfile: "src/rc.rs".to_owned(),
+        confs: vec![ConfigItem {
+            inc: "resources".to_owned(),
+            exc: vec![],
+            suppressed_front: "resources".to_owned(),
+        }],
+    })
+    .unwrap();
+}
+
 fn install_oboe() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     if target_os != "android" {
@@ -63,6 +77,8 @@ fn install_oboe() {
 }
 
 fn main() {
+    #[cfg(all(windows, feature = "with_rc"))]
+    build_rc_source();
     #[cfg(all(windows, feature = "inline"))]
     build_manifest();
     #[cfg(windows)]

--- a/libs/simple_rc/Cargo.toml
+++ b/libs/simple_rc/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "simple_rc"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde_derive = "1.0"
+serde = "1.0"
+walkdir = "2"
+confy = { git = "https://github.com/open-trade/confy" }
+hbb_common = { path = "../hbb_common" }

--- a/libs/simple_rc/examples/generate.rs
+++ b/libs/simple_rc/examples/generate.rs
@@ -1,0 +1,23 @@
+extern crate simple_rc;
+
+use simple_rc::*;
+
+fn main() {
+    {
+        const CONF_FILE: &str = "simple_rc.toml";
+        generate(CONF_FILE).unwrap();
+    }
+
+    {
+        generate_with_conf(&Config {
+            outfile: "src/rc.rs".to_owned(),
+            confs: vec![ConfigItem {
+                inc: "D:/projects/windows/RustDeskTempTopMostWindow/x64/Release/xxx".to_owned(),
+                // exc: vec!["*.dll".to_owned(), "*.exe".to_owned()],
+                exc: vec![],
+                suppressed_front: "D:/projects/windows".to_owned(),
+            }],
+        })
+        .unwrap();
+    }
+}

--- a/libs/simple_rc/simple_rc.toml
+++ b/libs/simple_rc/simple_rc.toml
@@ -1,0 +1,12 @@
+# The output source file
+outfile = "src/rc.rs"
+
+# The resource config list.
+[[confs]]
+# The file or director to integrate.
+inc = "D:/projects/windows/RustDeskTempTopMostWindow/x64/Release/xxx"
+# The exclusions.
+exc = ["*.dll", "*.exe"]
+# The front path that will ignore for extracting.
+# The following config will make base output path to be "RustDeskTempTopMostWindow/x64/Release/xxx".
+suppressed_front = "D:/projects/windows"

--- a/libs/simple_rc/src/lib.rs
+++ b/libs/simple_rc/src/lib.rs
@@ -1,0 +1,208 @@
+use hbb_common::{bail, ResultType};
+use serde_derive::{Deserialize, Serialize};
+use std::{collections::HashMap, fs::File, io::prelude::*, path::Path};
+use walkdir::WalkDir;
+
+//mod rc;
+
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
+pub struct ConfigItem {
+    // include directory or file
+    pub inc: String,
+    // exclude files
+    pub exc: Vec<String>,
+    // out_path = origin_path - suppressed_front
+    pub suppressed_front: String,
+}
+
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Config {
+    // output source file
+    pub outfile: String,
+    // config items
+    pub confs: Vec<ConfigItem>,
+}
+
+pub fn get_outin_files<'a>(item: &'a ConfigItem) -> ResultType<HashMap<String, String>> {
+    let mut outin_filemap = HashMap::new();
+
+    for entry in WalkDir::new(&item.inc).follow_links(true) {
+        let path = entry?.into_path();
+        if path.is_file() {
+            let mut exclude = false;
+            for excfile in item.exc.iter() {
+                if excfile.starts_with("*.") {
+                    if let Some(ext) = path.extension().and_then(|x| x.to_str()) {
+                        if excfile.ends_with(&format!(".{}", ext)) {
+                            exclude = true;
+                            break;
+                        }
+                    }
+                } else {
+                    if path.ends_with(Path::new(excfile)) {
+                        exclude = true;
+                        break;
+                    }
+                }
+            }
+            if exclude {
+                continue;
+            }
+
+            let mut suppressed_front = item.suppressed_front.clone();
+            if !suppressed_front.is_empty() && suppressed_front.ends_with('/') {
+                suppressed_front.push('/');
+            }
+            let outpath = path.strip_prefix(Path::new(&suppressed_front))?;
+            let outfile = if outpath.is_absolute() {
+                match outpath
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .map(|f| f.to_string())
+                {
+                    None => {
+                        bail!("Failed to get filename of {}", outpath.display());
+                    }
+                    Some(s) => s,
+                }
+            } else {
+                match outpath.to_str() {
+                    None => {
+                        bail!("Failed to convert {} to string", outpath.display());
+                    }
+                    // Simple replace \ to / here.
+                    // A better way is to use lib [path-slash](https://github.com/rhysd/path-slash)
+                    Some(s) => s.to_string().replace("\\", "/"),
+                }
+            };
+            let infile = match path.canonicalize()?.to_str() {
+                None => {
+                    bail!("Failed to get file path of {}", path.display());
+                }
+                Some(s) => s.to_string(),
+            };
+            if let Some(_) = outin_filemap.insert(outfile.clone(), infile) {
+                bail!("outfile {} is set before", outfile);
+            }
+        }
+    }
+
+    Ok(outin_filemap)
+}
+
+pub fn generate(conf_file: &str) -> ResultType<()> {
+    let conf = confy::load_path(conf_file)?;
+    generate_with_conf(&conf)?;
+    Ok(())
+}
+
+pub fn generate_with_conf<'a>(conf: &'a Config) -> ResultType<()> {
+    let mut outfile = File::create(&conf.outfile)?;
+
+    outfile.write(
+        br##"use hbb_common::{bail, ResultType};
+use std::{
+    fs::{self, File},
+    io::prelude::*,
+    path::Path,
+};
+
+"##,
+    )?;
+
+    outfile.write(b"#[allow(dead_code)]\n")?;
+    outfile.write(b"pub fn extract_resources(root_path: &str) -> ResultType<()> {\n")?;
+    outfile.write(b"    let mut resources: Vec<(&str, &[u8])> = Vec::new();\n")?;
+
+    let mut outin_files = HashMap::new();
+    for item in conf.confs.iter() {
+        for (o, i) in get_outin_files(item)?.into_iter() {
+            if let Some(_) = outin_files.insert(o.clone(), i) {
+                bail!("outfile {} is set before", o);
+            }
+        }
+    }
+
+    let mut count = 1;
+    for (o, i) in outin_files.iter() {
+        let mut infile = File::open(&i)?;
+        let mut buffer = Vec::<u8>::new();
+        infile.read_to_end(&mut buffer)?;
+
+        let var_outfile = format!("outfile_{}", count);
+        let var_outdata = format!("outdata_{}", count);
+
+        write!(outfile, "    let {} = \"{}\";\n", var_outfile, o)?;
+        write!(outfile, "    let {}: &[u8] = &[\n        ", var_outdata)?;
+
+        let mut line_num = 20;
+        for v in buffer {
+            if line_num == 0 {
+                write!(outfile, "\n        ")?;
+                line_num = 20;
+            }
+            write!(outfile, "{:#04x}, ", v)?;
+            line_num -= 1;
+        }
+        write!(outfile, "\n    ];\n")?;
+
+        write!(
+            outfile,
+            "    resources.push(({}, &{}));\n",
+            var_outfile, var_outdata
+        )?;
+
+        count += 1;
+    }
+
+    outfile.write(b"    do_extract(root_path, resources)?;\n")?;
+    outfile.write(b"    Ok(())\n")?;
+    outfile.write(b"}\n")?;
+
+    outfile.write(
+        br##"
+#[allow(dead_code)]
+fn do_extract(root_path: &str, resources: Vec<(&str, &[u8])>) -> ResultType<()> {
+    let mut root_path = root_path.replace("\\", "/");
+    if !root_path.ends_with('/') {
+        root_path.push('/');
+    }
+    let root_path = Path::new(&root_path);
+    for (outfile, data) in resources {
+        let outfile_path = root_path.join(outfile);
+        match outfile_path.parent().and_then(|p| p.to_str()) {
+            None => {
+                bail!("Failed to get parent of {}", outfile_path.display());
+            }
+            Some(p) => {
+                fs::create_dir_all(p)?;
+                let mut of = File::create(outfile_path)?;
+                of.write_all(data)?;
+                of.flush()?;
+            }
+        }
+    }
+    Ok(())
+}
+"##,
+    )?;
+
+    outfile.flush()?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+
+    // #[test]
+    // fn test_extract() {
+    //     use super::*;
+    //     rc::extract_resources("D:").unwrap();
+    // }
+}

--- a/libs/virtual_display/src/win10/IddController.c
+++ b/libs/virtual_display/src/win10/IddController.c
@@ -64,14 +64,14 @@ const char* GetLastMsg()
     return g_lastMsg;
 }
 
-BOOL InstallUpdate(LPCTSTR fullInfPath, PBOOL rebootRequired)
+BOOL InstallUpdate(LPCWSTR fullInfPath, PBOOL rebootRequired)
 {
     SetLastMsg("Sucess");
 
-    // UpdateDriverForPlugAndPlayDevices may return FALSE while driver was successfully installed...
-    if (FALSE == UpdateDriverForPlugAndPlayDevices(
+    // UpdateDriverForPlugAndPlayDevicesW may return FALSE while driver was successfully installed...
+    if (FALSE == UpdateDriverForPlugAndPlayDevicesW(
         NULL,
-        _T("RustDeskIddDriver"),    // match hardware id in the inf file
+        L"RustDeskIddDriver",    // match hardware id in the inf file
         fullInfPath,
         INSTALLFLAG_FORCE
             // | INSTALLFLAG_NONINTERACTIVE  // INSTALLFLAG_NONINTERACTIVE may cause error 0xe0000247
@@ -82,7 +82,7 @@ BOOL InstallUpdate(LPCTSTR fullInfPath, PBOOL rebootRequired)
         DWORD error = GetLastError();
         if (error != 0)
         {
-            SetLastMsg("UpdateDriverForPlugAndPlayDevices failed, last error 0x%x\n", error);
+            SetLastMsg("UpdateDriverForPlugAndPlayDevicesW failed, last error 0x%x\n", error);
             if (g_printMsg)
             {
                 printf(g_lastMsg);
@@ -94,11 +94,11 @@ BOOL InstallUpdate(LPCTSTR fullInfPath, PBOOL rebootRequired)
     return TRUE;
 }
 
-BOOL Uninstall(LPCTSTR fullInfPath, PBOOL rebootRequired)
+BOOL Uninstall(LPCWSTR fullInfPath, PBOOL rebootRequired)
 {
     SetLastMsg("Sucess");
 
-    if (FALSE == DiUninstallDriver(
+    if (FALSE == DiUninstallDriverW(
         NULL,
         fullInfPath,
         0,
@@ -108,7 +108,7 @@ BOOL Uninstall(LPCTSTR fullInfPath, PBOOL rebootRequired)
         DWORD error = GetLastError();
         if (error != 0)
         {
-            SetLastMsg("DiUninstallDriver failed, last error 0x%x\n", error);
+            SetLastMsg("DiUninstallDriverW failed, last error 0x%x\n", error);
             if (g_printMsg)
             {
                 printf(g_lastMsg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,6 @@ mod lang;
 
 #[cfg(windows)]
 pub mod clipboard_file;
+
+#[cfg(all(windows, feature = "with_rc"))]
+pub mod rc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,10 @@ fn main() {
                 hbb_common::allow_err!(platform::uninstall_me());
                 hbb_common::allow_err!(platform::install_me("desktopicon startmenu",));
                 return;
+            } else if args[0] == "--extract" {
+                #[cfg(feature = "with_rc")]
+                hbb_common::allow_err!(crate::rc::extract_resources(&args[1]));
+                return;
             }
         }
         if args[0] == "--remove" {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -755,7 +755,7 @@ pub fn get_install_info() -> (String, String, String, String) {
 }
 
 pub fn update_me() -> ResultType<()> {
-    let (_, _, _, exe) = get_install_info();
+    let (_, path, _, exe) = get_install_info();
     let src_exe = std::env::current_exe()?.to_str().unwrap_or("").to_owned();
     let cmds = format!(
         "
@@ -763,10 +763,12 @@ pub fn update_me() -> ResultType<()> {
         sc stop {app_name}
         taskkill /F /IM {app_name}.exe
         copy /Y \"{src_exe}\" \"{exe}\"
+        \"{src_exe}\" --extract \"{path}\"
         sc start {app_name}
     ",
         src_exe = src_exe,
         exe = exe,
+        path = path,
         app_name = APP_NAME,
     );
     std::thread::sleep(std::time::Duration::from_millis(1000));
@@ -890,6 +892,7 @@ copy /Y \"{tmp_path}\\Uninstall {app_name}.lnk\" \"{start_menu}\\\"
 chcp 65001
 md \"{path}\"
 copy /Y \"{src_exe}\" \"{exe}\"
+\"{src_exe}\" --extract \"{path}\"
 reg add {subkey} /f
 reg add {subkey} /f /v DisplayIcon /t REG_SZ /d \"{exe}\"
 reg add {subkey} /f /v DisplayName /t REG_SZ /d \"{app_name}\"

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -1,0 +1,38 @@
+use hbb_common::{bail, ResultType};
+use std::{
+    fs::{self, File},
+    io::prelude::*,
+    path::Path,
+};
+
+#[allow(dead_code)]
+pub fn extract_resources(root_path: &str) -> ResultType<()> {
+    let mut resources: Vec<(&str, &[u8])> = Vec::new();
+    resources.push((outfile_4, &outdata_4));
+    do_extract(root_path, resources)?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn do_extract(root_path: &str, resources: Vec<(&str, &[u8])>) -> ResultType<()> {
+    let mut root_path = root_path.replace("\\", "/");
+    if !root_path.ends_with('/') {
+        root_path.push('/');
+    }
+    let root_path = Path::new(&root_path);
+    for (outfile, data) in resources {
+        let outfile_path = root_path.join(outfile);
+        match outfile_path.parent().and_then(|p| p.to_str()) {
+            None => {
+                bail!("Failed to get parent of {}", outfile_path.display());
+            }
+            Some(p) => {
+                fs::create_dir_all(p)?;
+                let mut of = File::create(outfile_path)?;
+                of.write_all(data)?;
+                of.flush()?;
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
OS: Win10

1. Fixed: IDD driver use utf-8 path.
2. Add: simple_rc. Integrate kinds of files. Reading resources to a resource file. Then extract the resources to a target path.

```
# 
# The output source file
outfile = "src/rc.rs"

# The resource config list.
[[confs]]
# The file or director to integrate.
inc = "D:/projects/windows/RustDeskTempTopMostWindow/x64/Release/xxx"
# The exclusions.
exc = ["*.dll", "*.exe"]
# The front path that will ignore for extracting.
# The following config will make base output path to be "RustDeskTempTopMostWindow/x64/Release/xxx".
suppressed_front = "D:/projects/windows"
```