### PR TITLE
fix m1 pro scrap compile error

### DIFF
--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -13,7 +13,13 @@ fn link_vcpkg(mut path: PathBuf, name: &str) -> PathBuf {
         target_arch = "arm64".to_owned();
     }
     let mut target = if target_os == "macos" {
-        "x64-osx".to_owned()
+        if target_arch == "x64" {
+            "x64-osx".to_owned()
+        } else if target_arch == "arm64"{
+            "arm64-osx".to_owned()
+        } else {
+            format!("{}-{}", target_arch, target_os)
+        }
     } else if target_os == "windows" {
         "x64-windows-static".to_owned()
     } else {


### PR DESCRIPTION
When I first compiled RustDesk on Mac Book M1 Pro. The libvpx header file cannot be found while compiling scrap lib.
The specific error information is as follows：
```
Caused by:
  process didn't exit successfully: `/Users/songwei/work/rustdesk/target/debug/build/scrap-5dd93ef048b3ac32/build-script-build` (exit status: 101)
  --- stdout
  cargo:info=x64-osx
  cargo:rustc-link-lib=static=yuv
  cargo:rustc-link-search=/Users/songwei/vcpkg/installed/x64-osx/lib
  cargo:include=/Users/songwei/vcpkg/installed/x64-osx/include
  cargo:info=x64-osx
  cargo:rustc-link-lib=static=vpx
  cargo:rustc-link-search=/Users/songwei/vcpkg/installed/x64-osx/lib
  cargo:include=/Users/songwei/vcpkg/installed/x64-osx/include
  rerun-if-changed=/Users/songwei/work/rustdesk/libs/scrap/vpx_ffi.h
  rerun-if-changed=/Users/songwei/vcpkg/installed/x64-osx/include

  --- stderr
  /Users/songwei/work/rustdesk/libs/scrap/vpx_ffi.h:1:10: fatal error: 'vpx/vp8.h' file not found
  /Users/songwei/work/rustdesk/libs/scrap/vpx_ffi.h:1:10: fatal error: 'vpx/vp8.h' file not found, err: true
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ()', libs/scrap/build.rs:128:18
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Through my careful observation,`target os` and `link directory` were found to be incorrect.When installing Library via VCPKG on M1 Pro, the correct path is as follows: `~/vcpkg/installed/arm64-osx`, not `~/vcpkg/installed/x64-osx`.
The end result is this：
```
$ cargo build
   Compiling scrap v0.5.0 (/Users/songwei/work/rustdesk/libs/scrap)
    Finished dev [unoptimized + debuginfo] target(s) in 2.64s
```
I successfully ran RustDesk on Mac Book M1 Pro.So I am honored and happy to find and solve this problem, and hope to help the RustDesk community.
 
 
 
