### PR TITLE
fix: flatpak x86_64 artifact name

### DIFF
--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -1133,12 +1133,12 @@ jobs:
   build-flatpak-amd64:
     name: Build Flatpak
     needs: [build-rustdesk-linux-amd64]
-    runs-on: ${{ matrix.job.os }}
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         job:
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, arch: x86_64 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-18.04, arch: x86_64 }
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR provide a quick fix for downloading artifact to build flatpak on x86_64.

Note:
We build all artifacts on qemu ubuntu18.04. So `os` in matrix job is just for naming artifacts now. And the reason why we use ubuntu-20.04 host is for a better performance with prebuilt qemu 3.x. In the prior step,  we use ubuntu-18.04 for naming, so flatpak should be configured too.