### PR TITLE
Fix detection of display server inside flatpak

### DIFF
--- a/libs/hbb_common/Cargo.toml
+++ b/libs/hbb_common/Cargo.toml
@@ -38,6 +38,7 @@ machine-uid = "0.2"
 
 [features]
 quic = []
+flatpak = []
 
 [build-dependencies]
 protobuf-codegen = { version = "3.1" }


### PR DESCRIPTION
Fixes detection of running display server when running as flatpak by using `flatpak-spawn` as [discussed](https://github.com/rustdesk/rustdesk/discussions/1537#discussioncomment-3854473). I've added a flatpak feature to hbb_common that has to be enabled when building for flatpak. With this PR it is possible to connect to a machine that is running rustdesk inside a flatpak as long as rustdesk is opened.