### PR TITLE
Fix/flutter keyboard compatibility

### DIFF
--- a/flutter/lib/desktop/widgets/remote_menubar.dart
+++ b/flutter/lib/desktop/widgets/remote_menubar.dart
@@ -1542,11 +1542,15 @@ class _KeyboardMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var ffiModel = Provider.of<FfiModel>(context);
-    if (ffiModel.permissions['keyboard'] == false) return Offstage();
+    // Do not check permission here?
+    // var ffiModel = Provider.of<FfiModel>(context);
+    // if (ffiModel.permissions['keyboard'] == false) return Offstage();
     if (stateGlobal.grabKeyboard) {
       if (bind.sessionIsKeyboardModeSupported(id: id, mode: _kKeyMapMode)) {
         bind.sessionSetKeyboardMode(id: id, value: _kKeyMapMode);
+      } else if (bind.sessionIsKeyboardModeSupported(
+          id: id, mode: _kKeyLegacyMode)) {
+        bind.sessionSetKeyboardMode(id: id, value: _kKeyLegacyMode);
       }
       return Offstage();
     }

--- a/flutter/lib/desktop/widgets/remote_menubar.dart
+++ b/flutter/lib/desktop/widgets/remote_menubar.dart
@@ -23,6 +23,10 @@ import '../../common/shared_state.dart';
 import './popup_menu.dart';
 import './kb_layout_type_chooser.dart';
 
+const _kKeyLegacyMode = 'legacy';
+const _kKeyMapMode = 'map';
+const _kKeyTranslateMode = 'translate';
+
 class MenubarState {
   final kStoreKey = 'remoteMenubarState';
   late RxBool show;
@@ -1540,9 +1544,10 @@ class _KeyboardMenu extends StatelessWidget {
   Widget build(BuildContext context) {
     var ffiModel = Provider.of<FfiModel>(context);
     if (ffiModel.permissions['keyboard'] == false) return Offstage();
-    // Do not support peer 1.1.9.
     if (stateGlobal.grabKeyboard) {
-      bind.sessionSetKeyboardMode(id: id, value: 'map');
+      if (bind.sessionIsKeyboardModeSupported(id: id, mode: _kKeyMapMode)) {
+        bind.sessionSetKeyboardMode(id: id, value: _kKeyMapMode);
+      }
       return Offstage();
     }
     return _IconSubmenuButton(
@@ -1555,13 +1560,13 @@ class _KeyboardMenu extends StatelessWidget {
 
   mode() {
     return futureBuilder(future: () async {
-      return await bind.sessionGetKeyboardMode(id: id) ?? 'legacy';
+      return await bind.sessionGetKeyboardMode(id: id) ?? _kKeyLegacyMode;
     }(), hasData: (data) {
       final groupValue = data as String;
       List<KeyboardModeMenu> modes = [
-        KeyboardModeMenu(key: 'legacy', menu: 'Legacy mode'),
-        KeyboardModeMenu(key: 'map', menu: 'Map mode'),
-        KeyboardModeMenu(key: 'translate', menu: 'Translate mode'),
+        KeyboardModeMenu(key: _kKeyLegacyMode, menu: 'Legacy mode'),
+        KeyboardModeMenu(key: _kKeyMapMode, menu: 'Map mode'),
+        KeyboardModeMenu(key: _kKeyTranslateMode, menu: 'Translate mode'),
       ];
       List<_RadioMenuButton> list = [];
       onChanged(String? value) async {
@@ -1571,13 +1576,13 @@ class _KeyboardMenu extends StatelessWidget {
 
       for (KeyboardModeMenu mode in modes) {
         if (bind.sessionIsKeyboardModeSupported(id: id, mode: mode.key)) {
-          if (mode.key == 'translate') {
+          if (mode.key == _kKeyTranslateMode) {
             if (Platform.isLinux || pi.platform == kPeerPlatformLinux) {
               continue;
             }
           }
           var text = translate(mode.menu);
-          if (mode.key == 'translate') {
+          if (mode.key == _kKeyTranslateMode) {
             text = '$text beta';
           }
           list.add(_RadioMenuButton<String>(


### PR DESCRIPTION
1. Flutter keyboard grab, set legacy mode, if only legacy mode is supported.
2. Do not check keyboard permission on menu build. Or else the connection has to be closed and connect again, to make the keyboard menu show.