### PR TITLE
tray bug fix

### DIFF
--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -198,7 +198,7 @@ pub fn core_main() -> Option<Vec<String>> {
             {
                 std::thread::spawn(move || crate::start_server(true));
                 crate::platform::macos::hide_dock();
-                crate::tray::make_tray();
+                crate::ui::macos::make_tray();
                 return None;
             }
             #[cfg(target_os = "linux")]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -21,7 +21,7 @@ mod cm;
 #[cfg(feature = "inline")]
 pub mod inline;
 #[cfg(target_os = "macos")]
-mod macos;
+pub mod macos;
 pub mod remote;
 #[cfg(target_os = "windows")]
 pub mod win_privacy;


### PR DESCRIPTION
When running the tray program on a Mac computer, the program ends just by showing the menu without pressing the Quit button.
Also, when the computer wakes up after sleeping for a long time, the program automatically shuts down.

![Untitled 2](https://user-images.githubusercontent.com/3592759/215906231-8ee8f0b1-d375-4683-95be-f0b4929d37ec.png)
