### PR TITLE
fix. Mobile. Style of input on "changeID" dialog

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -63,8 +63,9 @@ void changeIdDialog() {
       final Iterable violations = rules.where((r) => !r.validate(newId));
       if (violations.isNotEmpty) {
         setState(() {
-          msg =
-              '${translate('Prompt')}: ${violations.map((r) => r.name).join(', ')}';
+          msg = isDesktop
+              ? '${translate('Prompt')}:  ${violations.map((r) => r.name).join(', ')}'
+              : violations.map((r) => r.name).join(', ');
         });
         return;
       }
@@ -87,7 +88,9 @@ void changeIdDialog() {
       }
       setState(() {
         isInProgress = false;
-        msg = '${translate('Prompt')}: ${translate(status)}';
+        msg = isDesktop
+            ? '${translate('Prompt')}: ${translate(status)}'
+            : translate(status);
       });
     }
 
@@ -103,7 +106,7 @@ void changeIdDialog() {
           TextField(
             decoration: InputDecoration(
                 labelText: translate('Your new ID'),
-                border: const OutlineInputBorder(),
+                border: isDesktop ? const OutlineInputBorder() : null,
                 errorText: msg.isEmpty ? null : translate(msg),
                 suffixText: '${rxId.value.length}/16',
                 suffixStyle: const TextStyle(fontSize: 12, color: Colors.grey)),
@@ -123,27 +126,26 @@ void changeIdDialog() {
           const SizedBox(
             height: 8.0,
           ),
-          Obx(() => Wrap(
-                runSpacing: 8,
-                spacing: 4,
-                children: rules.map((e) {
-                  var checked = e.validate(rxId.value);
-                  return Chip(
-                      label: Text(
-                        e.name,
-                        style: TextStyle(
-                            color: checked
-                                ? const Color(0xFF0A9471)
-                                : Color.fromARGB(255, 198, 86, 157)),
-                      ),
-                      backgroundColor: checked
-                          ? const Color(0xFFD0F7ED)
-                          : Color.fromARGB(255, 247, 205, 232));
-                }).toList(),
-              )),
-          const SizedBox(
-            height: 8.0,
-          ),
+          isDesktop
+              ? Obx(() => Wrap(
+                    runSpacing: 8,
+                    spacing: 4,
+                    children: rules.map((e) {
+                      var checked = e.validate(rxId.value);
+                      return Chip(
+                          label: Text(
+                            e.name,
+                            style: TextStyle(
+                                color: checked
+                                    ? const Color(0xFF0A9471)
+                                    : Color.fromARGB(255, 198, 86, 157)),
+                          ),
+                          backgroundColor: checked
+                              ? const Color(0xFFD0F7ED)
+                              : Color.fromARGB(255, 247, 205, 232));
+                    }).toList(),
+                  )).marginOnly(bottom: 8)
+              : SizedBox.shrink(),
           Offstage(
               offstage: !isInProgress, child: const LinearProgressIndicator())
         ],


### PR DESCRIPTION
This MR https://github.com/rustdesk/rustdesk/pull/3280 unifiyed this dialog with "permantent password" dialog. But changeID is a shared dialog and i was not aware of that.

- Input not bordered on mobile
- Remove pills
- Remove "Prompt" from validation message (same as "password" on mobile)

|before mobile | after mobil | password mobile|
|-- |-- |-- |
|![dialog-mobile-change-id-before](https://user-images.githubusercontent.com/67791701/222931480-5f15dc67-4e4d-4bc5-9e2a-ada62ea9f06e.png)|![dialog-mobile-change-id-after](https://user-images.githubusercontent.com/67791701/222931478-da6e7b41-7c73-4457-ab55-ceab3285d4a9.png)|![dialog-mobile-change-id-password](https://user-images.githubusercontent.com/67791701/222931481-e60dd527-8a64-4a5f-92e0-9b72957b3963.png) not changed, just to compare|

Desktop still as wanted

![dialog-desktop-change-id-after](https://user-images.githubusercontent.com/67791701/222931505-e775b2b6-b89d-46a4-be5a-f1b585e9d95e.png)
