### PR TITLE
Fix file transfer bugs

### DIFF
--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -93,6 +93,7 @@ class _FileManagerPageState extends State<FileManagerPage>
       Wakelock.enable();
     }
     debugPrint("File manager page init success with id ${widget.id}");
+    model.onDirChanged = breadCrumbScrollToEnd;
     // register location listener
     _locationNodeLocal.addListener(onLocalLocationFocusChanged);
     _locationNodeRemote.addListener(onRemoteLocationFocusChanged);
@@ -100,17 +101,18 @@ class _FileManagerPageState extends State<FileManagerPage>
 
   @override
   void dispose() {
-    model.onClose();
-    _ffi.close();
-    _ffi.dialogManager.dismissAll();
-    if (!Platform.isLinux) {
-      Wakelock.disable();
-    }
-    Get.delete<FFI>(tag: 'ft_${widget.id}');
-    _locationNodeLocal.removeListener(onLocalLocationFocusChanged);
-    _locationNodeRemote.removeListener(onRemoteLocationFocusChanged);
-    _locationNodeLocal.dispose();
-    _locationNodeRemote.dispose();
+    model.onClose().whenComplete(() {
+      _ffi.close();
+      _ffi.dialogManager.dismissAll();
+      if (!Platform.isLinux) {
+        Wakelock.disable();
+      }
+      Get.delete<FFI>(tag: 'ft_${widget.id}');
+      _locationNodeLocal.removeListener(onLocalLocationFocusChanged);
+      _locationNodeRemote.removeListener(onRemoteLocationFocusChanged);
+      _locationNodeLocal.dispose();
+      _locationNodeRemote.dispose();
+    });
     super.dispose();
   }
 
@@ -636,7 +638,6 @@ class _FileManagerPageState extends State<FileManagerPage>
             }),
             IconButton(
                 onPressed: () {
-                  breadCrumbScrollToEnd(isLocal);
                   model.refresh(isLocal: isLocal);
                 },
                 splashRadius: kDesktopIconButtonSplashRadius,
@@ -999,9 +1000,7 @@ class _FileManagerPageState extends State<FileManagerPage>
   }
 
   openDirectory(String path, {bool isLocal = false}) {
-    model.openDirectory(path, isLocal: isLocal).then((_) {
-      breadCrumbScrollToEnd(isLocal);
-    });
+    model.openDirectory(path, isLocal: isLocal);
   }
 
   void handleDragDone(DropDoneDetails details, bool isLocal) {

--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -825,7 +825,7 @@ class _FileManagerPageState extends State<FileManagerPage>
                     final x = offset.dx;
                     final y = offset.dy + size.height + 1;
 
-                    final isPeerWindows = isWindows(isLocal);
+                    final isPeerWindows = model.getCurrentIsWindows(isLocal);
                     final List<MenuEntryBase> menuItems = [
                       MenuEntryButton(
                           childBuilder: (TextStyle? style) => isPeerWindows
@@ -913,7 +913,8 @@ class _FileManagerPageState extends State<FileManagerPage>
       bool isLocal, void Function(List<String>) onPressed) {
     final path = model.getCurrentDir(isLocal).path;
     final breadCrumbList = List<BreadCrumbItem>.empty(growable: true);
-    if (isWindows(isLocal) && path == '/') {
+    final isWindows = model.getCurrentIsWindows(isLocal);
+    if (isWindows && path == '/') {
       breadCrumbList.add(BreadCrumbItem(
           content: TextButton(
                   child: buildWindowsThisPC(),
@@ -922,7 +923,7 @@ class _FileManagerPageState extends State<FileManagerPage>
                   onPressed: () => onPressed(['/']))
               .marginSymmetric(horizontal: 4)));
     } else {
-      final list = PathUtil.split(path, model.getCurrentIsWindows(isLocal));
+      final list = PathUtil.split(path, isWindows);
       breadCrumbList.addAll(list.asMap().entries.map((e) => BreadCrumbItem(
           content: TextButton(
                   child: Text(e.value),
@@ -932,14 +933,6 @@ class _FileManagerPageState extends State<FileManagerPage>
               .marginSymmetric(horizontal: 4))));
     }
     return breadCrumbList;
-  }
-
-  bool isWindows(bool isLocal) {
-    if (isLocal) {
-      return Platform.isWindows;
-    } else {
-      return _ffi.ffiModel.pi.platform.toLowerCase() == "windows";
-    }
   }
 
   breadCrumbScrollToEnd(bool isLocal) {

--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -801,7 +801,8 @@ class _FileManagerPageState extends State<FileManagerPage>
                         onPointerSignal: (e) {
                           if (e is PointerScrollEvent) {
                             final sc = getBreadCrumbScrollController(isLocal);
-                            sc.jumpTo(sc.offset + e.scrollDelta.dy / 4);
+                            final scale = Platform.isWindows ? 2 : 4;
+                            sc.jumpTo(sc.offset + e.scrollDelta.dy / scale);
                           }
                         },
                         child: BreadCrumb(

--- a/flutter/lib/mobile/pages/file_manager_page.dart
+++ b/flutter/lib/mobile/pages/file_manager_page.dart
@@ -32,15 +32,17 @@ class _FileManagerPageState extends State<FileManagerPage> {
           .showLoading(translate('Connecting...'), onCancel: closeConnection);
     });
     gFFI.ffiModel.updateEventListener(widget.id);
+    model.onDirChanged = (_) => breadCrumbScrollToEnd();
     Wakelock.enable();
   }
 
   @override
   void dispose() {
-    model.onClose();
-    gFFI.close();
-    gFFI.dialogManager.dismissAll();
-    Wakelock.disable();
+    model.onClose().whenComplete(() {
+      gFFI.close();
+      gFFI.dialogManager.dismissAll();
+      Wakelock.disable();
+    });
     super.dispose();
   }
 
@@ -309,7 +311,6 @@ class _FileManagerPageState extends State<FileManagerPage> {
                 }
                 if (entries[index].isDirectory || entries[index].isDrive) {
                   model.openDirectory(entries[index].path);
-                  breadCrumbScrollToEnd();
                 } else {
                   // Perform file-related tasks.
                 }

--- a/flutter/lib/mobile/pages/file_manager_page.dart
+++ b/flutter/lib/mobile/pages/file_manager_page.dart
@@ -138,7 +138,7 @@ class _FileManagerPageState extends State<FileManagerPage> {
                             child: Row(
                               children: [
                                 Icon(
-                                    model.currentShowHidden
+                                    model.getCurrentShowHidden()
                                         ? Icons.check_box_outlined
                                         : Icons.check_box_outline_blank,
                                     color: Theme.of(context).iconTheme.color),
@@ -185,7 +185,8 @@ class _FileManagerPageState extends State<FileManagerPage> {
                                                 model.createDir(PathUtil.join(
                                                     model.currentDir.path,
                                                     name.value.text,
-                                                    model.currentIsWindows));
+                                                    model
+                                                        .getCurrentIsWindows()));
                                                 close();
                                               }
                                             },
@@ -351,12 +352,12 @@ class _FileManagerPageState extends State<FileManagerPage> {
               if (model.currentHome.startsWith(list[0])) {
                 // absolute path
                 for (var item in list) {
-                  path = PathUtil.join(path, item, model.currentIsWindows);
+                  path = PathUtil.join(path, item, model.getCurrentIsWindows());
                 }
               } else {
                 path += model.currentHome;
                 for (var item in list) {
-                  path = PathUtil.join(path, item, model.currentIsWindows);
+                  path = PathUtil.join(path, item, model.getCurrentIsWindows());
                 }
               }
               model.openDirectory(path);
@@ -500,7 +501,7 @@ class _FileManagerPageState extends State<FileManagerPage> {
   List<BreadCrumbItem> getPathBreadCrumbItems(
       void Function() onHome, void Function(List<String>) onPressed) {
     final path = model.currentShortPath;
-    final list = PathUtil.split(path, model.currentIsWindows);
+    final list = PathUtil.split(path, model.getCurrentIsWindows());
     final breadCrumbList = [
       BreadCrumbItem(
           content: IconButton(


### PR DESCRIPTION
### Fix
- can't load/save config successfully.
- path can't split for breadCrumb when local is Windows.

### Opt
- add `onDirChanged` for `breadCrumbScrollToEnd` instead of wrong event moment
- better rate for mouse wheel to controll BreadCrumbScroll in Windows