### PR TITLE
ignore style warnings in libs/scrap

### DIFF
--- a/libs/scrap/src/common/wayland.rs
+++ b/libs/scrap/src/common/wayland.rs
@@ -4,6 +4,7 @@ use std::{io, sync::RwLock, time::Duration};
 
 pub struct Capturer(Display, Box<dyn Recorder>, bool, Vec<u8>);
 
+#[allow(non_upper_case_globals)]
 pub const is_cursor_embedded: bool = true;
 
 lazy_static::lazy_static! {

--- a/libs/scrap/src/common/x11.rs
+++ b/libs/scrap/src/common/x11.rs
@@ -3,6 +3,7 @@ use std::{io, ops, time::Duration};
 
 pub struct Capturer(x11::Capturer);
 
+#[allow(non_upper_case_globals)]
 pub const is_cursor_embedded: bool = false;
 
 impl Capturer {


### PR DESCRIPTION
Constant `is_cursor_embedded` does not follow the Rust standard stylistic convention of upper-case global variables and constants. This causes two warnings to be thrown when compiling (tested on Arch Linux, commit = 68fda34, Rust = 1.66.0), one each for the Wayland and X11 common modules. Since these variables are not new, their names should not be modified; to remove the warnings, this patch allows non-style-conforming names on these two constant declarations specifically, suppressing the warnings. It does not affect stylistic warnings on any other code within the project.

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>
Cc: fufesou <shuanglongchen@yeah.net>