### PR TITLE
opt: allows handle key events by rdev with mouse moves to outside of window

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -157,6 +157,11 @@ class _RemotePageState extends State<RemotePage>
                       focusNode: _rawKeyFocusNode,
                       onFocusChange: (bool v) {
                         _imageFocused = v;
+                        if (_imageFocused) {
+                          _ffi.inputModel.enterOrLeave(true);
+                        } else {
+                          _ffi.inputModel.enterOrLeave(false);
+                        }
                       },
                       inputModel: _ffi.inputModel,
                       child: getBodyForDesktop(context)));
@@ -195,7 +200,6 @@ class _RemotePageState extends State<RemotePage>
         //
       }
     }
-    _ffi.inputModel.enterOrLeave(true);
   }
 
   void leaveView(PointerExitEvent evt) {
@@ -208,7 +212,6 @@ class _RemotePageState extends State<RemotePage>
         //
       }
     }
-    _ffi.inputModel.enterOrLeave(false);
   }
 
   Widget getBodyForDesktop(BuildContext context) {

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -37,8 +37,7 @@ class ConnectionTabPage extends StatefulWidget {
   State<ConnectionTabPage> createState() => _ConnectionTabPageState(params);
 }
 
-class _ConnectionTabPageState extends State<ConnectionTabPage>
-    with MultiWindowListener {
+class _ConnectionTabPageState extends State<ConnectionTabPage> {
   final tabController = Get.put(DesktopTabController(
       tabType: DesktopTabType.remoteScreen,
       onSelected: (_, id) => bind.setCurSessionId(id: id)));
@@ -106,13 +105,11 @@ class _ConnectionTabPageState extends State<ConnectionTabPage>
       }
       _update_remote_count();
     });
-    DesktopMultiWindow.addListener(this);
   }
 
   @override
   void dispose() {
     super.dispose();
-    DesktopMultiWindow.removeListener(this);
     _menubarState.save();
   }
 

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -37,7 +37,8 @@ class ConnectionTabPage extends StatefulWidget {
   State<ConnectionTabPage> createState() => _ConnectionTabPageState(params);
 }
 
-class _ConnectionTabPageState extends State<ConnectionTabPage> {
+class _ConnectionTabPageState extends State<ConnectionTabPage>
+    with MultiWindowListener {
   final tabController = Get.put(DesktopTabController(
       tabType: DesktopTabType.remoteScreen,
       onSelected: (_, id) => bind.setCurSessionId(id: id)));
@@ -105,12 +106,24 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
       }
       _update_remote_count();
     });
+    DesktopMultiWindow.addListener(this);
   }
 
   @override
   void dispose() {
     super.dispose();
+    DesktopMultiWindow.removeListener(this);
     _menubarState.save();
+  }
+
+  @override
+  void onWindowBlur() {
+    super.onWindowBlur();
+    final state = tabController.state.value;
+    if (state.tabs.isNotEmpty) {
+      final sessionId = state.tabs[state.selected].key;
+      bind.sessionEnterOrLeave(id: sessionId, enter: false);
+    }
   }
 
   @override

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -117,16 +117,6 @@ class _ConnectionTabPageState extends State<ConnectionTabPage>
   }
 
   @override
-  void onWindowBlur() {
-    super.onWindowBlur();
-    final state = tabController.state.value;
-    if (state.tabs.isNotEmpty) {
-      final sessionId = state.tabs[state.selected].key;
-      bind.sessionEnterOrLeave(id: sessionId, enter: false);
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
     final tabWidget = Obx(
       () => Container(


### PR DESCRIPTION
This PR allows to press the combinations or the key like:
- Alt + Tab
- Win, etc.

whenever the mouse is inside or outside of window.

Solution:
- reuse key focus event.
- add a multi window listener to cancel the key focus, when the user is operating all the other windows. 