### PR TITLE
opt: more precise control method for transfering files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk"
-version = "1.1.9"
+version = "1.2.0"
 dependencies = [
  "android_logger",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk"
-version = "1.1.9"
+version = "1.2.0"
 authors = ["rustdesk <info@rustdesk.com>"]
 edition = "2021"
 build= "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,6 @@ resources = ["mac-tray.png"]
 #!!! rembember call "strip target/release/rustdesk"
 # which reduce binary size a lot
 [profile.release]
-debug = true
 #lto = true
 #codegen-units = 1
 #panic = 'abort'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ resources = ["mac-tray.png"]
 #!!! rembember call "strip target/release/rustdesk"
 # which reduce binary size a lot
 [profile.release]
+debug = true
 #lto = true
 #codegen-units = 1
 #panic = 'abort'

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -269,7 +269,7 @@ message FileResponse {
 message FileTransferDigest {
   int32 id = 1;
   sint32 file_num = 2;
-  uint64 last_edit_timestamp = 3;
+  uint64 last_modified = 3;
   uint64 file_size = 4;
   bool is_upload = 5;
 }

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -244,13 +244,13 @@ message FileAction {
   oneof union {
     ReadDir read_dir = 1;
     FileTransferSendRequest send = 2;
-    FileTransferSendConfirmRequest send_confirm = 9;
     FileTransferReceiveRequest receive = 3;
     FileDirCreate create = 4;
     FileRemoveDir remove_dir = 5;
     FileRemoveFile remove_file = 6;
     ReadAllFiles all_files = 7;
     FileTransferCancel cancel = 8;
+    FileTransferSendConfirmRequest send_confirm = 9;
   }
 }
 
@@ -271,6 +271,7 @@ message FileTransferDigest {
   sint32 file_num = 2;
   uint64 last_edit_timestamp = 3;
   uint64 file_size = 4;
+  bool is_upload = 5;
 }
 
 message FileTransferBlock {

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -244,6 +244,7 @@ message FileAction {
   oneof union {
     ReadDir read_dir = 1;
     FileTransferSendRequest send = 2;
+    FileTransferSendConfirmRequest send_confirm = 9;
     FileTransferReceiveRequest receive = 3;
     FileDirCreate create = 4;
     FileRemoveDir remove_dir = 5;
@@ -261,7 +262,15 @@ message FileResponse {
     FileTransferBlock block = 2;
     FileTransferError error = 3;
     FileTransferDone done = 4;
+    FileTransferDigest digest = 5;
   }
+}
+
+message FileTransferDigest {
+  int32 id = 1;
+  sint32 file_num = 2;
+  uint64 last_edit_timestamp = 3;
+  uint64 file_size = 4;
 }
 
 message FileTransferBlock {
@@ -269,6 +278,7 @@ message FileTransferBlock {
   sint32 file_num = 2;
   bytes data = 3;
   bool compressed = 4;
+  uint32 blk_id = 5;
 }
 
 message FileTransferError {
@@ -281,6 +291,15 @@ message FileTransferSendRequest {
   int32 id = 1;
   string path = 2;
   bool include_hidden = 3;
+}
+
+message FileTransferSendConfirmRequest {
+  int32 id = 1;
+  sint32 file_num = 2;
+  oneof union {
+    bool skip = 3;
+    uint32 offset_blk = 4;
+  }
 }
 
 message FileTransferDone {

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -455,8 +455,7 @@ impl TransferJob {
             file_num: self.file_num,
             last_edit_timestamp: last_modified,
             file_size: meta.len(),
-            unknown_fields: Default::default(),
-            cached_size: Default::default(),
+            ..Default::default()
         });
         msg.set_file_response(resp);
         stream.send(&msg).await?;

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -192,7 +192,7 @@ pub fn is_file_exists(file_path: &str) -> bool {
 }
 
 pub fn can_enable_overwrite_detection(version: i64) -> bool {
-    version >= get_version_number("1.1.9")
+    version >= get_version_number("1.2.0")
 }
 
 #[derive(Default)]

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -191,6 +191,7 @@ pub fn is_file_exists(file_path: &str) -> bool {
     return Path::new(file_path).exists();
 }
 
+#[inline]
 pub fn can_enable_overwrite_detection(version: i64) -> bool {
     version >= get_version_number("1.2.0")
 }
@@ -525,14 +526,14 @@ impl TransferJob {
             match r.union {
                 Some(file_transfer_send_confirm_request::Union::skip(s)) => {
                     if s {
-                        log::info!("skip file id:{}, file_num:{}", r.id, r.file_num);
+                        log::debug!("skip file id:{}, file_num:{}", r.id, r.file_num);
                         self.skip_current_file();
                     } else {
                         self.set_file_confirmed(true);
                     }
                 }
                 Some(file_transfer_send_confirm_request::Union::offset_blk(offset)) => {
-                    log::info!("file confirmed");
+                    log::debug!("file confirmed");
                     self.set_file_confirmed(true);
                 }
                 _ => {}
@@ -701,11 +702,17 @@ pub fn create_dir(dir: &str) -> ResultType<()> {
     Ok(())
 }
 
+pub enum DigestCheckResult {
+    IsSame,
+    NeedConfirm(FileTransferDigest),
+    NoSuchFile,
+}
+
 #[inline]
 pub fn is_write_need_confirmation(
     file_path: &str,
     digest: &FileTransferDigest,
-) -> ResultType<Option<FileTransferDigest>> {
+) -> ResultType<DigestCheckResult> {
     let path = Path::new(file_path);
     if path.exists() && path.is_file() {
         let metadata = std::fs::metadata(path)?;
@@ -721,9 +728,9 @@ pub fn is_write_need_confirmation(
             metadata.len()
         );
         if remote_mt == local_mt && digest.file_size == metadata.len() {
-            return Ok(None);
+            return Ok(DigestCheckResult::IsSame);
         }
-        Ok(Some(FileTransferDigest {
+        Ok(DigestCheckResult::NeedConfirm(FileTransferDigest {
             id: digest.id,
             file_num: digest.file_num,
             last_edit_timestamp: local_mt.as_secs(),
@@ -731,6 +738,6 @@ pub fn is_write_need_confirmation(
             ..Default::default()
         }))
     } else {
-        Ok(None)
+        Ok(DigestCheckResult::NoSuchFile)
     }
 }

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -5,7 +5,6 @@ use crate::{
     compress::{compress, decompress},
     config::{Config, COMPRESS_LEVEL},
 };
-use log::log;
 #[cfg(windows)]
 use std::os::windows::prelude::*;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -472,7 +471,7 @@ impl TransferJob {
         resp.set_digest(FileTransferDigest {
             id: self.id,
             file_num: self.file_num,
-            last_edit_timestamp: last_modified,
+            last_modified,
             file_size: meta.len(),
             ..Default::default()
         });
@@ -646,7 +645,6 @@ pub async fn handle_read_jobs(
 ) -> ResultType<()> {
     let mut finished = Vec::new();
     for job in jobs.iter_mut() {
-        // println!("[fs.rs:588] handle_read_jobs. {:?}", job.id);
         match job.read(stream).await {
             Err(err) => {
                 stream
@@ -662,7 +660,7 @@ pub async fn handle_read_jobs(
                     finished.push(job.id());
                     stream.send(&new_done(job.id(), job.file_num())).await?;
                 } else {
-                    log::info!("waiting confirmation.");
+                    // waiting confirmation.
                 }
             }
         }
@@ -717,23 +715,15 @@ pub fn is_write_need_confirmation(
     if path.exists() && path.is_file() {
         let metadata = std::fs::metadata(path)?;
         let modified_time = metadata.modified()?;
-        let remote_mt = Duration::from_secs(digest.last_edit_timestamp);
+        let remote_mt = Duration::from_secs(digest.last_modified);
         let local_mt = modified_time.duration_since(UNIX_EPOCH)?;
-        log::info!(
-            "{:?}:rm:{},lm:{},rf:{},lf:{}",
-            path,
-            remote_mt.as_secs(),
-            local_mt.as_secs(),
-            digest.file_size,
-            metadata.len()
-        );
         if remote_mt == local_mt && digest.file_size == metadata.len() {
             return Ok(DigestCheckResult::IsSame);
         }
         Ok(DigestCheckResult::NeedConfirm(FileTransferDigest {
             id: digest.id,
             file_num: digest.file_num,
-            last_edit_timestamp: local_mt.as_secs(),
+            last_modified: local_mt.as_secs(),
             file_size: metadata.len(),
             ..Default::default()
         }))

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -1,4 +1,4 @@
-use crate::{bail, message_proto::*, ResultType};
+use crate::{bail, message_proto::*, ResultType, Stream};
 use std::path::{Path, PathBuf};
 // https://doc.rust-lang.org/std/os/windows/fs/trait.MetadataExt.html
 use crate::{
@@ -198,6 +198,8 @@ pub struct TransferJob {
     files: Vec<FileEntry>,
     file_num: i32,
     file: Option<File>,
+    file_confirmed: bool,
+    file_is_waiting: bool,
     total_size: u64,
     finished_size: u64,
     transferred: u64,
@@ -360,7 +362,7 @@ impl TransferJob {
         }
     }
 
-    pub async fn read(&mut self) -> ResultType<Option<FileTransferBlock>> {
+    pub async fn read(&mut self, stream: &mut Stream) -> ResultType<Option<FileTransferBlock>> {
         let file_num = self.file_num as usize;
         if file_num >= self.files.len() {
             self.file.take();
@@ -371,12 +373,40 @@ impl TransferJob {
             match File::open(self.join(&name)).await {
                 Ok(file) => {
                     self.file = Some(file);
+                    self.file_confirmed = false;
+                    self.file_is_waiting = false;
                 }
                 Err(err) => {
                     self.file_num += 1;
+                    self.file_confirmed = false;
+                    self.file_is_waiting = false;
                     return Err(err.into());
                 }
             }
+        }
+        if !self.file_confirmed() {
+            if !self.file_is_waiting() {
+                let mut msg = Message::new();
+                let mut resp = FileResponse::new();
+                let meta = self.file.as_ref().unwrap().metadata().await?;
+                let last_modified = meta
+                    .modified()?
+                    .duration_since(SystemTime::UNIX_EPOCH)?
+                    .as_secs();
+                resp.set_digest(FileTransferDigest {
+                    id: self.id,
+                    file_num: self.file_num,
+                    last_edit_timestamp: last_modified,
+                    file_size: meta.len(),
+                    unknown_fields: Default::default(),
+                    cached_size: Default::default(),
+                });
+                self.set_file_is_waiting(true);
+                msg.set_file_response(resp);
+                stream.send(&msg);
+                println!("digest message is sent. waiting for confirm.");
+            }
+            return Ok(None);
         }
         const BUF_SIZE: usize = 128 * 1024;
         let mut buf: Vec<u8> = Vec::with_capacity(BUF_SIZE);
@@ -390,6 +420,8 @@ impl TransferJob {
                 Err(err) => {
                     self.file_num += 1;
                     self.file = None;
+                    self.file_confirmed = false;
+                    self.file_is_waiting = false;
                     return Err(err.into());
                 }
                 Ok(n) => {
@@ -404,6 +436,8 @@ impl TransferJob {
         if offset == 0 {
             self.file_num += 1;
             self.file = None;
+            self.file_confirmed = false;
+            self.file_is_waiting = false;
         } else {
             self.finished_size += offset as u64;
             if !is_compressed_file(name) {
@@ -429,6 +463,30 @@ impl TransferJob {
 
     pub fn default_overwrite_strategy(&self) -> Option<bool> {
         self.default_overwrite_strategy
+    }
+
+    pub fn set_file_confirmed(&mut self, file_confirmed: bool) {
+        self.file_confirmed = file_confirmed;
+    }
+
+    pub fn set_file_is_waiting(&mut self, file_is_waiting: bool) {
+        self.file_is_waiting = file_is_waiting;
+    }
+
+    pub fn file_is_waiting(&self) -> bool {
+        self.file_is_waiting
+    }
+
+    pub fn file_confirmed(&self) -> bool {
+        self.file_confirmed
+    }
+
+    pub fn skip_current_file(&mut self) -> bool {
+        self.file.take();
+        self.set_file_confirmed(false);
+        self.set_file_is_waiting(false);
+        self.file_num += 1;
+        true
     }
 }
 
@@ -526,7 +584,7 @@ pub async fn handle_read_jobs(
 ) -> ResultType<()> {
     let mut finished = Vec::new();
     for job in jobs.iter_mut() {
-        match job.read().await {
+        match job.read(stream).await {
             Err(err) => {
                 stream
                     .send(&new_error(job.id(), err, job.file_num()))
@@ -536,8 +594,10 @@ pub async fn handle_read_jobs(
                 stream.send(&new_block(block)).await?;
             }
             Ok(None) => {
-                finished.push(job.id());
-                stream.send(&new_done(job.id(), job.file_num())).await?;
+                if !job.file_confirmed && !job.file_is_waiting {
+                    finished.push(job.id());
+                    stream.send(&new_done(job.id(), job.file_num())).await?;
+                }
             }
         }
     }

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -198,11 +198,11 @@ pub struct TransferJob {
     files: Vec<FileEntry>,
     file_num: i32,
     file: Option<File>,
-    file_confirmed: bool,
-    file_is_waiting: bool,
     total_size: u64,
     finished_size: u64,
     transferred: u64,
+    file_confirmed: bool,
+    file_is_waiting: bool,
     default_overwrite_strategy: Option<bool>,
 }
 
@@ -315,6 +315,7 @@ impl TransferJob {
     }
 
     pub async fn write(&mut self, block: FileTransferBlock, raw: Option<&[u8]>) -> ResultType<()> {
+        println!("write file transfer blk[{},{}]", block.id, block.file_num);
         if block.id != self.id {
             bail!("Wrong id");
         }
@@ -386,25 +387,8 @@ impl TransferJob {
         }
         if !self.file_confirmed() {
             if !self.file_is_waiting() {
-                let mut msg = Message::new();
-                let mut resp = FileResponse::new();
-                let meta = self.file.as_ref().unwrap().metadata().await?;
-                let last_modified = meta
-                    .modified()?
-                    .duration_since(SystemTime::UNIX_EPOCH)?
-                    .as_secs();
-                resp.set_digest(FileTransferDigest {
-                    id: self.id,
-                    file_num: self.file_num,
-                    last_edit_timestamp: last_modified,
-                    file_size: meta.len(),
-                    unknown_fields: Default::default(),
-                    cached_size: Default::default(),
-                });
+                self.send_current_digest(stream).await?;
                 self.set_file_is_waiting(true);
-                msg.set_file_response(resp);
-                stream.send(&msg);
-                println!("digest message is sent. waiting for confirm.");
             }
             return Ok(None);
         }
@@ -457,6 +441,32 @@ impl TransferJob {
             ..Default::default()
         }))
     }
+
+    async fn send_current_digest(&mut self, stream: &mut Stream) -> ResultType<()> {
+        let mut msg = Message::new();
+        let mut resp = FileResponse::new();
+        let meta = self.file.as_ref().unwrap().metadata().await?;
+        let last_modified = meta
+            .modified()?
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_secs();
+        resp.set_digest(FileTransferDigest {
+            id: self.id,
+            file_num: self.file_num,
+            last_edit_timestamp: last_modified,
+            file_size: meta.len(),
+            unknown_fields: Default::default(),
+            cached_size: Default::default(),
+        });
+        msg.set_file_response(resp);
+        stream.send(&msg).await?;
+        println!(
+            "id: {}, file_num:{}, digest message is sent. waiting for confirm. msg: {:?}",
+            self.id, self.file_num, msg
+        );
+        Ok(())
+    }
+
     pub fn set_overwrite_strategy(&mut self, overwrite_strategy: Option<bool>) {
         self.default_overwrite_strategy = overwrite_strategy;
     }
@@ -488,6 +498,29 @@ impl TransferJob {
         self.file_num += 1;
         true
     }
+
+    pub fn confirm(&mut self, r: &FileTransferSendConfirmRequest) -> bool {
+        if self.file_num() != r.file_num {
+            log::debug!("file num truncated, ignoring");
+        } else {
+            match r.union {
+                Some(file_transfer_send_confirm_request::Union::skip(s)) => {
+                    if s {
+                        log::debug!("skip current file");
+                        self.skip_current_file();
+                    } else {
+                        self.set_file_confirmed(true);
+                    }
+                }
+                Some(file_transfer_send_confirm_request::Union::offset_blk(offset)) => {
+                    println!("file confirmed");
+                    self.set_file_confirmed(true);
+                }
+                _ => {}
+            }
+        }
+        true
+    }
 }
 
 #[inline]
@@ -506,6 +539,7 @@ pub fn new_error<T: std::string::ToString>(id: i32, err: T, file_num: i32) -> Me
 
 #[inline]
 pub fn new_dir(id: i32, files: Vec<FileEntry>) -> Message {
+    println!("[fs.rs:510] create new dir");
     let mut resp = FileResponse::new();
     resp.set_dir(FileDirectory {
         id,
@@ -584,6 +618,7 @@ pub async fn handle_read_jobs(
 ) -> ResultType<()> {
     let mut finished = Vec::new();
     for job in jobs.iter_mut() {
+        // println!("[fs.rs:588] handle_read_jobs. {:?}", job.id);
         match job.read(stream).await {
             Err(err) => {
                 stream
@@ -597,6 +632,8 @@ pub async fn handle_read_jobs(
                 if !job.file_confirmed && !job.file_is_waiting {
                     finished.push(job.id());
                     stream.send(&new_done(job.id(), job.file_num())).await?;
+                } else {
+                    log::info!("waiting confirmation.");
                 }
             }
         }
@@ -645,8 +682,16 @@ pub fn is_write_need_confirmation(
     if path.exists() && path.is_file() {
         let metadata = std::fs::metadata(path)?;
         let modified_time = metadata.modified()?;
-        let remote_mt = Duration::from_millis(digest.last_edit_timestamp);
+        let remote_mt = Duration::from_secs(digest.last_edit_timestamp);
         let local_mt = modified_time.duration_since(UNIX_EPOCH)?;
+        println!(
+            "{:?}:rm:{},lm:{},rf:{},lf:{}",
+            path,
+            remote_mt.as_secs(),
+            local_mt.as_secs(),
+            digest.file_size,
+            metadata.len()
+        );
         // if
         // is_recv && remote_mt >= local_mt) || (!is_recv && remote_mt <= local_mt) ||
         if remote_mt == local_mt && digest.file_size == metadata.len() {

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -1,4 +1,4 @@
-use crate::{bail, message_proto::*, ResultType, Stream};
+use crate::{bail, get_version_number, message_proto::*, ResultType, Stream};
 use std::path::{Path, PathBuf};
 // https://doc.rust-lang.org/std/os/windows/fs/trait.MetadataExt.html
 use crate::{
@@ -191,6 +191,10 @@ pub fn is_file_exists(file_path: &str) -> bool {
     return Path::new(file_path).exists();
 }
 
+pub fn can_enable_overwrite_detection(version: i64) -> bool {
+    version >= get_version_number("1.1.9")
+}
+
 #[derive(Default)]
 pub struct TransferJob {
     id: i32,
@@ -201,6 +205,7 @@ pub struct TransferJob {
     total_size: u64,
     finished_size: u64,
     transferred: u64,
+    enable_overwrite_detection: bool,
     file_confirmed: bool,
     file_is_waiting: bool,
     default_overwrite_strategy: Option<bool>,
@@ -229,20 +234,31 @@ fn is_compressed_file(name: &str) -> bool {
 }
 
 impl TransferJob {
-    pub fn new_write(id: i32, path: String, files: Vec<FileEntry>) -> Self {
-        println!("new write {}", path);
+    pub fn new_write(
+        id: i32,
+        path: String,
+        files: Vec<FileEntry>,
+        enable_override_detection: bool,
+    ) -> Self {
+        log::info!("new write {}", path);
         let total_size = files.iter().map(|x| x.size as u64).sum();
         Self {
             id,
             path: get_path(&path),
             files,
             total_size,
+            enable_overwrite_detection: enable_override_detection,
             ..Default::default()
         }
     }
 
-    pub fn new_read(id: i32, path: String, include_hidden: bool) -> ResultType<Self> {
-        println!("new read {}", path);
+    pub fn new_read(
+        id: i32,
+        path: String,
+        include_hidden: bool,
+        enable_override_detection: bool,
+    ) -> ResultType<Self> {
+        log::info!("new read {}", path);
         let files = get_recursive_files(&path, include_hidden)?;
         let total_size = files.iter().map(|x| x.size as u64).sum();
         Ok(Self {
@@ -250,6 +266,7 @@ impl TransferJob {
             path: get_path(&path),
             files,
             total_size,
+            enable_overwrite_detection: enable_override_detection,
             ..Default::default()
         })
     }
@@ -315,7 +332,6 @@ impl TransferJob {
     }
 
     pub async fn write(&mut self, block: FileTransferBlock, raw: Option<&[u8]>) -> ResultType<()> {
-        println!("write file transfer blk[{},{}]", block.id, block.file_num);
         if block.id != self.id {
             bail!("Wrong id");
         }
@@ -385,12 +401,14 @@ impl TransferJob {
                 }
             }
         }
-        if !self.file_confirmed() {
-            if !self.file_is_waiting() {
-                self.send_current_digest(stream).await?;
-                self.set_file_is_waiting(true);
+        if self.enable_overwrite_detection {
+            if !self.file_confirmed() {
+                if !self.file_is_waiting() {
+                    self.send_current_digest(stream).await?;
+                    self.set_file_is_waiting(true);
+                }
+                return Ok(None);
             }
-            return Ok(None);
         }
         const BUF_SIZE: usize = 128 * 1024;
         let mut buf: Vec<u8> = Vec::with_capacity(BUF_SIZE);
@@ -459,9 +477,11 @@ impl TransferJob {
         });
         msg.set_file_response(resp);
         stream.send(&msg).await?;
-        println!(
+        log::info!(
             "id: {}, file_num:{}, digest message is sent. waiting for confirm. msg: {:?}",
-            self.id, self.file_num, msg
+            self.id,
+            self.file_num,
+            msg
         );
         Ok(())
     }
@@ -500,19 +520,19 @@ impl TransferJob {
 
     pub fn confirm(&mut self, r: &FileTransferSendConfirmRequest) -> bool {
         if self.file_num() != r.file_num {
-            log::debug!("file num truncated, ignoring");
+            log::info!("file num truncated, ignoring");
         } else {
             match r.union {
                 Some(file_transfer_send_confirm_request::Union::skip(s)) => {
                     if s {
-                        println!("skip current file");
+                        log::info!("skip file id:{}, file_num:{}", r.id, r.file_num);
                         self.skip_current_file();
                     } else {
                         self.set_file_confirmed(true);
                     }
                 }
                 Some(file_transfer_send_confirm_request::Union::offset_blk(offset)) => {
-                    println!("file confirmed");
+                    log::info!("file confirmed");
                     self.set_file_confirmed(true);
                 }
                 _ => {}
@@ -538,7 +558,6 @@ pub fn new_error<T: std::string::ToString>(id: i32, err: T, file_num: i32) -> Me
 
 #[inline]
 pub fn new_dir(id: i32, files: Vec<FileEntry>) -> Message {
-    println!("[fs.rs:510] create new dir");
     let mut resp = FileResponse::new();
     resp.set_dir(FileDirectory {
         id,
@@ -584,7 +603,7 @@ pub fn new_receive(id: i32, path: String, files: Vec<FileEntry>) -> Message {
 
 #[inline]
 pub fn new_send(id: i32, path: String, include_hidden: bool) -> Message {
-    println!("new send: {},id : {}", path, id);
+    log::info!("new send: {},id : {}", path, id);
     let mut action = FileAction::new();
     action.set_send(FileTransferSendRequest {
         id,
@@ -637,7 +656,8 @@ pub async fn handle_read_jobs(
                 stream.send(&new_block(block)).await?;
             }
             Ok(None) => {
-                if !job.file_confirmed && !job.file_is_waiting {
+                if !job.enable_overwrite_detection || (!job.file_confirmed && !job.file_is_waiting)
+                {
                     finished.push(job.id());
                     stream.send(&new_done(job.id(), job.file_num())).await?;
                 } else {

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -506,7 +506,7 @@ impl TransferJob {
             match r.union {
                 Some(file_transfer_send_confirm_request::Union::skip(s)) => {
                     if s {
-                        log::debug!("skip current file");
+                        println!("skip current file");
                         self.skip_current_file();
                     } else {
                         self.set_file_confirmed(true);
@@ -557,6 +557,15 @@ pub fn new_block(block: FileTransferBlock) -> Message {
     resp.set_block(block);
     let mut msg_out = Message::new();
     msg_out.set_file_response(resp);
+    msg_out
+}
+
+#[inline]
+pub fn new_send_confirm(r: FileTransferSendConfirmRequest) -> Message {
+    let mut msg_out = Message::new();
+    let mut action = FileAction::new();
+    action.set_send_confirm(r);
+    msg_out.set_file_action(action);
     msg_out
 }
 
@@ -677,14 +686,14 @@ pub fn create_dir(dir: &str) -> ResultType<()> {
 pub fn is_write_need_confirmation(
     file_path: &str,
     digest: &FileTransferDigest,
-) -> ResultType<bool> {
+) -> ResultType<Option<FileTransferDigest>> {
     let path = Path::new(file_path);
     if path.exists() && path.is_file() {
         let metadata = std::fs::metadata(path)?;
         let modified_time = metadata.modified()?;
         let remote_mt = Duration::from_secs(digest.last_edit_timestamp);
         let local_mt = modified_time.duration_since(UNIX_EPOCH)?;
-        println!(
+        log::info!(
             "{:?}:rm:{},lm:{},rf:{},lf:{}",
             path,
             remote_mt.as_secs(),
@@ -692,15 +701,17 @@ pub fn is_write_need_confirmation(
             digest.file_size,
             metadata.len()
         );
-        // if
-        // is_recv && remote_mt >= local_mt) || (!is_recv && remote_mt <= local_mt) ||
         if remote_mt == local_mt && digest.file_size == metadata.len() {
-            // I'm recving or sending an newer modified file!
-            // or a
-            return Ok(false);
+            return Ok(None);
         }
-        Ok(true)
+        Ok(Some(FileTransferDigest {
+            id: digest.id,
+            file_num: digest.file_num,
+            last_edit_timestamp: local_mt.as_secs(),
+            file_size: metadata.len(),
+            ..Default::default()
+        }))
     } else {
-        Ok(false)
+        Ok(None)
     }
 }

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -5,8 +5,10 @@ use crate::{
     compress::{compress, decompress},
     config::{Config, COMPRESS_LEVEL},
 };
+use log::log;
 #[cfg(windows)]
 use std::os::windows::prelude::*;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::{fs::File, io::*};
 
 pub fn read_dir(path: &PathBuf, include_hidden: bool) -> ResultType<FileDirectory> {
@@ -184,6 +186,11 @@ pub fn get_recursive_files(path: &str, include_hidden: bool) -> ResultType<Vec<F
     read_dir_recursive(&get_path(path), &get_path(""), include_hidden)
 }
 
+#[inline]
+pub fn is_file_exists(file_path: &str) -> bool {
+    return Path::new(file_path).exists();
+}
+
 #[derive(Default)]
 pub struct TransferJob {
     id: i32,
@@ -194,6 +201,7 @@ pub struct TransferJob {
     total_size: u64,
     finished_size: u64,
     transferred: u64,
+    default_overwrite_strategy: Option<bool>,
 }
 
 #[inline]
@@ -220,6 +228,7 @@ fn is_compressed_file(name: &str) -> bool {
 
 impl TransferJob {
     pub fn new_write(id: i32, path: String, files: Vec<FileEntry>) -> Self {
+        println!("new write {}", path);
         let total_size = files.iter().map(|x| x.size as u64).sum();
         Self {
             id,
@@ -231,6 +240,7 @@ impl TransferJob {
     }
 
     pub fn new_read(id: i32, path: String, include_hidden: bool) -> ResultType<Self> {
+        println!("new read {}", path);
         let files = get_recursive_files(&path, include_hidden)?;
         let total_size = files.iter().map(|x| x.size as u64).sum();
         Ok(Self {
@@ -342,7 +352,7 @@ impl TransferJob {
     }
 
     #[inline]
-    fn join(&self, name: &str) -> PathBuf {
+    pub fn join(&self, name: &str) -> PathBuf {
         if name.is_empty() {
             self.path.clone()
         } else {
@@ -413,6 +423,13 @@ impl TransferJob {
             ..Default::default()
         }))
     }
+    pub fn set_overwrite_strategy(&mut self, overwrite_strategy: Option<bool>) {
+        self.default_overwrite_strategy = overwrite_strategy;
+    }
+
+    pub fn default_overwrite_strategy(&self) -> Option<bool> {
+        self.default_overwrite_strategy
+    }
 }
 
 #[inline]
@@ -467,6 +484,7 @@ pub fn new_receive(id: i32, path: String, files: Vec<FileEntry>) -> Message {
 
 #[inline]
 pub fn new_send(id: i32, path: String, include_hidden: bool) -> Message {
+    println!("new send: {},id : {}", path, id);
     let mut action = FileAction::new();
     action.set_send(FileTransferSendRequest {
         id,
@@ -556,4 +574,28 @@ pub fn remove_file(file: &str) -> ResultType<()> {
 pub fn create_dir(dir: &str) -> ResultType<()> {
     std::fs::create_dir_all(get_path(dir))?;
     Ok(())
+}
+
+#[inline]
+pub fn is_write_need_confirmation(
+    file_path: &str,
+    digest: &FileTransferDigest,
+) -> ResultType<bool> {
+    let path = Path::new(file_path);
+    if path.exists() && path.is_file() {
+        let metadata = std::fs::metadata(path)?;
+        let modified_time = metadata.modified()?;
+        let remote_mt = Duration::from_millis(digest.last_edit_timestamp);
+        let local_mt = modified_time.duration_since(UNIX_EPOCH)?;
+        // if
+        // is_recv && remote_mt >= local_mt) || (!is_recv && remote_mt <= local_mt) ||
+        if remote_mt == local_mt && digest.file_size == metadata.len() {
+            // I'm recving or sending an newer modified file!
+            // or a
+            return Ok(false);
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -505,14 +505,14 @@ impl AudioHandler {
         use hbb_common::config::APP_NAME;
 
         self.simple = Some(Simple::new(
-            None,                   // Use the default server
-            APP_NAME,               // Our application’s name
-            Direction::Playback,    // We want a playback stream
-            None,                   // Use the default device
-            "playback",             // Description of our stream
-            &spec,                  // Our sample format
-            None,                   // Use default channel map
-            None,                   // Use default buffering attributes
+            None,                // Use the default server
+            APP_NAME,            // Our application’s name
+            Direction::Playback, // We want a playback stream
+            None,                // Use the default device
+            "playback",          // Description of our stream
+            &spec,               // Our sample format
+            None,                // Use default channel map
+            None,                // Use default buffering attributes
         )?);
         self.sample_rate = (format0.sample_rate, format0.sample_rate);
         Ok(())
@@ -1204,7 +1204,7 @@ pub enum Data {
     AddPortForward((i32, String, i32)),
     ToggleClipboardFile,
     NewRDP,
-    SetConfirmOverrideFile((i32, i32, bool, bool)),
+    SetConfirmOverrideFile((i32, i32, bool, bool, bool)),
 }
 
 #[derive(Clone)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -322,7 +322,11 @@ impl Client {
         Ok((conn, direct))
     }
 
-    async fn secure_connection(peer_id: &str, signed_id_pk: Vec<u8>, conn: &mut Stream) -> ResultType<()> {
+    async fn secure_connection(
+        peer_id: &str,
+        signed_id_pk: Vec<u8>,
+        conn: &mut Stream,
+    ) -> ResultType<()> {
         let rs_pk = get_rs_pk("OeVuKk5nlHiXp+APNn0Y3pC1Iwpwn44JGqrQCsWqmBw=");
         let mut sign_pk = None;
         if !signed_id_pk.is_empty() && rs_pk.is_some() {
@@ -1200,6 +1204,8 @@ pub enum Data {
     AddPortForward((i32, String, i32)),
     ToggleClipboardFile,
     NewRDP,
+    // ConfirmOverrideFile((i32, String, String, bool, bool)),
+    SetConfirmOverrideFile((i32, i32, bool, bool)),
 }
 
 #[derive(Clone)]
@@ -1207,6 +1213,12 @@ pub enum Key {
     ControlKey(ControlKey),
     Chr(u32),
     _Raw(u32),
+}
+
+#[derive(Clone)]
+pub enum OverrideStrategy {
+    Skip,
+    Overwrite,
 }
 
 lazy_static::lazy_static! {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1204,7 +1204,6 @@ pub enum Data {
     AddPortForward((i32, String, i32)),
     ToggleClipboardFile,
     NewRDP,
-    // ConfirmOverrideFile((i32, String, String, bool, bool)),
     SetConfirmOverrideFile((i32, i32, bool, bool)),
 }
 
@@ -1213,12 +1212,6 @@ pub enum Key {
     ControlKey(ControlKey),
     Chr(u32),
     _Raw(u32),
-}
-
-#[derive(Clone)]
-pub enum OverrideStrategy {
-    Skip,
-    Overwrite,
 }
 
 lazy_static::lazy_static! {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -63,6 +63,7 @@ pub enum FS {
         file_num: i32,
         file_size: u64,
         modified_time: u64,
+        is_upload: bool,
     },
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -62,7 +62,7 @@ pub enum FS {
         id: i32,
         file_num: i32,
         file_size: u64,
-        modified_time: u64,
+        last_modified: u64,
         is_upload: bool,
     },
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -58,6 +58,12 @@ pub enum FS {
         id: i32,
         file_num: i32,
     },
+    CheckDigest {
+        id: i32,
+        file_num: i32,
+        file_size: u64,
+        modified_time: u64,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -266,5 +266,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_start_service_tip", "点击 [启动服务] 或打开 [屏幕录制] 权限开启手机屏幕共享服务。"),
         ("Account", "账号"),
         ("Quit", "退出"),
+        ("Overwrite", "覆盖"),
+        ("This file exists, skip or overwrite this file?", "这个文件/文件夹已存在，跳过/覆盖?")
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -266,5 +266,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_start_service_tip", "Коснитесь [Запуск промежуточного сервера] или ОТКРЫТЬ разрешение [Скриншот], чтобы запустить службу демонстрации экрана."),
         ("Account", "Аккаунт"),
         ("Quit", "Выйти"),
+        ("Overwrite", "крышка"),
+        ("This file exists, skip or overwrite this file?", "Этот файл существует, пропустить или перезаписать этот файл?")
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -265,5 +265,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_version_audio_tip", ""),
         ("android_start_service_tip", ""),
         ("Account", ""),
+        ("Overwrite", ""),
+        ("This file exists, skip or overwrite this file?", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -266,5 +266,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_start_service_tip", "點擊 [啟動服務] 或打開 [屏幕錄製] 權限開啟手機屏幕共享服務。"),
         ("Account", "帳戶"),
         ("Quit", "退出"),
+        ("Overwrite", "覆蓋"),
+        ("This file exists, skip or overwrite this file?", "這個文件/文件夾已存在，跳過/覆蓋？")
     ].iter().cloned().collect();
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1020,7 +1020,9 @@ impl Connection {
         if let Ok(q) = o.enable_file_transfer.enum_value() {
             if q != BoolOption::NotSet {
                 self.enable_file_transfer = q == BoolOption::Yes;
-                self.send_to_cm(ipc::Data::ClipboardFileEnabled(self.file_transfer_enabled()));
+                self.send_to_cm(ipc::Data::ClipboardFileEnabled(
+                    self.file_transfer_enabled(),
+                ));
             }
         }
         if let Ok(q) = o.disable_clipboard.enum_value() {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -861,7 +861,7 @@ impl Connection {
                     }
                 }
                 Some(message::Union::file_action(fa)) => {
-                    println!("recv file_action, {:?}", fa);
+                    log::info!("recv file_action, {:?}", fa);
                     if self.file_transfer.is_some() {
                         match fa.union {
                             Some(file_action::Union::read_dir(rd)) => {
@@ -891,7 +891,6 @@ impl Connection {
                                 }
                             }
                             Some(file_action::Union::receive(r)) => {
-                                println!("[connection.rs:891] recv FileTransferReceiveRequest");
                                 self.send_fs(ipc::FS::NewWrite {
                                     path: r.path,
                                     id: r.id,
@@ -928,7 +927,6 @@ impl Connection {
                                 fs::remove_job(c.id, &mut self.read_jobs);
                             }
                             Some(file_action::Union::send_confirm(r)) => {
-                                println!("recv send confirm request");
                                 if let Some(job) = fs::get_job(r.id, &mut self.read_jobs) {
                                     job.confirm(&r);
                                 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -255,7 +255,7 @@ impl Connection {
                             }
                         }
                         ipc::Data::RawMessage(bytes) => {
-                            conn.stream.send_raw(bytes).await;
+                            allow_err!(conn.stream.send_raw(bytes).await);
                         }
                         ipc::Data::ClipbaordFile(_clip) => {
                             if conn.file_transfer_enabled() {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -955,6 +955,7 @@ impl Connection {
                         file_num: d.file_num,
                         file_size: d.file_size,
                         modified_time: d.last_edit_timestamp,
+                        is_upload: true,
                     }),
                     _ => {}
                 },

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2,6 +2,7 @@ use super::{input_service::*, *};
 #[cfg(windows)]
 use crate::clipboard_file::*;
 use crate::{common::update_clipboard, ipc};
+use hbb_common::message_proto::file_transfer_send_confirm_request::Union;
 use hbb_common::{
     config::Config,
     fs,
@@ -920,6 +921,10 @@ impl Connection {
                             Some(file_action::Union::cancel(c)) => {
                                 self.send_fs(ipc::FS::CancelWrite { id: c.id });
                                 fs::remove_job(c.id, &mut self.read_jobs);
+                            }
+                            Some(file_action::Union::send_confirm(r)) => {
+                                //
+                                println!("recv send confirm request");
                             }
                             _ => {}
                         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -862,7 +862,6 @@ impl Connection {
                     }
                 }
                 Some(message::Union::file_action(fa)) => {
-                    log::info!("recv file_action, {:?}", fa);
                     if self.file_transfer.is_some() {
                         match fa.union {
                             Some(file_action::Union::read_dir(rd)) => {
@@ -957,7 +956,7 @@ impl Connection {
                         id: d.id,
                         file_num: d.file_num,
                         file_size: d.file_size,
-                        modified_time: d.last_edit_timestamp,
+                        last_modified: d.last_modified,
                         is_upload: true,
                     }),
                     _ => {}

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -6,6 +6,7 @@ use clipboard::{
 };
 use hbb_common::fs::{
     can_enable_overwrite_detection, get_string, is_write_need_confirmation, new_send_confirm,
+    DigestCheckResult,
 };
 use hbb_common::log::log;
 use hbb_common::{
@@ -192,23 +193,29 @@ impl ConnectionManager {
                         if let Some(file) = job.files().get(file_num as usize) {
                             let path = get_string(&job.join(&file.name));
                             match is_write_need_confirmation(&path, &digest) {
-                                Ok(digest) => {
-                                    if let Some(mut digest) = digest {
-                                        // upload to server, but server has the same file, request
-                                        digest.is_upload = is_upload;
-                                        log::info!(
+                                Ok(digest_result) => {
+                                    match digest_result {
+                                        DigestCheckResult::IsSame => {
+                                            req.set_skip(true);
+                                            let msg_out = new_send_confirm(req);
+                                            Self::send(msg_out, conn).await;
+                                        }
+                                        DigestCheckResult::NeedConfirm(mut digest) => {
+                                            // upload to server, but server has the same file, request
+                                            digest.is_upload = is_upload;
+                                            log::info!(
                                             "server has the same file, send server digest to local"
                                         );
-                                        let mut msg_out = Message::new();
-                                        let mut fr = FileResponse::new();
-                                        fr.set_digest(digest);
-                                        msg_out.set_file_response(fr);
-                                        Self::send(msg_out, conn).await;
-                                    } else {
-                                        log::info!("skip job {}, file_num {}", id, file_num);
-                                        req.set_skip(true);
-                                        let msg_out = new_send_confirm(req);
-                                        Self::send(msg_out, conn).await;
+                                            let mut msg_out = Message::new();
+                                            let mut fr = FileResponse::new();
+                                            fr.set_digest(digest);
+                                            msg_out.set_file_response(fr);
+                                            Self::send(msg_out, conn).await;
+                                        }
+                                        DigestCheckResult::NoSuchFile => {
+                                            let msg_out = new_send_confirm(req);
+                                            Self::send(msg_out, conn).await;
+                                        }
                                     }
                                 }
                                 Err(err) => {

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -170,6 +170,7 @@ impl ConnectionManager {
                     file_num,
                     file_size,
                     modified_time,
+                    is_upload,
                 } => {
                     if let Some(job) = fs::get_job(id, write_jobs) {
                         let mut req = FileTransferSendConfirmRequest {
@@ -189,20 +190,21 @@ impl ConnectionManager {
                             let path = get_string(&job.join(&file.name));
                             match is_write_need_confirmation(&path, &digest) {
                                 Ok(digest) => {
-                                    if digest.is_none() {
-                                        log::info!("skip job {}, file_num {}", id, file_num);
-                                        req.set_skip(true);
-                                        let msg_out = new_send_confirm(req);
-                                        Self::send(msg_out, conn).await;
-                                    } else {
+                                    if let Some(mut digest) = digest {
                                         // upload to server, but server has the same file, request
+                                        digest.is_upload = is_upload;
                                         println!(
                                             "server has the same file, send server digest to local"
                                         );
                                         let mut msg_out = Message::new();
                                         let mut fr = FileResponse::new();
-                                        fr.set_digest(digest.unwrap());
+                                        fr.set_digest(digest);
                                         msg_out.set_file_response(fr);
+                                        Self::send(msg_out, conn).await;
+                                    } else {
+                                        log::info!("skip job {}, file_num {}", id, file_num);
+                                        req.set_skip(true);
+                                        let msg_out = new_send_confirm(req);
                                         Self::send(msg_out, conn).await;
                                     }
                                 }

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -1,14 +1,17 @@
 use crate::ipc::{self, new_listener, Connection, Data};
+use crate::VERSION;
 #[cfg(windows)]
 use clipboard::{
     create_cliprdr_context, empty_clipboard, get_rx_clip_client, server_clip_file, set_conn_enabled,
 };
-use hbb_common::fs::{get_string, is_write_need_confirmation, new_send_confirm};
+use hbb_common::fs::{
+    can_enable_overwrite_detection, get_string, is_write_need_confirmation, new_send_confirm,
+};
 use hbb_common::log::log;
 use hbb_common::{
     allow_err,
     config::{Config, ICON},
-    fs, log,
+    fs, get_version_number, log,
     message_proto::*,
     protobuf::Message as _,
     tokio::{self, sync::mpsc, task::spawn_blocking},
@@ -137,6 +140,7 @@ impl ConnectionManager {
                     id,
                     mut files,
                 } => {
+                    let od = can_enable_overwrite_detection(get_version_number(VERSION));
                     write_jobs.push(fs::TransferJob::new_write(
                         id,
                         path,
@@ -148,6 +152,7 @@ impl ConnectionManager {
                                 ..Default::default()
                             })
                             .collect(),
+                        od,
                     ));
                 }
                 ipc::FS::CancelWrite { id } => {
@@ -191,7 +196,7 @@ impl ConnectionManager {
                                     if let Some(mut digest) = digest {
                                         // upload to server, but server has the same file, request
                                         digest.is_upload = is_upload;
-                                        println!(
+                                        log::info!(
                                             "server has the same file, send server digest to local"
                                         );
                                         let mut msg_out = Message::new();

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -117,7 +117,6 @@ impl ConnectionManager {
                     dir,
                     include_hidden,
                 } => {
-                    // println!("[cm.rs:126] ipc::FS::ReadDir recved");
                     Self::read_dir(&dir, include_hidden, conn).await;
                 }
                 ipc::FS::RemoveDir {
@@ -138,7 +137,6 @@ impl ConnectionManager {
                     id,
                     mut files,
                 } => {
-                    println!("new write in ipc::FS::NewWrite");
                     write_jobs.push(fs::TransferJob::new_write(
                         id,
                         path,
@@ -274,7 +272,6 @@ impl ConnectionManager {
             let mut file_response = FileResponse::new();
             file_response.set_dir(fd);
             msg_out.set_file_response(file_response);
-            // println!("[cm.rs:229] set dir");
             Self::send(msg_out, conn).await;
         }
     }
@@ -337,7 +334,6 @@ impl ConnectionManager {
     }
 
     async fn send(msg: Message, conn: &mut Connection) {
-        println!("send msg: {:?}", msg);
         match msg.write_to_bytes() {
             Ok(bytes) => allow_err!(conn.send(&Data::RawMessage(bytes)).await),
             err => allow_err!(err),

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -173,7 +173,7 @@ impl ConnectionManager {
                     id,
                     file_num,
                     file_size,
-                    modified_time,
+                    last_modified,
                     is_upload,
                 } => {
                     if let Some(job) = fs::get_job(id, write_jobs) {
@@ -186,7 +186,7 @@ impl ConnectionManager {
                         let digest = FileTransferDigest {
                             id,
                             file_num,
-                            last_edit_timestamp: modified_time,
+                            last_modified,
                             file_size,
                             ..Default::default()
                         };
@@ -203,9 +203,6 @@ impl ConnectionManager {
                                         DigestCheckResult::NeedConfirm(mut digest) => {
                                             // upload to server, but server has the same file, request
                                             digest.is_upload = is_upload;
-                                            log::info!(
-                                            "server has the same file, send server digest to local"
-                                        );
                                             let mut msg_out = Message::new();
                                             let mut fr = FileResponse::new();
                                             fr.set_digest(digest);
@@ -346,6 +343,7 @@ impl ConnectionManager {
     }
 
     async fn send(msg: Message, conn: &mut Connection) {
+        println!("send msg: {:?}", msg);
         match msg.write_to_bytes() {
             Ok(bytes) => allow_err!(conn.send(&Data::RawMessage(bytes)).await),
             err => allow_err!(err),

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -114,6 +114,7 @@ impl ConnectionManager {
                     dir,
                     include_hidden,
                 } => {
+                    // println!("[cm.rs:126] ipc::FS::ReadDir recved");
                     Self::read_dir(&dir, include_hidden, conn).await;
                 }
                 ipc::FS::RemoveDir {
@@ -134,6 +135,7 @@ impl ConnectionManager {
                     id,
                     mut files,
                 } => {
+                    println!("new write in ipc::FS::NewWrite");
                     write_jobs.push(fs::TransferJob::new_write(
                         id,
                         path,
@@ -158,6 +160,30 @@ impl ConnectionManager {
                         job.modify_time();
                         Self::send(fs::new_done(id, file_num), conn).await;
                         fs::remove_job(id, write_jobs);
+                    }
+                }
+                ipc::FS::CheckDigest {
+                    id,
+                    file_num,
+                    file_size,
+                    modified_time,
+                } => {
+                    if let Some(job) = fs::get_job(id, write_jobs) {
+                        // TODO
+                        let mut msg_out = Message::new();
+                        let mut file_action = FileAction::new();
+                        file_action.set_send_confirm(FileTransferSendConfirmRequest {
+                            id,
+                            file_num,
+                            union: Some(file_transfer_send_confirm_request::Union::offset_blk(0)),
+                            ..Default::default()
+                        });
+                        msg_out.set_file_action(file_action);
+                        println!(
+                            "[CHECK DIGEST] dig dest recved. confirmed. msg: {:?}",
+                            msg_out
+                        );
+                        Self::send(msg_out, conn).await;
                     }
                 }
                 ipc::FS::WriteBlock {
@@ -219,6 +245,7 @@ impl ConnectionManager {
             let mut file_response = FileResponse::new();
             file_response.set_dir(fd);
             msg_out.set_file_response(file_response);
+            // println!("[cm.rs:229] set dir");
             Self::send(msg_out, conn).await;
         }
     }
@@ -281,6 +308,7 @@ impl ConnectionManager {
     }
 
     async fn send(msg: Message, conn: &mut Connection) {
+        println!("send msg: {:?}", msg);
         match msg.write_to_bytes() {
             Ok(bytes) => allow_err!(conn.send(&Data::RawMessage(bytes)).await),
             err => allow_err!(err),

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -3,6 +3,8 @@ use crate::ipc::{self, new_listener, Connection, Data};
 use clipboard::{
     create_cliprdr_context, empty_clipboard, get_rx_clip_client, server_clip_file, set_conn_enabled,
 };
+use hbb_common::fs::{get_string, is_write_need_confirmation, new_send_confirm};
+use hbb_common::log::log;
 use hbb_common::{
     allow_err,
     config::{Config, ICON},
@@ -10,6 +12,7 @@ use hbb_common::{
     message_proto::*,
     protobuf::Message as _,
     tokio::{self, sync::mpsc, task::spawn_blocking},
+    ResultType,
 };
 use sciter::{make_args, Element, Value, HELEMENT};
 use std::{
@@ -169,21 +172,45 @@ impl ConnectionManager {
                     modified_time,
                 } => {
                     if let Some(job) = fs::get_job(id, write_jobs) {
-                        // TODO
-                        let mut msg_out = Message::new();
-                        let mut file_action = FileAction::new();
-                        file_action.set_send_confirm(FileTransferSendConfirmRequest {
+                        let mut req = FileTransferSendConfirmRequest {
                             id,
                             file_num,
                             union: Some(file_transfer_send_confirm_request::Union::offset_blk(0)),
                             ..Default::default()
-                        });
-                        msg_out.set_file_action(file_action);
-                        println!(
-                            "[CHECK DIGEST] dig dest recved. confirmed. msg: {:?}",
-                            msg_out
-                        );
-                        Self::send(msg_out, conn).await;
+                        };
+                        let digest = FileTransferDigest {
+                            id,
+                            file_num,
+                            last_edit_timestamp: modified_time,
+                            file_size,
+                            ..Default::default()
+                        };
+                        if let Some(file) = job.files().get(file_num as usize) {
+                            let path = get_string(&job.join(&file.name));
+                            match is_write_need_confirmation(&path, &digest) {
+                                Ok(digest) => {
+                                    if digest.is_none() {
+                                        log::info!("skip job {}, file_num {}", id, file_num);
+                                        req.set_skip(true);
+                                        let msg_out = new_send_confirm(req);
+                                        Self::send(msg_out, conn).await;
+                                    } else {
+                                        // upload to server, but server has the same file, request
+                                        println!(
+                                            "server has the same file, send server digest to local"
+                                        );
+                                        let mut msg_out = Message::new();
+                                        let mut fr = FileResponse::new();
+                                        fr.set_digest(digest.unwrap());
+                                        msg_out.set_file_response(fr);
+                                        Self::send(msg_out, conn).await;
+                                    }
+                                }
+                                Err(err) => {
+                                    Self::send(fs::new_error(id, err, file_num), conn).await;
+                                }
+                            }
+                        }
                     }
                 }
                 ipc::FS::WriteBlock {

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -694,7 +694,7 @@ handler.confirmDeleteFiles = function(id, i, name) {
     </div>", function(res=null) {
       if (!res) {
         jt.updateJobStatus(id, i - 1, "cancel");
-        file_transfer.job_table.confirmDeletePolling();
+        file_transfer.job_table.cancelDeletePolling();
       } else if (res.skip) {
         if (res.remember){
           jt.updateJobStatus(id, i, "cancel");

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -717,7 +717,7 @@ handler.confirmDeleteFiles = function(id, i, name) {
     });
 }
 
-handler.overrideFileConfirm = function(id, file_num, to) {
+handler.overrideFileConfirm = function(id, file_num, to, is_upload) {
   var jt = file_transfer.job_table;
   var job = jt.job_map[id];
   stdout.println("job type: " + job.type);
@@ -732,15 +732,15 @@ handler.overrideFileConfirm = function(id, file_num, to) {
         jt.updateJobStatus(id, -1, "cancel");
       } else if (res.skip) {
         if (res.remember){
-          handler.set_write_override(id,file_num,false,true); //
+          handler.set_write_override(id,file_num,false,true, is_upload); //
         } else {
-          handler.set_write_override(id,file_num,false,false); //
+          handler.set_write_override(id,file_num,false,false,is_upload); //
         }
       } else {
         if (res.remember){
-          handler.set_write_override(id,file_num,true,true); //
+          handler.set_write_override(id,file_num,true,true,is_upload); //
         } else {
-          handler.set_write_override(id,file_num,true,false); //
+          handler.set_write_override(id,file_num,true,false,is_upload); //
         }
       }
     });

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -679,6 +679,7 @@ function confirmDelete(id ,path, is_remote) {
 }
 
 handler.confirmDeleteFiles = function(id, i, name) {
+  stdout.println("id=" + id +", i=" +",name="+name);
   var jt = file_transfer.job_table;
   var job = jt.job_map[id];
   if (!job) return;
@@ -712,6 +713,28 @@ handler.confirmDeleteFiles = function(id, i, name) {
       }
       if(i+1 >= n){
         file_transfer.job_table.confirmDeletePolling(job.is_remote);
+      }
+    });
+}
+
+handler.overrideFileConfirm = function(id, file_num, to) {
+  var jt = file_transfer.job_table;
+  var job = jt.job_map[id];
+  stdout.println("job type: " + job.type);
+  stdout.println(id + path + to);
+  stdout.println(JSON.stringify(job));
+  msgbox("custom-skip", "Confirm Write Strategy", "<div .form> \
+        <div>" + translate('Overwrite') + translate('files') + ".</div> \
+        <div>" + translate('This file exists in your computer, skip or overwrite this file?') + "</div> \
+        <div.ellipsis style=\"font-weight: bold;\" .text>" + to + "</div> \
+        <div><button|checkbox(remember) {ts}>" + translate('Do this for all conflicts') + "</button></div> \
+    </div>", function(res=null) {
+      if (!res) {
+        jt.updateJobStatus(id, -1, "cancel");
+      } else if (res.skip) {
+        handler.set_write_override(id,file_num,false,true); //
+      } else {
+        handler.set_write_override(id,file_num,true,false); //
       }
     });
 }

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -721,20 +721,27 @@ handler.overrideFileConfirm = function(id, file_num, to) {
   var jt = file_transfer.job_table;
   var job = jt.job_map[id];
   stdout.println("job type: " + job.type);
-  stdout.println(id + path + to);
   stdout.println(JSON.stringify(job));
   msgbox("custom-skip", "Confirm Write Strategy", "<div .form> \
         <div>" + translate('Overwrite') + translate('files') + ".</div> \
-        <div>" + translate('This file exists in your computer, skip or overwrite this file?') + "</div> \
+        <div>" + translate('This file exists, skip or overwrite this file?') + "</div> \
         <div.ellipsis style=\"font-weight: bold;\" .text>" + to + "</div> \
         <div><button|checkbox(remember) {ts}>" + translate('Do this for all conflicts') + "</button></div> \
     </div>", function(res=null) {
       if (!res) {
         jt.updateJobStatus(id, -1, "cancel");
       } else if (res.skip) {
-        handler.set_write_override(id,file_num,false,true); //
+        if (res.remember){
+          handler.set_write_override(id,file_num,false,true); //
+        } else {
+          handler.set_write_override(id,file_num,false,false); //
+        }
       } else {
-        handler.set_write_override(id,file_num,true,false); //
+        if (res.remember){
+          handler.set_write_override(id,file_num,true,true); //
+        } else {
+          handler.set_write_override(id,file_num,true,false); //
+        }
       }
     });
 }

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -679,7 +679,6 @@ function confirmDelete(id ,path, is_remote) {
 }
 
 handler.confirmDeleteFiles = function(id, i, name) {
-  stdout.println("id=" + id +", i=" +",name="+name);
   var jt = file_transfer.job_table;
   var job = jt.job_map[id];
   if (!job) return;
@@ -695,6 +694,7 @@ handler.confirmDeleteFiles = function(id, i, name) {
     </div>", function(res=null) {
       if (!res) {
         jt.updateJobStatus(id, i - 1, "cancel");
+        file_transfer.job_table.confirmDeletePolling();
       } else if (res.skip) {
         if (res.remember){
           jt.updateJobStatus(id, i, "cancel");
@@ -718,9 +718,6 @@ handler.confirmDeleteFiles = function(id, i, name) {
 
 handler.overrideFileConfirm = function(id, file_num, to, is_upload) {
   var jt = file_transfer.job_table;
-  var job = jt.job_map[id];
-  stdout.println("job type: " + job.type);
-  stdout.println(JSON.stringify(job));
   msgbox("custom-skip", "Confirm Write Strategy", "<div .form> \
         <div>" + translate('Overwrite') + translate('files') + ".</div> \
         <div>" + translate('This file exists, skip or overwrite this file?') + "</div> \

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -695,7 +695,6 @@ handler.confirmDeleteFiles = function(id, i, name) {
     </div>", function(res=null) {
       if (!res) {
         jt.updateJobStatus(id, i - 1, "cancel");
-        file_transfer.job_table.cancelDeletePolling();
       } else if (res.skip) {
         if (res.remember){
           jt.updateJobStatus(id, i, "cancel");
@@ -730,6 +729,7 @@ handler.overrideFileConfirm = function(id, file_num, to, is_upload) {
     </div>", function(res=null) {
       if (!res) {
         jt.updateJobStatus(id, -1, "cancel");
+        handler.cancel_job(id);
       } else if (res.skip) {
         if (res.remember){
           handler.set_write_override(id,file_num,false,true, is_upload); //

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -12,7 +12,7 @@ use clipboard::{
 };
 use enigo::{self, Enigo, KeyboardControllable};
 use hbb_common::fs::{
-    can_enable_overwrite_detection, get_string, is_file_exists, new_send_confirm,
+    can_enable_overwrite_detection, get_string, is_file_exists, new_send_confirm, DigestCheckResult,
 };
 use hbb_common::log::log;
 use hbb_common::{
@@ -1857,104 +1857,141 @@ impl Remote {
                         }
                     }
                 }
-                Some(message::Union::file_response(fr)) => match fr.union {
-                    Some(file_response::Union::dir(fd)) => {
-                        let entries = fd.entries.to_vec();
-                        let mut m = make_fd(fd.id, &entries, fd.id > 0);
-                        if fd.id <= 0 {
-                            m.set_item("path", fd.path);
-                        }
-                        self.handler.call("updateFolderFiles", &make_args!(m));
-                        if let Some(job) = fs::get_job(fd.id, &mut self.write_jobs) {
-                            job.set_files(entries);
-                        } else if let Some(job) = self.remove_jobs.get_mut(&fd.id) {
-                            job.files = entries;
-                        }
-                    }
-                    Some(file_response::Union::digest(digest)) => {
-                        if digest.is_upload {
-                            if let Some(job) = fs::get_job(digest.id, &mut self.read_jobs) {
-                                if let Some(file) = job.files().get(digest.file_num as usize) {
-                                    let read_path = get_string(&job.join(&file.name));
-                                    self.handler.call(
-                                        "overrideFileConfirm",
-                                        &make_args!(digest.id, digest.file_num, read_path, true),
-                                    );
-                                }
+                Some(message::Union::file_response(fr)) => {
+                    match fr.union {
+                        Some(file_response::Union::dir(fd)) => {
+                            let entries = fd.entries.to_vec();
+                            let mut m = make_fd(fd.id, &entries, fd.id > 0);
+                            if fd.id <= 0 {
+                                m.set_item("path", fd.path);
                             }
-                        } else {
-                            if let Some(job) = fs::get_job(digest.id, &mut self.write_jobs) {
-                                if let Some(file) = job.files().get(digest.file_num as usize) {
-                                    let write_path = get_string(&job.join(&file.name));
-                                    let overwrite_strategy = job.default_overwrite_strategy();
-                                    match fs::is_write_need_confirmation(&write_path, &digest) {
-                                        Ok(res) => {
-                                            if res.is_some() {
-                                                // need confirm
-                                                if overwrite_strategy.is_none() {
-                                                    self.handler.call(
-                                                        "overrideFileConfirm",
-                                                        &make_args!(
-                                                            digest.id,
-                                                            digest.file_num,
-                                                            write_path,
-                                                            false
-                                                        ),
-                                                    );
-                                                } else {
-                                                    let msg = new_send_confirm(
-                                                        FileTransferSendConfirmRequest {
-                                                            id: digest.id,
-                                                            file_num: digest.file_num,
-                                                            union: if overwrite_strategy.unwrap() {
-                                                                Some(file_transfer_send_confirm_request::Union::offset_blk(0))
-                                                            } else {
-                                                                Some(file_transfer_send_confirm_request::Union::skip(true))
-                                                            },
-                                                            ..Default::default()
-                                                        },
-                                                    );
-                                                    allow_err!(peer.send(&msg).await);
-                                                }
-                                            } else {
-                                                let msg= new_send_confirm(FileTransferSendConfirmRequest {
+                            self.handler.call("updateFolderFiles", &make_args!(m));
+                            if let Some(job) = fs::get_job(fd.id, &mut self.write_jobs) {
+                                job.set_files(entries);
+                            } else if let Some(job) = self.remove_jobs.get_mut(&fd.id) {
+                                job.files = entries;
+                            }
+                        }
+                        Some(file_response::Union::digest(digest)) => {
+                            if digest.is_upload {
+                                if let Some(job) = fs::get_job(digest.id, &mut self.read_jobs) {
+                                    if let Some(file) = job.files().get(digest.file_num as usize) {
+                                        let read_path = get_string(&job.join(&file.name));
+                                        let overwrite_strategy = job.default_overwrite_strategy();
+                                        if let Some(overwrite) = overwrite_strategy {
+                                            let req = FileTransferSendConfirmRequest {
                                                 id: digest.id,
                                                 file_num: digest.file_num,
-                                                union: Some(file_transfer_send_confirm_request::Union::skip(true)),
+                                                union: Some(if overwrite {
+                                                    file_transfer_send_confirm_request::Union::offset_blk(0)
+                                                } else {
+                                                    file_transfer_send_confirm_request::Union::skip(
+                                                        true,
+                                                    )
+                                                }),
                                                 ..Default::default()
-                                            });
-                                                allow_err!(peer.send(&msg).await);
-                                            }
+                                            };
+                                            job.confirm(&req);
+                                            let msg = new_send_confirm(req);
+                                            allow_err!(peer.send(&msg).await);
+                                        } else {
+                                            self.handler.call(
+                                                "overrideFileConfirm",
+                                                &make_args!(
+                                                    digest.id,
+                                                    digest.file_num,
+                                                    read_path,
+                                                    true
+                                                ),
+                                            );
                                         }
-                                        Err(err) => {
-                                            println!("error recving digest: {}", err);
+                                    }
+                                }
+                            } else {
+                                if let Some(job) = fs::get_job(digest.id, &mut self.write_jobs) {
+                                    if let Some(file) = job.files().get(digest.file_num as usize) {
+                                        let write_path = get_string(&job.join(&file.name));
+                                        let overwrite_strategy = job.default_overwrite_strategy();
+                                        match fs::is_write_need_confirmation(&write_path, &digest) {
+                                            Ok(res) => match res {
+                                                DigestCheckResult::IsSame => {
+                                                    let msg= new_send_confirm(FileTransferSendConfirmRequest {
+                                                        id: digest.id,
+                                                        file_num: digest.file_num,
+                                                        union: Some(file_transfer_send_confirm_request::Union::skip(true)),
+                                                        ..Default::default()
+                                                    });
+                                                    allow_err!(peer.send(&msg).await);
+                                                }
+                                                DigestCheckResult::NeedConfirm(digest) => {
+                                                    if let Some(overwrite) = overwrite_strategy {
+                                                        let msg = new_send_confirm(
+                                                            FileTransferSendConfirmRequest {
+                                                                id: digest.id,
+                                                                file_num: digest.file_num,
+                                                                union: Some(if overwrite {
+                                                                    file_transfer_send_confirm_request::Union::offset_blk(0)
+                                                                } else {
+                                                                    file_transfer_send_confirm_request::Union::skip(true)
+                                                                }),
+                                                                ..Default::default()
+                                                            },
+                                                        );
+                                                        allow_err!(peer.send(&msg).await);
+                                                    } else {
+                                                        self.handler.call(
+                                                            "overrideFileConfirm",
+                                                            &make_args!(
+                                                                digest.id,
+                                                                digest.file_num,
+                                                                write_path,
+                                                                false
+                                                            ),
+                                                        );
+                                                    }
+                                                }
+                                                DigestCheckResult::NoSuchFile => {
+                                                    let msg = new_send_confirm(
+                                                    FileTransferSendConfirmRequest {
+                                                        id: digest.id,
+                                                        file_num: digest.file_num,
+                                                        union: Some(file_transfer_send_confirm_request::Union::offset_blk(0)),
+                                                        ..Default::default()
+                                                    },
+                                                );
+                                                    allow_err!(peer.send(&msg).await);
+                                                }
+                                            },
+                                            Err(err) => {
+                                                println!("error recving digest: {}", err);
+                                            }
                                         }
                                     }
                                 }
                             }
                         }
-                    }
-                    Some(file_response::Union::block(block)) => {
-                        log::info!("file response block, file num: {}", block.file_num);
-                        if let Some(job) = fs::get_job(block.id, &mut self.write_jobs) {
-                            if let Err(_err) = job.write(block, None).await {
-                                // to-do: add "skip" for writing job
+                        Some(file_response::Union::block(block)) => {
+                            log::info!("file response block, file num: {}", block.file_num);
+                            if let Some(job) = fs::get_job(block.id, &mut self.write_jobs) {
+                                if let Err(_err) = job.write(block, None).await {
+                                    // to-do: add "skip" for writing job
+                                }
+                                self.update_jobs_status();
                             }
-                            self.update_jobs_status();
                         }
-                    }
-                    Some(file_response::Union::done(d)) => {
-                        if let Some(job) = fs::get_job(d.id, &mut self.write_jobs) {
-                            job.modify_time();
-                            fs::remove_job(d.id, &mut self.write_jobs);
+                        Some(file_response::Union::done(d)) => {
+                            if let Some(job) = fs::get_job(d.id, &mut self.write_jobs) {
+                                job.modify_time();
+                                fs::remove_job(d.id, &mut self.write_jobs);
+                            }
+                            self.handle_job_status(d.id, d.file_num, None);
                         }
-                        self.handle_job_status(d.id, d.file_num, None);
+                        Some(file_response::Union::error(e)) => {
+                            self.handle_job_status(e.id, e.file_num, Some(e.error));
+                        }
+                        _ => {}
                     }
-                    Some(file_response::Union::error(e)) => {
-                        self.handle_job_status(e.id, e.file_num, Some(e.error));
-                    }
-                    _ => {}
-                },
+                }
                 Some(message::Union::misc(misc)) => match misc.union {
                     Some(misc::Union::audio_format(f)) => {
                         self.audio_sender.send(MediaData::AudioFormat(f)).ok();

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -803,6 +803,7 @@ impl Handler {
     }
 
     fn reconnect(&mut self) {
+        println!("reconnecting");
         let cloned = self.clone();
         let mut lock = self.write().unwrap();
         lock.thread.take().map(|t| t.join());
@@ -1567,7 +1568,6 @@ impl Remote {
                                 to,
                                 job.files().len()
                             );
-                            let config = self.handler.lc.read().unwrap().version;
                             let m = make_fd(job.id(), job.files(), true);
                             self.handler.call("updateFolderFiles", &make_args!(m));
                             let files = job.files().clone();

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -11,7 +11,9 @@ use clipboard::{
     get_rx_clip_client, server_clip_file,
 };
 use enigo::{self, Enigo, KeyboardControllable};
-use hbb_common::fs::{get_string, is_file_exists, new_send_confirm};
+use hbb_common::fs::{
+    can_enable_overwrite_detection, get_string, is_file_exists, new_send_confirm,
+};
 use hbb_common::log::log;
 use hbb_common::{
     allow_err,
@@ -716,7 +718,6 @@ impl Handler {
     }
 
     fn read_remote_dir(&mut self, path: String, include_hidden: bool) {
-        // println!("remote.rs: read_remote_dir()");
         let mut msg_out = Message::new();
         let mut file_action = FileAction::new();
         file_action.set_read_dir(ReadDir {
@@ -1546,25 +1547,27 @@ impl Remote {
                 allow_err!(peer.send(&msg).await);
             }
             Data::SendFiles((id, path, to, include_hidden, is_remote)) => {
-                println!("send files, is remote {}", is_remote);
+                log::info!("send files, is remote {}", is_remote);
+                let od = can_enable_overwrite_detection(self.handler.lc.read().unwrap().version);
                 if is_remote {
-                    println!("New job {}, write to {} from remote {}", id, to, path);
+                    log::debug!("New job {}, write to {} from remote {}", id, to, path);
                     self.write_jobs
-                        .push(fs::TransferJob::new_write(id, to, Vec::new()));
+                        .push(fs::TransferJob::new_write(id, to, Vec::new(), od));
                     allow_err!(peer.send(&fs::new_send(id, path, include_hidden)).await);
                 } else {
-                    match fs::TransferJob::new_read(id, path.clone(), include_hidden) {
+                    match fs::TransferJob::new_read(id, path.clone(), include_hidden, od) {
                         Err(err) => {
                             self.handle_job_status(id, -1, Some(err.to_string()));
                         }
                         Ok(job) => {
-                            println!(
+                            log::debug!(
                                 "New job {}, read {} to remote {}, {} files",
                                 id,
                                 path,
                                 to,
                                 job.files().len()
                             );
+                            let config = self.handler.lc.read().unwrap().version;
                             let m = make_fd(job.id(), job.files(), true);
                             self.handler.call("updateFolderFiles", &make_args!(m));
                             let files = job.files().clone();
@@ -1789,7 +1792,6 @@ impl Remote {
 
     async fn handle_msg_from_peer(&mut self, data: &[u8], peer: &mut Stream) -> bool {
         if let Ok(msg_in) = Message::parse_from_bytes(&data) {
-            // println!("recved msg from peer, decoded: {:?}", msg_in);
             match msg_in.union {
                 Some(message::Union::video_frame(vf)) => {
                     if !self.first_frame {
@@ -1937,13 +1939,11 @@ impl Remote {
                         if let Some(job) = fs::get_job(block.id, &mut self.write_jobs) {
                             if let Err(_err) = job.write(block, None).await {
                                 // to-do: add "skip" for writing job
-                                println!("error: {}", _err);
                             }
                             self.update_jobs_status();
                         }
                     }
                     Some(file_response::Union::done(d)) => {
-                        log::info!("file response done");
                         if let Some(job) = fs::get_job(d.id, &mut self.write_jobs) {
                             job.modify_time();
                             fs::remove_job(d.id, &mut self.write_jobs);

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -214,7 +214,7 @@ impl sciter::EventHandler for Handler {
         fn toggle_option(String);
         fn get_remember();
         fn peer_platform();
-        fn set_write_override(i32,i32, bool,bool,bool); // ,
+        fn set_write_override(i32, i32, bool, bool, bool);
     }
 }
 

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -12,6 +12,7 @@ use clipboard::{
 };
 use enigo::{self, Enigo, KeyboardControllable};
 use hbb_common::fs::{get_string, is_file_exists};
+use hbb_common::log::log;
 use hbb_common::{
     allow_err,
     config::{self, Config, PeerConfig},
@@ -713,6 +714,7 @@ impl Handler {
     }
 
     fn read_remote_dir(&mut self, path: String, include_hidden: bool) {
+        // println!("remote.rs: read_remote_dir()");
         let mut msg_out = Message::new();
         let mut file_action = FileAction::new();
         file_action.set_read_dir(ReadDir {
@@ -1525,7 +1527,7 @@ impl Remote {
     }
 
     async fn handle_msg_from_ui(&mut self, data: Data, peer: &mut Stream) -> bool {
-        println!("new msg from ui");
+        // log::info!("new msg from ui, {}",data);
         match data {
             Data::Close => {
                 return false;
@@ -1767,6 +1769,7 @@ impl Remote {
 
     async fn handle_msg_from_peer(&mut self, data: &[u8], peer: &mut Stream) -> bool {
         if let Ok(msg_in) = Message::parse_from_bytes(&data) {
+            println!("recved msg from peer, decoded: {:?}", msg_in);
             match msg_in.union {
                 Some(message::Union::video_frame(vf)) => {
                     if !self.first_frame {
@@ -1834,11 +1837,7 @@ impl Remote {
                 }
                 Some(message::Union::file_response(fr)) => match fr.union {
                     Some(file_response::Union::dir(fd)) => {
-                        println!("file_response is dir: {}", fd.path);
                         let entries = fd.entries.to_vec();
-                        for entry in &entries {
-                            println!("dir file: {}", entry.name);
-                        }
                         let mut m = make_fd(fd.id, &entries, fd.id > 0);
                         if fd.id <= 0 {
                             m.set_item("path", fd.path);
@@ -1851,6 +1850,7 @@ impl Remote {
                         }
                     }
                     Some(file_response::Union::digest(digest)) => {
+                        log::info!("recv file transfer digest");
                         if let Some(job) = fs::get_job(digest.id, &mut self.write_jobs) {
                             if let Some(file) = job.files().get(digest.file_num as usize) {
                                 let write_path = get_string(&job.join(&file.name));
@@ -1910,7 +1910,7 @@ impl Remote {
                         }
                     }
                     Some(file_response::Union::block(block)) => {
-                        println!("file response block, file num: {}", block.file_num);
+                        log::info!("file response block, file num: {}", block.file_num);
                         if let Some(job) = fs::get_job(block.id, &mut self.write_jobs) {
                             if let Err(_err) = job.write(block, None).await {
                                 // to-do: add "skip" for writing job
@@ -1920,7 +1920,7 @@ impl Remote {
                         }
                     }
                     Some(file_response::Union::done(d)) => {
-                        println!("file response done");
+                        log::info!("file response done");
                         if let Some(job) = fs::get_job(d.id, &mut self.write_jobs) {
                             job.modify_time();
                             fs::remove_job(d.id, &mut self.write_jobs);
@@ -2007,6 +2007,14 @@ impl Remote {
                         self.audio_sender.send(MediaData::AudioFrame(frame)).ok();
                     }
                 }
+                Some(message::Union::file_action(action)) => match action.union {
+                    Some(file_action::Union::send_confirm(c)) => {
+                        if let Some(job) = fs::get_job(c.id, &mut self.read_jobs) {
+                            job.confirm(&c);
+                        }
+                    }
+                    _ => {}
+                },
                 _ => {}
             }
         }

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -214,7 +214,7 @@ impl sciter::EventHandler for Handler {
         fn toggle_option(String);
         fn get_remember();
         fn peer_platform();
-        fn set_write_override(i32,i32, bool,bool); // ,
+        fn set_write_override(i32,i32, bool,bool,bool); // ,
     }
 }
 
@@ -536,12 +536,14 @@ impl Handler {
         file_num: i32,
         is_override: bool,
         remember: bool,
+        is_upload: bool,
     ) -> bool {
         self.send(Data::SetConfirmOverrideFile((
             job_id,
             file_num,
             is_override,
             remember,
+            is_upload,
         )));
         true
     }
@@ -1589,25 +1591,43 @@ impl Remote {
                     }
                 }
             }
-            Data::SetConfirmOverrideFile((id, file_num, need_override, remember)) => {
-                if let Some(job) = fs::get_job(id, &mut self.write_jobs) {
-                    if remember {
-                        job.set_overwrite_strategy(Some(need_override));
+            Data::SetConfirmOverrideFile((id, file_num, need_override, remember, is_upload)) => {
+                if is_upload {
+                    if let Some(job) = fs::get_job(id, &mut self.read_jobs) {
+                        if remember {
+                            job.set_overwrite_strategy(Some(need_override));
+                        }
+                        job.confirm(&FileTransferSendConfirmRequest {
+                            id,
+                            file_num,
+                            union: if need_override {
+                                Some(file_transfer_send_confirm_request::Union::offset_blk(0))
+                            } else {
+                                Some(file_transfer_send_confirm_request::Union::skip(true))
+                            },
+                            ..Default::default()
+                        });
                     }
-                    let mut msg = Message::new();
-                    let mut file_action = FileAction::new();
-                    file_action.set_send_confirm(FileTransferSendConfirmRequest {
-                        id,
-                        file_num,
-                        union: if need_override {
-                            Some(file_transfer_send_confirm_request::Union::offset_blk(0))
-                        } else {
-                            Some(file_transfer_send_confirm_request::Union::skip(true))
-                        },
-                        ..Default::default()
-                    });
-                    msg.set_file_action(file_action);
-                    allow_err!(peer.send(&msg).await);
+                } else {
+                    if let Some(job) = fs::get_job(id, &mut self.write_jobs) {
+                        if remember {
+                            job.set_overwrite_strategy(Some(need_override));
+                        }
+                        let mut msg = Message::new();
+                        let mut file_action = FileAction::new();
+                        file_action.set_send_confirm(FileTransferSendConfirmRequest {
+                            id,
+                            file_num,
+                            union: if need_override {
+                                Some(file_transfer_send_confirm_request::Union::offset_blk(0))
+                            } else {
+                                Some(file_transfer_send_confirm_request::Union::skip(true))
+                            },
+                            ..Default::default()
+                        });
+                        msg.set_file_action(file_action);
+                        allow_err!(peer.send(&msg).await);
+                    }
                 }
             }
             Data::RemoveDirAll((id, path, is_remote)) => {
@@ -1850,50 +1870,63 @@ impl Remote {
                         }
                     }
                     Some(file_response::Union::digest(digest)) => {
-                        if let Some(job) = fs::get_job(digest.id, &mut self.write_jobs) {
-                            if let Some(file) = job.files().get(digest.file_num as usize) {
-                                let write_path = get_string(&job.join(&file.name));
-                                let overwrite_strategy = job.default_overwrite_strategy();
-                                match fs::is_write_need_confirmation(&write_path, &digest) {
-                                    Ok(res) => {
-                                        if res.is_some() {
-                                            // need confirm
-                                            if overwrite_strategy.is_none() {
-                                                self.handler.call(
-                                                    "overrideFileConfirm",
-                                                    &make_args!(
-                                                        digest.id,
-                                                        digest.file_num,
-                                                        write_path
-                                                    ),
-                                                );
-                                            } else {
-                                                let msg = new_send_confirm(
-                                                    FileTransferSendConfirmRequest {
-                                                        id: digest.id,
-                                                        file_num: digest.file_num,
-                                                        union: if overwrite_strategy.unwrap() {
-                                                            Some(file_transfer_send_confirm_request::Union::offset_blk(0))
-                                                        } else {
-                                                            Some(file_transfer_send_confirm_request::Union::skip(true))
+                        if digest.is_upload {
+                            if let Some(job) = fs::get_job(digest.id, &mut self.read_jobs) {
+                                if let Some(file) = job.files().get(digest.file_num as usize) {
+                                    let read_path = get_string(&job.join(&file.name));
+                                    self.handler.call(
+                                        "overrideFileConfirm",
+                                        &make_args!(digest.id, digest.file_num, read_path, true),
+                                    );
+                                }
+                            }
+                        } else {
+                            if let Some(job) = fs::get_job(digest.id, &mut self.write_jobs) {
+                                if let Some(file) = job.files().get(digest.file_num as usize) {
+                                    let write_path = get_string(&job.join(&file.name));
+                                    let overwrite_strategy = job.default_overwrite_strategy();
+                                    match fs::is_write_need_confirmation(&write_path, &digest) {
+                                        Ok(res) => {
+                                            if res.is_some() {
+                                                // need confirm
+                                                if overwrite_strategy.is_none() {
+                                                    self.handler.call(
+                                                        "overrideFileConfirm",
+                                                        &make_args!(
+                                                            digest.id,
+                                                            digest.file_num,
+                                                            write_path,
+                                                            false
+                                                        ),
+                                                    );
+                                                } else {
+                                                    let msg = new_send_confirm(
+                                                        FileTransferSendConfirmRequest {
+                                                            id: digest.id,
+                                                            file_num: digest.file_num,
+                                                            union: if overwrite_strategy.unwrap() {
+                                                                Some(file_transfer_send_confirm_request::Union::offset_blk(0))
+                                                            } else {
+                                                                Some(file_transfer_send_confirm_request::Union::skip(true))
+                                                            },
+                                                            ..Default::default()
                                                         },
-                                                        ..Default::default()
-                                                    },
-                                                );
-                                                allow_err!(peer.send(&msg).await);
-                                            }
-                                        } else {
-                                            let msg= new_send_confirm(FileTransferSendConfirmRequest {
+                                                    );
+                                                    allow_err!(peer.send(&msg).await);
+                                                }
+                                            } else {
+                                                let msg= new_send_confirm(FileTransferSendConfirmRequest {
                                                 id: digest.id,
                                                 file_num: digest.file_num,
                                                 union: Some(file_transfer_send_confirm_request::Union::skip(true)),
                                                 ..Default::default()
                                             });
-                                            allow_err!(peer.send(&msg).await);
+                                                allow_err!(peer.send(&msg).await);
+                                            }
                                         }
-                                    }
-                                    Err(err) => {
-                                        println!("error recving digest: {}", err);
+                                        Err(err) => {
+                                            println!("error recving digest: {}", err);
+                                        }
                                     }
                                 }
                             }

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -3,6 +3,7 @@ use crate::clipboard_file::*;
 use crate::{
     client::*,
     common::{self, check_clipboard, update_clipboard, ClipboardContext, CLIPBOARD_INTERVAL},
+    VERSION,
 };
 #[cfg(windows)]
 use clipboard::{
@@ -10,10 +11,11 @@ use clipboard::{
     get_rx_clip_client, server_clip_file,
 };
 use enigo::{self, Enigo, KeyboardControllable};
+use hbb_common::fs::{get_string, is_file_exists};
 use hbb_common::{
     allow_err,
     config::{self, Config, PeerConfig},
-    fs, log,
+    fs, get_version_number, log,
     message_proto::{permission_info::Permission, *},
     protobuf::Message as _,
     rendezvous_proto::ConnType,
@@ -211,6 +213,7 @@ impl sciter::EventHandler for Handler {
         fn toggle_option(String);
         fn get_remember();
         fn peer_platform();
+        fn set_write_override(i32,i32, bool,bool); // ,
     }
 }
 
@@ -524,6 +527,22 @@ impl Handler {
 
     fn get_remember(&mut self) -> bool {
         self.lc.read().unwrap().remember
+    }
+
+    fn set_write_override(
+        &mut self,
+        job_id: i32,
+        file_num: i32,
+        is_override: bool,
+        remember: bool,
+    ) -> bool {
+        self.send(Data::SetConfirmOverrideFile((
+            job_id,
+            file_num,
+            is_override,
+            remember,
+        )));
+        true
     }
 
     fn t(&self, name: String) -> String {
@@ -1506,6 +1525,7 @@ impl Remote {
     }
 
     async fn handle_msg_from_ui(&mut self, data: Data, peer: &mut Stream) -> bool {
+        println!("new msg from ui");
         match data {
             Data::Close => {
                 return false;
@@ -1522,8 +1542,9 @@ impl Remote {
                 allow_err!(peer.send(&msg).await);
             }
             Data::SendFiles((id, path, to, include_hidden, is_remote)) => {
+                println!("send files, is remote {}", is_remote);
                 if is_remote {
-                    log::debug!("New job {}, write to {} from remote {}", id, to, path);
+                    println!("New job {}, write to {} from remote {}", id, to, path);
                     self.write_jobs
                         .push(fs::TransferJob::new_write(id, to, Vec::new()));
                     allow_err!(peer.send(&fs::new_send(id, path, include_hidden)).await);
@@ -1533,7 +1554,7 @@ impl Remote {
                             self.handle_job_status(id, -1, Some(err.to_string()));
                         }
                         Ok(job) => {
-                            log::debug!(
+                            println!(
                                 "New job {}, read {} to remote {}, {} files",
                                 id,
                                 path,
@@ -1564,6 +1585,27 @@ impl Remote {
                             &make_args!(id, file_num, job.files[i].name.clone()),
                         );
                     }
+                }
+            }
+            Data::SetConfirmOverrideFile((id, file_num, need_override, remember)) => {
+                if let Some(job) = fs::get_job(id, &mut self.write_jobs) {
+                    if remember {
+                        job.set_overwrite_strategy(Some(need_override));
+                    }
+                    let mut msg = Message::new();
+                    let mut file_action = FileAction::new();
+                    file_action.set_send_confirm(FileTransferSendConfirmRequest {
+                        id,
+                        file_num,
+                        union: if need_override {
+                            Some(file_transfer_send_confirm_request::Union::offset_blk(0))
+                        } else {
+                            Some(file_transfer_send_confirm_request::Union::skip(true))
+                        },
+                        ..Default::default()
+                    });
+                    msg.set_file_action(file_action);
+                    allow_err!(peer.send(&msg).await);
                 }
             }
             Data::RemoveDirAll((id, path, is_remote)) => {
@@ -1792,7 +1834,11 @@ impl Remote {
                 }
                 Some(message::Union::file_response(fr)) => match fr.union {
                     Some(file_response::Union::dir(fd)) => {
+                        println!("file_response is dir: {}", fd.path);
                         let entries = fd.entries.to_vec();
+                        for entry in &entries {
+                            println!("dir file: {}", entry.name);
+                        }
                         let mut m = make_fd(fd.id, &entries, fd.id > 0);
                         if fd.id <= 0 {
                             m.set_item("path", fd.path);
@@ -1804,15 +1850,77 @@ impl Remote {
                             job.files = entries;
                         }
                     }
+                    Some(file_response::Union::digest(digest)) => {
+                        if let Some(job) = fs::get_job(digest.id, &mut self.write_jobs) {
+                            if let Some(file) = job.files().get(digest.file_num as usize) {
+                                let write_path = get_string(&job.join(&file.name));
+                                let overwrite_strategy = job.default_overwrite_strategy();
+                                match fs::is_write_need_confirmation(&write_path, &digest) {
+                                    Ok(res) => {
+                                        if res {
+                                            // need confirm
+                                            if overwrite_strategy.is_none() {
+                                                self.handler.call(
+                                                    "overrideFileConfirm",
+                                                    &make_args!(
+                                                        digest.id,
+                                                        digest.file_num,
+                                                        write_path
+                                                    ),
+                                                );
+                                            } else {
+                                                let mut msg = Message::new();
+                                                let mut file_action = FileAction::new();
+                                                file_action
+                                                    .set_send_confirm(FileTransferSendConfirmRequest {
+                                                        id: digest.id,
+                                                        file_num: digest.file_num,
+                                                        union: Some(
+                                                            if overwrite_strategy.unwrap() {
+                                                                file_transfer_send_confirm_request::Union::offset_blk(0)
+                                                            } else {
+                                                                file_transfer_send_confirm_request::Union::skip(true)
+                                                            },
+                                                        ),
+                                                        ..Default::default()
+                                                    });
+                                                msg.set_file_action(file_action);
+                                                allow_err!(peer.send(&msg).await);
+                                            }
+                                        } else {
+                                            // file with digest need send
+                                            let mut msg = Message::new();
+                                            let mut file_action = FileAction::new();
+                                            file_action
+                                                .set_send_confirm(FileTransferSendConfirmRequest {
+                                                id: digest.id,
+                                                file_num: digest.file_num,
+                                                union: Some(file_transfer_send_confirm_request::Union::offset_blk(0)),
+                                                ..Default::default()
+                                            });
+                                            msg.set_file_action(file_action);
+                                            allow_err!(peer.send(&msg).await);
+                                        }
+                                    }
+                                    Err(err) => {
+                                        println!("error recving digest: {}", err);
+                                    }
+                                }
+                            }
+                        }
+                    }
                     Some(file_response::Union::block(block)) => {
+                        println!("file response block, file num: {}", block.file_num);
                         if let Some(job) = fs::get_job(block.id, &mut self.write_jobs) {
                             if let Err(_err) = job.write(block, None).await {
                                 // to-do: add "skip" for writing job
+                                println!("error: {}", _err);
                             }
                             self.update_jobs_status();
                         }
                     }
                     Some(file_response::Union::done(d)) => {
+                        println!("file response done");
                         if let Some(job) = fs::get_job(d.id, &mut self.write_jobs) {
                             job.modify_time();
                             fs::remove_job(d.id, &mut self.write_jobs);

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -11,7 +11,7 @@ use clipboard::{
     get_rx_clip_client, server_clip_file,
 };
 use enigo::{self, Enigo, KeyboardControllable};
-use hbb_common::fs::{get_string, is_file_exists};
+use hbb_common::fs::{get_string, is_file_exists, new_send_confirm};
 use hbb_common::log::log;
 use hbb_common::{
     allow_err,
@@ -1769,7 +1769,7 @@ impl Remote {
 
     async fn handle_msg_from_peer(&mut self, data: &[u8], peer: &mut Stream) -> bool {
         if let Ok(msg_in) = Message::parse_from_bytes(&data) {
-            println!("recved msg from peer, decoded: {:?}", msg_in);
+            // println!("recved msg from peer, decoded: {:?}", msg_in);
             match msg_in.union {
                 Some(message::Union::video_frame(vf)) => {
                     if !self.first_frame {
@@ -1850,14 +1850,13 @@ impl Remote {
                         }
                     }
                     Some(file_response::Union::digest(digest)) => {
-                        log::info!("recv file transfer digest");
                         if let Some(job) = fs::get_job(digest.id, &mut self.write_jobs) {
                             if let Some(file) = job.files().get(digest.file_num as usize) {
                                 let write_path = get_string(&job.join(&file.name));
                                 let overwrite_strategy = job.default_overwrite_strategy();
                                 match fs::is_write_need_confirmation(&write_path, &digest) {
                                     Ok(res) => {
-                                        if res {
+                                        if res.is_some() {
                                             // need confirm
                                             if overwrite_strategy.is_none() {
                                                 self.handler.call(
@@ -1869,36 +1868,27 @@ impl Remote {
                                                     ),
                                                 );
                                             } else {
-                                                let mut msg = Message::new();
-                                                let mut file_action = FileAction::new();
-                                                file_action
-                                                    .set_send_confirm(FileTransferSendConfirmRequest {
+                                                let msg = new_send_confirm(
+                                                    FileTransferSendConfirmRequest {
                                                         id: digest.id,
                                                         file_num: digest.file_num,
-                                                        union: Some(
-                                                            if overwrite_strategy.unwrap() {
-                                                                file_transfer_send_confirm_request::Union::offset_blk(0)
-                                                            } else {
-                                                                file_transfer_send_confirm_request::Union::skip(true)
-                                                            },
-                                                        ),
+                                                        union: if overwrite_strategy.unwrap() {
+                                                            Some(file_transfer_send_confirm_request::Union::offset_blk(0))
+                                                        } else {
+                                                            Some(file_transfer_send_confirm_request::Union::skip(true))
+                                                        },
                                                         ..Default::default()
-                                                    });
-                                                msg.set_file_action(file_action);
+                                                    },
+                                                );
                                                 allow_err!(peer.send(&msg).await);
                                             }
                                         } else {
-                                            // file with digest need send
-                                            let mut msg = Message::new();
-                                            let mut file_action = FileAction::new();
-                                            file_action
-                                                .set_send_confirm(FileTransferSendConfirmRequest {
+                                            let msg= new_send_confirm(FileTransferSendConfirmRequest {
                                                 id: digest.id,
                                                 file_num: digest.file_num,
-                                                union: Some(file_transfer_send_confirm_request::Union::offset_blk(0)),
+                                                union: Some(file_transfer_send_confirm_request::Union::skip(true)),
                                                 ..Default::default()
                                             });
-                                            msg.set_file_action(file_action);
                                             allow_err!(peer.send(&msg).await);
                                         }
                                     }


### PR DESCRIPTION
It's necessary to skip identical files when transfering files. It will improve performance and user experience when using RustDesk. This PR brings features below:

- skip identical files (modified time and file size are identical in both remote and local fs).
- can make a choice by users when encountering an overwrite behaviors(same file name but not identical) during uploading/downloading files or folders. (can only be triggered when both running the specific version and above).
