### PR TITLE
Feat/translate mode win2win hotkey

### DIFF
--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -203,11 +203,13 @@ message KeyEvent {
   bool press = 2;
   oneof union {
     ControlKey control_key = 3;
-    // high word, sym key code. win: virtual-key code, linux: keysym ?, macos: 
-    // low word, position key code. win: scancode, linux: key code, macos: key code
+    // position key code. win: scancode, linux: key code, macos: key code
     uint32 chr = 4;
     uint32 unicode = 5;
     string seq = 6;
+    // high word. virtual keycode
+    // low word. unicode
+    uint32 win2win_hotkey = 7;
   }
   repeated ControlKey modifiers = 8;
   KeyboardMode mode = 9;

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -517,6 +517,11 @@ pub fn event_to_key_events(
         }
     };
 
+    println!(
+        "REMOVE ME ==================================== key_events {:?}",
+        &key_events
+    );
+
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if keyboard_mode != KeyboardMode::Translate {
         let is_numpad_key = is_numpad_key(&event);
@@ -893,8 +898,10 @@ fn try_file_win2win_hotkey(
     events: &mut Vec<KeyEvent>,
 ) {
     if peer == OS_LOWER_WINDOWS && is_hot_key_modifiers_down() && unsafe { !IS_0X021D_DOWN } {
+        let mut down = false;
         let win2win_hotkey = match event.event_type {
             EventType::KeyPress(..) => {
+                down = true;
                 if let Some(unicode) = get_unicode_from_vk(event.platform_code as u32) {
                     Some((unicode as u32 & 0x0000FFFF) | (event.platform_code << 16))
                 } else {
@@ -907,6 +914,7 @@ fn try_file_win2win_hotkey(
         if let Some(code) = win2win_hotkey {
             let mut evt = key_event.clone();
             evt.set_win2win_hotkey(code);
+            evt.down = down;
             events.push(evt);
         }
     }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -517,11 +517,6 @@ pub fn event_to_key_events(
         }
     };
 
-    println!(
-        "REMOVE ME ==================================== key_events {:?}",
-        &key_events
-    );
-
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if keyboard_mode != KeyboardMode::Translate {
         let is_numpad_key = is_numpad_key(&event);

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1,8 +1,6 @@
 use super::*;
 #[cfg(target_os = "linux")]
 use crate::common::IS_X11;
-#[cfg(target_os = "windows")]
-use crate::platform::windows::get_char_from_unicode;
 #[cfg(target_os = "macos")]
 use dispatch::Queue;
 use enigo::{Enigo, Key, KeyboardControllable, MouseButton, MouseControllable};
@@ -1294,13 +1292,12 @@ fn translate_keyboard_mode(evt: &KeyEvent) {
 
 #[cfg(target_os = "windows")]
 fn simulate_win2win_hotkey(code: u32, down: bool) {
-    let mut simulated = false;
-
     let unicode: u16 = (code & 0x0000FFFF) as u16;
-    if unicode != 0 {
+    if down {
         // Try convert unicode to virtual keycode first.
         // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-vkkeyscanw
         let res = unsafe { winapi::um::winuser::VkKeyScanW(unicode) };
+        println!("REMOVE ME =============================== VkKeyScanW {} {}", unicode, res);
         if res as u16 != 0xFFFF {
             let vk = res & 0x00FF;
             let flag = res >> 8;
@@ -1319,14 +1316,13 @@ fn simulate_win2win_hotkey(code: u32, down: bool) {
                     allow_err!(rdev::simulate(&EventType::KeyRelease(modifiers[rpos])));
                 }
             }
-            simulated = true;
+            return;
         }
     }
 
-    if simulated {
-        let keycode: u16 = ((code >> 16) & 0x0000FFFF) as u16;
-        allow_err!(rdev::simulate_code(Some(keycode), None, down));
-    }
+    let keycode: u16 = ((code >> 16) & 0x0000FFFF) as u16;
+    println!("REMOVE ME =============================== simulate_win2win_hotkey down {} {},{}", down, unicode, keycode);
+    allow_err!(rdev::simulate_code(Some(keycode), None, down));
 }
 
 pub fn handle_key_(evt: &KeyEvent) {

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1297,7 +1297,6 @@ fn simulate_win2win_hotkey(code: u32, down: bool) {
         // Try convert unicode to virtual keycode first.
         // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-vkkeyscanw
         let res = unsafe { winapi::um::winuser::VkKeyScanW(unicode) };
-        println!("REMOVE ME =============================== VkKeyScanW {} {}", unicode, res);
         if res as u16 != 0xFFFF {
             let vk = res & 0x00FF;
             let flag = res >> 8;
@@ -1321,7 +1320,6 @@ fn simulate_win2win_hotkey(code: u32, down: bool) {
     }
 
     let keycode: u16 = ((code >> 16) & 0x0000FFFF) as u16;
-    println!("REMOVE ME =============================== simulate_win2win_hotkey down {} {},{}", down, unicode, keycode);
     allow_err!(rdev::simulate_code(Some(keycode), None, down));
 }
 


### PR DESCRIPTION
Win -> Win, better hotkey support

Send both unicode and virtual keycode to the remote side.

1. If unicode can be converted to virtual keycode, simulate the converted virutal keycode.
2. Else simulate the virtual keycode sent by client side.

**Caution:**
This PR has modified of the key event message in message.proto.  The modification cannot be compatible with the previous nightly version.
**Please download the latest version control on the control end and the controlled end.**

`win2win_hotkey ` is the new filed.
```
message KeyEvent {
  bool down = 1;
  bool press = 2;
  oneof union {
    ControlKey control_key = 3;
    // position key code. win: scancode, linux: key code, macos: key code
    uint32 chr = 4;
    uint32 unicode = 5;
    string seq = 6;
    // high word. virtual keycode
    // low word. unicode
    uint32 win2win_hotkey = 7;
  }
  repeated ControlKey modifiers = 8;
  KeyboardMode mode = 9;
}
```
