### PR TITLE
opt: add preventClose to handle close event manually

### DIFF
--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -33,21 +33,13 @@ class DesktopHomePage extends StatefulWidget {
 const borderColor = Color(0xFF2F65BA);
 
 class _DesktopHomePageState extends State<DesktopHomePage>
-    with TrayListener, WindowListener, AutomaticKeepAliveClientMixin {
+    with TrayListener, AutomaticKeepAliveClientMixin {
   final _leftPaneScrollController = ScrollController();
 
   @override
   bool get wantKeepAlive => true;
   var updateUrl = '';
   StreamSubscription? _uniLinksSubscription;
-
-  @override
-  void onWindowClose() async {
-    super.onWindowClose();
-    // hide window on close
-    await windowManager.hide();
-    rustDeskWinManager.unregisterActiveWindow(0);
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -425,7 +417,6 @@ class _DesktopHomePageState extends State<DesktopHomePage>
     // disable this tray because we use tray function provided by rust now
     // initTray();
     trayManager.addListener(this);
-    windowManager.addListener(this);
     rustDeskWinManager.registerActiveWindowListener(onActiveWindowChanged);
     rustDeskWinManager.registerActiveWindow(0);
     rustDeskWinManager.setMethodHandler((call, fromWindowId) async {
@@ -471,9 +462,9 @@ class _DesktopHomePageState extends State<DesktopHomePage>
   @override
   void dispose() {
     // destoryTray();
-    rustDeskWinManager.unregisterActiveWindowListener(onActiveWindowChanged);
+    // fix: disable unregister to prevent from receiving events from other windows
+    // rustDeskWinManager.unregisterActiveWindowListener(onActiveWindowChanged);
     trayManager.removeListener(this);
-    windowManager.removeListener(this);
     _uniLinksSubscription?.cancel();
     super.dispose();
   }

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -499,6 +499,21 @@ class WindowActionPanelState extends State<WindowActionPanel>
   }
 
   @override
+  void onWindowClose() async {
+    // hide window on close
+    if (widget.isMainWindow) {
+      await windowManager.hide();
+      rustDeskWinManager.unregisterActiveWindow(0);
+    } else {
+      widget.onClose?.call();
+      WindowController.fromWindowId(windowId!).hide();
+      rustDeskWinManager
+          .call(WindowType.Main, kWindowEventHide, {"id": windowId!});
+    }
+    super.onWindowClose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -140,6 +140,8 @@ void runMultiWindow(
   String title,
 ) async {
   await initEnv(appType);
+  // set prevent close to true, we handle close event manually
+  WindowController.fromWindowId(windowId!).setPreventClose(true);
   late Widget widget;
   switch (appType) {
     case kAppTypeDesktopRemote:

--- a/flutter/lib/utils/multi_window_manager.dart
+++ b/flutter/lib/utils/multi_window_manager.dart
@@ -166,6 +166,7 @@ class RustDeskMultiWindowManager {
           // no such window already
           return;
         }
+        await WindowController.fromWindowId(wId).setPreventClose(false);
         await WindowController.fromWindowId(wId).close();
       } on Error {
         return;
@@ -206,6 +207,12 @@ class RustDeskMultiWindowManager {
     
   }
 
+  /// Remove active window which has [`windowId`]
+  /// 
+  /// [Avaliability]
+  /// This function should only be called from main window.
+  /// For other windows, please post a unregister(hide) event to main window handler:
+  /// `rustDeskWinManager.call(WindowType.Main, kWindowEventHide, {"id": windowId!});`
   void unregisterActiveWindow(int windowId) {
     if (!_activeWindows.contains(windowId)) {
       // ignore

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -64,7 +64,7 @@ dependencies:
     desktop_multi_window:
         git:
             url: https://github.com/Kingtous/rustdesk_desktop_multi_window
-            ref: 39a8a5b8aed059a89a1694ed2dffe69e31da2ac1
+            ref: 8d9db30df28eddfdb11ded4aaba6f0fe96547960
     freezed_annotation: ^2.0.3
     tray_manager:
         git:


### PR DESCRIPTION
This PR add a feature, which can prevent window from closing when user quit the window from both of `right-click menu` and `close` button.  This fixes a bug from some situations which may cause an inconsistent state of prior PR #1976, causing rustdesk cannot exit when all windows are hidden.