### PR TITLE
fix: cm window size, hide window on startup linux

### DIFF
--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -19,6 +19,8 @@ const int kMobileDefaultDisplayHeight = 1280;
 const int kDesktopDefaultDisplayWidth = 1080;
 const int kDesktopDefaultDisplayHeight = 720;
 
+const Size kConnectionManagerWindowSize = Size(300, 400);
+
 /// [kDefaultScrollAmountMultiplier] indicates how many rows can be scrolled after a minimum scroll action of mouse
 const kDefaultScrollAmountMultiplier = 5.0;
 const kDefaultScrollDuration = Duration(milliseconds: 50);

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -103,6 +103,7 @@ void runMainApp(bool startService) async {
     restoreWindowPosition(WindowType.Main);
     await windowManager.show();
     await windowManager.focus();
+    await windowManager.setOpacity(1);
   });
 }
 
@@ -190,8 +191,13 @@ void runPortForwardScreen(Map<String, dynamic> argument) async {
 void runConnectionManagerScreen() async {
   // initialize window
   WindowOptions windowOptions =
-      getHiddenTitleBarWindowOptions(size: const Size(300, 400));
-  await initEnv(kAppTypeMain);
+      getHiddenTitleBarWindowOptions(size: kConnectionManagerWindowSize);
+  // ensure initial window size to be changed
+  await windowManager.setSize(kConnectionManagerWindowSize);
+  await Future.wait([
+    windowManager.setAlignment(Alignment.topRight),
+    initEnv(kAppTypeMain)
+  ]);
   runApp(GetMaterialApp(
       debugShowCheckedModeBanner: false,
       theme: MyTheme.lightTheme,
@@ -206,17 +212,17 @@ void runConnectionManagerScreen() async {
       home: const DesktopServerPage(),
       builder: _keepScaleBuilder()));
   windowManager.waitUntilReadyToShow(windowOptions, () async {
-    await windowManager.setAlignment(Alignment.topRight);
-    await windowManager.show();
-    await windowManager.focus();
-    await windowManager.setAlignment(Alignment.topRight); // ensure
+    windowManager.show();
+    windowManager.focus();
+    windowManager.setOpacity(1);
+    windowManager.setAlignment(Alignment.topRight); // ensure
   });
 }
 
 WindowOptions getHiddenTitleBarWindowOptions({Size? size}) {
   return WindowOptions(
     size: size,
-    center: true,
+    center: false,
     backgroundColor: Colors.transparent,
     skipTaskbar: false,
     titleBarStyle: TitleBarStyle.hidden,

--- a/flutter/linux/my_application.cc
+++ b/flutter/linux/my_application.cc
@@ -53,6 +53,7 @@ static void my_application_activate(GApplication* application) {
   // bdw->setCustomFrame(true);               // <-- add this line
   gtk_window_set_default_size(window, 800, 600);   // <-- comment this line
   gtk_widget_show(GTK_WIDGET(window));
+  gtk_widget_set_opacity(GTK_WIDGET(window), 0);
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);


### PR DESCRIPTION
- fix: cm initial size incorrect sometimes mentioned by @Heap-Hop .
- opt: linux can hide window when rustdesk core not ready now. prevent rustdesk from white screen when start-up @rustdesk 