### PR TITLE
Fix elevation

### DIFF
--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 pub(super) const APP_TYPE_MAIN: &str = "main";
+pub(super) const APP_TYPE_CM: &str = "cm";
 pub(super) const APP_TYPE_DESKTOP_REMOTE: &str = "remote";
 pub(super) const APP_TYPE_DESKTOP_FILE_TRANSFER: &str = "file transfer";
 pub(super) const APP_TYPE_DESKTOP_PORT_FORWARD: &str = "port forward";
@@ -528,11 +529,7 @@ pub mod connection_manager {
             assert!(h.get("name").is_none());
             h.insert("name", name);
 
-            if let Some(s) = GLOBAL_EVENT_STREAM
-                .read()
-                .unwrap()
-                .get(super::APP_TYPE_MAIN)
-            {
+            if let Some(s) = GLOBAL_EVENT_STREAM.read().unwrap().get(super::APP_TYPE_CM) {
                 s.add(serde_json::ser::to_string(&h).unwrap_or("".to_owned()));
             };
         }

--- a/src/server/portable_service.rs
+++ b/src/server/portable_service.rs
@@ -118,11 +118,9 @@ impl SharedMemory {
 
     fn flink(name: String) -> ResultType<String> {
         let disk = std::env::var("SystemDrive").unwrap_or("C:".to_string());
-        let mut dir = PathBuf::from(disk);
-        let dir1 = dir.join("ProgramData");
-        let dir2 = std::env::var("TEMP")
-            .map(|d| PathBuf::from(d))
-            .unwrap_or(dir.join("Windows").join("Temp"));
+        let dir1 = PathBuf::from(format!("{}\\ProgramData", disk));
+        let dir2 = PathBuf::from(format!("{}\\Windows\\Temp", disk));
+        let mut dir;
         if dir1.exists() {
             dir = dir1;
         } else if dir2.exists() {

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -954,10 +954,7 @@ pub fn get_current_display() -> ResultType<(usize, usize, Display)> {
 fn start_uac_elevation_check() {
     static START: Once = Once::new();
     START.call_once(|| {
-        if !crate::platform::is_installed()
-            && !crate::platform::is_root()
-            && !crate::portable_service::client::running()
-        {
+        if !crate::platform::is_installed() && !crate::platform::is_root() {
             std::thread::spawn(|| loop {
                 std::thread::sleep(std::time::Duration::from_secs(1));
                 if let Ok(uac) = crate::ui::win_privacy::is_process_consent_running() {


### PR DESCRIPTION
1. fix different flink in two processes.
2. filter foreground window to avoid frequent elevation prompts
3. fix cm push_event

`consent.exe`,  which is used to identify whether UAC is running, may run until it's killed in taskMgr in special case, and that causes elevation prompt at start up without any UAC or foreground elevation window.