### PR TITLE
feat: [mobile] more precise control method for transfering files

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -37,8 +37,8 @@ class MyTheme {
 }
 
 final ButtonStyle flatButtonStyle = TextButton.styleFrom(
-  minimumSize: Size(88, 36),
-  padding: EdgeInsets.symmetric(horizontal: 16.0),
+  minimumSize: Size(0, 36),
+  padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 10.0),
   shape: const RoundedRectangleBorder(
     borderRadius: BorderRadius.all(Radius.circular(2.0)),
   ),

--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -144,6 +144,28 @@ class FileModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  overrideFileConfirm(Map<String,dynamic> evt) async {
+    final resp = await showFileConfirmDialog(
+        translate("Overwrite"), "${evt['read_path']}", true);
+    if (false == resp) {
+      cancelJob(int.tryParse(evt['id']) ?? 0);
+    } else {
+      var msg = Map()
+        ..['id'] = evt['id']
+        ..['file_num'] = evt['file_num']
+        ..['is_upload'] = evt['is_upload']
+        ..['remember'] = fileConfirmCheckboxRemember.toString();
+      if (resp == null) {
+        // skip
+        msg['need_override'] = 'false';
+      } else {
+        // overwrite
+        msg['need_override'] = 'true';
+      }
+      FFI.setByName("set_confirm_override_file", jsonEncode(msg));
+    }
+  }
+
   jobReset() {
     _jobProgress.clear();
     notifyListeners();
@@ -389,6 +411,60 @@ class FileModel extends ChangeNotifier {
                       onPressed: () => close(true),
                       child: Text(translate("OK"))),
                 ]),
+        useAnimation: false);
+  }
+
+  bool fileConfirmCheckboxRemember = false;
+
+  Future<bool?> showFileConfirmDialog(
+      String title, String content, bool showCheckbox) async {
+    return await DialogManager.show<bool?>(
+            (setState, Function(bool? v) close) => CustomAlertDialog(
+            title: Row(
+              children: [
+                Icon(Icons.warning, color: Colors.red),
+                SizedBox(width: 20),
+                Text(title)
+              ],
+            ),
+            content: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(translate("This file exists, skip or overwrite this file?"),
+                      style: TextStyle(fontWeight: FontWeight.bold)),
+                  SizedBox(height: 5),
+                  Text(content),
+                  showCheckbox
+                      ? CheckboxListTile(
+                    contentPadding: const EdgeInsets.all(0),
+                    dense: true,
+                    controlAffinity: ListTileControlAffinity.leading,
+                    title: Text(
+                      translate("Do this for all conflicts"),
+                    ),
+                    value: fileConfirmCheckboxRemember,
+                    onChanged: (v) {
+                      if (v == null) return;
+                      setState(() => fileConfirmCheckboxRemember = v);
+                    },
+                  )
+                      : SizedBox.shrink()
+                ]),
+            actions: [
+              TextButton(
+                  style: flatButtonStyle,
+                  onPressed: () => close(false),
+                  child: Text(translate("Cancel"))),
+              TextButton(
+                  style: flatButtonStyle,
+                  onPressed: () => close(null),
+                  child: Text(translate("Skip"))),
+              TextButton(
+                  style: flatButtonStyle,
+                  onPressed: () => close(true),
+                  child: Text(translate("OK"))),
+            ]),
         useAnimation: false);
   }
 

--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -253,6 +253,7 @@ class FileModel extends ChangeNotifier {
         "id": _jobId.toString(),
         "path": from.path,
         "to": PathUtil.join(toPath, from.name, isWindows),
+        "file_num": "0",
         "show_hidden": showHidden.toString(),
         "is_remote": (!(items.isLocal!)).toString()
       };

--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -144,7 +144,7 @@ class FileModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  overrideFileConfirm(Map<String,dynamic> evt) async {
+  overrideFileConfirm(Map<String, dynamic> evt) async {
     final resp = await showFileConfirmDialog(
         translate("Overwrite"), "${evt['read_path']}", true);
     if (false == resp) {
@@ -418,53 +418,56 @@ class FileModel extends ChangeNotifier {
 
   Future<bool?> showFileConfirmDialog(
       String title, String content, bool showCheckbox) async {
+    fileConfirmCheckboxRemember = false;
     return await DialogManager.show<bool?>(
-            (setState, Function(bool? v) close) => CustomAlertDialog(
-            title: Row(
-              children: [
-                Icon(Icons.warning, color: Colors.red),
-                SizedBox(width: 20),
-                Text(title)
-              ],
-            ),
-            content: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(translate("This file exists, skip or overwrite this file?"),
-                      style: TextStyle(fontWeight: FontWeight.bold)),
-                  SizedBox(height: 5),
-                  Text(content),
-                  showCheckbox
-                      ? CheckboxListTile(
-                    contentPadding: const EdgeInsets.all(0),
-                    dense: true,
-                    controlAffinity: ListTileControlAffinity.leading,
-                    title: Text(
-                      translate("Do this for all conflicts"),
-                    ),
-                    value: fileConfirmCheckboxRemember,
-                    onChanged: (v) {
-                      if (v == null) return;
-                      setState(() => fileConfirmCheckboxRemember = v);
-                    },
-                  )
-                      : SizedBox.shrink()
+        (setState, Function(bool? v) close) => CustomAlertDialog(
+                title: Row(
+                  children: [
+                    Icon(Icons.warning, color: Colors.red),
+                    SizedBox(width: 20),
+                    Text(title)
+                  ],
+                ),
+                content: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                          translate(
+                              "This file exists, skip or overwrite this file?"),
+                          style: TextStyle(fontWeight: FontWeight.bold)),
+                      SizedBox(height: 5),
+                      Text(content),
+                      showCheckbox
+                          ? CheckboxListTile(
+                              contentPadding: const EdgeInsets.all(0),
+                              dense: true,
+                              controlAffinity: ListTileControlAffinity.leading,
+                              title: Text(
+                                translate("Do this for all conflicts"),
+                              ),
+                              value: fileConfirmCheckboxRemember,
+                              onChanged: (v) {
+                                if (v == null) return;
+                                setState(() => fileConfirmCheckboxRemember = v);
+                              },
+                            )
+                          : SizedBox.shrink()
+                    ]),
+                actions: [
+                  TextButton(
+                      style: flatButtonStyle,
+                      onPressed: () => close(false),
+                      child: Text(translate("Cancel"))),
+                  TextButton(
+                      style: flatButtonStyle,
+                      onPressed: () => close(null),
+                      child: Text(translate("Skip"))),
+                  TextButton(
+                      style: flatButtonStyle,
+                      onPressed: () => close(true),
+                      child: Text(translate("OK"))),
                 ]),
-            actions: [
-              TextButton(
-                  style: flatButtonStyle,
-                  onPressed: () => close(false),
-                  child: Text(translate("Cancel"))),
-              TextButton(
-                  style: flatButtonStyle,
-                  onPressed: () => close(null),
-                  child: Text(translate("Skip"))),
-              TextButton(
-                  style: flatButtonStyle,
-                  onPressed: () => close(true),
-                  child: Text(translate("OK"))),
-            ]),
         useAnimation: false);
   }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -156,6 +156,8 @@ class FfiModel with ChangeNotifier {
         FFI.fileModel.jobDone(evt);
       } else if (name == 'job_error') {
         FFI.fileModel.jobError(evt);
+      } else if (name == 'override_file_confirm') {
+        FFI.fileModel.overrideFileConfirm(evt);
       } else if (name == 'try_start_without_auth') {
         FFI.serverModel.loginRequest(evt);
       } else if (name == 'on_client_authorized') {

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -544,6 +544,7 @@ impl TransferJob {
     }
 
     pub fn set_file_confirmed(&mut self, file_confirmed: bool) {
+        log::info!("id: {}, file_confirmed: {}", self.id, file_confirmed);
         self.file_confirmed = file_confirmed;
     }
 
@@ -581,7 +582,6 @@ impl TransferJob {
                     }
                 }
                 Some(file_transfer_send_confirm_request::Union::offset_blk(offset)) => {
-                    log::debug!("file confirmed");
                     self.set_file_confirmed(true);
                 }
                 _ => {}

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -581,7 +581,7 @@ impl TransferJob {
                         self.set_file_confirmed(true);
                     }
                 }
-                Some(file_transfer_send_confirm_request::Union::offset_blk(offset)) => {
+                Some(file_transfer_send_confirm_request::Union::offset_blk(_offset)) => {
                     self.set_file_confirmed(true);
                 }
                 _ => {}

--- a/src/mobile.rs
+++ b/src/mobile.rs
@@ -1132,7 +1132,7 @@ pub mod connection_manager {
     use hbb_common::{
         allow_err,
         config::Config,
-        fs, log,
+        fs::{self, new_send_confirm, DigestCheckResult, get_string}, log,
         message_proto::*,
         protobuf::Message as _,
         tokio::{

--- a/src/mobile_ffi.rs
+++ b/src/mobile_ffi.rs
@@ -346,6 +346,31 @@ unsafe extern "C" fn set_by_name(name: *const c_char, value: *const c_char) {
                         }
                     }
                 }
+                "set_confirm_override_file" => {
+                    if let Ok(m) = serde_json::from_str::<HashMap<String, String>>(value) {
+                        if let (
+                            Some(id),
+                            Some(file_num),
+                            Some(need_override),
+                            Some(remember),
+                            Some(is_upload),
+                        ) = (
+                            m.get("id"),
+                            m.get("file_num"),
+                            m.get("need_override"),
+                            m.get("remember"),
+                            m.get("is_upload")
+                        ) {
+                            Session::set_confirm_override_file(
+                                id.parse().unwrap_or(0),
+                                file_num.parse().unwrap_or(0),
+                                need_override.eq("true"),
+                                remember.eq("true"),
+                                is_upload.eq("true"),
+                            );
+                        }
+                    }
+                }
                 "remove_file" => {
                     if let Ok(m) = serde_json::from_str::<HashMap<String, String>>(value) {
                         if let (

--- a/src/mobile_ffi.rs
+++ b/src/mobile_ffi.rs
@@ -324,12 +324,14 @@ unsafe extern "C" fn set_by_name(name: *const c_char, value: *const c_char) {
                             Some(id),
                             Some(path),
                             Some(to),
+                            Some(file_num),
                             Some(show_hidden),
                             Some(is_remote),
                         ) = (
                             m.get("id"),
                             m.get("path"),
                             m.get("to"),
+                            m.get("file_num"),
                             m.get("show_hidden"),
                             m.get("is_remote"),
                         ) {
@@ -337,6 +339,7 @@ unsafe extern "C" fn set_by_name(name: *const c_char, value: *const c_char) {
                                 id.parse().unwrap_or(0),
                                 path.to_owned(),
                                 to.to_owned(),
+                                file_num.parse().unwrap_or(0),
                                 show_hidden.eq("true"),
                                 is_remote.eq("true"),
                             );

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -7,8 +7,6 @@ use crate::common::update_clipboard;
 use crate::{common::MOBILE_INFO2, mobile::connection_manager::start_channel};
 use crate::{ipc, VERSION};
 use hbb_common::fs::can_enable_overwrite_detection;
-use hbb_common::log::debug;
-use hbb_common::message_proto::file_transfer_send_confirm_request::Union;
 use hbb_common::{
     config::Config,
     fs,
@@ -23,7 +21,6 @@ use hbb_common::{
     },
     tokio_util::codec::{BytesCodec, Framed},
 };
-use libc::{printf, send};
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use scrap::android::call_input_service_mouse_input;
 use serde_json::{json, value::Value};

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -8,15 +8,13 @@ use hbb_common::fs::{
     can_enable_overwrite_detection, get_string, is_write_need_confirmation, new_send_confirm,
     DigestCheckResult,
 };
-use hbb_common::log::log;
 use hbb_common::{
     allow_err,
     config::Config,
     fs, get_version_number, log,
     message_proto::*,
     protobuf::Message as _,
-    tokio::{self, sync::mpsc, task::spawn_blocking},
-    ResultType,
+    tokio::{self, sync::mpsc, task::spawn_blocking}
 };
 use sciter::{make_args, Element, Value, HELEMENT};
 use std::{
@@ -278,9 +276,9 @@ impl ConnectionManager {
                     }
                 }
                 ipc::FS::WriteOffset {
-                    id,
-                    file_num,
-                    offset_blk,
+                    id: _,
+                    file_num: _,
+                    offset_blk: _,
                 } => {}
             },
             #[cfg(windows)]

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -21,14 +21,13 @@ use clipboard::{
 };
 use enigo::{self, Enigo, KeyboardControllable};
 use hbb_common::fs::{
-    can_enable_overwrite_detection, get_string, is_file_exists, new_send_confirm,
+    can_enable_overwrite_detection, get_string, new_send_confirm,
     DigestCheckResult, RemoveJobMeta, get_job,
 };
-use hbb_common::log::log;
 use hbb_common::{
     allow_err,
-    config::{self, Config, LocalConfig, PeerConfig},
-    fs, get_version_number, log,
+    config::{Config, LocalConfig, PeerConfig},
+    fs, log,
     message_proto::{permission_info::Permission, *},
     protobuf::Message as _,
     rendezvous_proto::ConnType,
@@ -46,8 +45,7 @@ use hbb_common::{config::TransferSerde, fs::TransferJobMeta};
 use crate::clipboard_file::*;
 use crate::{
     client::*,
-    common::{self, check_clipboard, update_clipboard, ClipboardContext, CLIPBOARD_INTERVAL},
-    VERSION,
+    common::{self, check_clipboard, update_clipboard, ClipboardContext, CLIPBOARD_INTERVAL}
 };
 
 type Video = AssetPtr<video_destination>;
@@ -1345,7 +1343,7 @@ impl RemoveJob {
         }
     }
 
-    pub fn gen_meta(&self) -> RemoveJobMeta {
+    pub fn _gen_meta(&self) -> RemoveJobMeta {
         RemoveJobMeta {
             path: self.path.clone(),
             is_remote: self.is_remote,


### PR DESCRIPTION
This PR gives `rustdesk for android` to support features proposed by #469, and fix compilation issues with branch `master`. 

> - skip identical files (modified time and file size are identical in both remote and local fs).
> - can make a choice by users when encountering an overwrite behaviors(same file name but not identical) during uploading/downloading files or folders. (can only be triggered when both running the specific version and above).