### PR TITLE
Fix/archlinux deps

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -1447,6 +1447,9 @@ jobs:
             python
             ttf-arphic-uming
             libappindicator-gtk3
+            pam
+            gst-plugins-base
+            gst-plugin-pipewire
           scripts: |
             cd res && HBB=`pwd`/.. FLUTTER=1 makepkg -f
 

--- a/res/PKGBUILD
+++ b/res/PKGBUILD
@@ -7,7 +7,7 @@ arch=('x86_64')
 url=""
 license=('AGPL-3.0')
 groups=()
-depends=('gtk3' 'xdotool' 'libxcb' 'libxfixes' 'alsa-lib' 'curl' 'libva' 'libvdpau' 'libappindicator-gtk3')
+depends=('gtk3' 'xdotool' 'libxcb' 'libxfixes' 'alsa-lib' 'curl' 'libva' 'libvdpau' 'libappindicator-gtk3' 'pam' 'gst-plugins-base' 'gst-plugin-pipewire')
 makedepends=()
 checkdepends=()
 optdepends=()
@@ -22,9 +22,6 @@ noextract=()
 md5sums=() #generate with 'makepkg -g'
 
 package() {
-  pacman -S --noconfirm gst-plugins-base || true
-  pacman -S --noconfirm gst-plugin-pipewire || true
-  pacman -S --noconfirm pam
   if [[ ${FLUTTER} ]]; then
 	  mkdir -p "${pkgdir}/usr/lib/rustdesk" && cp -r ${HBB}/flutter/build/linux/x64/release/bundle/* -t "${pkgdir}/usr/lib/rustdesk"
   fi

--- a/res/PKGBUILD
+++ b/res/PKGBUILD
@@ -22,7 +22,9 @@ noextract=()
 md5sums=() #generate with 'makepkg -g'
 
 package() {
-  pacman -S --noconfirm pam gst-plugins-base gst-plugin-pipewire
+  pacman -S --noconfirm gst-plugins-base || true
+  pacman -S --noconfirm gst-plugin-pipewire || true
+  pacman -S --noconfirm pam
   if [[ ${FLUTTER} ]]; then
 	  mkdir -p "${pkgdir}/usr/lib/rustdesk" && cp -r ${HBB}/flutter/build/linux/x64/release/bundle/* -t "${pkgdir}/usr/lib/rustdesk"
   fi

--- a/res/PKGBUILD
+++ b/res/PKGBUILD
@@ -7,7 +7,7 @@ arch=('x86_64')
 url=""
 license=('AGPL-3.0')
 groups=()
-depends=('gtk3' 'xdotool' 'libxcb' 'libxfixes' 'alsa-lib' 'curl' 'libva' 'libvdpau' 'libappindicator-gtk3' 'pam' 'gst-plugins-base' 'gst-plugin-pipewire')
+depends=('gtk3' 'xdotool' 'libxcb' 'libxfixes' 'alsa-lib' 'curl' 'libva' 'libvdpau' 'libappindicator-gtk3')
 makedepends=()
 checkdepends=()
 optdepends=()
@@ -22,6 +22,7 @@ noextract=()
 md5sums=() #generate with 'makepkg -g'
 
 package() {
+  pacman -S --noconfirm pam gst-plugins-base gst-plugin-pipewire
   if [[ ${FLUTTER} ]]; then
 	  mkdir -p "${pkgdir}/usr/lib/rustdesk" && cp -r ${HBB}/flutter/build/linux/x64/release/bundle/* -t "${pkgdir}/usr/lib/rustdesk"
   fi


### PR DESCRIPTION
Fix archlinux PKGBUILD depends. 

Add depends in the workflow for now.

Depends in runtime should better be put into `package()`.
https://wiki.archlinux.org/title/PKGBUILD#:~:text=Dependencies%20defined%20inside,run%20the%20software.

However permission error occurs here on github workflow.
https://github.com/fufesou/rustdesk/actions/runs/4695949715/jobs/8325765588

I'm trying to add `sudo`.
![1681444005822](https://user-images.githubusercontent.com/13586388/231936639-2c93ca4d-aba9-49c1-9ce9-e6b17ed3377b.png)
https://github.com/fufesou/rustdesk/actions/runs/4696121406

I'll submit another PR if it works.



