### PR TITLE
fix: make event loop in tray compatible with main window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5876,7 +5876,7 @@ dependencies = [
 [[package]]
 name = "tao"
 version = "0.18.1"
-source = "git+https://github.com/tauri-apps/tao?branch=muda#0c1417884161d165b8852fbf11be5492edef9fe7"
+source = "git+https://github.com/Kingtous/tao?branch=muda#dea701661a182cf2d944d5d05b5d299c78079871"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -5921,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "tao-macros"
 version = "0.1.1"
-source = "git+https://github.com/tauri-apps/tao?branch=muda#0c1417884161d165b8852fbf11be5492edef9fe7"
+source = "git+https://github.com/Kingtous/tao?branch=muda#dea701661a182cf2d944d5d05b5d299c78079871"
 dependencies = [
  "proc-macro2 1.0.54",
  "quote 1.0.26",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ objc_id = "0.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 tray-icon = "0.4"
-tao = { git = "https://github.com/tauri-apps/tao", branch = "muda" }
+tao = { git = "https://github.com/Kingtous/tao", branch = "muda" }
 image = "0.24"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1581,7 +1581,13 @@ bool checkArguments() {
 /// Returns true if we successfully handle the uri provided.
 /// [Functions]
 /// 1. New Connection: rustdesk://connection/new/your_peer_id
+/// 2. Bring the main window to the top: empty uriPath
 bool parseRustdeskUri(String uriPath) {
+  // If we invoke uri with blank path, we just bring the main window to tht top.
+  if (uriPath.isEmpty) {
+    window_on_top(null);
+    return true;
+  }
   final uri = Uri.tryParse(uriPath);
   if (uri == null) {
     debugPrint("uri is not valid: $uriPath");

--- a/flutter/lib/models/native_model.dart
+++ b/flutter/lib/models/native_model.dart
@@ -173,13 +173,10 @@ class PlatformFFI {
       if (Platform.isLinux) {
         // Start a dbus service, no need to await
         _ffiBind.mainStartDbusServer();
+        _ffiBind.mainStartPa();
       } else if (Platform.isMacOS && isMain) {
-        Future.wait([
-          // Start dbus service.
-          _ffiBind.mainStartDbusServer(),
-          // Start local audio pulseaudio server.
-          _ffiBind.mainStartPa()
-        ]);
+        // Start ipc service for uri links.
+        _ffiBind.mainStartIpcUrlServer();
       }
       _startListenEvent(_ffiBind); // global event
       try {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -969,13 +969,20 @@ impl PeerConfig {
 
     fn path(id: &str) -> PathBuf {
         //If the id contains invalid chars, encode it
-        let forbidden_paths = Regex::new(r".*[<>:/\\|\?\*].*").unwrap();
-        let id_encoded = if forbidden_paths.is_match(id) {
-            "base64_".to_string() + base64::encode(id, base64::Variant::Original).as_str()
+        let forbidden_paths = Regex::new(r".*[<>:/\\|\?\*].*");
+        let path: PathBuf;
+        if let Ok(forbidden_paths) = forbidden_paths {
+            let id_encoded = if forbidden_paths.is_match(id) {
+                "base64_".to_string() + base64::encode(id, base64::Variant::Original).as_str()
+            } else {
+                id.to_string()
+            };
+            path = [PEERS, id_encoded.as_str()].iter().collect();
         } else {
-            id.to_string()
-        };
-        let path: PathBuf = [PEERS, id_encoded.as_str()].iter().collect();
+            log::warn!("Regex create failed: {:?}", forbidden_paths.err());
+            // fallback for failing to create this regex.
+            path = [PEERS, id.replace(":", "_").as_str()].iter().collect();
+        }
         Config::with_extension(Config::path(path))
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -454,7 +454,7 @@ pub async fn start_ipc_url_server() {
                             let mut m = HashMap::new();
                             m.insert("name", "on_url_scheme_received");
                             m.insert("url", url.as_str());
-                            let event = serde_json::to_string(&m).unwrap();
+                            let event = serde_json::to_string(&m).unwrap_or("".to_owned());
                             match crate::flutter::push_global_event(crate::flutter::APP_TYPE_MAIN, event) {
                                 None => log::warn!("No main window app found!"),
                                 Some(..) => {}

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -131,10 +131,6 @@ pub fn make_tray() -> hbb_common::ResultType<()> {
 
     let event_loop = EventLoopBuilder::new().build();
 
-    unsafe {
-        crate::platform::delegate::set_delegate(None);
-    }
-
     let tray_menu = Menu::new();
     let quit_i = MenuItem::new(crate::client::translate("Exit".to_owned()), true, None);
     tray_menu.append_items(&[&quit_i]);


### PR DESCRIPTION
Currently the menu in tray not working due to lack of Delegate, this PR reverts the tao delegate and add some interfaces to do our own logic.

Tested on macOS,

Conditions below works:

- service is not installed, invoke by uni links or just clicking the app icon in dashboard -> open successfully
- service is installed, invoke by uni links or  just clicking the app icon in dashboard -> open successfully