### PR TITLE
WIP: replace canvas with texture for the better performance of decoding and showing video frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4859,6 +4859,7 @@ dependencies = [
  "include_dir",
  "jni 0.19.0",
  "lazy_static",
+ "libloading",
  "libpulse-binding",
  "libpulse-simple-binding",
  "mac_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-run = "rustdesk"
 
 [lib]
 name = "librustdesk"
-crate-type = ["cdylib", "staticlib", "rlib"]
+crate-type = ["cdylib"]
 
 [[bin]]
 name = "naming"
@@ -68,6 +68,7 @@ url = { version = "2.1", features = ["serde"] }
 reqwest = { version = "0.11", features = ["blocking", "json", "rustls-tls"], default-features=false }
 chrono = "0.4.23"
 cidr-utils = "0.5.9"
+libloading = "0.7.4"
 
 [target.'cfg(not(any(target_os = "android", target_os = "linux")))'.dependencies]
 cpal = "0.13.5"

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -19,6 +19,7 @@ import 'package:flutter_hbb/utils/multi_window_manager.dart';
 import 'package:flutter_hbb/utils/platform_channel.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
+import 'package:texture_rgba_renderer/texture_rgba_renderer.dart';
 import 'package:uni_links/uni_links.dart';
 import 'package:uni_links_desktop/uni_links_desktop.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -44,6 +45,10 @@ var isWeb = false;
 var isWebDesktop = false;
 var version = "";
 int androidVersion = 0;
+/// Incriment count for textureId.
+int _textureId = 0;
+int get newTextureId => _textureId ++;
+final textureRenderer = TextureRgbaRenderer();
 
 /// only available for Windows target
 int windowsBuildNumber = 0;

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1446,14 +1446,15 @@ class FFI {
           }
         } else if (message is EventToUI_Rgba) {
           // Fetch the image buffer from rust codes.
-          final sz = platformFFI.getRgbaSize(id);
-          if (sz == null || sz == 0) {
-            return;
-          }
-          final rgba = platformFFI.getRgba(id, sz);
-          if (rgba != null) {
-            imageModel.onRgba(rgba);
-          }
+          // final sz = platformFFI.getRgbaSize(id);
+          // if (sz == null || sz == 0) {
+          //   return;
+          // }
+          // final rgba = platformFFI.getRgba(id, sz);
+          // if (rgba != null) {
+          //   imageModel.onRgba(rgba);
+          // }
+          // imageModel.onRgba(rgba);
         }
       }
       debugPrint('Exit session event loop');

--- a/flutter/lib/models/native_model.dart
+++ b/flutter/lib/models/native_model.dart
@@ -30,6 +30,9 @@ typedef F4Dart = int Function(Pointer<Utf8>);
 typedef F5 = Void Function(Pointer<Utf8>);
 typedef F5Dart = void Function(Pointer<Utf8>);
 typedef HandleEvent = Future<void> Function(Map<String, dynamic> evt);
+// pub fn session_register_texture(id: *const char, ptr: usize) 
+typedef F6 = Void Function(Pointer<Utf8>, Uint64);
+typedef F6Dart = void Function(Pointer<Utf8>, int);
 
 /// FFI wrapper around the native Rust core.
 /// Hides the platform differences.
@@ -52,6 +55,8 @@ class PlatformFFI {
   F3? _session_get_rgba;
   F4Dart? _session_get_rgba_size;
   F5Dart? _session_next_rgba;
+  F6Dart? _session_register_texture;
+  
 
   static get localeName => Platform.localeName;
 
@@ -130,6 +135,13 @@ class PlatformFFI {
     malloc.free(a);
   }
 
+  void registerTexture(String id, int ptr) {
+    if (_session_register_texture == null) return;
+    final a = id.toNativeUtf8();
+    _session_register_texture!(a, ptr);
+    malloc.free(a);
+  }
+
   /// Init the FFI class, loads the native Rust core library.
   Future<void> init(String appType) async {
     _appType = appType;
@@ -150,6 +162,7 @@ class PlatformFFI {
           dylib.lookupFunction<F4, F4Dart>("session_get_rgba_size");
       _session_next_rgba =
           dylib.lookupFunction<F5, F5Dart>("session_next_rgba");
+      _session_register_texture = dylib.lookupFunction<F6, F6Dart>("session_register_texture");
       try {
         // SYSTEM user failed
         _dir = (await getApplicationDocumentsDirectory()).path;

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -92,6 +92,7 @@ dependencies:
     password_strength: ^0.2.0
     flutter_launcher_icons: ^0.11.0
     flutter_keyboard_visibility: ^5.4.0
+    texture_rgba_renderer: ^0.0.6
 
 
 dev_dependencies:

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -298,7 +298,7 @@ impl InvokeUiSession for SciterHandler {
         std::ptr::null()
     }
 
-    fn next_rgba(&mut self) {}
+    fn next_rgba(&self) {}
 }
 
 pub struct SciterSession(Session<SciterHandler>);

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -798,7 +798,7 @@ pub trait InvokeUiSession: Send + Sync + Clone + 'static + Sized + Default {
     fn on_voice_call_waiting(&self);
     fn on_voice_call_incoming(&self);
     fn get_rgba(&self) -> *const u8;
-    fn next_rgba(&mut self);
+    fn next_rgba(&self);
 }
 
 impl<T: InvokeUiSession> Deref for Session<T> {


### PR DESCRIPTION
BREAKING:

This PR does a refactor, which replaces the general canvas with native `Texture` provided by Flutter official.

Benefits:
Remove the time interval between the two messages brought by binary messager and the calling chain. which reduces the processing time from 40ms to <10ms per frame.

Related:

- #3141 