### PR TITLE
unify padding of dialogs

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -648,8 +648,6 @@ class CustomAlertDialog extends StatelessWidget {
       child: AlertDialog(
         scrollable: true,
         title: title,
-        contentPadding: EdgeInsets.fromLTRB(
-            contentPadding ?? padding, 25, contentPadding ?? padding, 10),
         content: ConstrainedBox(
           constraints: contentBoxConstraints,
           child: Theme(


### PR DESCRIPTION
Unify the padding of dialogs

| before | after  |
|--            |--         |
|     ![rustdesk-settings-dialog-padding](https://user-images.githubusercontent.com/67791701/218046934-5ccf0cba-1675-4653-9478-ef759b03ac96.png)          |       ![rustdesk-settings-dialog-padding-fixed](https://user-images.githubusercontent.com/67791701/218046977-530484a1-60d6-4c8a-996d-32c444f13771.png) |