### PR TITLE
fix desktop entry key/values

### DIFF
--- a/res/rustdesk.desktop
+++ b/res/rustdesk.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.5.0
+Version=1.5
 Name=RustDesk
 GenericName=Remote Desktop
 Comment=Remote Desktop

--- a/res/rustdesk.desktop
+++ b/res/rustdesk.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.2.0
+Version=1.5.0
 Name=RustDesk
 GenericName=Remote Desktop
 Comment=Remote Desktop
@@ -16,4 +16,4 @@ X-Desktop-File-Install-Version=0.23
 
 [Desktop Action new-window]
 Name=Open a New Window
-
+Exec=rustdesk %u


### PR DESCRIPTION
Similar to #1255 and related to #1299, running `desktop-file-validate /usr/share/applications/rustdesk.desktop` on Ubuntu 22.04 returns the following:  
```
/usr/share/applications/rustdesk.desktop: error: value "1.2.0" for key "Version" in group "Desktop Entry" is not a known version
/usr/share/applications/rustdesk.desktop: error: required key "Exec" in group "Desktop Action new-window" is not present
```
* "Version" refers to the Freedesktop Specification[1], not the program's one. Given that this was correctly defined in `rustdesk-link.desktop`, the same value should be used here too.
* The new-window section is missing the `Exec` key. Ubuntu 22.04 refuses to launch from the Activities overview (apps menu) without this key.  

[1] https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html