### PR TITLE
Run some services even no subscribers.

### DIFF
--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -31,7 +31,7 @@ pub fn new() -> GenericService {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn new() -> GenericService {
     let sp = GenericService::new(NAME, true);
-    sp.run(pa_impl::run);
+    sp.run(pa_impl::run, GenericService::run_on_subscribes);
     sp
 }
 

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -24,7 +24,7 @@ static RESTARTING: AtomicBool = AtomicBool::new(false);
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn new() -> GenericService {
     let sp = GenericService::new(NAME, true);
-    sp.repeat::<cpal_impl::State, _>(33, cpal_impl::run);
+    sp.repeat::<cpal_impl::State, _, _>(33, cpal_impl::run, GenericService::run_on_subscribes);
     sp
 }
 

--- a/src/server/clipboard_service.rs
+++ b/src/server/clipboard_service.rs
@@ -29,7 +29,7 @@ impl super::service::Reset for State {
 
 pub fn new() -> GenericService {
     let sp = GenericService::new(NAME, true);
-    sp.repeat::<State, _>(INTERVAL, run);
+    sp.repeat::<State, _, _>(INTERVAL, run, GenericService::run_on_subscribes);
     sp
 }
 

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -118,13 +118,13 @@ pub type MouseCursorService = ServiceTmpl<MouseCursorSub>;
 
 pub fn new_cursor() -> MouseCursorService {
     let sp = MouseCursorService::new(NAME_CURSOR, true);
-    sp.repeat::<StateCursor, _>(33, run_cursor);
+    sp.repeat::<StateCursor, _, _>(33, run_cursor, MouseCursorService::run_on_subscribes);
     sp
 }
 
 pub fn new_pos() -> GenericService {
     let sp = GenericService::new(NAME_POS, false);
-    sp.repeat::<StatePos, _>(33, run_pos);
+    sp.repeat::<StatePos, _, _>(33, run_pos, GenericService::run_always);
     sp
 }
 

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -151,7 +151,7 @@ impl VideoFrameController {
 
 pub fn new() -> GenericService {
     let sp = GenericService::new(NAME, true);
-    sp.run(run);
+    sp.run(run, GenericService::run_on_subscribes);
     sp
 }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/3585

If "Show remote cursor" is not checked, "mouse_pos" service has no subscribers.
Then the controlled side cannot detect if local mouse is moved.
There's no way to set local mouse with higher prority.