### PR TITLE
Fix. Android settings. theme always show "Dark theme"

### DIFF
--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -397,8 +397,13 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
                 showLanguageSettings(gFFI.dialogManager);
               }),
           SettingsTile.navigation(
-            title: Text(translate('Dark Theme')),
-            leading: Icon(Icons.dark_mode),
+            title: Text(translate(
+                Theme.of(context).brightness == Brightness.light
+                    ? 'Dark Theme'
+                    : 'Light Theme')),
+            leading: Icon(Theme.of(context).brightness == Brightness.light
+                ? Icons.dark_mode
+                : Icons.light_mode),
             onPressed: (context) {
               showThemeSettings(gFFI.dialogManager);
             },

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Seguretat"),
         ("Theme", "Tema"),
         ("Dark Theme", "Tema Fosc"),
+        ("Light Theme", ""),
         ("Dark", "Fosc"),
         ("Light", "Clar"),
         ("Follow System", "Tema del sistema"),

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "安全"),
         ("Theme", "主题"),
         ("Dark Theme", "暗黑主题"),
+        ("Light Theme", ""),
         ("Dark", "黑暗"),
         ("Light", "明亮"),
         ("Follow System", "跟随系统"),

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", ""),
         ("Theme", ""),
         ("Dark Theme", ""),
+        ("Light Theme", ""),
         ("Dark", ""),
         ("Light", ""),
         ("Follow System", ""),

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Sikkerhed"),
         ("Theme", "Thema"),
         ("Dark Theme", "Mørk Tema"),
+        ("Light Theme", ""),
         ("Dark", "Mørk"),
         ("Light", "Lys"),
         ("Follow System", "Følg System"),

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Sicherheit"),
         ("Theme", "Farbgebung"),
         ("Dark Theme", "Dunkle Farbgebung"),
+        ("Light Theme", "Helle Farbgebung"),
         ("Dark", "Dunkel"),
         ("Light", "Hell"),
         ("Follow System", "Systemstandard"),

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", ""),
         ("Theme", ""),
         ("Dark Theme", ""),
+        ("Light Theme", ""),
         ("Dark", ""),
         ("Light", ""),
         ("Follow System", ""),

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Seguridad"),
         ("Theme", "Tema"),
         ("Dark Theme", "Tema Oscuro"),
+        ("Light Theme", ""),
         ("Dark", "Oscuro"),
         ("Light", "Claro"),
         ("Follow System", "Tema del sistema"),

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "امنیت"),
         ("Theme", "نمایه"),
         ("Dark Theme", "نمایه تیره"),
+        ("Light Theme", ""),
         ("Dark", "تیره"),
         ("Light", "روشن"),
         ("Follow System", "پیروی از سیستم"),

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Sécurité"),
         ("Theme", "Thème"),
         ("Dark Theme", "Thème somble"),
+        ("Light Theme", ""),
         ("Dark", "Sombre"),
         ("Light", "Clair"),
         ("Follow System", "Suivi système"),

--- a/src/lang/gr.rs
+++ b/src/lang/gr.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Ασφάλεια"),
         ("Theme", "Θέμα"),
         ("Dark Theme", "Σκούρο θέμα"),
+        ("Light Theme", ""),
         ("Dark", "Σκούρο"),
         ("Light", "Φωτεινό"),
         ("Follow System", "Από το σύστημα"),

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Biztonság"),
         ("Theme", "Téma"),
         ("Dark Theme", "Sötét téma"),
+        ("Light Theme", ""),
         ("Dark", "Sötét"),
         ("Light", "Világos"),
         ("Follow System", ""),

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Keamanan"),
         ("Theme", "Tema"),
         ("Dark Theme", "Tema gelap"),
+        ("Light Theme", ""),
         ("Dark", "Gelap"),
         ("Light", "Terang"),
         ("Follow System", "Ikuti sistem"),

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Sicurezza"),
         ("Theme", "Tema"),
         ("Dark Theme", "Tema Scuro"),
+        ("Light Theme", ""),
         ("Dark", "Scuro"),
         ("Light", "Chiaro"),
         ("Follow System", "Segui il sistema"),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", ""),
         ("Theme", ""),
         ("Dark Theme", ""),
+        ("Light Theme", ""),
         ("Dark", ""),
         ("Light", ""),
         ("Follow System", ""),

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", ""),
         ("Theme", ""),
         ("Dark Theme", ""),
+        ("Light Theme", ""),
         ("Dark", ""),
         ("Light", ""),
         ("Follow System", ""),

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", ""),
         ("Theme", ""),
         ("Dark Theme", ""),
+        ("Light Theme", ""),
         ("Dark", ""),
         ("Light", ""),
         ("Follow System", ""),

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Beveiliging"),
         ("Theme", "Thema"),
         ("Dark Theme", "Donker Thema"),
+        ("Light Theme", ""),
         ("Dark", "Donker"),
         ("Light", "Licht"),
         ("Follow System", "Volg Systeem"),

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Zabezpieczenia"),
         ("Theme", "Motyw"),
         ("Dark Theme", "Ciemny motyw"),
+        ("Light Theme", ""),
         ("Dark", "Ciemny"),
         ("Light", "Jasny"),
         ("Follow System", "Zgodny z systemem"),

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", ""),
         ("Theme", ""),
         ("Dark Theme", ""),
+        ("Light Theme", ""),
         ("Dark", ""),
         ("Light", ""),
         ("Follow System", ""),

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Segurança"),
         ("Theme", "Tema"),
         ("Dark Theme", "Tema escuro"),
+        ("Light Theme", ""),
         ("Dark", "Escuro"),
         ("Light", "Claro"),
         ("Follow System", "Seguir sistema"),

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Securitate"),
         ("Theme", "Temă"),
         ("Dark Theme", "Temă întunecată"),
+        ("Light Theme", ""),
         ("Dark", "Întunecat"),
         ("Light", "Luminos"),
         ("Follow System", "Urmărește sistem"),

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Безопасность"),
         ("Theme", "Тема"),
         ("Dark Theme", "Тёмная тема"),
+        ("Light Theme", ""),
         ("Dark", "Тёмная"),
         ("Light", "Светлая"),
         ("Follow System", "Системная"),

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", ""),
         ("Theme", ""),
         ("Dark Theme", ""),
+        ("Light Theme", ""),
         ("Dark", ""),
         ("Light", ""),
         ("Follow System", ""),

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Varnost"),
         ("Theme", "Tema"),
         ("Dark Theme", "Temna tema"),
+        ("Light Theme", ""),
         ("Dark", "Temna"),
         ("Light", "Svetla"),
         ("Follow System", "Sistemska"),

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Siguria"),
         ("Theme", "Theme"),
         ("Dark Theme", "Theme e errët"),
+        ("Light Theme", ""),
         ("Dark", "E errët"),
         ("Light", "Drita"),
         ("Follow System", "Ndiq sistemin"),

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Bezbednost"),
         ("Theme", "Tema"),
         ("Dark Theme", "Tamna tema"),
+        ("Light Theme", ""),
         ("Dark", "Tamno"),
         ("Light", "Svetlo"),
         ("Follow System", "Prema sistemu"),

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Säkerhet"),
         ("Theme", "Tema"),
         ("Dark Theme", "Mörkt tema"),
+        ("Light Theme", ""),
         ("Dark", "Mörk"),
         ("Light", "Ljus"),
         ("Follow System", "Följ system"),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", ""),
         ("Theme", ""),
         ("Dark Theme", ""),
+        ("Light Theme", ""),
         ("Dark", ""),
         ("Light", ""),
         ("Follow System", ""),

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "ความปลอดภัย"),
         ("Theme", "ธีม"),
         ("Dark Theme", "ธีมมืด"),
+        ("Light Theme", ""),
         ("Dark", "มืด"),
         ("Light", "สว่าง"),
         ("Follow System", "ตามระบบ"),

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Güvenlik"),
         ("Theme", "Tema"),
         ("Dark Theme", "Koyu Tema"),
+        ("Light Theme", ""),
         ("Dark", "Koyu"),
         ("Light", "Açık"),
         ("Follow System", "Sisteme Uy"),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "安全"),
         ("Theme", "主題"),
         ("Dark Theme", "暗黑主題"),
+        ("Light Theme", ""),
         ("Dark", "黑暗"),
         ("Light", "明亮"),
         ("Follow System", "跟隨系統"),

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", "Безпека"),
         ("Theme", "Тема"),
         ("Dark Theme", "Темна тема"),
+        ("Light Theme", ""),
         ("Dark", "Темна"),
         ("Light", "Світла"),
         ("Follow System", "Як у системі"),

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -349,6 +349,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Security", ""),
         ("Theme", ""),
         ("Dark Theme", ""),
+        ("Light Theme", ""),
         ("Dark", ""),
         ("Light", ""),
         ("Follow System", ""),


### PR DESCRIPTION
Android settings always show "Dark theme" and icon, even it is already in dark mode.

|before |after|after|
|-- |-- |-- |
|![mobile-settings-theme-dark-before](https://user-images.githubusercontent.com/67791701/222791667-78b2df9a-2fc7-44dd-9fcf-4581b6518e0b.png)|![mobile-settings-theme-dark-after](https://user-images.githubusercontent.com/67791701/222791668-ea5cedc5-484e-4790-9d10-bb64edfe9cb9.png)|![mobile-settings-theme-light-after](https://user-images.githubusercontent.com/67791701/222791663-cf513e40-79bf-4506-bd17-a0c40241775c.png)|

screenshot shows a typo "**t**heme", its fixed.

