### PR TITLE
fix: Unix <-> Windows sub-folder collapsed

### DIFF
--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -767,6 +767,13 @@ pub fn create_dir(dir: &str) -> ResultType<()> {
     Ok(())
 }
 
+#[inline]
+pub fn transform_windows_path(entries: &mut Vec<FileEntry>) {
+    for entry in entries {
+        entry.name = entry.name.replace("\\", "/");
+    }
+}
+
 pub enum DigestCheckResult {
     IsSame,
     NeedConfirm(FileTransferDigest),

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -1644,7 +1644,15 @@ impl Remote {
                             );
                             let m = make_fd(job.id(), job.files(), true);
                             self.handler.call("updateFolderFiles", &make_args!(m));
+                            #[cfg(not(windows))]
                             let files = job.files().clone();
+                            #[cfg(windows)]
+                            let mut files = job.files().clone();
+                            #[cfg(windows)]
+                            if self.handler.peer_platform() != "Windows" {
+                                // peer is not windows, need transform \ to /
+                                fs::transform_windows_path(&mut files);
+                            }
                             self.read_jobs.push(job);
                             self.timer = time::interval(MILLI1);
                             allow_err!(peer.send(&fs::new_receive(id, to, file_num, files)).await);

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -2019,7 +2019,13 @@ impl Remote {
                 Some(message::Union::file_response(fr)) => {
                     match fr.union {
                         Some(file_response::Union::dir(fd)) => {
-                            let entries = fd.entries.to_vec();
+                            let mut entries = fd.entries.to_vec();
+                            #[cfg(not(windows))]
+                            {
+                                if self.handler.peer_platform() == "Windows" {
+                                    fs::transform_windows_path(&mut entries);
+                                }
+                            }  
                             let mut m = make_fd(fd.id, &entries, fd.id > 0);
                             if fd.id <= 0 {
                                 m.set_item("path", fd.path);


### PR DESCRIPTION
This PR fixs the problem described below:

Scene: unix(local) <- windows(remote), transfering folder, which layout is:

- folder
  - subfolder
    - test.txt
  - test2.txt

origin version of rustdesk, the `subfolder` disappeared, and recognizes the folder as a part of the name of `test.txt`, which is `subfolder\\test.txt`.

This PR add the fix, which will transform "\\" to "/" when:
- remote is Windows.
- local is Unix based system.
