### PR TITLE
portable-service: enable quick support by rename as xxxqs.exe

### DIFF
--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-for-windows:
-    name: ${{ matrix.job.target }} (${{ matrix.job.os }}) ${{ matrix.job.suffix }}
+    name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false
@@ -23,8 +23,7 @@ jobs:
         job:
           # - { target: i686-pc-windows-msvc        , os: windows-2019                  }
           # - { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
-          - { target: x86_64-pc-windows-msvc      , os: windows-2019, suffix: ""   , extra-build-args: ""             }
-          - { target: x86_64-pc-windows-msvc      , os: windows-2019, suffix: "-qs", extra-build-args: "--quick_start" }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019 }
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
@@ -84,13 +83,13 @@ jobs:
         shell: bash
 
       - name: Build rustdesk
-        run: python3 .\build.py --portable --hwcodec --flutter ${{ matrix.job.extra-build-args }}
+        run: python3 .\build.py --portable --hwcodec --flutter
 
       - name: Rename rustdesk
         shell: bash
         run: |
           for name in rustdesk*??-install.exe; do
-              mv "$name" "${name%%-install.exe}-${{ matrix.job.target }}${{ matrix.job.suffix }}.exe"
+              mv "$name" "${name%%-install.exe}-${{ matrix.job.target }}.exe"
           done
 
       - name: Publish Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ flutter = ["flutter_rust_bridge"]
 default = ["use_dasp"]
 hwcodec = ["scrap/hwcodec"]
 mediacodec = ["scrap/mediacodec"]
-quick_start = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/build.py
+++ b/build.py
@@ -82,11 +82,6 @@ def make_parser():
         help='Build windows portable'
     )
     parser.add_argument(
-        '--quick_start',
-        action='store_true',
-        help='Windows quick start portable'
-    )
-    parser.add_argument(
         '--flatpak',
         action='store_true',
         help='Build rustdesk libs with the flatpak feature enabled'
@@ -194,8 +189,6 @@ def get_features(args):
     features = ['inline']
     if windows:
         features.extend(get_rc_features(args))
-        if args.quick_start:
-            features.append('quick_start')
     if args.hwcodec:
         features.append('hwcodec')
     if args.flutter:

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -90,10 +90,13 @@ class _ConnectionPageState extends State<ConnectionPage>
         Get.forceAppUpdate();
       }
       isWindowMinisized = false;
-    } else if (eventName == 'close') {
-      // called more then one time
-      bind.mainOnMainWindowClose();
     }
+  }
+
+  @override
+  void onWindowClose() {
+    super.onWindowClose();
+    bind.mainOnMainWindowClose();
   }
 
   @override

--- a/libs/portable/src/main.rs
+++ b/libs/portable/src/main.rs
@@ -64,6 +64,7 @@ fn main() {
         i += 1;
     }
     let click_setup = args.is_empty() && arg_exe.to_lowercase().ends_with("install.exe");
+    let quick_support = args.is_empty() && arg_exe.to_lowercase().ends_with("qs.exe");
 
     let reader = BinaryReader::default();
     if let Some(exe) = setup(
@@ -72,7 +73,9 @@ fn main() {
         click_setup || args.contains(&"--silent-install".to_owned()),
     ) {
         if click_setup {
-            args = vec!["--install".to_owned()]
+            args = vec!["--install".to_owned()];
+        } else if quick_support {
+            args = vec!["--quick_support".to_owned()];
         }
         execute(exe, args);
     }

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1178,6 +1178,7 @@ pub fn main_account_auth_result() -> String {
 }
 
 pub fn main_on_main_window_close() {
+    // may called more than one times
     #[cfg(windows)]
     crate::portable_service::client::drop_portable_service_shared_memory();
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,7 +15,7 @@ use hbb_common::{
     protobuf::Message as _,
     rendezvous_proto::*,
     tcp::FramedStream,
-    tokio::{self, sync::mpsc},
+    tokio,
 };
 
 use crate::common::get_app_name;
@@ -43,23 +43,6 @@ lazy_static::lazy_static! {
 }
 
 struct UIHostHandler;
-
-// to-do: dead code?
-fn check_connect_status(
-    reconnect: bool,
-) -> (
-    Arc<Mutex<Status>>,
-    Arc<Mutex<HashMap<String, String>>>,
-    mpsc::UnboundedSender<ipc::Data>,
-    Arc<Mutex<String>>,
-) {
-    let status = Arc::new(Mutex::new((0, false, 0, "".to_owned())));
-    let options = Arc::new(Mutex::new(Config::get_options()));
-    let (tx, rx) = mpsc::unbounded_channel::<ipc::Data>();
-    let password = Arc::new(Mutex::new(String::default()));
-    std::thread::spawn(move || crate::ui_interface::check_connect_status_(reconnect, rx));
-    (status, options, tx, password)
-}
 
 pub fn start(args: &mut [String]) {
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
When the suffix is ​​`qs.exe`, eg: rustdesk-1.2.0-win7-install-qs.exe, it will request elevation and run the portable service at startup.
The old ci exe can be removed.