### PR TITLE
Flutter desktop new remote menu

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -447,7 +447,10 @@ void msgBox(
         0,
         wrap(translate('OK'), () {
           dialogManager.dismissAll();
-          closeConnection();
+          // https://github.com/fufesou/rustdesk/blob/5e9a31340b899822090a3731769ae79c6bf5f3e5/src/ui/common.tis#L263
+          if (type.indexOf("custom") < 0) {
+            closeConnection();
+          }
         }));
   }
   if (hasCancel == null) {
@@ -739,4 +742,40 @@ Future<List<Peer>>? matchPeers(String searchText, List<Peer> peers) async {
     }
   }
   return filteredList;
+}
+
+class PrivacyModeState {
+  static String tag(String id) => 'privacy_mode_' + id;
+
+  static void init(String id) {
+    final RxBool state = false.obs;
+    Get.put(state, tag: tag(id));
+  }
+
+  static void delete(String id) => Get.delete(tag: tag(id));
+  static RxBool find(String id) => Get.find<RxBool>(tag: tag(id));
+}
+
+class BlockInputState {
+  static String tag(String id) => 'block_input_' + id;
+
+  static void init(String id) {
+    final RxBool state = false.obs;
+    Get.put(state, tag: tag(id));
+  }
+
+  static void delete(String id) => Get.delete(tag: tag(id));
+  static RxBool find(String id) => Get.find<RxBool>(tag: tag(id));
+}
+
+class CurrentDisplayState {
+  static String tag(String id) => 'current_display_' + id;
+
+  static void init(String id) {
+    final RxInt state = RxInt(0);
+    Get.put(state, tag: tag(id));
+  }
+
+  static void delete(String id) => Get.delete(tag: tag(id));
+  static RxInt find(String id) => Get.find<RxInt>(tag: tag(id));
 }

--- a/flutter/lib/desktop/pages/desktop_tab_page.dart
+++ b/flutter/lib/desktop/pages/desktop_tab_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_home_page.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_setting_page.dart';
 import 'package:flutter_hbb/desktop/widgets/tabbar_widget.dart';
+import 'package:get/get.dart';
 import 'package:window_manager/window_manager.dart';
 
 class DesktopTabPage extends StatefulWidget {
@@ -33,26 +34,29 @@ class _DesktopTabPageState extends State<DesktopTabPage> {
   @override
   Widget build(BuildContext context) {
     final dark = isDarkTheme();
-    return DragToResizeArea(
-      child: Container(
-        decoration: BoxDecoration(
-            border: Border.all(color: MyTheme.color(context).border!)),
-        child: Scaffold(
-            backgroundColor: MyTheme.color(context).bg,
-            body: DesktopTab(
-              controller: tabController,
-              theme: dark ? TarBarTheme.dark() : TarBarTheme.light(),
-              isMainWindow: true,
-              tail: ActionIcon(
-                message: 'Settings',
-                icon: IconFont.menu,
-                theme: dark ? TarBarTheme.dark() : TarBarTheme.light(),
-                onTap: onAddSetting,
-                is_close: false,
-              ),
-            )),
-      ),
-    );
+    RxBool fullscreen = false.obs;
+    Get.put(fullscreen, tag: 'fullscreen');
+    return Obx(() => DragToResizeArea(
+          resizeEdgeSize: fullscreen.value ? 1.0 : 8.0,
+          child: Container(
+            decoration: BoxDecoration(
+                border: Border.all(color: MyTheme.color(context).border!)),
+            child: Scaffold(
+                backgroundColor: MyTheme.color(context).bg,
+                body: DesktopTab(
+                  controller: tabController,
+                  theme: dark ? TarBarTheme.dark() : TarBarTheme.light(),
+                  isMainWindow: true,
+                  tail: ActionIcon(
+                    message: 'Settings',
+                    icon: IconFont.menu,
+                    theme: dark ? TarBarTheme.dark() : TarBarTheme.light(),
+                    onTap: onAddSetting,
+                    is_close: false,
+                  ),
+                )),
+          ),
+        ));
   }
 
   void onAddSetting() {

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -9,9 +9,11 @@ import 'package:flutter_hbb/models/chat_model.dart';
 import 'package:get/get.dart';
 import 'package:provider/provider.dart';
 import 'package:wakelock/wakelock.dart';
+import 'package:tuple/tuple.dart';
 
 // import 'package:window_manager/window_manager.dart';
 
+import '../widgets/remote_menubar.dart';
 import '../../common.dart';
 import '../../mobile/widgets/dialog.dart';
 import '../../mobile/widgets/overlay.dart';
@@ -21,16 +23,14 @@ import '../../models/platform_model.dart';
 final initText = '\1' * 1024;
 
 class RemotePage extends StatefulWidget {
-  RemotePage(
-      {Key? key,
-      required this.id,
-      required this.tabBarHeight,
-      required this.fullscreenID})
-      : super(key: key);
+  RemotePage({
+    Key? key,
+    required this.id,
+    required this.tabBarHeight,
+  }) : super(key: key);
 
   final String id;
   final double tabBarHeight;
-  final Rx<String> fullscreenID;
 
   @override
   _RemotePageState createState() => _RemotePageState();
@@ -50,11 +50,15 @@ class _RemotePageState extends State<RemotePage>
 
   late FFI _ffi;
 
+  void _updateTabBarHeight() {
+    _ffi.canvasModel.tabBarHeight = widget.tabBarHeight;
+  }
+
   @override
   void initState() {
     super.initState();
     _ffi = FFI();
-    _ffi.canvasModel.tabBarHeight = super.widget.tabBarHeight;
+    _updateTabBarHeight();
     Get.put(_ffi, tag: widget.id);
     _ffi.connect(widget.id, tabBarHeight: super.widget.tabBarHeight);
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -70,6 +74,9 @@ class _RemotePageState extends State<RemotePage>
     _ffi.listenToMouse(true);
     _ffi.qualityMonitorModel.checkShowQualityMonitor(widget.id);
     // WindowManager.instance.addListener(this);
+    PrivacyModeState.init(widget.id);
+    BlockInputState.init(widget.id);
+    CurrentDisplayState.init(widget.id);
   }
 
   @override
@@ -90,6 +97,9 @@ class _RemotePageState extends State<RemotePage>
     // WindowManager.instance.removeListener(this);
     Get.delete<FFI>(tag: widget.id);
     super.dispose();
+    PrivacyModeState.delete(widget.id);
+    BlockInputState.delete(widget.id);
+    CurrentDisplayState.delete(widget.id);
   }
 
   void resetTool() {
@@ -217,6 +227,7 @@ class _RemotePageState extends State<RemotePage>
   @override
   Widget build(BuildContext context) {
     super.build(context);
+    _updateTabBarHeight();
     return WillPopScope(
         onWillPop: () async {
           clientClose(_ffi.dialogManager);
@@ -289,6 +300,7 @@ class _RemotePageState extends State<RemotePage>
   }
 
   Widget? getBottomAppBar(FfiModel ffiModel) {
+    final RxBool fullscreen = Get.find(tag: 'fullscreen');
     return MouseRegion(
         cursor: SystemMouseCursors.basic,
         child: BottomAppBar(
@@ -323,15 +335,11 @@ class _RemotePageState extends State<RemotePage>
                           : <Widget>[
                               IconButton(
                                 color: Colors.white,
-                                icon: Icon(widget.fullscreenID.value.isEmpty
+                                icon: Icon(fullscreen.isTrue
                                     ? Icons.fullscreen
                                     : Icons.close_fullscreen),
                                 onPressed: () {
-                                  if (widget.fullscreenID.value.isEmpty) {
-                                    widget.fullscreenID.value = widget.id;
-                                  } else {
-                                    widget.fullscreenID.value = "";
-                                  }
+                                  fullscreen.value = !fullscreen.value;
                                 },
                               )
                             ]) +
@@ -404,7 +412,7 @@ class _RemotePageState extends State<RemotePage>
     }
     if (_isPhysicalMouse) {
       _ffi.handleMouse(getEvent(e, 'mousemove'),
-          tabBarHeight: super.widget.tabBarHeight);
+          tabBarHeight: widget.tabBarHeight);
     }
   }
 
@@ -418,7 +426,7 @@ class _RemotePageState extends State<RemotePage>
     }
     if (_isPhysicalMouse) {
       _ffi.handleMouse(getEvent(e, 'mousedown'),
-          tabBarHeight: super.widget.tabBarHeight);
+          tabBarHeight: widget.tabBarHeight);
     }
   }
 
@@ -426,7 +434,7 @@ class _RemotePageState extends State<RemotePage>
     if (e.kind != ui.PointerDeviceKind.mouse) return;
     if (_isPhysicalMouse) {
       _ffi.handleMouse(getEvent(e, 'mouseup'),
-          tabBarHeight: super.widget.tabBarHeight);
+          tabBarHeight: widget.tabBarHeight);
     }
   }
 
@@ -434,7 +442,7 @@ class _RemotePageState extends State<RemotePage>
     if (e.kind != ui.PointerDeviceKind.mouse) return;
     if (_isPhysicalMouse) {
       _ffi.handleMouse(getEvent(e, 'mousemove'),
-          tabBarHeight: super.widget.tabBarHeight);
+          tabBarHeight: widget.tabBarHeight);
     }
   }
 
@@ -500,6 +508,10 @@ class _RemotePageState extends State<RemotePage>
       ));
     }
     paints.add(QualityMonitor(_ffi.qualityMonitorModel));
+    paints.add(RemoteMenubar(
+      id: widget.id,
+      ffi: _ffi,
+    ));
     return Stack(
       children: paints,
     );

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -197,19 +197,19 @@ class _RemotePageState extends State<RemotePage>
     return Scaffold(
         backgroundColor: MyTheme.color(context).bg,
         // resizeToAvoidBottomInset: true,
-        floatingActionButton: _showBar
-            ? null
-            : FloatingActionButton(
-                mini: true,
-                child: Icon(Icons.expand_less),
-                backgroundColor: MyTheme.accent,
-                onPressed: () {
-                  setState(() {
-                    _showBar = !_showBar;
-                  });
-                }),
-        bottomNavigationBar:
-            _showBar && hasDisplays ? getBottomAppBar(ffiModel) : null,
+        // floatingActionButton: _showBar
+        //     ? null
+        //     : FloatingActionButton(
+        //         mini: true,
+        //         child: Icon(Icons.expand_less),
+        //         backgroundColor: MyTheme.accent,
+        //         onPressed: () {
+        //           setState(() {
+        //             _showBar = !_showBar;
+        //           });
+        //         }),
+        // bottomNavigationBar:
+        //     _showBar && hasDisplays ? getBottomAppBar(ffiModel) : null,
         body: Overlay(
           initialEntries: [
             OverlayEntry(builder: (context) {

--- a/flutter/lib/desktop/screen/desktop_remote_screen.dart
+++ b/flutter/lib/desktop/screen/desktop_remote_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hbb/common.dart';
 import 'package:flutter_hbb/desktop/pages/connection_tab_page.dart';
+import 'package:get/get.dart';
 import 'package:provider/provider.dart';
 
 /// multi-tab desktop remote screen
@@ -11,6 +12,8 @@ class DesktopRemoteScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    RxBool fullscreen = false.obs;
+    Get.put(fullscreen, tag: 'fullscreen');
     return MultiProvider(
         providers: [
           ChangeNotifierProvider.value(value: gFFI.ffiModel),

--- a/flutter/lib/desktop/widgets/material_mod_popup_menu.dart
+++ b/flutter/lib/desktop/widgets/material_mod_popup_menu.dart
@@ -1,0 +1,1321 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/material.dart';
+
+// Examples can assume:
+// enum Commands { heroAndScholar, hurricaneCame }
+// late bool _heroAndScholar;
+// late dynamic _selection;
+// late BuildContext context;
+// void setState(VoidCallback fn) { }
+// enum Menu { itemOne, itemTwo, itemThree, itemFour }
+
+const Duration _kMenuDuration = Duration(milliseconds: 300);
+const double _kMenuCloseIntervalEnd = 2.0 / 3.0;
+const double _kMenuHorizontalPadding = 16.0;
+const double _kMenuDividerHeight = 16.0;
+//const double _kMenuMaxWidth = 5.0 * _kMenuWidthStep;
+const double _kMenuMinWidth = 2.0 * _kMenuWidthStep;
+const double _kMenuMaxWidth = double.infinity;
+// const double _kMenuVerticalPadding = 8.0;
+const double _kMenuVerticalPadding = 0.0;
+const double _kMenuWidthStep = 0.0;
+//const double _kMenuScreenPadding = 8.0;
+const double _kMenuScreenPadding = 0.0;
+const double _kDefaultIconSize = 24.0;
+
+/// Used to configure how the [PopupMenuButton] positions its popup menu.
+enum PopupMenuPosition {
+  /// Menu is positioned over the anchor.
+  over,
+
+  /// Menu is positioned under the anchor.
+  under,
+
+  // Only support right side (TextDirection.ltr) for now
+  /// Menu is positioned over side the anchor
+  overSide,
+
+  // Only support right side (TextDirection.ltr) for now
+  /// Menu is positioned under side the anchor
+  underSide,
+}
+
+/// A base class for entries in a material design popup menu.
+///
+/// The popup menu widget uses this interface to interact with the menu items.
+/// To show a popup menu, use the [showMenu] function. To create a button that
+/// shows a popup menu, consider using [PopupMenuButton].
+///
+/// The type `T` is the type of the value(s) the entry represents. All the
+/// entries in a given menu must represent values with consistent types.
+///
+/// A [PopupMenuEntry] may represent multiple values, for example a row with
+/// several icons, or a single entry, for example a menu item with an icon (see
+/// [PopupMenuItem]), or no value at all (for example, [PopupMenuDivider]).
+///
+/// See also:
+///
+///  * [PopupMenuItem], a popup menu entry for a single value.
+///  * [PopupMenuDivider], a popup menu entry that is just a horizontal line.
+///  * [CheckedPopupMenuItem], a popup menu item with a checkmark.
+///  * [showMenu], a method to dynamically show a popup menu at a given location.
+///  * [PopupMenuButton], an [IconButton] that automatically shows a menu when
+///    it is tapped.
+abstract class PopupMenuEntry<T> extends StatefulWidget {
+  /// Abstract const constructor. This constructor enables subclasses to provide
+  /// const constructors so that they can be used in const expressions.
+  const PopupMenuEntry({Key? key}) : super(key: key);
+
+  /// The amount of vertical space occupied by this entry.
+  ///
+  /// This value is used at the time the [showMenu] method is called, if the
+  /// `initialValue` argument is provided, to determine the position of this
+  /// entry when aligning the selected entry over the given `position`. It is
+  /// otherwise ignored.
+  double get height;
+
+  /// Whether this entry represents a particular value.
+  ///
+  /// This method is used by [showMenu], when it is called, to align the entry
+  /// representing the `initialValue`, if any, to the given `position`, and then
+  /// later is called on each entry to determine if it should be highlighted (if
+  /// the method returns true, the entry will have its background color set to
+  /// the ambient [ThemeData.highlightColor]). If `initialValue` is null, then
+  /// this method is not called.
+  ///
+  /// If the [PopupMenuEntry] represents a single value, this should return true
+  /// if the argument matches that value. If it represents multiple values, it
+  /// should return true if the argument matches any of them.
+  bool represents(T? value);
+}
+
+/// A horizontal divider in a material design popup menu.
+///
+/// This widget adapts the [Divider] for use in popup menus.
+///
+/// See also:
+///
+///  * [PopupMenuItem], for the kinds of items that this widget divides.
+///  * [showMenu], a method to dynamically show a popup menu at a given location.
+///  * [PopupMenuButton], an [IconButton] that automatically shows a menu when
+///    it is tapped.
+class PopupMenuDivider extends PopupMenuEntry<Never> {
+  /// Creates a horizontal divider for a popup menu.
+  ///
+  /// By default, the divider has a height of 16 logical pixels.
+  const PopupMenuDivider({Key? key, this.height = _kMenuDividerHeight})
+      : super(key: key);
+
+  /// The height of the divider entry.
+  ///
+  /// Defaults to 16 pixels.
+  @override
+  final double height;
+
+  @override
+  bool represents(void value) => false;
+
+  @override
+  State<PopupMenuDivider> createState() => _PopupMenuDividerState();
+}
+
+class _PopupMenuDividerState extends State<PopupMenuDivider> {
+  @override
+  Widget build(BuildContext context) => Divider(height: widget.height);
+}
+
+// This widget only exists to enable _PopupMenuRoute to save the sizes of
+// each menu item. The sizes are used by _PopupMenuRouteLayout to compute the
+// y coordinate of the menu's origin so that the center of selected menu
+// item lines up with the center of its PopupMenuButton.
+class _MenuItem extends SingleChildRenderObjectWidget {
+  const _MenuItem({
+    Key? key,
+    required this.onLayout,
+    required Widget? child,
+  })  : assert(onLayout != null),
+        super(key: key, child: child);
+
+  final ValueChanged<Size> onLayout;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderMenuItem(onLayout);
+  }
+
+  @override
+  void updateRenderObject(
+      BuildContext context, covariant _RenderMenuItem renderObject) {
+    renderObject.onLayout = onLayout;
+  }
+}
+
+class _RenderMenuItem extends RenderShiftedBox {
+  _RenderMenuItem(this.onLayout, [RenderBox? child])
+      : assert(onLayout != null),
+        super(child);
+
+  ValueChanged<Size> onLayout;
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    if (child == null) {
+      return Size.zero;
+    }
+    return child!.getDryLayout(constraints);
+  }
+
+  @override
+  void performLayout() {
+    if (child == null) {
+      size = Size.zero;
+    } else {
+      child!.layout(constraints, parentUsesSize: true);
+      size = constraints.constrain(child!.size);
+      final BoxParentData childParentData = child!.parentData! as BoxParentData;
+      childParentData.offset = Offset.zero;
+    }
+    onLayout(size);
+  }
+}
+
+/// An item in a material design popup menu.
+///
+/// To show a popup menu, use the [showMenu] function. To create a button that
+/// shows a popup menu, consider using [PopupMenuButton].
+///
+/// To show a checkmark next to a popup menu item, consider using
+/// [CheckedPopupMenuItem].
+///
+/// Typically the [child] of a [PopupMenuItem] is a [Text] widget. More
+/// elaborate menus with icons can use a [ListTile]. By default, a
+/// [PopupMenuItem] is [kMinInteractiveDimension] pixels high. If you use a widget
+/// with a different height, it must be specified in the [height] property.
+///
+/// {@tool snippet}
+///
+/// Here, a [Text] widget is used with a popup menu item. The `Menu` type
+/// is an enum, not shown here.
+///
+/// ```dart
+/// const PopupMenuItem<Menu>(
+///   value: Menu.itemOne,
+///   child: Text('Item 1'),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// See the example at [PopupMenuButton] for how this example could be used in a
+/// complete menu, and see the example at [CheckedPopupMenuItem] for one way to
+/// keep the text of [PopupMenuItem]s that use [Text] widgets in their [child]
+/// slot aligned with the text of [CheckedPopupMenuItem]s or of [PopupMenuItem]
+/// that use a [ListTile] in their [child] slot.
+///
+/// See also:
+///
+///  * [PopupMenuDivider], which can be used to divide items from each other.
+///  * [CheckedPopupMenuItem], a variant of [PopupMenuItem] with a checkmark.
+///  * [showMenu], a method to dynamically show a popup menu at a given location.
+///  * [PopupMenuButton], an [IconButton] that automatically shows a menu when
+///    it is tapped.
+class PopupMenuItem<T> extends PopupMenuEntry<T> {
+  /// Creates an item for a popup menu.
+  ///
+  /// By default, the item is [enabled].
+  ///
+  /// The `enabled` and `height` arguments must not be null.
+  const PopupMenuItem({
+    Key? key,
+    this.value,
+    this.onTap,
+    this.enabled = true,
+    this.height = kMinInteractiveDimension,
+    this.padding,
+    this.textStyle,
+    this.mouseCursor,
+    required this.child,
+  })  : assert(enabled != null),
+        assert(height != null),
+        super(key: key);
+
+  /// The value that will be returned by [showMenu] if this entry is selected.
+  final T? value;
+
+  /// Called when the menu item is tapped.
+  final VoidCallback? onTap;
+
+  /// Whether the user is permitted to select this item.
+  ///
+  /// Defaults to true. If this is false, then the item will not react to
+  /// touches.
+  final bool enabled;
+
+  /// The minimum height of the menu item.
+  ///
+  /// Defaults to [kMinInteractiveDimension] pixels.
+  @override
+  final double height;
+
+  /// The padding of the menu item.
+  ///
+  /// Note that [height] may interact with the applied padding. For example,
+  /// If a [height] greater than the height of the sum of the padding and [child]
+  /// is provided, then the padding's effect will not be visible.
+  ///
+  /// When null, the horizontal padding defaults to 16.0 on both sides.
+  final EdgeInsets? padding;
+
+  /// The text style of the popup menu item.
+  ///
+  /// If this property is null, then [PopupMenuThemeData.textStyle] is used.
+  /// If [PopupMenuThemeData.textStyle] is also null, then [TextTheme.subtitle1]
+  /// of [ThemeData.textTheme] is used.
+  final TextStyle? textStyle;
+
+  /// {@template flutter.material.popupmenu.mouseCursor}
+  /// The cursor for a mouse pointer when it enters or is hovering over the
+  /// widget.
+  ///
+  /// If [mouseCursor] is a [MaterialStateProperty<MouseCursor>],
+  /// [MaterialStateProperty.resolve] is used for the following [MaterialState]s:
+  ///
+  ///  * [MaterialState.hovered].
+  ///  * [MaterialState.focused].
+  ///  * [MaterialState.disabled].
+  /// {@endtemplate}
+  ///
+  /// If null, then the value of [PopupMenuThemeData.mouseCursor] is used. If
+  /// that is also null, then [MaterialStateMouseCursor.clickable] is used.
+  final MouseCursor? mouseCursor;
+
+  /// The widget below this widget in the tree.
+  ///
+  /// Typically a single-line [ListTile] (for menus with icons) or a [Text]. An
+  /// appropriate [DefaultTextStyle] is put in scope for the child. In either
+  /// case, the text should be short enough that it won't wrap.
+  final Widget? child;
+
+  @override
+  bool represents(T? value) => value == this.value;
+
+  @override
+  PopupMenuItemState<T, PopupMenuItem<T>> createState() =>
+      PopupMenuItemState<T, PopupMenuItem<T>>();
+}
+
+/// The [State] for [PopupMenuItem] subclasses.
+///
+/// By default this implements the basic styling and layout of Material Design
+/// popup menu items.
+///
+/// The [buildChild] method can be overridden to adjust exactly what gets placed
+/// in the menu. By default it returns [PopupMenuItem.child].
+///
+/// The [handleTap] method can be overridden to adjust exactly what happens when
+/// the item is tapped. By default, it uses [Navigator.pop] to return the
+/// [PopupMenuItem.value] from the menu route.
+///
+/// This class takes two type arguments. The second, `W`, is the exact type of
+/// the [Widget] that is using this [State]. It must be a subclass of
+/// [PopupMenuItem]. The first, `T`, must match the type argument of that widget
+/// class, and is the type of values returned from this menu.
+class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
+  /// The menu item contents.
+  ///
+  /// Used by the [build] method.
+  ///
+  /// By default, this returns [PopupMenuItem.child]. Override this to put
+  /// something else in the menu entry.
+  @protected
+  Widget? buildChild() => widget.child;
+
+  /// The handler for when the user selects the menu item.
+  ///
+  /// Used by the [InkWell] inserted by the [build] method.
+  ///
+  /// By default, uses [Navigator.pop] to return the [PopupMenuItem.value] from
+  /// the menu route.
+  @protected
+  void handleTap() {
+    widget.onTap?.call();
+
+    Navigator.pop<T>(context, widget.value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final PopupMenuThemeData popupMenuTheme = PopupMenuTheme.of(context);
+    TextStyle style = widget.textStyle ??
+        popupMenuTheme.textStyle ??
+        theme.textTheme.subtitle1!;
+
+    if (!widget.enabled) style = style.copyWith(color: theme.disabledColor);
+
+    Widget item = AnimatedDefaultTextStyle(
+      style: style,
+      duration: kThemeChangeDuration,
+      child: Container(
+        alignment: AlignmentDirectional.centerStart,
+        constraints: BoxConstraints(minHeight: widget.height),
+        padding: widget.padding ??
+            const EdgeInsets.symmetric(horizontal: _kMenuHorizontalPadding),
+        child: buildChild(),
+      ),
+    );
+
+    if (!widget.enabled) {
+      final bool isDark = theme.brightness == Brightness.dark;
+      item = IconTheme.merge(
+        data: IconThemeData(opacity: isDark ? 0.5 : 0.38),
+        child: item,
+      );
+    }
+
+    return MergeSemantics(
+      child: Semantics(
+        enabled: widget.enabled,
+        button: true,
+        child: InkWell(
+          onTap: widget.enabled ? handleTap : null,
+          canRequestFocus: widget.enabled,
+          mouseCursor: _EffectiveMouseCursor(
+              widget.mouseCursor, popupMenuTheme.mouseCursor),
+          child: item,
+        ),
+      ),
+    );
+  }
+}
+
+/// An item with a checkmark in a material design popup menu.
+///
+/// To show a popup menu, use the [showMenu] function. To create a button that
+/// shows a popup menu, consider using [PopupMenuButton].
+///
+/// A [CheckedPopupMenuItem] is kMinInteractiveDimension pixels high, which
+/// matches the default minimum height of a [PopupMenuItem]. The horizontal
+/// layout uses [ListTile]; the checkmark is an [Icons.done] icon, shown in the
+/// [ListTile.leading] position.
+///
+/// {@tool snippet}
+///
+/// Suppose a `Commands` enum exists that lists the possible commands from a
+/// particular popup menu, including `Commands.heroAndScholar` and
+/// `Commands.hurricaneCame`, and further suppose that there is a
+/// `_heroAndScholar` member field which is a boolean. The example below shows a
+/// menu with one menu item with a checkmark that can toggle the boolean, and
+/// one menu item without a checkmark for selecting the second option. (It also
+/// shows a divider placed between the two menu items.)
+///
+/// ```dart
+/// PopupMenuButton<Commands>(
+///   onSelected: (Commands result) {
+///     switch (result) {
+///       case Commands.heroAndScholar:
+///         setState(() { _heroAndScholar = !_heroAndScholar; });
+///         break;
+///       case Commands.hurricaneCame:
+///         // ...handle hurricane option
+///         break;
+///       // ...other items handled here
+///     }
+///   },
+///   itemBuilder: (BuildContext context) => <PopupMenuEntry<Commands>>[
+///     CheckedPopupMenuItem<Commands>(
+///       checked: _heroAndScholar,
+///       value: Commands.heroAndScholar,
+///       child: const Text('Hero and scholar'),
+///     ),
+///     const PopupMenuDivider(),
+///     const PopupMenuItem<Commands>(
+///       value: Commands.hurricaneCame,
+///       child: ListTile(leading: Icon(null), title: Text('Bring hurricane')),
+///     ),
+///     // ...other items listed here
+///   ],
+/// )
+/// ```
+/// {@end-tool}
+///
+/// In particular, observe how the second menu item uses a [ListTile] with a
+/// blank [Icon] in the [ListTile.leading] position to get the same alignment as
+/// the item with the checkmark.
+///
+/// See also:
+///
+///  * [PopupMenuItem], a popup menu entry for picking a command (as opposed to
+///    toggling a value).
+///  * [PopupMenuDivider], a popup menu entry that is just a horizontal line.
+///  * [showMenu], a method to dynamically show a popup menu at a given location.
+///  * [PopupMenuButton], an [IconButton] that automatically shows a menu when
+///    it is tapped.
+class CheckedPopupMenuItem<T> extends PopupMenuItem<T> {
+  /// Creates a popup menu item with a checkmark.
+  ///
+  /// By default, the menu item is [enabled] but unchecked. To mark the item as
+  /// checked, set [checked] to true.
+  ///
+  /// The `checked` and `enabled` arguments must not be null.
+  const CheckedPopupMenuItem({
+    Key? key,
+    T? value,
+    this.checked = false,
+    bool enabled = true,
+    EdgeInsets? padding,
+    double height = kMinInteractiveDimension,
+    Widget? child,
+  })  : assert(checked != null),
+        super(
+          key: key,
+          value: value,
+          enabled: enabled,
+          padding: padding,
+          height: height,
+          child: child,
+        );
+
+  /// Whether to display a checkmark next to the menu item.
+  ///
+  /// Defaults to false.
+  ///
+  /// When true, an [Icons.done] checkmark is displayed.
+  ///
+  /// When this popup menu item is selected, the checkmark will fade in or out
+  /// as appropriate to represent the implied new state.
+  final bool checked;
+
+  /// The widget below this widget in the tree.
+  ///
+  /// Typically a [Text]. An appropriate [DefaultTextStyle] is put in scope for
+  /// the child. The text should be short enough that it won't wrap.
+  ///
+  /// This widget is placed in the [ListTile.title] slot of a [ListTile] whose
+  /// [ListTile.leading] slot is an [Icons.done] icon.
+  @override
+  Widget? get child => super.child;
+
+  @override
+  PopupMenuItemState<T, CheckedPopupMenuItem<T>> createState() =>
+      _CheckedPopupMenuItemState<T>();
+}
+
+class _CheckedPopupMenuItemState<T>
+    extends PopupMenuItemState<T, CheckedPopupMenuItem<T>>
+    with SingleTickerProviderStateMixin {
+  static const Duration _fadeDuration = Duration(milliseconds: 150);
+  late AnimationController _controller;
+  Animation<double> get _opacity => _controller.view;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(duration: _fadeDuration, vsync: this)
+      ..value = widget.checked ? 1.0 : 0.0
+      ..addListener(() => setState(() {/* animation changed */}));
+  }
+
+  @override
+  void handleTap() {
+    // This fades the checkmark in or out when tapped.
+    if (widget.checked)
+      _controller.reverse();
+    else
+      _controller.forward();
+    super.handleTap();
+  }
+
+  @override
+  Widget buildChild() {
+    return ListTile(
+      enabled: widget.enabled,
+      leading: FadeTransition(
+        opacity: _opacity,
+        child: Icon(_controller.isDismissed ? null : Icons.done),
+      ),
+      title: widget.child,
+    );
+  }
+}
+
+class _PopupMenu<T> extends StatelessWidget {
+  const _PopupMenu({
+    Key? key,
+    required this.route,
+    required this.semanticLabel,
+    this.constraints,
+  }) : super(key: key);
+
+  final _PopupMenuRoute<T> route;
+  final String? semanticLabel;
+  final BoxConstraints? constraints;
+
+  @override
+  Widget build(BuildContext context) {
+    final double unit = 1.0 /
+        (route.items.length +
+            1.5); // 1.0 for the width and 0.5 for the last item's fade.
+    final List<Widget> children = <Widget>[];
+    final PopupMenuThemeData popupMenuTheme = PopupMenuTheme.of(context);
+
+    for (int i = 0; i < route.items.length; i += 1) {
+      final double start = (i + 1) * unit;
+      final double end = (start + 1.5 * unit).clamp(0.0, 1.0);
+      final CurvedAnimation opacity = CurvedAnimation(
+        parent: route.animation!,
+        curve: Interval(start, end),
+      );
+      Widget item = route.items[i];
+      if (route.initialValue != null &&
+          route.items[i].represents(route.initialValue)) {
+        item = Container(
+          color: Theme.of(context).highlightColor,
+          child: item,
+        );
+      }
+      children.add(
+        _MenuItem(
+          onLayout: (Size size) {
+            route.itemSizes[i] = size;
+          },
+          child: FadeTransition(
+            opacity: opacity,
+            child: item,
+          ),
+        ),
+      );
+    }
+
+    final CurveTween opacity =
+        CurveTween(curve: const Interval(0.0, 1.0 / 3.0));
+    final CurveTween width = CurveTween(curve: Interval(0.0, unit));
+    final CurveTween height =
+        CurveTween(curve: Interval(0.0, unit * route.items.length));
+
+    final Widget child = ConstrainedBox(
+      constraints: constraints ??
+          const BoxConstraints(
+            minWidth: _kMenuMinWidth,
+            maxWidth: _kMenuMaxWidth,
+          ),
+      child: IntrinsicWidth(
+        stepWidth: _kMenuWidthStep,
+        child: Semantics(
+          scopesRoute: true,
+          namesRoute: true,
+          explicitChildNodes: true,
+          label: semanticLabel,
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(
+              vertical: _kMenuVerticalPadding,
+            ),
+            child: ListBody(children: children),
+          ),
+        ),
+      ),
+    );
+
+    return AnimatedBuilder(
+      animation: route.animation!,
+      builder: (BuildContext context, Widget? child) {
+        return FadeTransition(
+          opacity: opacity.animate(route.animation!),
+          child: Material(
+            shape: route.shape ?? popupMenuTheme.shape,
+            color: route.color ?? popupMenuTheme.color,
+            type: MaterialType.card,
+            elevation: route.elevation ?? popupMenuTheme.elevation ?? 8.0,
+            child: Align(
+              alignment: AlignmentDirectional.topEnd,
+              widthFactor: width.evaluate(route.animation!),
+              heightFactor: height.evaluate(route.animation!),
+              child: child,
+            ),
+          ),
+        );
+      },
+      child: child,
+    );
+  }
+}
+
+// Positioning of the menu on the screen.
+class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
+  _PopupMenuRouteLayout(
+    this.position,
+    this.itemSizes,
+    this.selectedItemIndex,
+    this.textDirection,
+    this.padding,
+    this.avoidBounds,
+  );
+
+  // Rectangle of underlying button, relative to the overlay's dimensions.
+  final RelativeRect position;
+
+  // The sizes of each item are computed when the menu is laid out, and before
+  // the route is laid out.
+  List<Size?> itemSizes;
+
+  // The index of the selected item, or null if PopupMenuButton.initialValue
+  // was not specified.
+  final int? selectedItemIndex;
+
+  // Whether to prefer going to the left or to the right.
+  final TextDirection textDirection;
+
+  // The padding of unsafe area.
+  EdgeInsets padding;
+
+  // List of rectangles that we should avoid overlapping. Unusable screen area.
+  final Set<Rect> avoidBounds;
+
+  // We put the child wherever position specifies, so long as it will fit within
+  // the specified parent size padded (inset) by 8. If necessary, we adjust the
+  // child's position so that it fits.
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+    // The menu can be at most the size of the overlay minus 8.0 pixels in each
+    // direction.
+    return BoxConstraints.loose(constraints.biggest).deflate(
+      const EdgeInsets.all(_kMenuScreenPadding) + padding,
+    );
+  }
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    // size: The size of the overlay.
+    // childSize: The size of the menu, when fully open, as determined by
+    // getConstraintsForChild.
+
+    final double buttonHeight = size.height - position.top - position.bottom;
+    // Find the ideal vertical position.
+    double y = position.top;
+    if (selectedItemIndex != null && itemSizes != null) {
+      double selectedItemOffset = _kMenuVerticalPadding;
+      for (int index = 0; index < selectedItemIndex!; index += 1) {
+        selectedItemOffset += itemSizes[index]!.height;
+      }
+      selectedItemOffset += itemSizes[selectedItemIndex!]!.height / 2;
+      y = y + buttonHeight / 2.0 - selectedItemOffset;
+    }
+
+    // Find the ideal horizontal position.
+    double x;
+    // if (position.left > position.right) {
+    //   // Menu button is closer to the right edge, so grow to the left, aligned to the right edge.
+    //   x = size.width - position.right - childSize.width;
+    // } else if (position.left < position.right) {
+    //   // Menu button is closer to the left edge, so grow to the right, aligned to the left edge.
+    //   x = position.left;
+    // } else {
+    // Menu button is equidistant from both edges, so grow in reading direction.
+    assert(textDirection != null);
+    switch (textDirection) {
+      case TextDirection.rtl:
+        x = size.width - position.right - childSize.width;
+        break;
+      case TextDirection.ltr:
+        x = position.left;
+        break;
+    }
+    //}
+    final Offset wantedPosition = Offset(x, y);
+    final Offset originCenter = position.toRect(Offset.zero & size).center;
+    final Iterable<Rect> subScreens =
+        DisplayFeatureSubScreen.subScreensInBounds(
+            Offset.zero & size, avoidBounds);
+    final Rect subScreen = _closestScreen(subScreens, originCenter);
+    return _fitInsideScreen(subScreen, childSize, wantedPosition);
+  }
+
+  Rect _closestScreen(Iterable<Rect> screens, Offset point) {
+    Rect closest = screens.first;
+    for (final Rect screen in screens) {
+      if ((screen.center - point).distance <
+          (closest.center - point).distance) {
+        closest = screen;
+      }
+    }
+    return closest;
+  }
+
+  Offset _fitInsideScreen(Rect screen, Size childSize, Offset wantedPosition) {
+    double x = wantedPosition.dx;
+    double y = wantedPosition.dy;
+    // Avoid going outside an area defined as the rectangle 8.0 pixels from the
+    // edge of the screen in every direction.
+    if (x < screen.left + _kMenuScreenPadding + padding.left) {
+      x = screen.left + _kMenuScreenPadding + padding.left;
+    } else if (x + childSize.width >
+        screen.right - _kMenuScreenPadding - padding.right) {
+      x = screen.right - childSize.width - _kMenuScreenPadding - padding.right;
+    }
+    if (y < screen.top + _kMenuScreenPadding + padding.top) {
+      y = _kMenuScreenPadding + padding.top;
+    } else if (y + childSize.height >
+        screen.bottom - _kMenuScreenPadding - padding.bottom) {
+      y = screen.bottom -
+          childSize.height -
+          _kMenuScreenPadding -
+          padding.bottom;
+    }
+
+    return Offset(x, y);
+  }
+
+  @override
+  bool shouldRelayout(_PopupMenuRouteLayout oldDelegate) {
+    // If called when the old and new itemSizes have been initialized then
+    // we expect them to have the same length because there's no practical
+    // way to change length of the items list once the menu has been shown.
+    assert(itemSizes.length == oldDelegate.itemSizes.length);
+
+    return position != oldDelegate.position ||
+        selectedItemIndex != oldDelegate.selectedItemIndex ||
+        textDirection != oldDelegate.textDirection ||
+        !listEquals(itemSizes, oldDelegate.itemSizes) ||
+        padding != oldDelegate.padding ||
+        !setEquals(avoidBounds, oldDelegate.avoidBounds);
+  }
+}
+
+class _PopupMenuRoute<T> extends PopupRoute<T> {
+  _PopupMenuRoute({
+    required this.position,
+    required this.items,
+    this.initialValue,
+    this.elevation,
+    required this.barrierLabel,
+    this.semanticLabel,
+    this.shape,
+    this.color,
+    required this.capturedThemes,
+    this.constraints,
+  }) : itemSizes = List<Size?>.filled(items.length, null);
+
+  final RelativeRect position;
+  final List<PopupMenuEntry<T>> items;
+  final List<Size?> itemSizes;
+  final T? initialValue;
+  final double? elevation;
+  final String? semanticLabel;
+  final ShapeBorder? shape;
+  final Color? color;
+  final CapturedThemes capturedThemes;
+  final BoxConstraints? constraints;
+
+  @override
+  Animation<double> createAnimation() {
+    return CurvedAnimation(
+      parent: super.createAnimation(),
+      curve: Curves.linear,
+      reverseCurve: const Interval(0.0, _kMenuCloseIntervalEnd),
+    );
+  }
+
+  @override
+  Duration get transitionDuration => _kMenuDuration;
+
+  @override
+  bool get barrierDismissible => true;
+
+  @override
+  Color? get barrierColor => null;
+
+  @override
+  final String barrierLabel;
+
+  @override
+  Widget buildPage(BuildContext context, Animation<double> animation,
+      Animation<double> secondaryAnimation) {
+    int? selectedItemIndex;
+    if (initialValue != null) {
+      for (int index = 0;
+          selectedItemIndex == null && index < items.length;
+          index += 1) {
+        if (items[index].represents(initialValue)) selectedItemIndex = index;
+      }
+    }
+
+    final Widget menu = _PopupMenu<T>(
+      route: this,
+      semanticLabel: semanticLabel,
+      constraints: constraints,
+    );
+    final MediaQueryData mediaQuery = MediaQuery.of(context);
+    return MediaQuery.removePadding(
+      context: context,
+      removeTop: true,
+      removeBottom: true,
+      removeLeft: true,
+      removeRight: true,
+      child: Builder(
+        builder: (BuildContext context) {
+          return CustomSingleChildLayout(
+            delegate: _PopupMenuRouteLayout(
+              position,
+              itemSizes,
+              selectedItemIndex,
+              Directionality.of(context),
+              mediaQuery.padding,
+              _avoidBounds(mediaQuery),
+            ),
+            child: capturedThemes.wrap(menu),
+          );
+        },
+      ),
+    );
+  }
+
+  Set<Rect> _avoidBounds(MediaQueryData mediaQuery) {
+    return DisplayFeatureSubScreen.avoidBounds(mediaQuery).toSet();
+  }
+}
+
+/// Show a popup menu that contains the `items` at `position`.
+///
+/// `items` should be non-null and not empty.
+///
+/// If `initialValue` is specified then the first item with a matching value
+/// will be highlighted and the value of `position` gives the rectangle whose
+/// vertical center will be aligned with the vertical center of the highlighted
+/// item (when possible).
+///
+/// If `initialValue` is not specified then the top of the menu will be aligned
+/// with the top of the `position` rectangle.
+///
+/// In both cases, the menu position will be adjusted if necessary to fit on the
+/// screen.
+///
+/// Horizontally, the menu is positioned so that it grows in the direction that
+/// has the most room. For example, if the `position` describes a rectangle on
+/// the left edge of the screen, then the left edge of the menu is aligned with
+/// the left edge of the `position`, and the menu grows to the right. If both
+/// edges of the `position` are equidistant from the opposite edge of the
+/// screen, then the ambient [Directionality] is used as a tie-breaker,
+/// preferring to grow in the reading direction.
+///
+/// The positioning of the `initialValue` at the `position` is implemented by
+/// iterating over the `items` to find the first whose
+/// [PopupMenuEntry.represents] method returns true for `initialValue`, and then
+/// summing the values of [PopupMenuEntry.height] for all the preceding widgets
+/// in the list.
+///
+/// The `elevation` argument specifies the z-coordinate at which to place the
+/// menu. The elevation defaults to 8, the appropriate elevation for popup
+/// menus.
+///
+/// The `context` argument is used to look up the [Navigator] and [Theme] for
+/// the menu. It is only used when the method is called. Its corresponding
+/// widget can be safely removed from the tree before the popup menu is closed.
+///
+/// The `useRootNavigator` argument is used to determine whether to push the
+/// menu to the [Navigator] furthest from or nearest to the given `context`. It
+/// is `false` by default.
+///
+/// The `semanticLabel` argument is used by accessibility frameworks to
+/// announce screen transitions when the menu is opened and closed. If this
+/// label is not provided, it will default to
+/// [MaterialLocalizations.popupMenuLabel].
+///
+/// See also:
+///
+///  * [PopupMenuItem], a popup menu entry for a single value.
+///  * [PopupMenuDivider], a popup menu entry that is just a horizontal line.
+///  * [CheckedPopupMenuItem], a popup menu item with a checkmark.
+///  * [PopupMenuButton], which provides an [IconButton] that shows a menu by
+///    calling this method automatically.
+///  * [SemanticsConfiguration.namesRoute], for a description of edge triggered
+///    semantics.
+Future<T?> showMenu<T>({
+  required BuildContext context,
+  required RelativeRect position,
+  required List<PopupMenuEntry<T>> items,
+  T? initialValue,
+  double? elevation,
+  String? semanticLabel,
+  ShapeBorder? shape,
+  Color? color,
+  bool useRootNavigator = false,
+  BoxConstraints? constraints,
+}) {
+  assert(context != null);
+  assert(position != null);
+  assert(useRootNavigator != null);
+  assert(items != null && items.isNotEmpty);
+  assert(debugCheckHasMaterialLocalizations(context));
+
+  switch (Theme.of(context).platform) {
+    case TargetPlatform.iOS:
+    case TargetPlatform.macOS:
+      break;
+    case TargetPlatform.android:
+    case TargetPlatform.fuchsia:
+    case TargetPlatform.linux:
+    case TargetPlatform.windows:
+      semanticLabel ??= MaterialLocalizations.of(context).popupMenuLabel;
+  }
+
+  final NavigatorState navigator =
+      Navigator.of(context, rootNavigator: useRootNavigator);
+  return navigator.push(_PopupMenuRoute<T>(
+    position: position,
+    items: items,
+    initialValue: initialValue,
+    elevation: elevation,
+    semanticLabel: semanticLabel,
+    barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+    shape: shape,
+    color: color,
+    capturedThemes:
+        InheritedTheme.capture(from: context, to: navigator.context),
+    constraints: constraints,
+  ));
+}
+
+/// Signature for the callback invoked when a menu item is selected. The
+/// argument is the value of the [PopupMenuItem] that caused its menu to be
+/// dismissed.
+///
+/// Used by [PopupMenuButton.onSelected].
+typedef PopupMenuItemSelected<T> = void Function(T value);
+
+/// Signature for the callback invoked when a [PopupMenuButton] is dismissed
+/// without selecting an item.
+///
+/// Used by [PopupMenuButton.onCanceled].
+typedef PopupMenuCanceled = void Function();
+
+/// Signature used by [PopupMenuButton] to lazily construct the items shown when
+/// the button is pressed.
+///
+/// Used by [PopupMenuButton.itemBuilder].
+typedef PopupMenuItemBuilder<T> = List<PopupMenuEntry<T>> Function(
+    BuildContext context);
+
+/// Displays a menu when pressed and calls [onSelected] when the menu is dismissed
+/// because an item was selected. The value passed to [onSelected] is the value of
+/// the selected menu item.
+///
+/// One of [child] or [icon] may be provided, but not both. If [icon] is provided,
+/// then [PopupMenuButton] behaves like an [IconButton].
+///
+/// If both are null, then a standard overflow icon is created (depending on the
+/// platform).
+///
+/// {@tool dartpad}
+/// This example shows a menu with four items, selecting between an enum's
+/// values and setting a `_selectedMenu` field based on the selection
+///
+/// ** See code in examples/api/lib/material/popupmenu/popupmenu.0.dart **
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [PopupMenuItem], a popup menu entry for a single value.
+///  * [PopupMenuDivider], a popup menu entry that is just a horizontal line.
+///  * [CheckedPopupMenuItem], a popup menu item with a checkmark.
+///  * [showMenu], a method to dynamically show a popup menu at a given location.
+class PopupMenuButton<T> extends StatefulWidget {
+  /// Creates a button that shows a popup menu.
+  ///
+  /// The [itemBuilder] argument must not be null.
+  const PopupMenuButton({
+    Key? key,
+    required this.itemBuilder,
+    this.initialValue,
+    this.onSelected,
+    this.onCanceled,
+    this.tooltip,
+    this.elevation,
+    this.padding = const EdgeInsets.all(8.0),
+    this.child,
+    this.splashRadius,
+    this.icon,
+    this.iconSize,
+    this.offset = Offset.zero,
+    this.enabled = true,
+    this.shape,
+    this.color,
+    this.enableFeedback,
+    this.constraints,
+    this.position = PopupMenuPosition.over,
+  })  : assert(itemBuilder != null),
+        assert(enabled != null),
+        assert(
+          !(child != null && icon != null),
+          'You can only pass [child] or [icon], not both.',
+        ),
+        super(key: key);
+
+  /// Called when the button is pressed to create the items to show in the menu.
+  final PopupMenuItemBuilder<T> itemBuilder;
+
+  /// The value of the menu item, if any, that should be highlighted when the menu opens.
+  final T? initialValue;
+
+  /// Called when the user selects a value from the popup menu created by this button.
+  ///
+  /// If the popup menu is dismissed without selecting a value, [onCanceled] is
+  /// called instead.
+  final PopupMenuItemSelected<T>? onSelected;
+
+  /// Called when the user dismisses the popup menu without selecting an item.
+  ///
+  /// If the user selects a value, [onSelected] is called instead.
+  final PopupMenuCanceled? onCanceled;
+
+  /// Text that describes the action that will occur when the button is pressed.
+  ///
+  /// This text is displayed when the user long-presses on the button and is
+  /// used for accessibility.
+  final String? tooltip;
+
+  /// The z-coordinate at which to place the menu when open. This controls the
+  /// size of the shadow below the menu.
+  ///
+  /// Defaults to 8, the appropriate elevation for popup menus.
+  final double? elevation;
+
+  /// Matches IconButton's 8 dps padding by default. In some cases, notably where
+  /// this button appears as the trailing element of a list item, it's useful to be able
+  /// to set the padding to zero.
+  final EdgeInsetsGeometry padding;
+
+  /// The splash radius.
+  ///
+  /// If null, default splash radius of [InkWell] or [IconButton] is used.
+  final double? splashRadius;
+
+  /// If provided, [child] is the widget used for this button
+  /// and the button will utilize an [InkWell] for taps.
+  final Widget? child;
+
+  /// If provided, the [icon] is used for this button
+  /// and the button will behave like an [IconButton].
+  final Widget? icon;
+
+  /// The offset is applied relative to the initial position
+  /// set by the [position].
+  ///
+  /// When not set, the offset defaults to [Offset.zero].
+  final Offset offset;
+
+  /// Whether this popup menu button is interactive.
+  ///
+  /// Must be non-null, defaults to `true`
+  ///
+  /// If `true` the button will respond to presses by displaying the menu.
+  ///
+  /// If `false`, the button is styled with the disabled color from the
+  /// current [Theme] and will not respond to presses or show the popup
+  /// menu and [onSelected], [onCanceled] and [itemBuilder] will not be called.
+  ///
+  /// This can be useful in situations where the app needs to show the button,
+  /// but doesn't currently have anything to show in the menu.
+  final bool enabled;
+
+  /// If provided, the shape used for the menu.
+  ///
+  /// If this property is null, then [PopupMenuThemeData.shape] is used.
+  /// If [PopupMenuThemeData.shape] is also null, then the default shape for
+  /// [MaterialType.card] is used. This default shape is a rectangle with
+  /// rounded edges of BorderRadius.circular(2.0).
+  final ShapeBorder? shape;
+
+  /// If provided, the background color used for the menu.
+  ///
+  /// If this property is null, then [PopupMenuThemeData.color] is used.
+  /// If [PopupMenuThemeData.color] is also null, then
+  /// Theme.of(context).cardColor is used.
+  final Color? color;
+
+  /// Whether detected gestures should provide acoustic and/or haptic feedback.
+  ///
+  /// For example, on Android a tap will produce a clicking sound and a
+  /// long-press will produce a short vibration, when feedback is enabled.
+  ///
+  /// See also:
+  ///
+  ///  * [Feedback] for providing platform-specific feedback to certain actions.
+  final bool? enableFeedback;
+
+  /// If provided, the size of the [Icon].
+  ///
+  /// If this property is null, then [IconThemeData.size] is used.
+  /// If [IconThemeData.size] is also null, then
+  /// default size is 24.0 pixels.
+  final double? iconSize;
+
+  /// Optional size constraints for the menu.
+  ///
+  /// When unspecified, defaults to:
+  /// ```dart
+  /// const BoxConstraints(
+  ///   minWidth: 2.0 * 56.0,
+  ///   maxWidth: 5.0 * 56.0,
+  /// )
+  /// ```
+  ///
+  /// The default constraints ensure that the menu width matches maximum width
+  /// recommended by the material design guidelines.
+  /// Specifying this parameter enables creation of menu wider than
+  /// the default maximum width.
+  final BoxConstraints? constraints;
+
+  /// Whether the popup menu is positioned over or under the popup menu button.
+  ///
+  /// [offset] is used to change the position of the popup menu relative to the
+  /// position set by this parameter.
+  ///
+  /// When not set, the position defaults to [PopupMenuPosition.over] which makes the
+  /// popup menu appear directly over the button that was used to create it.
+  final PopupMenuPosition position;
+
+  @override
+  PopupMenuButtonState<T> createState() => PopupMenuButtonState<T>();
+}
+
+/// The [State] for a [PopupMenuButton].
+///
+/// See [showButtonMenu] for a way to programmatically open the popup menu
+/// of your button state.
+class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
+  /// A method to show a popup menu with the items supplied to
+  /// [PopupMenuButton.itemBuilder] at the position of your [PopupMenuButton].
+  ///
+  /// By default, it is called when the user taps the button and [PopupMenuButton.enabled]
+  /// is set to `true`. Moreover, you can open the button by calling the method manually.
+  ///
+  /// You would access your [PopupMenuButtonState] using a [GlobalKey] and
+  /// show the menu of the button with `globalKey.currentState.showButtonMenu`.
+  void showButtonMenu() {
+    final PopupMenuThemeData popupMenuTheme = PopupMenuTheme.of(context);
+    final RenderBox button = context.findRenderObject()! as RenderBox;
+    final RenderBox overlay =
+        Navigator.of(context).overlay!.context.findRenderObject()! as RenderBox;
+    final Offset offset;
+    switch (widget.position) {
+      case PopupMenuPosition.over:
+        offset = widget.offset;
+        break;
+      case PopupMenuPosition.under:
+        offset =
+            Offset(0.0, button.size.height - (widget.padding.vertical / 2)) +
+                widget.offset;
+        break;
+      case PopupMenuPosition.overSide:
+        offset =
+            Offset(button.size.width - (widget.padding.horizontal / 2), 0.0) +
+                widget.offset;
+        break;
+      case PopupMenuPosition.underSide:
+        offset = Offset(button.size.width - (widget.padding.horizontal / 2),
+                button.size.height - (widget.padding.vertical / 2)) +
+            widget.offset;
+        break;
+    }
+    final RelativeRect position = RelativeRect.fromRect(
+      Rect.fromPoints(
+        button.localToGlobal(offset, ancestor: overlay),
+        button.localToGlobal(button.size.bottomRight(Offset.zero) + offset,
+            ancestor: overlay),
+      ),
+      Offset.zero & overlay.size,
+    );
+    final List<PopupMenuEntry<T>> items = widget.itemBuilder(context);
+    // Only show the menu if there is something to show
+    if (items.isNotEmpty) {
+      showMenu<T?>(
+        context: context,
+        elevation: widget.elevation ?? popupMenuTheme.elevation,
+        items: items,
+        initialValue: widget.initialValue,
+        position: position,
+        shape: widget.shape ?? popupMenuTheme.shape,
+        color: widget.color ?? popupMenuTheme.color,
+        constraints: widget.constraints,
+      ).then<void>((T? newValue) {
+        if (!mounted) return null;
+        if (newValue == null) {
+          widget.onCanceled?.call();
+          return null;
+        }
+        widget.onSelected?.call(newValue);
+      });
+    }
+  }
+
+  bool get _canRequestFocus {
+    final NavigationMode mode = MediaQuery.maybeOf(context)?.navigationMode ??
+        NavigationMode.traditional;
+    switch (mode) {
+      case NavigationMode.traditional:
+        return widget.enabled;
+      case NavigationMode.directional:
+        return true;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final IconThemeData iconTheme = IconTheme.of(context);
+    final bool enableFeedback = widget.enableFeedback ??
+        PopupMenuTheme.of(context).enableFeedback ??
+        true;
+
+    assert(debugCheckHasMaterialLocalizations(context));
+
+    if (widget.child != null)
+      return Tooltip(
+        message:
+            widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
+        child: InkWell(
+          onTap: widget.enabled ? showButtonMenu : null,
+          canRequestFocus: _canRequestFocus,
+          radius: widget.splashRadius,
+          enableFeedback: enableFeedback,
+          child: widget.child,
+        ),
+      );
+
+    return IconButton(
+      icon: widget.icon ?? Icon(Icons.adaptive.more),
+      padding: widget.padding,
+      splashRadius: widget.splashRadius,
+      iconSize: widget.iconSize ?? iconTheme.size ?? _kDefaultIconSize,
+      tooltip:
+          widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
+      onPressed: widget.enabled ? showButtonMenu : null,
+      enableFeedback: enableFeedback,
+    );
+  }
+}
+
+// This MaterialStateProperty is passed along to the menu item's InkWell which
+// resolves the property against MaterialState.disabled, MaterialState.hovered,
+// MaterialState.focused.
+class _EffectiveMouseCursor extends MaterialStateMouseCursor {
+  const _EffectiveMouseCursor(this.widgetCursor, this.themeCursor);
+
+  final MouseCursor? widgetCursor;
+  final MaterialStateProperty<MouseCursor?>? themeCursor;
+
+  @override
+  MouseCursor resolve(Set<MaterialState> states) {
+    return MaterialStateProperty.resolveAs<MouseCursor?>(
+            widgetCursor, states) ??
+        themeCursor?.resolve(states) ??
+        MaterialStateMouseCursor.clickable.resolve(states);
+  }
+
+  @override
+  String get debugDescription => 'MaterialStateMouseCursor(PopupMenuItemState)';
+}

--- a/flutter/lib/desktop/widgets/popup_menu.dart
+++ b/flutter/lib/desktop/widgets/popup_menu.dart
@@ -1,0 +1,375 @@
+import 'dart:core';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:tuple/tuple.dart';
+
+import './material_mod_popup_menu.dart' as modMenu;
+
+const kInvalidValueStr = "InvalidValueStr";
+
+// https://stackoverflow.com/questions/68318314/flutter-popup-menu-inside-popup-menu
+class PopupMenuChildrenItem<T> extends modMenu.PopupMenuEntry<T> {
+  const PopupMenuChildrenItem({
+    key,
+    this.height = kMinInteractiveDimension,
+    this.padding,
+    this.enable = true,
+    this.textStyle,
+    this.onTap,
+    this.position = modMenu.PopupMenuPosition.overSide,
+    this.offset = Offset.zero,
+    required this.itemBuilder,
+    required this.child,
+  }) : super(key: key);
+
+  final modMenu.PopupMenuPosition position;
+  final Offset offset;
+  final TextStyle? textStyle;
+  final EdgeInsets? padding;
+  final bool enable;
+  final void Function()? onTap;
+  final List<modMenu.PopupMenuEntry<T>> Function(BuildContext) itemBuilder;
+  final Widget child;
+
+  @override
+  final double height;
+
+  @override
+  bool represents(T? value) => false;
+
+  @override
+  MyPopupMenuItemState<T, PopupMenuChildrenItem<T>> createState() =>
+      MyPopupMenuItemState<T, PopupMenuChildrenItem<T>>();
+}
+
+class MyPopupMenuItemState<T, W extends PopupMenuChildrenItem<T>>
+    extends State<W> {
+  @protected
+  void handleTap(T value) {
+    widget.onTap?.call();
+    Navigator.pop<T>(context, value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final PopupMenuThemeData popupMenuTheme = PopupMenuTheme.of(context);
+    TextStyle style = widget.textStyle ??
+        popupMenuTheme.textStyle ??
+        theme.textTheme.subtitle1!;
+
+    return modMenu.PopupMenuButton<T>(
+      enabled: widget.enable,
+      position: widget.position,
+      offset: widget.offset,
+      onSelected: handleTap,
+      itemBuilder: widget.itemBuilder,
+      padding: EdgeInsets.zero,
+      child: AnimatedDefaultTextStyle(
+        style: style,
+        duration: kThemeChangeDuration,
+        child: Container(
+          alignment: AlignmentDirectional.centerStart,
+          constraints: BoxConstraints(minHeight: widget.height),
+          padding: widget.padding ?? const EdgeInsets.symmetric(horizontal: 16),
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+}
+
+class MenuConfig {
+  // adapt to the screen height
+  static const fontSize = 14.0;
+  static const midPadding = 10.0;
+  static const iconScale = 0.8;
+  static const iconWidth = 12.0;
+  static const iconHeight = 12.0;
+
+  final double secondMenuHeight;
+  final Color commonColor;
+
+  const MenuConfig(
+      {required this.commonColor,
+      this.secondMenuHeight = kMinInteractiveDimension});
+}
+
+abstract class MenuEntryBase<T> {
+  modMenu.PopupMenuEntry<T> build(BuildContext context, MenuConfig conf);
+}
+
+class MenuEntryDivider<T> extends MenuEntryBase<T> {
+  @override
+  modMenu.PopupMenuEntry<T> build(BuildContext context, MenuConfig conf) {
+    return const modMenu.PopupMenuDivider();
+  }
+}
+
+typedef RadioOptionsGetter = List<Tuple2<String, String>> Function();
+typedef RadioCurOptionGetter = Future<String> Function();
+typedef RadioOptionSetter = Future<void> Function(String);
+
+class MenuEntrySubRadios<T> extends MenuEntryBase<T> {
+  final String text;
+  final RadioOptionsGetter optionsGetter;
+  final RadioCurOptionGetter curOptionGetter;
+  final RadioOptionSetter optionSetter;
+  final RxString _curOption = "".obs;
+
+  MenuEntrySubRadios(
+      {required this.text,
+      required this.optionsGetter,
+      required this.curOptionGetter,
+      required this.optionSetter}) {
+    () async {
+      _curOption.value = await curOptionGetter();
+    }();
+  }
+
+  List<Tuple2<String, String>> get options => optionsGetter();
+  RxString get curOption => _curOption;
+  setOption(String option) async {
+    await optionSetter(option);
+    final opt = await curOptionGetter();
+    if (_curOption.value != opt) {
+      _curOption.value = opt;
+    }
+  }
+
+  modMenu.PopupMenuEntry<T> _buildSecondMenu(
+      BuildContext context, MenuConfig conf, Tuple2<String, String> opt) {
+    return modMenu.PopupMenuItem(
+      padding: EdgeInsets.zero,
+      child: TextButton(
+        child: Container(
+          alignment: AlignmentDirectional.centerStart,
+          constraints: BoxConstraints(minHeight: conf.secondMenuHeight),
+          child: Row(
+            children: [
+              SizedBox(
+                  width: 20.0,
+                  height: 20.0,
+                  child: Obx(() => opt.item2 == curOption.value
+                      ? Icon(
+                          Icons.check,
+                          color: conf.commonColor,
+                        )
+                      : SizedBox.shrink())),
+              const SizedBox(width: MenuConfig.midPadding),
+              Text(
+                opt.item1,
+                style: const TextStyle(
+                    color: Colors.black,
+                    fontSize: MenuConfig.fontSize,
+                    fontWeight: FontWeight.normal),
+              )
+            ],
+          ),
+        ),
+        onPressed: () {
+          if (opt.item2 != curOption.value) {
+            setOption(opt.item2);
+          }
+        },
+      ),
+    );
+  }
+
+  @override
+  modMenu.PopupMenuEntry<T> build(BuildContext context, MenuConfig conf) {
+    return PopupMenuChildrenItem(
+      height: conf.secondMenuHeight,
+      padding: EdgeInsets.zero,
+      itemBuilder: (BuildContext context) =>
+          options.map((opt) => _buildSecondMenu(context, conf, opt)).toList(),
+      child: Row(children: [
+        const SizedBox(width: MenuConfig.midPadding),
+        Text(
+          text,
+          style: const TextStyle(
+              color: Colors.black,
+              fontSize: MenuConfig.fontSize,
+              fontWeight: FontWeight.normal),
+        ),
+        Expanded(
+            child: Align(
+          alignment: Alignment.centerRight,
+          child: Icon(
+            Icons.keyboard_arrow_right,
+            color: conf.commonColor,
+          ),
+        ))
+      ]),
+    );
+  }
+}
+
+typedef SwitchGetter = Future<bool> Function();
+typedef SwitchSetter = Future<void> Function(bool);
+
+abstract class MenuEntrySwitchBase<T> extends MenuEntryBase<T> {
+  final String text;
+
+  MenuEntrySwitchBase({required this.text});
+
+  RxBool get curOption;
+  Future<void> setOption(bool option);
+
+  @override
+  modMenu.PopupMenuEntry<T> build(BuildContext context, MenuConfig conf) {
+    return modMenu.PopupMenuItem(
+      padding: EdgeInsets.zero,
+      child: Obx(
+        () => SwitchListTile(
+          value: curOption.value,
+          onChanged: (v) {
+            setOption(v);
+          },
+          title: Container(
+              alignment: AlignmentDirectional.centerStart,
+              constraints: BoxConstraints(minHeight: conf.secondMenuHeight),
+              child: Text(
+                text,
+                style: const TextStyle(
+                    color: Colors.black,
+                    fontSize: MenuConfig.fontSize,
+                    fontWeight: FontWeight.normal),
+              )),
+          dense: true,
+          visualDensity: const VisualDensity(
+            horizontal: VisualDensity.minimumDensity,
+            vertical: VisualDensity.minimumDensity,
+          ),
+          contentPadding: EdgeInsets.only(left: 8.0),
+        ),
+      ),
+    );
+  }
+}
+
+class MenuEntrySwitch<T> extends MenuEntrySwitchBase<T> {
+  final SwitchGetter getter;
+  final SwitchSetter setter;
+  final RxBool _curOption = false.obs;
+
+  MenuEntrySwitch(
+      {required String text, required this.getter, required this.setter})
+      : super(text: text) {
+    () async {
+      _curOption.value = await getter();
+    }();
+  }
+
+  @override
+  RxBool get curOption => _curOption;
+  @override
+  setOption(bool option) async {
+    await setter(option);
+    final opt = await getter();
+    if (_curOption.value != opt) {
+      _curOption.value = opt;
+    }
+  }
+}
+
+typedef Switch2Getter = RxBool Function();
+typedef Switch2Setter = Future<void> Function(bool);
+
+class MenuEntrySwitch2<T> extends MenuEntrySwitchBase<T> {
+  final Switch2Getter getter;
+  final SwitchSetter setter;
+
+  MenuEntrySwitch2(
+      {required String text, required this.getter, required this.setter})
+      : super(text: text);
+
+  @override
+  RxBool get curOption => getter();
+  @override
+  setOption(bool option) async {
+    await setter(option);
+  }
+}
+
+class MenuEntrySubMenu<T> extends MenuEntryBase<T> {
+  final String text;
+  final List<MenuEntryBase<T>> entries;
+
+  MenuEntrySubMenu({
+    required this.text,
+    required this.entries,
+  });
+
+  @override
+  modMenu.PopupMenuEntry<T> build(BuildContext context, MenuConfig conf) {
+    return PopupMenuChildrenItem(
+      height: conf.secondMenuHeight,
+      padding: EdgeInsets.zero,
+      position: modMenu.PopupMenuPosition.overSide,
+      itemBuilder: (BuildContext context) =>
+          entries.map((entry) => entry.build(context, conf)).toList(),
+      child: Row(children: [
+        const SizedBox(width: MenuConfig.midPadding),
+        Text(
+          text,
+          style: const TextStyle(
+              color: Colors.black,
+              fontSize: MenuConfig.fontSize,
+              fontWeight: FontWeight.normal),
+        ),
+        Expanded(
+            child: Align(
+          alignment: Alignment.centerRight,
+          child: Icon(
+            Icons.keyboard_arrow_right,
+            color: conf.commonColor,
+          ),
+        ))
+      ]),
+    );
+  }
+}
+
+class MenuEntryButton<T> extends MenuEntryBase<T> {
+  final Widget Function(TextStyle? style) childBuilder;
+  Function() proc;
+
+  MenuEntryButton({
+    required this.childBuilder,
+    required this.proc,
+  });
+
+  @override
+  modMenu.PopupMenuEntry<T> build(BuildContext context, MenuConfig conf) {
+    return modMenu.PopupMenuItem(
+      padding: EdgeInsets.zero,
+      child: TextButton(
+        child: Container(
+            alignment: AlignmentDirectional.centerStart,
+            constraints: BoxConstraints(minHeight: conf.secondMenuHeight),
+            child: childBuilder(
+              const TextStyle(
+                  color: Colors.black,
+                  fontSize: MenuConfig.fontSize,
+                  fontWeight: FontWeight.normal),
+            )),
+        onPressed: () {
+          proc();
+        },
+      ),
+    );
+  }
+}
+
+class CustomMenu<T> {
+  final List<MenuEntryBase<T>> entries;
+  final MenuConfig conf;
+
+  const CustomMenu({required this.entries, required this.conf});
+
+  List<modMenu.PopupMenuEntry<T>> build(BuildContext context) {
+    return entries.map((entry) => entry.build(context, conf)).toList();
+  }
+}

--- a/flutter/lib/desktop/widgets/remote_menubar.dart
+++ b/flutter/lib/desktop/widgets/remote_menubar.dart
@@ -10,7 +10,7 @@ import '../../mobile/widgets/overlay.dart';
 import '../../models/model.dart';
 import '../../models/platform_model.dart';
 import './popup_menu.dart';
-import './material_mod_popup_menu.dart' as modMenu;
+import './material_mod_popup_menu.dart' as mod_menu;
 
 class _MenubarTheme {
   static const Color commonColor = MyTheme.accent;
@@ -50,19 +50,22 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
   }
 
   Widget _buildShowHide(BuildContext context) {
-    return SizedBox(
-        width: 100,
-        height: 5,
-        child: TextButton(
-            onHover: (bool v) {
-              _hideColor.value = v ? Colors.white60 : Colors.white24;
-            },
-            onPressed: () {
-              _show.value = !_show.value;
-            },
-            child: Obx(() => Container(
-                  color: _hideColor.value,
-                ))));
+    return Obx(() => Tooltip(
+          message: translate(_show.value ? "Hide Menubar" : "Show Menubar"),
+          child: SizedBox(
+              width: 100,
+              height: 5,
+              child: TextButton(
+                  onHover: (bool v) {
+                    _hideColor.value = v ? Colors.white60 : Colors.white24;
+                  },
+                  onPressed: () {
+                    _show.value = !_show.value;
+                  },
+                  child: Obx(() => Container(
+                        color: _hideColor.value,
+                      )))),
+        ));
   }
 
   Widget _buildMenubar(BuildContext context) {
@@ -73,7 +76,7 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
         menubarItems.add(IconButton(
           tooltip: translate('Mobile Actions'),
           color: _MenubarTheme.commonColor,
-          icon: Icon(Icons.build),
+          icon: const Icon(Icons.build),
           onPressed: () {
             if (mobileActionsOverlayEntry == null) {
               showMobileActionsOverlay();
@@ -92,7 +95,7 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
     }
     menubarItems.add(_buildClose(context));
     return PopupMenuTheme(
-        data: PopupMenuThemeData(
+        data: const PopupMenuThemeData(
             textStyle: TextStyle(color: _MenubarTheme.commonColor)),
         child: Column(mainAxisSize: MainAxisSize.min, children: [
           Container(
@@ -112,11 +115,11 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
         setFullscreen(!isFullscreen);
       },
       icon: Obx(() => isFullscreen
-          ? Icon(
+          ? const Icon(
               Icons.fullscreen_exit,
               color: _MenubarTheme.commonColor,
             )
-          : Icon(
+          : const Icon(
               Icons.fullscreen,
               color: _MenubarTheme.commonColor,
             )),
@@ -130,7 +133,7 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
         widget.ffi.chatModel.changeCurrentID(ChatModel.clientModeID);
         widget.ffi.chatModel.toggleChatOverlay();
       },
-      icon: Icon(
+      icon: const Icon(
         Icons.message,
         color: _MenubarTheme.commonColor,
       ),
@@ -139,24 +142,25 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
 
   Widget _buildMonitor(BuildContext context) {
     final pi = widget.ffi.ffiModel.pi;
-    return modMenu.PopupMenuButton(
+    return mod_menu.PopupMenuButton(
       tooltip: translate('Select Monitor'),
       padding: EdgeInsets.zero,
-      position: modMenu.PopupMenuPosition.under,
+      position: mod_menu.PopupMenuPosition.under,
       icon: Stack(
         alignment: Alignment.center,
         children: [
-          Icon(
+          const Icon(
             Icons.personal_video,
             color: _MenubarTheme.commonColor,
           ),
           Padding(
-            padding: EdgeInsets.only(bottom: 3.9),
+            padding: const EdgeInsets.only(bottom: 3.9),
             child: Obx(() {
               RxInt display = CurrentDisplayState.find(widget.id);
               return Text(
                 "${display.value + 1}/${pi.displays.length}",
-                style: TextStyle(color: _MenubarTheme.commonColor, fontSize: 8),
+                style: const TextStyle(
+                    color: _MenubarTheme.commonColor, fontSize: 8),
               );
             }),
           )
@@ -164,14 +168,14 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
       ),
       itemBuilder: (BuildContext context) {
         final List<Widget> rowChildren = [];
-        final double selectorScale = 1.3;
+        const double selectorScale = 1.3;
         for (int i = 0; i < pi.displays.length; i++) {
           rowChildren.add(Transform.scale(
             scale: selectorScale,
             child: Stack(
               alignment: Alignment.center,
               children: [
-                Icon(
+                const Icon(
                   Icons.personal_video,
                   color: _MenubarTheme.commonColor,
                 ),
@@ -179,12 +183,13 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
                   child: Container(
                       alignment: AlignmentDirectional.center,
                       constraints:
-                          BoxConstraints(minHeight: _MenubarTheme.height),
+                          const BoxConstraints(minHeight: _MenubarTheme.height),
                       child: Padding(
-                        padding: EdgeInsets.only(bottom: 2.5),
+                        padding: const EdgeInsets.only(bottom: 2.5),
                         child: Text(
                           (i + 1).toString(),
-                          style: TextStyle(color: _MenubarTheme.commonColor),
+                          style:
+                              const TextStyle(color: _MenubarTheme.commonColor),
                         ),
                       )),
                   onPressed: () {
@@ -200,8 +205,8 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
             ),
           ));
         }
-        return <modMenu.PopupMenuEntry<String>>[
-          modMenu.PopupMenuItem<String>(
+        return <mod_menu.PopupMenuEntry<String>>[
+          mod_menu.PopupMenuItem<String>(
             height: _MenubarTheme.height,
             padding: EdgeInsets.zero,
             child: Row(
@@ -214,18 +219,18 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
   }
 
   Widget _buildControl(BuildContext context) {
-    return modMenu.PopupMenuButton(
+    return mod_menu.PopupMenuButton(
       padding: EdgeInsets.zero,
-      icon: Icon(
+      icon: const Icon(
         Icons.bolt,
         color: _MenubarTheme.commonColor,
       ),
       tooltip: translate('Control Actions'),
-      position: modMenu.PopupMenuPosition.under,
+      position: mod_menu.PopupMenuPosition.under,
       itemBuilder: (BuildContext context) => _getControlMenu()
           .map((entry) => entry.build(
               context,
-              MenuConfig(
+              const MenuConfig(
                 commonColor: _MenubarTheme.commonColor,
                 secondMenuHeight: _MenubarTheme.height,
               )))
@@ -234,19 +239,19 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
   }
 
   Widget _buildDisplay(BuildContext context) {
-    return modMenu.PopupMenuButton(
+    return mod_menu.PopupMenuButton(
       padding: EdgeInsets.zero,
-      icon: Icon(
+      icon: const Icon(
         Icons.tv,
         color: _MenubarTheme.commonColor,
       ),
       tooltip: translate('Display Settings'),
-      position: modMenu.PopupMenuPosition.under,
+      position: mod_menu.PopupMenuPosition.under,
       onSelected: (String item) {},
       itemBuilder: (BuildContext context) => _getDisplayMenu()
           .map((entry) => entry.build(
               context,
-              MenuConfig(
+              const MenuConfig(
                 commonColor: _MenubarTheme.commonColor,
                 secondMenuHeight: _MenubarTheme.height,
               )))
@@ -260,7 +265,7 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
       onPressed: () {
         clientClose(widget.ffi.dialogManager);
       },
-      icon: Icon(
+      icon: const Icon(
         Icons.close,
         color: _MenubarTheme.commonColor,
       ),
@@ -332,7 +337,7 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
       if (pi.platform == 'Linux' || pi.sasEnabled) {
         displayMenu.add(MenuEntryButton<String>(
           childBuilder: (TextStyle? style) => Text(
-            translate('Insert') + ' Ctrl + Alt + Del',
+            '${translate("Insert")} Ctrl + Alt + Del',
             style: style,
           ),
           proc: () {
@@ -357,8 +362,7 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
         displayMenu.add(MenuEntryButton<String>(
           childBuilder: (TextStyle? style) => Obx(() => Text(
                 translate(
-                    (BlockInputState.find(widget.id).value ? 'Unb' : 'B') +
-                        'lock user input'),
+                    '${BlockInputState.find(widget.id).value ? "Unb" : "B"}lock user input'),
                 style: style,
               )),
           proc: () {
@@ -366,7 +370,7 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
             RxBool blockInput = BlockInputState.find(widget.id);
             bind.sessionToggleOption(
                 id: widget.id,
-                value: (blockInput.value ? 'un' : '') + 'block-input');
+                value: '${blockInput.value ? "un" : ""}block-input');
             blockInput.value = !blockInput.value;
           },
         ));
@@ -447,7 +451,7 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
       MenuEntrySwitch<String>(
           text: translate('Show remote cursor'),
           getter: () async {
-            return await bind.sessionGetToggleOptionSync(
+            return bind.sessionGetToggleOptionSync(
                 id: widget.id, arg: 'show-remote-cursor');
           },
           setter: (bool v) async {
@@ -457,7 +461,7 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
       MenuEntrySwitch<String>(
           text: translate('Show quality monitor'),
           getter: () async {
-            return await bind.sessionGetToggleOptionSync(
+            return bind.sessionGetToggleOptionSync(
                 id: widget.id, arg: 'show-quality-monitor');
           },
           setter: (bool v) async {

--- a/flutter/lib/desktop/widgets/remote_menubar.dart
+++ b/flutter/lib/desktop/widgets/remote_menubar.dart
@@ -1,0 +1,560 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_hbb/models/chat_model.dart';
+import 'package:get/get.dart';
+import 'package:tuple/tuple.dart';
+
+import '../../common.dart';
+import '../../mobile/widgets/dialog.dart';
+import '../../mobile/widgets/overlay.dart';
+import '../../models/model.dart';
+import '../../models/platform_model.dart';
+import './popup_menu.dart';
+import './material_mod_popup_menu.dart' as modMenu;
+
+class _MenubarTheme {
+  static const Color commonColor = MyTheme.accent;
+  static const double height = kMinInteractiveDimension;
+}
+
+class RemoteMenubar extends StatefulWidget {
+  final String id;
+  final FFI ffi;
+
+  const RemoteMenubar({
+    Key? key,
+    required this.id,
+    required this.ffi,
+  }) : super(key: key);
+
+  @override
+  State<RemoteMenubar> createState() => _RemoteMenubarState();
+}
+
+class _RemoteMenubarState extends State<RemoteMenubar> {
+  final RxBool _show = false.obs;
+  final Rx<Color> _hideColor = Colors.white12.obs;
+
+  bool get isFullscreen => Get.find<RxBool>(tag: 'fullscreen').isTrue;
+  void setFullscreen(bool v) {
+    Get.find<RxBool>(tag: 'fullscreen').value = v;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: Obx(
+          () => _show.value ? _buildMenubar(context) : _buildShowHide(context)),
+    );
+  }
+
+  Widget _buildShowHide(BuildContext context) {
+    return SizedBox(
+        width: 100,
+        height: 5,
+        child: TextButton(
+            onHover: (bool v) {
+              _hideColor.value = v ? Colors.white60 : Colors.white24;
+            },
+            onPressed: () {
+              _show.value = !_show.value;
+            },
+            child: Obx(() => Container(
+                  color: _hideColor.value,
+                ))));
+  }
+
+  Widget _buildMenubar(BuildContext context) {
+    final List<Widget> menubarItems = [];
+    if (!isWebDesktop) {
+      menubarItems.add(_buildFullscreen(context));
+      if (widget.ffi.ffiModel.isPeerAndroid) {
+        menubarItems.add(IconButton(
+          tooltip: translate('Mobile Actions'),
+          color: _MenubarTheme.commonColor,
+          icon: Icon(Icons.build),
+          onPressed: () {
+            if (mobileActionsOverlayEntry == null) {
+              showMobileActionsOverlay();
+            } else {
+              hideMobileActionsOverlay();
+            }
+          },
+        ));
+      }
+    }
+    menubarItems.add(_buildMonitor(context));
+    menubarItems.add(_buildControl(context));
+    menubarItems.add(_buildDisplay(context));
+    if (!isWeb) {
+      menubarItems.add(_buildChat(context));
+    }
+    menubarItems.add(_buildClose(context));
+    return PopupMenuTheme(
+        data: PopupMenuThemeData(
+            textStyle: TextStyle(color: _MenubarTheme.commonColor)),
+        child: Column(mainAxisSize: MainAxisSize.min, children: [
+          Container(
+              color: Colors.white,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: menubarItems,
+              )),
+          _buildShowHide(context),
+        ]));
+  }
+
+  Widget _buildFullscreen(BuildContext context) {
+    return IconButton(
+      tooltip: translate(isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'),
+      onPressed: () {
+        setFullscreen(!isFullscreen);
+      },
+      icon: Obx(() => isFullscreen
+          ? Icon(
+              Icons.fullscreen_exit,
+              color: _MenubarTheme.commonColor,
+            )
+          : Icon(
+              Icons.fullscreen,
+              color: _MenubarTheme.commonColor,
+            )),
+    );
+  }
+
+  Widget _buildChat(BuildContext context) {
+    return IconButton(
+      tooltip: translate('Chat'),
+      onPressed: () {
+        widget.ffi.chatModel.changeCurrentID(ChatModel.clientModeID);
+        widget.ffi.chatModel.toggleChatOverlay();
+      },
+      icon: Icon(
+        Icons.message,
+        color: _MenubarTheme.commonColor,
+      ),
+    );
+  }
+
+  Widget _buildMonitor(BuildContext context) {
+    final pi = widget.ffi.ffiModel.pi;
+    return modMenu.PopupMenuButton(
+      tooltip: translate('Select Monitor'),
+      padding: EdgeInsets.zero,
+      position: modMenu.PopupMenuPosition.under,
+      icon: Stack(
+        alignment: Alignment.center,
+        children: [
+          Icon(
+            Icons.personal_video,
+            color: _MenubarTheme.commonColor,
+          ),
+          Padding(
+            padding: EdgeInsets.only(bottom: 3.9),
+            child: Obx(() {
+              RxInt display = CurrentDisplayState.find(widget.id);
+              return Text(
+                "${display.value + 1}/${pi.displays.length}",
+                style: TextStyle(color: _MenubarTheme.commonColor, fontSize: 8),
+              );
+            }),
+          )
+        ],
+      ),
+      itemBuilder: (BuildContext context) {
+        final List<Widget> rowChildren = [];
+        final double selectorScale = 1.3;
+        for (int i = 0; i < pi.displays.length; i++) {
+          rowChildren.add(Transform.scale(
+            scale: selectorScale,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                Icon(
+                  Icons.personal_video,
+                  color: _MenubarTheme.commonColor,
+                ),
+                TextButton(
+                  child: Container(
+                      alignment: AlignmentDirectional.center,
+                      constraints:
+                          BoxConstraints(minHeight: _MenubarTheme.height),
+                      child: Padding(
+                        padding: EdgeInsets.only(bottom: 2.5),
+                        child: Text(
+                          (i + 1).toString(),
+                          style: TextStyle(color: _MenubarTheme.commonColor),
+                        ),
+                      )),
+                  onPressed: () {
+                    RxInt display = CurrentDisplayState.find(widget.id);
+                    if (display.value != i) {
+                      bind.sessionSwitchDisplay(id: widget.id, value: i);
+                      pi.currentDisplay = i;
+                      display.value = i;
+                    }
+                  },
+                )
+              ],
+            ),
+          ));
+        }
+        return <modMenu.PopupMenuEntry<String>>[
+          modMenu.PopupMenuItem<String>(
+            height: _MenubarTheme.height,
+            padding: EdgeInsets.zero,
+            child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: rowChildren),
+          )
+        ];
+      },
+    );
+  }
+
+  Widget _buildControl(BuildContext context) {
+    return modMenu.PopupMenuButton(
+      padding: EdgeInsets.zero,
+      icon: Icon(
+        Icons.bolt,
+        color: _MenubarTheme.commonColor,
+      ),
+      tooltip: translate('Control Actions'),
+      position: modMenu.PopupMenuPosition.under,
+      itemBuilder: (BuildContext context) => _getControlMenu()
+          .map((entry) => entry.build(
+              context,
+              MenuConfig(
+                commonColor: _MenubarTheme.commonColor,
+                secondMenuHeight: _MenubarTheme.height,
+              )))
+          .toList(),
+    );
+  }
+
+  Widget _buildDisplay(BuildContext context) {
+    return modMenu.PopupMenuButton(
+      padding: EdgeInsets.zero,
+      icon: Icon(
+        Icons.tv,
+        color: _MenubarTheme.commonColor,
+      ),
+      tooltip: translate('Display Settings'),
+      position: modMenu.PopupMenuPosition.under,
+      onSelected: (String item) {},
+      itemBuilder: (BuildContext context) => _getDisplayMenu()
+          .map((entry) => entry.build(
+              context,
+              MenuConfig(
+                commonColor: _MenubarTheme.commonColor,
+                secondMenuHeight: _MenubarTheme.height,
+              )))
+          .toList(),
+    );
+  }
+
+  Widget _buildClose(BuildContext context) {
+    return IconButton(
+      tooltip: translate('Close'),
+      onPressed: () {
+        clientClose(widget.ffi.dialogManager);
+      },
+      icon: Icon(
+        Icons.close,
+        color: _MenubarTheme.commonColor,
+      ),
+    );
+  }
+
+  List<MenuEntryBase<String>> _getControlMenu() {
+    final pi = widget.ffi.ffiModel.pi;
+    final perms = widget.ffi.ffiModel.permissions;
+
+    final List<MenuEntryBase<String>> displayMenu = [];
+
+    if (pi.version.isNotEmpty) {
+      displayMenu.add(MenuEntryButton<String>(
+        childBuilder: (TextStyle? style) => Text(
+          translate('Refresh'),
+          style: style,
+        ),
+        proc: () {
+          Navigator.pop(context);
+          bind.sessionRefresh(id: widget.id);
+        },
+      ));
+    }
+    displayMenu.add(MenuEntryButton<String>(
+      childBuilder: (TextStyle? style) => Text(
+        translate('OS Password'),
+        style: style,
+      ),
+      proc: () {
+        Navigator.pop(context);
+        showSetOSPassword(widget.id, false, widget.ffi.dialogManager);
+      },
+    ));
+
+    if (!isWebDesktop) {
+      if (perms['keyboard'] != false && perms['clipboard'] != false) {
+        displayMenu.add(MenuEntryButton<String>(
+          childBuilder: (TextStyle? style) => Text(
+            translate('Paste'),
+            style: style,
+          ),
+          proc: () {
+            Navigator.pop(context);
+            () async {
+              ClipboardData? data =
+                  await Clipboard.getData(Clipboard.kTextPlain);
+              if (data != null && data.text != null) {
+                bind.sessionInputString(id: widget.id, value: data.text ?? "");
+              }
+            }();
+          },
+        ));
+      }
+
+      displayMenu.add(MenuEntryButton<String>(
+        childBuilder: (TextStyle? style) => Text(
+          translate('Reset canvas'),
+          style: style,
+        ),
+        proc: () {
+          Navigator.pop(context);
+          widget.ffi.cursorModel.reset();
+        },
+      ));
+    }
+
+    if (perms['keyboard'] != false) {
+      if (pi.platform == 'Linux' || pi.sasEnabled) {
+        displayMenu.add(MenuEntryButton<String>(
+          childBuilder: (TextStyle? style) => Text(
+            translate('Insert') + ' Ctrl + Alt + Del',
+            style: style,
+          ),
+          proc: () {
+            Navigator.pop(context);
+            bind.sessionCtrlAltDel(id: widget.id);
+          },
+        ));
+      }
+
+      displayMenu.add(MenuEntryButton<String>(
+        childBuilder: (TextStyle? style) => Text(
+          translate('Insert Lock'),
+          style: style,
+        ),
+        proc: () {
+          Navigator.pop(context);
+          bind.sessionLockScreen(id: widget.id);
+        },
+      ));
+
+      if (pi.platform == 'Windows') {
+        displayMenu.add(MenuEntryButton<String>(
+          childBuilder: (TextStyle? style) => Obx(() => Text(
+                translate(
+                    (BlockInputState.find(widget.id).value ? 'Unb' : 'B') +
+                        'lock user input'),
+                style: style,
+              )),
+          proc: () {
+            Navigator.pop(context);
+            RxBool blockInput = BlockInputState.find(widget.id);
+            bind.sessionToggleOption(
+                id: widget.id,
+                value: (blockInput.value ? 'un' : '') + 'block-input');
+            blockInput.value = !blockInput.value;
+          },
+        ));
+      }
+    }
+
+    if (gFFI.ffiModel.permissions["restart"] != false &&
+        (pi.platform == "Linux" ||
+            pi.platform == "Windows" ||
+            pi.platform == "Mac OS")) {
+      displayMenu.add(MenuEntryButton<String>(
+        childBuilder: (TextStyle? style) => Text(
+          translate('Restart Remote Device'),
+          style: style,
+        ),
+        proc: () {
+          Navigator.pop(context);
+          showRestartRemoteDevice(pi, widget.id, gFFI.dialogManager);
+        },
+      ));
+    }
+
+    return displayMenu;
+  }
+
+  List<MenuEntryBase<String>> _getDisplayMenu() {
+    final displayMenu = [
+      MenuEntrySubRadios<String>(
+          text: translate('Ratio'),
+          optionsGetter: () => [
+                Tuple2<String, String>(translate('Original'), 'original'),
+                Tuple2<String, String>(translate('Shrink'), 'shrink'),
+                Tuple2<String, String>(translate('Stretch'), 'stretch'),
+              ],
+          curOptionGetter: () async {
+            return await bind.sessionGetOption(
+                    id: widget.id, arg: 'view-style') ??
+                '';
+          },
+          optionSetter: (String v) async {
+            await bind.sessionPeerOption(
+                id: widget.id, name: "view-style", value: v);
+            widget.ffi.canvasModel.updateViewStyle();
+          }),
+      MenuEntrySubRadios<String>(
+          text: translate('Scroll Style'),
+          optionsGetter: () => [
+                Tuple2<String, String>(translate('ScrollAuto'), 'scrollauto'),
+                Tuple2<String, String>(translate('Scrollbar'), 'scrollbar'),
+              ],
+          curOptionGetter: () async {
+            return await bind.sessionGetOption(
+                    id: widget.id, arg: 'scroll-style') ??
+                '';
+          },
+          optionSetter: (String v) async {
+            await bind.sessionPeerOption(
+                id: widget.id, name: "scroll-style", value: v);
+            widget.ffi.canvasModel.updateScrollStyle();
+          }),
+      MenuEntrySubRadios<String>(
+          text: translate('Image Quality'),
+          optionsGetter: () => [
+                Tuple2<String, String>(translate('Good image quality'), 'best'),
+                Tuple2<String, String>(translate('Balanced'), 'balanced'),
+                Tuple2<String, String>(
+                    translate('Optimize reaction time'), 'low'),
+              ],
+          curOptionGetter: () async {
+            String quality =
+                await bind.sessionGetImageQuality(id: widget.id) ?? 'balanced';
+            if (quality == '') quality = 'balanced';
+            return quality;
+          },
+          optionSetter: (String v) async {
+            await bind.sessionSetImageQuality(id: widget.id, value: v);
+          }),
+      MenuEntrySwitch<String>(
+          text: translate('Show remote cursor'),
+          getter: () async {
+            return await bind.sessionGetToggleOptionSync(
+                id: widget.id, arg: 'show-remote-cursor');
+          },
+          setter: (bool v) async {
+            await bind.sessionToggleOption(
+                id: widget.id, value: 'show-remote-cursor');
+          }),
+      MenuEntrySwitch<String>(
+          text: translate('Show quality monitor'),
+          getter: () async {
+            return await bind.sessionGetToggleOptionSync(
+                id: widget.id, arg: 'show-quality-monitor');
+          },
+          setter: (bool v) async {
+            await bind.sessionToggleOption(
+                id: widget.id, value: 'show-quality-monitor');
+            widget.ffi.qualityMonitorModel.checkShowQualityMonitor(widget.id);
+          }),
+    ];
+
+    final perms = widget.ffi.ffiModel.permissions;
+    final pi = widget.ffi.ffiModel.pi;
+
+    if (perms['audio'] != false) {
+      displayMenu.add(_createSwitchMenuEntry('Mute', 'disable-audio'));
+    }
+    if (perms['keyboard'] != false) {
+      if (perms['clipboard'] != false) {
+        displayMenu.add(
+            _createSwitchMenuEntry('Disable clipboard', 'disable-clipboard'));
+      }
+      displayMenu.add(_createSwitchMenuEntry(
+          'Lock after session end', 'lock-after-session-end'));
+      if (pi.platform == 'Windows') {
+        displayMenu.add(MenuEntrySwitch2<String>(
+            text: translate('Privacy mode'),
+            getter: () {
+              return PrivacyModeState.find(widget.id);
+            },
+            setter: (bool v) async {
+              Navigator.pop(context);
+              await bind.sessionToggleOption(
+                  id: widget.id, value: 'privacy-mode');
+            }));
+      }
+    }
+    return displayMenu;
+  }
+
+  MenuEntrySwitch<String> _createSwitchMenuEntry(String text, String option) {
+    return MenuEntrySwitch<String>(
+        text: translate(text),
+        getter: () async {
+          return bind.sessionGetToggleOptionSync(id: widget.id, arg: option);
+        },
+        setter: (bool v) async {
+          await bind.sessionToggleOption(id: widget.id, value: option);
+        });
+  }
+}
+
+void showSetOSPassword(
+    String id, bool login, OverlayDialogManager dialogManager) async {
+  final controller = TextEditingController();
+  var password = await bind.sessionGetOption(id: id, arg: "os-password") ?? "";
+  var autoLogin = await bind.sessionGetOption(id: id, arg: "auto-login") != "";
+  controller.text = password;
+  dialogManager.show((setState, close) {
+    return CustomAlertDialog(
+        title: Text(translate('OS Password')),
+        content: Column(mainAxisSize: MainAxisSize.min, children: [
+          PasswordWidget(controller: controller),
+          CheckboxListTile(
+            contentPadding: const EdgeInsets.all(0),
+            dense: true,
+            controlAffinity: ListTileControlAffinity.leading,
+            title: Text(
+              translate('Auto Login'),
+            ),
+            value: autoLogin,
+            onChanged: (v) {
+              if (v == null) return;
+              setState(() => autoLogin = v);
+            },
+          ),
+        ]),
+        actions: [
+          TextButton(
+            style: flatButtonStyle,
+            onPressed: () {
+              close();
+            },
+            child: Text(translate('Cancel')),
+          ),
+          TextButton(
+            style: flatButtonStyle,
+            onPressed: () {
+              var text = controller.text.trim();
+              bind.sessionPeerOption(id: id, name: "os-password", value: text);
+              bind.sessionPeerOption(
+                  id: id, name: "auto-login", value: autoLogin ? 'Y' : '');
+              if (text != "" && login) {
+                bind.sessionInputOsPassword(id: id, value: text);
+              }
+              close();
+            },
+            child: Text(translate('OK')),
+          ),
+        ]);
+  });
+}

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -172,9 +172,9 @@ class FfiModel with ChangeNotifier {
       } else if (name == 'update_quality_status') {
         parent.target?.qualityMonitorModel.updateQualityStatus(evt);
       } else if (name == 'update_block_input_state') {
-        updateBlockInputState(evt);
+        updateBlockInputState(evt, peerId);
       } else if (name == 'update_privacy_mode') {
-        updatePrivacyMode(evt);
+        updatePrivacyMode(evt, peerId);
       }
     };
   }
@@ -231,9 +231,9 @@ class FfiModel with ChangeNotifier {
       } else if (name == 'update_quality_status') {
         parent.target?.qualityMonitorModel.updateQualityStatus(evt);
       } else if (name == 'update_block_input_state') {
-        updateBlockInputState(evt);
+        updateBlockInputState(evt, peerId);
       } else if (name == 'update_privacy_mode') {
-        updatePrivacyMode(evt);
+        updatePrivacyMode(evt, peerId);
       }
     };
     platformFFI.setEventCallback(cb);
@@ -305,6 +305,12 @@ class FfiModel with ChangeNotifier {
     _pi.sasEnabled = evt['sas_enabled'] == "true";
     _pi.currentDisplay = int.parse(evt['current_display']);
 
+    try {
+      CurrentDisplayState.find(peerId).value = _pi.currentDisplay;
+    } catch (e) {
+      //
+    }
+
     if (isPeerAndroid) {
       _touchMode = true;
       if (parent.target?.ffiModel.permissions['keyboard'] != false) {
@@ -343,13 +349,24 @@ class FfiModel with ChangeNotifier {
     notifyListeners();
   }
 
-  updateBlockInputState(Map<String, dynamic> evt) {
+  updateBlockInputState(Map<String, dynamic> evt, String peerId) {
     _inputBlocked = evt['input_state'] == 'on';
     notifyListeners();
+    try {
+      BlockInputState.find(peerId).value = evt['input_state'] == 'on';
+    } catch (e) {
+      //
+    }
   }
 
-  updatePrivacyMode(Map<String, dynamic> evt) {
+  updatePrivacyMode(Map<String, dynamic> evt, String peerId) {
     notifyListeners();
+    try {
+      PrivacyModeState.find(peerId).value =
+          bind.sessionGetToggleOptionSync(id: peerId, arg: 'privacy-mode');
+    } catch (e) {
+      //
+    }
   }
 }
 

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "比例"),
         ("Image Quality", "画质"),
         ("Scroll Style", "滚屏方式"),
+        ("Show Menubar", "显示菜单栏"),
+        ("Hide Menubar", "隐藏菜单栏"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", "正在重启远程设备"),
         ("remote_restarting_tip", "远程设备正在重启, 请关闭当前提示框, 并在一段时间后使用永久密码重新连接"),
         ("Copied", "已复制"),
+        ("Exit Fullscreen", "退出全屏"),
+        ("Fullscreen", "全屏"),
+        ("Mobile Actions", "移动端操作"),
+        ("Select Monitor", "选择监视器"),
+        ("Control Actions", "控制操作"),
+        ("Display Settings", "显示设置"),
+        ("Ratio", "比例"),
+        ("Image Quality", "画质"),
+        ("Scroll Style", "滚屏方式"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Poměr"),
         ("Image Quality", "Kvalita obrazu"),
         ("Scroll Style", "Štýl posúvania"),
+        ("Show Menubar", "Zobrazit panel nabídek"),
+        ("Hide Menubar", "skrýt panel nabídek"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", ""),
         ("remote_restarting_tip", ""),
         ("Copied", ""),
+        ("Exit Fullscreen", "Ukončete celou obrazovku"),
+        ("Fullscreen", "Celá obrazovka"),
+        ("Mobile Actions", "Mobilní akce"),
+        ("Select Monitor", "Vyberte možnost Monitor"),
+        ("Control Actions", "Ovládací akce"),
+        ("Display Settings", "Nastavení obrazovky"),
+        ("Ratio", "Poměr"),
+        ("Image Quality", "Kvalita obrazu"),
+        ("Scroll Style", "Štýl posúvania"),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Forhold"),
         ("Image Quality", "Billede kvalitet"),
         ("Scroll Style", "Rulstil"),
+        ("Show Menubar", "Vis menulinje"),
+        ("Hide Menubar", "skjul menulinjen"),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", ""),
         ("remote_restarting_tip", ""),
         ("Copied", ""),
+        ("Exit Fullscreen", "Afslut fuldskærm"),
+        ("Fullscreen", "Fuld skærm"),
+        ("Mobile Actions", "Mobile handlinger"),
+        ("Select Monitor", "Vælg Monitor"),
+        ("Control Actions", "Kontrolhandlinger"),
+        ("Display Settings", "Skærmindstillinger"),
+        ("Ratio", "Forhold"),
+        ("Image Quality", "Billede kvalitet"),
+        ("Scroll Style", "Rulstil"),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Verhältnis"),
         ("Image Quality", "Bildqualität"),
         ("Scroll Style", "Scroll-Stil"),
+        ("Show Menubar", "Menüleiste anzeigen"),
+        ("Hide Menubar", "Menüleiste ausblenden"),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", "Entferntes Gerät wird neu gestartet"),
         ("remote_restarting_tip", "Entferntes Gerät startet neu, bitte schließen Sie diese Meldung und verbinden Sie sich mit dem dauerhaften Passwort erneut."),
         ("Copied", ""),
+        ("Exit Fullscreen", "Vollbild beenden"),
+        ("Fullscreen", "Ganzer Bildschirm"),
+        ("Mobile Actions", "Mobile Aktionen"),
+        ("Select Monitor", "Wählen Sie Überwachen aus"),
+        ("Control Actions", "Kontrollaktionen"),
+        ("Display Settings", "Bildschirmeinstellungen"),
+        ("Ratio", "Verhältnis"),
+        ("Image Quality", "Bildqualität"),
+        ("Scroll Style", "Scroll-Stil"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Proporcio"),
         ("Image Quality", "Bilda Kvalito"),
         ("Scroll Style", "Ruluma Stilo"),
+        ("Show Menubar", "Montru menubreton"),
+        ("Hide Menubar", "kaŝi menubreton"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", ""),
         ("remote_restarting_tip", ""),
         ("Copied", ""),
+        ("Exit Fullscreen", "Eliru Plenekranon"),
+        ("Fullscreen", "Plenekrane"),
+        ("Mobile Actions", "Poŝtelefonaj Agoj"),
+        ("Select Monitor", "Elektu Monitoron"),
+        ("Control Actions", "Kontrolaj Agoj"),
+        ("Display Settings", "Montraj Agordoj"),
+        ("Ratio", "Proporcio"),
+        ("Image Quality", "Bilda Kvalito"),
+        ("Scroll Style", "Ruluma Stilo"),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Relación"),
         ("Image Quality", "La calidad de imagen"),
         ("Scroll Style", "Estilo de desplazamiento"),
+        ("Show Menubar", "ajustes de pantalla"),
+        ("Hide Menubar", "ocultar barra de menú"),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", "Reiniciando dispositivo remoto"),
         ("remote_restarting_tip", "Dispositivo remoto reiniciando, favor de cerrar este mensaje y reconectarse con la contraseña permamente despues de un momento."),
         ("Copied", ""),
+        ("Exit Fullscreen", "Salir de pantalla completa"),
+        ("Fullscreen", "Pantalla completa"),
+        ("Mobile Actions", "Acciones móviles"),
+        ("Select Monitor", "Seleccionar monitor"),
+        ("Control Actions", "Acciones de control"),
+        ("Display Settings", "Configuración de pantalla"),
+        ("Ratio", "Relación"),
+        ("Image Quality", "La calidad de imagen"),
+        ("Scroll Style", "Estilo de desplazamiento"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", ""),
         ("remote_restarting_tip", ""),
         ("Copied", ""),
+        ("Exit Fullscreen", "Quitter le mode plein écran"),
+        ("Fullscreen", "Plein écran"),
+        ("Mobile Actions", "Actions mobiles"),
+        ("Select Monitor", "Sélectionnez Moniteur"),
+        ("Control Actions", "Actions de contrôle"),
+        ("Display Settings", "Paramètres d'affichage"),
+        ("Ratio", "Rapport"),
+        ("Image Quality", "Qualité d'image"),
+        ("Scroll Style", "Style de défilement"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Rapport"),
         ("Image Quality", "Qualité d'image"),
         ("Scroll Style", "Style de défilement"),
+        ("Show Menubar", "Afficher la barre de menus"),
+        ("Hide Menubar", "masquer la barre de menus"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Hányados"),
         ("Image Quality", "Képminőség"),
         ("Scroll Style", "Görgetési stílus"),
+        ("Show Menubar", "Menüsor megjelenítése"),
+        ("Hide Menubar", "menüsor elrejtése"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", ""),
         ("remote_restarting_tip", ""),
         ("Copied", ""),
+        ("Exit Fullscreen", "Lépjen ki a teljes képernyőről"),
+        ("Fullscreen", "Teljes képernyő"),
+        ("Mobile Actions", "mobil műveletek"),
+        ("Select Monitor", "Válassza a Monitor lehetőséget"),
+        ("Control Actions", "Irányítási műveletek"),
+        ("Display Settings", "Megjelenítési beállítások"),
+        ("Ratio", "Hányados"),
+        ("Image Quality", "Képminőség"),
+        ("Scroll Style", "Görgetési stílus"),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", "Memulai Ulang Perangkat Jarak Jauh"),
         ("remote_restarting_tip", ""),
         ("Copied", ""),
+        ("Exit Fullscreen", "Keluar dari Layar Penuh"),
+        ("Fullscreen", "Layar penuh"),
+        ("Mobile Actions", "Tindakan Seluler"),
+        ("Select Monitor", "Pilih Monitor"),
+        ("Control Actions", "Tindakan Kontrol"),
+        ("Display Settings", "Pengaturan tampilan"),
+        ("Ratio", "Perbandingan"),
+        ("Image Quality", "Kualitas gambar"),
+        ("Scroll Style", "Gaya Gulir"),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Perbandingan"),
         ("Image Quality", "Kualitas gambar"),
         ("Scroll Style", "Gaya Gulir"),
+        ("Show Menubar", "Tampilkan bilah menu"),
+        ("Hide Menubar", "sembunyikan bilah menu"),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -301,5 +301,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Are you sure you want to restart", "Sei sicuro di voler riavviare?"),
         ("Restarting Remote Device", "Il dispositivo remoto si sta riavviando"),
         ("remote_restarting_tip", "Riavviare il dispositivo remoto"),
+        ("Exit Fullscreen", "Esci dalla modalità schermo intero"),
+        ("Fullscreen", "A schermo intero"),
+        ("Mobile Actions", "Azioni mobili"),
+        ("Select Monitor", "Seleziona Monitora"),
+        ("Control Actions", "Azioni di controllo"),
+        ("Display Settings", "Impostazioni di visualizzazione"),
+        ("Ratio", "Rapporto"),
+        ("Image Quality", "Qualità dell'immagine"),
+        ("Scroll Style", "Stile di scorrimento"),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -310,5 +310,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Rapporto"),
         ("Image Quality", "Qualità dell'immagine"),
         ("Scroll Style", "Stile di scorrimento"),
+        ("Show Menubar", "Mostra la barra dei menu"),
+        ("Hide Menubar", "nascondi la barra dei menu"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -308,5 +308,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "比率"),
         ("Image Quality", "画質"),
         ("Scroll Style", "スクロール スタイル"),
+        ("Show Menubar", "メニューバーを表示"),
+        ("Hide Menubar", "メニューバーを隠す"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -299,5 +299,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Are you sure you want to restart", "本当に再起動しますか"),
         ("Restarting Remote Device", "リモート端末を再起動中"),
         ("remote_restarting_tip", "リモート端末は再起動中です。このメッセージボックスを閉じて、しばらくした後に固定のパスワードを使用して再接続してください。"),
+        ("Exit Fullscreen", "全画面表示を終了"),
+        ("Fullscreen", "全画面表示"),
+        ("Mobile Actions", "モバイル アクション"),
+        ("Select Monitor", "モニターを選択"),
+        ("Control Actions", "コントロール アクション"),
+        ("Display Settings", "ディスプレイの設定"),
+        ("Ratio", "比率"),
+        ("Image Quality", "画質"),
+        ("Scroll Style", "スクロール スタイル"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -308,5 +308,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "비율"),
         ("Image Quality", "이미지 품질"),
         ("Scroll Style", "스크롤 스타일"),
+        ("Show Menubar", "메뉴 표시줄 표시"),
+        ("Hide Menubar", "메뉴 표시줄 숨기기"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -299,5 +299,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Are you sure you want to restart", "정말로 재시작 하시겠습니까"),
         ("Restarting Remote Device", "원격 기기를 다시 시작하는중"),
         ("remote_restarting_tip", "원격 장치를 다시 시작하는 중입니다. 이 메시지 상자를 닫고 잠시 후 영구 비밀번호로 다시 연결하십시오."),
+        ("Exit Fullscreen", "전체 화면 종료"),
+        ("Fullscreen", "전체화면"),
+        ("Mobile Actions", "모바일 액션"),
+        ("Select Monitor", "모니터 선택"),
+        ("Control Actions", "제어 작업"),
+        ("Display Settings", "화면 설정"),
+        ("Ratio", "비율"),
+        ("Image Quality", "이미지 품질"),
+        ("Scroll Style", "스크롤 스타일"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -312,5 +312,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Stosunek"),
         ("Image Quality", "Jakość obrazu"),
         ("Scroll Style", "Styl przewijania"),
+        ("Show Menubar", "Pokaż pasek menu"),
+        ("Hide Menubar", "ukryj pasek menu"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -303,5 +303,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Set security password", "Ustaw hasło zabezpieczające"),
         ("Connection not allowed", "Połączenie niedozwolone"),
         ("Copied", ""),
+        ("Exit Fullscreen", "Wyłączyć tryb pełnoekranowy"),
+        ("Fullscreen", "Pełny ekran"),
+        ("Mobile Actions", "Działania mobilne"),
+        ("Select Monitor", "Wybierz Monitor"),
+        ("Control Actions", "Działania kontrolne"),
+        ("Display Settings", "Ustawienia wyświetlania"),
+        ("Ratio", "Stosunek"),
+        ("Image Quality", "Jakość obrazu"),
+        ("Scroll Style", "Styl przewijania"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT
+++ b/src/lang/pt_PT
@@ -299,5 +299,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Are you sure you want to restart", "Tem a certeza que pretende reiniciar"),
         ("Restarting Remote Device", "A reiniciar sistema remoto"),
         ("remote_restarting_tip", ""),
+        ("Exit Fullscreen", "Sair da tela cheia"),
+        ("Fullscreen", "Tela cheia"),
+        ("Mobile Actions", "Ações para celular"),
+        ("Select Monitor", "Selecionar monitor"),
+        ("Control Actions", "Ações de controle"),
+        ("Display Settings", "Configurações do visor"),
+        ("Ratio", "Razão"),
+        ("Image Quality", "Qualidade da imagem"),
+        ("Scroll Style", "Estilo de rolagem"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -308,5 +308,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Razão"),
         ("Image Quality", "Qualidade da imagem"),
         ("Scroll Style", "Estilo de rolagem"),
+        ("Show Menubar", "Mostrar barra de menus"),
+        ("Hide Menubar", "ocultar barra de menu"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", ""),
         ("remote_restarting_tip", ""),
         ("Copied", ""),
+        ("Exit Fullscreen", ""),
+        ("Fullscreen", ""),
+        ("Mobile Actions", ""),
+        ("Select Monitor", ""),
+        ("Control Actions", ""),
+        ("Display Settings", ""),
+        ("Ratio", ""),
+        ("Image Quality", ""),
+        ("Scroll Style", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", ""),
         ("Image Quality", ""),
         ("Scroll Style", ""),
+        ("Show Menubar", ""),
+        ("Hide Menubar", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", "Перезагрузка удаленного устройства"),
         ("remote_restarting_tip", "Удаленное устройство перезапускается. Пожалуйста, закройте это сообщение и через некоторое время переподключитесь, используя постоянный пароль."),
         ("Copied", ""),
+        ("Exit Fullscreen", "Выйти из полноэкранного режима"),
+        ("Fullscreen", "Полноэкранный"),
+        ("Mobile Actions", "Мобильные действия"),
+        ("Select Monitor", "Выберите монитор"),
+        ("Control Actions", "Действия по управлению"),
+        ("Display Settings", "Настройки отображения"),
+        ("Ratio", "Соотношение"),
+        ("Image Quality", "Качество изображения"),
+        ("Scroll Style", "Стиль прокрутки"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Соотношение"),
         ("Image Quality", "Качество изображения"),
         ("Scroll Style", "Стиль прокрутки"),
+        ("Show Menubar", "Показать строку меню"),
+        ("Hide Menubar", "скрыть строку меню"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Pomer"),
         ("Image Quality", "Kvalita obrazu"),
         ("Scroll Style", "Štýl posúvania"),
+        ("Show Menubar", "Zobraziť panel s ponukami"),
+        ("Hide Menubar", "skryť panel s ponukami"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", ""),
         ("remote_restarting_tip", ""),
         ("Copied", ""),
+        ("Exit Fullscreen", "Ukončiť celú obrazovku"),
+        ("Fullscreen", "Celá obrazovka"),
+        ("Mobile Actions", "Mobilné akcie"),
+        ("Select Monitor", "Vyberte možnosť Monitor"),
+        ("Control Actions", "Kontrolné akcie"),
+        ("Display Settings", "Nastavenia displeja"),
+        ("Ratio", "Pomer"),
+        ("Image Quality", "Kvalita obrazu"),
+        ("Scroll Style", "Štýl posúvania"),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", ""),
         ("remote_restarting_tip", ""),
         ("Copied", ""),
+        ("Exit Fullscreen", ""),
+        ("Fullscreen", ""),
+        ("Mobile Actions", ""),
+        ("Select Monitor", ""),
+        ("Control Actions", ""),
+        ("Display Settings", ""),
+        ("Ratio", ""),
+        ("Image Quality", ""),
+        ("Scroll Style", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", ""),
         ("Image Quality", ""),
         ("Scroll Style", ""),
+        ("Show Menubar", ""),
+        ("Hide Menubar", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", "Uzaktan yeniden başlatılıyor"),
         ("remote_restarting_tip", ""),
         ("Copied", ""),
+        ("Exit Fullscreen", "Tam ekrandan çık"),
+        ("Fullscreen", "Tam ekran"),
+        ("Mobile Actions", "Mobil İşlemler"),
+        ("Select Monitor", "Monitörü Seç"),
+        ("Control Actions", "Kontrol Eylemleri"),
+        ("Display Settings", "Görüntü ayarları"),
+        ("Ratio", "Oran"),
+        ("Image Quality", "Görüntü kalitesi"),
+        ("Scroll Style", "Kaydırma Stili"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Oran"),
         ("Image Quality", "Görüntü kalitesi"),
         ("Scroll Style", "Kaydırma Stili"),
+        ("Show Menubar", "Menü çubuğunu göster"),
+        ("Hide Menubar", "menü çubuğunu gizle"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "比例"),
         ("Image Quality", "畫質"),
         ("Scroll Style", "滾動樣式"),
+        ("Show Menubar", "顯示菜單欄"),
+        ("Hide Menubar", "隱藏菜單欄"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", "正在重啓遠程設備"),
         ("remote_restarting_tip", "遠程設備正在重啓，請關閉當前提示框，並在一段時間後使用永久密碼重新連接"),
         ("Copied", "已複製"),
+        ("Exit Fullscreen", "退出全屏"),
+        ("Fullscreen", "全屏"),
+        ("Mobile Actions", "移動端操作"),
+        ("Select Monitor", "選擇監視器"),
+        ("Control Actions", "控制操作"),
+        ("Display Settings", "顯示設置"),
+        ("Ratio", "比例"),
+        ("Image Quality", "畫質"),
+        ("Scroll Style", "滾動樣式"),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -302,5 +302,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Restarting Remote Device", "Đang khởi động lại thiết bị từ xa"),
         ("remote_restarting_tip", "Thiết bị từ xa đang khởi động lại, hãy đóng cửa sổ tin nhắn này và kết nối lại với mật khẩu vĩnh viễn sau một khoảng thời gian"),
         ("Copied", ""),
+        ("Exit Fullscreen", "Thoát toàn màn hình"),
+        ("Fullscreen", "Toàn màn hình"),
+        ("Mobile Actions", "Hành động trên thiết bị di động"),
+        ("Select Monitor", "Chọn màn hình"),
+        ("Control Actions", "Kiểm soát hành động"),
+        ("Display Settings", "Thiết lập hiển thị"),
+        ("Ratio", "Tỉ lệ"),
+        ("Image Quality", "Chất lượng hình ảnh"),
+        ("Scroll Style", "Kiểu cuộn"),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -311,5 +311,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Ratio", "Tỉ lệ"),
         ("Image Quality", "Chất lượng hình ảnh"),
         ("Scroll Style", "Kiểu cuộn"),
+        ("Show Menubar", "Hiển thị thanh menu"),
+        ("Hide Menubar", "ẩn thanh menu"),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
Add flutter menubar for desktop, tested on windows.

TODO:
1. Connection status icon.
2. Switch peer id and peer OS account.
3. Prevent frequent clicks on some switch options, eg privacy mode.
4. Floating menubar.

![20220828215944](https://user-images.githubusercontent.com/13586388/187077983-5dbfc47e-1de8-46e7-9148-a26a6119808f.png)
![20220828220226](https://user-images.githubusercontent.com/13586388/187077989-be239e73-9610-4b5a-9222-1e4212b14cf7.png)
![20220828220243](https://user-images.githubusercontent.com/13586388/187077994-4ad098b8-9c93-43ae-88c2-295c7a7e4a03.png)
![20220828220138](https://user-images.githubusercontent.com/13586388/187077998-382a5879-6b9c-47fe-9f2c-03f10ffde2a3.png)
![20220828220124](https://user-images.githubusercontent.com/13586388/187078000-81f20351-7c9d-4cd9-987a-d2336d1ed6b3.png)




