### PR TITLE
feat: support changing id via cmdline

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -667,6 +667,11 @@ pub fn get_id() -> String {
     }
 }
 
+pub fn set_id(v: String) -> ResultType<()> {
+    Config::set_id(&v);
+    set_config("id", v)
+}
+
 pub async fn get_rendezvous_server(ms_timeout: u64) -> (String, Vec<String>) {
     if let Ok(Some(v)) = get_config_async("rendezvous_server", ms_timeout).await {
         let mut urls = v.split(",");

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,13 @@ fn main() {
                 import_config(&filepath);
             }
             return;
+        } else if args[0] == "--id" {
+            if args.len() == 2 {
+                ipc::set_id(args[1].to_owned()).unwrap();
+            } else if args.len() == 1 {
+                println!("{}", ipc::get_id());
+            }
+            return;
         } else if args[0] == "--password" {
             if args.len() == 2 {
                 ipc::set_permanent_password(args[1].to_owned()).unwrap();


### PR DESCRIPTION
This PR adds the following features:

+ Get current ID via command line
  + Note: `println!` does not work for no-console mode under Windows, i.e. `#![windows_subsystem = "windows"]`. See https://github.com/rust-lang/rust/issues/67159#issuecomment-563014833. This also explains why `./rustdesk.exe --version` shows nothing.
+ Set ID via command line

### Example Usage

```shell
$ ./rustdesk.exe --id 119206784
```

Result:

![image](https://user-images.githubusercontent.com/24671280/188835638-659906ef-0a83-4b65-8a9c-e6ff3778dda2.png)
