### PR TITLE
feat: Added support for ipv4 network conversion under nat64 network

### DIFF
--- a/libs/hbb_common/src/socket_client.rs
+++ b/libs/hbb_common/src/socket_client.rs
@@ -3,6 +3,7 @@ use crate::{
     tcp::FramedStream,
     udp::FramedSocket,
     ResultType,
+    is_nat64_ipv4
 };
 use anyhow::Context;
 use std::net::SocketAddr;
@@ -12,7 +13,7 @@ use tokio_socks::{IntoTargetAddr, TargetAddr};
 fn to_socket_addr(host: &str) -> ResultType<SocketAddr> {
     use std::net::ToSocketAddrs;
     host.to_socket_addrs()?
-        .filter(|x| x.is_ipv4())
+        .filter(|x| x.is_ipv4() || is_nat64_ipv4(x))
         .next()
         .context("Failed to solve")
 }
@@ -63,7 +64,7 @@ pub async fn connect_tcp<'t, T: IntoTargetAddr<'t>>(
         .await
     } else {
         let addr = std::net::ToSocketAddrs::to_socket_addrs(&target_addr)?
-            .filter(|x| x.is_ipv4())
+            .filter(|x| x.is_ipv4() || is_nat64_ipv4(x))
             .next()
             .context("Invalid target addr, no valid ipv4 address can be resolved.")?;
         Ok(FramedStream::new(addr, local, ms_timeout).await?)

--- a/libs/hbb_common/src/udp.rs
+++ b/libs/hbb_common/src/udp.rs
@@ -1,4 +1,4 @@
-use crate::{bail, ResultType};
+use crate::{bail, ResultType, is_nat64_ipv4};
 use anyhow::anyhow;
 use bytes::{Bytes, BytesMut};
 use futures::{SinkExt, StreamExt};
@@ -49,7 +49,7 @@ impl FramedSocket {
 
     #[allow(clippy::never_loop)]
     pub async fn new_reuse<T: std::net::ToSocketAddrs>(addr: T) -> ResultType<Self> {
-        for addr in addr.to_socket_addrs()?.filter(|x| x.is_ipv4()) {
+        for addr in addr.to_socket_addrs()?.filter(|x| x.is_ipv4() || is_nat64_ipv4(x)) {
             let socket = new_socket(addr, true, 0)?.into_udp_socket();
             return Ok(Self::Direct(UdpFramed::new(
                 UdpSocket::from_std(socket)?,
@@ -63,7 +63,7 @@ impl FramedSocket {
         addr: T,
         buf_size: usize,
     ) -> ResultType<Self> {
-        for addr in addr.to_socket_addrs()?.filter(|x| x.is_ipv4()) {
+        for addr in addr.to_socket_addrs()?.filter(|x| x.is_ipv4() || is_nat64_ipv4(x)) {
             return Ok(Self::Direct(UdpFramed::new(
                 UdpSocket::from_std(new_socket(addr, false, buf_size)?.into_udp_socket())?,
                 BytesCodec::new(),

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -340,8 +340,8 @@ impl RendezvousMediator {
         let relay_server = self.get_relay_server(fla.relay_server);
         msg_out.set_local_addr(LocalAddr {
             id: Config::get_id(),
-            socket_addr: AddrMangle::encode(peer_addr).into(),
-            local_addr: AddrMangle::encode(local_addr).into(),
+            socket_addr: AddrMangle::encode(1, peer_addr).into(),
+            local_addr: AddrMangle::encode(1, local_addr).into(),
             relay_server,
             version: crate::VERSION.to_owned(),
             ..Default::default()


### PR DESCRIPTION
When filtering the address, judge whether the address belonging to ipv6 has a special prefix of nat64 to avoid filtering out the ipv4 address under nat64