### PR TITLE
Translations. Add "RDP Settings"

### DIFF
--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -1115,7 +1115,7 @@ void _rdpDialog(String id) async {
     }
 
     return CustomAlertDialog(
-      title: Text('RDP ${translate('Settings')}'),
+      title: Text(translate('RDP Settings')),
       content: ConstrainedBox(
         constraints: const BoxConstraints(minWidth: 500),
         child: Column(

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", "安装虚拟显示器驱动，以便在没有连接显示器的情况下启动虚拟显示器进行控制。"),
-        ("confirm_idd_driver_tip", "安装虚拟显示器驱动的选项已勾选。请注意，测试证书将被安装以信任虚拟显示器驱动。测试证书仅会用于信任Rustdesk的驱动。")
+        ("confirm_idd_driver_tip", "安装虚拟显示器驱动的选项已勾选。请注意，测试证书将被安装以信任虚拟显示器驱动。测试证书仅会用于信任Rustdesk的驱动。"),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", "Keine Übertragungen im Gange"),
         ("Set one-time password length", "Länge des Einmalpassworts festlegen"),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", "RDP Einstellungen"),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", "Δεν υπάρχει μεταφορά σε εξέλιξη"),
         ("Set one-time password length", "Μέγεθος κωδικού μιας χρήσης"),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", "No hay transferencias en curso"),
         ("Set one-time password length", "Establecer contraseña de un solo uso"),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", "هیچ انتقالی در حال انجام نیست"),
         ("Set one-time password length", "طول رمز یکبار مصرف را تعیین کنید"),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", "Nessun trasferimento in corso"),
         ("Set one-time password length", "Imposta la lunghezza della password monouso"),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", "Geen overdrachten in uitvoering"),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", "Brak transferów w toku"),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", "Передача не осуществляется"),
         ("Set one-time password length", "Установить длину одноразового пароля"),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -462,6 +462,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("No transfers in progress", ""),
         ("Set one-time password length", ""),
         ("idd_driver_tip", ""),
-        ("confirm_idd_driver_tip", "")
+        ("confirm_idd_driver_tip", ""),
+        ("RDP Settings", ""),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
String concation in keys break RTL languages. Makes it impossible for translators doing the job right.