### PR TITLE
fix_deadlock_general_service

### DIFF
--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -89,7 +89,12 @@ impl<T: Subscriber + From<ConnInner>> Service for ServiceTmpl<T> {
 
     fn join(&self) {
         self.0.write().unwrap().active = false;
-        self.0.write().unwrap().handle.take().map(JoinHandle::join);
+        let handle = self.0.write().unwrap().handle.take();
+        if let Some(handle) = handle {
+            if let Err(e) = handle.join() {
+                log::error!("Failed to join thread for service {}, {:?}", self.name(), e);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

[`self.0.write().unwrap().handle.take().map(JoinHandle::join);`](https://github.com/rustdesk/rustdesk/blob/7c2cf6c9b37a19887094113a8266db43f0c9e1ac/src/server/service.rs#L92)

Thread handle join hold the write lock.
While [`sp.active()`](https://github.com/rustdesk/rustdesk/blob/7c2cf6c9b37a19887094113a8266db43f0c9e1ac/src/server/service.rs#L188) hold the read lock.