### PR TITLE
fix: window on top when url scheme received from ipc

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1581,13 +1581,7 @@ bool checkArguments() {
 /// Returns true if we successfully handle the uri provided.
 /// [Functions]
 /// 1. New Connection: rustdesk://connection/new/your_peer_id
-/// 2. Bring the main window to the top: empty uriPath
 bool parseRustdeskUri(String uriPath) {
-  // If we invoke uri with blank path, we just bring the main window to tht top.
-  if (uriPath.isEmpty) {
-    window_on_top(null);
-    return true;
-  }
   final uri = Uri.tryParse(uriPath);
   if (uri == null) {
     debugPrint("uri is not valid: $uriPath");

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -211,7 +211,12 @@ class FfiModel with ChangeNotifier {
         parent.target?.elevationModel.onPortableServiceRunning(evt);
       } else if (name == 'on_url_scheme_received') {
         final url = evt['url'].toString();
-        parseRustdeskUri(url);
+        // If we invoke uri with blank path, we just bring the main window to the top.
+        if (url.isEmpty) {
+          window_on_top(null);
+        } else {
+          parseRustdeskUri(url);
+        }
       } else if (name == 'on_voice_call_waiting') {
         // Waiting for the response from the peer.
         parent.target?.chatModel.onVoiceCallWaiting();


### PR DESCRIPTION
This PR moves the uri empty check into `on_url_scheme_received `, which is received from IPC.

Place the empty check directly in `parseRustdeskUri` will cause the following command fails:

- `rustdesk rustdesk://xxx`, which is required from cli and macos uni links fallback.

Tested on macOS Ventura 13.3.1.