### PR TITLE
Fix/macos texture stride align

### DIFF
--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -1228,10 +1228,10 @@ packages:
     dependency: "direct main"
     description:
       name: texture_rgba_renderer
-      sha256: fbb09b2c6b4ce71261927f9e7e4ea339af3e2f3f2b175f6fb921de1c66ec848d
+      sha256: ec8d124e4c1d7dfff854ae34e95d7d9d877b8f9d291c383c67686e4b15cf538e
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.8"
+    version: "0.0.12"
   timing:
     dependency: transitive
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -92,7 +92,7 @@ dependencies:
   password_strength: ^0.2.0
   flutter_launcher_icons: ^0.11.0
   flutter_keyboard_visibility: ^5.4.0
-  texture_rgba_renderer: ^0.0.8
+  texture_rgba_renderer: ^0.0.12
   percent_indicator: ^4.2.2
 
 dev_dependencies:

--- a/libs/scrap/examples/record-screen.rs
+++ b/libs/scrap/examples/record-screen.rs
@@ -18,7 +18,7 @@ use webm::mux;
 use webm::mux::Track;
 
 use scrap::vpxcodec as vpx_encode;
-use scrap::{TraitCapturer, Capturer, Display, STRIDE_ALIGN};
+use scrap::{TraitCapturer, Capturer, Display, STRIDE};
 
 const USAGE: &'static str = "
 Simple WebM screen capture.
@@ -137,7 +137,7 @@ fn main() -> io::Result<()> {
         if let Ok(frame) = c.frame(Duration::from_millis(0)) {
             let ms = time.as_secs() * 1000 + time.subsec_millis() as u64;
 
-            for frame in vpx.encode(ms as i64, &frame, STRIDE_ALIGN).unwrap() {
+            for frame in vpx.encode(ms as i64, &frame, STRIDE).unwrap() {
                 vt.add_frame(frame.data, frame.pts as u64 * 1_000_000, frame.key);
             }
         }

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -306,12 +306,13 @@ impl Decoder {
     pub fn handle_video_frame(
         &mut self,
         frame: &video_frame::Union,
+        stride_align: usize,
         fmt: ImageFormat,
         rgb: &mut Vec<u8>,
     ) -> ResultType<bool> {
         match frame {
             video_frame::Union::Vp9s(vp9s) => {
-                Decoder::handle_vp9s_video_frame(&mut self.vpx, vp9s, fmt, rgb)
+                Decoder::handle_vp9s_video_frame(&mut self.vpx, vp9s, stride_align, fmt, rgb)
             }
             #[cfg(feature = "hwcodec")]
             video_frame::Union::H264s(h264s) => {
@@ -352,6 +353,7 @@ impl Decoder {
     fn handle_vp9s_video_frame(
         decoder: &mut VpxDecoder,
         vp9s: &EncodedVideoFrames,
+        stride_align: usize,
         fmt: ImageFormat,
         rgb: &mut Vec<u8>,
     ) -> ResultType<bool> {
@@ -369,7 +371,7 @@ impl Decoder {
         if last_frame.is_null() {
             Ok(false)
         } else {
-            last_frame.to(fmt, 1, rgb);
+            last_frame.to(fmt, stride_align, rgb);
             Ok(true)
         }
     }

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -380,6 +380,7 @@ impl Decoder {
     fn handle_hw_video_frame(
         decoder: &mut HwDecoder,
         frames: &EncodedVideoFrames,
+        stride_align: usize,
         fmt: ImageFormat,
         raw: &mut Vec<u8>,
         i420: &mut Vec<u8>,
@@ -388,7 +389,7 @@ impl Decoder {
         for h264 in frames.frames.iter() {
             for image in decoder.decode(&h264.data)? {
                 // TODO: just process the last frame
-                if image.to_fmt(fmt, raw, i420).is_ok() {
+                if image.to_fmt(stride_align, fmt, raw, i420).is_ok() {
                     ret = true;
                 }
             }
@@ -400,12 +401,13 @@ impl Decoder {
     fn handle_mediacodec_video_frame(
         decoder: &mut MediaCodecDecoder,
         frames: &EncodedVideoFrames,
+        stride_align: usize,
         fmt: ImageFormat,
         raw: &mut Vec<u8>,
     ) -> ResultType<bool> {
         let mut ret = false;
         for h264 in frames.frames.iter() {
-            return decoder.decode(&h264.data, fmt, raw);
+            return decoder.decode(&h264.data, stride_align, fmt, raw);
         }
         return Ok(false);
     }

--- a/libs/scrap/src/common/convert.rs
+++ b/libs/scrap/src/common/convert.rs
@@ -144,7 +144,7 @@ extern "C" {
 fn get_vpx_i420_stride(
     width: usize,
     height: usize,
-    stride_align: usize,
+    stride: usize,
 ) -> (usize, usize, usize, usize, usize, usize) {
     let mut img = Default::default();
     unsafe {
@@ -153,7 +153,7 @@ fn get_vpx_i420_stride(
             vpx_img_fmt::VPX_IMG_FMT_I420,
             width as _,
             height as _,
-            stride_align as _,
+            stride as _,
             0x1 as _,
         );
     }
@@ -169,7 +169,7 @@ fn get_vpx_i420_stride(
 
 pub fn i420_to_rgb(width: usize, height: usize, src: &[u8], dst: &mut Vec<u8>) {
     let (_, _, src_stride_y, src_stride_uv, u, v) =
-        get_vpx_i420_stride(width, height, super::STRIDE_ALIGN);
+        get_vpx_i420_stride(width, height, super::STRIDE);
     let src_y = src.as_ptr();
     let src_u = src[u..].as_ptr();
     let src_v = src[v..].as_ptr();
@@ -192,7 +192,7 @@ pub fn i420_to_rgb(width: usize, height: usize, src: &[u8], dst: &mut Vec<u8>) {
 
 pub fn bgra_to_i420(width: usize, height: usize, src: &[u8], dst: &mut Vec<u8>) {
     let (_, h, dst_stride_y, dst_stride_uv, u, v) =
-        get_vpx_i420_stride(width, height, super::STRIDE_ALIGN);
+        get_vpx_i420_stride(width, height, super::STRIDE);
     dst.resize(h * dst_stride_y * 2, 0); // waste some memory to ensure memory safety
     let dst_y = dst.as_mut_ptr();
     let dst_u = dst[u..].as_mut_ptr();
@@ -215,7 +215,7 @@ pub fn bgra_to_i420(width: usize, height: usize, src: &[u8], dst: &mut Vec<u8>) 
 
 pub fn rgba_to_i420(width: usize, height: usize, src: &[u8], dst: &mut Vec<u8>) {
     let (_, h, dst_stride_y, dst_stride_uv, u, v) =
-        get_vpx_i420_stride(width, height, super::STRIDE_ALIGN);
+        get_vpx_i420_stride(width, height, super::STRIDE);
     dst.resize(h * dst_stride_y * 2, 0); // waste some memory to ensure memory safety
     let dst_y = dst.as_mut_ptr();
     let dst_u = dst[u..].as_mut_ptr();
@@ -246,7 +246,7 @@ pub unsafe fn nv12_to_i420(
     dst: &mut Vec<u8>,
 ) {
     let (_, h, dst_stride_y, dst_stride_uv, u, v) =
-        get_vpx_i420_stride(width, height, super::STRIDE_ALIGN);
+        get_vpx_i420_stride(width, height, super::STRIDE);
     dst.resize(h * dst_stride_y * 2, 0); // waste some memory to ensure memory safety
     let dst_y = dst.as_mut_ptr();
     let dst_u = dst[u..].as_mut_ptr();

--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -1,6 +1,6 @@
 use crate::{
     codec::{EncoderApi, EncoderCfg},
-    hw, ImageFormat, HW_STRIDE_ALIGN,
+    hw, ImageFormat, HW_STRIDE,
 };
 use hbb_common::{
     anyhow::{anyhow, Context},
@@ -52,7 +52,7 @@ impl EncoderApi for HwEncoder {
                     width: config.width as _,
                     height: config.height as _,
                     pixfmt: DEFAULT_PIXFMT,
-                    align: HW_STRIDE_ALIGN as _,
+                    align: HW_STRIDE as _,
                     bitrate: config.bitrate * 1000,
                     timebase: DEFAULT_TIME_BASE,
                     gop: DEFAULT_GOP,
@@ -236,7 +236,7 @@ pub struct HwDecoderImage<'a> {
 }
 
 impl HwDecoderImage<'_> {
-    pub fn to_fmt(&self, stride_align: usize, fmt: ImageFormat, fmt_data: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
+    pub fn to_fmt(&self, stride: usize, fmt: ImageFormat, fmt_data: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
         let frame = self.frame;
         match frame.pixfmt {
             AVPixelFormat::AV_PIX_FMT_NV12 => hw::hw_nv12_to(
@@ -249,7 +249,7 @@ impl HwDecoderImage<'_> {
                 frame.linesize[1] as _,
                 fmt_data,
                 i420,
-                HW_STRIDE_ALIGN,
+                HW_STRIDE,
             ),
             AVPixelFormat::AV_PIX_FMT_YUV420P => {
                 hw::hw_i420_to(
@@ -269,12 +269,12 @@ impl HwDecoderImage<'_> {
         }
     }
 
-    pub fn bgra(&self, stride_align: usize, bgra: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
-        self.to_fmt(stride_align, ImageFormat::ARGB, bgra, i420)
+    pub fn bgra(&self, stride: usize, bgra: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
+        self.to_fmt(stride, ImageFormat::ARGB, bgra, i420)
     }
 
-    pub fn rgba(&self, stride_align: usize, rgba: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
-        self.to_fmt(stride_align, ImageFormat::ABGR, rgba, i420)
+    pub fn rgba(&self, stride: usize, rgba: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
+        self.to_fmt(stride, ImageFormat::ABGR, rgba, i420)
     }
 }
 
@@ -296,7 +296,7 @@ pub fn check_config() {
         width: 1920,
         height: 1080,
         pixfmt: DEFAULT_PIXFMT,
-        align: HW_STRIDE_ALIGN as _,
+        align: HW_STRIDE as _,
         bitrate: 0,
         timebase: DEFAULT_TIME_BASE,
         gop: DEFAULT_GOP,

--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -236,7 +236,7 @@ pub struct HwDecoderImage<'a> {
 }
 
 impl HwDecoderImage<'_> {
-    pub fn to_fmt(&self, fmt: ImageFormat, fmt_data: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
+    pub fn to_fmt(&self, stride_align: usize, fmt: ImageFormat, fmt_data: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
         let frame = self.frame;
         match frame.pixfmt {
             AVPixelFormat::AV_PIX_FMT_NV12 => hw::hw_nv12_to(
@@ -269,12 +269,12 @@ impl HwDecoderImage<'_> {
         }
     }
 
-    pub fn bgra(&self, bgra: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
-        self.to_fmt(ImageFormat::ARGB, bgra, i420)
+    pub fn bgra(&self, stride_align: usize, bgra: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
+        self.to_fmt(stride_align, ImageFormat::ARGB, bgra, i420)
     }
 
-    pub fn rgba(&self, rgba: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
-        self.to_fmt(ImageFormat::ABGR, rgba, i420)
+    pub fn rgba(&self, stride_align: usize, rgba: &mut Vec<u8>, i420: &mut Vec<u8>) -> ResultType<()> {
+        self.to_fmt(stride_align, ImageFormat::ABGR, rgba, i420)
     }
 }
 

--- a/libs/scrap/src/common/mediacodec.rs
+++ b/libs/scrap/src/common/mediacodec.rs
@@ -50,7 +50,8 @@ impl MediaCodecDecoder {
         MediaCodecDecoders { h264, h265 }
     }
 
-    pub fn decode(&mut self, data: &[u8], fmt: ImageFormat, raw: &mut Vec<u8>) -> ResultType<bool> {
+    // to-do: apply stride_align to raw output data
+    pub fn decode(&mut self, data: &[u8], stride_align: usize, fmt: ImageFormat, raw: &mut Vec<u8>) -> ResultType<bool> {
         match self.dequeue_input_buffer(Duration::from_millis(10))? {
             Some(mut input_buffer) => {
                 let mut buf = input_buffer.buffer_mut();

--- a/libs/scrap/src/common/mediacodec.rs
+++ b/libs/scrap/src/common/mediacodec.rs
@@ -50,8 +50,8 @@ impl MediaCodecDecoder {
         MediaCodecDecoders { h264, h265 }
     }
 
-    // to-do: apply stride_align to raw output data
-    pub fn decode(&mut self, data: &[u8], stride_align: usize, fmt: ImageFormat, raw: &mut Vec<u8>) -> ResultType<bool> {
+    // to-do: apply stride to raw output data
+    pub fn decode(&mut self, data: &[u8], stride: usize, fmt: ImageFormat, raw: &mut Vec<u8>) -> ResultType<bool> {
         match self.dequeue_input_buffer(Duration::from_millis(10))? {
             Some(mut input_buffer) => {
                 let mut buf = input_buffer.buffer_mut();

--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -37,8 +37,8 @@ pub mod hwcodec;
 pub mod mediacodec;
 pub mod vpxcodec;
 pub use self::convert::*;
-pub const STRIDE_ALIGN: usize = 64; // commonly used in libvpx vpx_img_alloc caller
-pub const HW_STRIDE_ALIGN: usize = 0; // recommended by av_frame_get_buffer
+pub const STRIDE: usize = 64; // commonly used in libvpx vpx_img_alloc caller
+pub const HW_STRIDE: usize = 0; // recommended by av_frame_get_buffer
 
 pub mod record;
 mod vpx;

--- a/libs/scrap/src/common/vpxcodec.rs
+++ b/libs/scrap/src/common/vpxcodec.rs
@@ -541,13 +541,15 @@ impl Image {
 
     pub fn to(&self, fmt: ImageFormat, stride_align: usize, dst: &mut Vec<u8>) {
         let h = self.height();
-        let mut w = self.width();
-        let bps = match fmt {
+        let w = self.width();
+        let bytes_per_pixel = match fmt {
             ImageFormat::Raw => 3,
             ImageFormat::ARGB | ImageFormat::ABGR => 4,
         };
-        w = (w + stride_align - 1) & !(stride_align - 1);
-        dst.resize(h * w * bps, 0);
+        // https://github.com/lemenkov/libyuv/blob/6900494d90ae095d44405cd4cc3f346971fa69c9/source/convert_argb.cc#L128
+        // https://github.com/lemenkov/libyuv/blob/6900494d90ae095d44405cd4cc3f346971fa69c9/source/convert_argb.cc#L129
+        let bytes_per_row = (w * bytes_per_pixel + stride_align - 1) & !(stride_align - 1);
+        dst.resize(h * bytes_per_row, 0);
         let img = self.inner();
         unsafe {
             match fmt {
@@ -560,7 +562,7 @@ impl Image {
                         img.planes[2],
                         img.stride[2],
                         dst.as_mut_ptr(),
-                        (w * bps) as _,
+                        bytes_per_row as _,
                         self.width() as _,
                         self.height() as _,
                     );
@@ -574,7 +576,7 @@ impl Image {
                         img.planes[2],
                         img.stride[2],
                         dst.as_mut_ptr(),
-                        (w * bps) as _,
+                        bytes_per_row as _,
                         self.width() as _,
                         self.height() as _,
                     );
@@ -588,7 +590,7 @@ impl Image {
                         img.planes[2],
                         img.stride[2],
                         dst.as_mut_ptr(),
-                        (w * bps) as _,
+                        bytes_per_row as _,
                         self.width() as _,
                         self.height() as _,
                     );

--- a/src/client.rs
+++ b/src/client.rs
@@ -944,12 +944,7 @@ impl VideoHandler {
         }
         match &vf.union {
             Some(frame) => {
-                // windows && flutter_texture_render, fmt is ImageFormat::ABGR
-                #[cfg(all(target_os = "windows", feature = "flutter_texture_render"))]
-                let fmt = ImageFormat::ABGR;
-                #[cfg(not(all(target_os = "windows", feature = "flutter_texture_render")))]
-                let fmt = ImageFormat::ARGB;
-                let res = self.decoder.handle_video_frame(frame, STRIDE_ALIGN, fmt, &mut self.rgb);
+                let res = self.decoder.handle_video_frame(frame, STRIDE_ALIGN, ImageFormat::ARGB, &mut self.rgb);
                 if self.record {
                     self.recorder
                         .lock()

--- a/src/client.rs
+++ b/src/client.rs
@@ -49,7 +49,7 @@ use scrap::{
 };
 
 use crate::{
-    common::{self, is_keyboard_mode_supported},
+    common::{self, is_keyboard_mode_supported, STRIDE_ALIGN},
     server::video_service::{SCRAP_X11_REF_URL, SCRAP_X11_REQUIRED},
 };
 
@@ -949,7 +949,7 @@ impl VideoHandler {
                 let fmt = ImageFormat::ABGR;
                 #[cfg(not(all(target_os = "windows", feature = "flutter_texture_render")))]
                 let fmt = ImageFormat::ARGB;
-                let res = self.decoder.handle_video_frame(frame, fmt, &mut self.rgb);
+                let res = self.decoder.handle_video_frame(frame, STRIDE_ALIGN, fmt, &mut self.rgb);
                 if self.record {
                     self.recorder
                         .lock()

--- a/src/client.rs
+++ b/src/client.rs
@@ -49,7 +49,7 @@ use scrap::{
 };
 
 use crate::{
-    common::{self, is_keyboard_mode_supported, STRIDE_ALIGN_RGBA_OUTPUT},
+    common::{self, is_keyboard_mode_supported, DST_STRIDE_RGBA},
     server::video_service::{SCRAP_X11_REF_URL, SCRAP_X11_REQUIRED},
 };
 
@@ -944,7 +944,7 @@ impl VideoHandler {
         }
         match &vf.union {
             Some(frame) => {
-                let res = self.decoder.handle_video_frame(frame, STRIDE_ALIGN_RGBA_OUTPUT, ImageFormat::ARGB, &mut self.rgb);
+                let res = self.decoder.handle_video_frame(frame, DST_STRIDE_RGBA, ImageFormat::ARGB, &mut self.rgb);
                 if self.record {
                     self.recorder
                         .lock()

--- a/src/client.rs
+++ b/src/client.rs
@@ -49,7 +49,7 @@ use scrap::{
 };
 
 use crate::{
-    common::{self, is_keyboard_mode_supported, STRIDE_ALIGN},
+    common::{self, is_keyboard_mode_supported, STRIDE_ALIGN_RGBA_OUTPUT},
     server::video_service::{SCRAP_X11_REF_URL, SCRAP_X11_REQUIRED},
 };
 
@@ -944,7 +944,7 @@ impl VideoHandler {
         }
         match &vf.union {
             Some(frame) => {
-                let res = self.decoder.handle_video_frame(frame, STRIDE_ALIGN, ImageFormat::ARGB, &mut self.rgb);
+                let res = self.decoder.handle_video_frame(frame, STRIDE_ALIGN_RGBA_OUTPUT, ImageFormat::ARGB, &mut self.rgb);
                 if self.record {
                     self.recorder
                         .lock()

--- a/src/common.rs
+++ b/src/common.rs
@@ -42,9 +42,9 @@ pub const SYNC_PEER_INFO_DISPLAYS: i32 = 1;
 #[cfg(all(target_os = "macos", feature = "flutter_texture_render"))]
 // https://developer.apple.com/forums/thread/712709
 // Memory alignment should be multiple of 64.
-pub const STRIDE_ALIGN_RGBA_OUTPUT: usize = 64;
+pub const DST_STRIDE_RGBA: usize = 64;
 #[cfg(not(all(target_os = "macos", feature = "flutter_texture_render")))]
-pub const STRIDE_ALIGN_RGBA_OUTPUT: usize = 1;
+pub const DST_STRIDE_RGBA: usize = 1;
 
 // the executable name of the portable version
 pub const PORTABLE_APPNAME_RUNTIME_ENV_KEY: &str = "RUSTDESK_APPNAME";

--- a/src/common.rs
+++ b/src/common.rs
@@ -42,9 +42,9 @@ pub const SYNC_PEER_INFO_DISPLAYS: i32 = 1;
 #[cfg(all(target_os = "macos", feature = "flutter_texture_render"))]
 // https://developer.apple.com/forums/thread/712709
 // Memory alignment should be multiple of 64.
-pub const STRIDE_ALIGN: usize = 64;
+pub const STRIDE_ALIGN_RGBA_OUTPUT: usize = 64;
 #[cfg(not(all(target_os = "macos", feature = "flutter_texture_render")))]
-pub const STRIDE_ALIGN: usize = 1;
+pub const STRIDE_ALIGN_RGBA_OUTPUT: usize = 1;
 
 // the executable name of the portable version
 pub const PORTABLE_APPNAME_RUNTIME_ENV_KEY: &str = "RUSTDESK_APPNAME";

--- a/src/common.rs
+++ b/src/common.rs
@@ -39,6 +39,11 @@ pub const CLIPBOARD_INTERVAL: u64 = 333;
 
 pub const SYNC_PEER_INFO_DISPLAYS: i32 = 1;
 
+#[cfg(all(target_os = "macos", feature = "flutter_texture_render"))]
+pub const STRIDE_ALIGN: usize = 16;
+#[cfg(not(all(target_os = "macos", feature = "flutter_texture_render")))]
+pub const STRIDE_ALIGN: usize = 1;
+
 // the executable name of the portable version
 pub const PORTABLE_APPNAME_RUNTIME_ENV_KEY: &str = "RUSTDESK_APPNAME";
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -40,7 +40,9 @@ pub const CLIPBOARD_INTERVAL: u64 = 333;
 pub const SYNC_PEER_INFO_DISPLAYS: i32 = 1;
 
 #[cfg(all(target_os = "macos", feature = "flutter_texture_render"))]
-pub const STRIDE_ALIGN: usize = 16;
+// https://developer.apple.com/forums/thread/712709
+// Memory alignment should be multiple of 64.
+pub const STRIDE_ALIGN: usize = 64;
 #[cfg(not(all(target_os = "macos", feature = "flutter_texture_render")))]
 pub const STRIDE_ALIGN: usize = 1;
 

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -154,7 +154,7 @@ pub struct FlutterHandler {
 
 #[cfg(feature = "flutter_texture_render")]
 pub type FlutterRgbaRendererPluginOnRgba =
-    unsafe extern "C" fn(texture_rgba: *mut c_void, buffer: *const u8, len: c_int, width: c_int, height: c_int, stride_align: c_int);
+    unsafe extern "C" fn(texture_rgba: *mut c_void, buffer: *const u8, len: c_int, width: c_int, height: c_int, stride: c_int);
 
 // Video Texture Renderer in Flutter
 #[cfg(feature = "flutter_texture_render")]
@@ -206,7 +206,7 @@ impl VideoRenderer {
         self.width = width;
         self.height = height;
         self.data_len = if width > 0 && height > 0 {
-            let sa1 = crate::common::STRIDE_ALIGN_RGBA_OUTPUT - 1;
+            let sa1 = crate::common::DST_STRIDE_RGBA - 1;
             let row_bytes = (width as usize * 4 + sa1) & !sa1;
             row_bytes * height as usize
         } else {
@@ -226,7 +226,7 @@ impl VideoRenderer {
                     rgba.len() as _,
                     self.width as _,
                     self.height as _,
-                    crate::common::STRIDE_ALIGN_RGBA_OUTPUT as _,
+                    crate::common::DST_STRIDE_RGBA as _,
                 )
             };
         }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -154,7 +154,7 @@ pub struct FlutterHandler {
 
 #[cfg(feature = "flutter_texture_render")]
 pub type FlutterRgbaRendererPluginOnRgba =
-    unsafe extern "C" fn(texture_rgba: *mut c_void, buffer: *const u8, width: c_int, height: c_int);
+    unsafe extern "C" fn(texture_rgba: *mut c_void, buffer: *const u8, len: c_int, width: c_int, height: c_int, stride_align: c_int);
 
 // Video Texture Renderer in Flutter
 #[cfg(feature = "flutter_texture_render")]
@@ -223,8 +223,10 @@ impl VideoRenderer {
                 func(
                     self.ptr as _,
                     rgba.as_ptr() as _,
+                    rgba.len() as _,
                     self.width as _,
                     self.height as _,
+                    crate::common::STRIDE_ALIGN as _,
                 )
             };
         }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -206,7 +206,7 @@ impl VideoRenderer {
         self.width = width;
         self.height = height;
         self.data_len = if width > 0 && height > 0 {
-            let sa1 = crate::common::STRIDE_ALIGN - 1;
+            let sa1 = crate::common::STRIDE_ALIGN_RGBA_OUTPUT - 1;
             let row_bytes = (width as usize * 4 + sa1) & !sa1;
             row_bytes * height as usize
         } else {
@@ -226,7 +226,7 @@ impl VideoRenderer {
                     rgba.len() as _,
                     self.width as _,
                     self.height as _,
-                    crate::common::STRIDE_ALIGN as _,
+                    crate::common::STRIDE_ALIGN_RGBA_OUTPUT as _,
                 )
             };
         }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -206,7 +206,9 @@ impl VideoRenderer {
         self.width = width;
         self.height = height;
         self.data_len = if width > 0 && height > 0 {
-            (width * height * 4) as usize
+            let sa1 = crate::common::STRIDE_ALIGN - 1;
+            let w = (width as usize + sa1) & !sa1;
+            w * (height as usize) * 4
         } else {
             0
         };

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -207,8 +207,8 @@ impl VideoRenderer {
         self.height = height;
         self.data_len = if width > 0 && height > 0 {
             let sa1 = crate::common::STRIDE_ALIGN - 1;
-            let w = (width as usize + sa1) & !sa1;
-            w * (height as usize) * 4
+            let row_bytes = (width as usize * 4 + sa1) & !sa1;
+            row_bytes * height as usize
         } else {
             0
         };


### PR DESCRIPTION
1. Fix stride align computation.
```
- w = (w + stride_align - 1) & !(stride_align - 1);
- dst.resize(h * w * bps, 0);
+ // https://github.com/lemenkov/libyuv/blob/6900494d90ae095d44405cd4cc3f346971fa69c9/source/convert_argb.cc#L128
+ // https://github.com/lemenkov/libyuv/blob/6900494d90ae095d44405cd4cc3f346971fa69c9/source/convert_argb.cc#L129
+ let bytes_per_row = (w * bytes_per_pixel + stride - 1) & !(stride - 1);
+ dst.resize(h * bytes_per_row, 0);
```
3. https://github.com/rustdesk/rustdesk/issues/3424

```rust
#[cfg(all(target_os = "macos", feature = "flutter_texture_render"))]
// https://developer.apple.com/forums/thread/712709
// Memory alignment should be multiple of 64.
pub const DST_STRIDE_RGBA: usize = 64;
#[cfg(not(all(target_os = "macos", feature = "flutter_texture_render")))]
pub const DST_STRIDE_RGBA: usize = 1;
```