### PR TITLE
Skip anything after an # symbol in the filename.

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -37,6 +37,11 @@ pub fn get_license_from_string(s: &str) -> ResultType<License> {
         s
     };
     if s.contains("host=") {
+        let s = if s.contains("#") {
+            &s[0..s.find("#").unwrap_or(s.len())]
+        } else {
+            s
+        };
         let strs: Vec<&str> = s.split("host=").collect();
         if strs.len() == 2 {
             let strs2: Vec<&str> = strs[1].split(",key=").collect();


### PR DESCRIPTION
Windows renames files adding (1), (2) etc. before the .exe in case of duplicates, which causes the host or key values to be garbled.

This allows to protect from this adding a final "#" symbol to the filename.