### PR TITLE
fix import config bug when use filename insteadof path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,16 @@ fn main() {
             }
         } else if args[0] == "--import-config" {
             if args.len() == 2 {
-                import_config(&args[1]);
+                let mut filepath = args[1].to_owned();
+                let path = std::path::Path::new(&args[1]);
+                if !path.is_absolute() {
+                    let mut cur = std::env::current_dir().unwrap();
+                    cur.push(path);
+                    filepath = cur.to_str().unwrap().to_string();
+                } else {
+                    filepath = path.to_str().unwrap().to_string();
+                }
+                import_config(&filepath);
             }
             return;
         } else if args[0] == "--password" {


### PR DESCRIPTION
file the issue: https://github.com/rustdesk/rustdesk/issues/734
issue description: when user input filename, import_config can't get the real path of the file, so can not wrtie config

change point: add a current path to the filename, so import config can get the file path