### PR TITLE
Refact/led sync

### DIFF
--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -359,9 +359,6 @@ impl Enigo {
     }
 
     fn key_to_keycode(&self, key: Key) -> u16 {
-        unsafe {
-            LAYOUT = std::ptr::null_mut();
-        }
         // do not use the codes from crate winapi they're
         // wrongly typed with i32 instead of i16 use the
         // ones provided by win/keycodes.rs that are prefixed
@@ -456,6 +453,9 @@ impl Enigo {
     }
 
     fn get_layoutdependent_keycode(&self, chr: char) -> u16 {
+        unsafe {
+            LAYOUT = std::ptr::null_mut();
+        }
         // NOTE VkKeyScanW uses the current keyboard LAYOUT
         // to specify a LAYOUT use VkKeyScanExW and GetKeyboardLayout
         // or load one with LoadKeyboardLayoutW

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -366,24 +366,71 @@ pub fn is_modifier(key: &rdev::Key) -> bool {
 
 #[inline]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn is_numpad_rdev_key(key: &rdev::Key) -> bool {
+    matches!(
+        key,
+        Key::Kp0
+            | Key::Kp1
+            | Key::Kp2
+            | Key::Kp3
+            | Key::Kp4
+            | Key::Kp5
+            | Key::Kp6
+            | Key::Kp7
+            | Key::Kp8
+            | Key::Kp9
+            | Key::KpMinus
+            | Key::KpMultiply
+            | Key::KpDivide
+            | Key::KpPlus
+            | Key::KpDecimal
+    )
+}
+
+#[inline]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn is_letter_rdev_key(key: &rdev::Key) -> bool {
+    matches!(
+        key,
+        Key::KeyA
+            | Key::KeyB
+            | Key::KeyC
+            | Key::KeyD
+            | Key::KeyE
+            | Key::KeyF
+            | Key::KeyG
+            | Key::KeyH
+            | Key::KeyI
+            | Key::KeyJ
+            | Key::KeyK
+            | Key::KeyL
+            | Key::KeyM
+            | Key::KeyN
+            | Key::KeyO
+            | Key::KeyP
+            | Key::KeyQ
+            | Key::KeyR
+            | Key::KeyS
+            | Key::KeyT
+            | Key::KeyU
+            | Key::KeyV
+            | Key::KeyW
+            | Key::KeyX
+            | Key::KeyY
+            | Key::KeyZ
+    )
+}
+
+#[inline]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn is_numpad_key(event: &Event) -> bool {
-    matches!(event.event_type, EventType::KeyPress(key) | EventType::KeyRelease(key) if match key {
-        Key::Kp0 | Key::Kp1 | Key::Kp2 | Key::Kp3 | Key::Kp4 | Key::Kp5 | Key::Kp6 | Key::Kp7 | Key::Kp8 |
-        Key::Kp9 | Key::KpMinus | Key::KpMultiply | Key::KpDivide | Key::KpPlus | Key::KpDecimal => true,
-        _ => false
-    })
+    matches!(event.event_type, EventType::KeyPress(key) | EventType::KeyRelease(key) if is_numpad_rdev_key(&key))
 }
 
 #[inline]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn is_letter_key(event: &Event) -> bool {
-    matches!(event.event_type, EventType::KeyPress(key) | EventType::KeyRelease(key) if match key {
-        Key::KeyA | Key::KeyB | Key::KeyC | Key::KeyD | Key::KeyE | Key::KeyF | Key::KeyG | Key::KeyH |
-        Key::KeyI | Key::KeyJ | Key::KeyK | Key::KeyL | Key::KeyM | Key::KeyN | Key::KeyO | Key::KeyP |
-        Key::KeyQ | Key::KeyR | Key::KeyS | Key::KeyT | Key::KeyU | Key::KeyV | Key::KeyW | Key::KeyX |
-        Key::KeyY | Key::KeyZ => true,
-        _ => false
-    })
+    matches!(event.event_type, EventType::KeyPress(key) | EventType::KeyRelease(key) if is_letter_rdev_key(&key))
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -350,6 +350,7 @@ pub fn get_keyboard_mode_enum() -> KeyboardMode {
 }
 
 #[inline]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub fn is_modifier(key: &rdev::Key) -> bool {
     matches!(
         key,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod platform;
 mod keyboard;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-pub use keyboard::keycode_to_rdev_key;
+pub use keyboard::{keycode_to_rdev_key, is_numpad_rdev_key, is_letter_rdev_key};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use platform::{get_cursor, get_cursor_data, get_cursor_pos, start_os_service};
 #[cfg(not(any(target_os = "ios")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 pub mod platform;
 mod keyboard;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-pub use keyboard::{keycode_to_rdev_key, is_numpad_rdev_key, is_letter_rdev_key};
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use platform::{get_cursor, get_cursor_data, get_cursor_pos, start_os_service};
 #[cfg(not(any(target_os = "ios")))]
 /// cbindgen:ignore

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1394,6 +1394,7 @@ fn skip_led_sync_control_key(key: &ControlKey) -> bool {
 }
 
 #[inline]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn is_numpad_control_key(key: &ControlKey) -> bool {
     matches!(
         key,

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -160,14 +160,16 @@ impl LockModesHandler {
             en.key_click(enigo::Key::CapsLock);
         }
 
-        let event_num_enabled = Self::is_modifier_enabled(key_event, ControlKey::NumLock);
-        let local_num_enabled = en.get_key_state(enigo::Key::NumLock);
-        #[cfg(not(target_os = "windows"))]
-        let disable_numlock = false;
-        #[cfg(target_os = "windows")]
-        let disable_numlock = is_numlock_disabled(key_event);
-        let num_lock_changed =
-            is_numpad_key && event_num_enabled != local_num_enabled && !disable_numlock;
+        let mut num_lock_changed = false;
+        if is_numpad_key {
+            let event_num_enabled = Self::is_modifier_enabled(key_event, ControlKey::NumLock);
+            let local_num_enabled = en.get_key_state(enigo::Key::NumLock);
+            #[cfg(not(target_os = "windows"))]
+            let disable_numlock = false;
+            #[cfg(target_os = "windows")]
+            let disable_numlock = is_numlock_disabled(key_event);
+            num_lock_changed = event_num_enabled != local_num_enabled && !disable_numlock;
+        }
         if num_lock_changed {
             en.key_click(enigo::Key::NumLock);
         }

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -161,7 +161,7 @@ impl LockModesHandler {
         }
 
         let mut num_lock_changed = false;
-        if is_numpad_key || is_legacy_mode(key_event) {
+        if is_numpad_key {
             let event_num_enabled = Self::is_modifier_enabled(key_event, ControlKey::NumLock);
             let local_num_enabled = en.get_key_state(enigo::Key::NumLock);
             #[cfg(not(target_os = "windows"))]
@@ -1461,7 +1461,12 @@ pub fn handle_key_(evt: &KeyEvent) {
                 let is_numpad_key = false;
                 #[cfg(any(target_os = "windows", target_os = "linux"))]
                 let is_numpad_key = is_numpad_control_key(&key);
-                _lock_mode_handler = Some(LockModesHandler::new_handler(&evt, is_numpad_key));
+                // Legacy mode need to disable numlock if home/end/arraws/page down/page up
+                // are pressed.
+                _lock_mode_handler = Some(LockModesHandler::new_handler(
+                    &evt,
+                    is_numpad_key || is_legacy_mode(evt),
+                ));
             }
         }
         Some(key_event::Union::Chr(code)) => {

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1439,10 +1439,10 @@ pub fn handle_key_(evt: &KeyEvent) {
             }
         }
         (Some(key_event::Union::Chr(code)), KeyboardMode::Map | KeyboardMode::Translate) => {
-            let key = crate::keycode_to_rdev_key(*code);
+            let key = crate::keyboard::keycode_to_rdev_key(*code);
             if !skip_led_sync_rdev_key(&key) {
                 _lock_mode_handler =
-                    Some(LockModesHandler::new(evt, crate::is_numpad_rdev_key(&key)));
+                    Some(LockModesHandler::new(evt, crate::keyboard::is_numpad_rdev_key(&key)));
             }
         }
         _ => {}

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -8,8 +8,6 @@ use hbb_common::{config::COMPRESS_LEVEL, get_time, protobuf::EnumOrUnknown};
 use rdev::{self, EventType, Key as RdevKey, KeyCode, RawKey};
 #[cfg(target_os = "macos")]
 use rdev::{CGEventSourceStateID, CGEventTapLocation, VirtualInput};
-#[cfg(any(target_os = "windows", target_os = "linux"))]
-use std::collections::HashSet;
 use std::{
     convert::TryFrom,
     ops::Sub,

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -161,7 +161,7 @@ impl LockModesHandler {
         }
 
         let mut num_lock_changed = false;
-        if is_numpad_key {
+        if is_numpad_key || is_legacy_mode(key_event) {
             let event_num_enabled = Self::is_modifier_enabled(key_event, ControlKey::NumLock);
             let local_num_enabled = en.get_key_state(enigo::Key::NumLock);
             #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
1. Fix build
2. Move `LAYOUT` to the connrect place.
```rust
        unsafe {
            LAYOUT = std::ptr::null_mut();
        }
```
3. Check is numpad key when sync `NumLock`.
4. The code is very strange. Change this code to the logic of version 1.1.9.
```rust
#[cfg(target_os = "windows")]
fn has_numpad_key(key_event: &KeyEvent) -> bool {
    key_event
        .modifiers
        .iter()
        .filter(|&&ck| NUMPAD_KEY_MAP.get(&ck.value()).is_some())
        .count()
        != 0
}
...
fn is_numlock_disabled(key_event: &KeyEvent) -> bool {
    // disable numlock if press home etc when numlock is on,
    // because we will get numpad value (7,8,9 etc) if not
    if key_event.mode.enum_value_or(KeyboardMode::Legacy) == KeyboardMode::Legacy {
        has_numpad_key(key_event)
    } else {
        false
    }
}
```

The logic of 1.1.9 is 
```rust
    match evt.union {
        Some(key_event::Union::control_key(ck)) => {
            if let Some(key) = KEY_MAP.get(&ck.value()) {
                #[cfg(windows)]
                if let Some(_) = NUMPAD_KEY_MAP.get(&ck.value()) {
                    disable_numlock = en.get_key_state(Key::NumLock);
                    if disable_numlock {
                        en.key_down(Key::NumLock).ok();
                        en.key_up(Key::NumLock);
                    }
                }
...
```