### PR TITLE
Fix for builds where locale can't be set easily

### DIFF
--- a/build.py
+++ b/build.py
@@ -17,7 +17,7 @@ flutter_win_target_dir = 'flutter/build/windows/runner/Release/'
 
 
 def get_version():
-    with open("Cargo.toml") as fh:
+    with open("Cargo.toml", encoding="utf-8") as fh:
         for line in fh:
             if line.startswith("version"):
                 return line.replace("version", "").replace("=", "").replace('"', '').strip()


### PR DESCRIPTION
On local github workflow runners setting system locale can be a bit cumbersome. This minor patch should be mostly harmless.