### PR TITLE
fix: Shift + (  in french keyboard

### DIFF
--- a/pynput_service.py
+++ b/pynput_service.py
@@ -22,7 +22,6 @@ class MyController(Controller):
         keysym = self._keysym(key)
         # Get keycode according to system language
         keycode = self._display.keysym_to_keycode(keysym)
-        print(keycode)
 
         fake_input(self._display, event,  keycode)
         self._display.sync()

--- a/pynput_service.py
+++ b/pynput_service.py
@@ -1,12 +1,14 @@
 from pynput.keyboard import Key, Controller
 from pynput.keyboard._xorg import KeyCode
 from pynput._util.xorg import display_manager
-import Xlib
 import os
 import sys
 import socket
+from Xlib.ext.xtest import fake_input
+from Xlib import X
 
 KeyCode._from_symbol("\0")  # test
+
 
 class MyController(Controller):
     def _handle(self, key, is_press):
@@ -14,52 +16,17 @@ class MyController(Controller):
         :param event: The *X* keyboard event.
         :param int keysym: The keysym to handle.
         """
-        event = Xlib.display.event.KeyPress if is_press \
-            else Xlib.display.event.KeyRelease
+        event = X.KeyPress if is_press \
+            else X.KeyRelease
+
         keysym = self._keysym(key)
+        # Get keycode according to system language
+        keycode = self._display.keysym_to_keycode(keysym)
+        print(keycode)
 
-        # Make sure to verify that the key was resolved
-        if keysym is None:
-            raise self.InvalidKeyException(key)
+        fake_input(self._display, event,  keycode)
+        self._display.sync()
 
-        # If the key has a virtual key code, use that immediately with
-        # fake_input; fake input,being an X server extension, has access to
-        # more internal state that we do
-        if key.vk is not None:
-            with display_manager(self._display) as dm:
-                Xlib.ext.xtest.fake_input(
-                    dm,
-                    Xlib.X.KeyPress if is_press else Xlib.X.KeyRelease,
-                    dm.keysym_to_keycode(key.vk))
-
-        # Otherwise use XSendEvent; we need to use this in the general case to
-        # work around problems with keyboard layouts
-        else:
-            try:
-                keycode, shift_state = self.keyboard_mapping[keysym]
-                with self.modifiers as modifiers:
-                    alt_gr = Key.alt_gr in modifiers
-                if alt_gr:
-                    self._send_key(event, keycode, shift_state)
-                else:
-                    with display_manager(self._display) as dm:
-                        Xlib.ext.xtest.fake_input(
-                            dm,
-                            Xlib.X.KeyPress if is_press else Xlib.X.KeyRelease,
-                            keycode)
-
-            except KeyError:
-                with self._borrow_lock:
-                    keycode, index, count = self._borrows[keysym]
-                    self._send_key(
-                        event,
-                        keycode,
-                        index_to_shift(self._display, index))
-                    count += 1 if is_press else -1
-                    self._borrows[keysym] = (keycode, index, count)
-
-        # Notify any running listeners
-        self._emit('_on_fake_event', key, is_press)
 
 keyboard = MyController()
 
@@ -77,7 +44,7 @@ server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 server.bind(server_address)
 server.listen(1)
 clientsocket, address = server.accept()
-os.system('chmod a+rw %s'%server_address)
+os.system('chmod a+rw %s' % server_address)
 print("Got pynput connection")
 
 
@@ -121,4 +88,3 @@ def loop():
 loop()
 clientsocket.close()
 server.close()
-


### PR DESCRIPTION
#406

## Context

On a French keyboard, the keycode for both `(` and `5` should be 14, but the keycode for `(` in pynput is 187. Use xlib's `keysym_to_keycode` fixes this bug. 
```python3
from pynput.keyboard import Controller, KeyCode
import os

from Xlib.display import Display

keyboard = Controller()

pynput_keysym = keyboard._keysym(KeyCode.from_char('('))
print(f'pynput keysym: {pynput_keysym}')  # 40
pynput_keycode = keyboard.keyboard_mapping[pynput_keysym]
print(f'pynput keysym: {pynput_keycode}')  # (187, 0)

_display = Display(os.environ['DISPLAY'])

PARENLEFT_KEYSYM = 40
keycode = _display.keysym_to_keycode(PARENLEFT_KEYSYM)
print(f'xlib keycode: {keycode}')   # 14
# If the default input source is a US keyboard, keycode is 187
```

## Changelog
- Replaced pynput's `keyboard_mapping` with xlib's `keysym_to_keycode`.
- Replaced pynput's `_send_key` with xlib's `send_event`.
- Removed a useless code.

## Feedback wanted

I tested the US keyboard and the French keyboard, everything works fine, do I need to test other keyboards?