### PR TITLE
Added new public server information

### DIFF
--- a/docs/README-PL.md
+++ b/docs/README-PL.md
@@ -24,11 +24,11 @@ RustDesk zaprasza do współpracy każdego. Zobacz [`docs/CONTRIBUTING.md`](CONT
 Poniżej znajdują się serwery, z których można korzystać za darmo, może się to zmienić z upływem czasu. Jeśli nie znajdujesz się w pobliżu jednego z nich, Twoja prędkość połączenia może być niska.
 | Lokalizacja | Dostawca | Specyfikacja |
 | --------- | ------------- | ------------------ |
-| Seul | AWS lightsail | 1 VCPU / 0.5GB RAM |
-| Singapur | Vultr | 1 VCPU / 1GB RAM |
-| Dallas | Vultr | 1 VCPU / 1GB RAM |
-| Germany | Hetzner | 2 VCPU / 4GB RAM |
-| Germany | Codext | 4 VCPU / 8GB RAM |
+| Seul | AWS lightsail | vCPU / 0.5GB RAM |
+| Germany | Hetzner | 2 vCPU / 4GB RAM |
+| Germany | Codext | 4 vCPU / 8GB RAM |
+| Finland (Helsinki) | 0x101 Cyber Security | 4 vCPU / 8GB RAM |
+| USA (Ashburn) | 0x101 Cyber Security | 4 vCPU / 8GB RAM |
 
 ## Zależności
 


### PR DESCRIPTION
New public servers added. Vultr removed (https://twitter.com/rustdesk/status/1595597511980470272)

https://github.com/rustdesk/rustdesk/discussions/1657

Corrected VCPU to vCPU