### PR TITLE
flutter_desktop: remote menu refactor

### DIFF
--- a/flutter/lib/desktop/widgets/remote_menubar.dart
+++ b/flutter/lib/desktop/widgets/remote_menubar.dart
@@ -106,18 +106,24 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
             width: 100,
             height: 13,
             child: TextButton(
-                onHover: (bool v) {
-                  _hideColor.value = v ? Colors.white60 : Colors.white24;
-                },
-                onPressed: () {
-                  _show.value = !_show.value;
-                  if (_show.isTrue) {
-                    _updateScreen();
-                  }
-                },
-                child: Obx(() => Container(
+              onHover: (bool v) {
+                _hideColor.value = v ? Colors.white60 : Colors.white24;
+              },
+              onPressed: () {
+                _show.value = !_show.value;
+                _hideColor.value = Colors.white24;
+                if (_show.isTrue) {
+                  _updateScreen();
+                }
+              },
+              child: Obx(() => Container(
+                    decoration: BoxDecoration(
                       color: _hideColor.value,
-                    ).marginOnly(bottom: 8.0))))));
+                      border: Border.all(color: MyTheme.border),
+                      borderRadius: BorderRadius.all(Radius.circular(5.0)),
+                    ),
+                  ).marginOnly(bottom: 8.0)),
+            ))));
   }
 
   _updateScreen() async {
@@ -170,7 +176,11 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
             textStyle: TextStyle(color: _MenubarTheme.commonColor)),
         child: Column(mainAxisSize: MainAxisSize.min, children: [
           Container(
-              color: Colors.white,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                border: Border.all(color: MyTheme.border),
+                borderRadius: BorderRadius.all(Radius.circular(10.0)),
+              ),
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: menubarItems,


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

Add border for menubar in remote page.

![微信截图_20221030182938](https://user-images.githubusercontent.com/13586388/198873996-0dfbe561-a235-4ef3-8e0a-c2505b565155.png)


![微信截图_20221030183000](https://user-images.githubusercontent.com/13586388/198873998-f4d9d282-f0f7-4d4d-92b7-d20e6584edc7.png)

TODO:
1. Make menubar draggable.
