### PR TITLE
Dialog. Adjust padding of the title.

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -653,6 +653,7 @@ class CustomAlertDialog extends StatelessWidget {
       child: AlertDialog(
         scrollable: true,
         title: title,
+        titlePadding: EdgeInsets.fromLTRB(padding, 24, padding, 0),
         contentPadding: EdgeInsets.fromLTRB(
             contentPadding ?? padding, 25, contentPadding ?? padding, 10),
         content: ConstrainedBox(


### PR DESCRIPTION
Using the defined padding also for the title for an even alignment. If no title is used, [its top padding](https://api.flutter.dev/flutter/material/SimpleDialog/titlePadding.html) will not apply

before > after
![rustdesk-dialog-title-padding-before-after](https://user-images.githubusercontent.com/67791701/218255973-b8ae4601-1a52-4362-ba08-cfddfd06cadd.png)

Note:

The value for the contentPadding can be set by a constructor argument (there is [one call that makes use of it](https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/mobile/widgets/dialog.dart#L156)). This value is apply to the content but not to the title nor action. This can lead to an not nice looking alignment, especially if a title is used and the value is similar or smaller than the default value.
