### PR TITLE
fix last commit

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -183,6 +183,14 @@ class _RemotePageState extends State<RemotePage>
   }
 
   @override
+  void onWindowMaximize() {
+    super.onWindowMaximize();
+    if (!Platform.isLinux) {
+      Wakelock.enable();
+    }
+  }
+
+  @override
   void onWindowMinimize() {
     super.onWindowMinimize();
     if (!Platform.isLinux) {


### PR DESCRIPTION
When the window is unminimized, onWindowMaximize  or onWindowRestore can be called when the old state was maximized or not.