### PR TITLE
opt: file transfer can resume when encountering reconnecting or close&open window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk"
-version = "1.1.9"
+version = "1.2.0"
 dependencies = [
  "android_logger 0.11.0",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-run = "rustdesk"
 
 [lib]
 name = "librustdesk"
-crate-type = ["cdylib", "staticlib", "rlib"] 
+crate-type = ["cdylib", "staticlib", "rlib"]
 
 [[bin]]
 name = "naming"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk"
-version = "1.1.9"
+version = "1.2.0"
 authors = ["rustdesk <info@rustdesk.com>"]
 edition = "2021"
 build= "build.rs"

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -264,7 +264,6 @@ message FileResponse {
     FileTransferError error = 3;
     FileTransferDone done = 4;
     FileTransferDigest digest = 5;
-    FileTransferDirOffsetRequest offset = 6;
   }
 }
 
@@ -304,14 +303,6 @@ message FileTransferSendConfirmRequest {
     bool skip = 3;
     uint32 offset_blk = 4;
   }
-}
-
-message FileTransferDirOffsetRequest {
-  int32 id = 1;
-  // start from file_num
-  sint32 file_num = 2;
-  // current file blk offset
-  uint32 offset_blk = 3;
 }
 
 message FileTransferDone {

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -245,13 +245,13 @@ message FileAction {
   oneof union {
     ReadDir read_dir = 1;
     FileTransferSendRequest send = 2;
-    FileTransferSendConfirmRequest send_confirm = 9;
     FileTransferReceiveRequest receive = 3;
     FileDirCreate create = 4;
     FileRemoveDir remove_dir = 5;
     FileRemoveFile remove_file = 6;
     ReadAllFiles all_files = 7;
     FileTransferCancel cancel = 8;
+    FileTransferSendConfirmRequest send_confirm = 9;
   }
 }
 
@@ -272,6 +272,7 @@ message FileTransferDigest {
   sint32 file_num = 2;
   uint64 last_edit_timestamp = 3;
   uint64 file_size = 4;
+  bool is_upload = 5;
 }
 
 message FileTransferBlock {

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -304,6 +304,14 @@ message FileTransferSendConfirmRequest {
   }
 }
 
+message FileTransferDirOffsetRequest {
+  int32 id = 1;
+  // start from file_num
+  sint32 file_num = 2;
+  // current file blk offset
+  uint32 offset_blk = 3;
+}
+
 message FileTransferDone {
   int32 id = 1;
   sint32 file_num = 2;

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -245,6 +245,7 @@ message FileAction {
   oneof union {
     ReadDir read_dir = 1;
     FileTransferSendRequest send = 2;
+    FileTransferSendConfirmRequest send_confirm = 9;
     FileTransferReceiveRequest receive = 3;
     FileDirCreate create = 4;
     FileRemoveDir remove_dir = 5;
@@ -262,7 +263,15 @@ message FileResponse {
     FileTransferBlock block = 2;
     FileTransferError error = 3;
     FileTransferDone done = 4;
+    FileTransferDigest digest = 5;
   }
+}
+
+message FileTransferDigest {
+  int32 id = 1;
+  sint32 file_num = 2;
+  uint64 last_edit_timestamp = 3;
+  uint64 file_size = 4;
 }
 
 message FileTransferBlock {
@@ -270,6 +279,7 @@ message FileTransferBlock {
   sint32 file_num = 2;
   bytes data = 3;
   bool compressed = 4;
+  uint32 blk_id = 5;
 }
 
 message FileTransferError {
@@ -282,6 +292,15 @@ message FileTransferSendRequest {
   int32 id = 1;
   string path = 2;
   bool include_hidden = 3;
+}
+
+message FileTransferSendConfirmRequest {
+  int32 id = 1;
+  sint32 file_num = 2;
+  oneof union {
+    bool skip = 3;
+    uint32 offset_blk = 4;
+  }
 }
 
 message FileTransferDone {

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -264,6 +264,7 @@ message FileResponse {
     FileTransferError error = 3;
     FileTransferDone done = 4;
     FileTransferDigest digest = 5;
+    FileTransferDirOffsetRequest offset = 6;
   }
 }
 

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -270,7 +270,7 @@ message FileResponse {
 message FileTransferDigest {
   int32 id = 1;
   sint32 file_num = 2;
-  uint64 last_edit_timestamp = 3;
+  uint64 last_modified = 3;
   uint64 file_size = 4;
   bool is_upload = 5;
 }

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -294,6 +294,7 @@ message FileTransferSendRequest {
   int32 id = 1;
   string path = 2;
   bool include_hidden = 3;
+  int32 file_num = 4;
 }
 
 message FileTransferSendConfirmRequest {
@@ -322,6 +323,7 @@ message FileTransferReceiveRequest {
   int32 id = 1;
   string path = 2; // path written to
   repeated FileEntry files = 3;
+  int32 file_num = 4;
 }
 
 message FileRemoveDir {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1,3 +1,8 @@
+use crate::log;
+use directories_next::ProjectDirs;
+use rand::Rng;
+use serde_derive::{Deserialize, Serialize};
+use sodiumoxide::crypto::sign;
 use std::{
     collections::HashMap,
     fs,

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -157,11 +157,9 @@ pub struct PeerInfoSerde {
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct TransferSerde {
     #[serde(default)]
-    pub write_jobs: Vec<TransferJobMeta>,
+    pub write_jobs: Vec<String>,
     #[serde(default)]
-    pub read_jobs: Vec<TransferJobMeta>,
-    #[serde(default)]
-    pub remove_jobs: Vec<RemoveJobMeta>,
+    pub read_jobs: Vec<String>,
 }
 
 fn patch(path: PathBuf) -> PathBuf {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1,8 +1,3 @@
-use crate::log;
-use directories_next::ProjectDirs;
-use rand::Rng;
-use serde_derive::{Deserialize, Serialize};
-use sodiumoxide::crypto::sign;
 use std::{
     collections::HashMap,
     fs,
@@ -145,6 +140,8 @@ pub struct PeerConfig {
     pub options: HashMap<String, String>,
     #[serde(default)]
     pub info: PeerInfoSerde,
+    #[serde(default)]
+    pub transfer: TransferSerde,
 }
 
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize, Clone)]
@@ -155,6 +152,16 @@ pub struct PeerInfoSerde {
     pub hostname: String,
     #[serde(default)]
     pub platform: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct TransferSerde {
+    #[serde(default)]
+    pub write_jobs: Vec<TransferJobMeta>,
+    #[serde(default)]
+    pub read_jobs: Vec<TransferJobMeta>,
+    #[serde(default)]
+    pub remove_jobs: Vec<RemoveJobMeta>,
 }
 
 fn patch(path: PathBuf) -> PathBuf {
@@ -864,6 +871,7 @@ impl LanPeers {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn test_serialize() {
         let cfg: Config = Default::default();

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -201,7 +201,10 @@ pub fn can_enable_overwrite_detection(version: i64) -> bool {
 #[derive(Default)]
 pub struct TransferJob {
     id: i32,
+    remote: String,
     path: PathBuf,
+    show_hidden: bool,
+    is_remote: bool,
     files: Vec<FileEntry>,
     file_num: i32,
     file: Option<File>,
@@ -217,7 +220,9 @@ pub struct TransferJob {
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct TransferJobMeta {
     pub id: i32,
-    pub path: PathBuf,
+    pub remote: String,
+    pub to: String,
+    pub show_hidden: bool,
     pub file_num: i32,
 }
 
@@ -253,7 +258,10 @@ fn is_compressed_file(name: &str) -> bool {
 impl TransferJob {
     pub fn new_write(
         id: i32,
+        remote: String,
         path: String,
+        show_hidden: bool,
+        is_remote: bool,
         files: Vec<FileEntry>,
         enable_override_detection: bool,
     ) -> Self {
@@ -261,7 +269,10 @@ impl TransferJob {
         let total_size = files.iter().map(|x| x.size as u64).sum();
         Self {
             id,
+            remote,
             path: get_path(&path),
+            show_hidden,
+            is_remote,
             files,
             total_size,
             enable_overwrite_detection: enable_override_detection,
@@ -271,7 +282,10 @@ impl TransferJob {
 
     pub fn new_read(
         id: i32,
+        remote: String,
         path: String,
+        show_hidden: bool,
+        is_remote: bool,
         include_hidden: bool,
         enable_override_detection: bool,
     ) -> ResultType<Self> {
@@ -280,7 +294,10 @@ impl TransferJob {
         let total_size = files.iter().map(|x| x.size as u64).sum();
         Ok(Self {
             id,
+            remote,
             path: get_path(&path),
+            show_hidden,
+            is_remote,
             files,
             total_size,
             enable_overwrite_detection: enable_override_detection,
@@ -561,8 +578,10 @@ impl TransferJob {
     pub fn gen_meta(&self) -> TransferJobMeta {
         TransferJobMeta {
             id: self.id,
-            path: self.path.clone(),
+            remote: self.remote.to_string(),
+            to: self.path.to_string_lossy().to_string(),
             file_num: self.file_num,
+            show_hidden: self.show_hidden
         }
     }
 }

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -229,6 +229,8 @@ pub struct TransferJobMeta {
     pub show_hidden: bool,
     #[serde(default)]
     pub file_num: i32,
+    #[serde(default)]
+    pub is_remote: bool
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
@@ -583,13 +585,15 @@ impl TransferJob {
         true
     }
 
+    #[inline]
     pub fn gen_meta(&self) -> TransferJobMeta {
         TransferJobMeta {
             id: self.id,
             remote: self.remote.to_string(),
             to: self.path.to_string_lossy().to_string(),
             file_num: self.file_num,
-            show_hidden: self.show_hidden
+            show_hidden: self.show_hidden,
+            is_remote: self.is_remote
         }
     }
 }

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -219,17 +219,25 @@ pub struct TransferJob {
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct TransferJobMeta {
+    #[serde(default)]
     pub id: i32,
+    #[serde(default)]
     pub remote: String,
+    #[serde(default)]
     pub to: String,
+    #[serde(default)]
     pub show_hidden: bool,
+    #[serde(default)]
     pub file_num: i32,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct RemoveJobMeta {
+    #[serde(default)]
     pub path: String,
+    #[serde(default)]
     pub is_remote: bool,
+    #[serde(default)]
     pub no_confirm: bool,
 }
 

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -200,13 +200,15 @@ pub fn can_enable_overwrite_detection(version: i64) -> bool {
 
 #[derive(Default)]
 pub struct TransferJob {
-    id: i32,
-    remote: String,
-    path: PathBuf,
-    show_hidden: bool,
-    is_remote: bool,
-    files: Vec<FileEntry>,
-    file_num: i32,
+    pub id: i32,
+    pub remote: String,
+    pub path: PathBuf,
+    pub show_hidden: bool,
+    pub is_remote: bool,
+    pub is_last_job: bool,
+    pub file_num: i32,
+    pub files: Vec<FileEntry>,
+
     file: Option<File>,
     total_size: u64,
     finished_size: u64,
@@ -707,6 +709,9 @@ pub async fn handle_read_jobs(
 ) -> ResultType<()> {
     let mut finished = Vec::new();
     for job in jobs.iter_mut() {
+        if job.is_last_job {
+            continue;
+        }
         match job.read(stream).await {
             Err(err) => {
                 stream

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -455,8 +455,7 @@ impl TransferJob {
             file_num: self.file_num,
             last_edit_timestamp: last_modified,
             file_size: meta.len(),
-            unknown_fields: Default::default(),
-            cached_size: Default::default(),
+            ..Default::default()
         });
         msg.set_file_response(resp);
         stream.send(&msg).await?;

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -270,6 +270,7 @@ impl TransferJob {
         id: i32,
         remote: String,
         path: String,
+        file_num: i32,
         show_hidden: bool,
         is_remote: bool,
         files: Vec<FileEntry>,
@@ -281,6 +282,7 @@ impl TransferJob {
             id,
             remote,
             path: get_path(&path),
+            file_num,
             show_hidden,
             is_remote,
             files,
@@ -294,6 +296,7 @@ impl TransferJob {
         id: i32,
         remote: String,
         path: String,
+        file_num: i32,
         show_hidden: bool,
         is_remote: bool,
         include_hidden: bool,
@@ -306,6 +309,7 @@ impl TransferJob {
             id,
             remote,
             path: get_path(&path),
+            file_num,
             show_hidden,
             is_remote,
             files,
@@ -645,12 +649,13 @@ pub fn new_send_confirm(r: FileTransferSendConfirmRequest) -> Message {
 }
 
 #[inline]
-pub fn new_receive(id: i32, path: String, files: Vec<FileEntry>) -> Message {
+pub fn new_receive(id: i32, path: String, file_num: i32, files: Vec<FileEntry>) -> Message {
     let mut action = FileAction::new();
     action.set_receive(FileTransferReceiveRequest {
         id,
         path,
         files: files.into(),
+        file_num,
         ..Default::default()
     });
     let mut msg_out = Message::new();
@@ -659,13 +664,14 @@ pub fn new_receive(id: i32, path: String, files: Vec<FileEntry>) -> Message {
 }
 
 #[inline]
-pub fn new_send(id: i32, path: String, include_hidden: bool) -> Message {
+pub fn new_send(id: i32, path: String, file_num: i32, include_hidden: bool) -> Message {
     log::info!("new send: {},id : {}", path, id);
     let mut action = FileAction::new();
     action.set_send(FileTransferSendRequest {
         id,
         path,
         include_hidden,
+        file_num,
         ..Default::default()
     });
     let mut msg_out = Message::new();

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -230,7 +230,7 @@ pub struct TransferJobMeta {
     #[serde(default)]
     pub file_num: i32,
     #[serde(default)]
-    pub is_remote: bool
+    pub is_remote: bool,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
@@ -299,11 +299,10 @@ impl TransferJob {
         file_num: i32,
         show_hidden: bool,
         is_remote: bool,
-        include_hidden: bool,
         enable_override_detection: bool,
     ) -> ResultType<Self> {
         log::info!("new read {}", path);
-        let files = get_recursive_files(&path, include_hidden)?;
+        let files = get_recursive_files(&path, show_hidden)?;
         let total_size = files.iter().map(|x| x.size as u64).sum();
         Ok(Self {
             id,
@@ -597,7 +596,7 @@ impl TransferJob {
             to: self.path.to_string_lossy().to_string(),
             file_num: self.file_num,
             show_hidden: self.show_hidden,
-            is_remote: self.is_remote
+            is_remote: self.is_remote,
         }
     }
 }

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -192,7 +192,7 @@ pub fn is_file_exists(file_path: &str) -> bool {
 }
 
 pub fn can_enable_overwrite_detection(version: i64) -> bool {
-    version >= get_version_number("1.1.9")
+    version >= get_version_number("1.2.0")
 }
 
 #[derive(Default)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1326,7 +1326,8 @@ pub enum Data {
     ToggleClipboardFile,
     NewRDP,
     SetConfirmOverrideFile((i32, i32, bool, bool, bool)),
-    ResumeTransfer,
+    AddJob((i32, String, String, i32, bool, bool)),
+    ResumeJob((i32, bool)),
 }
 
 #[derive(Clone)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,20 @@
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    ops::Deref,
+    sync::{mpsc, Arc, RwLock},
+};
+
 pub use async_trait::async_trait;
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
     Device, Host, StreamConfig,
 };
+use magnum_opus::{Channels::*, Decoder as AudioDecoder};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
 use hbb_common::{
     allow_err,
     anyhow::{anyhow, Context},
@@ -19,23 +30,14 @@ use hbb_common::{
     tokio::time::Duration,
     AddrMangle, ResultType, Stream,
 };
-use magnum_opus::{Channels::*, Decoder as AudioDecoder};
 use scrap::{Decoder, Image, VideoCodecId};
-use sha2::{Digest, Sha256};
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    ops::Deref,
-    sync::{mpsc, Arc, RwLock},
-};
-use uuid::Uuid;
+
+pub use super::lang::*;
 pub mod file_trait;
 pub use file_trait::FileManager;
 pub const SEC30: Duration = Duration::from_secs(30);
 
 pub struct Client;
-
-pub use super::lang::*;
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 lazy_static::lazy_static! {
@@ -1324,6 +1326,7 @@ pub enum Data {
     ToggleClipboardFile,
     NewRDP,
     SetConfirmOverrideFile((i32, i32, bool, bool, bool)),
+    ResumeTransfer,
 }
 
 #[derive(Clone)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1323,6 +1323,8 @@ pub enum Data {
     AddPortForward((i32, String, i32)),
     ToggleClipboardFile,
     NewRDP,
+    // ConfirmOverrideFile((i32, String, String, bool, bool)),
+    SetConfirmOverrideFile((i32, i32, bool, bool)),
 }
 
 #[derive(Clone)]
@@ -1330,6 +1332,12 @@ pub enum Key {
     ControlKey(ControlKey),
     Chr(u32),
     _Raw(u32),
+}
+
+#[derive(Clone)]
+pub enum OverrideStrategy {
+    Skip,
+    Overwrite,
 }
 
 lazy_static::lazy_static! {

--- a/src/client.rs
+++ b/src/client.rs
@@ -533,14 +533,14 @@ impl AudioHandler {
         }
 
         self.simple = Some(Simple::new(
-            None,                   // Use the default server
-            &crate::get_app_name(), // Our application’s name
-            Direction::Playback,    // We want a playback stream
-            None,                   // Use the default device
-            "playback",             // Description of our stream
-            &spec,                  // Our sample format
-            None,                   // Use default channel map
-            None,                   // Use default buffering attributes
+            None,                // Use the default server
+            &crate::get_app_name(),            // Our application’s name
+            Direction::Playback, // We want a playback stream
+            None,                // Use the default device
+            "playback",          // Description of our stream
+            &spec,               // Our sample format
+            None,                // Use default channel map
+            None,                // Use default buffering attributes
         )?);
         self.sample_rate = (format0.sample_rate, format0.sample_rate);
         Ok(())
@@ -1323,7 +1323,7 @@ pub enum Data {
     AddPortForward((i32, String, i32)),
     ToggleClipboardFile,
     NewRDP,
-    SetConfirmOverrideFile((i32, i32, bool, bool)),
+    SetConfirmOverrideFile((i32, i32, bool, bool, bool)),
 }
 
 #[derive(Clone)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1323,7 +1323,6 @@ pub enum Data {
     AddPortForward((i32, String, i32)),
     ToggleClipboardFile,
     NewRDP,
-    // ConfirmOverrideFile((i32, String, String, bool, bool)),
     SetConfirmOverrideFile((i32, i32, bool, bool)),
 }
 
@@ -1332,12 +1331,6 @@ pub enum Key {
     ControlKey(ControlKey),
     Chr(u32),
     _Raw(u32),
-}
-
-#[derive(Clone)]
-pub enum OverrideStrategy {
-    Skip,
-    Overwrite,
 }
 
 lazy_static::lazy_static! {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1313,7 +1313,7 @@ pub enum Data {
     Close,
     Login((String, bool)),
     Message(Message),
-    SendFiles((i32, String, String, bool, bool)),
+    SendFiles((i32, String, String, i32, bool, bool)),
     RemoveDirAll((i32, String, bool)),
     ConfirmDeleteFiles((i32, i32)),
     SetNoConfirm(i32),

--- a/src/client.rs
+++ b/src/client.rs
@@ -535,14 +535,14 @@ impl AudioHandler {
         }
 
         self.simple = Some(Simple::new(
-            None,                // Use the default server
-            &crate::get_app_name(),            // Our application’s name
-            Direction::Playback, // We want a playback stream
-            None,                // Use the default device
-            "playback",          // Description of our stream
-            &spec,               // Our sample format
-            None,                // Use default channel map
-            None,                // Use default buffering attributes
+            None,                   // Use the default server
+            &crate::get_app_name(), // Our application’s name
+            Direction::Playback,    // We want a playback stream
+            None,                   // Use the default device
+            "playback",             // Description of our stream
+            &spec,                  // Our sample format
+            None,                   // Use default channel map
+            None,                   // Use default buffering attributes
         )?);
         self.sample_rate = (format0.sample_rate, format0.sample_rate);
         Ok(())

--- a/src/client/file_trait.rs
+++ b/src/client/file_trait.rs
@@ -86,4 +86,20 @@ pub trait FileManager: Interface {
     ) {
         self.send(Data::SendFiles((id, path, to, file_num, include_hidden, is_remote)));
     }
+
+    fn add_job(
+        &mut self,
+        id: i32,
+        path: String,
+        to: String,
+        file_num: i32,
+        include_hidden: bool,
+        is_remote: bool,
+    ) {
+        self.send(Data::AddJob((id, path, to, file_num, include_hidden, is_remote)));
+    }
+
+    fn resume_job(&mut self, id: i32, is_remote: bool){
+        self.send(Data::ResumeJob((id,is_remote)));
+    }
 }

--- a/src/client/file_trait.rs
+++ b/src/client/file_trait.rs
@@ -80,9 +80,10 @@ pub trait FileManager: Interface {
         id: i32,
         path: String,
         to: String,
+        file_num: i32,
         include_hidden: bool,
         is_remote: bool,
     ) {
-        self.send(Data::SendFiles((id, path, to, include_hidden, is_remote)));
+        self.send(Data::SendFiles((id, path, to, file_num, include_hidden, is_remote)));
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -63,7 +63,7 @@ pub enum FS {
         id: i32,
         file_num: i32,
         file_size: u64,
-        modified_time: u64,
+        last_modified: u64,
         is_upload: bool,
     },
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -59,6 +59,12 @@ pub enum FS {
         id: i32,
         file_num: i32,
     },
+    CheckDigest {
+        id: i32,
+        file_num: i32,
+        file_size: u64,
+        modified_time: u64,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -44,6 +44,7 @@ pub enum FS {
     NewWrite {
         path: String,
         id: i32,
+        file_num: i32,
         files: Vec<(String, u64)>,
     },
     CancelWrite {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -64,6 +64,7 @@ pub enum FS {
         file_num: i32,
         file_size: u64,
         modified_time: u64,
+        is_upload: bool,
     },
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -59,6 +59,11 @@ pub enum FS {
         id: i32,
         file_num: i32,
     },
+    WriteOffset {
+        id: i32,
+        file_num: i32,
+        offset_blk: u32
+    },
     CheckDigest {
         id: i32,
         file_num: i32,

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -266,6 +266,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_start_service_tip", "点击 [启动服务] 或打开 [屏幕录制] 权限开启手机屏幕共享服务。"),
         ("Account", "账号"),
         ("Quit", "退出"),
+        ("Overwrite", "覆盖"),
+        ("This file exists, skip or overwrite this file?", "这个文件/文件夹已存在，跳过/覆盖?")
         ("doc_mac_permission", "https://rustdesk.com/docs/zh-cn/manual/mac/#启用权限"),
         ("Help", "帮助"),
     ].iter().cloned().collect();

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -267,7 +267,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Account", "账号"),
         ("Quit", "退出"),
         ("Overwrite", "覆盖"),
-        ("This file exists, skip or overwrite this file?", "这个文件/文件夹已存在，跳过/覆盖?")
+        ("This file exists, skip or overwrite this file?", "这个文件/文件夹已存在，跳过/覆盖?"),
         ("doc_mac_permission", "https://rustdesk.com/docs/zh-cn/manual/mac/#启用权限"),
         ("Help", "帮助"),
     ].iter().cloned().collect();

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -266,6 +266,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_start_service_tip", "Нажмите [Запуск промежуточного сервера] или ОТКРЫТЬ разрешение [Скриншот], чтобы запустить службу демонстрации экрана."),
         ("Account", "Аккаунт"),
         ("Quit", "Выйти"),
+        ("Overwrite", "крышка"),
+        ("This file exists, skip or overwrite this file?", "Этот файл существует, пропустить или перезаписать этот файл?")
         ("doc_mac_permission", "https://rustdesk.com/docs/en/manual/mac/#enable-permissions"),
         ("Help", "Помощь"),
     ].iter().cloned().collect();

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -267,7 +267,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Account", "Аккаунт"),
         ("Quit", "Выйти"),
         ("Overwrite", "крышка"),
-        ("This file exists, skip or overwrite this file?", "Этот файл существует, пропустить или перезаписать этот файл?")
+        ("This file exists, skip or overwrite this file?", "Этот файл существует, пропустить или перезаписать этот файл?"),
         ("doc_mac_permission", "https://rustdesk.com/docs/en/manual/mac/#enable-permissions"),
         ("Help", "Помощь"),
     ].iter().cloned().collect();

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -265,6 +265,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_version_audio_tip", ""),
         ("android_start_service_tip", ""),
         ("Account", ""),
+        ("Overwrite", ""),
+        ("This file exists, skip or overwrite this file?", "")
         ("Quit", ""),
         ("doc_mac_permission", ""),
         ("Help", ""),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -266,6 +266,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("android_start_service_tip", "點擊 [啟動服務] 或打開 [屏幕錄製] 權限開啟手機屏幕共享服務。"),
         ("Account", "帳戶"),
         ("Quit", "退出"),
+        ("Overwrite", "覆蓋"),
+        ("This file exists, skip or overwrite this file?", "這個文件/文件夾已存在，跳過/覆蓋？")
         ("doc_mac_permission", "https://rustdesk.com/docs/zh-tw/manual/mac/#啟用權限"),
         ("Help", "幫助"),
     ].iter().cloned().collect();

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -267,7 +267,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Account", "帳戶"),
         ("Quit", "退出"),
         ("Overwrite", "覆蓋"),
-        ("This file exists, skip or overwrite this file?", "這個文件/文件夾已存在，跳過/覆蓋？")
+        ("This file exists, skip or overwrite this file?", "這個文件/文件夾已存在，跳過/覆蓋？"),
         ("doc_mac_permission", "https://rustdesk.com/docs/zh-tw/manual/mac/#啟用權限"),
         ("Help", "幫助"),
     ].iter().cloned().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,12 +39,13 @@ fn main() {
         println!("{}", crate::VERSION);
         return;
     }
-    #[cfg(not(feature = "inline"))]
+    // TODO: 提交去除inline
+    #[cfg(feature = "inline")]
     {
         use hbb_common::env_logger::*;
         init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info"));
     }
-    #[cfg(feature = "inline")]
+    #[cfg(not(feature = "inline"))]
     {
         let mut path = hbb_common::config::Config::log_path();
         if args.len() > 0 && args[0].starts_with("--") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,13 +39,12 @@ fn main() {
         println!("{}", crate::VERSION);
         return;
     }
-    // TODO: 提交去除inline
-    #[cfg(feature = "inline")]
+    #[cfg(not(feature = "inline"))]
     {
         use hbb_common::env_logger::*;
         init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info"));
     }
-    #[cfg(not(feature = "inline"))]
+    #[cfg(feature = "inline")]
     {
         let mut path = hbb_common::config::Config::log_path();
         if args.len() > 0 && args[0].starts_with("--") {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -6,6 +6,7 @@ use crate::common::update_clipboard;
 use crate::ipc;
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use crate::{common::MOBILE_INFO2, mobile::connection_manager::start_channel};
+use hbb_common::message_proto::file_transfer_send_confirm_request::Union;
 use hbb_common::{
     config::Config,
     fs,
@@ -1017,6 +1018,10 @@ impl Connection {
                             Some(file_action::Union::cancel(c)) => {
                                 self.send_fs(ipc::FS::CancelWrite { id: c.id });
                                 fs::remove_job(c.id, &mut self.read_jobs);
+                            }
+                            Some(file_action::Union::send_confirm(r)) => {
+                                //
+                                println!("recv send confirm request");
                             }
                             _ => {}
                         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -955,7 +955,7 @@ impl Connection {
                     }
                 }
                 Some(message::Union::file_action(fa)) => {
-                    println!("recv file_action, {:?}", fa);
+                    log::info!("recv file_action, {:?}", fa);
                     if self.file_transfer.is_some() {
                         match fa.union {
                             Some(file_action::Union::read_dir(rd)) => {
@@ -988,7 +988,6 @@ impl Connection {
                                 }
                             }
                             Some(file_action::Union::receive(r)) => {
-                                println!("[connection.rs:891] recv FileTransferReceiveRequest");
                                 self.send_fs(ipc::FS::NewWrite {
                                     path: r.path,
                                     id: r.id,
@@ -1025,7 +1024,6 @@ impl Connection {
                                 fs::remove_job(c.id, &mut self.read_jobs);
                             }
                             Some(file_action::Union::send_confirm(r)) => {
-                                println!("recv send confirm request");
                                 if let Some(job) = fs::get_job(r.id, &mut self.read_jobs) {
                                     job.confirm(&r);
                                 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3,9 +3,10 @@ use super::{input_service::*, *};
 use crate::clipboard_file::*;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::common::update_clipboard;
-use crate::ipc;
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use crate::{common::MOBILE_INFO2, mobile::connection_manager::start_channel};
+use crate::{ipc, VERSION};
+use hbb_common::fs::can_enable_overwrite_detection;
 use hbb_common::log::debug;
 use hbb_common::message_proto::file_transfer_send_confirm_request::Union;
 use hbb_common::{
@@ -974,7 +975,16 @@ impl Connection {
                                 let id = s.id;
                                 let od =
                                     can_enable_overwrite_detection(get_version_number(VERSION));
-                                match fs::TransferJob::new_read(id, s.path.clone(), s.file_num, s.include_hidden, od) {
+                                let path = s.path.clone();
+                                match fs::TransferJob::new_read(
+                                    id,
+                                    "".to_string(),
+                                    path.clone(),
+                                    s.file_num,
+                                    s.include_hidden,
+                                    false,
+                                    od,
+                                ) {
                                     Err(err) => {
                                         self.send(fs::new_error(id, err, 0)).await;
                                     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -275,7 +275,7 @@ impl Connection {
                             }
                         }
                         ipc::Data::RawMessage(bytes) => {
-                            conn.stream.send_raw(bytes).await;
+                            allow_err!(conn.stream.send_raw(bytes).await);
                         }
                         #[cfg(windows)]
                         ipc::Data::ClipbaordFile(_clip) => {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -955,7 +955,6 @@ impl Connection {
                     }
                 }
                 Some(message::Union::file_action(fa)) => {
-                    log::info!("recv file_action, {:?}", fa);
                     if self.file_transfer.is_some() {
                         match fa.union {
                             Some(file_action::Union::read_dir(rd)) => {
@@ -1051,7 +1050,7 @@ impl Connection {
                         id: d.id,
                         file_num: d.file_num,
                         file_size: d.file_size,
-                        modified_time: d.last_edit_timestamp,
+                        last_modified: d.last_modified,
                         is_upload: true,
                     }),
                     _ => {}

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -974,7 +974,7 @@ impl Connection {
                                 let id = s.id;
                                 let od =
                                     can_enable_overwrite_detection(get_version_number(VERSION));
-                                match fs::TransferJob::new_read(id, s.path.clone(), s.include_hidden) {
+                                match fs::TransferJob::new_read(id, s.path.clone(), s.include_hidden, od) {
                                     Err(err) => {
                                         self.send(fs::new_error(id, err, 0)).await;
                                     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1052,6 +1052,7 @@ impl Connection {
                         file_num: d.file_num,
                         file_size: d.file_size,
                         modified_time: d.last_edit_timestamp,
+                        is_upload: true,
                     }),
                     _ => {}
                 },

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1054,14 +1054,6 @@ impl Connection {
                         last_modified: d.last_modified,
                         is_upload: true,
                     }),
-                    Some(file_response::Union::offset(offset)) => {
-                        // TODO: i32
-                        // self.send_fs(ipc::FS::WriteOffset {
-                        //     id: offset.id,
-                        //     file_num: offset.file_num,
-                        //     offset_blk: offset.offset_blk,
-                        // });
-                    }
                     _ => {}
                 },
                 Some(message::Union::misc(misc)) => match misc.union {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1053,6 +1053,14 @@ impl Connection {
                         last_modified: d.last_modified,
                         is_upload: true,
                     }),
+                    Some(file_response::Union::offset(offset)) => {
+                        // TODO: i32
+                        // self.send_fs(ipc::FS::WriteOffset {
+                        //     id: offset.id,
+                        //     file_num: offset.file_num,
+                        //     offset_blk: offset.offset_blk,
+                        // });
+                    }
                     _ => {}
                 },
                 Some(message::Union::misc(misc)) => match misc.union {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -974,7 +974,7 @@ impl Connection {
                                 let id = s.id;
                                 let od =
                                     can_enable_overwrite_detection(get_version_number(VERSION));
-                                match fs::TransferJob::new_read(id, s.path.clone(), s.include_hidden, od) {
+                                match fs::TransferJob::new_read(id, s.path.clone(), s.file_num, s.include_hidden, od) {
                                     Err(err) => {
                                         self.send(fs::new_error(id, err, 0)).await;
                                     }
@@ -990,6 +990,7 @@ impl Connection {
                                 self.send_fs(ipc::FS::NewWrite {
                                     path: r.path,
                                     id: r.id,
+                                    file_num: r.file_num,
                                     files: r
                                         .files
                                         .to_vec()

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -136,7 +136,6 @@ impl ConnectionManager {
                     dir,
                     include_hidden,
                 } => {
-                    // println!("[cm.rs:126] ipc::FS::ReadDir recved");
                     Self::read_dir(&dir, include_hidden, conn).await;
                 }
                 ipc::FS::RemoveDir {
@@ -157,7 +156,6 @@ impl ConnectionManager {
                     id,
                     mut files,
                 } => {
-                    println!("new write in ipc::FS::NewWrite");
                     write_jobs.push(fs::TransferJob::new_write(
                         id,
                         path,
@@ -293,7 +291,6 @@ impl ConnectionManager {
             let mut file_response = FileResponse::new();
             file_response.set_dir(fd);
             msg_out.set_file_response(file_response);
-            // println!("[cm.rs:229] set dir");
             Self::send(msg_out, conn).await;
         }
     }
@@ -356,7 +353,6 @@ impl ConnectionManager {
     }
 
     async fn send(msg: Message, conn: &mut Connection) {
-        println!("send msg: {:?}", msg);
         match msg.write_to_bytes() {
             Ok(bytes) => allow_err!(conn.send(&Data::RawMessage(bytes)).await),
             err => allow_err!(err),

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -158,14 +158,17 @@ impl ConnectionManager {
                 ipc::FS::NewWrite {
                     path,
                     id,
+                    file_num,
                     mut files,
                 } => {
                     let od = can_enable_overwrite_detection(get_version_number(VERSION));
                     // cm has no show_hidden context
+                    // dummy remote, show_hidden, is_remote
                     write_jobs.push(fs::TransferJob::new_write(
                         id,
                         "".to_string(),
                         path,
+                        file_num,
                         false,
                         false,
                         files

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -179,7 +179,7 @@ impl ConnectionManager {
                                 ..Default::default()
                             })
                             .collect(),
-                            od,
+                        od,
                     ));
                 }
                 ipc::FS::CancelWrite { id } => {
@@ -278,10 +278,10 @@ impl ConnectionManager {
                     }
                 }
                 ipc::FS::WriteOffset {
-                    id,file_num,offset_blk
-                } => {
-                    
-                }
+                    id,
+                    file_num,
+                    offset_blk,
+                } => {}
             },
             #[cfg(windows)]
             Data::ClipbaordFile(_clip) => {

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -371,7 +371,6 @@ impl ConnectionManager {
     }
 
     async fn send(msg: Message, conn: &mut Connection) {
-        println!("send msg: {:?}", msg);
         match msg.write_to_bytes() {
             Ok(bytes) => allow_err!(conn.send(&Data::RawMessage(bytes)).await),
             err => allow_err!(err),

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -192,7 +192,7 @@ impl ConnectionManager {
                     id,
                     file_num,
                     file_size,
-                    modified_time,
+                    last_modified,
                     is_upload,
                 } => {
                     if let Some(job) = fs::get_job(id, write_jobs) {
@@ -205,7 +205,7 @@ impl ConnectionManager {
                         let digest = FileTransferDigest {
                             id,
                             file_num,
-                            last_edit_timestamp: modified_time,
+                            last_modified,
                             file_size,
                             ..Default::default()
                         };
@@ -222,9 +222,6 @@ impl ConnectionManager {
                                         DigestCheckResult::NeedConfirm(mut digest) => {
                                             // upload to server, but server has the same file, request
                                             digest.is_upload = is_upload;
-                                            log::info!(
-                                            "server has the same file, send server digest to local"
-                                        );
                                             let mut msg_out = Message::new();
                                             let mut fr = FileResponse::new();
                                             fr.set_digest(digest);
@@ -365,6 +362,7 @@ impl ConnectionManager {
     }
 
     async fn send(msg: Message, conn: &mut Connection) {
+        println!("send msg: {:?}", msg);
         match msg.write_to_bytes() {
             Ok(bytes) => allow_err!(conn.send(&Data::RawMessage(bytes)).await),
             err => allow_err!(err),

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -161,9 +161,13 @@ impl ConnectionManager {
                     mut files,
                 } => {
                     let od = can_enable_overwrite_detection(get_version_number(VERSION));
+                    // cm has no show_hidden context
                     write_jobs.push(fs::TransferJob::new_write(
                         id,
+                        "".to_string(),
                         path,
+                        false,
+                        false,
                         files
                             .drain(..)
                             .map(|f| FileEntry {
@@ -172,7 +176,7 @@ impl ConnectionManager {
                                 ..Default::default()
                             })
                             .collect(),
-                        od,
+                            od,
                     ));
                 }
                 ipc::FS::CancelWrite { id } => {

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -270,6 +270,11 @@ impl ConnectionManager {
                         }
                     }
                 }
+                ipc::FS::WriteOffset {
+                    id,file_num,offset_blk
+                } => {
+                    
+                }
             },
             #[cfg(windows)]
             Data::ClipbaordFile(_clip) => {

--- a/src/ui/file_transfer.css
+++ b/src/ui/file_transfer.css
@@ -220,6 +220,10 @@ table.job-table tr.is_remote svg {
   transform: scale(-1, 1); 
 }
 
+table.job-table tr.is_remote div.svg_continue svg {
+  transform: scale(1, 1); 
+}
+
 table.job-table tr td div.text {
   width: *;
   overflow-x: hidden;

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -694,7 +694,7 @@ handler.confirmDeleteFiles = function(id, i, name) {
     </div>", function(res=null) {
       if (!res) {
         jt.updateJobStatus(id, i - 1, "cancel");
-        file_transfer.job_table.confirmDeletePolling();
+        file_transfer.job_table.cancelDeletePolling();
       } else if (res.skip) {
         if (res.remember){
           jt.updateJobStatus(id, i, "cancel");

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -19,6 +19,7 @@ var svg_refresh = <svg viewBox="0 0 551.13 551.13">
 <path d="m482.24 310.01c0 113.97-92.707 206.67-206.67 206.67s-206.67-92.708-206.67-206.67c0-102.21 74.639-187.09 172.23-203.56v65.78l86.114-86.114-86.114-86.115v71.641c-116.65 16.802-206.67 117.14-206.67 238.37 0 132.96 108.16 241.12 241.12 241.12s241.12-108.16 241.12-241.12z"/>
 </svg>;
 var svg_cancel = <svg .cancel viewBox="0 0 612 612"><polygon points="612 36.004 576.52 0.603 306 270.61 35.478 0.603 0 36.004 270.52 306.01 0 576 35.478 611.4 306 341.41 576.52 611.4 612 576 341.46 306.01"/></svg>;
+var svg_continue = <svg .continue t="1652493728825" class="icon" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="793" ne="0.8429451094012732" width="200" height="200"><path d="M458.69056 948.9408v74.39872c-102.4512-10.22464-196.25472-51.00544-272.1024-113.024l52.2752-52.2752c62.09024 48.87552 137.58464 81.39776 219.8272 90.89536z m562.47296-434.70848c0 263.99744-202.6496 482.9696-460.06784 509.0304v-74.5472c216.6272-25.99424 385.95584-211.73248 385.95584-435.072 0-223.27296-169.32352-409.00096-385.95584-434.9952V5.19168c257.42336 26.07104 460.06784 245.0432 460.06784 509.04064zM166.24128 785.83296l-52.13696 52.14208C50.82112 760.9088 9.51808 665.20576 0 560.67584h73.36448c9.1136 84.41856 42.44992 161.85344 92.8768 225.15712zM113.77664 190.88384l51.65056 51.6608C117.12 303.5392 84.64384 377.56928 74.3424 458.2656H0.95744C12.032 357.632 52.60288 265.53344 113.77664 190.88384zM458.69056 5.12v73.30304c-82.69312 9.55392-158.5664 42.37824-220.8512 91.6992L186.17856 118.4768C262.10304 56.2688 356.06528 15.36 458.69568 5.12z" p-id="794"></path><path d="M652.8 512l-276.48 166.4v-332.8z" p-id="795"></path></svg>;
 var svg_computer = <svg .computer viewBox="0 0 480 480">
 <g>
 <path fill="#2C8CFF" d="m276 395v11.148c0 2.327-1.978 4.15-4.299 3.985-21.145-1.506-42.392-1.509-63.401-0.011-2.322 0.166-4.3-1.657-4.3-3.985v-11.137c0-2.209 1.791-4 4-4h64c2.209 0 4 1.791 4 4zm204-340v288c0 17.65-14.35 32-32 32h-416c-17.65 0-32-14.35-32-32v-288c0-17.65 14.35-32 32-32h416c17.65 0 32 14.35 32 32zm-125.62 386.36c-70.231-21.843-158.71-21.784-228.76 0-4.22 1.31-6.57 5.8-5.26 10.02 1.278 4.085 5.639 6.591 10.02 5.26 66.093-20.58 151.37-21.125 219.24 0 4.22 1.31 8.71-1.04 10.02-5.26s-1.04-8.71-5.26-10.02z"/>
@@ -100,6 +101,13 @@ class JobTable: Reactor.Component {
     refreshDir(is_remote);
   }
 
+  event click $(svg.continue) (_, me) {
+    var job = this.jobs[me.parent.parent.parent.index];
+    var id = job.id;
+    this.continueJob(id);
+    this.update();
+  }
+
   function clearAllJobs() {
     this.jobs = [];
     this.job_map = {};
@@ -123,7 +131,9 @@ class JobTable: Reactor.Component {
     this.jobs.push({ type: "transfer",
                      id: id, path: path, to: to,
                      include_hidden: show_hidden,
-                     is_remote: is_remote });
+                     is_remote: is_remote,
+                     is_last: false
+                    });
     this.job_map[id] = this.jobs[this.jobs.length - 1];
     handler.send_files(id, path, to, 0, show_hidden, is_remote);
     var self = this;
@@ -134,12 +144,21 @@ class JobTable: Reactor.Component {
     var job = { type: "transfer",
     id: id, path: path, to: to,
     include_hidden: show_hidden,
-    is_remote: is_remote };
+    is_remote: is_remote, is_last: true, file_num: file_num };
     this.jobs.push(job);
     this.job_map[id] = this.jobs[this.jobs.length - 1];
     jobIdCounter = id + 1;
-    handler.send_files(id, path, to, file_num, show_hidden, is_remote);
+    handler.add_job(id, path, to, file_num, show_hidden, is_remote);
     stdout.println(JSON.stringify(job));
+  }
+
+  function continueJob(id) {
+    var job = this.job_map[id];
+    if (job == null || !job.is_last){
+      return;
+    }
+    job.is_last = false;
+    handler.resume_job(job.id, job.is_remote);
   }
 
   function addDelDir(path, is_remote) {
@@ -275,6 +294,9 @@ class JobTable: Reactor.Component {
       <div .text>
         <div .path>{job.path}</div>
         <div id={"s" + job.id}>{this.getStatus(job)}</div>
+      </div>
+      <div class="svg_continue" style={job.is_last ? "" : "visibility: hidden"}>
+        {svg_continue}
       </div>
       {svg_cancel}
     </td></tr>;
@@ -673,7 +695,7 @@ handler.clearAllJobs = function() {
 }
 
 handler.addJob = function (id, path, to, file_num, show_hidden, is_remote) {
-  stdout.println("restore job: " + is_remote);
+  // stdout.println("restore job: " + is_remote);
   file_transfer.job_table.addJob(id,path,to,file_num,show_hidden,is_remote);
 }
 

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -717,7 +717,7 @@ handler.confirmDeleteFiles = function(id, i, name) {
     });
 }
 
-handler.overrideFileConfirm = function(id, file_num, to) {
+handler.overrideFileConfirm = function(id, file_num, to, is_upload) {
   var jt = file_transfer.job_table;
   var job = jt.job_map[id];
   stdout.println("job type: " + job.type);
@@ -732,15 +732,15 @@ handler.overrideFileConfirm = function(id, file_num, to) {
         jt.updateJobStatus(id, -1, "cancel");
       } else if (res.skip) {
         if (res.remember){
-          handler.set_write_override(id,file_num,false,true); //
+          handler.set_write_override(id,file_num,false,true, is_upload); //
         } else {
-          handler.set_write_override(id,file_num,false,false); //
+          handler.set_write_override(id,file_num,false,false,is_upload); //
         }
       } else {
         if (res.remember){
-          handler.set_write_override(id,file_num,true,true); //
+          handler.set_write_override(id,file_num,true,true,is_upload); //
         } else {
-          handler.set_write_override(id,file_num,true,false); //
+          handler.set_write_override(id,file_num,true,false,is_upload); //
         }
       }
     });

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -679,6 +679,7 @@ function confirmDelete(id ,path, is_remote) {
 }
 
 handler.confirmDeleteFiles = function(id, i, name) {
+  stdout.println("id=" + id +", i=" +",name="+name);
   var jt = file_transfer.job_table;
   var job = jt.job_map[id];
   if (!job) return;
@@ -712,6 +713,28 @@ handler.confirmDeleteFiles = function(id, i, name) {
       }
       if(i+1 >= n){
         file_transfer.job_table.confirmDeletePolling(job.is_remote);
+      }
+    });
+}
+
+handler.overrideFileConfirm = function(id, file_num, to) {
+  var jt = file_transfer.job_table;
+  var job = jt.job_map[id];
+  stdout.println("job type: " + job.type);
+  stdout.println(id + path + to);
+  stdout.println(JSON.stringify(job));
+  msgbox("custom-skip", "Confirm Write Strategy", "<div .form> \
+        <div>" + translate('Overwrite') + translate('files') + ".</div> \
+        <div>" + translate('This file exists in your computer, skip or overwrite this file?') + "</div> \
+        <div.ellipsis style=\"font-weight: bold;\" .text>" + to + "</div> \
+        <div><button|checkbox(remember) {ts}>" + translate('Do this for all conflicts') + "</button></div> \
+    </div>", function(res=null) {
+      if (!res) {
+        jt.updateJobStatus(id, -1, "cancel");
+      } else if (res.skip) {
+        handler.set_write_override(id,file_num,false,true); //
+      } else {
+        handler.set_write_override(id,file_num,true,false); //
       }
     });
 }

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -721,20 +721,27 @@ handler.overrideFileConfirm = function(id, file_num, to) {
   var jt = file_transfer.job_table;
   var job = jt.job_map[id];
   stdout.println("job type: " + job.type);
-  stdout.println(id + path + to);
   stdout.println(JSON.stringify(job));
   msgbox("custom-skip", "Confirm Write Strategy", "<div .form> \
         <div>" + translate('Overwrite') + translate('files') + ".</div> \
-        <div>" + translate('This file exists in your computer, skip or overwrite this file?') + "</div> \
+        <div>" + translate('This file exists, skip or overwrite this file?') + "</div> \
         <div.ellipsis style=\"font-weight: bold;\" .text>" + to + "</div> \
         <div><button|checkbox(remember) {ts}>" + translate('Do this for all conflicts') + "</button></div> \
     </div>", function(res=null) {
       if (!res) {
         jt.updateJobStatus(id, -1, "cancel");
       } else if (res.skip) {
-        handler.set_write_override(id,file_num,false,true); //
+        if (res.remember){
+          handler.set_write_override(id,file_num,false,true); //
+        } else {
+          handler.set_write_override(id,file_num,false,false); //
+        }
       } else {
-        handler.set_write_override(id,file_num,true,false); //
+        if (res.remember){
+          handler.set_write_override(id,file_num,true,true); //
+        } else {
+          handler.set_write_override(id,file_num,true,false); //
+        }
       }
     });
 }

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -679,7 +679,6 @@ function confirmDelete(id ,path, is_remote) {
 }
 
 handler.confirmDeleteFiles = function(id, i, name) {
-  stdout.println("id=" + id +", i=" +",name="+name);
   var jt = file_transfer.job_table;
   var job = jt.job_map[id];
   if (!job) return;
@@ -695,6 +694,7 @@ handler.confirmDeleteFiles = function(id, i, name) {
     </div>", function(res=null) {
       if (!res) {
         jt.updateJobStatus(id, i - 1, "cancel");
+        file_transfer.job_table.confirmDeletePolling();
       } else if (res.skip) {
         if (res.remember){
           jt.updateJobStatus(id, i, "cancel");
@@ -718,9 +718,6 @@ handler.confirmDeleteFiles = function(id, i, name) {
 
 handler.overrideFileConfirm = function(id, file_num, to, is_upload) {
   var jt = file_transfer.job_table;
-  var job = jt.job_map[id];
-  stdout.println("job type: " + job.type);
-  stdout.println(JSON.stringify(job));
   msgbox("custom-skip", "Confirm Write Strategy", "<div .form> \
         <div>" + translate('Overwrite') + translate('files') + ".</div> \
         <div>" + translate('This file exists, skip or overwrite this file?') + "</div> \

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -125,7 +125,7 @@ class JobTable: Reactor.Component {
                      include_hidden: show_hidden,
                      is_remote: is_remote });
     this.job_map[id] = this.jobs[this.jobs.length - 1];
-    handler.send_files(id, path, to, show_hidden, is_remote);
+    handler.send_files(id, path, to, 0, show_hidden, is_remote);
     var self = this;
     self.timer(30ms, function() { self.update(); });
   }
@@ -138,7 +138,7 @@ class JobTable: Reactor.Component {
     this.jobs.push(job);
     this.job_map[id] = this.jobs[this.jobs.length - 1];
     jobIdCounter = id + 1;
-    handler.send_files(id, path, to, show_hidden, is_remote);
+    handler.send_files(id, path, to, file_num, show_hidden, is_remote);
     stdout.println(JSON.stringify(job));
   }
 

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -695,7 +695,6 @@ handler.confirmDeleteFiles = function(id, i, name) {
     </div>", function(res=null) {
       if (!res) {
         jt.updateJobStatus(id, i - 1, "cancel");
-        file_transfer.job_table.cancelDeletePolling();
       } else if (res.skip) {
         if (res.remember){
           jt.updateJobStatus(id, i, "cancel");
@@ -730,6 +729,7 @@ handler.overrideFileConfirm = function(id, file_num, to, is_upload) {
     </div>", function(res=null) {
       if (!res) {
         jt.updateJobStatus(id, -1, "cancel");
+        handler.cancel_job(id);
       } else if (res.skip) {
         if (res.remember){
           handler.set_write_override(id,file_num,false,true, is_upload); //

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -100,6 +100,12 @@ class JobTable: Reactor.Component {
     refreshDir(is_remote);
   }
 
+  function clearAllJobs() {
+    this.jobs = [];
+    this.job_map = {};
+    this.update();
+  }
+
   function send(path, is_remote) {
     var to;
     var show_hidden;
@@ -122,6 +128,14 @@ class JobTable: Reactor.Component {
     handler.send_files(id, path, to, show_hidden, is_remote);
     var self = this;
     self.timer(30ms, function() { self.update(); });
+  }
+
+  function addJob(id, path, to, show_hidden, is_remote) {
+    this.jobs.push({ type: "transfer",
+                     id: id, path: path, to: to,
+                     include_hidden: show_hidden,
+                     is_remote: is_remote });
+    this.job_map[id] = this.jobs[this.jobs.length - 1];
   }
 
   function addDelDir(path, is_remote) {
@@ -647,6 +661,18 @@ handler.jobError = function(id, err, file_num = -1) {
     handler.msgbox("custom-error", "Failed", err);
   }
   file_transfer.job_table.updateJobStatus(id, file_num, err);
+}
+
+handler.clearAllJobs = function() {
+  file_transfer.job_table.clearAllJobs();
+}
+
+handler.addJob = function (id, path, to, file_num, show_hidden, is_remote) {
+  file_transfer.job_table.addJob(id,path,to,file_num,show_hidden,is_remote);
+}
+
+handler.updateTransferList = function () {
+  file_transfer.job_table.update();
 }
 
 function refreshDir(is_remote) {

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -130,12 +130,16 @@ class JobTable: Reactor.Component {
     self.timer(30ms, function() { self.update(); });
   }
 
-  function addJob(id, path, to, show_hidden, is_remote) {
-    this.jobs.push({ type: "transfer",
-                     id: id, path: path, to: to,
-                     include_hidden: show_hidden,
-                     is_remote: is_remote });
+  function addJob(id, path, to, file_num, show_hidden, is_remote) {
+    var job = { type: "transfer",
+    id: id, path: path, to: to,
+    include_hidden: show_hidden,
+    is_remote: is_remote };
+    this.jobs.push(job);
     this.job_map[id] = this.jobs[this.jobs.length - 1];
+    jobIdCounter = id + 1;
+    handler.send_files(id, path, to, show_hidden, is_remote);
+    stdout.println(JSON.stringify(job));
   }
 
   function addDelDir(path, is_remote) {
@@ -617,6 +621,7 @@ function initializeFileTransfer()
 }
 
 handler.updateFolderFiles = function(fd) {
+  stdout.println("update folder files: " + JSON.stringify(fd));
   fd.entries = fd.entries || [];
   if (fd.id > 0) {
     var jt = file_transfer.job_table;
@@ -668,6 +673,7 @@ handler.clearAllJobs = function() {
 }
 
 handler.addJob = function (id, path, to, file_num, show_hidden, is_remote) {
+  stdout.println("restore job: " + is_remote);
   file_transfer.job_table.addJob(id,path,to,file_num,show_hidden,is_remote);
 }
 

--- a/src/ui/file_transfer.tis
+++ b/src/ui/file_transfer.tis
@@ -621,7 +621,7 @@ function initializeFileTransfer()
 }
 
 handler.updateFolderFiles = function(fd) {
-  stdout.println("update folder files: " + JSON.stringify(fd));
+  // stdout.println("update folder files: " + JSON.stringify(fd));
   fd.entries = fd.entries || [];
   if (fd.id > 0) {
     var jt = file_transfer.job_table;

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -1319,7 +1319,7 @@ async fn io_loop(handler: Handler) {
         clipboard_file_context: None,
     };
     remote.io_loop(&key, &token).await;
-    remote.sync_jobs_status_to_local();
+    remote.sync_jobs_status_to_local().await;
 }
 
 struct RemoveJob {
@@ -1452,7 +1452,7 @@ impl Remote {
                         }
                     }
                 }
-                self.sync_jobs_status_to_local();
+                self.sync_jobs_status_to_local().await;
                 log::debug!("Exit io_loop of id={}", self.handler.id);
             }
             Err(err) => {
@@ -1798,6 +1798,7 @@ impl Remote {
     }
 
     async fn sync_jobs_status_to_local(&mut self) -> bool {
+        println!("sync job status");
         let mut config: PeerConfig = self.handler.load_config();
         let mut transfer_metas = TransferSerde::default();
         for job in self.read_jobs.iter() {
@@ -1895,6 +1896,10 @@ impl Remote {
                             } else if let Some(job) = self.remove_jobs.get_mut(&fd.id) {
                                 job.files = entries;
                             }
+                        }
+                        Some(file_response::Union::offset(offset)) => {
+                            // TODO: offset
+                            // upload
                         }
                         Some(file_response::Union::digest(digest)) => {
                             if digest.is_upload {

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -1319,6 +1319,7 @@ async fn io_loop(handler: Handler) {
         clipboard_file_context: None,
     };
     remote.io_loop(&key, &token).await;
+    remote.sync_jobs_status_to_local().await;
 }
 
 struct RemoveJob {
@@ -1451,7 +1452,6 @@ impl Remote {
                         }
                     }
                 }
-                self.sync_jobs_status_to_local().await;
                 log::debug!("Exit io_loop of id={}", self.handler.id);
             }
             Err(err) => {
@@ -1876,6 +1876,7 @@ impl Remote {
             let json_str = serde_json::to_string(&job.gen_meta()).unwrap();
             transfer_metas.write_jobs.push(json_str);
         }
+        log::info!("meta: {:?}",transfer_metas);
         config.transfer = transfer_metas;
         self.handler.save_config(config);
         true

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -768,6 +768,7 @@ impl Handler {
     }
 
     fn reconnect(&mut self) {
+        println!("reconnecting");
         let cloned = self.clone();
         let mut lock = self.write().unwrap();
         lock.thread.take().map(|t| t.join());
@@ -1559,7 +1560,6 @@ impl Remote {
                                 to,
                                 job.files().len()
                             );
-                            let config = self.handler.lc.read().unwrap().version;
                             let m = make_fd(job.id(), job.files(), true);
                             self.handler.call("updateFolderFiles", &make_args!(m));
                             let files = job.files().clone();

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -1542,6 +1542,7 @@ impl Remote {
     }
 
     async fn load_last_jobs(&mut self) {
+        println!("start load last jobs");
         self.handler.call("clearAllJobs",&make_args!());
         let pc = self.handler.load_config();
         if pc.transfer.write_jobs.is_empty() && pc.transfer.read_jobs.is_empty() {
@@ -1845,6 +1846,7 @@ impl Remote {
             transfer_metas.remove_jobs.push(job.gen_meta());
         }
         config.transfer = transfer_metas;
+        println!("{:?}", config.transfer);
         self.handler.save_config(config);
         true
     }

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -219,7 +219,7 @@ impl sciter::EventHandler for Handler {
         fn toggle_option(String);
         fn get_remember();
         fn peer_platform();
-        fn set_write_override(i32,i32, bool,bool); // ,
+        fn set_write_override(i32,i32, bool,bool,bool); // ,
     }
 }
 
@@ -546,12 +546,14 @@ impl Handler {
         file_num: i32,
         is_override: bool,
         remember: bool,
+        is_upload: bool,
     ) -> bool {
         self.send(Data::SetConfirmOverrideFile((
             job_id,
             file_num,
             is_override,
             remember,
+            is_upload,
         )));
         true
     }
@@ -1580,25 +1582,43 @@ impl Remote {
                     }
                 }
             }
-            Data::SetConfirmOverrideFile((id, file_num, need_override, remember)) => {
-                if let Some(job) = fs::get_job(id, &mut self.write_jobs) {
-                    if remember {
-                        job.set_overwrite_strategy(Some(need_override));
+            Data::SetConfirmOverrideFile((id, file_num, need_override, remember, is_upload)) => {
+                if is_upload {
+                    if let Some(job) = fs::get_job(id, &mut self.read_jobs) {
+                        if remember {
+                            job.set_overwrite_strategy(Some(need_override));
+                        }
+                        job.confirm(&FileTransferSendConfirmRequest {
+                            id,
+                            file_num,
+                            union: if need_override {
+                                Some(file_transfer_send_confirm_request::Union::offset_blk(0))
+                            } else {
+                                Some(file_transfer_send_confirm_request::Union::skip(true))
+                            },
+                            ..Default::default()
+                        });
                     }
-                    let mut msg = Message::new();
-                    let mut file_action = FileAction::new();
-                    file_action.set_send_confirm(FileTransferSendConfirmRequest {
-                        id,
-                        file_num,
-                        union: if need_override {
-                            Some(file_transfer_send_confirm_request::Union::offset_blk(0))
-                        } else {
-                            Some(file_transfer_send_confirm_request::Union::skip(true))
-                        },
-                        ..Default::default()
-                    });
-                    msg.set_file_action(file_action);
-                    allow_err!(peer.send(&msg).await);
+                } else {
+                    if let Some(job) = fs::get_job(id, &mut self.write_jobs) {
+                        if remember {
+                            job.set_overwrite_strategy(Some(need_override));
+                        }
+                        let mut msg = Message::new();
+                        let mut file_action = FileAction::new();
+                        file_action.set_send_confirm(FileTransferSendConfirmRequest {
+                            id,
+                            file_num,
+                            union: if need_override {
+                                Some(file_transfer_send_confirm_request::Union::offset_blk(0))
+                            } else {
+                                Some(file_transfer_send_confirm_request::Union::skip(true))
+                            },
+                            ..Default::default()
+                        });
+                        msg.set_file_action(file_action);
+                        allow_err!(peer.send(&msg).await);
+                    }
                 }
             }
             Data::RemoveDirAll((id, path, is_remote)) => {
@@ -1841,50 +1861,63 @@ impl Remote {
                         }
                     }
                     Some(file_response::Union::digest(digest)) => {
-                        if let Some(job) = fs::get_job(digest.id, &mut self.write_jobs) {
-                            if let Some(file) = job.files().get(digest.file_num as usize) {
-                                let write_path = get_string(&job.join(&file.name));
-                                let overwrite_strategy = job.default_overwrite_strategy();
-                                match fs::is_write_need_confirmation(&write_path, &digest) {
-                                    Ok(res) => {
-                                        if res.is_some() {
-                                            // need confirm
-                                            if overwrite_strategy.is_none() {
-                                                self.handler.call(
-                                                    "overrideFileConfirm",
-                                                    &make_args!(
-                                                        digest.id,
-                                                        digest.file_num,
-                                                        write_path
-                                                    ),
-                                                );
-                                            } else {
-                                                let msg = new_send_confirm(
-                                                    FileTransferSendConfirmRequest {
-                                                        id: digest.id,
-                                                        file_num: digest.file_num,
-                                                        union: if overwrite_strategy.unwrap() {
-                                                            Some(file_transfer_send_confirm_request::Union::offset_blk(0))
-                                                        } else {
-                                                            Some(file_transfer_send_confirm_request::Union::skip(true))
+                        if digest.is_upload {
+                            if let Some(job) = fs::get_job(digest.id, &mut self.read_jobs) {
+                                if let Some(file) = job.files().get(digest.file_num as usize) {
+                                    let read_path = get_string(&job.join(&file.name));
+                                    self.handler.call(
+                                        "overrideFileConfirm",
+                                        &make_args!(digest.id, digest.file_num, read_path, true),
+                                    );
+                                }
+                            }
+                        } else {
+                            if let Some(job) = fs::get_job(digest.id, &mut self.write_jobs) {
+                                if let Some(file) = job.files().get(digest.file_num as usize) {
+                                    let write_path = get_string(&job.join(&file.name));
+                                    let overwrite_strategy = job.default_overwrite_strategy();
+                                    match fs::is_write_need_confirmation(&write_path, &digest) {
+                                        Ok(res) => {
+                                            if res.is_some() {
+                                                // need confirm
+                                                if overwrite_strategy.is_none() {
+                                                    self.handler.call(
+                                                        "overrideFileConfirm",
+                                                        &make_args!(
+                                                            digest.id,
+                                                            digest.file_num,
+                                                            write_path,
+                                                            false
+                                                        ),
+                                                    );
+                                                } else {
+                                                    let msg = new_send_confirm(
+                                                        FileTransferSendConfirmRequest {
+                                                            id: digest.id,
+                                                            file_num: digest.file_num,
+                                                            union: if overwrite_strategy.unwrap() {
+                                                                Some(file_transfer_send_confirm_request::Union::offset_blk(0))
+                                                            } else {
+                                                                Some(file_transfer_send_confirm_request::Union::skip(true))
+                                                            },
+                                                            ..Default::default()
                                                         },
-                                                        ..Default::default()
-                                                    },
-                                                );
-                                                allow_err!(peer.send(&msg).await);
-                                            }
-                                        } else {
-                                            let msg= new_send_confirm(FileTransferSendConfirmRequest {
+                                                    );
+                                                    allow_err!(peer.send(&msg).await);
+                                                }
+                                            } else {
+                                                let msg= new_send_confirm(FileTransferSendConfirmRequest {
                                                 id: digest.id,
                                                 file_num: digest.file_num,
                                                 union: Some(file_transfer_send_confirm_request::Union::skip(true)),
                                                 ..Default::default()
                                             });
-                                            allow_err!(peer.send(&msg).await);
+                                                allow_err!(peer.send(&msg).await);
+                                            }
                                         }
-                                    }
-                                    Err(err) => {
-                                        println!("error recving digest: {}", err);
+                                        Err(err) => {
+                                            println!("error recving digest: {}", err);
+                                        }
                                     }
                                 }
                             }

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -219,7 +219,7 @@ impl sciter::EventHandler for Handler {
         fn toggle_option(String);
         fn get_remember();
         fn peer_platform();
-        fn set_write_override(i32,i32, bool,bool,bool); // ,
+        fn set_write_override(i32, i32, bool, bool, bool);
     }
 }
 


### PR DESCRIPTION
This PR brings more flexible network requirements when transfering. Improvements are listed below:

- Supports resuming file transfer by resending send request.
- Supports resuming folder transfer by sending offset of the uncompleted index to the remote.

Time to trigger the logic of resuming file-transfer progress:
- when reopen file transfer window if transfer lists was not fully complete in the prior file-transfer progress and the tranfer window was closed.
- when reconnection behavior is triggered (poor network, etc.) and successfully reconnect to the remote server.