### PR TITLE
Corrected IPv4 Validation

### DIFF
--- a/libs/hbb_common/src/lib.rs
+++ b/libs/hbb_common/src/lib.rs
@@ -286,7 +286,7 @@ pub fn get_time() -> i64 {
 
 #[inline]
 pub fn is_ipv4_str(id: &str) -> bool {
-    regex::Regex::new(r"^\d+\.\d+\.\d+\.\d+(:\d+)?$")
+    regex::Regex::new(r"^(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
         .unwrap()
         .is_match(id)
 }
@@ -393,6 +393,21 @@ mod test {
         assert!(is_ipv6_str("[1:2::0]:1"));
         assert!(!is_ipv6_str("[1:2::0]:"));
         assert!(!is_ipv6_str("1:2::0]:1"));
+    }
+    
+    #[test]
+    fn test_ipv4() {
+        assert!(is_ipv4_str("1.2.3.4"));
+        assert!(is_ipv4_str("192.168.0.1"));
+        assert!(is_ipv4_str("0.0.0.0"));
+        assert!(is_ipv4_str("255.255.255.255"));
+        assert!(!is_ipv4_str("256.0.0.0"));
+        assert!(!is_ipv4_str("256.256.256.256"));
+        assert!(!is_ipv4_str("1:2:"));
+        assert!(!is_ipv4_str("192.168.0.256"));
+        assert!(!is_ipv4_str("192.168.0.1/24"));
+        assert!(!is_ipv4_str("192.168.0."));
+        assert!(!is_ipv4_str("192.168..1"));   
     }
 
     #[test]


### PR DESCRIPTION
Current IPv4 validation accepting non-IPv4 addresses such as `000000.010101.256.101`, `192.168.0.300`, `256.0.0.0` and bunch of other cases I mentioned in test cases. Newly defined pattern will take care all of such cases.
You can play with newly defined regex pattern here: https://regex101.com/r/j4lkR3/1