### PR TITLE
Fix/wayland portal cursor mode

### DIFF
--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -12,7 +12,7 @@ cfg_if! {
         mod x11;
         pub use self::linux::*;
         pub use self::x11::Frame;
-        pub use self::wayland::{set_map_err, detect_cursor_embeded};
+        pub use self::wayland::{set_map_err, detect_cursor_embedded};
             } else {
                 mod x11;
                 pub use self::x11::*;

--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -12,7 +12,7 @@ cfg_if! {
         mod x11;
         pub use self::linux::*;
         pub use self::x11::Frame;
-        pub use self::wayland::set_map_err;
+        pub use self::wayland::{set_map_err, detect_cursor_embeded};
             } else {
                 mod x11;
                 pub use self::x11::*;
@@ -76,7 +76,7 @@ pub fn is_cursor_embedded() -> bool {
     if is_x11() {
         x11::IS_CURSOR_EMBEDDED
     } else {
-        wayland::IS_CURSOR_EMBEDDED
+        unsafe { wayland::IS_CURSOR_EMBEDDED }
     }
 }
 

--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -12,7 +12,7 @@ cfg_if! {
         mod x11;
         pub use self::linux::*;
         pub use self::x11::Frame;
-        pub use self::wayland::{set_map_err, detect_cursor_embedded};
+        pub use self::wayland::set_map_err;
             } else {
                 mod x11;
                 pub use self::x11::*;
@@ -76,7 +76,7 @@ pub fn is_cursor_embedded() -> bool {
     if is_x11() {
         x11::IS_CURSOR_EMBEDDED
     } else {
-        unsafe { wayland::IS_CURSOR_EMBEDDED }
+        wayland::is_cursor_embedded()
     }
 }
 

--- a/libs/scrap/src/common/wayland.rs
+++ b/libs/scrap/src/common/wayland.rs
@@ -10,7 +10,7 @@ lazy_static::lazy_static! {
     static ref MAP_ERR: RwLock<Option<fn(err: String)-> io::Error>> = Default::default();
 }
 
-pub fn detect_cursor_embeded() {
+pub fn detect_cursor_embedded() {
     if unsafe { IS_CURSOR_EMBEDDED } {
         use crate::common::wayland::pipewire::get_available_cursor_modes;
         match get_available_cursor_modes() {

--- a/libs/scrap/src/common/wayland.rs
+++ b/libs/scrap/src/common/wayland.rs
@@ -4,22 +4,29 @@ use std::{io, sync::RwLock, time::Duration};
 
 pub struct Capturer(Display, Box<dyn Recorder>, bool, Vec<u8>);
 
-pub static mut IS_CURSOR_EMBEDDED: bool = true;
+static mut IS_CURSOR_EMBEDDED: Option<bool> = None;
 
 lazy_static::lazy_static! {
     static ref MAP_ERR: RwLock<Option<fn(err: String)-> io::Error>> = Default::default();
 }
 
-pub fn detect_cursor_embedded() {
-    if unsafe { IS_CURSOR_EMBEDDED } {
-        use crate::common::wayland::pipewire::get_available_cursor_modes;
-        match get_available_cursor_modes() {
-            Ok(modes) => unsafe {
-                IS_CURSOR_EMBEDDED = (modes & 0x02) > 0;
-            },
-            Err(..) => unsafe {
-                IS_CURSOR_EMBEDDED = false;
-            },
+pub fn is_cursor_embedded() -> bool {
+    unsafe {
+        if IS_CURSOR_EMBEDDED.is_none() {
+            init_cursor_embedded();
+        }
+        IS_CURSOR_EMBEDDED.unwrap_or(false)
+    }
+}
+
+unsafe fn init_cursor_embedded() {
+    use crate::common::wayland::pipewire::get_available_cursor_modes;
+    match get_available_cursor_modes() {
+        Ok(modes) => {
+            IS_CURSOR_EMBEDDED = Some((modes & 0x02) > 0);
+        }
+        Err(..) => {
+            IS_CURSOR_EMBEDDED = Some(false);
         }
     }
 }
@@ -88,7 +95,7 @@ impl Display {
     }
 
     pub fn all() -> io::Result<Vec<Display>> {
-        Ok(pipewire::get_capturables(unsafe { IS_CURSOR_EMBEDDED })
+        Ok(pipewire::get_capturables(is_cursor_embedded())
             .map_err(map_err)?
             .drain(..)
             .map(|x| Display(x))

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -415,6 +415,12 @@ static mut INIT: bool = false;
 const RESTORE_TOKEN: &str = "restore_token";
 const RESTORE_TOKEN_CONF_KEY: &str = "wayland-restore-token";
 
+pub fn get_available_cursor_modes() -> Result<u32, dbus::Error> {
+    let conn = SyncConnection::new_session()?;
+    let portal = get_portal(&conn);
+    portal.available_cursor_modes()
+}
+
 // mostly inspired by https://gitlab.gnome.org/snippets/19
 fn request_screen_cast(
     capture_cursor: bool,

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -473,7 +473,17 @@ fn request_screen_cast(
             args.insert("multiple".into(), Variant(Box::new(true)));
             args.insert("types".into(), Variant(Box::new(1u32))); //| 2u32)));
 
-            let cursor_mode = if capture_cursor { 2u32 } else { 1u32 };
+            let mut cursor_mode = 0u32;
+            let mut available_cursor_modes = 0u32;
+            if let Ok(modes) = portal.available_cursor_modes() {
+                available_cursor_modes = modes;
+            }
+            if capture_cursor {
+                cursor_mode = 2u32 & available_cursor_modes;
+            }
+            if cursor_mode == 0 {
+                cursor_mode = 1u32 & available_cursor_modes;
+            }
             let plasma = std::env::var("DESKTOP_SESSION").map_or(false, |s| s.contains("plasma"));
             if plasma && capture_cursor {
                 // Warn the user if capturing the cursor is tried on kde as this can crash
@@ -483,7 +493,9 @@ fn request_screen_cast(
                     desktop, see https://bugs.kde.org/show_bug.cgi?id=435042 for details! \
                     You have been warned.");
             }
-            args.insert("cursor_mode".into(), Variant(Box::new(cursor_mode)));
+            if cursor_mode > 0 {
+                args.insert("cursor_mode".into(), Variant(Box::new(cursor_mode)));
+            }
             let session: dbus::Path = r
                 .results
                 .get("session_handle")

--- a/src/common.rs
+++ b/src/common.rs
@@ -52,7 +52,7 @@ pub fn global_init() -> bool {
     #[cfg(target_os = "linux")]
     {
         if !*IS_X11 {
-            crate::server::wayland::set_wayland_scrap_map_err();
+            crate::server::wayland::init();
         }
     }
     true

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -1,6 +1,9 @@
 use super::*;
 use hbb_common::{allow_err, platform::linux::DISTRO};
-use scrap::{detect_cursor_embedded, set_map_err, Capturer, Display, Frame, TraitCapturer};
+use scrap::{
+    detect_cursor_embedded, is_cursor_embedded, set_map_err, Capturer, Display, Frame,
+    TraitCapturer,
+};
 use std::io;
 
 use super::video_service::{
@@ -130,7 +133,7 @@ pub(super) async fn check_init() -> ResultType<()> {
                 let num = all.len();
                 let (primary, mut displays) = super::video_service::get_displays_2(&all);
                 for display in displays.iter_mut() {
-                    display.cursor_embedded = true;
+                    display.cursor_embedded = is_cursor_embedded();
                 }
 
                 let mut rects: Vec<((i32, i32), usize, usize)> = Vec::new();

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -1,6 +1,6 @@
 use super::*;
 use hbb_common::{allow_err, platform::linux::DISTRO};
-use scrap::{set_map_err, Capturer, Display, Frame, TraitCapturer};
+use scrap::{detect_cursor_embeded, set_map_err, Capturer, Display, Frame, TraitCapturer};
 use std::io;
 
 use super::video_service::{
@@ -12,7 +12,8 @@ lazy_static::lazy_static! {
     static ref LOG_SCRAP_COUNT: Mutex<u32> = Mutex::new(0);
 }
 
-pub fn set_wayland_scrap_map_err() {
+pub fn init() {
+    detect_cursor_embeded();
     set_map_err(map_err_scrap);
 }
 

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -1,9 +1,6 @@
 use super::*;
 use hbb_common::{allow_err, platform::linux::DISTRO};
-use scrap::{
-    detect_cursor_embedded, is_cursor_embedded, set_map_err, Capturer, Display, Frame,
-    TraitCapturer,
-};
+use scrap::{is_cursor_embedded, set_map_err, Capturer, Display, Frame, TraitCapturer};
 use std::io;
 
 use super::video_service::{
@@ -16,7 +13,6 @@ lazy_static::lazy_static! {
 }
 
 pub fn init() {
-    detect_cursor_embedded();
     set_map_err(map_err_scrap);
 }
 

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -1,6 +1,6 @@
 use super::*;
 use hbb_common::{allow_err, platform::linux::DISTRO};
-use scrap::{detect_cursor_embeded, set_map_err, Capturer, Display, Frame, TraitCapturer};
+use scrap::{detect_cursor_embedded, set_map_err, Capturer, Display, Frame, TraitCapturer};
 use std::io;
 
 use super::video_service::{
@@ -13,7 +13,7 @@ lazy_static::lazy_static! {
 }
 
 pub fn init() {
-    detect_cursor_embeded();
+    detect_cursor_embedded();
     set_map_err(map_err_scrap);
 }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/2798

Query and check availible cursor modes.

```rust
unsafe fn init_cursor_embedded() {
    use crate::common::wayland::pipewire::get_available_cursor_modes;
    match get_available_cursor_modes() {
        Ok(modes) => {
            IS_CURSOR_EMBEDDED = Some((modes & 0x02) > 0);
        }
        Err(..) => {
            IS_CURSOR_EMBEDDED = Some(false);
        }
    }
}
```

```rust
            let mut cursor_mode = 0u32;
            let mut available_cursor_modes = 0u32;
            if let Ok(modes) = portal.available_cursor_modes() {
                available_cursor_modes = modes;
            }
            if capture_cursor {
                cursor_mode = 2u32 & available_cursor_modes;
            }
            if cursor_mode == 0 {
                cursor_mode = 1u32 & available_cursor_modes;
            }
...
            if cursor_mode > 0 {
                args.insert("cursor_mode".into(), Variant(Box::new(cursor_mode)));
            }
```