### PR TITLE
feat: add windows sign config

### DIFF
--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -88,12 +88,41 @@ jobs:
       - name: Build rustdesk
         run: python3 .\build.py --portable --hwcodec --flutter
 
-      - name: Rename rustdesk
+      - name: Sign rustdesk files
+        uses: DanaBear/code-sign-action@v4
+        with:
+          certificate: '${{ secrets.WINDOWS_PFX_BASE64 }}'
+          password: '${{ secrets.WINDOWS_PFX_PASSWORD }}'
+          certificatesha1: '${{ secrets.WINDOWS_PFX_SHA1_THUMBPRINT }}'
+          # certificatename: '${{ secrets.CERTNAME }}'
+          folder: './flutter/build/windows/runner/Release/'
+          recursive: true
+
+      - name: Build self-extracted executable
         shell: bash
         run: |
-          for name in rustdesk*??-install.exe; do
-              mv "$name" "${name%%-install.exe}-${{ matrix.job.target }}.exe"
-          done
+          pushd ./libs/portable
+          python3 ./generate.py -f ../../flutter/build/windows/runner/Release/ -o . -e ../../flutter/build/windows/runner/Release/
+          popd
+          mkdir -p ./SignOutput
+          mv ./target/release/rustdesk-portable-packer.exe ./SignOutput/rustdesk-${{ env.VERSION }}-${{ matrix.job.target }}.exe
+
+      # - name: Rename rustdesk
+      #   shell: bash
+      #   run: |
+      #     for name in rustdesk*??-install.exe; do
+      #         mv "$name" ./SignOutput/"${name%%-install.exe}-${{ matrix.job.target }}.exe"
+      #     done
+
+      - name: Sign rustdesk self-extracted file
+        uses: DanaBear/code-sign-action@v4
+        with:
+          certificate: '${{ secrets.WINDOWS_PFX_BASE64 }}'
+          password: '${{ secrets.WINDOWS_PFX_PASSWORD }}'
+          certificatesha1: '${{ secrets.WINDOWS_PFX_SHA1_THUMBPRINT }}'
+          # certificatename: '${{ secrets.WINDOWS_PFX_NAME }}'
+          folder: './SignOutput'
+          recursive: false
 
       - name: Publish Release
         uses: softprops/action-gh-release@v1
@@ -101,7 +130,7 @@ jobs:
           prerelease: true
           tag_name: ${{ env.TAG_NAME }}
           files: |
-            rustdesk-*.exe
+            ./SignOutput/rustdesk-*.exe
 
   build-for-macOS:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }}) [${{ matrix.job.extra-build-args }}]

--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
 
       - name: Replace engine with rustdesk custom flutter engine
         run: |
@@ -157,6 +158,7 @@ jobs:
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -90,7 +90,7 @@ jobs:
         run: python3 .\build.py --portable --hwcodec --flutter
 
       - name: Sign rustdesk files
-        uses: DanaBear/code-sign-action@v4
+        uses: GermanBluefox/code-sign-action@v7
         with:
           certificate: '${{ secrets.WINDOWS_PFX_BASE64 }}'
           password: '${{ secrets.WINDOWS_PFX_PASSWORD }}'
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         run: |
           pushd ./libs/portable
-          python3 ./generate.py -f ../../flutter/build/windows/runner/Release/ -o . -e ../../flutter/build/windows/runner/Release/
+          python3 ./generate.py -f ../../flutter/build/windows/runner/Release/ -o . -e ../../flutter/build/windows/runner/Release/rustdesk.exe
           popd
           mkdir -p ./SignOutput
           mv ./target/release/rustdesk-portable-packer.exe ./SignOutput/rustdesk-${{ env.VERSION }}-${{ matrix.job.target }}.exe
@@ -116,7 +116,7 @@ jobs:
       #     done
 
       - name: Sign rustdesk self-extracted file
-        uses: DanaBear/code-sign-action@v4
+        uses: GermanBluefox/code-sign-action@v7
         with:
           certificate: '${{ secrets.WINDOWS_PFX_BASE64 }}'
           password: '${{ secrets.WINDOWS_PFX_PASSWORD }}'


### PR DESCRIPTION
This PR adds a sign config for windows.

The following secrets must be set:

- WINDOWS_PFX_BASE64 
    -  via `certutil -encode .\CERT.pfx .\CERT.base64.txt`, copy base64 code **WITHOUT** `===begin xxx ===` and `===end xxx===`
- WINDOWS_PFX_PASSWORD 
- WINDOWS_PFX_SHA1_THUMBPRINT
    - via `Get-PfxCertificate -FilePath .\CERT.pfx` in powershell.