### PR TITLE
fix cursor active, portable service

### DIFF
--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -674,8 +674,11 @@ fn fix_modifiers(modifiers: &[EnumOrUnknown<ControlKey>], en: &mut Enigo, ck: i3
 // Update time to avoid send cursor position event to the peer.
 // See `run_pos` --> `set_cursor_position` --> `exclude`
 #[inline]
-pub fn update_latest_input_cursor_time() {
-    LATEST_PEER_INPUT_CURSOR.lock().unwrap().time = get_time();
+pub fn update_latest_input_cursor_time(conn: i32) {
+    log_fo_file(&format!("update_latest_input_cursor_time process id {}", std::process::id()));
+    let mut lock = LATEST_PEER_INPUT_CURSOR.lock().unwrap();
+    lock.conn = conn;
+    lock.time = get_time();
 }
 
 #[inline]

--- a/src/server/portable_service.rs
+++ b/src/server/portable_service.rs
@@ -903,7 +903,7 @@ pub mod client {
 
     pub fn handle_mouse(evt: &MouseEvent, conn: i32) {
         if RUNNING.lock().unwrap().clone() {
-            crate::input_service::update_latest_input_cursor_time();
+            crate::input_service::update_latest_input_cursor_time(conn);
             handle_mouse_(evt, conn).ok();
         } else {
             crate::input_service::handle_mouse_(evt, conn);


### PR DESCRIPTION
Update peer input `time`  besides `conn`.

https://github.com/rustdesk/rustdesk/issues/3819#issuecomment-1536357409