### PR TITLE
remove unnecessary allow block

### DIFF
--- a/libs/scrap/src/common/wayland.rs
+++ b/libs/scrap/src/common/wayland.rs
@@ -4,7 +4,6 @@ use std::{io, sync::RwLock, time::Duration};
 
 pub struct Capturer(Display, Box<dyn Recorder>, bool, Vec<u8>);
 
-#[allow(non_upper_case_globals)]
 pub const IS_CURSOR_EMBEDDED: bool = true;
 
 lazy_static::lazy_static! {

--- a/libs/scrap/src/common/x11.rs
+++ b/libs/scrap/src/common/x11.rs
@@ -3,7 +3,6 @@ use std::{io, ops, time::Duration};
 
 pub struct Capturer(x11::Capturer);
 
-#[allow(non_upper_case_globals)]
 pub const IS_CURSOR_EMBEDDED: bool = false;
 
 impl Capturer {


### PR DESCRIPTION
Patch #2701 (609117c: "ignore style warnings in libs/scrap") was merged, but the RustDesk team decided to later instead changed is_cursor_embedded to uppercase (see discussion on the PR), thus no longer triggering the warning and no longer needing the allow block. This was changed in (b723f84: "fix linux to mac, keyboard input"). This patch removes the now unnecessary allowances.

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>
Cc: fufseou <shuanglongchen@yeah.net>