### PR TITLE
hbb_common: Use OUT_DIR in build.rs

### DIFF
--- a/libs/hbb_common/.gitignore
+++ b/libs/hbb_common/.gitignore
@@ -1,4 +1,3 @@
 /target
 **/*.rs.bk
 Cargo.lock
-src/protos/

--- a/libs/hbb_common/build.rs
+++ b/libs/hbb_common/build.rs
@@ -1,8 +1,11 @@
 fn main() {
-    std::fs::create_dir_all("src/protos").unwrap();
+    let out_dir = format!("{}/protos", std::env::var("OUT_DIR").unwrap());
+
+    std::fs::create_dir_all(&out_dir).unwrap();
+    
     protobuf_codegen::Codegen::new()
         .pure()
-        .out_dir("src/protos")
+        .out_dir(out_dir)
         .inputs(&["protos/rendezvous.proto", "protos/message.proto"])
         .include("protos")
         .customize(

--- a/libs/hbb_common/src/protos/mod.rs
+++ b/libs/hbb_common/src/protos/mod.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));


### PR DESCRIPTION
Using the `scrap` fork in a project, and thus `hbb_common`. Had issues compiling on NixOS with [`crane`](https://github.com/ipetkov/crane).

As per a discussion there, `src` should ideally be left untouched, and all generated items need to come from `OUT_DIR`. 