### PR TITLE
Feat/plugin framework

### DIFF
--- a/src/plugin/callback_msg.rs
+++ b/src/plugin/callback_msg.rs
@@ -61,7 +61,7 @@ struct MsgToConfig {
 /// content: The content.
 /// len:     The length of the content.
 #[no_mangle]
-pub extern "C" fn cb_msg(
+pub(super) extern "C" fn cb_msg(
     peer: *const c_char,
     target: *const c_char,
     id: *const c_char,

--- a/src/plugin/plog.rs
+++ b/src/plugin/plog.rs
@@ -13,7 +13,7 @@ fn is_level(level: *const c_char, level_bytes: &[u8]) -> bool {
 }
 
 #[no_mangle]
-pub(super) extern "C" fn log(level: *const c_char, msg: *const c_char) {
+pub(super) extern "C" fn plugin_log(level: *const c_char, msg: *const c_char) {
     if level.is_null() || msg.is_null() {
         return;
     }

--- a/src/plugin/plugins.rs
+++ b/src/plugin/plugins.rs
@@ -302,7 +302,7 @@ fn load_plugin_path(path: &str) -> ResultType<()> {
             msg: callback_msg::cb_msg,
             get_conf: config::cb_get_conf,
             get_id: config::cb_get_local_peer_id,
-            log: super::plog::log,
+            log: super::plog::plugin_log,
         },
     };
     plugin.init(&init_data, path)?;

--- a/src/plugin/plugins.rs
+++ b/src/plugin/plugins.rs
@@ -409,6 +409,12 @@ pub fn handle_client_event(id: &str, peer: &str, event: &[u8]) -> Option<Message
                 let (code, msg) = get_code_msg_from_ret(ret);
                 free_c_ptr(ret as _);
                 if code > ERR_RUSTDESK_HANDLE_BASE && code < ERR_PLUGIN_HANDLE_BASE {
+                    log::debug!(
+                        "Plugin {} failed to handle client event, code: {}, msg: {}",
+                        id,
+                        code,
+                        msg
+                    );
                     let name = match PLUGIN_INFO.read().unwrap().get(id) {
                         Some(plugin) => plugin.desc.name(),
                         None => "???",
@@ -429,7 +435,8 @@ pub fn handle_client_event(id: &str, peer: &str, event: &[u8]) -> Option<Message
                     }
                 } else {
                     log::error!(
-                        "Failed to handle client event, code: {}, msg: {}",
+                        "Plugin {} failed to handle client event, code: {}, msg: {}",
+                        id,
                         code,
                         msg
                     );


### PR DESCRIPTION
Change the function name `log` to `plugin_log`.

The `log` function name causes strange bug whey trying to trigger plugin functions.

The `log` function is called by `amp2Log2` 

![image](https://user-images.githubusercontent.com/13586388/234303629-8711b124-9c9b-47e5-bff6-ffee4dccf354.png)


![image](https://user-images.githubusercontent.com/13586388/234303352-d3206ae2-7fac-47e7-a4e9-7fa6ea7aaa30.png)


