### PR TITLE
fix macos sticky fn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#edddb71a88bd8a4737ef4216861b426490c49f2e"
+source = "git+https://github.com/fufesou/rdev#196b589573f90703a601e6b105dd7c917fc388f9"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#bc2db2f13dfdc95df8a02eb03f71325c173283dc"
+source = "git+https://github.com/fufesou/rdev#edddb71a88bd8a4737ef4216861b426490c49f2e"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.3",

--- a/libs/enigo/src/macos/macos_impl.rs
+++ b/libs/enigo/src/macos/macos_impl.rs
@@ -40,6 +40,7 @@ const BUF_LEN: usize = 4;
 #[allow(improper_ctypes)]
 #[allow(non_snake_case)]
 #[link(name = "ApplicationServices", kind = "framework")]
+#[link(name = "Carbon", kind = "framework")]
 extern "C" {
     fn CFDataGetBytePtr(theData: CFDataRef) -> *const u8;
     fn TISCopyCurrentKeyboardInputSource() -> TISInputSourceRef;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -523,6 +523,8 @@ impl Connection {
             rdev::set_dw_mouse_extra_info(enigo::ENIGO_INPUT_EXTRA_VALUE);
             rdev::set_dw_keyboard_extra_info(enigo::ENIGO_INPUT_EXTRA_VALUE);
         }
+        #[cfg(target_os = "macos")]
+        reset_input_ondisconn();
         loop {
             match receiver.recv_timeout(std::time::Duration::from_millis(500)) {
                 Ok(v) => match v {

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -288,6 +288,7 @@ fn modifier_sleep() {
 }
 
 #[inline]
+#[cfg(not(target_os = "macos"))]
 fn is_pressed(key: &Key, en: &mut Enigo) -> bool {
     get_modifier_state(key.clone(), en)
 }
@@ -780,13 +781,13 @@ fn click_capslock(en: &mut Enigo) {
     #[cfg(not(targe_os = "macos"))]
     en.key_click(enigo::Key::CapsLock);
     #[cfg(target_os = "macos")]
-    en.key_down(enigo::Key::CapsLock);
+    let _ = en.key_down(enigo::Key::CapsLock);
 }
 
-fn click_numlock(en: &mut Enigo) {
+fn click_numlock(_en: &mut Enigo) {
     // without numlock in macos
     #[cfg(not(target_os = "macos"))]
-    en.key_click(enigo::Key::NumLock);
+    _en.key_click(enigo::Key::NumLock);
 }
 
 fn sync_numlock_capslock_status(key_event: &KeyEvent) {
@@ -872,6 +873,7 @@ fn is_altgr_pressed() -> bool {
         .is_some()
 }
 
+#[cfg(not(target_os = "macos"))]
 fn press_modifiers(en: &mut Enigo, key_event: &KeyEvent, to_release: &mut Vec<Key>) {
     for ref ck in key_event.modifiers.iter() {
         if let Some(key) = control_key_value_to_key(ck.value()) {
@@ -889,14 +891,14 @@ fn press_modifiers(en: &mut Enigo, key_event: &KeyEvent, to_release: &mut Vec<Ke
     }
 }
 
-fn sync_modifiers(en: &mut Enigo, key_event: &KeyEvent, to_release: &mut Vec<Key>) {
+fn sync_modifiers(en: &mut Enigo, key_event: &KeyEvent, _to_release: &mut Vec<Key>) {
     #[cfg(target_os = "macos")]
     add_flags_to_enigo(en, key_event);
 
     if key_event.down {
         release_unpressed_modifiers(en, key_event);
         #[cfg(not(target_os = "macos"))]
-        press_modifiers(en, key_event, to_release);
+        press_modifiers(en, key_event, _to_release);
     }
 }
 
@@ -944,6 +946,7 @@ fn process_seq(en: &mut Enigo, sequence: &str) {
     en.key_sequence(&sequence);
 }
 
+#[cfg(not(target_os = "macos"))]
 fn release_keys(en: &mut Enigo, to_release: &Vec<Key>) {
     for key in to_release {
         en.key_up(key.clone());

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -223,7 +223,9 @@ lazy_static::lazy_static! {
     static ref IS_SERVER: bool =  std::env::args().nth(1) == Some("--server".to_owned());
 }
 
+#[cfg(target_os = "macos")]
 static mut VIRTUAL_INPUT_MTX: Mutex<()> = Mutex::new(());
+#[cfg(target_os = "macos")]
 static mut VIRTUAL_INPUT: Option<VirtualInput> = None;
 
 // First call set_uinput() will create keyboard and mouse clients.
@@ -697,6 +699,7 @@ pub fn handle_key(evt: &KeyEvent) {
     std::thread::sleep(Duration::from_millis(20));
 }
 
+#[cfg(target_os = "macos")]
 #[inline]
 fn reset_input() {
     unsafe {

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -1,3 +1,4 @@
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 use super::ui_interface::get_option_opt;
 #[cfg(target_os = "linux")]
 use hbb_common::log::{debug, error, info};
@@ -44,7 +45,7 @@ pub fn start_tray() {
         } else {
             *control_flow = ControlFlow::Wait;
         }
-        let stopped = is_service_stoped();
+        let stopped = is_service_stopped();
         let state = if stopped { 2 } else { 1 };
         let old = *old_state.lock().unwrap();
         if state != old {
@@ -101,7 +102,7 @@ pub fn start_tray() {
     }
     if let Some(mut appindicator) = get_default_app_indicator() {
         let mut menu = gtk::Menu::new();
-        let stoped = is_service_stoped();
+        let stoped = is_service_stopped();
         // start/stop service
         let label = if stoped {
             crate::client::translate("Start Service".to_owned())
@@ -137,7 +138,7 @@ pub fn start_tray() {
 
 #[cfg(target_os = "linux")]
 fn change_service_state() {
-    if is_service_stoped() {
+    if is_service_stopped() {
         debug!("Now try to start service");
         crate::ipc::set_option("stop-service", "");
     } else {
@@ -151,7 +152,7 @@ fn change_service_state() {
 fn update_tray_service_item(item: &gtk::MenuItem) {
     use gtk::traits::GtkMenuItemExt;
 
-    if is_service_stoped() {
+    if is_service_stopped() {
         item.set_label(&crate::client::translate("Start Service".to_owned()));
     } else {
         item.set_label(&crate::client::translate("Stop service".to_owned()));
@@ -194,7 +195,8 @@ fn get_default_app_indicator() -> Option<AppIndicator> {
 /// Check if service is stoped.
 /// Return [`true`] if service is stoped, [`false`] otherwise.
 #[inline]
-fn is_service_stoped() -> bool {
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn is_service_stopped() -> bool {
     if let Some(v) = get_option_opt("stop-service") {
         v == "Y"
     } else {

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -158,6 +158,7 @@ pub fn get_license() -> String {
 }
 
 #[inline]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 pub fn get_option_opt(key: &str) -> Option<String> {
     OPTIONS.lock().unwrap().get(key).map(|x| x.clone())
 }
@@ -199,11 +200,13 @@ pub fn set_local_flutter_config(key: String, value: String) {
     LocalConfig::set_flutter_config(key, value);
 }
 
+#[cfg(feature = "flutter")]
 #[inline]
 pub fn get_kb_layout_type() -> String {
     LocalConfig::get_kb_layout_type()
 }
 
+#[cfg(feature = "flutter")]
 #[inline]
 pub fn set_kb_layout_type(kb_layout_type: String) {
     LocalConfig::set_kb_layout_type(kb_layout_type);


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

1. Workaround https://stackoverflow.com/questions/74938870/sticky-fn-after-home-is-simulated-programmatically-macos.
2. Supress some warns.
3. MacOS, use private CGEventSource