### PR TITLE
fix elevated process crash when remote insert lock screen

### DIFF
--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1193,7 +1193,9 @@ fn is_function_key(ck: &EnumOrUnknown<ControlKey>) -> bool {
         });
         res = true;
     } else if ck.value() == ControlKey::LockScreen.value() {
-        lock_screen_2();
+        std::thread::spawn(|| {
+            lock_screen_2();
+        });
         res = true;
     }
     return res;


### PR DESCRIPTION
`Cannot start a runtime from within a runtime` occurs because the insert lock will start a new tokio runtime in the portable service ipc tokio runtime.