### PR TITLE
fix: sending file from local to remote

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1607,8 +1607,7 @@ async fn start_ipc(
                             file_num,
                             data,
                             compressed}) = data {
-                                stream.send(&Data::FS(ipc::FS::WriteBlock{id, file_num, data: Bytes::new(), compressed})).await?;
-                                stream.send_raw(data).await?;
+                                stream.send(&Data::FS(ipc::FS::WriteBlock{id, file_num, data, compressed})).await?;
                         } else {
                             stream.send(&data).await?;
                         }


### PR DESCRIPTION
This fixes a bug where 0 byte files were being created when sending from local to remote.