### PR TITLE
force relay when id is suffixed with "/r"

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1405,13 +1405,14 @@ bool callUniLinksUriHandler(Uri uri) {
 connectMainDesktop(String id,
     {required bool isFileTransfer,
     required bool isTcpTunneling,
-    required bool isRDP}) async {
+    required bool isRDP,
+    bool? forceRelay}) async {
   if (isFileTransfer) {
-    await rustDeskWinManager.newFileTransfer(id);
+    await rustDeskWinManager.newFileTransfer(id, forceRelay: forceRelay);
   } else if (isTcpTunneling || isRDP) {
-    await rustDeskWinManager.newPortForward(id, isRDP);
+    await rustDeskWinManager.newPortForward(id, isRDP, forceRelay: forceRelay);
   } else {
-    await rustDeskWinManager.newRemoteDesktop(id);
+    await rustDeskWinManager.newRemoteDesktop(id, forceRelay: forceRelay);
   }
 }
 
@@ -1422,7 +1423,8 @@ connectMainDesktop(String id,
 connect(BuildContext context, String id,
     {bool isFileTransfer = false,
     bool isTcpTunneling = false,
-    bool isRDP = false}) async {
+    bool isRDP = false,
+    bool forceRelay = false}) async {
   if (id == '') return;
   id = id.replaceAll(' ', '');
   assert(!(isFileTransfer && isTcpTunneling && isRDP),
@@ -1430,18 +1432,18 @@ connect(BuildContext context, String id,
 
   if (isDesktop) {
     if (desktopType == DesktopType.main) {
-      await connectMainDesktop(
-        id,
-        isFileTransfer: isFileTransfer,
-        isTcpTunneling: isTcpTunneling,
-        isRDP: isRDP,
-      );
+      await connectMainDesktop(id,
+          isFileTransfer: isFileTransfer,
+          isTcpTunneling: isTcpTunneling,
+          isRDP: isRDP,
+          forceRelay: forceRelay);
     } else {
       await rustDeskWinManager.call(WindowType.Main, kWindowConnect, {
         'id': id,
         'isFileTransfer': isFileTransfer,
         'isTcpTunneling': isTcpTunneling,
         'isRDP': isRDP,
+        "forceRelay": forceRelay,
       });
     }
   } else {
@@ -1735,6 +1737,7 @@ Future<void> updateSystemWindowTheme() async {
     }
   }
 }
+
 /// macOS only
 ///
 /// Note: not found a general solution for rust based AVFoundation bingding.

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -66,7 +66,8 @@ class _ConnectionPageState extends State<ConnectionPage>
     _idFocusNode.addListener(() {
       _idInputFocused.value = _idFocusNode.hasFocus;
       // select all to faciliate removing text, just following the behavior of address input of chrome
-      _idController.selection = TextSelection(baseOffset: 0, extentOffset: _idController.value.text.length);
+      _idController.selection = TextSelection(
+          baseOffset: 0, extentOffset: _idController.value.text.length);
     });
     windowManager.addListener(this);
   }
@@ -149,8 +150,11 @@ class _ConnectionPageState extends State<ConnectionPage>
   /// Callback for the connect button.
   /// Connects to the selected peer.
   void onConnect({bool isFileTransfer = false}) {
-    final id = _idController.id;
-    connect(context, id, isFileTransfer: isFileTransfer);
+    var id = _idController.id;
+    var forceRelay = id.endsWith(r'/r');
+    if (forceRelay) id = id.substring(0, id.length - 2);
+    connect(context, id,
+        isFileTransfer: isFileTransfer, forceRelay: forceRelay);
   }
 
   /// UI for the remote ID TextField.

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -556,6 +556,7 @@ class _DesktopHomePageState extends State<DesktopHomePage>
           isFileTransfer: call.arguments['isFileTransfer'],
           isTcpTunneling: call.arguments['isTcpTunneling'],
           isRDP: call.arguments['isRDP'],
+          forceRelay: call.arguments['forceRelay'],
         );
       }
     });

--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -46,8 +46,10 @@ enum MouseFocusScope {
 }
 
 class FileManagerPage extends StatefulWidget {
-  const FileManagerPage({Key? key, required this.id}) : super(key: key);
+  const FileManagerPage({Key? key, required this.id, this.forceRelay})
+      : super(key: key);
   final String id;
+  final bool? forceRelay;
 
   @override
   State<StatefulWidget> createState() => _FileManagerPageState();
@@ -102,7 +104,7 @@ class _FileManagerPageState extends State<FileManagerPage>
   void initState() {
     super.initState();
     _ffi = FFI();
-    _ffi.start(widget.id, isFileTransfer: true);
+    _ffi.start(widget.id, isFileTransfer: true, forceRelay: widget.forceRelay);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _ffi.dialogManager
           .showLoading(translate('Connecting...'), onCancel: closeConnection);

--- a/flutter/lib/desktop/pages/file_manager_tab_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_tab_page.dart
@@ -41,7 +41,11 @@ class _FileManagerTabPageState extends State<FileManagerTabPage> {
         selectedIcon: selectedIcon,
         unselectedIcon: unselectedIcon,
         onTabCloseButton: () => () => tabController.closeBy(params['id']),
-        page: FileManagerPage(key: ValueKey(params['id']), id: params['id'])));
+        page: FileManagerPage(
+          key: ValueKey(params['id']),
+          id: params['id'],
+          forceRelay: params['forceRelay'],
+        )));
   }
 
   @override
@@ -64,7 +68,11 @@ class _FileManagerTabPageState extends State<FileManagerTabPage> {
             selectedIcon: selectedIcon,
             unselectedIcon: unselectedIcon,
             onTabCloseButton: () => tabController.closeBy(id),
-            page: FileManagerPage(key: ValueKey(id), id: id)));
+            page: FileManagerPage(
+              key: ValueKey(id),
+              id: id,
+              forceRelay: args['forceRelay'],
+            )));
       } else if (call.method == "onDestroy") {
         tabController.clear();
       } else if (call.method == kWindowActionRebuild) {

--- a/flutter/lib/desktop/pages/port_forward_page.dart
+++ b/flutter/lib/desktop/pages/port_forward_page.dart
@@ -26,10 +26,12 @@ class _PortForward {
 }
 
 class PortForwardPage extends StatefulWidget {
-  const PortForwardPage({Key? key, required this.id, required this.isRDP})
+  const PortForwardPage(
+      {Key? key, required this.id, required this.isRDP, this.forceRelay})
       : super(key: key);
   final String id;
   final bool isRDP;
+  final bool? forceRelay;
 
   @override
   State<PortForwardPage> createState() => _PortForwardPageState();
@@ -47,7 +49,7 @@ class _PortForwardPageState extends State<PortForwardPage>
   void initState() {
     super.initState();
     _ffi = FFI();
-    _ffi.start(widget.id, isPortForward: true);
+    _ffi.start(widget.id, isPortForward: true, forceRelay: widget.forceRelay);
     Get.put(_ffi, tag: 'pf_${widget.id}');
     if (!Platform.isLinux) {
       Wakelock.enable();

--- a/flutter/lib/desktop/pages/port_forward_tab_page.dart
+++ b/flutter/lib/desktop/pages/port_forward_tab_page.dart
@@ -44,6 +44,7 @@ class _PortForwardTabPageState extends State<PortForwardTabPage> {
           key: ValueKey(params['id']),
           id: params['id'],
           isRDP: isRDP,
+          forceRelay: params['forceRelay'],
         )));
   }
 
@@ -72,7 +73,12 @@ class _PortForwardTabPageState extends State<PortForwardTabPage> {
             label: id,
             selectedIcon: selectedIcon,
             unselectedIcon: unselectedIcon,
-            page: PortForwardPage(id: id, isRDP: isRDP)));
+            page: PortForwardPage(
+              key: ValueKey(args['id']),
+              id: id,
+              isRDP: isRDP,
+              forceRelay: args['forceRelay'],
+            )));
       } else if (call.method == "onDestroy") {
         tabController.clear();
       } else if (call.method == kWindowActionRebuild) {

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -34,11 +34,13 @@ class RemotePage extends StatefulWidget {
     required this.id,
     required this.menubarState,
     this.switchUuid,
+    this.forceRelay,
   }) : super(key: key);
 
   final String id;
   final MenubarState menubarState;
   final String? switchUuid;
+  final bool? forceRelay;
   final SimpleWrapper<State<RemotePage>?> _lastState = SimpleWrapper(null);
 
   FFI get ffi => (_lastState.value! as _RemotePageState)._ffi;
@@ -107,6 +109,7 @@ class _RemotePageState extends State<RemotePage>
     _ffi.start(
       widget.id,
       switchUuid: widget.switchUuid,
+      forceRelay: widget.forceRelay,
     );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: []);

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -70,6 +70,7 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
           id: peerId,
           menubarState: _menubarState,
           switchUuid: params['switch_uuid'],
+          forceRelay: params['forceRelay'],
         ),
       ));
       _update_remote_count();
@@ -104,6 +105,7 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
             id: id,
             menubarState: _menubarState,
             switchUuid: switchUuid,
+            forceRelay: args['forceRelay'],
           ),
         ));
       } else if (call.method == "onDestroy") {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1339,7 +1339,8 @@ class FFI {
   void start(String id,
       {bool isFileTransfer = false,
       bool isPortForward = false,
-      String? switchUuid}) {
+      String? switchUuid,
+      bool? forceRelay}) {
     assert(!(isFileTransfer && isPortForward), 'more than one connect type');
     if (isFileTransfer) {
       connType = ConnType.fileTransfer;
@@ -1355,11 +1356,11 @@ class FFI {
     }
     // ignore: unused_local_variable
     final addRes = bind.sessionAddSync(
-      id: id,
-      isFileTransfer: isFileTransfer,
-      isPortForward: isPortForward,
-      switchUuid: switchUuid ?? "",
-    );
+        id: id,
+        isFileTransfer: isFileTransfer,
+        isPortForward: isPortForward,
+        switchUuid: switchUuid ?? "",
+        forceRelay: forceRelay ?? false);
     final stream = bind.sessionStart(id: id);
     final cb = ffiModel.startEventListener(id);
     () async {

--- a/flutter/lib/utils/multi_window_manager.dart
+++ b/flutter/lib/utils/multi_window_manager.dart
@@ -41,11 +41,15 @@ class RustDeskMultiWindowManager {
   int? _fileTransferWindowId;
   int? _portForwardWindowId;
 
-  Future<dynamic> newRemoteDesktop(String remoteId,
-      {String? switch_uuid}) async {
+  Future<dynamic> newRemoteDesktop(
+    String remoteId, {
+    String? switch_uuid,
+    bool? forceRelay,
+  }) async {
     var params = {
       "type": WindowType.RemoteDesktop.index,
       "id": remoteId,
+      "forceRelay": forceRelay
     };
     if (switch_uuid != null) {
       params['switch_uuid'] = switch_uuid;
@@ -78,9 +82,12 @@ class RustDeskMultiWindowManager {
     }
   }
 
-  Future<dynamic> newFileTransfer(String remoteId) async {
-    final msg =
-        jsonEncode({"type": WindowType.FileTransfer.index, "id": remoteId});
+  Future<dynamic> newFileTransfer(String remoteId, {bool? forceRelay}) async {
+    var msg = jsonEncode({
+      "type": WindowType.FileTransfer.index,
+      "id": remoteId,
+      "forceRelay": forceRelay,
+    });
 
     try {
       final ids = await DesktopMultiWindow.getAllSubWindowIds();
@@ -107,9 +114,14 @@ class RustDeskMultiWindowManager {
     }
   }
 
-  Future<dynamic> newPortForward(String remoteId, bool isRDP) async {
-    final msg = jsonEncode(
-        {"type": WindowType.PortForward.index, "id": remoteId, "isRDP": isRDP});
+  Future<dynamic> newPortForward(String remoteId, bool isRDP,
+      {bool? forceRelay}) async {
+    final msg = jsonEncode({
+      "type": WindowType.PortForward.index,
+      "id": remoteId,
+      "isRDP": isRDP,
+      "forceRelay": forceRelay,
+    });
 
     try {
       final ids = await DesktopMultiWindow.getAllSubWindowIds();

--- a/src/client.rs
+++ b/src/client.rs
@@ -916,6 +916,8 @@ pub struct LoginConfigHandler {
     pub direct: Option<bool>,
     pub received: bool,
     switch_uuid: Option<String>,
+    pub success_time: Option<hbb_common::tokio::time::Instant>,
+    pub direct_error_counter: usize,
 }
 
 impl Deref for LoginConfigHandler {
@@ -962,6 +964,8 @@ impl LoginConfigHandler {
         self.direct = None;
         self.received = false;
         self.switch_uuid = switch_uuid;
+        self.success_time = None;
+        self.direct_error_counter = 0;
     }
 
     /// Check if the client should auto login.

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,15 +3,15 @@ use std::{
     net::SocketAddr,
     ops::{Deref, Not},
     str::FromStr,
-    sync::{Arc, atomic::AtomicBool, mpsc, Mutex, RwLock},
+    sync::{atomic::AtomicBool, mpsc, Arc, Mutex, RwLock},
 };
 
 pub use async_trait::async_trait;
 use bytes::Bytes;
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 use cpal::{
-    Device,
-    Host, StreamConfig, traits::{DeviceTrait, HostTrait, StreamTrait},
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    Device, Host, StreamConfig,
 };
 use magnum_opus::{Channels::*, Decoder as AudioDecoder};
 use sha2::{Digest, Sha256};
@@ -19,26 +19,26 @@ use uuid::Uuid;
 
 pub use file_trait::FileManager;
 use hbb_common::{
-    AddrMangle,
     allow_err,
     anyhow::{anyhow, Context},
     bail,
     config::{
-        Config, CONNECT_TIMEOUT, PeerConfig, PeerInfoSerde, READ_TIMEOUT, RELAY_PORT,
+        Config, PeerConfig, PeerInfoSerde, CONNECT_TIMEOUT, READ_TIMEOUT, RELAY_PORT,
         RENDEZVOUS_TIMEOUT,
-    }, get_version_number,
-    log,
-    message_proto::{*, option_message::BoolOption},
+    },
+    get_version_number, log,
+    message_proto::{option_message::BoolOption, *},
     protobuf::Message as _,
     rand,
     rendezvous_proto::*,
-    ResultType,
     socket_client,
     sodiumoxide::crypto::{box_, secretbox, sign},
-    Stream, timeout, tokio::time::Duration,
+    timeout,
+    tokio::time::Duration,
+    AddrMangle, ResultType, Stream,
 };
-pub use helper::*;
 pub use helper::LatencyController;
+pub use helper::*;
 use scrap::{
     codec::{Decoder, DecoderCfg},
     record::{Recorder, RecorderContext},
@@ -943,7 +943,13 @@ impl LoginConfigHandler {
     ///
     /// * `id` - id of peer
     /// * `conn_type` - Connection type enum.
-    pub fn initialize(&mut self, id: String, conn_type: ConnType, switch_uuid: Option<String>) {
+    pub fn initialize(
+        &mut self,
+        id: String,
+        conn_type: ConnType,
+        switch_uuid: Option<String>,
+        force_relay: bool,
+    ) {
         self.id = id;
         self.conn_type = conn_type;
         let config = self.load_config();
@@ -952,7 +958,7 @@ impl LoginConfigHandler {
         self.session_id = rand::random();
         self.supported_encoding = None;
         self.restarting_remote_device = false;
-        self.force_relay = !self.get_option("force-always-relay").is_empty();
+        self.force_relay = !self.get_option("force-always-relay").is_empty() || force_relay;
         self.direct = None;
         self.received = false;
         self.switch_uuid = switch_uuid;

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -3,19 +3,19 @@ use crate::{
     flutter_ffi::EventToUI,
     ui_session_interface::{io_loop, InvokeUiSession, Session},
 };
-use flutter_rust_bridge::{StreamSink};
+use flutter_rust_bridge::StreamSink;
 use hbb_common::{
     bail, config::LocalConfig, get_version_number, message_proto::*, rendezvous_proto::ConnType,
     ResultType,
 };
 use serde_json::json;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     collections::HashMap,
     ffi::CString,
     os::raw::{c_char, c_int},
     sync::{Arc, RwLock},
 };
-use std::sync::atomic::{AtomicBool, Ordering};
 
 pub(super) const APP_TYPE_MAIN: &str = "main";
 pub(super) const APP_TYPE_CM: &str = "cm";
@@ -114,7 +114,7 @@ pub struct FlutterHandler {
     // SAFETY: [rgba] is guarded by [rgba_valid], and it's safe to reach [rgba] with `rgba_valid == true`.
     // We must check the `rgba_valid` before reading [rgba].
     pub rgba: Arc<RwLock<Vec<u8>>>,
-    pub rgba_valid: Arc<AtomicBool>
+    pub rgba_valid: Arc<AtomicBool>,
 }
 
 impl FlutterHandler {
@@ -449,6 +449,7 @@ pub fn session_add(
     is_file_transfer: bool,
     is_port_forward: bool,
     switch_uuid: &str,
+    force_relay: bool,
 ) -> ResultType<()> {
     let session_id = get_session_id(id.to_owned());
     LocalConfig::set_remote_id(&session_id);
@@ -477,7 +478,7 @@ pub fn session_add(
         .lc
         .write()
         .unwrap()
-        .initialize(session_id, conn_type, switch_uuid);
+        .initialize(session_id, conn_type, switch_uuid, force_relay);
 
     if let Some(same_id_session) = SESSIONS.write().unwrap().insert(id.to_owned(), session) {
         same_id_session.close();
@@ -667,7 +668,7 @@ pub fn session_get_rgba_size(id: *const char) -> usize {
     let id = unsafe { std::ffi::CStr::from_ptr(id as _) };
     if let Ok(id) = id.to_str() {
         if let Some(session) = SESSIONS.write().unwrap().get_mut(id) {
-           return session.rgba.read().unwrap().len();
+            return session.rgba.read().unwrap().len();
         }
     }
     0

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1,4 +1,3 @@
-use crate::ui_session_interface::InvokeUiSession;
 use crate::{
     client::file_trait::FileManager,
     common::make_fd_to_json,
@@ -7,7 +6,7 @@ use crate::{
     flutter::{session_add, session_start_},
     ui_interface::{self, *},
 };
-use flutter_rust_bridge::{StreamSink, SyncReturn, ZeroCopyBuffer};
+use flutter_rust_bridge::{StreamSink, SyncReturn};
 use hbb_common::{
     config::{self, LocalConfig, PeerConfig, ONLINE},
     fs, log,
@@ -157,9 +156,9 @@ pub fn session_record_screen(id: String, start: bool, width: usize, height: usiz
     }
 }
 
-pub fn session_reconnect(id: String) {
+pub fn session_reconnect(id: String, force_relay: bool) {
     if let Some(session) = SESSIONS.read().unwrap().get(&id) {
-        session.reconnect();
+        session.reconnect(force_relay);
     }
 }
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1,3 +1,4 @@
+use crate::ui_session_interface::InvokeUiSession;
 use crate::{
     client::file_trait::FileManager,
     common::make_fd_to_json,
@@ -20,7 +21,6 @@ use std::{
     os::raw::c_char,
     str::FromStr,
 };
-use crate::ui_session_interface::InvokeUiSession;
 
 // use crate::hbbs_http::account::AuthResult;
 
@@ -84,8 +84,15 @@ pub fn session_add_sync(
     is_file_transfer: bool,
     is_port_forward: bool,
     switch_uuid: String,
+    force_relay: bool,
 ) -> SyncReturn<String> {
-    if let Err(e) = session_add(&id, is_file_transfer, is_port_forward, &switch_uuid) {
+    if let Err(e) = session_add(
+        &id,
+        is_file_transfer,
+        is_port_forward,
+        &switch_uuid,
+        force_relay,
+    ) {
         SyncReturn(format!("Failed to add session with id {}, {}", &id, e))
     } else {
         SyncReturn("".to_owned())

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Tancat manualment pel peer"),
         ("Enable remote configuration modification", "Habilitar modificació remota de configuració"),
         ("Run without install", "Executar sense instal·lar"),
-        ("Always connected via relay", "Connectat sempre a través de relay"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Connecta sempre a través de relay"),
         ("whitelist_tip", ""),
         ("Login", "Inicia sessió"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "被对方手动关闭"),
         ("Enable remote configuration modification", "允许远程修改配置"),
         ("Run without install", "无安装运行"),
-        ("Always connected via relay", "强制走中继连接"),
+        ("Connect via relay", "中继连接"),
         ("Always connect via relay", "强制走中继连接"),
         ("whitelist_tip", "只有白名单里的ip才能访问我"),
         ("Login", "登录"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", "语音通话"),
         ("Text chat", "文字聊天"),
         ("Stop voice call", "停止语音聊天"),
+        ("relay_hint_tip", "可能无法直连，可以尝试中继连接。\n另外，如果想直接使用中继连接，可以在ID后面添加/r，或者在卡片选项里选择强制走中继连接。"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Ručně ukončeno protějškem"),
         ("Enable remote configuration modification", "Umožnit upravování nastavení vzdáleného"),
         ("Run without install", "Spustit bez instalování"),
-        ("Always connected via relay", "Vždy spojováno prostřednictvím brány pro předávání (relay)"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Vždy se spojovat prostřednictvím brány pro předávání (relay)"),
         ("whitelist_tip", "Přístup je umožněn pouze z IP adres, nacházejících se na seznamu povolených"),
         ("Login", "Přihlásit se"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Manuelt lukket af peer"),
         ("Enable remote configuration modification", "Tillad at ændre afstandskonfigurationen"),
         ("Run without install", "Kør uden installation"),
-        ("Always connected via relay", "Tilslut altid via relæ-server"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Forbindelse via relæ-server"),
         ("whitelist_tip", "Kun IP'er på udgivelseslisten kan få adgang til mig"),
         ("Login", "Login"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Von der Gegenstelle manuell geschlossen"),
         ("Enable remote configuration modification", "Änderung der Konfiguration aus der Ferne zulassen"),
         ("Run without install", "Ohne Installation ausführen"),
-        ("Always connected via relay", "Immer über Relay-Server verbunden"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Immer über Relay-Server verbinden"),
         ("whitelist_tip", "Nur IPs auf der Whitelist können zugreifen."),
         ("Login", "Anmelden"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", "Sprachanruf"),
         ("Text chat", "Text-Chat"),
         ("Stop voice call", "Sprachanruf beenden"),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -42,6 +42,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("request_elevation_tip","You can also request elevation if there is someone on the remote side."),
         ("wait_accept_uac_tip","Please wait for the remote user to accept the UAC dialog."),
         ("still_click_uac_tip", "Still requires the remote user to click OK on the UAC window of running RustDesk."),
-        ("config_microphone", "In order to speak remotely, you need to grant RustDesk \"Record Audio\" permissions.")
+        ("config_microphone", "In order to speak remotely, you need to grant RustDesk \"Record Audio\" permissions."),
+        ("relay_hint_tip", "It may not be possible to connect directly, you can try to connect via relay. \nIn addition, if you want to use relay on your first try, you can add the \"/r\" suffix to the ID, or select the option \"Always connect via relay\" in the peer card."),
         ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Manuale fermita de la samtavolano"),
         ("Enable remote configuration modification", "Permesi foran redaktadon de la konfiguracio"),
         ("Run without install", "Plenumi sen instali"),
-        ("Always connected via relay", "Ĉiam konektata per relajso"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Ĉiam konekti per relajso"),
         ("whitelist_tip", "Nur la IP en la blanka listo povas kontroli mian komputilon"),
         ("Login", "Konekti"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Cerrado manualmente por el par"),
         ("Enable remote configuration modification", "Habilitar modificación remota de configuración"),
         ("Run without install", "Ejecutar sin instalar"),
-        ("Always connected via relay", "Siempre conectado a través de relay"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Conéctese siempre a través de relay"),
         ("whitelist_tip", "Solo las direcciones IP autorizadas pueden conectarse a este escritorio"),
         ("Login", "Iniciar sesión"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", "Llamada de voz"),
         ("Text chat", "Chat de texto"),
         ("Stop voice call", "Detener llamada de voz"),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "به صورت دستی توسط میزبان بسته شد"),
         ("Enable remote configuration modification", "فعال بودن اعمال تغییرات پیکربندی از راه دور"),
         ("Run without install", "بدون نصب اجرا شود"),
-        ("Always connected via relay", "متصل است Relay همیشه با"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "برای اتصال استفاده شود Relay از"),
         ("whitelist_tip", "های مجاز می توانند به این دسکتاپ متصل شوند IP فقط"),
         ("Login", "ورود"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", "تماس صوتی"),
         ("Text chat", "گفتگو متنی (چت متنی)"),
         ("Stop voice call", "توقف تماس صوتی"),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Fermé manuellement par le pair"),
         ("Enable remote configuration modification", "Autoriser la modification de la configuration à distance"),
         ("Run without install", "Exécuter sans installer"),
-        ("Always connected via relay", "Forcer la connexion relais"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Forcer la connexion relais"),
         ("whitelist_tip", "Seule une IP de la liste blanche peut accéder à mon appareil"),
         ("Login", "Connexion"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gr.rs
+++ b/src/lang/gr.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Έκλεισε από τον απομακρυσμένο σταθμό"),
         ("Enable remote configuration modification", "Ενεργοποίηση απομακρυσμένης τροποποίησης ρυθμίσεων"),
         ("Run without install", "Εκτέλεση χωρίς εγκατάσταση"),
-        ("Always connected via relay", "Πάντα συνδεδεμένο μέσω αναμετάδοσης"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Σύνδεση πάντα μέσω αναμετάδοσης"),
         ("whitelist_tip", "Μόνο οι IP της λίστας επιτρεπόμενων έχουν πρόσβαση"),
         ("Login", "Σύνδεση"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "A kapcsolatot a másik fél manuálisan bezárta"),
         ("Enable remote configuration modification", "Távoli konfiguráció módosítás engedélyezése"),
         ("Run without install", "Futtatás feltelepítés nélkül"),
-        ("Always connected via relay", "Mindig közvetítőn keresztül csatlakozik"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Mindig közvetítőn keresztüli csatlakozás"),
         ("whitelist_tip", "Csak az engedélyezési listán szereplő címek csatlakozhatnak"),
         ("Login", "Belépés"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Ditutup secara manual oleh peer"),
         ("Enable remote configuration modification", "Aktifkan modifikasi konfigurasi jarak jauh"),
         ("Run without install", "Jalankan tanpa menginstal"),
-        ("Always connected via relay", "Selalu terhubung melalui relai"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Selalu terhubung melalui relai"),
         ("whitelist_tip", "Hanya whitelisted IP yang dapat mengakses saya"),
         ("Login", "Masuk"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Chiuso manualmente dal peer"),
         ("Enable remote configuration modification", "Abilita la modifica remota della configurazione"),
         ("Run without install", "Esegui senza installare"),
-        ("Always connected via relay", "Connesso sempre tramite relay"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Collegati sempre tramite relay"),
         ("whitelist_tip", "Solo gli indirizzi IP autorizzati possono connettersi a questo desktop"),
         ("Login", "Accedi"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", "Chiamata vocale"),
         ("Text chat", "Chat testuale"),
         ("Stop voice call", "Interrompi la chiamata vocale"),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "相手が手動で切断しました"),
         ("Enable remote configuration modification", "リモート設定変更を有効化"),
         ("Run without install", "インストールせずに実行"),
-        ("Always connected via relay", "常に中継サーバー経由で接続"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "常に中継サーバー経由で接続"),
         ("whitelist_tip", "ホワイトリストに登録されたIPからのみ接続を許可します"),
         ("Login", "ログイン"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "다른 사용자에 의해 종료됨"),
         ("Enable remote configuration modification", "원격 구성 변경 활성화"),
         ("Run without install", "설치 없이 실행"),
-        ("Always connected via relay", "항상 relay를 통해 접속됨"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "항상 relay를 통해 접속하기"),
         ("whitelist_tip", "화이트리스트에 있는 IP만 현 데스크탑에 접속 가능합니다"),
         ("Login", "로그인"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Пир қолымен жабылған"),
         ("Enable remote configuration modification", "Қашықтан қалыптарды өзгертуді іске қосу"),
         ("Run without install", "Орнатпай-ақ Іске қосу"),
-        ("Always connected via relay", "Әрқашан да релай сербері арқылы қосулы"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Әрқашан да релай сербері арқылы қосылу"),
         ("whitelist_tip", "Маған тек ақ-тізімделген IP қол жеткізе алады"),
         ("Login", "Кіру"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Połączenie zakończone ręcznie przez peer"),
         ("Enable remote configuration modification", "Włącz zdalną modyfikację konfiguracji"),
         ("Run without install", "Uruchom bez instalacji"),
-        ("Always connected via relay", "Zawsze połączony pośrednio"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Zawsze łącz pośrednio"),
         ("whitelist_tip", "Zezwalaj na łączenie z tym komputerem tylko z adresów IP znajdujących się na białej liście"),
         ("Login", "Zaloguj"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Fechada manualmente pelo destino"),
         ("Enable remote configuration modification", "Habilitar modificações de configuração remotas"),
         ("Run without install", "Executar sem instalar"),
-        ("Always connected via relay", "Sempre conectado via relay"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Sempre conectar via relay"),
         ("whitelist_tip", "Somente IPs na whitelist podem me acessar"),
         ("Login", "Login"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Fechada manualmente pelo parceiro"),
         ("Enable remote configuration modification", "Habilitar modificações de configuração remotas"),
         ("Run without install", "Executar sem instalar"),
-        ("Always connected via relay", "Sempre conectado via relay"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Sempre conectar via relay"),
         ("whitelist_tip", "Somente IPs confiáveis podem me acessar"),
         ("Login", "Login"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Închis manual de dispozitivul pereche"),
         ("Enable remote configuration modification", "Activează modificarea configurației de la distanță"),
         ("Run without install", "Rulează fără instalare"),
-        ("Always connected via relay", "Se conectează mereu prin retransmisie"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Se conectează mereu prin retransmisie"),
         ("whitelist_tip", "Doar adresele IP autorizate pot accesa acest dispozitiv"),
         ("Login", "Conectare"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Закрыто удалённым узлом вручную"),
         ("Enable remote configuration modification", "Разрешить удалённое изменение конфигурации"),
         ("Run without install", "Запустить без установки"),
-        ("Always connected via relay", "Всегда подключается через ретрансляционный сервер"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Всегда подключаться через ретрансляционный сервер"),
         ("whitelist_tip", "Только IP-адреса из белого списка могут получить доступ ко мне"),
         ("Login", "Войти"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", "Голосовой вызов"),
         ("Text chat", "Текстовый чат"),
         ("Stop voice call", "Завершить голосовой вызов"),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Manuálne ukončené opačnou stranou pripojenia"),
         ("Enable remote configuration modification", "Povoliť zmeny konfigurácie zo vzdialeného PC"),
         ("Run without install", "Spustiť bez inštalácie"),
-        ("Always connected via relay", "Vždy pripojené cez prepájací server"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Vždy pripájať cez prepájací server"),
         ("whitelist_tip", "Len vymenované IP adresy majú oprávnenie sa pripojiť k vzdialenej správe"),
         ("Login", "Prihlásenie"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Povezavo ročno prekinil odjemalec"),
         ("Enable remote configuration modification", "Omogoči oddaljeno spreminjanje nastavitev"),
         ("Run without install", "Zaženi brez namestitve"),
-        ("Always connected via relay", "Vedno povezan preko posrednika"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Vedno poveži preko posrednika"),
         ("whitelist_tip", "Dostop je možen samo iz dovoljenih IPjev"),
         ("Login", "Prijavi"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "E mbyllur manualisht nga peer"),
         ("Enable remote configuration modification", "Aktivizoni modifikimin e konfigurimit në distancë"),
         ("Run without install", "Ekzekuto pa instaluar"),
-        ("Always connected via relay", "Gjithmonë i ldihur me transmetues"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Gjithmonë lidheni me transmetues"),
         ("whitelist_tip", "Vetëm IP e listës së bardhë mund të më aksesoj."),
         ("Login", "Hyrje"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Klijent ručno raskinuo konekciju"),
         ("Enable remote configuration modification", "Dozvoli modifikaciju udaljene konfiguracije"),
         ("Run without install", "Pokreni bez instalacije"),
-        ("Always connected via relay", "Uvek spojne preko posrednika"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Uvek se spoj preko posrednika"),
         ("whitelist_tip", "Samo dozvoljene IP mi mogu pristupiti"),
         ("Login", "Prijava"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Stängd manuellt av klienten"),
         ("Enable remote configuration modification", "Tillåt fjärrkonfigurering"),
         ("Run without install", "Kör utan installation"),
-        ("Always connected via relay", "Anslut alltid via relay"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Anslut alltid via relay"),
         ("whitelist_tip", "Bara vitlistade IPs kan koppla upp till mig"),
         ("Login", "Logga in"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", ""),
         ("Enable remote configuration modification", ""),
         ("Run without install", ""),
-        ("Always connected via relay", ""),
+        ("Connect via relay", ""),
         ("Always connect via relay", ""),
         ("whitelist_tip", ""),
         ("Login", ""),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "ถูกปิดโดยอีกฝั่งการการเชื่อมต่อ"),
         ("Enable remote configuration modification", "เปิดการใช้งานการแก้ไขการตั้งค่าปลายทาง"),
         ("Run without install", "ใช้งานโดยไม่ต้องติดตั้ง"),
-        ("Always connected via relay", "เชื่อมต่อผ่านรีเลย์เสมอ"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "เชื่อมต่อผ่านรีเลย์เสมอ"),
         ("whitelist_tip", "อนุญาตเฉพาะการเชื่อมต่อจาก IP ที่ไวท์ลิสต์"),
         ("Login", "เข้าสู่ระบบ"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Eş tarafından manuel olarak kapatıldı"),
         ("Enable remote configuration modification", "Uzaktan yapılandırma değişikliğini etkinleştir"),
         ("Run without install", "Yüklemeden çalıştır"),
-        ("Always connected via relay", "Her zaman röle ile bağlı"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Always connect via relay"),
         ("whitelist_tip", "Bu masaüstüne yalnızca yetkili IP adresleri bağlanabilir"),
         ("Login", "Giriş yap"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "由對方手動關閉"),
         ("Enable remote configuration modification", "啟用遠端更改設定"),
         ("Run without install", "跳過安裝直接執行"),
-        ("Always connected via relay", "一律透過轉送連線"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "一律透過轉送連線"),
         ("whitelist_tip", "只有白名單中的 IP 可以存取"),
         ("Login", "登入"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Закрито вузлом вручну"),
         ("Enable remote configuration modification", "Дозволити віддалену зміну конфігурації"),
         ("Run without install", "Запустити без установки"),
-        ("Always connected via relay", "Завжди підключений через ретрансляційний сервер"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Завжди підключатися через ретрансляційний сервер"),
         ("whitelist_tip", "Тільки IP-адреси з білого списку можуть отримати доступ до мене"),
         ("Login", "Увійти"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -209,7 +209,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Closed manually by the peer", "Đóng thủ công bởi peer"),
         ("Enable remote configuration modification", "Cho phép thay đổi cấu hình bên từ xa"),
         ("Run without install", "Chạy mà không cần cài"),
-        ("Always connected via relay", "Luôn đuợc kết nối qua relay"),
+        ("Connect via relay", ""),
         ("Always connect via relay", "Luôn kết nối qua relay"),
         ("whitelist_tip", "Chỉ có những IP đựoc cho phép mới có thể truy cập"),
         ("Login", "Đăng nhập"),
@@ -449,5 +449,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Voice call", ""),
         ("Text chat", ""),
         ("Stop voice call", ""),
+        ("relay_hint_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -1,4 +1,3 @@
-use std::sync::RwLock;
 use std::{
     collections::HashMap,
     ops::{Deref, DerefMut},
@@ -15,7 +14,6 @@ use sciter::{
     Value,
 };
 
-use hbb_common::tokio::io::AsyncReadExt;
 use hbb_common::{
     allow_err, fs::TransferJobMeta, log, message_proto::*, rendezvous_proto::ConnType,
 };
@@ -348,7 +346,7 @@ impl sciter::EventHandler for SciterSession {
                     let site = AssetPtr::adopt(ptr as *mut video_destination);
                     log::debug!("[video] start video");
                     *VIDEO.lock().unwrap() = Some(site);
-                    self.reconnect();
+                    self.reconnect(false);
                 }
             }
             BEHAVIOR_EVENTS::VIDEO_INITIALIZED => {
@@ -397,7 +395,7 @@ impl sciter::EventHandler for SciterSession {
         fn transfer_file();
         fn tunnel();
         fn lock_screen();
-        fn reconnect();
+        fn reconnect(bool);
         fn get_chatbox();
         fn get_icon();
         fn get_home_dir();

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -1,24 +1,24 @@
+use std::sync::RwLock;
 use std::{
     collections::HashMap,
     ops::{Deref, DerefMut},
     sync::{Arc, Mutex},
 };
-use std::sync::RwLock;
 
 use sciter::{
     dom::{
-        Element,
-        event::{BEHAVIOR_EVENTS, EVENT_GROUPS, EventReason, PHASE_MASK}, HELEMENT,
+        event::{EventReason, BEHAVIOR_EVENTS, EVENT_GROUPS, PHASE_MASK},
+        Element, HELEMENT,
     },
     make_args,
+    video::{video_destination, AssetPtr, COLOR_SPACE},
     Value,
-    video::{AssetPtr, COLOR_SPACE, video_destination},
 };
 
+use hbb_common::tokio::io::AsyncReadExt;
 use hbb_common::{
     allow_err, fs::TransferJobMeta, log, message_proto::*, rendezvous_proto::ConnType,
 };
-use hbb_common::tokio::io::AsyncReadExt;
 
 use crate::{
     client::*,
@@ -286,7 +286,9 @@ impl InvokeUiSession for SciterHandler {
     }
 
     /// RGBA is directly rendered by [on_rgba]. No need to store the rgba for the sciter ui.
-    fn get_rgba(&self) -> *const u8  { std::ptr::null() }
+    fn get_rgba(&self) -> *const u8 {
+        std::ptr::null()
+    }
 
     fn next_rgba(&mut self) {}
 }
@@ -467,7 +469,11 @@ impl SciterSession {
             ConnType::DEFAULT_CONN
         };
 
-        session.lc.write().unwrap().initialize(id, conn_type, None);
+        session
+            .lc
+            .write()
+            .unwrap()
+            .initialize(id, conn_type, None, false);
 
         Self(session)
     }

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1,29 +1,30 @@
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
-use std::sync::{Arc, Mutex, RwLock};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use rdev::{Event, EventType::*};
 use uuid::Uuid;
 
-use hbb_common::{allow_err, message_proto::*};
-use hbb_common::{fs, get_version_number, log, Stream};
 use hbb_common::config::{Config, LocalConfig, PeerConfig, RS_PUB_KEY};
 use hbb_common::rendezvous_proto::ConnType;
 use hbb_common::tokio::{self, sync::mpsc};
+use hbb_common::{allow_err, message_proto::*};
+use hbb_common::{fs, get_version_number, log, Stream};
 
-use crate::{client::Data, client::Interface};
-use crate::client::{
-    check_if_retry, FileManager, handle_hash, handle_login_error, handle_login_from_ui,
-    handle_test_delay, input_os_password, Key, KEY_MAP, load_config, LoginConfigHandler,
-    QualityStatus, send_mouse, start_video_audio_threads,
-};
 use crate::client::io_loop::Remote;
+use crate::client::{
+    check_if_retry, handle_hash, handle_login_error, handle_login_from_ui, handle_test_delay,
+    input_os_password, load_config, send_mouse, start_video_audio_threads, FileManager, Key,
+    LoginConfigHandler, QualityStatus, KEY_MAP,
+};
 use crate::common::{self, GrabState};
 use crate::keyboard;
+use crate::{client::Data, client::Interface};
 
 pub static IS_IN: AtomicBool = AtomicBool::new(false);
 
@@ -531,9 +532,13 @@ impl<T: InvokeUiSession> Session<T> {
         }
     }
 
-    pub fn reconnect(&self) {
+    pub fn reconnect(&self, force_relay: bool) {
         self.send(Data::Close);
         let cloned = self.clone();
+        // override only if true
+        if true == force_relay {
+            cloned.lc.write().unwrap().force_relay = true;
+        }
         let mut lock = self.thread.lock().unwrap();
         lock.take().map(|t| t.join());
         *lock = Some(std::thread::spawn(move || {
@@ -674,9 +679,41 @@ impl<T: InvokeUiSession> Session<T> {
     pub fn request_voice_call(&self) {
         self.send(Data::NewVoiceCall);
     }
-    
+
     pub fn close_voice_call(&self) {
         self.send(Data::CloseVoiceCall);
+    }
+
+    pub fn show_relay_hint(
+        &mut self,
+        last_recv_time: tokio::time::Instant,
+        msgtype: &str,
+        title: &str,
+        text: &str,
+    ) -> bool {
+        let duration = Duration::from_secs(3);
+        let counter_interval = 3;
+        let lock = self.lc.read().unwrap();
+        let success_time = lock.success_time;
+        let direct = lock.direct.unwrap_or(false);
+        let received = lock.received;
+        drop(lock);
+        if let Some(success_time) = success_time {
+            if direct && last_recv_time.duration_since(success_time) < duration {
+                let retry_for_relay = direct && !received;
+                let retry = check_if_retry(msgtype, title, text, retry_for_relay);
+                if retry && !retry_for_relay {
+                    self.lc.write().unwrap().direct_error_counter += 1;
+                    if self.lc.read().unwrap().direct_error_counter % counter_interval == 0 {
+                        #[cfg(feature = "flutter")]
+                        return true;
+                    }
+                }
+            } else {
+                self.lc.write().unwrap().direct_error_counter = 0;
+            }
+        }
+        false
     }
 }
 
@@ -813,6 +850,7 @@ impl<T: InvokeUiSession> Interface for Session<T> {
                 "Connected, waiting for image...",
                 "",
             );
+            self.lc.write().unwrap().success_time = Some(tokio::time::Instant::now());
         }
         self.on_connected(self.lc.read().unwrap().conn_type);
         #[cfg(windows)]
@@ -958,7 +996,7 @@ pub async fn io_loop<T: InvokeUiSession>(handler: Session<T>) {
     let frame_count = Arc::new(AtomicUsize::new(0));
     let frame_count_cl = frame_count.clone();
     let ui_handler = handler.ui_handler.clone();
-    let (video_sender, audio_sender) = start_video_audio_threads(move |data: &mut Vec<u8> | {
+    let (video_sender, audio_sender) = start_video_audio_threads(move |data: &mut Vec<u8>| {
         frame_count_cl.fetch_add(1, Ordering::Relaxed);
         ui_handler.on_rgba(data);
     });


### PR DESCRIPTION
[#1597 ](https://github.com/rustdesk/rustdesk/issues/1597#issuecomment-1427040649)
works only on main window ID InputTextField

- [X] remember it  via "force-always-relay" option, what about addressbook?
     * sync before
- [x] hint dialog, our retry logic has no way to cover all cases, these dialog is our last defense, e.g. connection reset soon after connected without known reason.
     * add hint messagebox, but it's not easy to test it.
     * show hint messagebox when 
        * last_receive_time - success_time < 3 second
        * three times in a row
