### PR TITLE
Update AppImageBuilder.yml

### DIFF
--- a/appimage/AppImageBuilder.yml
+++ b/appimage/AppImageBuilder.yml
@@ -40,12 +40,12 @@ AppDir:
     - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-updates universe
     - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic multiverse
     - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-updates multiverse
-    - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-backports main restricted
-        universe multiverse
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
     - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-security main restricted
     - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-security universe
     - sourceline: deb http://archive.ubuntu.com/ubuntu/ bionic-security multiverse
     include:
+    - libc6:amd64
     - libgcc1:amd64
     - libgcrypt20:amd64
     - libgtk-3-0:amd64


### PR DESCRIPTION
included libc6:amd64 which contains /lib/x86_64-linux-gnu/libnsl.so.1

Should fix the libnsl.sl.1 error when starting the AppImage: 
/tmp/.mount_RustDeJm6xZn//usr/bin/rustdesk: error while loading shared libraries: libnsl.so.1: cannot open shared object file: No such file or directory