### PR TITLE
fix: cli compilation error when using cli feature

### DIFF
--- a/src/client/file_trait.rs
+++ b/src/client/file_trait.rs
@@ -9,7 +9,7 @@ pub trait FileManager: Interface {
         fs::get_home_as_string()
     }
 
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    #[cfg(not(any(target_os = "android", target_os = "ios", feature = "cli")))]
     fn read_dir(&self,path: String, include_hidden: bool) -> sciter::Value {
         match fs::read_dir(&fs::get_path(&path), include_hidden) {
             Err(_) => sciter::Value::null(),
@@ -22,9 +22,9 @@ pub trait FileManager: Interface {
         }
     }
 
-    #[cfg(any(target_os = "android", target_os = "ios"))]
+    #[cfg(any(target_os = "android", target_os = "ios", feature = "cli"))]
     fn read_dir(&self,path: &str, include_hidden: bool) -> String {
-        use crate::mobile::make_fd_to_json;
+        use crate::common::make_fd_to_json;
         match fs::read_dir(&fs::get_path(path), include_hidden){
             Ok(fd) => make_fd_to_json(fd),
             Err(_)=>"".into()

--- a/src/common.rs
+++ b/src/common.rs
@@ -605,3 +605,22 @@ pub fn make_privacy_mode_msg(state: back_notification::PrivacyModeState) -> Mess
     msg_out.set_misc(misc);
     msg_out
 }
+
+pub fn make_fd_to_json(fd: FileDirectory) -> String {
+    use serde_json::json;
+    let mut fd_json = serde_json::Map::new();
+    fd_json.insert("id".into(), json!(fd.id));
+    fd_json.insert("path".into(), json!(fd.path));
+
+    let mut entries = vec![];
+    for entry in fd.entries {
+        let mut entry_map = serde_json::Map::new();
+        entry_map.insert("entry_type".into(), json!(entry.entry_type.value()));
+        entry_map.insert("name".into(), json!(entry.name));
+        entry_map.insert("size".into(), json!(entry.size));
+        entry_map.insert("modified_time".into(), json!(entry.modified_time));
+        entries.push(entry_map);
+    }
+    fd_json.insert("entries".into(), json!(entries));
+    serde_json::to_string(&fd_json).unwrap_or("".into())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ fn main() {
         .about("RustDesk command line tool")
         .args_from_usage(&args)
         .get_matches();
-    use hbb_common::env_logger::*;
+    use hbb_common::{env_logger::*, config::LocalConfig};
     init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info"));
     if let Some(p) = matches.value_of("port-forward") {
         let options: Vec<String> = p.split(":").map(|x| x.to_owned()).collect();
@@ -213,6 +213,7 @@ fn main() {
             remote_host = options[3].clone();
         }
         let key = matches.value_of("key").unwrap_or("").to_owned();
-        cli::start_one_port_forward(options[0].clone(), port, remote_host, remote_port, key);
+        let token = LocalConfig::get_option("access_token");
+        cli::start_one_port_forward(options[0].clone(), port, remote_host, remote_port, key, token);
     }
 }

--- a/src/mobile.rs
+++ b/src/mobile.rs
@@ -1,4 +1,5 @@
 use crate::client::*;
+use crate::common::{make_fd_to_json};
 use flutter_rust_bridge::{StreamSink, ZeroCopyBuffer};
 use hbb_common::{
     allow_err,
@@ -1142,25 +1143,6 @@ impl Connection {
             ],
         );
     }
-}
-
-pub fn make_fd_to_json(fd: FileDirectory) -> String {
-    use serde_json::json;
-    let mut fd_json = serde_json::Map::new();
-    fd_json.insert("id".into(), json!(fd.id));
-    fd_json.insert("path".into(), json!(fd.path));
-
-    let mut entries = vec![];
-    for entry in fd.entries {
-        let mut entry_map = serde_json::Map::new();
-        entry_map.insert("entry_type".into(), json!(entry.entry_type.value()));
-        entry_map.insert("name".into(), json!(entry.name));
-        entry_map.insert("size".into(), json!(entry.size));
-        entry_map.insert("modified_time".into(), json!(entry.modified_time));
-        entries.push(entry_map);
-    }
-    fd_json.insert("entries".into(), json!(entries));
-    serde_json::to_string(&fd_json).unwrap_or("".into())
 }
 
 // Server Side

--- a/src/mobile_ffi.rs
+++ b/src/mobile_ffi.rs
@@ -1,6 +1,7 @@
 use crate::client::file_trait::FileManager;
 use crate::mobile::connection_manager::{self, get_clients_length, get_clients_state};
-use crate::mobile::{self, make_fd_to_json, Session};
+use crate::mobile::{self, Session};
+use crate::common::{make_fd_to_json};
 use flutter_rust_bridge::{StreamSink, ZeroCopyBuffer};
 use hbb_common::ResultType;
 use hbb_common::{


### PR DESCRIPTION
related issue: #719

The difference is:

- reuse `read_dir` in `cli` feature.
- keep the logic of `tis` unchanged.

All features 'inline', 'cli' are tested, Android&iOS .so compilations are also tested.