### PR TITLE
periodicly get cursor pos on conn

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -951,8 +951,8 @@ impl Connection {
                     noperms.push(super::audio_service::NAME);
                 }
                 let mut s = s.write().unwrap();
-                s.add_connection(self.inner.clone(), &noperms);
                 try_start_record_cursor_pos();
+                s.add_connection(self.inner.clone(), &noperms);
             }
         }
     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -541,7 +541,9 @@ impl Connection {
         conn.reset_resolution();
         ALIVE_CONNS.lock().unwrap().retain(|&c| c != id);
         if let Some(s) = conn.server.upgrade() {
-            s.write().unwrap().remove_connection(&conn.inner);
+            let mut s = s.write().unwrap();
+            s.remove_connection(&conn.inner);
+            try_stop_record_cursor_pos();
         }
         log::info!("#{} connection loop exited", id);
     }
@@ -948,9 +950,9 @@ impl Connection {
                 if !self.audio_enabled() {
                     noperms.push(super::audio_service::NAME);
                 }
-                s.write()
-                    .unwrap()
-                    .add_connection(self.inner.clone(), &noperms);
+                let mut s = s.write().unwrap();
+                s.add_connection(self.inner.clone(), &noperms);
+                try_start_record_cursor_pos();
             }
         }
     }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/3585

If "Show remote cursor" is not checked, "mouse_pos" service has no subscribers.
Then the controlled side cannot detect if local mouse is moved.
There's no way to set local mouse with higher prority.