### PR TITLE
Readability. Invert color of checkmark for darkmode

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -217,6 +217,9 @@ class MyTheme {
             style: ButtonStyle(splashFactory: NoSplash.splashFactory),
           )
         : null,
+    checkboxTheme: const CheckboxThemeData(
+      checkColor: MaterialStatePropertyAll(dark)
+    ),
   ).copyWith(
     extensions: <ThemeExtension<dynamic>>[
       ColorThemeExtension.dark,


### PR DESCRIPTION
Invert the color of the checkmark in darkmode for better contrast and readability.

| before | after |
|-- |--|
|![rustdesk-settings-checkmark-before](https://user-images.githubusercontent.com/67791701/218119989-eea64e59-c796-488f-98cd-cee5a23f0888.png)|![rustdesk-settings-checkmark-after](https://user-images.githubusercontent.com/67791701/218120067-9fd6c797-62d0-4112-87dd-24fec05d784b.png)|

