### PR TITLE
fix win, local detect some dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4371,7 +4371,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#1be26c7e8ed0d43cebdd8331d467bb61130a2e6e"
+source = "git+https://github.com/fufesou/rdev#238c9778da40056e2efda1e4264355bc89fb6358"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.3",

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -245,12 +245,13 @@ pub fn session_get_keyboard_mode(id: String) -> Option<String> {
 }
 
 pub fn session_set_keyboard_mode(id: String, value: String) {
-    let mut mode_updated = false;
+    let mut _mode_updated = false;
     if let Some(session) = SESSIONS.write().unwrap().get_mut(&id) {
         session.save_keyboard_mode(value);
-        mode_updated = true;
+        _mode_updated = true;
     }
-    if mode_updated {
+    #[cfg(windows)]
+    if _mode_updated {
         crate::keyboard::update_grab_get_key_name();
     }
 }
@@ -1188,6 +1189,7 @@ pub fn main_update_me() -> SyncReturn<bool> {
 
 pub fn set_cur_session_id(id: String) {
     super::flutter::set_cur_session_id(id);
+    #[cfg(windows)]
     crate::keyboard::update_grab_get_key_name();
 }
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -245,8 +245,13 @@ pub fn session_get_keyboard_mode(id: String) -> Option<String> {
 }
 
 pub fn session_set_keyboard_mode(id: String, value: String) {
+    let mut mode_updated = false;
     if let Some(session) = SESSIONS.write().unwrap().get_mut(&id) {
         session.save_keyboard_mode(value);
+        mode_updated = true;
+    }
+    if mode_updated {
+        crate::keyboard::update_grab_get_key_name();
     }
 }
 
@@ -1182,7 +1187,8 @@ pub fn main_update_me() -> SyncReturn<bool> {
 }
 
 pub fn set_cur_session_id(id: String) {
-    super::flutter::set_cur_session_id(id)
+    super::flutter::set_cur_session_id(id);
+    crate::keyboard::update_grab_get_key_name();
 }
 
 pub fn install_show_run_without_install() -> SyncReturn<bool> {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -64,6 +64,8 @@ pub mod client {
         match state {
             GrabState::Ready => {}
             GrabState::Run => {
+                #[cfg(windows)]
+                update_grab_get_key_name();
                 #[cfg(any(target_os = "windows", target_os = "macos"))]
                 KEYBOARD_HOOKED.swap(true, Ordering::SeqCst);
 
@@ -182,6 +184,15 @@ pub mod client {
     pub fn ctrl_alt_del() {
         send_key_event(&event_ctrl_alt_del());
     }
+}
+
+#[cfg(windows)]
+pub fn update_grab_get_key_name() {
+    match get_keyboard_mode_enum() {
+        KeyboardMode::Map => rdev::set_get_key_name(false),
+        KeyboardMode::Translate => rdev::set_get_key_name(true),
+        _ => {}
+    };
 }
 
 pub fn start_grab_loop() {


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

https://github.com/rustdesk/rustdesk/issues/2670.

https://github.com/rustdesk/rustdesk/issues/2670#issuecomment-1406511338

Add an option of whether to call `ToUnicodeEx`.

https://github.com/fufesou/rdev/blob/238c9778da40056e2efda1e4264355bc89fb6358/src/windows/grab.rs#L22
https://github.com/fufesou/rdev/blob/238c9778da40056e2efda1e4264355bc89fb6358/src/windows/keyboard.rs#L35
https://github.com/fufesou/rdev/blob/238c9778da40056e2efda1e4264355bc89fb6358/src/windows/keyboard.rs#L87


If "Map mode", do not call `ToUnicodeEx`.
If "Legacy mode", call `ToUnicodeEx` to get local character.