### PR TITLE
better print

### DIFF
--- a/flutter/macos/Runner/MainFlutterWindow.swift
+++ b/flutter/macos/Runner/MainFlutterWindow.swift
@@ -22,7 +22,7 @@ import texture_rgba_renderer
 class MainFlutterWindow: NSWindow {
     override func awakeFromNib() {
         if (!rustdesk_core_main()){
-            print("Rustdesk core returns false, exiting without launching Flutter app")
+            print("Rustdesk core returns false, exiting without launching Flutter app.")
             NSApplication.shared.terminate(self)
         }
         let flutterViewController = FlutterViewController.init()

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -22,21 +22,21 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   HINSTANCE hInstance = LoadLibraryA("librustdesk.dll");
   if (!hInstance)
   {
-    std::cout << "Failed to load librustdesk.dll" << std::endl;
+    std::cout << "Failed to load librustdesk.dll." << std::endl;
     return EXIT_FAILURE;
   }
   FUNC_RUSTDESK_CORE_MAIN rustdesk_core_main =
       (FUNC_RUSTDESK_CORE_MAIN)GetProcAddress(hInstance, "rustdesk_core_main_args");
   if (!rustdesk_core_main)
   {
-    std::cout << "Failed to get rustdesk_core_main" << std::endl;
+    std::cout << "Failed to get rustdesk_core_main." << std::endl;
     return EXIT_FAILURE;
   }
   FUNC_RUSTDESK_FREE_ARGS free_c_args =
       (FUNC_RUSTDESK_FREE_ARGS)GetProcAddress(hInstance, "free_c_args");
   if (!free_c_args)
   {
-    std::cout << "Failed to get free_c_args" << std::endl;
+    std::cout << "Failed to get free_c_args." << std::endl;
     return EXIT_FAILURE;
   }
   std::vector<std::string> command_line_arguments =
@@ -50,7 +50,11 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   char** c_args = rustdesk_core_main(&args_len);
   if (!c_args)
   {
-    std::cout << "Rustdesk core returns false, exiting without launching Flutter app" << std::endl;
+    std::string args_str = "";
+    for (const auto& argument : command_line_arguments) {
+      args_str += (argument + " ");
+    }
+    std::cout << "Rustdesk [" << args_str << "], core returns false, exiting without launching Flutter app." << std::endl;
     return EXIT_SUCCESS;
   }
   std::vector<std::string> rust_args(c_args, c_args + args_len);


### PR DESCRIPTION
Maybe better print.

Add `args_str` when printing `core returns false`.

```C++
    std::string args_str = "";
    for (const auto& argument : command_line_arguments) {
      args_str += (argument + " ");
    }
    std::cout << "Rustdesk [" << args_str << "], core returns false, exiting without launching Flutter app." << std::endl;
```
