### PR TITLE
fix session type when starting wayland via tty

### DIFF
--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -74,7 +74,7 @@ fn get_display_server_of_session(session: &str) -> String {
     } else {
         "".to_owned()
     };
-    if display_server.is_empty() {
+    if display_server.is_empty() || display_server == "tty" {
         // loginctl has not given the expected output.  try something else.
         if let Ok(sestype) = std::env::var("XDG_SESSION_TYPE") {
             display_server = sestype;


### PR DESCRIPTION
#87 might solve this issue
In the original code, if you start the wayland compositor via tty, your rustdesk will think you are using tty, and if you read XDG_SESSION_TYPE once while using tty, then if you are really using tty, "display_server" will still be tty, and if If the wayland compositor is used, then it will return wayland
```
dm -> xorg x11
dm -> wayland wayland
dm -> tty tty
tty -> tty tty
tty -> xorg x11
tty -> wayland tty
```