### PR TITLE
Feat: Grab hot key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,29 +1580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "evdev-rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46504075975d14f0463e5a41efa06820c94d4c04fecd01f70b95365d60de1caf"
-dependencies = [
- "bitflags",
- "evdev-sys",
- "libc",
- "log",
-]
-
-[[package]]
-name = "evdev-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ead42b547b15d47089c1243d907bcf0eb94e457046d3b315a26ac9c9e9ea6d"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4126,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/asur4s/rdev#22c8a6474065f03ecbddef7f47de0539ff3f5c4f"
+source = "git+https://github.com/asur4s/rdev#ea223720532f32652dab803db43f9ce437f2b019"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.3",
@@ -4134,7 +4111,6 @@ dependencies = [
  "core-graphics 0.22.3",
  "enum-map",
  "epoll",
- "evdev-rs",
  "inotify",
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4126,7 +4126,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/asur4s/rdev#71a2b9e014b5aaeb85d7bb4a5b7562e3a68cc509"
+source = "git+https://github.com/asur4s/rdev#22c8a6474065f03ecbddef7f47de0539ff3f5c4f"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,6 +1515,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "epoll"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20df693c700404f7e19d4d6fae6b15215d2913c27955d2b9d6f2c0f537511cd0"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "err-derive"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,6 +1577,29 @@ dependencies = [
  "bitvec",
  "libc",
  "nix 0.23.1",
+]
+
+[[package]]
+name = "evdev-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46504075975d14f0463e5a41efa06820c94d4c04fecd01f70b95365d60de1caf"
+dependencies = [
+ "bitflags",
+ "evdev-sys",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "evdev-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ead42b547b15d47089c1243d907bcf0eb94e457046d3b315a26ac9c9e9ea6d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2572,6 +2605,26 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "inotify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf888f9575c290197b2c948dc9e9ff10bd1a39ad1ea8585f734585fa6b9d3f9"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4073,15 +4126,20 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/asur4s/rdev#bff57a29e3f14d032ab7441b2d6cf029df8adaca"
+source = "git+https://github.com/asur4s/rdev#71a2b9e014b5aaeb85d7bb4a5b7562e3a68cc509"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.3",
  "core-foundation-sys 0.8.3",
  "core-graphics 0.22.3",
  "enum-map",
+ "epoll",
+ "evdev-rs",
+ "inotify",
  "lazy_static",
  "libc",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "widestring 1.0.2",
  "winapi 0.3.9",
  "x11 2.20.0",
@@ -4900,6 +4958,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
 
 [[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
 name = "strum_macros"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4908,6 +4972,19 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -4993,8 +5070,8 @@ checksum = "0f3ecc17269a19353b3558b313bba738b25d82993e30d62a18406a24aba4649b"
 dependencies = [
  "heck 0.3.3",
  "pkg-config",
- "strum",
- "strum_macros",
+ "strum 0.18.0",
+ "strum_macros 0.18.0",
  "thiserror",
  "toml",
  "version-compare 0.0.10",

--- a/src/client.rs
+++ b/src/client.rs
@@ -48,7 +48,7 @@ pub use super::lang::*;
 pub mod file_trait;
 pub mod helper;
 pub mod io_loop;
-
+use crate::ui_session_interface::global_save_keyboard_mode;
 pub static SERVER_KEYBOARD_ENABLED: AtomicBool = AtomicBool::new(true);
 pub static SERVER_FILE_TRANSFER_ENABLED: AtomicBool = AtomicBool::new(true);
 pub static SERVER_CLIPBOARD_ENABLED: AtomicBool = AtomicBool::new(true);
@@ -1293,6 +1293,9 @@ impl LoginConfigHandler {
     pub fn handle_peer_info(&mut self, pi: &PeerInfo) {
         if !pi.version.is_empty() {
             self.version = hbb_common::get_version_number(&pi.version);
+        }
+        if hbb_common::get_version_number(&pi.version) < hbb_common::get_version_number("1.2.0") {
+            global_save_keyboard_mode("legacy".to_owned());
         }
         self.features = pi.features.clone().into_option();
         let serde = PeerInfoSerde {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -906,18 +906,7 @@ impl<T: InvokeUiSession> Session<T> {
                 key_event.set_control_key(key.clone());
             }
             Key::_Raw(raw) => {
-                if raw > 'z' as u32 || raw < 'a' as u32 {
-                    key_event.set_unicode(raw);
-                    // TODO
-                    // if down_or_up == 0 {
-                    //     // ignore up, avoiding trigger twice
-                    //     return;
-                    // }
-                    // down_or_up = 1; // if press, turn into down for avoiding trigger twice on server side
-                } else {
-                    // to make ctrl+c works on windows
-                    key_event.set_chr(raw);
-                }
+                key_event.set_chr(raw);
             }
         }
 

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -80,13 +80,11 @@ impl<T: InvokeUiSession> Session<T> {
     }
 
     pub fn get_keyboard_mode(&self) -> String {
-        return std::env::var("KEYBOARD_MODE")
-            .unwrap_or(String::from("legacy"))
-            .to_lowercase();
+        global_get_keyboard_mode()
     }
 
     pub fn save_keyboard_mode(&self, value: String) {
-        std::env::set_var("KEYBOARD_MODE", value);
+        global_save_keyboard_mode(value);
     }
 
     pub fn save_view_style(&mut self, value: String) {
@@ -1549,4 +1547,14 @@ async fn send_note(url: String, id: String, conn_id: i32, note: String) {
 
 fn get_hotkey_state(key: RdevKey) -> bool {
     *MUTEX_SPECIAL_KEYS.lock().unwrap().get(&key).unwrap()
+}
+
+pub fn global_get_keyboard_mode() -> String {
+    return std::env::var("KEYBOARD_MODE")
+        .unwrap_or(String::from("map"))
+        .to_lowercase();
+}
+
+pub fn global_save_keyboard_mode(value: String) {
+    std::env::set_var("KEYBOARD_MODE", value);
 }

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -13,7 +13,7 @@ use hbb_common::rendezvous_proto::ConnType;
 use hbb_common::tokio::{self, sync::mpsc};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use rdev::Keyboard as RdevKeyboard;
-use rdev::{Event, EventType::*, Key as RdevKey, KeyboardState};
+use rdev::{Event, EventType, EventType::*, Key as RdevKey, KeyboardState};
 
 use hbb_common::{allow_err, message_proto::*};
 use hbb_common::{fs, get_version_number, log, Stream};
@@ -25,7 +25,9 @@ use std::sync::{Arc, Mutex, RwLock};
 /// IS_IN KEYBOARD_HOOKED sciter only
 pub static IS_IN: AtomicBool = AtomicBool::new(false);
 pub static KEYBOARD_HOOKED: AtomicBool = AtomicBool::new(true);
-
+pub static HOTKEY_HOOK_ENABLED: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "linux")]
+use rdev::IS_GRAB;
 #[cfg(windows)]
 static mut IS_ALT_GR: bool = false;
 
@@ -36,6 +38,21 @@ lazy_static::lazy_static! {
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 lazy_static::lazy_static! {
     static ref KEYBOARD: Arc<Mutex<RdevKeyboard>> = Arc::new(Mutex::new(RdevKeyboard::new().unwrap()));
+}
+
+lazy_static::lazy_static! {
+    static ref MUTEX_SPECIAL_KEYS: Mutex<HashMap<RdevKey, bool>> = {
+        let mut m = HashMap::new();
+        m.insert(RdevKey::ShiftLeft, false);
+        m.insert(RdevKey::ShiftRight, false);
+        m.insert(RdevKey::ControlLeft, false);
+        m.insert(RdevKey::ControlRight, false);
+        m.insert(RdevKey::Alt, false);
+        m.insert(RdevKey::AltGr, false);
+        m.insert(RdevKey::MetaLeft, false);
+        m.insert(RdevKey::MetaRight, false);
+        Mutex::new(m)
+    };
 }
 
 #[derive(Clone, Default)]
@@ -146,7 +163,12 @@ impl<T: InvokeUiSession> Session<T> {
             let decoder = scrap::codec::Decoder::video_codec_state(&self.id);
             let mut h264 = decoder.score_h264 > 0;
             let mut h265 = decoder.score_h265 > 0;
-            let (encoding_264, encoding_265) = self.lc.read().unwrap().supported_encoding.unwrap_or_default();
+            let (encoding_264, encoding_265) = self
+                .lc
+                .read()
+                .unwrap()
+                .supported_encoding
+                .unwrap_or_default();
             h264 = h264 && encoding_264;
             h265 = h265 && encoding_265;
             return (h264, h265);
@@ -622,6 +644,7 @@ impl<T: InvokeUiSession> Session<T> {
                     RdevKey::Quote => '\'',
                     RdevKey::LeftBracket => '[',
                     RdevKey::RightBracket => ']',
+                    RdevKey::Slash => '/',
                     RdevKey::BackSlash => '\\',
                     RdevKey::Minus => '-',
                     RdevKey::Equal => '=',
@@ -746,12 +769,24 @@ impl<T: InvokeUiSession> Session<T> {
     }
 
     pub fn enter(&self) {
+        HOTKEY_HOOK_ENABLED.store(true, Ordering::SeqCst);
+        #[cfg(target_os = "linux")]
+        unsafe {
+            IS_GRAB.store(true, Ordering::SeqCst);
+        }
+
         #[cfg(windows)]
         crate::platform::windows::stop_system_key_propagate(true);
         IS_IN.store(true, Ordering::SeqCst);
     }
 
     pub fn leave(&self) {
+        HOTKEY_HOOK_ENABLED.store(false, Ordering::SeqCst);
+        #[cfg(target_os = "linux")]
+        unsafe {
+            IS_GRAB.store(false, Ordering::SeqCst);
+        }
+
         for key in TO_RELEASE.lock().unwrap().iter() {
             self.map_keyboard_mode(false, *key, None)
         }
@@ -865,7 +900,7 @@ impl<T: InvokeUiSession> Session<T> {
                         ControlKey::Numpad9 => ControlKey::PageUp,
                         _ => key,
                     }
-                }else{
+                } else {
                     key
                 };
                 key_event.set_control_key(key.clone());
@@ -885,6 +920,16 @@ impl<T: InvokeUiSession> Session<T> {
                 }
             }
         }
+
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        let ctrl =
+            get_hotkey_state(RdevKey::ControlLeft) || get_hotkey_state(RdevKey::ControlRight);
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        let shift = get_hotkey_state(RdevKey::ShiftLeft) || get_hotkey_state(RdevKey::ShiftRight);
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        let command = get_hotkey_state(RdevKey::MetaLeft) || get_hotkey_state(RdevKey::MetaRight);
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        let alt = get_hotkey_state(RdevKey::Alt) || get_hotkey_state(RdevKey::AltGr);
 
         self.legacy_modifiers(&mut key_event, alt, ctrl, shift, command);
         if v == 1 {
@@ -914,6 +959,16 @@ impl<T: InvokeUiSession> Session<T> {
                 command = true;
             }
         }
+
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        let ctrl =
+            get_hotkey_state(RdevKey::ControlLeft) || get_hotkey_state(RdevKey::ControlRight);
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        let shift = get_hotkey_state(RdevKey::ShiftLeft) || get_hotkey_state(RdevKey::ShiftRight);
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        let command = get_hotkey_state(RdevKey::MetaLeft) || get_hotkey_state(RdevKey::MetaRight);
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        let alt = get_hotkey_state(RdevKey::Alt) || get_hotkey_state(RdevKey::AltGr);
 
         send_mouse(mask, x, y, alt, ctrl, shift, command, self);
         // on macos, ctrl + left button down = right button down, up won't emit, so we need to
@@ -1164,8 +1219,11 @@ impl<T: InvokeUiSession> Interface for Session<T> {
                 crate::platform::windows::add_recent_document(&path);
             }
         }
+        // rdev::grab and rdev::listen use the same api on macOS
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         self.start_keyboard_hook();
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        self.start_hotkey_grab();
     }
 
     async fn handle_hash(&mut self, pass: &str, hash: Hash, peer: &mut Stream) {
@@ -1208,11 +1266,103 @@ impl<T: InvokeUiSession> Interface for Session<T> {
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 impl<T: InvokeUiSession> Session<T> {
+    fn send_hotkey(&self, key: RdevKey, is_press: bool) {
+        log::info!("{:?} {:?}", key, is_press);
+    }
+
+    fn handle_hot_key_event(&self, event: Event) {
+        // keyboard long press
+        match event.event_type {
+            EventType::KeyPress(k) => {
+                if MUTEX_SPECIAL_KEYS.lock().unwrap().contains_key(&k) {
+                    if *MUTEX_SPECIAL_KEYS.lock().unwrap().get(&k).unwrap() {
+                        return;
+                    }
+                    MUTEX_SPECIAL_KEYS.lock().unwrap().insert(k, true);
+                }
+            }
+            EventType::KeyRelease(k) => {
+                if MUTEX_SPECIAL_KEYS.lock().unwrap().contains_key(&k) {
+                    MUTEX_SPECIAL_KEYS.lock().unwrap().insert(k, false);
+                }
+            }
+            _ => return,
+        };
+
+        // keyboard short press
+        match event.event_type {
+            EventType::KeyPress(key) => {
+                self.send_hotkey(key, true);
+                self.key_down_or_up(true, key, event);
+            }
+            EventType::KeyRelease(key) => {
+                self.send_hotkey(key, false);
+                self.key_down_or_up(false, key, event);
+            }
+            _ => {}
+        }
+    }
+
+    fn start_hotkey_grab(&self) {
+        if self.is_port_forward() || self.is_file_transfer() {
+            return;
+        }
+        let me = self.clone();
+
+        log::info!("hotkey grabing");
+        std::thread::spawn(move || {
+            std::env::set_var("KEYBOARD_ONLY", "y");
+
+            let func = move |event: Event| {
+                #[cfg(any(target_os = "windows", target_os = "macos"))]
+                if !HOTKEY_HOOK_ENABLED.load(Ordering::SeqCst) {
+                    return Some(event);
+                };
+                match event.event_type {
+                    EventType::KeyPress(key) | EventType::KeyRelease(key) => {
+                        #[cfg(any(target_os = "windows", target_os = "macos"))]
+                        if MUTEX_SPECIAL_KEYS.lock().unwrap().contains_key(&key) {
+                            me.handle_hot_key_event(event);
+                            return None;
+                        }
+
+                        #[cfg(target_os = "linux")]
+                        me.handle_hot_key_event(event);
+
+                        None
+                    }
+                    _ => Some(event),
+                }
+            };
+
+            #[cfg(target_os = "linux")]
+            {
+                use rdev::GRABED_KEYS;
+                GRABED_KEYS.lock().unwrap().insert(RdevKey::ShiftLeft);
+                GRABED_KEYS.lock().unwrap().insert(RdevKey::ShiftRight);
+                GRABED_KEYS.lock().unwrap().insert(RdevKey::ControlLeft);
+                GRABED_KEYS.lock().unwrap().insert(RdevKey::ControlRight);
+                GRABED_KEYS.lock().unwrap().insert(RdevKey::Alt);
+                GRABED_KEYS.lock().unwrap().insert(RdevKey::AltGr);
+                GRABED_KEYS.lock().unwrap().insert(RdevKey::MetaLeft);
+                GRABED_KEYS.lock().unwrap().insert(RdevKey::MetaRight);
+            }
+            if let Err(error) = rdev::grab(func) {
+                log::error!("Error: {:?}", error)
+            }
+        });
+    }
+
     fn start_keyboard_hook(&self) {
         if self.is_port_forward() || self.is_file_transfer() {
             return;
         }
         if !KEYBOARD_HOOKED.load(Ordering::SeqCst) {
+            return;
+        }
+        // rdev::grab and rdev::listen use the same api on macOS
+        #[cfg(target_os = "macos")]
+        if HOTKEY_HOOK_ENABLED.load(Ordering::SeqCst) {
             return;
         }
         log::info!("keyboard hooked");
@@ -1222,20 +1372,6 @@ impl<T: InvokeUiSession> Session<T> {
         std::thread::spawn(move || {
             // This will block.
             std::env::set_var("KEYBOARD_ONLY", "y");
-            lazy_static::lazy_static! {
-                static ref MUTEX_SPECIAL_KEYS: Mutex<HashMap<RdevKey, bool>> = {
-                    let mut m = HashMap::new();
-                    m.insert(RdevKey::ShiftLeft, false);
-                    m.insert(RdevKey::ShiftRight, false);
-                    m.insert(RdevKey::ControlLeft, false);
-                    m.insert(RdevKey::ControlRight, false);
-                    m.insert(RdevKey::Alt, false);
-                    m.insert(RdevKey::AltGr, false);
-                    m.insert(RdevKey::MetaLeft, false);
-                    m.insert(RdevKey::MetaRight, false);
-                    Mutex::new(m)
-                };
-            }
 
             let func = move |evt: Event| {
                 if !IS_IN.load(Ordering::SeqCst) || !SERVER_KEYBOARD_ENABLED.load(Ordering::SeqCst)
@@ -1420,4 +1556,8 @@ async fn start_one_port_forward<T: InvokeUiSession>(
 async fn send_note(url: String, id: String, conn_id: i32, note: String) {
     let body = serde_json::json!({ "id": id, "Id": conn_id, "note": note });
     allow_err!(crate::post_request(url, body.to_string(), "").await);
+}
+
+fn get_hotkey_state(key: RdevKey) -> bool {
+    *MUTEX_SPECIAL_KEYS.lock().unwrap().get(&key).unwrap()
 }


### PR DESCRIPTION
1. Support grab global shortcut keys: by grab ctrl, shift, alt, command.
2. Fix backquote error: unicode is unstable, so use char whenever possible.
3. Set map as default keyboard mode: if peer version < 1.2.0, keyboard mod switch to legacy.