### PR TITLE
opt: specify rust version for nightly

### DIFF
--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -44,6 +44,7 @@ jobs:
           toolchain: "1.62"
           target: ${{ matrix.job.target }}
           override: true
+          components: rustfmt
           profile: minimal # minimal component installation (ie, no documentation)
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.62"
           target: ${{ matrix.job.target }}
           override: true
           profile: minimal # minimal component installation (ie, no documentation)


### PR DESCRIPTION
This PR fixes nightly build by specifying rust compiler version to `1.62`, which is commonly used by our devs.