### PR TITLE
refact is_peer_version_ge, and fix version comparation > to >=

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -818,3 +818,21 @@ pub async fn get_key(sync: bool) -> String {
     }
     key
 }
+
+pub fn is_peer_version_ge(v: &str) -> bool {
+    #[cfg(not(any(feature = "flutter", feature = "cli")))]
+    if let Some(session) = crate::ui::CUR_SESSION.lock().unwrap().as_ref() {
+        return session.get_peer_version() >= hbb_common::get_version_number(v);
+    }
+
+    #[cfg(feature = "flutter")]
+    if let Some(session) = crate::flutter::SESSIONS
+        .read()
+        .unwrap()
+        .get(&*crate::flutter::CUR_SESSION_ID.read().unwrap())
+    {
+        return session.get_peer_version() >= hbb_common::get_version_number(v);
+    }
+
+    false
+}

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -339,24 +339,8 @@ pub fn get_keyboard_mode_enum() -> KeyboardMode {
         "translate" => KeyboardMode::Translate,
         "legacy" => KeyboardMode::Legacy,
         _ => {
-            // Set "map" as default mode if version > 1.2.0.
-            let mut is_peer_version_gt_1_2_0 = false;
-
-            #[cfg(not(any(feature = "flutter", feature = "cli")))]
-            if let Some(session) = CUR_SESSION.lock().unwrap().as_ref() {
-                is_peer_version_gt_1_2_0 =
-                    session.get_peer_version() > hbb_common::get_version_number("1.2.0");
-            }
-            #[cfg(feature = "flutter")]
-            if let Some(session) = SESSIONS
-                .read()
-                .unwrap()
-                .get(&*CUR_SESSION_ID.read().unwrap())
-            {
-                is_peer_version_gt_1_2_0 =
-                    session.get_peer_version() > hbb_common::get_version_number("1.2.0");
-            }
-            if is_peer_version_gt_1_2_0 {
+            // Set "map" as default mode if version >= 1.2.0.
+            if crate::is_peer_version_ge("1.2.0") {
                 KeyboardMode::Map
             } else {
                 KeyboardMode::Legacy

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -43,12 +43,14 @@ use sha2::{Digest, Sha256};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use std::sync::atomic::Ordering;
 use std::{
-    collections::HashSet,
     num::NonZeroI64,
     sync::{atomic::AtomicI64, mpsc as std_mpsc},
 };
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use system_shutdown;
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use std::collections::HashSet;
 
 pub type Sender = mpsc::UnboundedSender<(Instant, Arc<Message>)>;
 
@@ -153,6 +155,7 @@ pub struct Connection {
     voice_call_request_timestamp: Option<NonZeroI64>,
     audio_input_device_before_voice_call: Option<String>,
     options_in_login: Option<OptionMessage>,
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pressed_modifiers: HashSet<rdev::Key>,
     #[cfg(all(target_os = "linux", feature = "linux_headless"))]
     rx_cm_stream_ready: mpsc::Receiver<()>,
@@ -273,6 +276,7 @@ impl Connection {
             voice_call_request_timestamp: None,
             audio_input_device_before_voice_call: None,
             options_in_login: None,
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
             pressed_modifiers: Default::default(),
             #[cfg(all(target_os = "linux", feature = "linux_headless"))]
             rx_cm_stream_ready: _rx_cm_stream_ready,


### PR DESCRIPTION
1. Fix version comparation > to >=, when setting default keyboard mode.
2. Add a function to detect if current peer version >= ?.