### PR TITLE
opt: adapt global scroll on mobile & adjust desktop connection page scrollbar

### DIFF
--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -73,32 +73,47 @@ class _PeerCardState extends State<_PeerCard>
               _menuPos = RelativeRect.fromLTRB(x, y, x, y);
               _showPeerMenu(peer.id);
             },
-            child: ListTile(
-              contentPadding: const EdgeInsets.only(left: 12), //
-              subtitle: Text('${peer.username}@${peer.hostname}'),
-              title: Row(children: [
-                getOnline(4, peer.online),
-                Text(peer.alias.isEmpty ? formatID(peer.id) : peer.alias)
-              ]),
-              leading: Container(
-                  decoration: BoxDecoration(
-                    color: str2color('${peer.id}${peer.platform}', 0x7f),
-                    borderRadius: BorderRadius.circular(4),
+            child: Container(
+              padding: EdgeInsets.only(left: 12, top: 8, bottom: 8),
+              child: Row(
+                children: [
+                  Container(
+                      width: 50,
+                      height: 50,
+                      decoration: BoxDecoration(
+                        color: str2color('${peer.id}${peer.platform}', 0x7f),
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      padding: const EdgeInsets.all(6),
+                      child: getPlatformImage(peer.platform)),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(children: [
+                          getOnline(4, peer.online),
+                          Text(peer.alias.isEmpty
+                              ? formatID(peer.id)
+                              : peer.alias)
+                        ]),
+                        Text('${peer.username}@${peer.hostname}')
+                      ],
+                    ).paddingOnly(left: 8.0),
                   ),
-                  padding: const EdgeInsets.all(6),
-                  child: getPlatformImage(peer.platform)),
-              trailing: InkWell(
-                  child: const Padding(
-                      padding: EdgeInsets.all(12),
-                      child: Icon(Icons.more_vert)),
-                  onTapDown: (e) {
-                    final x = e.globalPosition.dx;
-                    final y = e.globalPosition.dy;
-                    _menuPos = RelativeRect.fromLTRB(x, y, x, y);
-                  },
-                  onTap: () {
-                    _showPeerMenu(peer.id);
-                  }),
+                  InkWell(
+                      child: const Padding(
+                          padding: EdgeInsets.all(12),
+                          child: Icon(Icons.more_vert)),
+                      onTapDown: (e) {
+                        final x = e.globalPosition.dx;
+                        final y = e.globalPosition.dy;
+                        _menuPos = RelativeRect.fromLTRB(x, y, x, y);
+                      },
+                      onTap: () {
+                        _showPeerMenu(peer.id);
+                      })
+                ],
+              ),
             )));
   }
 

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -63,6 +63,7 @@ class _ConnectionPageState extends State<ConnectionPage>
             scrollController: _scrollController,
             child: CustomScrollView(
               controller: _scrollController,
+              physics: NeverScrollableScrollPhysics(),
               slivers: [
                 SliverList(
                     delegate: SliverChildListDelegate([
@@ -72,7 +73,7 @@ class _ConnectionPageState extends State<ConnectionPage>
                     ],
                   ).marginOnly(top: 22),
                   SizedBox(height: 12),
-                  Divider(),
+                  Divider().paddingOnly(right: 12),
                 ])),
                 SliverFillRemaining(
                   hasScrollBody: false,
@@ -97,10 +98,10 @@ class _ConnectionPageState extends State<ConnectionPage>
                         menuPadding: EdgeInsets.only(left: 12.0, right: 3.0),
                       ),
                     ],
-                  ),
+                  ).paddingOnly(right: 12.0),
                 )
               ],
-            ).marginSymmetric(horizontal: 12.0),
+            ).paddingOnly(left: 12.0),
           ),
         ),
         const Divider(),

--- a/flutter/lib/mobile/pages/connection_page.dart
+++ b/flutter/lib/mobile/pages/connection_page.dart
@@ -66,15 +66,16 @@ class _ConnectionPageState extends State<ConnectionPage> {
   @override
   Widget build(BuildContext context) {
     Provider.of<FfiModel>(context);
-    return Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        mainAxisSize: MainAxisSize.max,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: <Widget>[
+    return CustomScrollView(
+      slivers: [
+        SliverList(
+            delegate: SliverChildListDelegate([
           _buildUpdateUI(),
           _buildRemoteIDTextField(),
-          Expanded(
-              child: PeerTabPage(
+        ])),
+        SliverFillRemaining(
+          hasScrollBody: false,
+          child: PeerTabPage(
             tabs: [
               translate('Recent Sessions'),
               translate('Favorites'),
@@ -87,8 +88,10 @@ class _ConnectionPageState extends State<ConnectionPage> {
               DiscoveredPeersView(),
               const AddressBook(),
             ],
-          )),
-        ]).marginOnly(top: 2, left: 10, right: 10);
+          ),
+        )
+      ],
+    ).marginOnly(top: 2, left: 10, right: 10);
   }
 
   /// Callback for the connect button.


### PR DESCRIPTION
- mobile: replace `ListTile` with `Container` due to lack of dry layout support for `ListTile`.
- desktop: align scrollbar to exact right position.