### PR TITLE
Strip release binary via Rust toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,10 +131,9 @@ osx_minimum_system_version = "10.14"
 resources = ["mac-tray.png"]
 
 #https://github.com/johnthagen/min-sized-rust
-#!!! rembember call "strip target/release/rustdesk"
-# which reduce binary size a lot
 [profile.release]
 lto = true
 codegen-units = 1
 panic = 'abort'
+strip = true
 #opt-level = 'z' # only have smaller size after strip


### PR DESCRIPTION
As of Rust 1.59, full stripping support has been added (see https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html#creating-stripped-binaries).

If the project is intended to compiled with older Rust versions, feel free to close the PR straight away :smile:.