### PR TITLE
fix autofocus

### DIFF
--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -1013,7 +1013,7 @@ void _rdpDialog(String id) async {
                     decoration: const InputDecoration(
                         border: OutlineInputBorder(), hintText: '3389'),
                     controller: portController,
-                    focusNode: FocusNode()..requestFocus(),
+                    autofocus: true,
                   ),
                 ),
               ],

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -634,7 +634,7 @@ void setPasswordDialog() async {
                         border: const OutlineInputBorder(),
                         errorText: errMsg0.isNotEmpty ? errMsg0 : null),
                     controller: p0,
-                    focusNode: FocusNode()..requestFocus(),
+                    autofocus: true,
                     onChanged: (value) {
                       rxPass.value = value.trim();
                     },


### PR DESCRIPTION
Same behavior as in https://github.com/rustdesk/rustdesk/pull/3145. Using `autofocus: true` according to https://api.flutter.dev/flutter/material/TextField/autofocus.html and https://docs.flutter.dev/cookbook/forms/focus#focus-a-text-field-as-soon-as-its-visible

- dialog permanent password. see #3157,
- dialog RDP settings

![rustdesk-rdp-settings](https://user-images.githubusercontent.com/67791701/218262361-a86c79ce-f2e8-4838-a29d-ca29272e3e04.gif)

There are some one-field situations where this effect is not pop up.

- https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/common/widgets/address_book.dart#L389
- https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/common/widgets/dialog.dart#L57
- https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/common/widgets/dialog.dart#L102
- https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/common/widgets/dialog.dart#L189
- https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/common/widgets/peer_card.dart#L644
- https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/desktop/pages/file_manager_page.dart#L801

 The focus is also set right with "autofocus", should these fields also be changed (and included in this PR)?