### PR TITLE
Auto refresh if too many frames without key frame

### DIFF
--- a/flutter/lib/plugin/widget.dart
+++ b/flutter/lib/plugin/widget.dart
@@ -79,7 +79,7 @@ class PluginItem extends StatelessWidget {
   final FFI? ffi;
   final String location;
   final PluginModel pluginModel;
-  final isMenu;
+  final bool isMenu;
 
   PluginItem({
     Key? key,

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -539,7 +539,7 @@ pub fn session_change_resolution(id: String, width: i32, height: i32) {
     }
 }
 
-pub fn session_set_size(_id: String, _width: i32, _height: i32) {
+pub fn session_set_size(_id: String, _width: usize, _height: usize) {
     #[cfg(feature = "flutter_texture_render")]
     if let Some(session) = SESSIONS.write().unwrap().get_mut(&_id) {
         session.set_size(_width, _height);

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1206,11 +1206,12 @@ pub async fn io_loop<T: InvokeUiSession>(handler: Session<T>) {
     let frame_count = Arc::new(AtomicUsize::new(0));
     let frame_count_cl = frame_count.clone();
     let ui_handler = handler.ui_handler.clone();
+    let video_callback = move |data: &mut Vec<u8>| {
+        frame_count_cl.fetch_add(1, Ordering::Relaxed);
+        ui_handler.on_rgba(data);
+    };
     let (video_sender, audio_sender, video_queue, decode_fps) =
-        start_video_audio_threads(move |data: &mut Vec<u8>| {
-            frame_count_cl.fetch_add(1, Ordering::Relaxed);
-            ui_handler.on_rgba(data);
-        });
+        start_video_audio_threads(handler.id.clone(), video_callback);
 
     let mut remote = Remote::new(
         handler,


### PR DESCRIPTION
1. Check `rgba.len()` before OpenGL rendering, to avoid crash (if `rgba_len` < `self.size`)
```rust
        let rgba_len = rgba.len();
        if rgba_len != self.size as usize {
            return;
        }
```
2. Autu send `refresh video` if the decoder does not process a key frame after 80 frames.
  If the key frame is processed before decoder is reset, the decoder will not process a key frame then.