### PR TITLE
avoid modify id manually

### DIFF
--- a/libs/hbb_common/src/lib.rs
+++ b/libs/hbb_common/src/lib.rs
@@ -202,6 +202,24 @@ pub fn get_modified_time(path: &std::path::Path) -> SystemTime {
         .unwrap_or(UNIX_EPOCH)
 }
 
+pub fn get_created_time(path: &std::path::Path) -> SystemTime {
+    std::fs::metadata(&path)
+        .map(|m| m.created().unwrap_or(UNIX_EPOCH))
+        .unwrap_or(UNIX_EPOCH)
+}
+
+pub fn get_exe_time() -> SystemTime {
+    std::env::current_exe().map_or(UNIX_EPOCH, |path| {
+        let m = get_modified_time(&path);
+        let c = get_created_time(&path);
+        if m > c {
+            m
+        } else {
+            c
+        }
+    })
+}
+
 pub fn get_uuid() -> Vec<u8> {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if let Ok(id) = machine_uid::get() {

--- a/libs/hbb_common/src/password_security.rs
+++ b/libs/hbb_common/src/password_security.rs
@@ -108,7 +108,7 @@ pub fn encrypt_vec_or_original(v: &[u8], version: &str) -> Vec<u8> {
     v.to_owned()
 }
 
-// String: password
+// Vec<u8>: password
 // bool: whether decryption is successful
 // bool: whether should store to re-encrypt when load
 pub fn decrypt_vec_or_original(v: &[u8], current_version: &str) -> (Vec<u8>, bool, bool) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn main() {
 }
 
 fn import_config(path: &str) {
-    use hbb_common::{config::*, get_modified_time};
+    use hbb_common::{config::*, get_exe_time, get_modified_time};
     let path2 = path.replace(".toml", "2.toml");
     let path2 = std::path::Path::new(&path2);
     let path = std::path::Path::new(path);
@@ -176,7 +176,9 @@ fn import_config(path: &str) {
         log::info!("Empty source config, skipped");
         return;
     }
-    if get_modified_time(&path) > get_modified_time(&Config::file()) {
+    if get_modified_time(&path) > get_modified_time(&Config::file())
+        && get_modified_time(&path) < get_exe_time()
+    {
         if store_path(Config::file(), config).is_err() {
             log::info!("config written");
         }


### PR DESCRIPTION
#1093 
1. avoid modifying id after installation or after using new portable
2. windows can use --import-config