### PR TITLE
fix autofocus

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1861,7 +1861,7 @@ void changeSocks5Proxy() async {
                         border: const OutlineInputBorder(),
                         errorText: proxyMsg.isNotEmpty ? proxyMsg : null),
                     controller: proxyController,
-                    focusNode: FocusNode()..requestFocus(),
+                    autofocus: true,
                   ),
                 ),
               ],


### PR DESCRIPTION
Fix autofocus for hostname in Settings | Network | proxy. 

Set cursor to "username" or "password", the focus goes back to "hostname"