### PR TITLE
Unify input behavior. Add ObscureText to proxy password input

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1832,6 +1832,7 @@ void changeSocks5Proxy() async {
   var proxyController = TextEditingController(text: proxy);
   var userController = TextEditingController(text: username);
   var pwdController = TextEditingController(text: password);
+  RxBool obscure = true.obs;
 
   var isInProgress = false;
   gFFI.dialogManager.show((setState, close) {
@@ -1929,12 +1930,17 @@ void changeSocks5Proxy() async {
                   width: 24.0,
                 ),
                 Expanded(
-                  child: TextField(
-                    decoration: const InputDecoration(
-                      border: OutlineInputBorder(),
-                    ),
-                    controller: pwdController,
-                  ),
+                  child: Obx(() => TextField(
+                        obscureText: obscure.value,
+                        decoration: InputDecoration(
+                            border: const OutlineInputBorder(),
+                            suffixIcon: IconButton(
+                                onPressed: () => obscure.value = !obscure.value,
+                                icon: Icon(obscure.value
+                                    ? Icons.visibility_off
+                                    : Icons.visibility))),
+                        controller: pwdController,
+                      )),
                 ),
               ],
             ),


### PR DESCRIPTION
Same purpose as in "RDP Settings", so do behave the same.

|before|now|
|-- |-- |
|![ui-password-obsuce-before](https://user-images.githubusercontent.com/67791701/219415603-0d427979-7be3-4146-8972-81d0571889db.png)|![ui-password-obsuce-after](https://user-images.githubusercontent.com/67791701/219415608-f7cf73d6-9f7b-4e95-aa57-626f24c2f46a.gif)|
