### PR TITLE
Refact/keyboard led state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#0dad4a59f911fe14934fefc8eed18d58cb057a81"
+source = "git+https://github.com/fufesou/rdev#89d2cb5c4bac81da4aafaedcf78af6af7c80c9d0"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#cd0d6ad907f8fda5cf77487bc962ef4246221d0c"
+source = "git+https://github.com/fufesou/rdev#0dad4a59f911fe14934fefc8eed18d58cb057a81"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#eaa35ff9af22891b4aae3a0a5e83472c16177cd8"
+source = "git+https://github.com/fufesou/rdev#cd0d6ad907f8fda5cf77487bc962ef4246221d0c"
 dependencies = [
  "cocoa",
  "core-foundation 0.9.3",

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -811,7 +811,7 @@ pub fn map_keyboard_mode(peer: &str, event: &Event, mut key_event: KeyEvent) -> 
     #[cfg(any(target_os = "android", target_os = "ios"))]
     let keycode = 0;
 
-    key_event.set_chr(keycode);
+    key_event.set_chr(keycode as _);
     Some(key_event)
 }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -477,7 +477,7 @@ pub fn event_to_key_events(
     };
 
     if keyboard_mode != KeyboardMode::Translate {
-        let is_numpad_key = is_numpad_key(&event.event_type);
+        let is_numpad_key = is_numpad_key(&event);
         for key_event in &mut key_events {
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             if let Some(lock_modes) = lock_modes {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -70,9 +70,9 @@ lazy_static::lazy_static! {
         #[cfg(target_os = "windows")]
         let codes = numpad_keys.iter().filter_map(|k| rdev::win_scancode_from_key(*k)).collect();
         #[cfg(target_os = "linux")]
-        let codes = numpad_keys.iter().filter_map(|k| rdev::linux_code_from_keycode(*k)).collect();
+        let codes = numpad_keys.iter().filter_map(|k| rdev::linux_code_from_code(*k)).collect();
         #[cfg(target_os = "macos")]
-        let codes = numpad_keys.iter().filter_map(|k| rdev::macos_code_from_keycode(*k)).collect();
+        let codes = numpad_keys.iter().filter_map(|k| rdev::macos_code_from_code(*k)).collect();
         Arc::new(codes)
     };
 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -70,9 +70,9 @@ lazy_static::lazy_static! {
         #[cfg(target_os = "windows")]
         let codes = numpad_keys.iter().filter_map(|k| rdev::win_scancode_from_key(*k)).collect();
         #[cfg(target_os = "linux")]
-        let codes = numpad_keys.iter().filter_map(|k| rdev::linux_code_from_code(*k)).collect();
+        let codes = numpad_keys.iter().filter_map(|k| rdev::linux_keycode_from_key(*k)).collect();
         #[cfg(target_os = "macos")]
-        let codes = numpad_keys.iter().filter_map(|k| rdev::macos_code_from_code(*k)).collect();
+        let codes = numpad_keys.iter().filter_map(|k| rdev::macos_keycode_from_key(*k)).collect();
         Arc::new(codes)
     };
 }
@@ -905,6 +905,8 @@ fn is_altgr(event: &Event) -> bool {
     }
 }
 
+#[inline]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 fn is_press(event: &Event) -> bool {
     matches!(event.event_type, EventType::KeyPress(_))
 }

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -878,14 +878,6 @@ fn simulate_(event_type: &EventType) {
     }
 }
 
-fn is_modifier_in_key_event(control_key: ControlKey, key_event: &KeyEvent) -> bool {
-    key_event
-        .modifiers
-        .iter()
-        .position(|&m| m == control_key.into())
-        .is_some()
-}
-
 #[inline]
 fn control_key_value_to_key(value: i32) -> Option<Key> {
     KEY_MAP.get(&value).and_then(|k| Some(*k))
@@ -1192,7 +1184,7 @@ pub fn handle_key_(evt: &KeyEvent) {
         return;
     }
 
-    let lock_mode_handler = if evt.down {
+    let _lock_mode_handler = if evt.down {
         Some(LockModesHandler::new(&evt))
     } else {
         None

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1184,24 +1184,27 @@ pub fn handle_key_(evt: &KeyEvent) {
         return;
     }
 
-    match evt.mode.unwrap() {
-        KeyboardMode::Map => {
-            let _lock_mode_handler = if evt.down {
+    let _lock_mode_handler = match &evt.union {
+        Some(key_event::Union::Unicode(..)) | Some(key_event::Union::Seq(..)) => {
+            Some(LockModesHandler::new(&evt))
+        },
+        _ => {
+            if evt.down {
                 Some(LockModesHandler::new(&evt))
             } else {
                 None
-            };
+            }
+        }
+    };
+
+    match evt.mode.unwrap() {
+        KeyboardMode::Map => {
             map_keyboard_mode(evt);
         }
         KeyboardMode::Translate => {
             translate_keyboard_mode(evt);
         }
         _ => {
-            let _lock_mode_handler = if evt.down {
-                Some(LockModesHandler::new(&evt))
-            } else {
-                None
-            };
             legacy_keyboard_mode(evt);
         }
     }

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1184,20 +1184,24 @@ pub fn handle_key_(evt: &KeyEvent) {
         return;
     }
 
-    let _lock_mode_handler = if evt.down {
-        Some(LockModesHandler::new(&evt))
-    } else {
-        None
-    };
-
     match evt.mode.unwrap() {
         KeyboardMode::Map => {
+            let _lock_mode_handler = if evt.down {
+                Some(LockModesHandler::new(&evt))
+            } else {
+                None
+            };
             map_keyboard_mode(evt);
         }
         KeyboardMode::Translate => {
             translate_keyboard_mode(evt);
         }
         _ => {
+            let _lock_mode_handler = if evt.down {
+                Some(LockModesHandler::new(&evt))
+            } else {
+                None
+            };
             legacy_keyboard_mode(evt);
         }
     }

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -124,8 +124,8 @@ struct LockModesHandler;
 
 impl LockModesHandler {
     #[inline]
-    fn is_modifier_enabled(key_event: &KeyEvent, modifier: ControlKey) {
-        key_event.modifiers.contains(&modifier.into());
+    fn is_modifier_enabled(key_event: &KeyEvent, modifier: ControlKey) -> bool {
+        key_event.modifiers.contains(&modifier.into())
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use rdev::{Event, EventType::*};
+use rdev::{Event, EventType::*, KeyCode};
 use uuid::Uuid;
 
 use hbb_common::config::{Config, LocalConfig, PeerConfig};
@@ -421,7 +421,7 @@ impl<T: InvokeUiSession> Session<T> {
                         rdev::win_scancode_from_key(key).unwrap_or_default()
                     }
                     "macos" => {
-                        let key = rdev::macos_key_from_code(code);
+                        let key = rdev::macos_key_from_code(code as _);
                         let key = match key {
                             rdev::Key::ControlLeft => rdev::Key::MetaLeft,
                             rdev::Key::MetaLeft => rdev::Key::ControlLeft,
@@ -429,7 +429,7 @@ impl<T: InvokeUiSession> Session<T> {
                             rdev::Key::MetaRight => rdev::Key::ControlLeft,
                             _ => key,
                         };
-                        rdev::macos_keycode_from_key(key).unwrap_or_default()
+                        rdev::macos_keycode_from_key(key).unwrap_or_default() as _
                     }
                     _ => {
                         let key = rdev::linux_key_from_code(code);
@@ -545,8 +545,8 @@ impl<T: InvokeUiSession> Session<T> {
         if scancode < 0 || keycode < 0 {
             return;
         }
-        let keycode: u32 = keycode as u32;
-        let scancode: u32 = scancode as u32;
+        let keycode: KeyCode = keycode as _;
+        let scancode: u32 = scancode as _;
 
         #[cfg(not(target_os = "windows"))]
         let key = rdev::key_from_code(keycode) as rdev::Key;


### PR DESCRIPTION
1. Refact.   Lock modifiers synchronization.
2. Refact.   Set default keyboard mode to "Map mode" if remote version >= 1.2.0.
3. Fix.         MacOS, getting CapsLock state and clicking CapsLock.

https://github.com/rustdesk/rustdesk/issues/478