### PR TITLE
opt: prevent duplicate window instance on windows

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1310,7 +1310,7 @@ bool callUniLinksUriHandler(Uri uri) {
     Future.delayed(Duration.zero, () {
       rustDeskWinManager.newRemoteDesktop(peerId);
     });
-    return true;
+    return false;
   }
   return false;
 }

--- a/flutter/lib/utils/multi_window_manager.dart
+++ b/flutter/lib/utils/multi_window_manager.dart
@@ -208,7 +208,7 @@ class RustDeskMultiWindowManager {
   }
 
   /// Remove active window which has [`windowId`]
-  /// 
+  ///
   /// [Availability]
   /// This function should only be called from main window.
   /// For other windows, please post a unregister(hide) event to main window handler:

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -52,18 +52,20 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   free_c_args(c_args, args_len);
 
   // uni links dispatch
-  // only do uni links when dispatch a rustdesk links
-  auto prefix = std::string(uniLinksPrefix);
-  if (!command_line_arguments.empty() && command_line_arguments.front().compare(0, prefix.size(), prefix.c_str()) == 0) {
-     HWND hwnd = ::FindWindow(_T("FLUTTER_RUNNER_WIN32_WINDOW"), _T("RustDesk"));
-    if (hwnd != NULL) {
+  HWND hwnd = ::FindWindow(_T("FLUTTER_RUNNER_WIN32_WINDOW"), _T("RustDesk"));
+  if (hwnd != NULL) {
+    if (!command_line_arguments.empty()) {
+      // Dispatch command line arguments
       DispatchToUniLinksDesktop(hwnd);
-
+    } else {
+      // Not called with arguments, or just open the app shortcut on desktop. 
+      // So we just show the main window instead.
       ::ShowWindow(hwnd, SW_NORMAL);
       ::SetForegroundWindow(hwnd);
-      return EXIT_FAILURE;
     }
+    return EXIT_FAILURE;
   }
+  
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent())

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -322,7 +322,7 @@ fn core_main_invoke_new_connection(mut args: std::env::Args) -> Option<Vec<Strin
             "RustDesk",
             (WM_USER + 2) as _, // referred from unilinks desktop pub
             uni_links.as_str(),
-            true,
+            false,
         );
         return if res { None } else { Some(Vec::new()) };
     }


### PR DESCRIPTION
This PR optimizes window management on Windows, which ensures only one active main window on Windows.

This PR also fixes an issue, which will open main window unexpectly when clicking connection shortcut on Desktop.