### PR TITLE
approve mode

### DIFF
--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -84,7 +84,6 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
       if (call.method == "new_remote_desktop") {
         final args = jsonDecode(call.arguments);
         final id = args['id'];
-        ConnectionTypeState.init(id);
         window_on_top(windowId());
         ConnectionTypeState.init(id);
         tabController.add(TabInfo(

--- a/flutter/lib/desktop/pages/server_page.dart
+++ b/flutter/lib/desktop/pages/server_page.dart
@@ -555,11 +555,12 @@ class _CmControlPanel extends StatelessWidget {
     final bool canElevate = bind.cmCanElevate();
     final model = Provider.of<ServerModel>(context);
     final showElevation = canElevate && model.showElevation;
+    final showAccept = model.approveMode != 'password';
     return Column(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
         Offstage(
-          offstage: !showElevation,
+          offstage: !showElevation || !showAccept,
           child: buildButton(context, color: Colors.green[700], onClick: () {
             handleAccept(context);
             handleElevate(context);
@@ -575,11 +576,17 @@ class _CmControlPanel extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Expanded(
-                child: buildButton(context, color: MyTheme.accent, onClick: () {
-              handleAccept(context);
-              windowManager.minimize();
-            }, text: 'Accept', textColor: Colors.white)),
+            if (showAccept)
+              Expanded(
+                child: Column(
+                  children: [
+                    buildButton(context, color: MyTheme.accent, onClick: () {
+                      handleAccept(context);
+                      windowManager.minimize();
+                    }, text: 'Accept', textColor: Colors.white),
+                  ],
+                ),
+              ),
             Expanded(
                 child: buildButton(context,
                     color: Colors.transparent,
@@ -621,7 +628,7 @@ class _CmControlPanel extends StatelessWidget {
       );
     }
     return Container(
-      height: 35,
+      height: 30,
       decoration: BoxDecoration(
           color: color, borderRadius: BorderRadius.circular(4), border: border),
       child: InkWell(

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -255,6 +255,9 @@ class FfiModel with ChangeNotifier {
     } else if (type == 'restarting') {
       showMsgBox(id, type, title, text, link, false, dialogManager,
           hasCancel: false);
+    } else if (type == 'wait-remote-accept-nook') {
+      msgBoxCommon(dialogManager, title, Text(translate(text)),
+          [msgBoxButton("Cancel", closeConnection)]);
     } else {
       var hasRetry = evt['hasRetry'] == 'true';
       showMsgBox(id, type, title, text, link, hasRetry, dialogManager);

--- a/src/client.rs
+++ b/src/client.rs
@@ -1337,6 +1337,15 @@ impl LoginConfigHandler {
             self.password = Default::default();
             interface.msgbox("re-input-password", err, "Do you want to enter again?", "");
             true
+        } else if err == "No Password Access" {
+            self.password = Default::default();
+            interface.msgbox(
+                "wait-remote-accept-nook",
+                "Prompt",
+                "Please wait for the remote side to accept your session request...",
+                "",
+            );
+            true
         } else {
             if err.contains(SCRAP_X11_REQUIRED) {
                 interface.msgbox("error", "Login Error", err, SCRAP_X11_REF_URL);
@@ -1434,11 +1443,7 @@ impl LoginConfigHandler {
             username: self.id.clone(),
             password: password.into(),
             my_id,
-            my_name: if cfg!(windows) {
-                crate::platform::get_active_username()
-            } else {
-                crate::username()
-            },
+            my_name: crate::username(),
             option: self.get_option_message(true).into(),
             session_id: self.session_id,
             version: crate::VERSION.to_string(),

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -226,6 +226,7 @@ pub fn core_main() -> Option<Vec<String>> {
             // meanwhile, return true to call flutter window to show control panel
             #[cfg(feature = "flutter")]
             crate::flutter::connection_manager::start_listen_ipc_thread();
+            crate::ui_interface::start_option_status_sync();
         }
     }
     //_async_logger_holder.map(|x| x.flush());

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -562,7 +562,7 @@ pub fn main_get_connect_status() -> String {
 
 pub fn main_check_connect_status() {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    check_mouse_time(); // avoid multi calls
+    start_option_status_sync(); // avoid multi calls
 }
 
 pub fn main_is_using_public_server() -> bool {

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -389,5 +389,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("This PC", "Aquest PC"),
         ("or", "o"),
         ("Continue with", "Continuar amb"),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", "使用"),
         ("Elevate", "提权"),
         ("Zoom cursor", "缩放鼠标"),
+        ("Accept sessions via password", "只允许密码访问"),
+        ("Accept sessions via click", "只允许点击访问"),
+        ("Accept sessions via both", "允许密码或点击访问"),
+        ("Please wait for the remote side to accept your session request...", "请等待对方接受你的连接..."),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", "Continuar con"),
         ("Elevate", "Elevar"),
         ("Zoom cursor", "Ampliar cursor"),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -389,5 +389,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("or", "یا"),
         ("Continue with", "ادامه با"),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", "Continuer avec"),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", "Folytatás a következővel"),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", "Continua con"),
         ("Elevate", "Eleva"),
         ("Zoom cursor", "Cursore zoom"),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", "Kontynuuj z"),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", "Continuar com"),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", "Продолжить с"),
         ("Elevate", "Повысить"),
         ("Zoom cursor", "Масштабировать курсор"),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", "bununla devam et"),
         ("Elevate", "Yükseltme"),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", "提權"),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", "只允許密碼訪問"),
+        ("Accept sessions via click", "只允許點擊訪問"),
+        ("Accept sessions via both", "允許密碼或點擊訪問"),
+        ("Please wait for the remote side to accept your session request...", "請等待對方接受你的連接..."),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -390,5 +390,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue with", ""),
         ("Elevate", ""),
         ("Zoom cursor", ""),
+        ("Accept sessions via password", ""),
+        ("Accept sessions via click", ""),
+        ("Accept sessions via both", ""),
+        ("Please wait for the remote side to accept your session request...", ""),
     ].iter().cloned().collect();
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1046,6 +1046,14 @@ impl Connection {
             }
             if !crate::is_ip(&lr.username) && lr.username != Config::get_id() {
                 self.send_login_error("Offline").await;
+            } else if Config::get_option("approve-mode") == "click" {
+                self.try_start_cm(lr.my_id, lr.my_name, false);
+                if hbb_common::get_version_number(&lr.version)
+                    >= hbb_common::get_version_number("1.2.0")
+                {
+                    self.send_login_error("No Password Access").await;
+                }
+                return true;
             } else if self.is_of_recent_session() {
                 self.try_start_cm(lr.my_id, lr.my_name, true);
                 self.send_logon_response().await;

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -135,6 +135,10 @@ impl SciterConnectionManager {
     fn elevate_portable(&self, id: i32) {
         crate::ui_cm_interface::elevate_portable(id);
     }
+
+    fn get_option(&self, key: String) -> String {
+        crate::ui_interface::get_option(key)
+    }
 }
 
 impl sciter::EventHandler for SciterConnectionManager {
@@ -155,5 +159,6 @@ impl sciter::EventHandler for SciterConnectionManager {
         fn send_msg(i32, String);
         fn can_elevate();
         fn elevate_portable(i32);
+        fn get_option(String);
     }
 }

--- a/src/ui/cm.tis
+++ b/src/ui/cm.tis
@@ -30,6 +30,7 @@ class Body: Reactor.Component
         var right_style = show_chat ? "" : "display: none";
         var disconnected = c.disconnected;
         var show_elevation_btn = handler.can_elevate() && show_elevation;
+        var show_accept_btn = handler.get_option('approve-mode') != 'password';
        // below size:* is work around for Linux, it alreayd set in css, but not work, shit sciter
         return <div .content style="size:*">
             <div .left-panel>
@@ -58,16 +59,15 @@ class Body: Reactor.Component
                 {c.port_forward ? <div>Port Forwarding: {c.port_forward}</div> : ""}
                 <div style="size:*"/>
                 <div .outer_buttons>
-                    {!auth && !disconnected && show_elevation_btn ? <button #elevate_accept .control .elevate .button><span><span><span>{svg_elevate}</span><span>{translate('Accept')}</span></span></span></button> : "" }
+                    {!auth && !disconnected && show_elevation_btn && show_accept_btn ? <button #elevate_accept .control .elevate .button><span><span><span>{svg_elevate}</span><span>{translate('Accept')}</span></span></span></button> : "" }
                     {auth && !disconnected && show_elevation_btn ? <button #elevate .control .elevate .button><span><span><span>{svg_elevate}</span><span>{translate('Elevate')}</span></span></span></button> : "" }
                     <div .inner_buttons style={auth ? "display:none;":""}>
-                        {!auth ? <button #accept .control .button>{translate('Accept')}</button> : "" }
+                        {!auth && show_accept_btn ? <button #accept .control .button>{translate('Accept')}</button> : "" }
                         {!auth ? <button #dismiss .control .outline>{translate('Dismiss')}</button> : "" }
                     </div>
                     {auth && !disconnected ? <button #disconnect .control .button>{translate('Disconnect')}</button> : "" }
                     {auth && disconnected ? <button #close .control .button>{translate('Close')}</button> : "" }
                 </div>
-                <div style={!show_elevation_btn ? "height:1 em;" : "display:none;"}></div>
                 {c.is_file_transfer || c.port_forward ? "" : <div .chaticon>{svg_chat}</div>}
             </div>
             <div .right-panel style={right_style}>
@@ -452,6 +452,21 @@ function getElaspsed(time, now) {
     }
     return out;
 }
+
+var ui_status_cache = [""];
+function check_update_ui() {
+    self.timer(1s, function() {
+        var approve_mode = handler.get_option('approve-mode');
+        var changed = false;
+        if (ui_status_cache[0] != approve_mode) {
+            ui_status_cache[0] = approve_mode;
+            changed = true;
+        }
+        if (changed) update();
+        check_update_ui();
+    });                          
+}
+check_update_ui();
 
 function updateTime() {
     self.timer(1s, function() {

--- a/src/ui/common.tis
+++ b/src/ui/common.tis
@@ -264,6 +264,13 @@ function msgbox(type, title, content, link="", callback=null, height=180, width=
         };
     } else if (type.indexOf("custom") < 0 && !is_port_forward && !callback) {
         callback = function() { view.close(); }
+    } else if (type == 'wait-remote-accept-nook') {
+        callback = function (res) {
+            if (!res) {
+                view.close();
+                return;
+            }
+        };
     }
     last_msgbox_tag = type + "-" + title + "-" + content + "-" + link;
     $(#msgbox).content(<MsgboxComponent width={width} height={height} auto_login={auto_login} type={type} title={title} content={content} link={link} remember={remember} callback={callback} contentStyle={contentStyle} hasRetry={hasRetry} />);

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -824,7 +824,8 @@ function watch_screen_recording() {
 class PasswordEyeArea : Reactor.Component {
     render() {
         var method = handler.get_option('verification-method');
-        var value = method != 'use-permanent-password' ? password_cache[0] : "-";
+        var mode= handler.get_option('approve-mode');
+        var value = mode == 'click' ||  method == 'use-permanent-password' ? "-" : password_cache[0];
         return
             <div .eye-area style="width: *">
                 <input|text @{this.input} readonly value={value} />
@@ -901,27 +902,46 @@ class PasswordArea: Reactor.Component {
 
     function renderPop() {
         var method = handler.get_option('verification-method');
+        var approve_mode= handler.get_option('approve-mode');
+        var show_password = approve_mode != 'click';
         return <popup><menu.context #edit-password-context>
-            <li #use-temporary-password><span>{svg_checkmark}</span>{translate('Use temporary password')}</li>
-            <li #use-permanent-password><span>{svg_checkmark}</span>{translate('Use permanent password')}</li>
-            <li #use-both-passwords><span>{svg_checkmark}</span>{translate('Use both passwords')}</li>
-            <div .separator />
-            <li #set-password  disabled={ method == 'use-temporary-password' ? "true" : "false" }>{translate('Set permanent password')}</li>
-            <TemporaryPasswordLengthMenu />
+            <li #approve-mode-password><span>{svg_checkmark}</span>{translate('Accept sessions via password')}</li>
+            <li #approve-mode-click><span>{svg_checkmark}</span>{translate('Accept sessions via click')}</li>
+            <li #approve-mode-both><span>{svg_checkmark}</span>{translate('Accept sessions via both')}</li>
+            { !show_password ? '' : <div .separator /> }
+            { !show_password ? '' : <li #use-temporary-password><span>{svg_checkmark}</span>{translate('Use temporary password')}</li> }
+            { !show_password ? '' : <li #use-permanent-password><span>{svg_checkmark}</span>{translate('Use permanent password')}</li> }
+            { !show_password ? '' : <li #use-both-passwords><span>{svg_checkmark}</span>{translate('Use both passwords')}</li> }
+            { !show_password ? '' : <div .separator /> }
+            { !show_password ? '' : <li #set-password  disabled={ method == 'use-temporary-password' ? "true" : "false" }>{translate('Set permanent password')}</li> }
+            { !show_password ? '' : <TemporaryPasswordLengthMenu /> }
         </menu></popup>;
     }
 
     function toggleMenuState() {
-        var id = handler.get_option('verification-method');
-        if (id != 'use-temporary-password' && id != 'use-permanent-password')
-            id = 'use-both-passwords';
-        for (var el in [this.$(li#use-temporary-password), this.$(li#use-permanent-password), this.$(li#use-both-passwords)]) {
-            el.attributes.toggleClass("selected", el.id == id);
+         var mode= handler.get_option('approve-mode');
+        var mode_id;
+        if (mode == 'password')
+            mode_id = 'approve-mode-password';
+        else if (mode == 'click')
+            mode_id = 'approve-mode-click';
+        else
+            mode_id = 'approve-mode-both';
+        var pwd_id = handler.get_option('verification-method');
+        if (pwd_id != 'use-temporary-password' && pwd_id != 'use-permanent-password')
+            pwd_id = 'use-both-passwords';
+        for (var el in this.$$(menu#edit-password-context>li)) {
+            if (el.id.indexOf("approve-mode-") == 0)
+                el.attributes.toggleClass("selected", el.id == mode_id);
+            if (el.id.indexOf("use-") == 0)
+                el.attributes.toggleClass("selected", el.id == pwd_id);
         }
     }
 
     event click $(svg#edit) (_, me) {
-        temporaryPasswordLengthMenu.update({show: true });
+        var approve_mode= handler.get_option('approve-mode');
+        var show_password = approve_mode != 'click';
+        if(show_password && temporaryPasswordLengthMenu) temporaryPasswordLengthMenu.update({show: true });
         var menu = $(menu#edit-password-context);        
         me.popup(menu);
     }
@@ -954,16 +974,28 @@ class PasswordArea: Reactor.Component {
             handler.set_option('verification-method', me.id);
             this.toggleMenuState();
             passwordArea.update();
+        } else if (me.id.indexOf('approve-mode') == 0) {
+            var approve_mode;
+            if (me.id == 'approve-mode-password')
+                approve_mode = 'password';
+            else if (me.id == 'approve-mode-click')
+                approve_mode = 'click';
+            else
+                approve_mode = '';
+            handler.set_option('approve-mode', approve_mode);
+            this.toggleMenuState();
+            passwordArea.update();
         }
     }
 }
 
-var password_cache = ["","",""];
+var password_cache = ["","","",""];
 function updatePasswordArea() {
     self.timer(1s, function() {
         var temporary_password = handler.temporary_password();
         var verification_method = handler.get_option('verification-method');
         var temporary_password_length = handler.get_option('temporary-password-length');
+        var approve_mode = handler.get_option('approve-mode');
         var update = false;
         if (password_cache[0] != temporary_password) {
             password_cache[0] = temporary_password;
@@ -975,6 +1007,10 @@ function updatePasswordArea() {
         }
         if (password_cache[2] != temporary_password_length) {
             password_cache[2] = temporary_password_length;
+            update = true;
+        }
+        if (password_cache[3] != approve_mode) {
+            password_cache[3] = approve_mode;
             update = true;
         }
         if (update) passwordArea.update();

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -874,7 +874,12 @@ pub fn check_zombie(children: Children) {
     }
 }
 
-pub(crate) fn check_connect_status(reconnect: bool) -> mpsc::UnboundedSender<ipc::Data> {
+pub fn start_option_status_sync() {
+    let _sender = SENDER.lock().unwrap();
+}
+
+// not call directly
+fn check_connect_status(reconnect: bool) -> mpsc::UnboundedSender<ipc::Data> {
     let (tx, rx) = mpsc::unbounded_channel::<ipc::Data>();
     std::thread::spawn(move || check_connect_status_(reconnect, rx));
     tx
@@ -898,7 +903,7 @@ pub fn account_auth_result() -> String {
 // notice: avoiding create ipc connecton repeatly,
 // because windows named pipe has serious memory leak issue.
 #[tokio::main(flavor = "current_thread")]
-pub(crate) async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc::Data>) {
+async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc::Data>) {
     let mut key_confirmed = false;
     let mut rx = rx;
     let mut mouse_time = 0;


### PR DESCRIPTION
#1869 
There is there mode: 
1. click accept only
2. password only
3. both

note:
1. If 1.1.9 connect to 1.2.0, 1.2.0 is click accpet only, the password box will still be displayed first, then it will show logining in until click.
2. For compatibility, 1.2.0 still pops up password inputbox If password is not remembered. Sometimes password inputbox override wait-remote-accept messagebox when response is very quick, eg when debug. After entering the password, waiting prompt will show again.