### PR TITLE
vp8

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1258,9 +1258,6 @@ class _DisplayState extends State<_Display> {
   }
 
   Widget codec(BuildContext context) {
-    if (!bind.mainHasHwcodec()) {
-      return Offstage();
-    }
     final key = 'codec-preference';
     onChanged(String value) async {
       await bind.mainSetUserDefaultOption(key: key, value: value);
@@ -1268,7 +1265,28 @@ class _DisplayState extends State<_Display> {
     }
 
     final groupValue = bind.mainGetUserDefaultOption(key: key);
-
+    var hwRadios = [];
+    try {
+      final Map codecsJson = jsonDecode(bind.mainSupportedHwdecodings());
+      final h264 = codecsJson['h264'] ?? false;
+      final h265 = codecsJson['h265'] ?? false;
+      if (h264) {
+        hwRadios.add(_Radio(context,
+            value: 'h264',
+            groupValue: groupValue,
+            label: 'H264',
+            onChanged: onChanged));
+      }
+      if (h265) {
+        hwRadios.add(_Radio(context,
+            value: 'h265',
+            groupValue: groupValue,
+            label: 'H265',
+            onChanged: onChanged));
+      }
+    } catch (e) {
+      debugPrint("failed to parse supported hwdecodings, err=$e");
+    }
     return _Card(title: 'Default Codec', children: [
       _Radio(context,
           value: 'auto',
@@ -1276,20 +1294,16 @@ class _DisplayState extends State<_Display> {
           label: 'Auto',
           onChanged: onChanged),
       _Radio(context,
+          value: 'vp8',
+          groupValue: groupValue,
+          label: 'VP8',
+          onChanged: onChanged),
+      _Radio(context,
           value: 'vp9',
           groupValue: groupValue,
           label: 'VP9',
           onChanged: onChanged),
-      _Radio(context,
-          value: 'h264',
-          groupValue: groupValue,
-          label: 'H264',
-          onChanged: onChanged),
-      _Radio(context,
-          value: 'h265',
-          groupValue: groupValue,
-          label: 'H265',
-          onChanged: onChanged),
+      ...hwRadios,
     ]);
   }
 

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1349,29 +1349,30 @@ class _DisplayMenuState extends State<_DisplayMenu> {
 
   codec() {
     return futureBuilder(future: () async {
-      final supportedHwcodec =
-          await bind.sessionSupportedHwcodec(id: widget.id);
+      final alternativeCodecs =
+          await bind.sessionAlternativeCodecs(id: widget.id);
       final codecPreference =
           await bind.sessionGetOption(id: widget.id, arg: 'codec-preference') ??
               '';
       return {
-        'supportedHwcodec': supportedHwcodec,
+        'alternativeCodecs': alternativeCodecs,
         'codecPreference': codecPreference
       };
     }(), hasData: (data) {
       final List<bool> codecs = [];
       try {
-        final Map codecsJson = jsonDecode(data['supportedHwcodec']);
+        final Map codecsJson = jsonDecode(data['alternativeCodecs']);
+        final vp8 = codecsJson['vp8'] ?? false;
         final h264 = codecsJson['h264'] ?? false;
         final h265 = codecsJson['h265'] ?? false;
+        codecs.add(vp8);
         codecs.add(h264);
         codecs.add(h265);
       } catch (e) {
         debugPrint("Show Codec Preference err=$e");
       }
-      final visible = bind.mainHasHwcodec() &&
-          codecs.length == 2 &&
-          (codecs[0] || codecs[1]);
+      final visible =
+          codecs.length == 3 && (codecs[0] || codecs[1] || codecs[2]);
       if (!visible) return Offstage();
       final groupValue = data['codecPreference'] as String;
       onChanged(String? value) async {
@@ -1393,6 +1394,13 @@ class _DisplayMenuState extends State<_DisplayMenu> {
               ffi: widget.ffi,
             ),
             _RadioMenuButton<String>(
+              child: Text(translate('VP8')),
+              value: 'vp8',
+              groupValue: groupValue,
+              onChanged: codecs[0] ? onChanged : null,
+              ffi: widget.ffi,
+            ),
+            _RadioMenuButton<String>(
               child: Text(translate('VP9')),
               value: 'vp9',
               groupValue: groupValue,
@@ -1403,14 +1411,14 @@ class _DisplayMenuState extends State<_DisplayMenu> {
               child: Text(translate('H264')),
               value: 'h264',
               groupValue: groupValue,
-              onChanged: codecs[0] ? onChanged : null,
+              onChanged: codecs[1] ? onChanged : null,
               ffi: widget.ffi,
             ),
             _RadioMenuButton<String>(
               child: Text(translate('H265')),
               value: 'h265',
               groupValue: groupValue,
-              onChanged: codecs[1] ? onChanged : null,
+              onChanged: codecs[2] ? onChanged : null,
               ffi: widget.ffi,
             ),
           ]);

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -973,9 +973,11 @@ void showOptions(
   if (hasHwcodec) {
     try {
       final Map codecsJson =
-          jsonDecode(await bind.sessionSupportedHwcodec(id: id));
+          jsonDecode(await bind.sessionAlternativeCodecs(id: id));
+      final vp8 = codecsJson['vp8'] ?? false;
       final h264 = codecsJson['h264'] ?? false;
       final h265 = codecsJson['h265'] ?? false;
+      codecs.add(vp8);
       codecs.add(h264);
       codecs.add(h265);
     } catch (e) {
@@ -1044,6 +1046,7 @@ void showOptions(
     if (hasHwcodec && codecs.length == 2 && (codecs[0] || codecs[1])) {
       radios.addAll([
         getRadio(translate('Auto'), 'auto', codec, setCodec),
+        getRadio('VP8', 'vp8', codec, setCodec),
         getRadio('VP9', 'vp9', codec, setCodec),
       ]);
       if (codecs[0]) {

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -24,6 +24,7 @@ message VideoFrame {
     YUV yuv = 8;
     EncodedVideoFrames h264s = 10;
     EncodedVideoFrames h265s = 11;
+    EncodedVideoFrames vp8s = 12;
   }
 }
 
@@ -76,6 +77,7 @@ message Features {
 message SupportedEncoding {
   bool h264 = 1;
   bool h265 = 2;
+  bool vp8 = 3;
 }
 
 message PeerInfo {
@@ -457,18 +459,20 @@ enum ImageQuality {
   Best = 4;
 }
 
-message VideoCodecState {
+message SupportedDecoding {
   enum PreferCodec {
     Auto = 0;
-    VPX = 1;
+    VP9 = 1;
     H264 = 2;
     H265 = 3;
+    VP8 = 4;
   }
 
-  int32 score_vpx = 1;
-  int32 score_h264 = 2;
-  int32 score_h265 = 3;
+  int32 ability_vp9 = 1;
+  int32 ability_h264 = 2;
+  int32 ability_h265 = 3;
   PreferCodec prefer = 4;
+  int32 ability_vp8 = 5;
 }
 
 message OptionMessage {
@@ -486,7 +490,7 @@ message OptionMessage {
   BoolOption disable_audio = 7;
   BoolOption disable_clipboard = 8;
   BoolOption enable_file_transfer = 9;
-  VideoCodecState video_codec_state = 10;
+  SupportedDecoding supported_decoding = 10;
   int32 custom_fps = 11;
   BoolOption disable_keyboard = 12;
 }

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -917,7 +917,8 @@ impl PeerConfig {
                 store = store || store2;
                 for opt in ["rdp_password", "os-password"] {
                     if let Some(v) = config.options.get_mut(opt) {
-                        let (encrypted, _, store2) = decrypt_str_or_original(v, PASSWORD_ENC_VERSION);
+                        let (encrypted, _, store2) =
+                            decrypt_str_or_original(v, PASSWORD_ENC_VERSION);
                         *v = encrypted;
                         store = store || store2;
                     }
@@ -1356,7 +1357,7 @@ impl UserDefaultConfig {
             "view_style" => self.get_string(key, "original", vec!["adaptive"]),
             "scroll_style" => self.get_string(key, "scrollauto", vec!["scrollbar"]),
             "image_quality" => self.get_string(key, "balanced", vec!["best", "low", "custom"]),
-            "codec-preference" => self.get_string(key, "auto", vec!["vp9", "h264", "h265"]),
+            "codec-preference" => self.get_string(key, "auto", vec!["vp8", "vp9", "h264", "h265"]),
             "custom_image_quality" => self.get_double_string(key, 50.0, 10.0, 100.0),
             "custom-fps" => self.get_double_string(key, 30.0, 10.0, 120.0),
             _ => self

--- a/libs/scrap/src/common/android.rs
+++ b/libs/scrap/src/common/android.rs
@@ -50,6 +50,7 @@ impl crate::TraitCapturer for Capturer {
 
 pub enum Frame<'a> {
     RAW(&'a [u8]),
+    VP8(&'a [u8]),
     VP9(&'a [u8]),
     Empty,
 }

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -1,7 +1,6 @@
-use std::ops::{Deref, DerefMut};
-#[cfg(feature = "hwcodec")]
 use std::{
     collections::HashMap,
+    ops::{Deref, DerefMut},
     sync::{Arc, Mutex},
 };
 
@@ -11,30 +10,31 @@ use crate::hwcodec::*;
 use crate::mediacodec::{
     MediaCodecDecoder, MediaCodecDecoders, H264_DECODER_SUPPORT, H265_DECODER_SUPPORT,
 };
-use crate::{vpxcodec::*, ImageFormat};
+use crate::{vpxcodec::*, CodecName, ImageFormat};
 
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use hbb_common::sysinfo::{System, SystemExt};
 use hbb_common::{
     anyhow::anyhow,
+    config::PeerConfig,
     log,
-    message_proto::{video_frame, EncodedVideoFrames, Message, VideoCodecState},
+    message_proto::{
+        supported_decoding::PreferCodec, video_frame, EncodedVideoFrames, Message,
+        SupportedDecoding, SupportedEncoding,
+    },
     ResultType,
 };
 #[cfg(any(feature = "hwcodec", feature = "mediacodec"))]
-use hbb_common::{
-    config::{Config2, PeerConfig},
-    lazy_static,
-    message_proto::video_codec_state::PreferCodec,
-};
+use hbb_common::{config::Config2, lazy_static};
 
-#[cfg(feature = "hwcodec")]
 lazy_static::lazy_static! {
-    static ref PEER_DECODER_STATES: Arc<Mutex<HashMap<i32, VideoCodecState>>> = Default::default();
+    static ref PEER_DECODINGS: Arc<Mutex<HashMap<i32, SupportedDecoding>>> = Default::default();
+    static ref CODEC_NAME: Arc<Mutex<CodecName>> = Arc::new(Mutex::new(CodecName::VP9));
 }
-const SCORE_VPX: i32 = 90;
 
 #[derive(Debug, Clone)]
 pub struct HwEncoderConfig {
-    pub codec_name: String,
+    pub name: String,
     pub width: usize,
     pub height: usize,
     pub bitrate: i32,
@@ -58,10 +58,6 @@ pub trait EncoderApi {
     fn set_bitrate(&mut self, bitrate: u32) -> ResultType<()>;
 }
 
-pub struct DecoderCfg {
-    pub vpx: VpxDecoderConfig,
-}
-
 pub struct Encoder {
     pub codec: Box<dyn EncoderApi>,
 }
@@ -81,7 +77,8 @@ impl DerefMut for Encoder {
 }
 
 pub struct Decoder {
-    vpx: VpxDecoder,
+    vp8: VpxDecoder,
+    vp9: VpxDecoder,
     #[cfg(feature = "hwcodec")]
     hw: HwDecoders,
     #[cfg(feature = "hwcodec")]
@@ -91,10 +88,10 @@ pub struct Decoder {
 }
 
 #[derive(Debug, Clone)]
-pub enum EncoderUpdate {
-    State(VideoCodecState),
+pub enum EncodingUpdate {
+    New(SupportedDecoding),
     Remove,
-    DisableHwIfNotExist,
+    NewOnlyVP9,
 }
 
 impl Encoder {
@@ -120,172 +117,156 @@ impl Encoder {
         }
     }
 
-    // TODO
-    pub fn update_video_encoder(id: i32, update: EncoderUpdate) {
+    pub fn update(id: i32, update: EncodingUpdate) {
+        let mut decodings = PEER_DECODINGS.lock().unwrap();
+        match update {
+            EncodingUpdate::New(decoding) => {
+                decodings.insert(id, decoding);
+            }
+            EncodingUpdate::Remove => {
+                decodings.remove(&id);
+            }
+            EncodingUpdate::NewOnlyVP9 => {
+                decodings.insert(
+                    id,
+                    SupportedDecoding {
+                        ability_vp9: 1,
+                        ..Default::default()
+                    },
+                );
+            }
+        }
+
+        let vp8_useable = decodings.len() > 0 && decodings.iter().all(|(_, s)| s.ability_vp8 > 0);
+        #[allow(unused_mut)]
+        let mut h264_name = None;
+        #[allow(unused_mut)]
+        let mut h265_name = None;
         #[cfg(feature = "hwcodec")]
         {
-            let mut states = PEER_DECODER_STATES.lock().unwrap();
-            match update {
-                EncoderUpdate::State(state) => {
-                    states.insert(id, state);
-                }
-                EncoderUpdate::Remove => {
-                    states.remove(&id);
-                }
-                EncoderUpdate::DisableHwIfNotExist => {
-                    if !states.contains_key(&id) {
-                        states.insert(id, VideoCodecState::default());
-                    }
-                }
+            let best = HwEncoder::best();
+            let h264_useable =
+                decodings.len() > 0 && decodings.iter().all(|(_, s)| s.ability_h264 > 0);
+            let h265_useable =
+                decodings.len() > 0 && decodings.iter().all(|(_, s)| s.ability_h265 > 0);
+            if h264_useable {
+                h264_name = best.h264.map_or(None, |c| Some(c.name));
             }
-            let name = HwEncoder::current_name();
-            if states.len() > 0 {
-                let best = HwEncoder::best();
-                let enabled_h264 = best.h264.is_some()
-                    && states.len() > 0
-                    && states.iter().all(|(_, s)| s.score_h264 > 0);
-                let enabled_h265 = best.h265.is_some()
-                    && states.len() > 0
-                    && states.iter().all(|(_, s)| s.score_h265 > 0);
-
-                // Preference first
-                let mut preference = PreferCodec::Auto;
-                let preferences: Vec<_> = states
-                    .iter()
-                    .filter(|(_, s)| {
-                        s.prefer == PreferCodec::VPX.into()
-                            || s.prefer == PreferCodec::H264.into() && enabled_h264
-                            || s.prefer == PreferCodec::H265.into() && enabled_h265
-                    })
-                    .map(|(_, s)| s.prefer)
-                    .collect();
-                if preferences.len() > 0 && preferences.iter().all(|&p| p == preferences[0]) {
-                    preference = preferences[0].enum_value_or(PreferCodec::Auto);
-                }
-
-                match preference {
-                    PreferCodec::VPX => *name.lock().unwrap() = None,
-                    PreferCodec::H264 => {
-                        *name.lock().unwrap() = best.h264.map_or(None, |c| Some(c.name))
-                    }
-                    PreferCodec::H265 => {
-                        *name.lock().unwrap() = best.h265.map_or(None, |c| Some(c.name))
-                    }
-                    PreferCodec::Auto => {
-                        // score encoder
-                        let mut score_vpx = SCORE_VPX;
-                        let mut score_h264 = best.h264.as_ref().map_or(0, |c| c.score);
-                        let mut score_h265 = best.h265.as_ref().map_or(0, |c| c.score);
-
-                        // score decoder
-                        score_vpx += states.iter().map(|s| s.1.score_vpx).sum::<i32>();
-                        if enabled_h264 {
-                            score_h264 += states.iter().map(|s| s.1.score_h264).sum::<i32>();
-                        }
-                        if enabled_h265 {
-                            score_h265 += states.iter().map(|s| s.1.score_h265).sum::<i32>();
-                        }
-
-                        if enabled_h265 && score_h265 >= score_vpx && score_h265 >= score_h264 {
-                            *name.lock().unwrap() = best.h265.map_or(None, |c| Some(c.name));
-                        } else if enabled_h264
-                            && score_h264 >= score_vpx
-                            && score_h264 >= score_h265
-                        {
-                            *name.lock().unwrap() = best.h264.map_or(None, |c| Some(c.name));
-                        } else {
-                            *name.lock().unwrap() = None;
-                        }
-                    }
-                }
-
-                log::info!(
-                    "connection count:{}, used preference:{:?}, encoder:{:?}",
-                    states.len(),
-                    preference,
-                    name.lock().unwrap()
-                )
-            } else {
-                *name.lock().unwrap() = None;
+            if h265_useable {
+                h265_name = best.h265.map_or(None, |c| Some(c.name));
             }
         }
-        #[cfg(not(feature = "hwcodec"))]
-        {
-            let _ = id;
-            let _ = update;
+
+        let mut name = CODEC_NAME.lock().unwrap();
+        let mut preference = PreferCodec::Auto;
+        let preferences: Vec<_> = decodings
+            .iter()
+            .filter(|(_, s)| {
+                s.prefer == PreferCodec::VP9.into()
+                    || s.prefer == PreferCodec::VP8.into() && vp8_useable
+                    || s.prefer == PreferCodec::H264.into() && h264_name.is_some()
+                    || s.prefer == PreferCodec::H265.into() && h265_name.is_some()
+            })
+            .map(|(_, s)| s.prefer)
+            .collect();
+        if preferences.len() > 0 && preferences.iter().all(|&p| p == preferences[0]) {
+            preference = preferences[0].enum_value_or(PreferCodec::Auto);
         }
+
+        #[allow(unused_mut)]
+        let mut auto_codec = CodecName::VP9;
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        if vp8_useable && System::new_all().total_memory() <= 4 * 1024 * 1024 * 1024 {
+            // 4 Gb
+            auto_codec = CodecName::VP8
+        }
+
+        match preference {
+            PreferCodec::VP8 => *name = CodecName::VP8,
+            PreferCodec::VP9 => *name = CodecName::VP9,
+            PreferCodec::H264 => *name = h264_name.map_or(auto_codec, |c| CodecName::H264(c)),
+            PreferCodec::H265 => *name = h265_name.map_or(auto_codec, |c| CodecName::H265(c)),
+            PreferCodec::Auto => *name = auto_codec,
+        }
+
+        log::info!(
+            "connection count:{}, used preference:{:?}, encoder:{:?}",
+            decodings.len(),
+            preference,
+            *name
+        )
     }
+
     #[inline]
-    pub fn current_hw_encoder_name() -> Option<String> {
-        #[cfg(feature = "hwcodec")]
-        if enable_hwcodec_option() {
-            return HwEncoder::current_name().lock().unwrap().clone();
-        } else {
-            return None;
-        }
-        #[cfg(not(feature = "hwcodec"))]
-        return None;
+    pub fn negotiated_codec() -> CodecName {
+        CODEC_NAME.lock().unwrap().clone()
     }
 
-    pub fn supported_encoding() -> (bool, bool) {
+    pub fn supported_encoding() -> SupportedEncoding {
+        #[allow(unused_mut)]
+        let mut encoding = SupportedEncoding {
+            vp8: true,
+            ..Default::default()
+        };
         #[cfg(feature = "hwcodec")]
         if enable_hwcodec_option() {
             let best = HwEncoder::best();
-            (
-                best.h264.as_ref().map_or(false, |c| c.score > 0),
-                best.h265.as_ref().map_or(false, |c| c.score > 0),
-            )
-        } else {
-            (false, false)
+            encoding.h264 = best.h264.is_some();
+            encoding.h265 = best.h265.is_some();
         }
-        #[cfg(not(feature = "hwcodec"))]
-        (false, false)
+        encoding
     }
 }
 
 impl Decoder {
-    pub fn video_codec_state(_id: &str) -> VideoCodecState {
+    pub fn supported_decodings(id_for_perfer: Option<&str>) -> SupportedDecoding {
+        #[allow(unused_mut)]
+        let mut decoding = SupportedDecoding {
+            ability_vp8: 1,
+            ability_vp9: 1,
+            prefer: id_for_perfer
+                .map_or(PreferCodec::Auto, |id| Self::codec_preference(id))
+                .into(),
+            ..Default::default()
+        };
         #[cfg(feature = "hwcodec")]
         if enable_hwcodec_option() {
             let best = HwDecoder::best();
-            return VideoCodecState {
-                score_vpx: SCORE_VPX,
-                score_h264: best.h264.map_or(0, |c| c.score),
-                score_h265: best.h265.map_or(0, |c| c.score),
-                prefer: Self::codec_preference(_id).into(),
-                ..Default::default()
-            };
+            decoding.ability_h264 = if best.h264.is_some() { 1 } else { 0 };
+            decoding.ability_h265 = if best.h265.is_some() { 1 } else { 0 };
         }
         #[cfg(feature = "mediacodec")]
         if enable_hwcodec_option() {
-            let score_h264 = if H264_DECODER_SUPPORT.load(std::sync::atomic::Ordering::SeqCst) {
-                92
-            } else {
-                0
-            };
-            let score_h265 = if H265_DECODER_SUPPORT.load(std::sync::atomic::Ordering::SeqCst) {
-                94
-            } else {
-                0
-            };
-            return VideoCodecState {
-                score_vpx: SCORE_VPX,
-                score_h264,
-                score_h265,
-                prefer: Self::codec_preference(_id).into(),
-                ..Default::default()
-            };
+            decoding.ability_h264 =
+                if H264_DECODER_SUPPORT.load(std::sync::atomic::Ordering::SeqCst) {
+                    1
+                } else {
+                    0
+                };
+            decoding.ability_h265 =
+                if H265_DECODER_SUPPORT.load(std::sync::atomic::Ordering::SeqCst) {
+                    1
+                } else {
+                    0
+                };
         }
-        VideoCodecState {
-            score_vpx: SCORE_VPX,
-            ..Default::default()
-        }
+        decoding
     }
 
-    pub fn new(config: DecoderCfg) -> Decoder {
-        let vpx = VpxDecoder::new(config.vpx).unwrap();
+    pub fn new() -> Decoder {
+        let vp8 = VpxDecoder::new(VpxDecoderConfig {
+            codec: VpxVideoCodecId::VP8,
+            num_threads: (num_cpus::get() / 2) as _,
+        })
+        .unwrap();
+        let vp9 = VpxDecoder::new(VpxDecoderConfig {
+            codec: VpxVideoCodecId::VP9,
+            num_threads: (num_cpus::get() / 2) as _,
+        })
+        .unwrap();
         Decoder {
-            vpx,
+            vp8,
+            vp9,
             #[cfg(feature = "hwcodec")]
             hw: if enable_hwcodec_option() {
                 HwDecoder::new_decoders()
@@ -310,8 +291,11 @@ impl Decoder {
         rgb: &mut Vec<u8>,
     ) -> ResultType<bool> {
         match frame {
+            video_frame::Union::Vp8s(vp8s) => {
+                Decoder::handle_vpxs_video_frame(&mut self.vp8, vp8s, fmt, rgb)
+            }
             video_frame::Union::Vp9s(vp9s) => {
-                Decoder::handle_vp9s_video_frame(&mut self.vpx, vp9s, fmt, rgb)
+                Decoder::handle_vpxs_video_frame(&mut self.vp9, vp9s, fmt, rgb)
             }
             #[cfg(feature = "hwcodec")]
             video_frame::Union::H264s(h264s) => {
@@ -349,15 +333,15 @@ impl Decoder {
         }
     }
 
-    fn handle_vp9s_video_frame(
+    fn handle_vpxs_video_frame(
         decoder: &mut VpxDecoder,
-        vp9s: &EncodedVideoFrames,
+        vpxs: &EncodedVideoFrames,
         fmt: (ImageFormat, usize),
         rgb: &mut Vec<u8>,
     ) -> ResultType<bool> {
         let mut last_frame = Image::new();
-        for vp9 in vp9s.frames.iter() {
-            for frame in decoder.decode(&vp9.data)? {
+        for vpx in vpxs.frames.iter() {
+            for frame in decoder.decode(&vpx.data)? {
                 drop(last_frame);
                 last_frame = frame;
             }
@@ -408,14 +392,15 @@ impl Decoder {
         return Ok(false);
     }
 
-    #[cfg(any(feature = "hwcodec", feature = "mediacodec"))]
     fn codec_preference(id: &str) -> PreferCodec {
         let codec = PeerConfig::load(id)
             .options
             .get("codec-preference")
             .map_or("".to_owned(), |c| c.to_owned());
-        if codec == "vp9" {
-            PreferCodec::VPX
+        if codec == "vp8" {
+            PreferCodec::VP8
+        } else if codec == "vp9" {
+            PreferCodec::VP9
         } else if codec == "h264" {
             PreferCodec::H264
         } else if codec == "h265" {

--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub use self::vpxcodec::*;
+use hbb_common::message_proto::{video_frame, VideoFrame};
 
 cfg_if! {
     if #[cfg(quartz)] {
@@ -91,4 +92,56 @@ pub fn is_cursor_embedded() -> bool {
 #[inline]
 pub fn is_cursor_embedded() -> bool {
     false
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodecName {
+    VP8,
+    VP9,
+    H264(String),
+    H265(String),
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum CodecFormat {
+    VP8,
+    VP9,
+    H264,
+    H265,
+    Unknown,
+}
+
+impl From<&VideoFrame> for CodecFormat {
+    fn from(it: &VideoFrame) -> Self {
+        match it.union {
+            Some(video_frame::Union::Vp8s(_)) => CodecFormat::VP8,
+            Some(video_frame::Union::Vp9s(_)) => CodecFormat::VP9,
+            Some(video_frame::Union::H264s(_)) => CodecFormat::H264,
+            Some(video_frame::Union::H265s(_)) => CodecFormat::H265,
+            _ => CodecFormat::Unknown,
+        }
+    }
+}
+
+impl From<&CodecName> for CodecFormat {
+    fn from(value: &CodecName) -> Self {
+        match value {
+            CodecName::VP8 => Self::VP8,
+            CodecName::VP9 => Self::VP9,
+            CodecName::H264(_) => Self::H264,
+            CodecName::H265(_) => Self::H265,
+        }
+    }
+}
+
+impl ToString for CodecFormat {
+    fn to_string(&self) -> String {
+        match self {
+            CodecFormat::VP8 => "VP8".into(),
+            CodecFormat::VP9 => "VP9".into(),
+            CodecFormat::H264 => "H264".into(),
+            CodecFormat::H265 => "H265".into(),
+            CodecFormat::Unknown => "Unknow".into(),
+        }
+    }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -44,9 +44,9 @@ use hbb_common::{
 };
 pub use helper::*;
 use scrap::{
-    codec::{Decoder, DecoderCfg},
+    codec::Decoder,
     record::{Recorder, RecorderContext},
-    ImageFormat, VpxDecoderConfig, VpxVideoCodecId,
+    ImageFormat,
 };
 
 use crate::{
@@ -917,12 +917,7 @@ impl VideoHandler {
     /// Create a new video handler.
     pub fn new() -> Self {
         VideoHandler {
-            decoder: Decoder::new(DecoderCfg {
-                vpx: VpxDecoderConfig {
-                    codec: VpxVideoCodecId::VP9,
-                    num_threads: (num_cpus::get() / 2) as _,
-                },
-            }),
+            decoder: Decoder::new(),
             rgb: Default::default(),
             recorder: Default::default(),
             record: false,
@@ -954,12 +949,7 @@ impl VideoHandler {
 
     /// Reset the decoder.
     pub fn reset(&mut self) {
-        self.decoder = Decoder::new(DecoderCfg {
-            vpx: VpxDecoderConfig {
-                codec: VpxVideoCodecId::VP9,
-                num_threads: 1,
-            },
-        });
+        self.decoder = Decoder::new();
     }
 
     /// Start or stop screen record.
@@ -973,7 +963,7 @@ impl VideoHandler {
                 filename: "".to_owned(),
                 width: w as _,
                 height: h as _,
-                codec_id: scrap::record::RecordCodecID::VP9,
+                format: scrap::CodecFormat::VP9,
                 tx: None,
             })
             .map_or(Default::default(), |r| Arc::new(Mutex::new(Some(r))));
@@ -999,7 +989,7 @@ pub struct LoginConfigHandler {
     pub conn_id: i32,
     features: Option<Features>,
     session_id: u64,
-    pub supported_encoding: Option<(bool, bool)>,
+    pub supported_encoding: SupportedEncoding,
     pub restarting_remote_device: bool,
     pub force_relay: bool,
     pub direct: Option<bool>,
@@ -1047,7 +1037,7 @@ impl LoginConfigHandler {
         self.remember = !config.password.is_empty();
         self.config = config;
         self.session_id = rand::random();
-        self.supported_encoding = None;
+        self.supported_encoding = Default::default();
         self.restarting_remote_device = false;
         self.force_relay = !self.get_option("force-always-relay").is_empty() || force_relay;
         self.direct = None;
@@ -1331,8 +1321,8 @@ impl LoginConfigHandler {
             msg.disable_clipboard = BoolOption::Yes.into();
             n += 1;
         }
-        let state = Decoder::video_codec_state(&self.id);
-        msg.video_codec_state = hbb_common::protobuf::MessageField::some(state);
+        msg.supported_decoding =
+            hbb_common::protobuf::MessageField::some(Decoder::supported_decodings(Some(&self.id)));
         n += 1;
 
         if n > 0 {
@@ -1565,10 +1555,7 @@ impl LoginConfigHandler {
         self.conn_id = pi.conn_id;
         // no matter if change, for update file time
         self.save_config(config);
-        #[cfg(any(feature = "hwcodec", feature = "mediacodec"))]
-        {
-            self.supported_encoding = Some((pi.encoding.h264, pi.encoding.h265));
-        }
+        self.supported_encoding = pi.encoding.clone().unwrap_or_default();
     }
 
     pub fn get_remote_dir(&self) -> String {
@@ -1626,10 +1613,10 @@ impl LoginConfigHandler {
     }
 
     pub fn change_prefer_codec(&self) -> Message {
-        let state = scrap::codec::Decoder::video_codec_state(&self.id);
+        let decoding = scrap::codec::Decoder::supported_decodings(Some(&self.id));
         let mut misc = Misc::new();
         misc.set_option(OptionMessage {
-            video_codec_state: hbb_common::protobuf::MessageField::some(state),
+            supported_decoding: hbb_common::protobuf::MessageField::some(decoding),
             ..Default::default()
         });
         let mut msg_out = Message::new();

--- a/src/client/helper.rs
+++ b/src/client/helper.rs
@@ -1,37 +1,8 @@
 use hbb_common::{
     get_time,
-    message_proto::{video_frame, Message, VideoFrame, VoiceCallRequest, VoiceCallResponse},
+    message_proto::{Message, VoiceCallRequest, VoiceCallResponse},
 };
-
-#[derive(PartialEq, Debug, Clone)]
-pub enum CodecFormat {
-    VP9,
-    H264,
-    H265,
-    Unknown,
-}
-
-impl From<&VideoFrame> for CodecFormat {
-    fn from(it: &VideoFrame) -> Self {
-        match it.union {
-            Some(video_frame::Union::Vp9s(_)) => CodecFormat::VP9,
-            Some(video_frame::Union::H264s(_)) => CodecFormat::H264,
-            Some(video_frame::Union::H265s(_)) => CodecFormat::H265,
-            _ => CodecFormat::Unknown,
-        }
-    }
-}
-
-impl ToString for CodecFormat {
-    fn to_string(&self) -> String {
-        match self {
-            CodecFormat::VP9 => "VP9".into(),
-            CodecFormat::H264 => "H264".into(),
-            CodecFormat::H265 => "H265".into(),
-            CodecFormat::Unknown => "Unknow".into(),
-        }
-    }
-}
+use scrap::CodecFormat;
 
 #[derive(Debug, Default)]
 pub struct QualityStatus {

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -29,10 +29,10 @@ use hbb_common::tokio::{
     time::{self, Duration, Instant, Interval},
 };
 use hbb_common::{allow_err, fs, get_time, log, message_proto::*, Stream};
+use scrap::CodecFormat;
 
 use crate::client::{
-    new_voice_call_request, Client, CodecFormat, MediaData, MediaSender, QualityStatus, MILLI1,
-    SEC30,
+    new_voice_call_request, Client, MediaData, MediaSender, QualityStatus, MILLI1, SEC30,
 };
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::common::{self, update_clipboard};
@@ -817,11 +817,10 @@ impl<T: InvokeUiSession> Remote<T> {
     }
 
     fn contains_key_frame(vf: &VideoFrame) -> bool {
+        use video_frame::Union::*;
         match &vf.union {
             Some(vf) => match vf {
-                video_frame::Union::Vp9s(f) => f.frames.iter().any(|e| e.key),
-                video_frame::Union::H264s(f) => f.frames.iter().any(|e| e.key),
-                video_frame::Union::H265s(f) => f.frames.iter().any(|e| e.key),
+                Vp8s(f) | Vp9s(f) | H264s(f) | H265s(f) => f.frames.iter().any(|e| e.key),
                 _ => false,
             },
             None => false,

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -969,6 +969,13 @@ pub fn main_has_hwcodec() -> SyncReturn<bool> {
     SyncReturn(has_hwcodec())
 }
 
+pub fn main_supported_hwdecodings() -> SyncReturn<String> {
+    let decoding = supported_hwdecodings();
+    let msg = HashMap::from([("h264", decoding.0), ("h265", decoding.1)]);
+
+    SyncReturn(serde_json::ser::to_string(&msg).unwrap_or("".to_owned()))
+}
+
 pub fn main_is_root() -> bool {
     is_root()
 }
@@ -1054,10 +1061,10 @@ pub fn session_send_note(id: String, note: String) {
     }
 }
 
-pub fn session_supported_hwcodec(id: String) -> String {
+pub fn session_alternative_codecs(id: String) -> String {
     if let Some(session) = SESSIONS.read().unwrap().get(&id) {
-        let (h264, h265) = session.supported_hwcodec();
-        let msg = HashMap::from([("h264", h264), ("h265", h265)]);
+        let (vp8, h264, h265) = session.alternative_codecs();
+        let msg = HashMap::from([("vp8", vp8), ("h264", h264), ("h265", h265)]);
         serde_json::ser::to_string(&msg).unwrap_or("".to_owned())
     } else {
         String::new()

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -533,7 +533,7 @@ impl Connection {
             let _ = privacy_mode::turn_off_privacy(0);
         }
         video_service::notify_video_frame_fetched(id, None);
-        scrap::codec::Encoder::update_video_encoder(id, scrap::codec::EncoderUpdate::Remove);
+        scrap::codec::Encoder::update(id, scrap::codec::EncodingUpdate::Remove);
         video_service::VIDEO_QOS.lock().unwrap().reset();
         if conn.authorized {
             password::update_temporary_password();
@@ -860,16 +860,7 @@ impl Connection {
             }
         }
 
-        #[cfg(feature = "hwcodec")]
-        {
-            let (h264, h265) = scrap::codec::Encoder::supported_encoding();
-            pi.encoding = Some(SupportedEncoding {
-                h264,
-                h265,
-                ..Default::default()
-            })
-            .into();
-        }
+        pi.encoding = Some(scrap::codec::Encoder::supported_encoding()).into();
 
         if self.port_forward_socket.is_some() {
             let mut msg_out = Message::new();
@@ -1145,21 +1136,21 @@ impl Connection {
         self.lr = lr.clone();
         if let Some(o) = lr.option.as_ref() {
             self.options_in_login = Some(o.clone());
-            if let Some(q) = o.video_codec_state.clone().take() {
-                scrap::codec::Encoder::update_video_encoder(
+            if let Some(q) = o.supported_decoding.clone().take() {
+                scrap::codec::Encoder::update(
                     self.inner.id(),
-                    scrap::codec::EncoderUpdate::State(q),
+                    scrap::codec::EncodingUpdate::New(q),
                 );
             } else {
-                scrap::codec::Encoder::update_video_encoder(
+                scrap::codec::Encoder::update(
                     self.inner.id(),
-                    scrap::codec::EncoderUpdate::DisableHwIfNotExist,
+                    scrap::codec::EncodingUpdate::NewOnlyVP9,
                 );
             }
         } else {
-            scrap::codec::Encoder::update_video_encoder(
+            scrap::codec::Encoder::update(
                 self.inner.id(),
-                scrap::codec::EncoderUpdate::DisableHwIfNotExist,
+                scrap::codec::EncodingUpdate::NewOnlyVP9,
             );
         }
         self.video_ack_required = lr.video_ack_required;
@@ -1758,11 +1749,8 @@ impl Connection {
                 .unwrap()
                 .update_user_fps(o.custom_fps as _);
         }
-        if let Some(q) = o.video_codec_state.clone().take() {
-            scrap::codec::Encoder::update_video_encoder(
-                self.inner.id(),
-                scrap::codec::EncoderUpdate::State(q),
-            );
+        if let Some(q) = o.supported_decoding.clone().take() {
+            scrap::codec::Encoder::update(self.inner.id(), scrap::codec::EncodingUpdate::New(q));
         }
         if let Ok(q) = o.lock_after_session_end.enum_value() {
             if q != BoolOption::NotSet {

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -161,8 +161,8 @@ class Header: Reactor.Component {
     }
 
     function renderDisplayPop() {
-        var codecs = handler.supported_hwcodec();
-        var show_codec = handler.has_hwcodec() && (codecs[0] || codecs[1]);
+        var codecs = handler.alternative_codecs();
+        var show_codec = codecs[0] || codecs[1] || codecs[2];
 
         var cursor_embedded = false;
         if ((pi.displays || []).length > 0) {
@@ -186,9 +186,10 @@ class Header: Reactor.Component {
                 {show_codec ? <div>
                 <div .separator />
                 <li #auto type="codec-preference"><span>{svg_checkmark}</span>Auto</li>
+                {codecs[0] ? <li #vp8 type="codec-preference"><span>{svg_checkmark}</span>VP8</li> : ""}
                 <li #vp9 type="codec-preference"><span>{svg_checkmark}</span>VP9</li>
-                {codecs[0] ? <li #h264 type="codec-preference"><span>{svg_checkmark}</span>H264</li> : ""}
-                {codecs[1] ? <li #h265 type="codec-preference"><span>{svg_checkmark}</span>H265</li> : ""}
+                {codecs[1] ? <li #h264 type="codec-preference"><span>{svg_checkmark}</span>H264</li> : ""}
+                {codecs[2] ? <li #h265 type="codec-preference"><span>{svg_checkmark}</span>H265</li> : ""}
                 </div> : ""}
                 <div .separator />
                 {!cursor_embedded && <li #show-remote-cursor .toggle-option><span>{svg_checkmark}</span>{translate('Show remote cursor')}</li>}

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -20,7 +20,6 @@ use hbb_common::{
 
 use crate::{
     client::*,
-    ui_interface::has_hwcodec,
     ui_session_interface::{InvokeUiSession, Session},
 };
 
@@ -197,7 +196,14 @@ impl InvokeUiSession for SciterHandler {
         self.call("confirmDeleteFiles", &make_args!(id, i, name));
     }
 
-    fn override_file_confirm(&self, id: i32, file_num: i32, to: String, is_upload: bool, is_identical: bool) {
+    fn override_file_confirm(
+        &self,
+        id: i32,
+        file_num: i32,
+        to: String,
+        is_upload: bool,
+        is_identical: bool,
+    ) {
         self.call(
             "overrideFileConfirm",
             &make_args!(id, file_num, to, is_upload, is_identical),
@@ -451,8 +457,7 @@ impl sciter::EventHandler for SciterSession {
         fn set_write_override(i32, i32, bool, bool, bool);
         fn get_keyboard_mode();
         fn save_keyboard_mode(String);
-        fn has_hwcodec();
-        fn supported_hwcodec();
+        fn alternative_codecs();
         fn change_prefer_codec();
         fn restart_remote_device();
         fn request_voice_call();
@@ -504,10 +509,6 @@ impl SciterSession {
         v
     }
 
-    fn has_hwcodec(&self) -> bool {
-        has_hwcodec()
-    }
-
     pub fn t(&self, name: String) -> String {
         crate::client::translate(name)
     }
@@ -516,9 +517,10 @@ impl SciterSession {
         super::get_icon()
     }
 
-    fn supported_hwcodec(&self) -> Value {
-        let (h264, h265) = self.0.supported_hwcodec();
+    fn alternative_codecs(&self) -> Value {
+        let (vp8, h264, h265) = self.0.alternative_codecs();
         let mut v = Value::array(0);
+        v.push(vp8);
         v.push(h264);
         v.push(h265);
         v

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -752,6 +752,13 @@ pub fn has_hwcodec() -> bool {
     return true;
 }
 
+#[cfg(feature = "flutter")]
+#[inline]
+pub fn supported_hwdecodings() -> (bool, bool) {
+    let decoding = scrap::codec::Decoder::supported_decodings(None);
+    (decoding.ability_h264 > 0, decoding.ability_h265 > 0)
+}
+
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 #[inline]
 pub fn is_root() -> bool {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -216,24 +216,16 @@ impl<T: InvokeUiSession> Session<T> {
         true
     }
 
-    pub fn supported_hwcodec(&self) -> (bool, bool) {
-        #[cfg(any(feature = "hwcodec", feature = "mediacodec"))]
-        {
-            let decoder = scrap::codec::Decoder::video_codec_state(&self.id);
-            let mut h264 = decoder.score_h264 > 0;
-            let mut h265 = decoder.score_h265 > 0;
-            let (encoding_264, encoding_265) = self
-                .lc
-                .read()
-                .unwrap()
-                .supported_encoding
-                .unwrap_or_default();
-            h264 = h264 && encoding_264;
-            h265 = h265 && encoding_265;
-            return (h264, h265);
-        }
-        #[allow(unreachable_code)]
-        (false, false)
+    pub fn alternative_codecs(&self) -> (bool, bool, bool) {
+        let decoder = scrap::codec::Decoder::supported_decodings(None);
+        let mut vp8 = decoder.ability_vp8 > 0;
+        let mut h264 = decoder.ability_h264 > 0;
+        let mut h265 = decoder.ability_h265 > 0;
+        let enc = &self.lc.read().unwrap().supported_encoding;
+        vp8 = vp8 && enc.vp8;
+        h264 = h264 && enc.h264;
+        h265 = h265 && enc.h265;
+        (vp8, h264, h265)
     }
 
     pub fn change_prefer_codec(&self) {


### PR DESCRIPTION
1. Add vp8 for low CPU usage.
2. If the controlled device's memory does not exceed 4 GB, vp8 will be the default codec, otherwise it will be vp9.