### PR TITLE
Update desktop_tab_page.dart

### DIFF
--- a/flutter/lib/desktop/pages/desktop_tab_page.dart
+++ b/flutter/lib/desktop/pages/desktop_tab_page.dart
@@ -23,7 +23,7 @@ class DesktopTabPage extends StatefulWidget {
       DesktopTabController tabController = Get.find();
       tabController.add(TabInfo(
           key: kTabLabelSettingPage,
-          label: kTabLabelSettingPage,
+          label: translate(kTabLabelSettingPage),
           selectedIcon: Icons.build_sharp,
           unselectedIcon: Icons.build_outlined,
           page: DesktopSettingPage(
@@ -46,7 +46,7 @@ class _DesktopTabPageState extends State<DesktopTabPage> {
     RemoteCountState.init();
     tabController.add(TabInfo(
         key: kTabLabelHomePage,
-        label: kTabLabelHomePage,
+        label: translate(kTabLabelHomePage),
         selectedIcon: Icons.home_sharp,
         unselectedIcon: Icons.home_outlined,
         closable: false,


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/commit/87a2705ba505223a7869f886911da6e09ca47298 <= This commit has removed in 'flutter/lib/desktop/widgets/tabbar_widget.dart' the label tab translations.  

Indeed it may be preferable that translations of these labels are made in desktop_tab_page.dart

