### PR TITLE
Invert Color of checkmark in darkmode

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1523,7 +1523,12 @@ Widget _OptionCheckBox(BuildContext context, String label, String key,
             () => Row(
               children: [
                 Checkbox(
-                        value: ref.value, onChanged: enabled ? onChanged : null)
+                        checkColor: 'light' ==
+                                MyTheme.getThemeModePreference().toShortString()
+                            ? Colors.white
+                            : Colors.black,
+                        value: ref.value,
+                        onChanged: enabled ? onChanged : null)
                     .marginOnly(right: 5),
                 Offstage(
                   offstage: !ref.value || checkedIcon == null,


### PR DESCRIPTION
Invert the color of the checkmark in darkmode for better contrast and readability.

| before | after |
|-- |--|
|![rustdesk-settings-checkmark-before](https://user-images.githubusercontent.com/67791701/218119989-eea64e59-c796-488f-98cd-cee5a23f0888.png)|![rustdesk-settings-checkmark-after](https://user-images.githubusercontent.com/67791701/218120067-9fd6c797-62d0-4112-87dd-24fec05d784b.png)|

Needs review. Not sure about the implementation. Looks poor this way. Did not found a API method which makes it easy to get the right color for the current theme. I am not familar with the theming stuff. With a bit of advice or a hint i am sure i can solve this in a better way … or discard it :-)