### PR TITLE
fix flutter install hang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "impersonate_system"
 version = "0.1.0"
-source = "git+https://github.com/21pages/impersonate-system#af4a82050580217a434c2024e181a98de24823ec"
+source = "git+https://github.com/21pages/impersonate-system#c48f37a8fd17413b2a4ba655c3873bdc5c8d25aa"
 dependencies = [
  "cc",
 ]

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -412,15 +412,6 @@ class _DesktopHomePageState extends State<DesktopHomePage>
   @override
   void initState() {
     super.initState();
-    Timer(const Duration(seconds: 1), () async {
-      final installed = bind.mainIsInstalled();
-      final root = await bind.mainIsRoot();
-      final release = await bind.mainIsRelease();
-      if (Platform.isWindows && release && !installed && !root) {
-        msgBox('custom-elevation-nocancel', 'Prompt', 'elevation_prompt', '',
-            gFFI.dialogManager);
-      }
-    });
     Timer(const Duration(seconds: 5), () async {
       updateUrl = await bind.mainGetSoftwareUpdateUrl();
       if (updateUrl.isNotEmpty) setState(() {});

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -85,11 +85,6 @@ pub fn core_main() -> Option<Vec<String>> {
                 .ok();
         }
     }
-    #[cfg(windows)]
-    #[cfg(not(debug_assertions))]
-    if !crate::platform::is_installed() && args.is_empty() {
-        crate::platform::elevate_or_run_as_system(is_setup, _is_elevate, _is_run_as_system);
-    }
     if args.is_empty() {
         std::thread::spawn(move || crate::start_server(false));
     } else {

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -34,5 +34,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("uac_warning", "Temporarily denied access due to elevation request, please wait for the remote user to accept the UAC dialog. To avoid this problem, it is recommended to install the software on the remote device or run it with administrator privileges."),
         ("elevated_foreground_window_warning", "Temporarily unable to use the mouse and keyboard, because the current window of the remote desktop requires higher privilege to operate, you can request the remote user to minimize the current window. To avoid this problem, it is recommended to install the software on the remote device or run it with administrator privileges."),
         ("JumpLink", "View"),
+        ("Stop service", "Stop Service"),
         ].iter().cloned().collect();
 }

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -1242,9 +1242,3 @@ function refreshCurrentUser() {
 function getHttpHeaders() {
     return "Authorization: Bearer " + handler.get_local_option("access_token");
 }
-
-$(body).timer(1000, function check_elevation(){
-    if (is_win && handler.is_release() && !handler.is_installed() && !handler.is_root()) {
-        msgbox("custom-elevation-nocancel", "Prompt", "elevation_prompt");
-    }
-});


### PR DESCRIPTION
1. Fix flutter install hang, the reason is  that rustdesk.exe will be killed by taskkill during install, now filtler current pid when taskill.
2. Remove startup elevation temporarily.
3. Copy broker when upgrade.
4. Update impersonate_system to support wide char, the error is from c char to wchar_t.