### PR TITLE
fix: add the required `pf_` prefix to RDP

### DIFF
--- a/flutter/lib/desktop/pages/port_forward_page.dart
+++ b/flutter/lib/desktop/pages/port_forward_page.dart
@@ -309,7 +309,8 @@ class _PortForwardPageState extends State<PortForwardPage>
                       child: SizedBox(
                         width: 120,
                         child: ElevatedButton(
-                          onPressed: () => bind.sessionNewRdp(id: widget.id),
+                          onPressed: () =>
+                              bind.sessionNewRdp(id: "pf_${widget.id}"),
                           child: Text(
                             translate('New RDP'),
                           ),


### PR DESCRIPTION
The `pr_` prefix of RDP session is missing, and the rust side cannot resolve the given session id,  which may fix: #4326 
