### PR TITLE
Update remote_menubar.dart

### DIFF
--- a/flutter/lib/desktop/widgets/remote_menubar.dart
+++ b/flutter/lib/desktop/widgets/remote_menubar.dart
@@ -498,7 +498,7 @@ class _RemoteMenubarState extends State<RemoteMenubar> {
 
   Widget _buildClose(BuildContext context) {
     return IconButton(
-      tooltip: translate('Close'),
+      tooltip: translate('Close connection'),
       onPressed: () {
         clientClose(widget.id, widget.ffi.dialogManager);
       },


### PR DESCRIPTION
Change 'Close' to 'Close connection' due to conflicts with 'Close' in context of close window.
