### PR TITLE
add DisplayVersion regkey in installer

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1028,6 +1028,7 @@ copy /Y \"{ORIGIN_PROCESS_EXE}\" \"{path}\\{broker_exe}\"
 reg add {subkey} /f
 reg add {subkey} /f /v DisplayIcon /t REG_SZ /d \"{exe}\"
 reg add {subkey} /f /v DisplayName /t REG_SZ /d \"{app_name}\"
+reg add {subkey} /f /v DisplayVersion /t REG_SZ /d \"{version}\"
 reg add {subkey} /f /v Version /t REG_SZ /d \"{version}\"
 reg add {subkey} /f /v InstallLocation /t REG_SZ /d \"{path}\"
 reg add {subkey} /f /v Publisher /t REG_SZ /d \"{app_name}\"


### PR DESCRIPTION
I'm planning to add RustDesk to Winget, but Winget relies on this info to detect the Version properly. This PR adds that change.
Before:
![before](https://user-images.githubusercontent.com/56180050/173343453-f3cb97b4-85e2-40de-8d14-05c8f84e0251.png)

After:
![after](https://user-images.githubusercontent.com/56180050/173343244-a501016c-feef-4967-a424-228ef5f87cb7.png)
