### PR TITLE
Feat/mouse forward back

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -466,14 +466,20 @@ class InputModel {
     evt['y'] = '${y.round()}';
     var buttons = '';
     switch (evt['buttons']) {
-      case 1:
+      case kPrimaryMouseButton:
         buttons = 'left';
         break;
-      case 2:
+      case kSecondaryMouseButton:
         buttons = 'right';
         break;
-      case 4:
+      case kMiddleMouseButton:
         buttons = 'wheel';
+        break;
+      case kBackMouseButton:
+        buttons = 'back';
+        break;
+      case kForwardMouseButton:
+        buttons = 'forward';
         break;
     }
     evt['buttons'] = buttons;

--- a/libs/enigo/src/lib.rs
+++ b/libs/enigo/src/lib.rs
@@ -104,6 +104,10 @@ pub enum MouseButton {
     Middle,
     /// Right mouse button
     Right,
+    /// Back mouse button
+    Back,
+    /// Forward mouse button
+    Forward,
 
     /// Scroll up button
     ScrollUp,

--- a/libs/enigo/src/linux/xdo.rs
+++ b/libs/enigo/src/linux/xdo.rs
@@ -57,6 +57,8 @@ fn mousebutton(button: MouseButton) -> c_int {
         MouseButton::ScrollDown => 5,
         MouseButton::ScrollLeft => 6,
         MouseButton::ScrollRight => 7,
+        MouseButton::Back => 8,
+        MouseButton::Forward => 9,
     }
 }
 

--- a/libs/enigo/src/macos/macos_impl.rs
+++ b/libs/enigo/src/macos/macos_impl.rs
@@ -226,7 +226,10 @@ impl MouseControllable for Enigo {
             MouseButton::Left => (CGMouseButton::Left, CGEventType::LeftMouseDown),
             MouseButton::Middle => (CGMouseButton::Center, CGEventType::OtherMouseDown),
             MouseButton::Right => (CGMouseButton::Right, CGEventType::RightMouseDown),
-            _ => unimplemented!(),
+            _ => {
+                log::info!("Unsupported button {:?}", button);
+                return Ok(());
+            },
         };
         let dest = CGPoint::new(current_x as f64, current_y as f64);
         if let Some(src) = self.event_source.as_ref() {
@@ -249,7 +252,10 @@ impl MouseControllable for Enigo {
             MouseButton::Left => (CGMouseButton::Left, CGEventType::LeftMouseUp),
             MouseButton::Middle => (CGMouseButton::Center, CGEventType::OtherMouseUp),
             MouseButton::Right => (CGMouseButton::Right, CGEventType::RightMouseUp),
-            _ => unimplemented!(),
+            _ => {
+                log::info!("Unsupported button {:?}", button);
+                return;
+            },
         };
         let dest = CGPoint::new(current_x as f64, current_y as f64);
         if let Some(src) = self.event_source.as_ref() {

--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -136,7 +136,10 @@ impl MouseControllable for Enigo {
                 MouseButton::Right => MOUSEEVENTF_RIGHTDOWN,
                 MouseButton::Back => MOUSEEVENTF_XDOWN,
                 MouseButton::Forward => MOUSEEVENTF_XDOWN,
-                _ => unimplemented!(),
+                _ => {
+                    log::info!("Unsupported button {:?}", button);
+                    return Ok(());
+                }
             },
             match button {
                 MouseButton::Back => XBUTTON1 as _,
@@ -163,7 +166,10 @@ impl MouseControllable for Enigo {
                 MouseButton::Right => MOUSEEVENTF_RIGHTUP,
                 MouseButton::Back => MOUSEEVENTF_XUP,
                 MouseButton::Forward => MOUSEEVENTF_XUP,
-                _ => unimplemented!(),
+                _ => {
+                    log::info!("Unsupported button {:?}", button);
+                    return;
+                }
             },
             match button {
                 MouseButton::Back => XBUTTON1 as _,

--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -134,9 +134,15 @@ impl MouseControllable for Enigo {
                 MouseButton::Left => MOUSEEVENTF_LEFTDOWN,
                 MouseButton::Middle => MOUSEEVENTF_MIDDLEDOWN,
                 MouseButton::Right => MOUSEEVENTF_RIGHTDOWN,
+                MouseButton::Back => MOUSEEVENTF_XDOWN,
+                MouseButton::Forward => MOUSEEVENTF_XDOWN,
                 _ => unimplemented!(),
             },
-            0,
+            match button {
+                MouseButton::Back => XBUTTON1 as _,
+                MouseButton::Forward => XBUTTON2 as _,
+                _ => 0, 
+            },
             0,
             0,
         );
@@ -155,9 +161,15 @@ impl MouseControllable for Enigo {
                 MouseButton::Left => MOUSEEVENTF_LEFTUP,
                 MouseButton::Middle => MOUSEEVENTF_MIDDLEUP,
                 MouseButton::Right => MOUSEEVENTF_RIGHTUP,
+                MouseButton::Back => MOUSEEVENTF_XUP,
+                MouseButton::Forward => MOUSEEVENTF_XUP,
                 _ => unimplemented!(),
             },
-            0,
+            match button {
+                MouseButton::Back => XBUTTON1 as _,
+                MouseButton::Forward => XBUTTON2 as _,
+                _ => 0, 
+            },
             0,
             0,
         );

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -885,9 +885,11 @@ pub fn session_send_mouse(id: String, msg: String) {
         }
         if let Some(buttons) = m.get("buttons") {
             mask |= match buttons.as_str() {
-                "left" => 1,
-                "right" => 2,
-                "wheel" => 4,
+                "left" => 0x01,
+                "right" => 0x02,
+                "wheel" => 0x04,
+                "back" => 0x08,
+                "forward" => 0x10,
                 _ => 0,
             } << 3;
         }

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -556,26 +556,38 @@ pub fn handle_mouse_(evt: &MouseEvent) {
             en.mouse_move_to(evt.x, evt.y);
         }
         1 => match buttons {
-            1 => {
+            0x01 => {
                 allow_err!(en.mouse_down(MouseButton::Left));
             }
-            2 => {
+            0x02 => {
                 allow_err!(en.mouse_down(MouseButton::Right));
             }
-            4 => {
+            0x04 => {
                 allow_err!(en.mouse_down(MouseButton::Middle));
+            }
+            0x08 => {
+                allow_err!(en.mouse_down(MouseButton::Back));
+            }
+            0x10 => {
+                allow_err!(en.mouse_down(MouseButton::Forward));
             }
             _ => {}
         },
         2 => match buttons {
-            1 => {
+            0x01 => {
                 en.mouse_up(MouseButton::Left);
             }
-            2 => {
+            0x02 => {
                 en.mouse_up(MouseButton::Right);
             }
-            4 => {
+            0x04 => {
                 en.mouse_up(MouseButton::Middle);
+            }
+            0x08 => {
+                en.mouse_up(MouseButton::Back);
+            }
+            0x10 => {
+                en.mouse_up(MouseButton::Forward);
             }
             _ => {}
         },


### PR DESCRIPTION
1. Support Win and Linux.
2. Unsupport MacOS.

Mark for MacOS, may be supported in the future.
https://apple.stackexchange.com/a/400084
https://superuser.com/a/1230059

https://github.com/rustdesk/rustdesk/issues/2230