### PR TITLE
opt: use our prebuilt vcpkg library for Windows

### DIFF
--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -87,18 +87,14 @@ jobs:
           Push-Location flutter ; flutter pub get ; Pop-Location
           ~/.cargo/bin/flutter_rust_bridge_codegen --rust-input ./src/flutter_ffi.rs --dart-output ./flutter/lib/generated_bridge.dart
 
-      - name: Restore from cache and install vcpkg
-        uses: lukka/run-vcpkg@v7
-        with:
-          setupOnly: true
-          vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
-
       - name: Install vcpkg dependencies
         run: |
-          $VCPKG_ROOT/vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static
-        shell: bash
-
+          cd C:\
+          git clone https://github.com/Kingtous/rustdesk_thirdpary_lib --depth=1 
+          
       - name: Build rustdesk
+        env:
+          VCPKG_ROOT: C:\rustdesk_thirdpary_lib\vcpkg
         run: python3 .\build.py --portable --hwcodec --flutter --feature IddDriver
 
       - name: Sign rustdesk files
@@ -192,12 +188,14 @@ jobs:
 
       - name: Install vcpkg dependencies
         run: |
-          $VCPKG_ROOT/vcpkg install libvpx:x86-windows-static libyuv:x86-windows-static opus:x86-windows-static
-        shell: bash
+          cd C:\
+          git clone https://github.com/Kingtous/rustdesk_thirdpary_lib --depth=1 
 
       - name: Build rustdesk
         id: build
         shell: bash
+        env:
+          VCPKG_ROOT: C:\rustdesk_thirdpary_lib\vcpkg
         run: |
           python3 res/inline-sciter.py
           # Patch sciter x86


### PR DESCRIPTION
related: https://github.com/rustdesk/rustdesk/discussions/3858

We have the prebuilt x86, x64-windows-static libraries to prevent building issues from the vcpkg upstream now.