### PR TITLE
feat: add the plugin registrar and api tables for both sides of rustdesk and plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5146,6 +5146,7 @@ dependencies = [
  "include_dir",
  "jni 0.19.0",
  "lazy_static",
+ "libloading",
  "libpulse-binding",
  "libpulse-simple-binding",
  "mac_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ hex = "0.4"
 reqwest = { version = "0.11", features = ["blocking", "json", "rustls-tls"], default-features=false }
 chrono = "0.4"
 cidr-utils = "0.5"
+libloading = "0.7"
 
 [target.'cfg(not(any(target_os = "android", target_os = "linux")))'.dependencies]
 cpal = "0.14"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,3 @@
-use std::{ffi::CStr, os::raw::c_char};
-
 use crate::plugins::PLUGIN_REGISTRAR;
 
 // API provided by RustDesk.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,31 @@
+use std::{ffi::CStr, os::raw::c_char};
+
+use crate::plugins::PLUGIN_REGISTRAR;
+
+pub type LoadPluginFunc = fn(*const i8) -> i32;
+pub type UnloadPluginFunc = fn(*const i8) -> i32;
+
+pub struct RustDeskApiTable {
+    pub register_plugin: LoadPluginFunc,
+    pub unload_plugin: UnloadPluginFunc,
+}
+
+#[no_mangle]
+fn load_plugin(path: *const i8) -> i32 {
+    PLUGIN_REGISTRAR.load_plugin(path)
+}
+
+#[no_mangle]
+fn unload_plugin(path: *const i8) -> i32 {
+    PLUGIN_REGISTRAR.unload_plugin(path)
+}
+
+impl Default for RustDeskApiTable {
+    fn default() -> Self {
+        let f = load_plugin;
+        Self {
+            register_plugin: load_plugin,
+            unload_plugin: unload_plugin,
+        }
+    }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,9 +2,11 @@ use std::{ffi::CStr, os::raw::c_char};
 
 use crate::plugins::PLUGIN_REGISTRAR;
 
+// API provided by RustDesk.
 pub type LoadPluginFunc = fn(*const i8) -> i32;
 pub type UnloadPluginFunc = fn(*const i8) -> i32;
 
+#[repr(C)]
 pub struct RustDeskApiTable {
     pub register_plugin: LoadPluginFunc,
     pub unload_plugin: UnloadPluginFunc,
@@ -20,9 +22,13 @@ fn unload_plugin(path: *const i8) -> i32 {
     PLUGIN_REGISTRAR.unload_plugin(path)
 }
 
+#[no_mangle]
+fn get_api_table() -> RustDeskApiTable {
+    RustDeskApiTable::default()
+}
+
 impl Default for RustDeskApiTable {
     fn default() -> Self {
-        let f = load_plugin;
         Self {
             register_plugin: load_plugin,
             unload_plugin: unload_plugin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,11 @@ mod license;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod port_forward;
 
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+mod plugins;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+mod api;
+
 mod tray;
 
 mod ui_cm_interface;

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -1,0 +1,57 @@
+use std::{collections::HashMap, path::Path, sync::Arc, ffi::CStr};
+
+use hbb_common::anyhow::{anyhow, Error};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref PLUGIN_REGISTRAR: Arc<PluginRegistar<PluginImpl>> =
+        Arc::new(PluginRegistar::<PluginImpl>::default());
+}
+
+pub trait Plugin {
+    // Return: the unique ID which identifies this plugin.
+    fn plugin_id(&self) -> String;
+    // Return: the name which is human-readable.
+    fn plugin_name(&self) -> String;
+}
+
+#[derive(Default, Clone)]
+pub struct PluginImpl {
+    id: String,
+    name: String,
+}
+
+impl Plugin for PluginImpl {
+    fn plugin_id(&self) -> String {
+        self.id.to_owned()
+    }
+
+    fn plugin_name(&self) -> String {
+        self.name.to_owned()
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct PluginRegistar<P: Plugin> {
+    plugins: HashMap<String, P>,
+}
+
+impl<P: Plugin> PluginRegistar<P> {
+    pub fn load_plugin(&self, path: *const i8) -> i32 {
+        let p = unsafe { CStr::from_ptr(path) };
+        0
+    }
+
+    pub fn unload_plugin(&self, path: *const i8) -> i32 {
+        let p = unsafe { CStr::from_ptr(path) };
+        0
+    }
+}
+
+impl TryFrom<&Path> for PluginImpl {
+    type Error = Error;
+
+    fn try_from(value: &Path) -> Result<Self, Self::Error> {
+        Err(anyhow!("Not implemented yet."))
+    }
+}

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -1,22 +1,42 @@
-use std::{collections::HashMap, path::Path, sync::Arc, ffi::CStr};
+use std::{
+    collections::HashMap,
+    ffi::CStr,
+    path::Path,
+    sync::{Arc, RwLock},
+};
 
 use hbb_common::anyhow::{anyhow, Error};
 use lazy_static::lazy_static;
+use libloading::Library;
 
 lazy_static! {
     pub static ref PLUGIN_REGISTRAR: Arc<PluginRegistar<PluginImpl>> =
         Arc::new(PluginRegistar::<PluginImpl>::default());
 }
+// API needed to be implemented by plugins.
+pub type PluginInitFunc = fn() -> i32;
+// API needed to be implemented by plugins.
+pub type PluginDisposeFunc = fn() -> i32;
 
 pub trait Plugin {
     // Return: the unique ID which identifies this plugin.
     fn plugin_id(&self) -> String;
     // Return: the name which is human-readable.
     fn plugin_name(&self) -> String;
+    // Return: the virtual table of the plugin.
+    fn plugin_vt(&self) -> &RustDeskPluginTable;
+}
+
+#[repr(C)]
+#[derive(Default, Clone)]
+pub struct RustDeskPluginTable {
+    pub init: Option<PluginInitFunc>,
+    pub dispose: Option<PluginDisposeFunc>,
 }
 
 #[derive(Default, Clone)]
 pub struct PluginImpl {
+    vt: RustDeskPluginTable,
     id: String,
     name: String,
 }
@@ -29,29 +49,57 @@ impl Plugin for PluginImpl {
     fn plugin_name(&self) -> String {
         self.name.to_owned()
     }
+
+    fn plugin_vt(&self) -> &RustDeskPluginTable {
+        &self.vt
+    }
 }
 
 #[derive(Default, Clone)]
 pub struct PluginRegistar<P: Plugin> {
-    plugins: HashMap<String, P>,
+    plugins: Arc<RwLock<HashMap<String, P>>>,
 }
 
 impl<P: Plugin> PluginRegistar<P> {
     pub fn load_plugin(&self, path: *const i8) -> i32 {
         let p = unsafe { CStr::from_ptr(path) };
-        0
+        let lib_path = p.to_str().unwrap_or("").to_owned();
+        let lib = unsafe { libloading::Library::new(lib_path.as_str()) };
+        match lib {
+            Ok(lib) => match lib.try_into() {
+                Ok(plugin) => {
+                    PLUGIN_REGISTRAR
+                        .plugins
+                        .write()
+                        .unwrap()
+                        .insert(lib_path, plugin);
+                    return 0;
+                }
+                Err(err) => {
+                    eprintln!("Load plugin failed: {}", err);
+                }
+            },
+            Err(err) => {
+                eprintln!("Load plugin failed: {}", err);
+            }
+        }
+        -1
     }
 
     pub fn unload_plugin(&self, path: *const i8) -> i32 {
         let p = unsafe { CStr::from_ptr(path) };
-        0
+        let lib_path = p.to_str().unwrap_or("").to_owned();
+        match PLUGIN_REGISTRAR.plugins.write().unwrap().remove(&lib_path) {
+            Some(_) => 0,
+            None => -1,
+        }
     }
 }
 
-impl TryFrom<&Path> for PluginImpl {
+impl TryFrom<Library> for PluginImpl {
     type Error = Error;
 
-    fn try_from(value: &Path) -> Result<Self, Self::Error> {
-        Err(anyhow!("Not implemented yet."))
+    fn try_from(library: Library) -> Result<Self, Self::Error> {
+        todo!()
     }
 }


### PR DESCRIPTION
This PR adds a plugin registrar to manage all plugins injected. And it also adds a library wrapper, and creates a simple test case with the `init` and `dispose` function, which needed by controlling the lifecycle of the plugin. 