### PR TITLE
devcontainer for vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian
+
+WORKDIR /
+RUN apt update -y && apt install -y g++ gcc git curl wget nasm yasm libgtk-3-dev clang libxcb-randr0-dev libxdo-dev libxfixes-dev libxcb-shape0-dev libxcb-xfixes0-dev libasound2-dev libpulse-dev cmake unzip zip sudo libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+
+RUN git clone https://github.com/microsoft/vcpkg && cd vcpkg && git checkout 134505003bb46e20fbace51ccfb69243fbbc5f82
+RUN /vcpkg/bootstrap-vcpkg.sh -disableMetrics
+RUN /vcpkg/vcpkg --disable-metrics install libvpx libyuv opus
+
+RUN groupadd -r user && useradd -r -g user user --home /home/user && mkdir -p /home/user && chown user /home/user && echo "user  ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/user
+WORKDIR /home/user
+RUN wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so
+USER user
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+RUN chmod +x rustup.sh
+RUN ./rustup.sh -y
+
+USER root
+ENV HOME=/home/user

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+    "name": "rustdesk",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            "BUILDKIT_INLINE_CACHE": "0"
+        }
+    },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/user/rustdesk,type=bind,consistency=cache",
+    "workspaceFolder": "/home/user/rustdesk",
+    "postStartCommand": "./entrypoint",
+    "remoteUser": "user",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vadimcn.vscode-lldb",
+                "mutantdino.resourcemonitor",
+                "rust-lang.rust-analyzer",
+                "tamasfe.even-better-toml",
+                "serayuzgur.crates"
+            ],
+            "settings": {
+                "files.watcherExclude": {
+                    "**/target/**": true
+                }
+            }
+        }
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ flatpak/.flatpak-builder/debian-binary
 flatpak/build/**
 # bridge file
 lib/generated_bridge.dart
+# vscode devcontainer
+.gitconfig
+.vscode-server/
+.ssh
+.devcontainer/.*


### PR DESCRIPTION

It will help to create a separate development environment in docker. It doesn't pollute the local system with tools and dependencies required for building rustdesktop. Even rustlang need not be installed.  Vscode can be connected to the dev environment container through dev containers extension.

The dockerfile for the dev environment is taken from [https://github.com/rustdesk/rustdesk/blob/master/Dockerfile](https://github.com/rustdesk/rustdesk/blob/master/Dockerfile) of the repo.

Pre-requisites:
- docker
- dev containers vscode extension

Open command pallete by pressing `ctrl+shift+p`and then goto `Dev Containers: Reopen in Container`. A new workspace will be opened that creates, installs required dependencies and runs dev environment. The vscode terminal points to container. It will also download and enable extensions such as lldb, rust-analyzer.

