### PR TITLE
opt: upgrade flutter ci/nightly to 3.7.0 stable

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -13,8 +13,7 @@ on:
 
 env:
   LLVM_VERSION: "10.0"
-  # Note: currently 3.0.5 does not support arm64 officially, we use latest stable version first.
-  FLUTTER_VERSION: "3.0.5"
+  FLUTTER_VERSION: "3.7.0"
   # vcpkg version: 2022.05.10
   # for multiarch gcc compatibility
   VCPKG_COMMIT_ID: "14e7bb4ae24616ec54ff6b2f6ef4e8659434ea44"
@@ -51,9 +50,9 @@ jobs:
         run: |
           flutter doctor -v
           flutter precache --windows
-          Invoke-WebRequest -Uri https://github.com/Kingtous/engine/releases/download/v3.0.5-rustdesk.2/windows-x64-flutter-release.zip -OutFile windows-x64-flutter-release.zip
+          Invoke-WebRequest -Uri https://github.com/Kingtous/engine/releases/download/v3.7.0-rustdesk/windows-x64-release-flutter.zip -OutFile windows-x64-flutter-release.zip
           Expand-Archive windows-x64-flutter-release.zip -DestinationPath engine
-          mv -Force engine/*  C:/hostedtoolcache/windows/flutter/stable-3.0.5-x64/bin/cache/artifacts/engine/windows-x64-release/
+          mv -Force engine/*  C:/hostedtoolcache/windows/flutter/stable-${{ env.FLUTTER_VERSION }}-x64/bin/cache/artifacts/engine/windows-x64-release/
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -853,12 +852,12 @@ jobs:
           # disable git safe.directory
           git config --global --add safe.directory "*"
           pushd /opt
-          # clone repo and reset to flutter 3.0.5
+          # clone repo and reset to flutter 3.7.0
           git clone https://github.com/sony/flutter-elinux.git || true
           pushd flutter-elinux
-            # reset to flutter 3.0.5
+            # reset to flutter 3.7.0
             git fetch
-            git reset --hard b09a90eee643859ce4e676839227edd9fd3feba8 
+            git reset --hard 51a1d685901f79fbac51665a967c3a1a789ecee5 
           popd
 
       - uses: Kingtous/run-on-arch-action@amd64-support
@@ -887,7 +886,6 @@ jobs:
             # Setup flutter-elinux
             export PATH=/opt/flutter-elinux/bin:$PATH
             flutter-elinux doctor -v
-            # edit to corresponding arch
             case ${{ matrix.job.arch }} in
               aarch64)
                 sed -i "s/Architecture: amd64/Architecture: arm64/g" ./build.py

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -882,10 +882,17 @@ jobs:
             git config --global --add safe.directory "*"
             pushd /workspace
             # we use flutter-elinux to build our rustdesk
-            sed -i "s/flutter build linux --release/flutter-elinux build linux/g" ./build.py
-            # Setup flutter-elinux
             export PATH=/opt/flutter-elinux/bin:$PATH
+            sed -i "s/flutter build linux --release/flutter-elinux build linux/g" ./build.py
+            # Setup flutter-elinux. Run doctor to check if issues here.
             flutter-elinux doctor -v
+            # Patch arm64 engine for flutter 3.6.0+
+            flutter-elinux precache --linux
+            pushd /tmp
+            curl -O https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.0-stable.tar.xz
+            tar -xvf flutter_linux_3.7.0-stable.tar.xz flutter/bin/cache/artifacts/engine/linux-x64/shader_lib
+            cp -R flutter/bin/cache/artifacts/engine/linux-x64/shader_lib /opt/flutter-elinux/flutter/bin/cache/artifacts/engine/linux-arm64
+            popd
             case ${{ matrix.job.arch }} in
               aarch64)
                 sed -i "s/Architecture: amd64/Architecture: arm64/g" ./build.py

--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   LLVM_VERSION: "10.0"
-  # Note: currently 3.0.5 does not support arm64 officially, we use latest stable version first.
   FLUTTER_VERSION: "3.7.0"
   TAG_NAME: "nightly"
   # vcpkg version: 2022.05.10
@@ -999,7 +998,7 @@ jobs:
           # disable git safe.directory
           git config --global --add safe.directory "*"
           pushd /opt
-          # clone repo and reset to flutter 3.0.5
+          # clone repo and reset to flutter 3.7.0
           git clone https://github.com/sony/flutter-elinux.git || true
           pushd flutter-elinux
             # reset to flutter 3.7.0

--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -1028,10 +1028,17 @@ jobs:
             git config --global --add safe.directory "*"
             pushd /workspace
             # we use flutter-elinux to build our rustdesk
-            sed -i "s/flutter build linux --release/flutter-elinux build linux/g" ./build.py
-            # Setup flutter-elinux
             export PATH=/opt/flutter-elinux/bin:$PATH
+            sed -i "s/flutter build linux --release/flutter-elinux build linux/g" ./build.py
+            # Setup flutter-elinux. Run doctor to check if issues here.
             flutter-elinux doctor -v
+            # Patch arm64 engine for flutter 3.6.0+
+            flutter-elinux precache --linux
+            pushd /tmp
+            curl -O https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.0-stable.tar.xz
+            tar -xvf flutter_linux_3.7.0-stable.tar.xz flutter/bin/cache/artifacts/engine/linux-x64/shader_lib
+            cp -R flutter/bin/cache/artifacts/engine/linux-x64/shader_lib /opt/flutter-elinux/flutter/bin/cache/artifacts/engine/linux-arm64
+            popd
             # edit to corresponding arch
             case ${{ matrix.job.arch }} in
               aarch64)

--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -9,7 +9,7 @@ on:
 env:
   LLVM_VERSION: "10.0"
   # Note: currently 3.0.5 does not support arm64 officially, we use latest stable version first.
-  FLUTTER_VERSION: "3.0.5"
+  FLUTTER_VERSION: "3.7.0"
   TAG_NAME: "nightly"
   # vcpkg version: 2022.05.10
   # for multiarch gcc compatibility
@@ -53,9 +53,9 @@ jobs:
         run: |
           flutter doctor -v
           flutter precache --windows
-          Invoke-WebRequest -Uri https://github.com/Kingtous/engine/releases/download/v3.0.5-rustdesk.2/windows-x64-flutter-release.zip -OutFile windows-x64-flutter-release.zip
+          Invoke-WebRequest -Uri https://github.com/Kingtous/engine/releases/download/v3.7.0-rustdesk/windows-x64-release-flutter.zip -OutFile windows-x64-flutter-release.zip
           Expand-Archive windows-x64-flutter-release.zip -DestinationPath engine
-          mv -Force engine/*  C:/hostedtoolcache/windows/flutter/stable-3.0.5-x64/bin/cache/artifacts/engine/windows-x64-release/
+          mv -Force engine/*  C:/hostedtoolcache/windows/flutter/stable-${{ env.FLUTTER_VERSION }}-x64/bin/cache/artifacts/engine/windows-x64-release/
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -1002,9 +1002,9 @@ jobs:
           # clone repo and reset to flutter 3.0.5
           git clone https://github.com/sony/flutter-elinux.git || true
           pushd flutter-elinux
-            # reset to flutter 3.0.5
+            # reset to flutter 3.7.0
             git fetch
-            git reset --hard b09a90eee643859ce4e676839227edd9fd3feba8 
+            git reset --hard 51a1d685901f79fbac51665a967c3a1a789ecee5 
           popd
 
       - uses: Kingtous/run-on-arch-action@amd64-support

--- a/flutter/lib/utils/multi_window_manager.dart
+++ b/flutter/lib/utils/multi_window_manager.dart
@@ -63,8 +63,7 @@ class RustDeskMultiWindowManager {
         ..setFrame(const Offset(0, 0) & const Size(1280, 720))
         ..center()
         ..setTitle(getWindowNameWithId(remoteId,
-            overrideType: WindowType.RemoteDesktop))
-        ..show();
+            overrideType: WindowType.RemoteDesktop));
       registerActiveWindow(remoteDesktopController.windowId);
       _remoteDesktopWindowId = remoteDesktopController.windowId;
     } else {
@@ -90,8 +89,7 @@ class RustDeskMultiWindowManager {
         ..setFrame(const Offset(0, 0) & const Size(1280, 720))
         ..center()
         ..setTitle(getWindowNameWithId(remoteId,
-            overrideType: WindowType.FileTransfer))
-        ..show();
+            overrideType: WindowType.FileTransfer));
       registerActiveWindow(fileTransferController.windowId);
       _fileTransferWindowId = fileTransferController.windowId;
     } else {
@@ -116,9 +114,8 @@ class RustDeskMultiWindowManager {
       portForwardController
         ..setFrame(const Offset(0, 0) & const Size(1280, 720))
         ..center()
-        ..setTitle(
-            getWindowNameWithId(remoteId, overrideType: WindowType.PortForward))
-        ..show();
+        ..setTitle(getWindowNameWithId(remoteId,
+            overrideType: WindowType.PortForward));
       registerActiveWindow(portForwardController.windowId);
       _portForwardWindowId = portForwardController.windowId;
     } else {

--- a/flutter/macos/Runner/MainFlutterWindow.swift
+++ b/flutter/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import desktop_drop
 import device_info_plus_macos
 import flutter_custom_cursor
 import package_info_plus_macos
-import path_provider_macos
+import path_provider_foundation
 import screen_retriever
 import sqflite
 // import tray_manager

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -75,14 +75,14 @@ dependencies:
     debounce_throttle: ^2.0.0
     file_picker: ^5.1.0
     flutter_svg: ^1.1.5
-    flutter_improved_scrolling: ^0.0.3
+    flutter_improved_scrolling: 
         # currently, we use flutter 3.0.5 for windows build, latest for other builds.
         #
         # for flutter 3.0.5, please use official version(just comment code below).
         # if build rustdesk by flutter >=3.3, please use our custom pub below (uncomment code below).
-        # git:
-        #     url: https://github.com/Kingtous/flutter_improved_scrolling
-        #     ref: 62f09545149f320616467c306c8c5f71714a18e6
+        git:
+            url: https://github.com/Kingtous/flutter_improved_scrolling
+            ref: 62f09545149f320616467c306c8c5f71714a18e6
     uni_links: ^0.5.1
     uni_links_desktop: ^0.1.4
     path: ^1.8.1

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
     # Use with the CupertinoIcons class for iOS style icons.
     cupertino_icons: ^1.0.3
     ffi: ^2.0.1
-    path_provider: ^2.0.2
+    path_provider: ^2.0.12
     external_path: ^1.0.1
     provider: ^6.0.3
     tuple: ^2.0.0


### PR DESCRIPTION
This PR upgrades flutter ci to `3.7.0`. And prevents unnecessary show-window event when creating windows.