### PR TITLE
Added new public server information

### DIFF
--- a/docs/README-DE.md
+++ b/docs/README-DE.md
@@ -25,11 +25,11 @@ Hier sind die Server, die du kostenlos nutzen kannst, es kann sein das sich dies
 
 | Standort  | Serverart     | Spezifikationen    | Kommentare |
 | --------- | ------------- | ------------------ | ---------- |
-| Seoul     | AWS lightsail | 1 VCPU / 0.5GB RAM |            |
-| Singapore | Vultr         | 1 VCPU / 1GB RAM   |            |
-| Dallas    | Vultr         | 1 VCPU / 1GB RAM   |            |
-| Germany   | Codext        | 2 VCPU / 4GB RAM   |
-| Germany   | Hetzner       | 4 VCPU / 8GB RAM   |
+| Seoul     | AWS lightsail | 1 vCPU / 0.5GB RAM |            |
+| Germany   | Codext        | 2 vCPU / 4GB RAM   |
+| Germany   | Hetzner       | 4 vCPU / 8GB RAM   |
+| Finland (Helsinki) | 0x101 Cyber Security | 4 vCPU / 8GB RAM |
+| USA (Ashburn) | 0x101 Cyber Security | 4 vCPU / 8GB RAM |
 
 ## Abhängigkeiten
 


### PR DESCRIPTION
New public servers added. Vultr removed (https://twitter.com/rustdesk/status/1595597511980470272)

https://github.com/rustdesk/rustdesk/discussions/1657

Corrected VCPU to vCPU

@danielehrhardt I think there might be wrong information regarding your server specs. At least the information provided in other readme files are different. You might want to correct that.t.