### PR TITLE
Hwcodec test odd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ use_samplerate = ["samplerate"]
 use_rubato = ["rubato"]
 use_dasp = ["dasp"]
 hwcodec = ["scrap/hwcodec"]
-default = ["use_dasp"]
+default = ["use_dasp", "hwcodec"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libs/scrap/src/common/convert.rs
+++ b/libs/scrap/src/common/convert.rs
@@ -271,7 +271,7 @@ pub mod hw {
         unsafe {
             super::ARGBToI420(
                 src.as_ptr(),
-                (src.len() / height) as _,
+                4 * width as i32,
                 dst_y,
                 stride_y as _,
                 dst_u,
@@ -303,7 +303,7 @@ pub mod hw {
         unsafe {
             super::ARGBToNV12(
                 src.as_ptr(),
-                (src.len() / height) as _,
+                4 * width as i32,
                 dst_y,
                 stride_y as _,
                 dst_uv,

--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -179,6 +179,7 @@ impl HwEncoder {
             let aligns = vec![64, 32, 16, 8, 4, 2, 1];
             for align in aligns {
                 if frame_length == ((width + align - 1) / align * align) * height * 4 {
+                    log::error!("set align {}", align);
                     return ODD_SCREEN_WIDTH_ALIGN.swap(align, Ordering::Relaxed) != align;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
     #[cfg(not(feature = "inline"))]
     {
         use hbb_common::env_logger::*;
-        init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info"));
+        init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "error"));
     }
     #[cfg(feature = "inline")]
     {

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -160,6 +160,10 @@ impl<T: Subscriber + From<ConnInner>> ServiceTmpl<T> {
 
     pub fn send_shared(&self, msg: Arc<Message>) {
         let mut lock = self.0.write().unwrap();
+        log::error!(
+            "send_shared subscribes count:{}",
+            lock.subscribes.values_mut().len()
+        );
         for s in lock.subscribes.values_mut() {
             s.send(msg.clone());
         }

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -63,10 +63,10 @@ function createNewConnect(id, type) {
     id = id.replace(/\s/g, "");
     app.remote_id.value = formatId(id);
     if (!id) return;
-    if (id == my_id) {
-        msgbox("custom-error", "Error", "You cannot connect to your own computer");
-        return;
-    }
+    // if (id == my_id) {
+    //     msgbox("custom-error", "Error", "You cannot connect to your own computer");
+    //     return;
+    // }
     handler.set_remote_id(id);
     handler.new_remote(id, type);
 }

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -2349,6 +2349,7 @@ impl Remote {
                         self.handler.call("switchDisplay", &make_args!(s.display));
                         self.video_sender.send(MediaData::Reset).ok();
                         if s.width > 0 && s.height > 0 {
+                            log::error!("remote size switch:({},{})", s.width, s.height);
                             VIDEO.lock().unwrap().as_mut().map(|v| {
                                 v.stop_streaming().ok();
                                 let ok = v.start_streaming(
@@ -2628,6 +2629,11 @@ impl Interface for Handler {
             // Nothing spectacular in decoder – done on CPU side.
             // So if you can do BGRA translation on your side – the better.
             // BGRA is used as internal image format so it will not require additional transformations.
+            log::error!(
+                "remote size login response:({},{})",
+                current.width,
+                current.height
+            );
             VIDEO.lock().unwrap().as_mut().map(|v| {
                 let ok = v.start_streaming(
                     (current.width as _, current.height as _),


### PR DESCRIPTION
1. Still using capture to find proper stride.
2. Login response is earlier than video_service::run(),  so the display info in login response may use wrong default stride, the only way I can think is to switch.
3. subscribe count problem can be reproduced.
4. test failed in real machine now