### PR TITLE
Rework on PeerCard menu

### DIFF
--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -565,9 +565,21 @@ abstract class BasePeerCard extends StatelessWidget {
   @protected
   MenuEntryBase<String> _addFavAction(String id) {
     return MenuEntryButton<String>(
-      childBuilder: (TextStyle? style) => Text(
-        translate('Add to Favorites'),
-        style: style,
+      childBuilder: (TextStyle? style) => Row(
+        children: [
+          Text(
+            translate('Add to Favorites'),
+            style: style,
+          ),
+          Expanded(
+              child: Align(
+            alignment: Alignment.centerRight,
+            child: Transform.scale(
+              scale: 0.8,
+              child: Icon(Icons.star_outline),
+            ),
+          ).marginOnly(right: 4)),
+        ],
       ),
       proc: () {
         () async {
@@ -587,9 +599,21 @@ abstract class BasePeerCard extends StatelessWidget {
   MenuEntryBase<String> _rmFavAction(
       String id, Future<void> Function() reloadFunc) {
     return MenuEntryButton<String>(
-      childBuilder: (TextStyle? style) => Text(
-        translate('Remove from Favorites'),
-        style: style,
+      childBuilder: (TextStyle? style) => Row(
+        children: [
+          Text(
+            translate('Remove from Favorites'),
+            style: style,
+          ),
+          Expanded(
+              child: Align(
+            alignment: Alignment.centerRight,
+            child: Transform.scale(
+              scale: 0.8,
+              child: Icon(Icons.star),
+            ),
+          ).marginOnly(right: 4)),
+        ],
       ),
       proc: () {
         () async {

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -518,7 +518,7 @@ abstract class BasePeerCard extends StatelessWidget {
       childBuilder: (TextStyle? style) => Row(
         children: [
           Text(
-            translate('Remove'),
+            translate('Delete'),
             style: style?.copyWith(color: Colors.red),
           ),
           Expanded(

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -827,6 +827,9 @@ class DiscoveredPeerCard extends BasePeerCard {
       _connectAction(context, peer),
       _transferFileAction(context, peer.id),
     ];
+
+    final List favs = (await bind.mainGetFav()).toList();
+
     if (isDesktop && peer.platform != 'Android') {
       menuItems.add(_tcpTunnelingAction(context, peer.id));
     }
@@ -837,6 +840,12 @@ class DiscoveredPeerCard extends BasePeerCard {
     menuItems.add(_wolAction(peer.id));
     if (Platform.isWindows) {
       menuItems.add(_createShortCutAction(peer.id));
+    }
+
+    if (!favs.contains(peer.id)) {
+      menuItems.add(_addFavAction(peer.id));
+    } else {
+      menuItems.add(_rmFavAction(peer.id, () async {}));
     }
 
     if (gFFI.userModel.userName.isNotEmpty) {

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -689,6 +689,9 @@ class RecentPeerCard extends BasePeerCard {
       _connectAction(context, peer),
       _transferFileAction(context, peer.id),
     ];
+
+    final List favs = (await bind.mainGetFav()).toList();
+
     if (isDesktop && peer.platform != 'Android') {
       menuItems.add(_tcpTunnelingAction(context, peer.id));
     }
@@ -705,7 +708,13 @@ class RecentPeerCard extends BasePeerCard {
     if (await bind.mainPeerHasPassword(id: peer.id)) {
       menuItems.add(_unrememberPasswordAction(peer.id));
     }
-    menuItems.add(_addFavAction(peer.id));
+
+    if (!favs.contains(peer.id)) {
+      menuItems.add(_addFavAction(peer.id));
+    } else {
+      menuItems.add(_rmFavAction(peer.id, () async {}));
+    }
+
     if (!gFFI.abModel.idContainBy(peer.id)) {
       menuItems.add(_addToAb(peer));
     }

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -682,8 +682,9 @@ abstract class BasePeerCard extends StatelessWidget {
                 child: TextFormField(
                   controller: controller,
                   autofocus: true,
-                  decoration:
-                      const InputDecoration(border: OutlineInputBorder()),
+                  decoration: InputDecoration(
+                      border: OutlineInputBorder(),
+                      labelText: translate('Name')),
                 ),
               ),
             ),

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -536,6 +536,10 @@ abstract class BasePeerCard extends StatelessWidget {
           if (isLan) {
             // TODO
           } else {
+            final favs = (await bind.mainGetFav()).toList();
+            if (favs.remove(id)) {
+              await bind.mainStoreFav(favs: favs);
+            }
             await bind.mainRemovePeer(id: id);
           }
           removePreference(id);

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -690,9 +690,6 @@ class RecentPeerCard extends BasePeerCard {
     }
     menuItems.add(MenuEntryDivider());
     menuItems.add(_renameAction(peer.id));
-    menuItems.add(_removeAction(peer.id, () async {
-      await bind.mainLoadRecentPeers();
-    }));
     if (await bind.mainPeerHasPassword(id: peer.id)) {
       menuItems.add(_unrememberPasswordAction(peer.id));
     }
@@ -700,6 +697,9 @@ class RecentPeerCard extends BasePeerCard {
     if (!gFFI.abModel.idContainBy(peer.id)) {
       menuItems.add(_addToAb(peer));
     }
+    menuItems.add(_removeAction(peer.id, () async {
+      await bind.mainLoadRecentPeers();
+    }));
     return menuItems;
   }
 
@@ -732,9 +732,6 @@ class FavoritePeerCard extends BasePeerCard {
     }
     menuItems.add(MenuEntryDivider());
     menuItems.add(_renameAction(peer.id));
-    menuItems.add(_removeAction(peer.id, () async {
-      await bind.mainLoadFavPeers();
-    }));
     if (await bind.mainPeerHasPassword(id: peer.id)) {
       menuItems.add(_unrememberPasswordAction(peer.id));
     }
@@ -744,6 +741,9 @@ class FavoritePeerCard extends BasePeerCard {
     if (!gFFI.abModel.idContainBy(peer.id)) {
       menuItems.add(_addToAb(peer));
     }
+    menuItems.add(_removeAction(peer.id, () async {
+      await bind.mainLoadFavPeers();
+    }));
     return menuItems;
   }
 
@@ -775,10 +775,10 @@ class DiscoveredPeerCard extends BasePeerCard {
       menuItems.add(_createShortCutAction(peer.id));
     }
     menuItems.add(MenuEntryDivider());
-    menuItems.add(_removeAction(peer.id, () async {}));
     if (!gFFI.abModel.idContainBy(peer.id)) {
       menuItems.add(_addToAb(peer));
     }
+    menuItems.add(_removeAction(peer.id, () async {}));
     return menuItems;
   }
 
@@ -811,13 +811,13 @@ class AddressBookPeerCard extends BasePeerCard {
     }
     menuItems.add(MenuEntryDivider());
     menuItems.add(_renameAction(peer.id));
-    menuItems.add(_removeAction(peer.id, () async {}));
     if (await bind.mainPeerHasPassword(id: peer.id)) {
       menuItems.add(_unrememberPasswordAction(peer.id));
     }
     if (gFFI.abModel.tags.isNotEmpty) {
       menuItems.add(_editTagAction(peer.id));
     }
+    menuItems.add(_removeAction(peer.id, () async {}));
     return menuItems;
   }
 

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -515,9 +515,21 @@ abstract class BasePeerCard extends StatelessWidget {
       String id, Future<void> Function() reloadFunc,
       {bool isLan = false}) {
     return MenuEntryButton<String>(
-      childBuilder: (TextStyle? style) => Text(
-        translate('Remove'),
-        style: style,
+      childBuilder: (TextStyle? style) => Row(
+        children: [
+          Text(
+            translate('Remove'),
+            style: style?.copyWith(color: Colors.red),
+          ),
+          Expanded(
+              child: Align(
+            alignment: Alignment.centerRight,
+            child: Transform.scale(
+              scale: 0.8,
+              child: Icon(Icons.delete_forever, color: Colors.red),
+            ),
+          ).marginOnly(right: 4)),
+        ],
       ),
       proc: () {
         () async {
@@ -697,6 +709,7 @@ class RecentPeerCard extends BasePeerCard {
     if (!gFFI.abModel.idContainBy(peer.id)) {
       menuItems.add(_addToAb(peer));
     }
+    menuItems.add(MenuEntryDivider());
     menuItems.add(_removeAction(peer.id, () async {
       await bind.mainLoadRecentPeers();
     }));
@@ -741,6 +754,7 @@ class FavoritePeerCard extends BasePeerCard {
     if (!gFFI.abModel.idContainBy(peer.id)) {
       menuItems.add(_addToAb(peer));
     }
+    menuItems.add(MenuEntryDivider());
     menuItems.add(_removeAction(peer.id, () async {
       await bind.mainLoadFavPeers();
     }));
@@ -778,6 +792,7 @@ class DiscoveredPeerCard extends BasePeerCard {
     if (!gFFI.abModel.idContainBy(peer.id)) {
       menuItems.add(_addToAb(peer));
     }
+    menuItems.add(MenuEntryDivider());
     menuItems.add(_removeAction(peer.id, () async {}));
     return menuItems;
   }
@@ -817,6 +832,7 @@ class AddressBookPeerCard extends BasePeerCard {
     if (gFFI.abModel.tags.isNotEmpty) {
       menuItems.add(_editTagAction(peer.id));
     }
+    menuItems.add(MenuEntryDivider());
     menuItems.add(_removeAction(peer.id, () async {}));
     return menuItems;
   }

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -739,9 +739,15 @@ class RecentPeerCard extends BasePeerCard {
       menuItems.add(_rmFavAction(peer.id, () async {}));
     }
 
-    if (!gFFI.abModel.idContainBy(peer.id)) {
+    if (gFFI.userModel.userName.isNotEmpty) {
+      // if (!gFFI.abModel.idContainBy(peer.id)) {
+      //   menuItems.add(_addToAb(peer));
+      // } else {
+      //   menuItems.add(_removeFromAb(peer));
+      // }
       menuItems.add(_addToAb(peer));
     }
+
     menuItems.add(MenuEntryDivider());
     menuItems.add(_removeAction(peer.id, () async {
       await bind.mainLoadRecentPeers();
@@ -784,9 +790,16 @@ class FavoritePeerCard extends BasePeerCard {
     menuItems.add(_rmFavAction(peer.id, () async {
       await bind.mainLoadFavPeers();
     }));
-    if (!gFFI.abModel.idContainBy(peer.id)) {
+
+    if (gFFI.userModel.userName.isNotEmpty) {
+      // if (!gFFI.abModel.idContainBy(peer.id)) {
+      //   menuItems.add(_addToAb(peer));
+      // } else {
+      //   menuItems.add(_removeFromAb(peer));
+      // }
       menuItems.add(_addToAb(peer));
     }
+
     menuItems.add(MenuEntryDivider());
     menuItems.add(_removeAction(peer.id, () async {
       await bind.mainLoadFavPeers();
@@ -821,10 +834,16 @@ class DiscoveredPeerCard extends BasePeerCard {
     if (Platform.isWindows) {
       menuItems.add(_createShortCutAction(peer.id));
     }
-    menuItems.add(MenuEntryDivider());
-    if (!gFFI.abModel.idContainBy(peer.id)) {
+
+    if (gFFI.userModel.userName.isNotEmpty) {
+      // if (!gFFI.abModel.idContainBy(peer.id)) {
+      //   menuItems.add(_addToAb(peer));
+      // } else {
+      //   menuItems.add(_removeFromAb(peer));
+      // }
       menuItems.add(_addToAb(peer));
     }
+
     menuItems.add(MenuEntryDivider());
     menuItems.add(_removeAction(peer.id, () async {}));
     return menuItems;
@@ -865,6 +884,7 @@ class AddressBookPeerCard extends BasePeerCard {
     if (gFFI.abModel.tags.isNotEmpty) {
       menuItems.add(_editTagAction(peer.id));
     }
+
     menuItems.add(MenuEntryDivider());
     menuItems.add(_removeAction(peer.id, () async {}));
     return menuItems;


### PR DESCRIPTION
### Fixes

- menu item "remove" doesn't remove peer from favorites
- menu showing always "add to favorites" even peer is already a favorite
- menu item "add to addressbook" disappear when clicked

### Changes

- move menu item "remove" to the last menu position, make its destructive role visible, change text to "delete"
- add missing menu item "add/remove favorite" to DiscoveredPeersCard
- hide menu item "add to address book" if not logged in.
- add visually feedback for state of "is favorite" in menu item "add/remove favorite"
- add missing label to Text input on "rename"

---

### Menu item "remove"

The "remove" entry is too close to its siblings is some ways.

|before | after |
|-- |-- |
|![remove-before](https://user-images.githubusercontent.com/67791701/219976511-86c73c5f-3b1b-4fb6-b1ac-ba9c05f8dbb8.png)|![remove-after](https://user-images.githubusercontent.com/67791701/220903141-278e0097-b190-4e4e-be88-ac68b264b1f1.png)|

### Menu item "Add to favorites" 

"Add favorites" is always shown in menu even if already in favs. 

**Now**:

|peer not in favs | peer in favs |
|-- |-- |
|![favorite-before](https://user-images.githubusercontent.com/67791701/219976509-aaf99b7f-e0df-4f11-a3d8-217a622081ac.png)|![favorite-after](https://user-images.githubusercontent.com/67791701/219976502-8ad6f2de-d357-4639-b352-27e519e6f530.png)|


#### add visual state indicator (behave like a checkbox)

|peer not in favs | peer in favs |
|-- |-- |
|![favorite-indicator-add](https://user-images.githubusercontent.com/67791701/219979396-48c63079-c539-4433-b237-abc2db0ff521.png)|![favorite-indicator-remove](https://user-images.githubusercontent.com/67791701/219979397-8324968f-1d39-4dbd-88ae-6dd244ff6580.png)|