### PR TITLE
fix mouse cannot be controled, when show remote cursor is on

### DIFF
--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -13,6 +13,8 @@ use std::{
     time::Instant,
 };
 
+const INVALID_CURSOR_POS: i32 = i32::MIN;
+
 #[derive(Default)]
 struct StateCursor {
     hcursor: u64,
@@ -28,14 +30,27 @@ impl super::service::Reset for StateCursor {
     }
 }
 
-#[derive(Default)]
 struct StatePos {
     cursor_pos: (i32, i32),
 }
 
+impl Default for StatePos {
+    fn default() -> Self {
+        Self {
+            cursor_pos: (INVALID_CURSOR_POS, INVALID_CURSOR_POS),
+        }
+    }
+}
+
 impl super::service::Reset for StatePos {
     fn reset(&mut self) {
-        self.cursor_pos = (0, 0);
+        self.cursor_pos = (INVALID_CURSOR_POS, INVALID_CURSOR_POS);
+    }
+}
+
+impl StatePos {
+    fn is_valid(&self) -> bool {
+        self.cursor_pos.0 != INVALID_CURSOR_POS && self.cursor_pos.1 != INVALID_CURSOR_POS
     }
 }
 
@@ -114,25 +129,27 @@ fn update_last_cursor_pos(x: i32, y: i32) {
 fn run_pos(sp: GenericService, state: &mut StatePos) -> ResultType<()> {
     if let Some((x, y)) = crate::get_cursor_pos() {
         update_last_cursor_pos(x, y);
-        if state.cursor_pos.0 != x || state.cursor_pos.1 != y {
-            state.cursor_pos = (x, y);
-            let mut msg_out = Message::new();
-            msg_out.set_cursor_position(CursorPosition {
-                x,
-                y,
-                ..Default::default()
-            });
-            let exclude = {
-                let now = get_time();
-                let lock = LATEST_INPUT_CURSOR.lock().unwrap();
-                if now - lock.time < 300 {
-                    lock.conn
-                } else {
-                    0
-                }
-            };
-            sp.send_without(msg_out, exclude);
+        if state.is_valid() {
+            if state.cursor_pos.0 != x || state.cursor_pos.1 != y {
+                let mut msg_out = Message::new();
+                msg_out.set_cursor_position(CursorPosition {
+                    x,
+                    y,
+                    ..Default::default()
+                });
+                let exclude = {
+                    let now = get_time();
+                    let lock = LATEST_INPUT_CURSOR.lock().unwrap();
+                    if now - lock.time < 300 {
+                        lock.conn
+                    } else {
+                        0
+                    }
+                };
+                sp.send_without(msg_out, exclude);
+            }
         }
+        state.cursor_pos = (x, y);
     }
 
     sp.snapshot(|sps| {


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

Ignore intial cursor position when opt "show remote cursor" is on.
