### PR TITLE
auto refresh if too many frames without a key frame

### DIFF
--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -181,7 +181,6 @@ struct VideoRenderer {
     ptr: usize,
     width: usize,
     height: usize,
-    size: usize,
     on_rgba_func: Option<Symbol<'static, FlutterRgbaRendererPluginOnRgba>>,
 }
 
@@ -210,7 +209,6 @@ impl Default for VideoRenderer {
             ptr: 0,
             width: 0,
             height: 0,
-            size: 0,
             on_rgba_func,
         }
     }

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1206,11 +1206,12 @@ pub async fn io_loop<T: InvokeUiSession>(handler: Session<T>) {
     let frame_count = Arc::new(AtomicUsize::new(0));
     let frame_count_cl = frame_count.clone();
     let ui_handler = handler.ui_handler.clone();
+    let video_callback = move |data: &mut scrap::ImageRgb| {
+        frame_count_cl.fetch_add(1, Ordering::Relaxed);
+        ui_handler.on_rgba(data);
+    };
     let (video_sender, audio_sender, video_queue, decode_fps) =
-        start_video_audio_threads(move |data: &mut scrap::ImageRgb| {
-            frame_count_cl.fetch_add(1, Ordering::Relaxed);
-            ui_handler.on_rgba(data);
-        });
+        start_video_audio_threads(handler.id.clone(), video_callback);
 
     let mut remote = Remote::new(
         handler,


### PR DESCRIPTION
I have seen that the key frame is processed before the decoder is reset.
This caused the decoder to have no keyframe, and the window was always black.

This rarely happens, but it's also a potential bug.
