### PR TITLE
Theme. Add secondary color, fix foreground color for buttons in dark mode

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -252,7 +252,8 @@ class MyTheme {
         ),
       ),
     ),
-    colorScheme: ColorScheme.light(primary: Colors.blue, background: grayBg),
+    colorScheme: ColorScheme.light(
+        primary: Colors.blue, secondary: accent, background: grayBg),
   ).copyWith(
     extensions: <ThemeExtension<dynamic>>[
       ColorThemeExtension.light,
@@ -317,6 +318,7 @@ class MyTheme {
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(
         backgroundColor: MyTheme.accent,
+        foregroundColor: Colors.white,
         disabledForegroundColor: Colors.white70,
         disabledBackgroundColor: Colors.white10,
         shape: RoundedRectangleBorder(
@@ -336,7 +338,6 @@ class MyTheme {
       ),
     ),
     checkboxTheme: const CheckboxThemeData(
-      checkColor: MaterialStatePropertyAll(dark),
       splashRadius: 0,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.all(
@@ -353,6 +354,7 @@ class MyTheme {
     ),
     colorScheme: ColorScheme.dark(
       primary: Colors.blue,
+      secondary: accent,
       background: Color(0xFF24252B),
     ),
   ).copyWith(


### PR DESCRIPTION
Bring back the colored checkboxes/radios. Using secondary color to avoid unwanted side effects based on `colorScheme.fromSwatch`.

- CheckColor is now white again, match better now.
- White text for buttons/dark mode 

### Desktop
|||
|--|--|
|![secondary-colors-dark](https://user-images.githubusercontent.com/67791701/224325135-2fa74dae-e65d-4845-a010-c7f77152ecfd.png)|![secondary-colors-light](https://user-images.githubusercontent.com/67791701/224325141-8787fab7-082e-4284-a9ee-0b01ca402b50.png)|

### Mobile

|||
|--|--|
|![secondary-colors-mobile-dark](https://user-images.githubusercontent.com/67791701/224325908-e4b27d6f-eb80-4eac-99d6-8ae9878271de.png)|![secondary-colors-mobile-light](https://user-images.githubusercontent.com/67791701/224325912-d1524c17-f49b-4301-aa8c-53f774f116a3.png)|
