### PR TITLE
Reimplement code extracting information from file name.

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -82,3 +82,60 @@ pub fn get_license_from_string(s: &str) -> ResultType<License> {
     }
     bail!("Failed to parse");
 }
+
+#[cfg(test)]
+#[cfg(target_os = "windows")]
+mod test {
+    #[test]
+    fn test_filename_license_string() {
+        assert_eq!(
+            get_license_from_string("rustdesk.exe"),
+            Ok(License {
+                host: "".to_owned(),
+                key: "".to_owned(),
+                api: "".to_owned(),
+            })
+        );
+        assert_eq!(
+            get_license_from_string("rustdesk"),
+            Ok(License {
+                host: "".to_owned(),
+                key: "".to_owned(),
+                api: "".to_owned(),
+            })
+        );
+        assert_eq!(
+            get_license_from_string("rustdesk-host=server.example.net.exe"),
+            Ok(License {
+                host: "server.example.net".to_owned(),
+                key: "".to_owned(),
+                api: "".to_owned(),
+            })
+        );
+        assert_eq!(
+            get_license_from_string("rustdesk-host=server.example.net,.exe"),
+            Ok(License {
+                host: "server.example.net".to_owned(),
+                key: "".to_owned(),
+                api: "".to_owned(),
+            })
+        );
+        // key in these tests is "foobar.,2" base64 encoded
+        assert_eq!(
+            get_license_from_string("rustdesk-host=server.example.net,key=Zm9vYmFyLiwyCg==.exe"),
+            Ok(License {
+                host: "server.example.net".to_owned(),
+                key: "Zm9vYmFyLiwyCg==".to_owned(),
+                api: "".to_owned(),
+            })
+        );
+        assert_eq!(
+            get_license_from_string("rustdesk-host=server.example.net,key=Zm9vYmFyLiwyCg==,.exe"),
+            Ok(License {
+                host: "server.example.net".to_owned(),
+                key: "Zm9vYmFyLiwyCg==".to_owned(),
+                api: "".to_owned(),
+            })
+        );
+    }
+}

--- a/src/license.rs
+++ b/src/license.rs
@@ -36,24 +36,38 @@ pub fn get_license_from_string(s: &str) -> ResultType<License> {
     } else {
         s
     };
+    /*
+     * The following code tokenizes the file name based on commas and
+     * extracts relevant parts sequentially.
+     * 
+     * host= is expected to be the first part.
+     * 
+     * Since Windows renames files adding (1), (2) etc. before the .exe
+     * in case of duplicates, which causes the host or key values to be
+     * garbled.
+     *
+     * This allows using a ',' (comma) symbol as a final delimiter.
+     */
     if s.contains("host=") {
-        let strs: Vec<&str> = s.split("host=").collect();
-        if strs.len() == 2 {
-            let strs2: Vec<&str> = strs[1].split(",key=").collect();
-            let host;
-            let mut key = "";
-            if strs2.len() == 2 {
-                host = strs2[0];
-                key = strs2[1];
-            } else {
-                host = strs[1];
+        let stripped = &s[s.find("host=").unwrap_or(0)..s.len()];
+        let strs: Vec<&str> = stripped.split(",").collect();
+        let mut host = "";
+        let mut key = "";
+        let strs_iter = strs.iter();
+        for el in strs_iter {
+            if el.starts_with("host=") {
+                host = &el[5..el.len()];
             }
-            return Ok(License {
-                host: host.to_owned(),
-                key: key.to_owned(),
-                api: "".to_owned(),
-            });
+
+            if el.starts_with("key=") {
+                key = &el[4..el.len()];
+            }
         }
+        return Ok(License {
+            host: host.to_owned(),
+            key: key.to_owned(),
+            api: "".to_owned(),
+        });
     } else {
         let strs = if s.contains("-licensed-") {
             s.split("-licensed-")


### PR DESCRIPTION
This code tokenizes the file name based on commas and extracts relevant parts sequentially.

`host=` is expected to be the first part.

Since Windows renames files adding (1), (2) etc. before the .exe in case of duplicates, which causes the host or key values to be garbled.

This allows using a `,` (comma) symbol as a final delimiter.

Fixes #4162