### PR TITLE
fix macos strid align

### DIFF
--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -306,12 +306,13 @@ impl Decoder {
     pub fn handle_video_frame(
         &mut self,
         frame: &video_frame::Union,
+        stride_align: usize,
         fmt: ImageFormat,
         rgb: &mut Vec<u8>,
     ) -> ResultType<bool> {
         match frame {
             video_frame::Union::Vp9s(vp9s) => {
-                Decoder::handle_vp9s_video_frame(&mut self.vpx, vp9s, fmt, rgb)
+                Decoder::handle_vp9s_video_frame(&mut self.vpx, vp9s, stride_align, fmt, rgb)
             }
             #[cfg(feature = "hwcodec")]
             video_frame::Union::H264s(h264s) => {
@@ -352,6 +353,7 @@ impl Decoder {
     fn handle_vp9s_video_frame(
         decoder: &mut VpxDecoder,
         vp9s: &EncodedVideoFrames,
+        stride_align: usize,
         fmt: ImageFormat,
         rgb: &mut Vec<u8>,
     ) -> ResultType<bool> {
@@ -369,7 +371,7 @@ impl Decoder {
         if last_frame.is_null() {
             Ok(false)
         } else {
-            last_frame.to(fmt, 1, rgb);
+            last_frame.to(fmt, stride_align, rgb);
             Ok(true)
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -49,7 +49,7 @@ use scrap::{
 };
 
 use crate::{
-    common::{self, is_keyboard_mode_supported},
+    common::{self, is_keyboard_mode_supported, STRIDE_ALIGN},
     server::video_service::{SCRAP_X11_REF_URL, SCRAP_X11_REQUIRED},
 };
 
@@ -949,7 +949,7 @@ impl VideoHandler {
                 let fmt = ImageFormat::ABGR;
                 #[cfg(not(all(target_os = "windows", feature = "flutter_texture_render")))]
                 let fmt = ImageFormat::ARGB;
-                let res = self.decoder.handle_video_frame(frame, fmt, &mut self.rgb);
+                let res = self.decoder.handle_video_frame(frame, STRIDE_ALIGN, fmt, &mut self.rgb);
                 if self.record {
                     self.recorder
                         .lock()

--- a/src/common.rs
+++ b/src/common.rs
@@ -39,6 +39,11 @@ pub const CLIPBOARD_INTERVAL: u64 = 333;
 
 pub const SYNC_PEER_INFO_DISPLAYS: i32 = 1;
 
+#[cfg(all(target_os = "macos", feature = "flutter_texture_render"))]
+pub const STRIDE_ALIGN: usize = 16;
+#[cfg(not(all(target_os = "macos", feature = "flutter_texture_render")))]
+pub const STRIDE_ALIGN: usize = 1;
+
 // the executable name of the portable version
 pub const PORTABLE_APPNAME_RUNTIME_ENV_KEY: &str = "RUSTDESK_APPNAME";
 

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -206,7 +206,9 @@ impl VideoRenderer {
         self.width = width;
         self.height = height;
         self.data_len = if width > 0 && height > 0 {
-            (width * height * 4) as usize
+            let sa1 = crate::common::STRIDE_ALIGN - 1;
+            let w = (width as usize + sa1) & !sa1;
+            w * (height as usize) * 4
         } else {
             0
         };


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/3424

```rust
#[cfg(all(target_os = "macos", feature = "flutter_texture_render"))]
pub const STRIDE_ALIGN: usize = 16;
#[cfg(not(all(target_os = "macos", feature = "flutter_texture_render")))]
pub const STRIDE_ALIGN: usize = 1;
```