### PR TITLE
Improve naming.rs

### DIFF
--- a/src/naming.rs
+++ b/src/naming.rs
@@ -9,19 +9,8 @@ fn gen_name(lic: &License) -> ResultType<String> {
 }
 
 fn main() {
-    let mut args = Vec::new();
-    let mut i = 0;
-    for arg in std::env::args() {
-        if i > 0 {
-            args.push(arg);
-        }
-        i += 1;
-    }
-    let api = if args.len() < 3 {
-        "".to_owned()
-    } else {
-        args[2].clone()
-    };
+    let args: Vec<_> = std::env::args().skip(1).collect();
+    let api = args.get(2).cloned().unwrap_or_default();
     if args.len() >= 2 {
         println!(
             "rustdesk-licensed-{}.exe",

--- a/src/naming.rs
+++ b/src/naming.rs
@@ -4,10 +4,8 @@ use hbb_common::ResultType;
 use license::*;
 
 fn gen_name(lic: &License) -> ResultType<String> {
-    let tmp = serde_json::to_vec::<License>(lic)?;
-    let tmp = URL_SAFE_NO_PAD.encode(&tmp);
-    let tmp: String = tmp.chars().rev().collect();
-    Ok(tmp)
+    let tmp = URL_SAFE_NO_PAD.encode(&serde_json::to_vec(lic)?);
+    Ok(tmp.chars().rev().collect())
 }
 
 fn main() {


### PR DESCRIPTION
- Simplify the loop that processes command-line arguments using the skip method of the std::env::args() iterator, instead of manually tracking the index and pushing to a vector.
- Make use of unwrap_or_default() to simplify the api variable initialization instead of an if-else statement.
- Improve the readability of the gen_name function