### PR TITLE
fix: arm architecture env

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -980,7 +980,7 @@ jobs:
         run: |
           for name in rustdesk*??.deb; do
               # use cp to duplicate deb files to fit other packages.
-              cp "$name" "${name%%.deb}--${{ matrix.job.arch }}-sciter.deb"
+              cp "$name" "${name%%.deb}-${{ matrix.job.arch }}-sciter.deb"
           done
 
       - name: Publish debian package
@@ -1103,11 +1103,11 @@ jobs:
             # edit to corresponding arch
             case ${{ matrix.job.arch }} in
               aarch64)
-                sed -i "s/Architecture: amd64/Architecture: arm64/g" ./build.py
+                export ARCH=arm64
                 sed -i "s/x64\/release/arm64\/release/g" ./build.py
               ;;
               armv7)
-                sed -i "s/Architecture: amd64/Architecture: arm/g" ./build.py
+                export ARCH=armhf
                 sed -i "s/x64\/release/arm\/release/g" ./build.py
               ;;
             esac


### PR DESCRIPTION
#3939 

Previously, we use `sed` to manually change the arch to the corresponding one but now we support setting `ARCH` environment to change the control file dynamically. This PR replaces `sed` with `export`, which fixes the problem above.