### PR TITLE
Unify input labels. Remove colon from login labels

### DIFF
--- a/flutter/lib/common/widgets/login.dart
+++ b/flutter/lib/common/widgets/login.dart
@@ -324,13 +324,13 @@ class LoginWidgetUserPass extends StatelessWidget {
           children: [
             const SizedBox(height: 8.0),
             DialogTextField(
-                title: '${translate("Username")}:',
+                title: translate("Username"),
                 controller: username,
                 focusNode: userFocusNode,
                 prefixIcon: Icon(Icons.account_circle_outlined),
                 errorText: usernameMsg),
             DialogTextField(
-                title: '${translate("Password")}:',
+                title: translate("Password"),
                 obscureText: true,
                 controller: pass,
                 prefixIcon: Icon(Icons.lock_outline),


### PR DESCRIPTION
Colons in floating labels used nowhere else

|before|now|
|-- |-- |
|![ui-login-colon-before](https://user-images.githubusercontent.com/67791701/219334866-8d43c52a-8707-4f05-9450-3d5b34d4bfbf.png)|![ui-login-colon-after](https://user-images.githubusercontent.com/67791701/219334869-f7f80045-df7e-4de2-b341-9fc8b7e62a28.png)|

