### PR TITLE
client side fps control for reduce delay 

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1228,9 +1228,9 @@ class _DisplayState extends State<_Display> {
                   children: [
                     Slider(
                       value: fpsValue.value,
-                      min: 10.0,
+                      min: 5.0,
                       max: 120.0,
-                      divisions: 22,
+                      divisions: 23,
                       onChanged: (double value) async {
                         fpsValue.value = value;
                         await bind.mainSetUserDefaultOption(

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1237,7 +1237,7 @@ class _DisplayMenuState extends State<_DisplayMenu> {
     final fpsOption =
         await bind.sessionGetOption(id: widget.id, arg: 'custom-fps');
     fpsInitValue = fpsOption == null ? 30 : double.tryParse(fpsOption) ?? 30;
-    if (fpsInitValue < 10 || fpsInitValue > 120) {
+    if (fpsInitValue < 5 || fpsInitValue > 120) {
       fpsInitValue = 30;
     }
     final RxDouble fpsSliderValue = RxDouble(fpsInitValue);
@@ -1260,9 +1260,9 @@ class _DisplayMenuState extends State<_DisplayMenu> {
         children: [
           Obx((() => Slider(
                 value: fpsSliderValue.value,
-                min: 10,
+                min: 5,
                 max: 120,
-                divisions: 22,
+                divisions: 23,
                 onChanged: (double value) {
                   fpsSliderValue.value = value;
                   debouncerFps.value = value;

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1363,7 +1363,7 @@ impl UserDefaultConfig {
             "image_quality" => self.get_string(key, "balanced", vec!["best", "low", "custom"]),
             "codec-preference" => self.get_string(key, "auto", vec!["vp8", "vp9", "h264", "h265"]),
             "custom_image_quality" => self.get_double_string(key, 50.0, 10.0, 100.0),
-            "custom-fps" => self.get_double_string(key, 30.0, 10.0, 120.0),
+            "custom-fps" => self.get_double_string(key, 30.0, 5.0, 120.0),
             _ => self
                 .options
                 .get(key)

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -65,6 +65,8 @@ pub struct Remote<T: InvokeUiSession> {
     frame_count: Arc<AtomicUsize>,
     video_format: CodecFormat,
     elevation_requested: bool,
+    fps_control: FpsControl,
+    decode_fps: Arc<AtomicUsize>,
 }
 
 impl<T: InvokeUiSession> Remote<T> {
@@ -76,6 +78,7 @@ impl<T: InvokeUiSession> Remote<T> {
         receiver: mpsc::UnboundedReceiver<Data>,
         sender: mpsc::UnboundedSender<Data>,
         frame_count: Arc<AtomicUsize>,
+        decode_fps: Arc<AtomicUsize>,
     ) -> Self {
         Self {
             handler,
@@ -100,6 +103,8 @@ impl<T: InvokeUiSession> Remote<T> {
             stop_voice_call_sender: None,
             voice_call_request_timestamp: None,
             elevation_requested: false,
+            fps_control: Default::default(),
+            decode_fps,
         }
     }
 
@@ -147,6 +152,7 @@ impl<T: InvokeUiSession> Remote<T> {
                 let mut rx_clip_client = rx_clip_client_lock.lock().await;
 
                 let mut status_timer = time::interval(Duration::new(1, 0));
+                let mut fps_instant = Instant::now();
 
                 loop {
                     tokio::select! {
@@ -224,9 +230,18 @@ impl<T: InvokeUiSession> Remote<T> {
                             }
                         }
                         _ = status_timer.tick() => {
-                            let speed = self.data_count.swap(0, Ordering::Relaxed);
+                            self.fps_control();
+                            let elapsed = fps_instant.elapsed().as_millis();
+                            if elapsed < 1000 {
+                                continue;
+                            }
+                            fps_instant = Instant::now();
+                            let mut speed = self.data_count.swap(0, Ordering::Relaxed);
+                            speed = speed * 1000 / elapsed as usize;
                             let speed = format!("{:.2}kB/s", speed as f32 / 1024 as f32);
-                            let fps = self.frame_count.swap(0, Ordering::Relaxed) as _;
+                            let mut fps = self.frame_count.swap(0, Ordering::Relaxed) as _;
+                            // Correcting the inaccuracy of status_timer
+                            fps = fps * 1000 / elapsed as i32;
                             self.handler.update_quality_status(QualityStatus {
                                 speed:Some(speed),
                                 fps:Some(fps),
@@ -824,6 +839,53 @@ impl<T: InvokeUiSession> Remote<T> {
                 _ => false,
             },
             None => false,
+        }
+    }
+    #[inline]
+    fn fps_control(&mut self) {
+        let len = self.video_queue.len();
+        let ctl = &mut self.fps_control;
+        // Current full speed decoding fps
+        let decode_fps = self.decode_fps.load(std::sync::atomic::Ordering::Relaxed);
+        // 500ms
+        let debounce = if decode_fps > 10 { decode_fps / 2 } else { 5 };
+        if len < debounce || decode_fps == 0 {
+            return;
+        }
+        let mut refresh = false;
+        // First setting , or the length of the queue still increases after setting, or exceed the size of the last setting again
+        if ctl.set_times < 10 // enough
+            && (ctl.set_times == 0
+                || (len > ctl.last_queue_size && ctl.last_set_instant.elapsed().as_secs() > 30))
+        {
+            // 80% fps to ensure decoding is faster than encoding
+            let mut custom_fps = decode_fps as i32 * 4 / 5;
+            if custom_fps < 1 {
+                custom_fps = 1;
+            }
+            // send custom fps
+            let mut misc = Misc::new();
+            misc.set_option(OptionMessage {
+                custom_fps,
+                ..Default::default()
+            });
+            let mut msg = Message::new();
+            msg.set_misc(misc);
+            self.sender.send(Data::Message(msg)).ok();
+            ctl.last_queue_size = len;
+            ctl.set_times += 1;
+            ctl.last_set_instant = Instant::now();
+            refresh = true;
+        }
+        // send refresh
+        if ctl.refresh_times < 10 // enough
+            && (refresh
+                || (len > self.video_queue.len() / 2
+                    && ctl.last_refresh_instant.elapsed().as_secs() > 30))
+        {
+            self.handler.refresh_video();
+            ctl.refresh_times += 1;
+            ctl.last_refresh_instant = Instant::now();
         }
     }
 
@@ -1486,6 +1548,26 @@ impl RemoveJob {
             path: self.path.clone(),
             is_remote: self.is_remote,
             no_confirm: self.no_confirm,
+        }
+    }
+}
+
+struct FpsControl {
+    last_queue_size: usize,
+    set_times: usize,
+    refresh_times: usize,
+    last_set_instant: Instant,
+    last_refresh_instant: Instant,
+}
+
+impl Default for FpsControl {
+    fn default() -> Self {
+        Self {
+            last_queue_size: Default::default(),
+            set_times: Default::default(),
+            refresh_times: Default::default(),
+            last_set_instant: Instant::now(),
+            last_refresh_instant: Instant::now(),
         }
     }
 }

--- a/src/server/video_qos.rs
+++ b/src/server/video_qos.rs
@@ -221,7 +221,9 @@ impl VideoQoS {
     }
 
     pub fn reset(&mut self) {
-        *self = Default::default();
+        self.fps = FPS;
+        self.user_fps = FPS;
+        self.updated = true;
     }
 
     pub fn check_abr_config(&mut self) -> bool {

--- a/src/server/video_qos.rs
+++ b/src/server/video_qos.rs
@@ -1,7 +1,7 @@
 use super::*;
 use std::time::Duration;
 pub const FPS: u8 = 30;
-pub const MIN_FPS: u8 = 10;
+pub const MIN_FPS: u8 = 1;
 pub const MAX_FPS: u8 = 120;
 trait Percent {
     fn as_percent(&self) -> u32;

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -547,7 +547,7 @@ fn run(sp: GenericService) -> ResultType<()> {
         check_uac_switch(c.privacy_mode_id, c._capturer_privacy_mode_id)?;
 
         let mut video_qos = VIDEO_QOS.lock().unwrap();
-        if video_qos.check_if_updated() {
+        if video_qos.check_if_updated() && video_qos.target_bitrate > 0 {
             log::debug!(
                 "qos is updated, target_bitrate:{}, fps:{}",
                 video_qos.target_bitrate,

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1162,7 +1162,7 @@ pub async fn io_loop<T: InvokeUiSession>(handler: Session<T>) {
     let frame_count = Arc::new(AtomicUsize::new(0));
     let frame_count_cl = frame_count.clone();
     let ui_handler = handler.ui_handler.clone();
-    let (video_sender, audio_sender, video_queue) =
+    let (video_sender, audio_sender, video_queue, decode_fps) =
         start_video_audio_threads(move |data: &mut Vec<u8>| {
             frame_count_cl.fetch_add(1, Ordering::Relaxed);
             ui_handler.on_rgba(data);
@@ -1176,6 +1176,7 @@ pub async fn io_loop<T: InvokeUiSession>(handler: Session<T>) {
         receiver,
         sender,
         frame_count,
+        decode_fps,
     );
     remote.io_loop(&key, &token).await;
     remote.sync_jobs_status_to_local().await;


### PR DESCRIPTION
1. Reduce fps if client video queue accumulates
2. Set custom fps only when using custom quality
3. Fix possible bitrate equal to zero when multiple connections