### PR TITLE
Use GitHub Dependabot to manage deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      
+  - package-ecosystem: "gradle"
+    directory: "/flutter/android"
+    schedule:
+      interval: "daily"
+      
+  - package-ecosystem: "pub"
+    directory: "/flutter"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
GitHub Dependabot doesn't support yarn v2+, so I disable the js module. 