### PR TITLE
File Manager. Fix wrong state of checkbox "show hidden files"

### DIFF
--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -802,7 +802,7 @@ class _FileManagerViewState extends State<FileManagerView> {
         switchType: SwitchType.scheckbox,
         text: translate("Show Hidden Files"),
         getter: () async {
-          return controller.options.value.isWindows;
+          return controller.options.value.showHidden;
         },
         setter: (bool v) async {
           controller.toggleShowHidden();


### PR DESCRIPTION
Checkbox "show hidden files" works, but does not show the truth.

| before | after|
|-- |-- |
|![before](https://user-images.githubusercontent.com/67791701/228673664-5e37a493-47e0-4bae-8b29-fbb7fd53aa9b.png)|![after](https://user-images.githubusercontent.com/67791701/228673660-f2aee849-a765-439d-9f60-42b0d0a6ab60.png)|
