### PR TITLE
Update linux.rs

### DIFF
--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -43,6 +43,10 @@ fn get_display_server_of_session(session: &str) -> String {
                 display_server
             }
         } else {
+            // loginctl has not given the expected output.  try something else.
+            if let OK(sestype) = std::env::var("XDG_SESSION_TYPE") {
+                return sestype.to_owned();
+            }
             // If the session is not a tty, then just return the type as usual
             display_server
         }
@@ -78,6 +82,11 @@ pub fn get_value_of_seat0(i: usize) -> String {
                 }
             }
         }
+    }
+
+    // loginctl has not given the expected output.  try something else.
+    if let Ok(sid) = std::env::var("XDG_SESSION_ID") { // could also execute "cat /proc/self/sessionid"
+         return sid.to_owned();
     }
 
     return "".to_owned();

--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -44,7 +44,7 @@ fn get_display_server_of_session(session: &str) -> String {
             }
         } else {
             // loginctl has not given the expected output.  try something else.
-            if let OK(sestype) = std::env::var("XDG_SESSION_TYPE") {
+            if let Ok(sestype) = std::env::var("XDG_SESSION_TYPE") {
                 return sestype.to_owned();
             }
             // If the session is not a tty, then just return the type as usual


### PR DESCRIPTION
Fix for #921 
in mx linux, when started with non-systemd init, loginctl returns null string to stdout (and an error message to stderr).  this patch will use XDG_SESSION_TYPE and XDG_SESSION_ID environment variables if the loginctl code fails to determine these.