### PR TITLE
better_linux_run_cmds: run cmds without creating tmp files

### DIFF
--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -42,7 +42,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Invalid IP", "Neplatná IP adresa"),
         ("id_change_tip", "Použít je mozné pouze znaky a-z, A-Z, 0-9 a _ (podtržítko). Dále je třeba aby začínalo na písmeno a-z, A-Z. Délka mezi 6 a 16 znaky."),
         ("Invalid format", "Neplatný formát"),
-        ("This function is turned off by the server", "Tato funkce je vypnuta serverem"),
+        ("server_not_support", "Server zatím nepodporuje"),
         ("Not available", "Není k dispozici"),
         ("Too frequent", "Příliš časté"),
         ("Cancel", "Storno"),

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -42,6 +42,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Invalid IP", "IP nevalida"),
         ("id_change_tip", "Nur la signoj a-z, A-Z, 0-9, _ (substreko) povas esti uzataj. La unua litero povas esti inter a-z, A-Z. La longeco devas esti inter 6 kaj 16."),
         ("Invalid format", "Formato nevalida"),
+        ("server_not_support", "Ankoraŭ ne subtenata de la servilo"),
         ("Not available", "Nedisponebla"),
         ("Too frequent", "Tro ofte ŝanĝita, bonvolu reprovi poste"),
         ("Cancel", "Nuligi"),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -42,7 +42,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Invalid IP", ""),
         ("id_change_tip", ""),
         ("Invalid format", ""),
-        ("This function is turned off by the server", ""),
+        ("server_not_support", ""),
         ("Not available", ""),
         ("Too frequent", ""),
         ("Cancel", ""),

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -42,7 +42,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Invalid IP", "Geçersiz IP adresi"),
         ("id_change_tip", "Yalnızca a-z, A-Z, 0-9 ve _ (alt çizgi) karakterlerini kullanabilirsiniz. İlk karakter a-z veya A-Z olmalıdır. Uzunluk 6 ile 16 karakter arasında olmalıdır."),
         ("Invalid format", "Hatalı Format"),
-        ("This function is turned off by the server", "Bu özellik sunucu tarafından kapatıldı"),
+        ("server_not_support", "Henüz sunucu tarafından desteklenmiyor"),
         ("Not available", "Erişilebilir değil"),
         ("Too frequent", "Çok sık"),
         ("Cancel", "İptal"),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -184,7 +184,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("x11 expected", "預期 x11"),
         ("Port", "連接埠"),
         ("Settings", "設定"),
-        ("Username", " 使用者名稱"),
+        ("Username", "使用者名稱"),
         ("Invalid port", "連接埠無效"),
         ("Closed manually by the peer", "由對方手動關閉"),
         ("Enable remote configuration modification", "啟用遠端更改設定"),


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

1. Use `sh -c ` to run cmds.
2. Update translations.