### PR TITLE
Unify dialogs. Reset input style to underlined for mobile, reset buttons to right aligned

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -839,7 +839,6 @@ class CustomAlertDialog extends StatelessWidget {
         ),
         actions: actions,
         actionsPadding: EdgeInsets.fromLTRB(padding, 0, padding, padding),
-        actionsAlignment: MainAxisAlignment.center,
       ),
     );
   }

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -201,16 +201,18 @@ class MyTheme {
         ),
       ),
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      fillColor: grayBg,
-      filled: true,
-      isDense: true,
-      contentPadding: EdgeInsets.all(15),
-      border: UnderlineInputBorder(
-        borderRadius: BorderRadius.circular(18),
-        borderSide: BorderSide.none,
-      ),
-    ),
+    inputDecorationTheme: isDesktop
+        ? InputDecorationTheme(
+            fillColor: grayBg,
+            filled: true,
+            isDense: true,
+            contentPadding: EdgeInsets.all(15),
+            border: UnderlineInputBorder(
+              borderRadius: BorderRadius.circular(18),
+              borderSide: BorderSide.none,
+            ),
+          )
+        : null,
     textTheme: const TextTheme(
         titleLarge: TextStyle(fontSize: 19, color: Colors.black87),
         titleSmall: TextStyle(fontSize: 14, color: Colors.black87),
@@ -295,16 +297,18 @@ class MyTheme {
         ),
       ),
     ),
-    inputDecorationTheme: InputDecorationTheme(
-      fillColor: Color(0xFF24252B),
-      filled: true,
-      isDense: true,
-      contentPadding: EdgeInsets.all(15),
-      border: UnderlineInputBorder(
-        borderRadius: BorderRadius.circular(18),
-        borderSide: BorderSide.none,
-      ),
-    ),
+    inputDecorationTheme: isDesktop
+        ? InputDecorationTheme(
+            fillColor: Color(0xFF24252B),
+            filled: true,
+            isDense: true,
+            contentPadding: EdgeInsets.all(15),
+            border: UnderlineInputBorder(
+              borderRadius: BorderRadius.circular(18),
+              borderSide: BorderSide.none,
+            ),
+          )
+        : null,
     textTheme: const TextTheme(
         titleLarge: TextStyle(fontSize: 19),
         titleSmall: TextStyle(fontSize: 14),


### PR DESCRIPTION
- separate InputStyle for mobile and desktop, underlined for mobile
- button align right for all

|before | after |
|-- |-- |
|![mobile-before](https://user-images.githubusercontent.com/67791701/226080424-b987e269-29ab-4f28-9640-39f69a36e9f2.png)|![mobile-after](https://user-images.githubusercontent.com/67791701/226080630-c5597bd1-2039-400f-aa60-f811fe83bec3.png)
|![desktop-before-2](https://user-images.githubusercontent.com/67791701/226080420-ce0aeb19-2022-4202-a177-7ff46d1a5f59.png)|![desktop-after-2](https://user-images.githubusercontent.com/67791701/226080421-e69878e3-f1ec-44b0-82f7-03486c7ad414.png)|


