### PR TITLE
fix keyboard options, revert change

### DIFF
--- a/flutter/lib/desktop/widgets/remote_menubar.dart
+++ b/flutter/lib/desktop/widgets/remote_menubar.dart
@@ -1561,9 +1561,8 @@ class _KeyboardMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Do not check permission here?
-    // var ffiModel = Provider.of<FfiModel>(context);
-    // if (ffiModel.permissions['keyboard'] == false) return Offstage();
+    var ffiModel = Provider.of<FfiModel>(context);
+    if (ffiModel.permissions['keyboard'] == false) return Offstage();
     if (stateGlobal.grabKeyboard) {
       if (bind.sessionIsKeyboardModeSupported(id: id, mode: _kKeyMapMode)) {
         bind.sessionSetKeyboardMode(id: id, value: _kKeyMapMode);


### PR DESCRIPTION
Fix incorrect change of https://github.com/rustdesk/rustdesk/pull/3375.
Point 2. The keyboard option show/hide when the peer enable/disable the permission.