### PR TITLE
remove closed as expected on switchsides

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1593,7 +1593,6 @@ impl Connection {
                                 uuid.to_string().as_ref(),
                             ])
                             .ok();
-                            self.send_close_reason_no_retry("Closed as expected").await;
                             self.on_close("switch sides", false).await;
                             return false;
                         }


### PR DESCRIPTION
call `closeConnection` in flutter is enough, this msgbox is useless and may prompt at next connect.