### PR TITLE
Release modifiers when exit

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -35,7 +35,8 @@ pub fn is_xfce() -> bool {
 
 pub fn breakdown_callback() {
     #[cfg(target_os = "linux")]
-    crate::input_service::clear_remapped_keycode()
+    crate::input_service::clear_remapped_keycode();
+    crate::input_service::release_modifiers();
 }
 
 // Android

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -618,6 +618,7 @@ impl Connection {
         }
         #[cfg(target_os = "linux")]
         clear_remapped_keycode();
+        release_modifiers();
         log::info!("Input thread exited");
     }
 

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -551,6 +551,24 @@ fn record_key_to_key(record_key: u64) -> Option<Key> {
     }
 }
 
+pub fn release_modifiers() {
+    let mut en = ENIGO.lock().unwrap();
+    for modifier in [
+        Key::Shift,
+        Key::Control,
+        Key::Alt,
+        Key::Meta,
+        Key::RightShift,
+        Key::RightControl,
+        Key::RightAlt,
+        Key::RWin,
+    ] {
+        if get_modifier_state(modifier, &mut en) {
+            en.key_up(modifier);
+        }
+    }
+}
+
 #[inline]
 fn release_record_key(record_key: KeysDown) {
     let func = move || match record_key {


### PR DESCRIPTION
Unexpected exit, modifiers are easy to stick. So release all modifiers on exit/breakdown.