### PR TITLE
feat: add macos p12 codesign for nightly build

### DIFF
--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -149,6 +149,12 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
+      - name: Import the codesign cert
+        uses: apple-actions/import-codesign-certs@v1
+        with: 
+          p12-file-base64: ${{ secrets.MACOS_P12_BASE64 }}
+          p12-password: ${{ secrets.MACOS_P12_PASSWORD }}
+
       - name: Install build runtime
         run: |
           brew install llvm create-dmg nasm yasm cmake gcc wget ninja

--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -154,6 +154,12 @@ jobs:
         with: 
           p12-file-base64: ${{ secrets.MACOS_P12_BASE64 }}
           p12-password: ${{ secrets.MACOS_P12_PASSWORD }}
+          keychain: rustdesk
+      
+      - name: Check sign 
+        run: |
+          security default-keychain -s rustdesk.keychain
+          security find-identity -v
 
       - name: Install build runtime
         run: |
@@ -216,6 +222,16 @@ jobs:
         run: |
           # --hwcodec not supported on macos yet
           ./build.py --flutter ${{ matrix.job.extra-build-args }}
+
+      - name: Codesign app and create signed dmg
+        run: |
+          security default-keychain -s rustdesk.keychain
+          security unlock-keychain -p ${{ secrets.MACOS_P12_PASSWORD }} rustdesk.keychain
+          # start sign the rustdesk.app and dmg
+          rm rustdesk-${{ env.VERSION }}.dmg || true
+          codesign --force -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep ./flutter/build/macos/Build/Products/Release/rustdesk.app -v
+          create-dmg rustdesk-${{ env.VERSION }}.dmg ./flutter/build/macos/Build/Products/Release/rustdesk.app
+          codesign --force -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep rustdesk-${{ env.VERSION }}.dmg -v
 
       - name: Rename rustdesk
         run: |


### PR DESCRIPTION


These secrets need to be configured first:

- MACOS_P12_BASE64
- MACOS_P12_PASSWORD
- MACOS_CODESIGN_IDENTITY

identity eg:
```
$ security find-identity -v
  1) ABCDABCDABCD "Apple Development: my@email.com (CODE)"
     1 valid identities found
```
so `MACOS_CODESIGN_IDENTITY` is `"Apple Development: my@email.com (CODE)"`. Note that the double quote should be included in the secret.
