### PR TITLE
feat: add build date on about page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ rdev = { git = "https://github.com/asur4s/rdev" }
 url = { version = "2.1", features = ["serde"] }
 
 reqwest = { version = "0.11", features = ["blocking", "json", "rustls-tls"], default-features=false }
+chrono = "0.4.23"
 
 [target.'cfg(not(any(target_os = "android", target_os = "linux")))'.dependencies]
 cpal = "0.13.5"

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1029,10 +1029,12 @@ class _AboutState extends State<_About> {
     return _futureBuilder(future: () async {
       final license = await bind.mainGetLicense();
       final version = await bind.mainGetVersion();
-      return {'license': license, 'version': version};
+      final buildDate = await bind.mainGetBuildDate();
+      return {'license': license, 'version': version, 'buildDate': buildDate};
     }(), hasData: (data) {
       final license = data['license'].toString();
       final version = data['version'].toString();
+      final buildDate = data['buildDate'].toString();
       const linkStyle = TextStyle(decoration: TextDecoration.underline);
       final scrollController = ScrollController();
       return DesktopScrollWrapper(
@@ -1048,6 +1050,7 @@ class _AboutState extends State<_About> {
                     height: 8.0,
                   ),
                   Text('Version: $version').marginSymmetric(vertical: 4.0),
+                  Text('Build Date: $buildDate').marginSymmetric(vertical: 4.0),
                   InkWell(
                       onTap: () {
                         launchUrlString('https://rustdesk.com/privacy');

--- a/libs/hbb_common/src/lib.rs
+++ b/libs/hbb_common/src/lib.rs
@@ -161,19 +161,23 @@ pub fn get_version_from_url(url: &str) -> String {
 }
 
 pub fn gen_version() {
+    use std::io::prelude::*;
     let mut file = File::create("./src/version.rs").unwrap();
     for line in read_lines("Cargo.toml").unwrap() {
         if let Ok(line) = line {
             let ab: Vec<&str> = line.split("=").map(|x| x.trim()).collect();
             if ab.len() == 2 && ab[0] == "version" {
-                use std::io::prelude::*;
-                file.write_all(format!("pub const VERSION: &str = {};", ab[1]).as_bytes())
+                file.write_all(format!("pub const VERSION: &str = {};\n", ab[1]).as_bytes())
                     .ok();
-                file.sync_all().ok();
                 break;
             }
         }
     }
+    // generate build date
+    let build_date = format!("{}", chrono::Local::now().format("%Y-%m-%d %H:%M"));
+    file.write_all(format!("pub const BUILD_DATE: &str = \"{}\";", build_date).as_bytes())
+        .ok();
+    file.sync_all().ok();
 }
 
 fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1025,6 +1025,10 @@ pub fn main_get_icon() -> String {
     return String::new();
 }
 
+pub fn main_get_build_date() -> String {
+    crate::BUILD_DATE.to_string()
+}
+
 #[no_mangle]
 unsafe extern "C" fn translate(name: *const c_char, locale: *const c_char) -> *const c_char {
     let name = CStr::from_ptr(name);


### PR DESCRIPTION
This PR adds a build date to show on about page, so users/devs can know which version is excatly in use.

![image](https://user-images.githubusercontent.com/39793325/202397158-32b5a076-ccdb-4f38-ac0a-1ee18d987a1b.png)
