### PR TITLE
fix: window overflow & prevent setMaximize when fullscreen

### DIFF
--- a/flutter/lib/models/state_model.dart
+++ b/flutter/lib/models/state_model.dart
@@ -28,10 +28,9 @@ class StateGlobal {
 
   setWindowId(int id) => _windowId = id;
   setMaximize(bool v) {
-    if (_maximize != v) {
+    if (_maximize != v && !_fullscreen) {
       _maximize = v;
-      _resizeEdgeSize.value =
-          _maximize ? kMaximizeEdgeSize : kWindowEdgeSize;
+      _resizeEdgeSize.value = _maximize ? kMaximizeEdgeSize : kWindowEdgeSize;
     }
   }
   setFullscreen(bool v) {
@@ -39,7 +38,13 @@ class StateGlobal {
       _fullscreen = v;
       _showTabBar.value = !_fullscreen;
       _resizeEdgeSize.value =
-          fullscreen ? kFullScreenEdgeSize : kWindowEdgeSize;
+          fullscreen
+          ? kFullScreenEdgeSize
+          : _maximize
+              ? kMaximizeEdgeSize
+              : kWindowEdgeSize;
+      print(
+          "fullscreen: ${fullscreen}, resizeEdgeSize: ${_resizeEdgeSize.value}");
       _windowBorderWidth.value = fullscreen ? 0 : kWindowBorderWidth;
       WindowController.fromWindowId(windowId)
           .setFullscreen(_fullscreen)

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -59,7 +59,7 @@ dependencies:
   desktop_multi_window:
     git:
       url: https://github.com/Kingtous/rustdesk_desktop_multi_window
-      ref: 3e2655677c54f421f9e378680d8171b95a211e0f
+      ref: e3947d4b4f8edaa655de63cd47f2a59a6e024218
   freezed_annotation: ^2.0.3
   flutter_custom_cursor: ^0.0.4
   window_size:


### PR DESCRIPTION
This PR fixes:

- the resize area still exists when entered fullscreen while in maximized status.
- the window overflow after exiting fullscreen.