### PR TITLE
client side view mode

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1318,6 +1318,7 @@ class _DisplayState extends State<_Display> {
 
   Widget other(BuildContext context) {
     return _Card(title: 'Other Default Options', children: [
+      otherRow('View Mode', 'view-only'),
       otherRow('show_monitors_tip', 'show_monitors_toolbar'),
       otherRow('Show remote cursor', 'show_remote_cursor'),
       otherRow('Zoom cursor', 'zoom-cursor'),

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -139,8 +139,9 @@ class _RemotePageState extends State<RemotePage>
     _ffi.ffiModel.updateEventListener(widget.id);
     _ffi.qualityMonitorModel.checkShowQualityMonitor(widget.id);
     // Session option should be set after models.dart/FFI.start
-    _showRemoteCursor.value = bind.sessionGetToggleOptionSync(
-        id: widget.id, arg: 'show-remote-cursor');
+    // _showRemoteCursor has been set by setViewOnly
+    _ffi.ffiModel.setViewOnly(widget.id,
+        bind.sessionGetToggleOptionSync(id: widget.id, arg: 'view-only'));
     _zoomCursor.value =
         bind.sessionGetToggleOptionSync(id: widget.id, arg: 'zoom-cursor');
     DesktopMultiWindow.addListener(this);

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -47,6 +47,7 @@ class FfiModel with ChangeNotifier {
   bool _touchMode = false;
   Timer? _timer;
   var _reconnects = 1;
+  bool _viewOnly = false;
   WeakReference<FFI> parent;
 
   Map<String, bool> get permissions => _permissions;
@@ -64,6 +65,8 @@ class FfiModel with ChangeNotifier {
   bool get touchMode => _touchMode;
 
   bool get isPeerAndroid => _pi.platform == kPeerPlatformAndroid;
+
+  bool get viewOnly => _viewOnly;
 
   set inputBlocked(v) {
     _inputBlocked = v;
@@ -373,7 +376,8 @@ class FfiModel with ChangeNotifier {
   _updateSessionWidthHeight(String id) {
     parent.target?.canvasModel.updateViewStyle();
     if (display.width <= 0 || display.height <= 0) {
-      debugPrintStack(label: 'invalid display size (${display.width},${display.height})');
+      debugPrintStack(
+          label: 'invalid display size (${display.width},${display.height})');
     } else {
       bind.sessionSetSize(id: id, width: display.width, height: display.height);
     }
@@ -514,6 +518,19 @@ class FfiModel with ChangeNotifier {
           bind.sessionGetToggleOptionSync(id: peerId, arg: 'privacy-mode');
     } catch (e) {
       //
+    }
+  }
+
+  void setViewOnly(String id, bool value) {
+    if (value) {
+      ShowRemoteCursorState.find(id).value = value;
+    } else {
+      ShowRemoteCursorState.find(id).value =
+          bind.sessionGetToggleOptionSync(id: id, arg: 'show-remote-cursor');
+    }
+    if (_viewOnly != value) {
+      _viewOnly = value;
+      notifyListeners();
     }
   }
 }

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -487,6 +487,7 @@ message OptionMessage {
   BoolOption enable_file_transfer = 9;
   VideoCodecState video_codec_state = 10;
   int32 custom_fps = 11;
+  BoolOption disable_keyboard = 12;
 }
 
 message TestDelay {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1061,6 +1061,10 @@ impl PeerConfig {
         if !mp.contains_key(key) {
             mp.insert(key.to_owned(), UserDefaultConfig::read().get(key));
         }
+        key = "view-only";
+        if !mp.contains_key(key) {
+            mp.insert(key.to_owned(), UserDefaultConfig::read().get(key));
+        }
         Ok(mp)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1296,7 +1296,12 @@ impl LoginConfigHandler {
         if let Some(custom_fps) = self.options.get("custom-fps") {
             msg.custom_fps = custom_fps.parse().unwrap_or(30);
         }
-        if self.get_toggle_option("show-remote-cursor") {
+        let view_only = self.get_toggle_option("view-only");
+        if view_only {
+            msg.disable_keyboard = BoolOption::Yes.into();
+            n += 1;
+        }
+        if view_only || self.get_toggle_option("show-remote-cursor") {
             msg.show_remote_cursor = BoolOption::Yes.into();
             n += 1;
         }
@@ -1312,7 +1317,7 @@ impl LoginConfigHandler {
             msg.enable_file_transfer = BoolOption::Yes.into();
             n += 1;
         }
-        if self.get_toggle_option("disable-clipboard") {
+        if view_only || self.get_toggle_option("disable-clipboard") {
             msg.disable_clipboard = BoolOption::Yes.into();
             n += 1;
         }

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -543,6 +543,12 @@ pub fn session_set_size(_id: String, _width: i32, _height: i32) {
     }
 }
 
+pub fn session_set_view_only(id: String, view_only: bool) {
+    if let Some(session) = SESSIONS.read().unwrap().get(&id) {
+        session.set_view_only(view_only);
+    }
+}
+
 pub fn main_get_sound_inputs() -> Vec<String> {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     return get_sound_inputs();

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", "此文件与对方的一致"),
         ("show_monitors_tip", ""),
+        ("View Mode", "浏览模式"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", "Mig"),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", "Ich"),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", "Yo"),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", "من"),
         ("identical_file_tip", "این فایل با فایل همتا یکسان است."),
         ("show_monitors_tip", "نمایش مانیتورها در نوار ابزار"),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", "Io"),
         ("identical_file_tip", "Questo file è identico a quello del peer."),
         ("show_monitors_tip", "Mostra schermi nella barra degli strumenti"),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", "瀏覽模式"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -479,5 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", ""),
         ("identical_file_tip", ""),
         ("show_monitors_tip", ""),
+        ("View Mode", ""),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
#3652
1. add `View Mode` in display settings
![1678931387809](https://user-images.githubusercontent.com/14891774/225489023-89522ee0-c60b-43b6-a783-5da2a478830b.png)
2. view mode behaviour:
 * disable keyboard
 * force disable clipboard, hide `Disable Clipboard` checkbox, won't change PeerConfig
 * force disable show remote cursor, hide `Show remote cursor` checkbox, won't change PeerConfig
 * hide keyboard mode icon
 * hide `Insert Ctrl + Alt + Del`,  `Insert Lock`, because they relay on keyEvent
 * Allow all the other
3. when view mode is unchecked, "Disable Clipboard" and "Show remote cursor" are selected in the same state as the configuration file.
4. Remember view mode, and add default setting for first connection.
![1678931861951](https://user-images.githubusercontent.com/14891774/225490110-dffed65b-27d0-42c1-a36c-6ca6f1d89761.png)

