### PR TITLE
Added additional intent-filter

### DIFF
--- a/flutter/android/app/src/main/AndroidManifest.xml
+++ b/flutter/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
             android:exported="false">
             <intent-filter android:priority="1000">
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
             </intent-filter>
         </receiver>
 


### PR DESCRIPTION
Hi, I saw that TeamViewer Host app uses this action in their intent filter in BootReceiver, so I think we should include it too.

About this intent:
This event is triggered when the device is booted up from a quick boot mode, which is a feature introduced in Android 5.0 Lollipop that allows devices to boot up faster by skipping certain system initialization steps.