### PR TITLE
fix. Mobile. Style of input on "whitelist" dialog

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -180,7 +180,7 @@ void changeWhiteList({Function()? callback}) async {
                 child: TextField(
                     maxLines: null,
                     decoration: InputDecoration(
-                      border: const OutlineInputBorder(),
+                      border: isDesktop ? const OutlineInputBorder() : null,
                       errorText: msg.isEmpty ? null : translate(msg),
                     ),
                     controller: controller,


### PR DESCRIPTION
Manage whitelists is a shared dialog, currently bordered on desktop, on mobile we have a not bordered style.


|mobile before | mobile after | desktop still bordered|
|-- |-- |-- |
|![dialog-mobil-whitelist-before](https://user-images.githubusercontent.com/67791701/222930002-7f74aa37-ed39-487d-81b4-c1ff0ea4b290.png)|![dialog-mobil-whitelist-after](https://user-images.githubusercontent.com/67791701/222930000-fe2c62ea-368e-4fe4-ae07-323d4fe006c0.png)|![dialog-desktop-whitelist-after](https://user-images.githubusercontent.com/67791701/222929999-c7d4c3db-142d-459a-9871-7eacedf60793.png)|

