### PR TITLE
win7 shcore lib using fix

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -61,10 +61,7 @@ pub fn start(args: &mut [String]) {
     allow_err!(sciter::set_options(sciter::RuntimeOptions::GfxLayer(
         sciter::GFX_LAYER::WARP
     )));
-    #[cfg(all(windows, not(feature = "inline")))]
-    unsafe {
-        winapi::um::shellscalingapi::SetProcessDpiAwareness(2);
-    }
+
     #[cfg(windows)]
     if args.len() > 0 && args[0] == "--tray" {
         let options = check_connect_status(false).1;


### PR DESCRIPTION
To be honest, I don’t understand at all what this block of code should do:

```
#[cfg(all(windows, not(feature = "inline")))]
    unsafe {
        winapi::um::shellscalingapi::SetProcessDpiAwareness(2);
    }
    
```

if the dpi awareness setting is done in [manifest](https://github.com/rustdesk/rustdesk/blob/master/manifest.xml) Therefore, in the end, I simply deleted this block of code, as expected, this did not affect the performance of the application and its appearance on Win7, 8.1, 10. (When connecting to a remote desktop, too)