### PR TITLE
enigo: check /usr/lib/rustdesk for pynput_service.py

### DIFF
--- a/libs/enigo/src/linux.rs
+++ b/libs/enigo/src/linux.rs
@@ -489,7 +489,10 @@ fn start_pynput_service(rx: mpsc::Receiver<(PyMsg, bool)>) {
     if !std::path::Path::new(&py).exists() {
         py = "/usr/share/rustdesk/files/pynput_service.py".to_owned();
         if !std::path::Path::new(&py).exists() {
-            log::error!("{} not exits", py);
+            py = "/usr/lib/rustdesk/pynput_service.py".to_owned();
+            if !std::path::Path::new(&py).exists() {
+                log::error!("{} not exits", py);
+            }
         }
     }
     log::info!("pynput service: {}", py);


### PR DESCRIPTION
I'm packaging the binary version of rustdesk for the AUR. According to the Arch Linux packaging guidelines, additional application modules such as the `pynput_service.py` should be installed to `/usr/lib/{pkg}`, where `pkg` is the name of the application (see https://wiki.archlinux.org/title/Arch_package_guidelines#Directories). This also applies to most other distributions which follow the Filesystem Hierarchy Standard (FHS). Thus it would be great to have rustdesk/enigo check `/usr/lib/rustdesk` for the pynput service script.

This PR makes enigo check `/usr/lib/rustdesk` for `pynput_service.py` in addition to the current behavior of checking the current working directory and `/usr/share/rustdesk/files`.