### PR TITLE
fix: macos crash on get interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,8 +1317,7 @@ checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 [[package]]
 name = "default-net"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e70d471b0ba4e722c85651b3bb04b6880dfdb1224a43ade80c1295314db646"
+source = "git+https://github.com/Kingtous/default-net#bdaad8dd5b08efcba303e71729d3d0b1d5ccdb25"
 dependencies = [
  "libc",
  "memalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ base64 = "0.13"
 sysinfo = "0.24"
 num_cpus = "1.13"
 bytes = { version = "1.2", features = ["serde"] }
-default-net = "0.11.0"
+default-net = { git = "https://github.com/Kingtous/default-net" }
 wol-rs = "0.9.1"
 flutter_rust_bridge = { git = "https://github.com/SoLongAndThanksForAllThePizza/flutter_rust_bridge", optional = true }
 errno = "0.2.8"


### PR DESCRIPTION
This PR fixes crash on getting interfaces on macOS vm, which cannot handle in our app due to lack of return value.

related: https://github.com/shellrow/default-net/pull/18 