### PR TITLE
fix win scancode filter, ignore 0xE0..

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -617,7 +617,8 @@ pub fn map_keyboard_mode(event: &Event, mut key_event: KeyEvent) -> Option<KeyEv
     let keycode = match peer.as_str() {
         "windows" => {
             // https://github.com/rustdesk/rustdesk/issues/1371
-            if event.scan_code > 255 {
+            // Filter scancodes that are greater than 255 and the hight word is not 0xE0.
+            if event.scan_code > 255 && (event.scan_code >> 8) != 0xE0 {
                 return None;
             }
             event.scan_code


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

https://github.com/rustdesk/rustdesk/issues/1371