### PR TITLE
remove unused code for code simulation

### DIFF
--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -462,12 +462,6 @@ impl Enigo {
         let current_window_thread_id =
             unsafe { GetWindowThreadProcessId(GetForegroundWindow(), std::ptr::null_mut()) };
         unsafe { LAYOUT = GetKeyboardLayout(current_window_thread_id) };
-        let keycode_and_shiftstate = unsafe { VkKeyScanExW(chr as _, LAYOUT) };
-        if keycode_and_shiftstate == (EVK_DECIMAL as i16) && chr == '.' {
-            // a workaround of italian keyboard shift + '.' issue
-            EVK_PERIOD as _
-        } else {
-            keycode_and_shiftstate as _
-        }
+        unsafe { VkKeyScanExW(chr as _, LAYOUT) as _ }
     }
 }


### PR DESCRIPTION
Remove unused code from https://github.com/rustdesk/rustdesk/commit/b526bf4a67f7e05b2d3f739864ecc31cabc18a85 .

":" results "." is because the `Shift` bit is not handled at that time. [ref](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-vkkeyscanw) 

https://github.com/rustdesk/rustdesk/issues/366#issuecomment-1120379312


