### PR TITLE
fix 10054: change direct to relay when RST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "error-code"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4168,6 +4189,7 @@ dependencies = [
  "default-net",
  "dispatch",
  "enigo",
+ "errno",
  "evdev",
  "flexi_logger",
  "flutter_rust_bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ num_cpus = "1.13"
 bytes = { version = "1.2", features = ["serde"] }
 default-net = "0.11.0"
 wol-rs = "0.9.1"
+errno = "0.2.8"
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features=false }

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -21,6 +21,7 @@ use std::{
 
 pub const RENDEZVOUS_TIMEOUT: u64 = 12_000;
 pub const CONNECT_TIMEOUT: u64 = 18_000;
+pub const READ_TIMEOUT: u64 = 30_000;
 pub const REG_INTERVAL: i64 = 12_000;
 pub const COMPRESS_LEVEL: i32 = 3;
 const SERIAL: i32 = 3;

--- a/src/client.rs
+++ b/src/client.rs
@@ -841,7 +841,7 @@ impl LoginConfigHandler {
         self.session_id = rand::random();
         self.supported_encoding = None;
         self.restarting_remote_device = false;
-        self.force_relay = false;
+        self.force_relay = !self.get_option("force-always-relay").is_empty();
     }
 
     pub fn should_auto_login(&self) -> String {

--- a/src/ui/ab.tis
+++ b/src/ui/ab.tis
@@ -316,7 +316,7 @@ class SessionList: Reactor.Component {
                     <li #connect>{translate('Connect')}</li>
                     <li #transfer>{translate('Transfer File')}</li>
                     <li #tunnel>{translate('TCP Tunneling')}</li>
-                    {false && !handler.using_public_server() && <li #force-always-relay><span>{svg_checkmark}</span>{translate('Always connect via relay')}</li>}
+                    <li #force-always-relay><span>{svg_checkmark}</span>{translate('Always connect via relay')}</li>
                     <li #rdp>RDP<EditRdpPort /></li>
                     <li #wol>{translate('WOL')}</li>
                     <div .separator />
@@ -396,7 +396,6 @@ class SessionList: Reactor.Component {
         if (el) {
           var force = handler.get_peer_option(id, "force-always-relay");
           el.attributes.toggleClass("selected", force == "Y");
-          el.attributes.toggleClass("line-through", force != "Y");
         }
         var conn = this.$(menu #connect);
         if (conn) {

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -2085,18 +2085,18 @@ impl Remote {
 
     async fn send_opts_after_login(&self, peer: &mut Stream) {
         if let Some(opts) = self
-        .handler
-        .lc
-        .read()
-        .unwrap()
-        .get_option_message_after_login()
-    {
-        let mut misc = Misc::new();
-        misc.set_option(opts);
-        let mut msg_out = Message::new();
-        msg_out.set_misc(misc);
-        allow_err!(peer.send(&msg_out).await);
-    }
+            .handler
+            .lc
+            .read()
+            .unwrap()
+            .get_option_message_after_login()
+        {
+            let mut misc = Misc::new();
+            misc.set_option(opts);
+            let mut msg_out = Message::new();
+            msg_out.set_misc(misc);
+            allow_err!(peer.send(&msg_out).await);
+        }
     }
 
     async fn handle_msg_from_peer(&mut self, data: &[u8], peer: &mut Stream) -> bool {
@@ -2714,9 +2714,10 @@ impl Interface for Handler {
         if direct && !received {
             let errno = errno::errno().0;
             log::info!("errno is {}", errno);
-            // TODO
+            // TODO: check mac and ios
             if cfg!(windows) && errno == 10054 || !cfg!(windows) && errno == 104 {
                 lc.force_relay = true;
+                lc.set_option("force-always-relay".to_owned(), "Y".to_owned());
             }
         }
     }

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -53,6 +53,7 @@ use crate::{
     client::*,
     common::{self, check_clipboard, update_clipboard, ClipboardContext, CLIPBOARD_INTERVAL},
 };
+use errno;
 
 type Video = AssetPtr<video_destination>;
 
@@ -1456,12 +1457,21 @@ impl Remote {
     async fn io_loop(&mut self, key: &str, token: &str) {
         let stop_clipboard = self.start_clipboard();
         let mut last_recv_time = Instant::now();
+        let mut received = false;
         let conn_type = if self.handler.is_file_transfer() {
             ConnType::FILE_TRANSFER
         } else {
             ConnType::default()
         };
-        match Client::start(&self.handler.id, key, token, conn_type).await {
+        match Client::start(
+            &self.handler.id,
+            key,
+            token,
+            conn_type,
+            self.handler.clone(),
+        )
+        .await
+        {
             Ok((mut peer, direct)) => {
                 SERVER_KEYBOARD_ENABLED.store(true, Ordering::SeqCst);
                 SERVER_CLIPBOARD_ENABLED.store(true, Ordering::SeqCst);
@@ -1484,11 +1494,13 @@ impl Remote {
                                 match res {
                                     Err(err) => {
                                         log::error!("Connection closed: {}", err);
+                                        self.handler.set_force_relay(direct, received);
                                         self.handler.msgbox("error", "Connection Error", &err.to_string());
                                         break;
                                     }
                                     Ok(ref bytes) => {
                                         last_recv_time = Instant::now();
+                                        received = true;
                                         self.data_count.fetch_add(bytes.len(), Ordering::Relaxed);
                                         if !self.handle_msg_from_peer(bytes, &mut peer).await {
                                             break
@@ -2694,6 +2706,23 @@ impl Interface for Handler {
             });
             handle_test_delay(t, peer).await;
         }
+    }
+
+    fn set_force_relay(&mut self, direct: bool, received: bool) {
+        let mut lc = self.lc.write().unwrap();
+        lc.force_relay = false;
+        if direct && !received {
+            let errno = errno::errno().0;
+            log::info!("errno is {}", errno);
+            // TODO
+            if cfg!(windows) && errno == 10054 || !cfg!(windows) && errno == 104 {
+                lc.force_relay = true;
+            }
+        }
+    }
+
+    fn is_force_relay(&self) -> bool {
+        self.lc.read().unwrap().force_relay
     }
 }
 


### PR DESCRIPTION
fix #1113 
1. client reconnect repeatly, port forward reconnect once.
2. Mac/ios connect successfully, handle the same as linux temporarily.

- [x] deal with secure connection