### PR TITLE
add password handling in uni links handler

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1599,8 +1599,9 @@ bool callUniLinksUriHandler(Uri uri) {
     final peerId = uri.path.substring("/new/".length);
     var param = uri.queryParameters;
     String? switch_uuid = param["switch_uuid"];
+    String? password = param["password"];
     Future.delayed(Duration.zero, () {
-      rustDeskWinManager.newRemoteDesktop(peerId, switch_uuid: switch_uuid);
+      rustDeskWinManager.newRemoteDesktop(peerId, password: password, switch_uuid: switch_uuid);
     });
     return true;
   }


### PR DESCRIPTION
A small but very useful feature. Adds the param to specify a password for the link:

`rustdesk://connection/new/12345?password=1234`

Allows 1-click connection to a computer without entering a password manually.