### PR TITLE
fix desktop entry categories

### DIFF
--- a/rustdesk.desktop
+++ b/rustdesk.desktop
@@ -8,7 +8,7 @@ Icon=/usr/share/rustdesk/files/rustdesk.png
 Terminal=false
 Type=Application
 StartupNotify=true
-Categories=Other;
+Categories=Network;RemoteAccess;GTK;
 Keywords=internet;
 Actions=new-window;
 


### PR DESCRIPTION
The category "Other" isn't a valid category [1] and causes unwanted
behavior on some DE's [2]. Thus I remove this category and add the
main category "Network" instead. I also add the additional categories
"RemoteAccess", since rustdesk is a tool to remotely access computers,
and "GTK", because it's based on GTK libraries.

[1] https://specifications.freedesktop.org/menu-spec/latest/apa.html
[2] https://aur.archlinux.org/packages/rustdesk-bin#comment-877405