### PR TITLE
fix resolutions query on linux

### DIFF
--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1556,11 +1556,11 @@ mod tests {
             scroll_style = "scrollbar"
             custom_resolution = true
             "#;
-            let mut compare_config = default_peer_config.clone();
-            compare_config.view_style = "adaptive".to_string();
-            compare_config.scroll_style = "scrollbar".to_string();
+            let mut cfg_to_compare = default_peer_config.clone();
+            cfg_to_compare.view_style = "adaptive".to_string();
+            cfg_to_compare.scroll_style = "scrollbar".to_string();
             let cfg = toml::from_str::<PeerConfig>(wrong_type_str);
-            assert_eq!(cfg, Ok(compare_config), "Failed to test wrong_type_str");
+            assert_eq!(cfg, Ok(cfg_to_compare), "Failed to test wrong_type_str");
 
             let wrong_field_str = r#"
             [custom_resolution]
@@ -1569,10 +1569,10 @@ mod tests {
             hello = "world"
             [ui_flutter]
             "#;
-            let mut compare_config = default_peer_config.clone();
-            compare_config.custom_resolution = Some(Resolution { w: 1920, h: 1080 });
+            let mut cfg_to_compare = default_peer_config.clone();
+            cfg_to_compare.custom_resolution = Some(Resolution { w: 1920, h: 1080 });
             let cfg = toml::from_str::<PeerConfig>(wrong_field_str);
-            assert_eq!(cfg, Ok(compare_config), "Failed to test wrong_field_str");
+            assert_eq!(cfg, Ok(cfg_to_compare), "Failed to test wrong_field_str");
         }
     }
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -789,7 +789,7 @@ pub fn resolutions(name: &str) -> Vec<Resolution> {
                 if let Some(caps) = re.captures(&xrandr_output) {
                     if let Some(resolutions) = caps.name("resolutions") {
                         let resolution_pat =
-                            r"\s*(?P<width>\d+)x(?P<height>\d+)\s+(?P<rates>(\d+\.\d+[*+ ]*)+)\s*\n";
+                            r"\s*(?P<width>\d+)x(?P<height>\d+)\s+(?P<rates>(\d+\.\d+[\S ]*)+)\s*\n";
                         let resolution_re = Regex::new(&format!(r"{}", resolution_pat)).unwrap();
                         for resolution_caps in resolution_re.captures_iter(resolutions.as_str()) {
                             if let Some((width, height)) =

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -774,6 +774,12 @@ pub fn resolutions(name: &str) -> Vec<Resolution> {
                 Virtual2 disconnected (normal left inverted right x axis y axis)
                 Virtual3 disconnected (normal left inverted right x axis y axis)
 
+                Screen 0: minimum 320 x 200, current 1920 x 1080, maximum 16384 x 16384
+                eDP-1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 344mm x 193mm
+                1920x1080     60.01*+  60.01    59.97    59.96    59.93  
+                1680x1050     59.95    59.88  
+                1600x1024     60.17  
+
                 XWAYLAND0 connected primary 1920x984+0+0 (normal left inverted right x axis y axis) 0mm x 0mm
                 Virtual1 connected primary 1920x984+0+0 (normal left inverted right x axis y axis) 0mm x 0mm
                 HDMI-0 connected (normal left inverted right x axis y axis)
@@ -783,7 +789,7 @@ pub fn resolutions(name: &str) -> Vec<Resolution> {
                 if let Some(caps) = re.captures(&xrandr_output) {
                     if let Some(resolutions) = caps.name("resolutions") {
                         let resolution_pat =
-                            r"\s*(?P<width>\d+)x(?P<height>\d+)\s+(?P<rates>(\d+\.\d+[* ]*)+)\s*\n";
+                            r"\s*(?P<width>\d+)x(?P<height>\d+)\s+(?P<rates>(\d+\.\d+[*+ ]*)+)\s*\n";
                         let resolution_re = Regex::new(&format!(r"{}", resolution_pat)).unwrap();
                         for resolution_caps in resolution_re.captures_iter(resolutions.as_str()) {
                             if let Some((width, height)) =

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -789,7 +789,7 @@ pub fn resolutions(name: &str) -> Vec<Resolution> {
                 if let Some(caps) = re.captures(&xrandr_output) {
                     if let Some(resolutions) = caps.name("resolutions") {
                         let resolution_pat =
-                            r"\s*(?P<width>\d+)x(?P<height>\d+)\s+(?P<rates>(\d+\.\d+[\S ]*)+)\s*\n";
+                            r"\s*(?P<width>\d+)x(?P<height>\d+)\s+(?P<rates>(\d+\.\d+\D*)+)\s*\n";
                         let resolution_re = Regex::new(&format!(r"{}", resolution_pat)).unwrap();
                         for resolution_caps in resolution_re.captures_iter(resolutions.as_str()) {
                             if let Some((width, height)) =


### PR DESCRIPTION
Fix another case that current regex cann't parse.

The rate behind `1920x1080` is `60.01*+`.

```
                Screen 0: minimum 320 x 200, current 1920 x 1080, maximum 16384 x 16384
                eDP-1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 344mm x 193mm
                1920x1080     60.01*+  60.01    59.97    59.96    59.93  
                1680x1050     59.95    59.88  
                1600x1024     60.17  
```

Empty, `*+` and `+` are all cases.

Answered by ChatGPT:
> In the output format of the `xrandr` command, each output lists its supported resolutions and refresh rates. Each combination of resolution and refresh rate is listed in the format `<width>x<height> <refresh>`. If the combination is the current resolution and refresh rate in use, a `*+` marker is added at the end. If the combination is another option, only a `+` marker is added.