### PR TITLE
Unify buttonstyle, unify dialog padding

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -662,8 +662,8 @@ class CustomAlertDialog extends StatelessWidget {
         scrollable: true,
         title: title,
         titlePadding: EdgeInsets.fromLTRB(padding, 24, padding, 0),
-        contentPadding: EdgeInsets.fromLTRB(
-            contentPadding ?? padding, 25, contentPadding ?? padding, 10),
+        contentPadding: EdgeInsets.fromLTRB(contentPadding ?? padding, 25,
+            contentPadding ?? padding, actions is List ? 10 : padding),
         content: ConstrainedBox(
           constraints: contentBoxConstraints,
           child: Theme(

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -500,12 +500,14 @@ class OverlayDialogManager {
                   Offstage(
                       offstage: !showCancel,
                       child: Center(
-                          child: TextButton(
-                              style: flatButtonStyle,
-                              onPressed: cancel,
-                              child: Text(translate('Cancel'),
-                                  style:
-                                      const TextStyle(color: MyTheme.accent)))))
+                          child: isDesktop
+                              ? dialogButton('Cancel', onPressed: cancel)
+                              : TextButton(
+                                  style: flatButtonStyle,
+                                  onPressed: cancel,
+                                  child: Text(translate('Cancel'),
+                                      style: const TextStyle(
+                                          color: MyTheme.accent)))))
                 ])),
         onCancel: showCancel ? cancel : null,
       );


### PR DESCRIPTION
|before|after|
|-- |-- |
|![ui-unify-button-dialog-desktop-before](https://user-images.githubusercontent.com/67791701/219307783-4dbd2f23-fc1b-4b25-9b10-36d31fd4c477.png)|![ui-unify-button-dialog-desktop-after](https://user-images.githubusercontent.com/67791701/219307779-c8927c44-b5e8-464c-9bf6-b9f0b5ab465c.png)|
|![ui-unify-button-dialog-mobile-before](https://user-images.githubusercontent.com/67791701/219307786-79ada872-44c1-48d2-80d6-6fe8fe2a9909.png)|![ui-unify-button-dialog-mobile-after](https://user-images.githubusercontent.com/67791701/219307789-854ba162-592d-44e7-8eb9-8c5d4b55380c.png)|

Are you using a specific cs guidline, e.g. to set the indention for the IDE? the default behavior of vscode looks somtimes weird. 