### PR TITLE
Show alias if set, on remote tab

### DIFF
--- a/flutter/lib/common/shared_state.dart
+++ b/flutter/lib/common/shared_state.dart
@@ -201,3 +201,25 @@ class RemoteCountState {
 
   static RxInt find() => Get.find<RxInt>(tag: tag());
 }
+
+class PeerStringOption {
+  static String tag(String id, String opt) => 'peer_{$opt}_$id';
+
+  static void init(String id, String opt, String Function() init_getter) {
+    final key = tag(id, opt);
+    if (!Get.isRegistered(tag: key)) {
+      final RxString value = RxString(init_getter());
+      Get.put(value, tag: key);
+    }
+  }
+
+  static void delete(String id, String opt) {
+    final key = tag(id, opt);
+    if (Get.isRegistered(tag: key)) {
+      Get.delete(tag: key);
+    }
+  }
+
+  static RxString find(String id, String opt) =>
+      Get.find<RxString>(tag: tag(id, opt));
+}

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -584,7 +584,7 @@ abstract class BasePeerCard extends StatelessWidget {
       submit() async {
         isInProgress.value = true;
         name = controller.text;
-        await bind.mainSetPeerOption(id: id, key: 'alias', value: name);
+        await bind.mainSetPeerAlias(id: id, alias: name);
         if (isAddressBook) {
           gFFI.abModel.setPeerAlias(id, name);
           await gFFI.abModel.pushAb();

--- a/flutter/lib/desktop/pages/file_manager_tab_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_tab_page.dart
@@ -83,6 +83,7 @@ class _FileManagerTabPageState extends State<FileManagerTabPage> {
             controller: tabController,
             onWindowCloseButton: handleWindowCloseButton,
             tail: const AddButton().paddingOnly(left: 10),
+            labelGetter: DesktopTab.labelGetterAlias,
           )),
     );
     return Platform.isMacOS

--- a/flutter/lib/desktop/pages/port_forward_tab_page.dart
+++ b/flutter/lib/desktop/pages/port_forward_tab_page.dart
@@ -94,6 +94,7 @@ class _PortForwardTabPageState extends State<PortForwardTabPage> {
               return true;
             },
             tail: AddButton().paddingOnly(left: 10),
+            labelGetter: DesktopTab.labelGetterAlias,
           )),
     );
     return Platform.isMacOS

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -128,6 +128,7 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
             onWindowCloseButton: handleWindowCloseButton,
             tail: const AddButton().paddingOnly(left: 10),
             pageViewBuilder: (pageView) => pageView,
+            labelGetter: DesktopTab.labelGetterAlias,
             tabBuilder: (key, icon, label, themeConf) => Obx(() {
               final connectionType = ConnectionTypeState.find(key);
               if (!connectionType.isValid()) {

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart' hide TabBarTheme;
 import 'package:flutter_hbb/common.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/main.dart';
+import 'package:flutter_hbb/common/shared_state.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
 import 'package:get/get.dart';
@@ -250,6 +251,15 @@ class DesktopTab extends StatelessWidget {
     tabType = controller.tabType;
     isMainWindow =
         tabType == DesktopTabType.main || tabType == DesktopTabType.cm;
+  }
+
+  static RxString labelGetterAlias(String peerId) {
+    final opt = 'alias';
+    PeerStringOption.init(peerId, opt, () {
+      final alias = bind.mainGetPeerOptionSync(id: peerId, key: opt);
+      return alias.isEmpty ? peerId : alias;
+    });
+    return PeerStringOption.find(peerId, opt);
   }
 
   @override

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -15,6 +15,7 @@ import 'package:flutter_hbb/models/file_model.dart';
 import 'package:flutter_hbb/models/server_model.dart';
 import 'package:flutter_hbb/models/user_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
+import 'package:flutter_hbb/common/shared_state.dart';
 import 'package:flutter_hbb/utils/multi_window_manager.dart';
 import 'package:tuple/tuple.dart';
 import 'package:image/image.dart' as img2;
@@ -189,6 +190,8 @@ class FfiModel with ChangeNotifier {
             rustDeskWinManager.newRemoteDesktop(arg);
           });
         }
+      } else if (name == 'alias') {
+        handleAliasChanged(evt);
       }
     };
   }
@@ -196,6 +199,13 @@ class FfiModel with ChangeNotifier {
   /// Bind the event listener to receive events from the Rust core.
   updateEventListener(String peerId) {
     platformFFI.setEventCallback(startEventListener(peerId));
+  }
+
+  handleAliasChanged(Map<String, dynamic> evt) {
+    final rxAlias = PeerStringOption.find(evt['id'], 'alias');
+    if (rxAlias.value != evt['alias']) {
+      rxAlias.value = evt['alias'];
+    }
   }
 
   handleSwitchDisplay(Map<String, dynamic> evt) {
@@ -927,7 +937,7 @@ class CursorModel with ChangeNotifier {
       // my throw exception, because the listener maybe already dispose
       notifyListeners();
     } catch (e) {
-      debugPrint('notify cursor: $e');
+      debugPrint('WARNING: updateCursorId $id, without notifyListeners(). $e');
     }
   }
 
@@ -980,6 +990,9 @@ class CursorModel with ChangeNotifier {
       _hotx = tmp.item2;
       _hoty = tmp.item3;
       notifyListeners();
+    } else {
+      debugPrint(
+          'WARNING: updateCursorId $id, cache is ${_cache == null ? "null" : "not null"}. without notifyListeners()');
     }
   }
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -592,6 +592,11 @@ pub fn main_set_peer_option_sync(id: String, key: String, value: String) -> Sync
     SyncReturn(true)
 }
 
+pub fn main_set_peer_alias(id: String, alias: String) {
+    main_broadcast_message(&HashMap::from([("name", "alias"), ("id", &id), ("alias", &alias)]));
+    set_peer_option(id, "alias".to_owned(), alias)
+}
+
 pub fn main_forget_password(id: String) {
     forget_password(id)
 }


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

https://github.com/rustdesk/rustdesk/issues/2054

Remote tab title is changed when peer is renamed in main peer page.

Direct rename peer on remote window (edit on tab) is not supported for now.

