### PR TITLE
Don't run github actions on ignored paths.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "README.md"
   push:
     branches:
       - master
@@ -14,6 +17,8 @@ on:
       - '*'
     paths-ignore:
       - ".github/**"
+      - "docs/**"
+      - "README.md"
 
 jobs:
   # ensure_cargo_fmt:

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -3,6 +3,9 @@ name: Full Flutter CI
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+    - "docs/**"
+    - "README.md"
   push:
     branches:
       - master
@@ -10,6 +13,8 @@ on:
       - '*'
     paths-ignore:
       - ".github/**"
+      - "docs/**"
+      - "README.md"
 
 env:
   LLVM_VERSION: "15.0.6"


### PR DESCRIPTION
Github Actions run even for changes in `docs/**` and `Readme.md` file. I feel these are irrelevant for running Github CI.

