### PR TITLE
start --server on gmd wayland

### DIFF
--- a/libs/enigo/src/linux/nix_impl.rs
+++ b/libs/enigo/src/linux/nix_impl.rs
@@ -115,7 +115,7 @@ impl Enigo {
 
 impl Default for Enigo {
     fn default() -> Self {
-        let is_x11 = "x11" == hbb_common::platform::linux::get_display_server();
+        let is_x11 = hbb_common::platform::linux::is_x11_or_headless();
         Self {
             is_x11,
             tfc: if is_x11 {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -938,7 +938,7 @@ impl PeerConfig {
         let _lock = CONFIG.read().unwrap();
         let mut config = self.clone();
         config.password = encrypt_vec_or_original(&config.password, PASSWORD_ENC_VERSION);
-        for opt in ["rdp_password", "os-username", "os-password"] {
+        for opt in ["rdp_password", "os-password"] {
             if let Some(v) = config.options.get_mut(opt) {
                 *v = encrypt_str_or_original(v, PASSWORD_ENC_VERSION)
             }

--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -5,6 +5,9 @@ lazy_static::lazy_static! {
     pub static ref DISTRO: Distro = Distro::new();
 }
 
+pub const DISPLAY_SERVER_WAYLAND: &str = "wayland";
+pub const DISPLAY_SERVER_X11: &str = "x11";
+
 pub struct Distro {
     pub name: String,
     pub version_id: String,
@@ -12,23 +15,41 @@ pub struct Distro {
 
 impl Distro {
     fn new() -> Self {
-        let name = run_cmds("awk -F'=' '/^NAME=/ {print $2}' /etc/os-release".to_owned())
+        let name = run_cmds("awk -F'=' '/^NAME=/ {print $2}' /etc/os-release")
             .unwrap_or_default()
             .trim()
             .trim_matches('"')
             .to_string();
-        let version_id =
-            run_cmds("awk -F'=' '/^VERSION_ID=/ {print $2}' /etc/os-release".to_owned())
-                .unwrap_or_default()
-                .trim()
-                .trim_matches('"')
-                .to_string();
+        let version_id = run_cmds("awk -F'=' '/^VERSION_ID=/ {print $2}' /etc/os-release")
+            .unwrap_or_default()
+            .trim()
+            .trim_matches('"')
+            .to_string();
         Self { name, version_id }
     }
 }
 
+#[inline]
+pub fn is_gdm_user(username: &str) -> bool {
+    username == "gdm"
+    // || username == "lightgdm"
+}
+
+#[inline]
+pub fn is_desktop_wayland() -> bool {
+    get_display_server() == DISPLAY_SERVER_WAYLAND
+}
+
+#[inline]
+pub fn is_x11_or_headless() -> bool {
+    !is_desktop_wayland()
+}
+
+// -1
+const INVALID_SESSION: &str = "4294967295";
+
 pub fn get_display_server() -> String {
-    let mut session = get_values_of_seat0([0].to_vec())[0].clone();
+    let mut session = get_values_of_seat0(&[0])[0].clone();
     if session.is_empty() {
         // loginctl has not given the expected output.  try something else.
         if let Ok(sid) = std::env::var("XDG_SESSION_ID") {
@@ -36,14 +57,20 @@ pub fn get_display_server() -> String {
             session = sid;
         }
         if session.is_empty() {
-            session = run_cmds("cat /proc/self/sessionid".to_owned()).unwrap_or_default();
+            session = run_cmds("cat /proc/self/sessionid").unwrap_or_default();
+            if session == INVALID_SESSION {
+                session = "".to_owned();
+            }
         }
     }
-
-    get_display_server_of_session(&session)
+    if session.is_empty() {
+        "".to_owned()
+    } else {
+        get_display_server_of_session(&session)
+    }
 }
 
-fn get_display_server_of_session(session: &str) -> String {
+pub fn get_display_server_of_session(session: &str) -> String {
     let mut display_server = if let Ok(output) =
         run_loginctl(Some(vec!["show-session", "-p", "Type", session]))
     // Check session type of the session
@@ -61,7 +88,7 @@ fn get_display_server_of_session(session: &str) -> String {
                     .replace("TTY=", "")
                     .trim_end()
                     .into();
-                if let Ok(xorg_results) = run_cmds(format!("ps -e | grep \"{tty}.\\\\+Xorg\""))
+                if let Ok(xorg_results) = run_cmds(&format!("ps -e | grep \"{tty}.\\\\+Xorg\""))
                 // And check if Xorg is running on that tty
                 {
                     if xorg_results.trim_end() != "" {
@@ -87,44 +114,68 @@ fn get_display_server_of_session(session: &str) -> String {
     display_server.to_lowercase()
 }
 
-pub fn get_values_of_seat0(indices: Vec<usize>) -> Vec<String> {
+#[inline]
+fn line_values(indices: &[usize], line: &str) -> Vec<String> {
+    indices
+        .into_iter()
+        .map(|idx| line.split_whitespace().nth(*idx).unwrap_or("").to_owned())
+        .collect::<Vec<String>>()
+}
+
+#[inline]
+pub fn get_values_of_seat0(indices: &[usize]) -> Vec<String> {
+    _get_values_of_seat0(indices, true)
+}
+
+#[inline]
+pub fn get_values_of_seat0_with_gdm_wayland(indices: &[usize]) -> Vec<String> {
+    _get_values_of_seat0(indices, false)
+}
+
+fn _get_values_of_seat0(indices: &[usize], ignore_gdm_wayland: bool) -> Vec<String> {
     if let Ok(output) = run_loginctl(None) {
         for line in String::from_utf8_lossy(&output.stdout).lines() {
             if line.contains("seat0") {
                 if let Some(sid) = line.split_whitespace().next() {
                     if is_active(sid) {
-                        return indices
-                            .into_iter()
-                            .map(|idx| line.split_whitespace().nth(idx).unwrap_or("").to_owned())
-                            .collect::<Vec<String>>();
+                        if ignore_gdm_wayland {
+                            if is_gdm_user(line.split_whitespace().nth(2).unwrap_or(""))
+                                && get_display_server_of_session(sid) == DISPLAY_SERVER_WAYLAND
+                            {
+                                continue;
+                            }
+                        }
+                        return line_values(indices, line);
                     }
                 }
             }
         }
-    }
 
-    // some case, there is no seat0 https://github.com/rustdesk/rustdesk/issues/73
-    if let Ok(output) = run_loginctl(None) {
+        // some case, there is no seat0 https://github.com/rustdesk/rustdesk/issues/73
         for line in String::from_utf8_lossy(&output.stdout).lines() {
             if let Some(sid) = line.split_whitespace().next() {
-                let d = get_display_server_of_session(sid);
-                if is_active(sid) && d != "tty" {
-                    return indices
-                        .into_iter()
-                        .map(|idx| line.split_whitespace().nth(idx).unwrap_or("").to_owned())
-                        .collect::<Vec<String>>();
+                if is_active(sid) {
+                    let d = get_display_server_of_session(sid);
+                    if ignore_gdm_wayland {
+                        if is_gdm_user(line.split_whitespace().nth(2).unwrap_or(""))
+                            && d == DISPLAY_SERVER_WAYLAND
+                        {
+                            continue;
+                        }
+                    }
+                    if d == "tty" {
+                        continue;
+                    }
+                    return line_values(indices, line);
                 }
             }
         }
     }
 
-    return indices
-        .iter()
-        .map(|_x| "".to_owned())
-        .collect::<Vec<String>>();
+    line_values(indices, "")
 }
 
-fn is_active(sid: &str) -> bool {
+pub fn is_active(sid: &str) -> bool {
     if let Ok(output) = run_loginctl(Some(vec!["show-session", "-p", "State", sid])) {
         String::from_utf8_lossy(&output.stdout).contains("active")
     } else {
@@ -132,15 +183,15 @@ fn is_active(sid: &str) -> bool {
     }
 }
 
-pub fn run_cmds(cmds: String) -> ResultType<String> {
+pub fn run_cmds(cmds: &str) -> ResultType<String> {
     let output = std::process::Command::new("sh")
-        .args(vec!["-c", &cmds])
+        .args(vec!["-c", cmds])
         .output()?;
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 #[cfg(not(feature = "flatpak"))]
-fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
+pub(super) fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
     let mut cmd = std::process::Command::new("loginctl");
     if let Some(a) = args {
         return cmd.args(a).output();
@@ -149,7 +200,7 @@ fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output
 }
 
 #[cfg(feature = "flatpak")]
-fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
+pub(super) fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
     let mut l_args = String::from("loginctl");
     if let Some(a) = args {
         l_args = format!("{} {}", l_args, a.join(" "));

--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -191,7 +191,7 @@ pub fn run_cmds(cmds: &str) -> ResultType<String> {
 }
 
 #[cfg(not(feature = "flatpak"))]
-pub(super) fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
+fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
     let mut cmd = std::process::Command::new("loginctl");
     if let Some(a) = args {
         return cmd.args(a).output();
@@ -200,7 +200,7 @@ pub(super) fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::proc
 }
 
 #[cfg(feature = "flatpak")]
-pub(super) fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
+fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
     let mut l_args = String::from("loginctl");
     if let Some(a) = args {
         l_args = format!("{} {}", l_args, a.join(" "));

--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -74,7 +74,7 @@ pub trait TraitCapturer {
 #[cfg(x11)]
 #[inline]
 pub fn is_x11() -> bool {
-    "x11" == hbb_common::platform::linux::get_display_server()
+    hbb_common::platform::linux::is_x11_or_headless()
 }
 
 #[cfg(x11)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -755,7 +755,7 @@ lazy_static::lazy_static! {
 
 #[cfg(target_os = "linux")]
 lazy_static::lazy_static! {
-    pub static ref IS_X11: bool = "x11" == hbb_common::platform::linux::get_display_server();
+    pub static ref IS_X11: bool = hbb_common::platform::linux::is_x11_or_headless();
 }
 
 pub fn make_fd_to_json(id: i32, path: String, entries: &Vec<FileEntry>) -> String {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -883,7 +883,7 @@ impl Connection {
             let dtype = crate::platform::linux::get_display_server();
             if dtype != "x11" && dtype != "wayland" {
                 res.set_error(format!(
-                    "Unsupported display server type {}, x11 or wayland expected",
+                    "Unsupported display server type \"{}\", x11 or wayland expected",
                     dtype
                 ));
                 let mut msg_out = Message::new();

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -189,6 +189,17 @@ impl<T: Subscriber + From<ConnInner>> ServiceTmpl<T> {
         }
     }
 
+    #[inline]
+    fn wait_prelogin(&self) {
+        #[cfg(target_os = "linux")]
+        while self.active() {
+            if crate::platform::linux::is_prelogin() {
+                break;
+            }
+            thread::sleep(time::Duration::from_millis(300));
+        }
+    }
+
     pub fn repeat<S, F>(&self, interval_ms: u64, callback: F)
     where
         F: 'static + FnMut(Self, &mut S) -> ResultType<()> + Send,
@@ -198,6 +209,8 @@ impl<T: Subscriber + From<ConnInner>> ServiceTmpl<T> {
         let mut callback = callback;
         let sp = self.clone();
         let thread = thread::spawn(move || {
+            sp.wait_prelogin();
+
             let mut state = S::default();
             let mut may_reset = false;
             while sp.active() {
@@ -232,6 +245,8 @@ impl<T: Subscriber + From<ConnInner>> ServiceTmpl<T> {
         let sp = self.clone();
         let mut callback = callback;
         let thread = thread::spawn(move || {
+            sp.wait_prelogin();
+
             let mut error_timeout = HIBERNATE_TIMEOUT;
             while sp.active() {
                 if sp.has_subscribes() {


### PR DESCRIPTION
1. Start --server on login interface (gdm wayland).
2. Better  detect of display server.
3. Fix potential bugs that prevent the --service from restarting --server.
https://github.com/rustdesk/rustdesk/blob/71d1bacf78a219e13fd5d97b32fb3da78ae7bda7/src/platform/linux.rs#L324
4. Reduce the frequency of loginctl calls. https://github.com/rustdesk/rustdesk/issues/3129


