### PR TITLE
File Manager. Show filename instead of path in tranfer list

### DIFF
--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -644,7 +644,7 @@ class _FileManagerPageState extends State<FileManagerPage>
                                             Duration(milliseconds: 500),
                                         message: item.jobName,
                                         child: Text(
-                                          item.jobName,
+                                          item.fileName,
                                           maxLines: 1,
                                           overflow: TextOverflow.ellipsis,
                                         ).paddingSymmetric(vertical: 10),

--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -500,6 +500,7 @@ class FileModel extends ChangeNotifier {
       for (var from in items.items) {
         final jobId = ++_jobId;
         _jobTable.add(JobProgress()
+          ..fileName = path.basename(from.path)
           ..jobName = from.path
           ..totalSize = from.size
           ..state = JobState.inProgress
@@ -853,7 +854,9 @@ class FileModel extends ChangeNotifier {
     int fileNum = jobDetail['file_num'];
     bool isRemote = jobDetail['is_remote'];
     final currJobId = _jobId++;
+    String fileName = path.basename(isRemote ? remote : to);
     var jobProgress = JobProgress()
+      ..fileName = fileName
       ..jobName = isRemote ? remote : to
       ..id = currJobId
       ..isRemote = isRemote
@@ -1121,6 +1124,7 @@ class JobProgress {
   var fileCount = 0;
   var isRemote = false;
   var jobName = "";
+  var fileName = "";
   var remote = "";
   var to = "";
   var showHidden = false;
@@ -1133,6 +1137,7 @@ class JobProgress {
     speed = 0;
     finishedSize = 0;
     jobName = "";
+    fileName = "";
     fileCount = 0;
     remote = "";
     to = "";


### PR DESCRIPTION
Items in tranfer list showing the full path, what is not very useful. Showing file name instaed. Full path is still visible via tooltip.

|before |after|
|-- |-- |
|![file-manager-filebasename-before](https://user-images.githubusercontent.com/67791701/222809734-66e28c7e-3d80-45cd-ab31-437aa264323a.png)|![file-manager-filebasename-after](https://user-images.githubusercontent.com/67791701/222809463-e5b591e2-f30b-48de-baac-ec5072811771.png)|

Please review code.