### PR TITLE
fix press/release single meta key

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 /// cbindgen:ignore
 pub mod platform;
 mod keyboard;
+pub use keyboard::keycode_to_rdev_key;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use platform::{get_cursor, get_cursor_data, get_cursor_pos, start_os_service};
 #[cfg(not(any(target_os = "ios")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 /// cbindgen:ignore
 pub mod platform;
 mod keyboard;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use keyboard::keycode_to_rdev_key;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use platform::{get_cursor, get_cursor_data, get_cursor_pos, start_os_service};

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1371,13 +1371,13 @@ fn simulate_win2win_hotkey(code: u32, down: bool) {
     allow_err!(rdev::simulate_code(Some(keycode), None, down));
 }
 
-#[cfg(any(target_os = "android", target_os = "ios"))]
-fn is_meta_key(_evt: &KeyEvent) -> bool {
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+fn is_win_linux_meta_key(_evt: &KeyEvent) -> bool {
     false
 }
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-fn is_meta_key(evt: &KeyEvent) -> bool {
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+fn is_win_linux_meta_key(evt: &KeyEvent) -> bool {
     match evt.mode.unwrap() {
         KeyboardMode::Map | KeyboardMode::Translate => match &evt.union {
             Some(key_event::Union::ControlKey(ck)) => {
@@ -1410,7 +1410,7 @@ pub fn handle_key_(evt: &KeyEvent) {
             Some(LockModesHandler::new(&evt))
         }
         _ => {
-            if evt.down && !is_meta_key(evt) {
+            if evt.down && !is_win_linux_meta_key(evt) {
                 Some(LockModesHandler::new(evt))
             } else {
                 None

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1410,6 +1410,9 @@ pub fn handle_key_(evt: &KeyEvent) {
             Some(LockModesHandler::new(&evt))
         }
         _ => {
+            // LockModesHandler should not be created when single meta is pressing and releasing.
+            // Because the drop function may insert "CapsLock Click" and "NumLock Click", which breaks single meta click.
+            // https://github.com/rustdesk/rustdesk/issues/3928#issuecomment-1496936687
             if evt.down && !is_win_linux_meta_key(evt) {
                 Some(LockModesHandler::new(evt))
             } else {


### PR DESCRIPTION
The host side may inadvertently click Numlock or CapsLock during the simulation of pressing and releasing the Meta key, causing the single Meta key to become ineffective.

```
Client Side:                Press/Release Meta
                                   |
                                   |
                                   v
Host Side:    "Press Meta"  "Click NulLock/CapsLock"  "Release Meta"
```

https://github.com/rustdesk/rustdesk/issues/3928

