### PR TITLE
Fix physical keyboard

### DIFF
--- a/flutter/android/app/src/main/AndroidManifest.xml
+++ b/flutter/android/app/src/main/AndroidManifest.xml
@@ -43,7 +43,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode|navigation"
             android:exported="true"
             android:hardwareAccelerated="true"
             android:launchMode="singleTop"

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -724,13 +724,17 @@ class FFI {
 
   static void inputKey(String name, {bool? down, bool? press}) {
     if (!ffiModel.keyboard()) return;
-    setByName(
-        'input_key',
-        json.encode(modify({
-          'name': name,
-          'down': (down ?? false).toString(),
-          'press': (press ?? true).toString()
-        })));
+    final Map<String, String> out = Map();
+    out['name'] = name;
+    // default: down = false
+    if (down == true) {
+      out['down'] = "true";
+    }
+    // default: press = true
+    if (press != false) {
+      out['press'] = "true";
+    }
+    setByName('input_key', json.encode(modify(out)));
   }
 
   static void moveMouse(double x, double y) {

--- a/flutter/lib/pages/remote_page.dart
+++ b/flutter/lib/pages/remote_page.dart
@@ -343,9 +343,14 @@ class _RemotePageState extends State<RemotePage> {
                     onKey: (data, e) {
                       final key = e.logicalKey;
                       if (e is RawKeyDownEvent) {
-                        if (e.repeat) {
+                        if (e.repeat &&
+                            !e.isAltPressed &&
+                            !e.isControlPressed &&
+                            !e.isShiftPressed &&
+                            !e.isMetaPressed) {
                           sendRawKey(e, press: true);
                         } else {
+                          sendRawKey(e, down: true);
                           if (e.isAltPressed && !FFI.alt) {
                             FFI.alt = true;
                           } else if (e.isControlPressed && !FFI.ctrl) {
@@ -355,7 +360,6 @@ class _RemotePageState extends State<RemotePage> {
                           } else if (e.isMetaPressed && !FFI.command) {
                             FFI.command = true;
                           }
-                          sendRawKey(e, down: true);
                         }
                       }
                       // [!_showEdit] workaround for soft-keyboard's control_key like Backspace / Enter


### PR DESCRIPTION
- fix physical keyboard input twice. 
  - #907 
  - #777
- add configChanges `navigation`, avoid recreating Android activity when keyboard changed