### PR TITLE
fix window border width whenn fullscreen

### DIFF
--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -116,12 +116,14 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
 
   @override
   Widget build(BuildContext context) {
-    final tabWidget = Container(
-      decoration: BoxDecoration(
+    final tabWidget = Obx(
+      () => Container(
+        decoration: BoxDecoration(
           border: Border.all(
               color: MyTheme.color(context).border!,
-              width: kWindowBorderWidth)),
-      child: Scaffold(
+              width: stateGlobal.windowBorderWidth.value),
+        ),
+        child: Scaffold(
           backgroundColor: Theme.of(context).backgroundColor,
           body: DesktopTab(
             controller: tabController,
@@ -182,7 +184,9 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
                 );
               }
             }),
-          )),
+          ),
+        ),
+      ),
     );
     return Platform.isMacOS
         ? tabWidget

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -593,7 +593,7 @@ class CanvasModel with ChangeNotifier {
     return parent.target?.ffiModel.display.height ?? defaultHeight;
   }
 
-  double get windowBorderWidth => stateGlobal.windowBorderWidth;
+  double get windowBorderWidth => stateGlobal.windowBorderWidth.value;
   double get tabBarHeight => stateGlobal.tabBarHeight;
 
   Size get size {

--- a/flutter/lib/models/state_model.dart
+++ b/flutter/lib/models/state_model.dart
@@ -8,14 +8,15 @@ class StateGlobal {
   bool _fullscreen = false;
   final RxBool _showTabBar = true.obs;
   final RxDouble _resizeEdgeSize = 8.0.obs;
+  final RxDouble _windowBorderWidth = RxDouble(kWindowBorderWidth);
   final RxBool showRemoteMenuBar = false.obs;
 
   int get windowId => _windowId;
   bool get fullscreen => _fullscreen;
   double get tabBarHeight => fullscreen ? 0 : kDesktopRemoteTabBarHeight;
-  double get windowBorderWidth => fullscreen ? 0 : kWindowBorderWidth;
   RxBool get showTabBar => _showTabBar;
   RxDouble get resizeEdgeSize => _resizeEdgeSize;
+  RxDouble get windowBorderWidth => _windowBorderWidth;
 
   setWindowId(int id) => _windowId = id;
   setFullscreen(bool v) {
@@ -24,6 +25,7 @@ class StateGlobal {
       _showTabBar.value = !_fullscreen;
       _resizeEdgeSize.value =
           fullscreen ? kFullScreenEdgeSize : kWindowEdgeSize;
+      _windowBorderWidth.value = fullscreen ? 0 : kWindowBorderWidth;
       WindowController.fromWindowId(windowId).setFullscreen(_fullscreen);
     }
   }


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

https://github.com/rustdesk/rustdesk/issues/2146
Set edge width to 0 when fullscreen.
But [bottom outline growing](https://github.com/rustdesk/rustdesk/issues/2146#issuecomment-1317078953) problem is not fixed.

