### PR TITLE
fix: upload race of deb and flatpak specific build

### DIFF
--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -1181,6 +1181,7 @@ jobs:
           done
 
       - name: Publish debian package
+        if: ${{ matrix.job.extra-build-features == '' }}
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true


### PR DESCRIPTION
This PR fixes the upload race of two deb packages with different features (none and `flatpak`), which will change the execution behavior (loginctl, etc) related to flatpak according to the upload order of these two jobs.

Now it will only publish the debian package with no extra features. The deb with  the `flatpak` feature should not be uploaded.

@21pages 