### PR TITLE
File Manager. Textoverflow for column file time

### DIFF
--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -430,6 +430,7 @@ class _FileManagerPageState extends State<FileManagerPage>
                                           message: lastModifiedStr,
                                           child: Text(
                                             lastModifiedStr,
+                                            overflow: TextOverflow.ellipsis,
                                             style: TextStyle(
                                               fontSize: 12,
                                               color: MyTheme.darkGray,


### PR DESCRIPTION
Add Overflow for column file time

### Before
![file-transfer-column-time-overflow-before](https://user-images.githubusercontent.com/67791701/222800225-512e3c5e-d41f-44c2-868a-b499746f143c.png)

### After 

![file-transfer-column-time-overflow-after](https://user-images.githubusercontent.com/67791701/222800226-3160ea33-4408-4501-9a89-9a58a1edd1de.png)
