### PR TITLE
delete RustDesk_hwcodec.toml on every check

### DIFF
--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -108,7 +108,7 @@ impl Encoder {
                     codec: Box::new(hw),
                 }),
                 Err(e) => {
-                    check_config_process(true);
+                    check_config_process();
                     *CODEC_NAME.lock().unwrap() = CodecName::VP9;
                     Err(e)
                 }

--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -199,7 +199,7 @@ impl HwDecoder {
             }
         }
         if fail {
-            check_config_process(true);
+            check_config_process();
         }
         HwDecoders { h264, h265 }
     }
@@ -323,13 +323,11 @@ pub fn check_config() {
     log::error!("Failed to serialize codec info");
 }
 
-pub fn check_config_process(force_reset: bool) {
+pub fn check_config_process() {
     use hbb_common::sysinfo::{ProcessExt, System, SystemExt};
 
     std::thread::spawn(move || {
-        if force_reset {
-            HwCodecConfig::remove();
-        }
+        HwCodecConfig::remove();
         if let Ok(exe) = std::env::current_exe() {
             if let Some(file_name) = exe.file_name().to_owned() {
                 let s = System::new_all();

--- a/src/server.rs
+++ b/src/server.rs
@@ -389,7 +389,7 @@ pub async fn start_server(is_server: bool) {
         use std::sync::Once;
         static ONCE: Once = Once::new();
         ONCE.call_once(|| {
-            scrap::hwcodec::check_config_process(false);
+            scrap::hwcodec::check_config_process();
         })
     }
 


### PR DESCRIPTION
The check process may crash, resulting in the inability to update the config, so delete it first every time.