### PR TITLE
hwcodec use nv12

### DIFF
--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -23,7 +23,7 @@ use hwcodec::{
 const CFG_KEY_ENCODER: &str = "bestHwEncoders";
 const CFG_KEY_DECODER: &str = "bestHwDecoders";
 
-const DEFAULT_PIXFMT: AVPixelFormat = AVPixelFormat::AV_PIX_FMT_YUV420P;
+const DEFAULT_PIXFMT: AVPixelFormat = AVPixelFormat::AV_PIX_FMT_NV12;
 pub const DEFAULT_TIME_BASE: [i32; 2] = [1, 30];
 const DEFAULT_GOP: i32 = i32::MAX;
 const DEFAULT_HW_QUALITY: Quality = Quality_Default;
@@ -327,6 +327,8 @@ pub fn check_config_process() {
     use hbb_common::sysinfo::{ProcessExt, System, SystemExt};
 
     std::thread::spawn(move || {
+        // Remove to avoid checking process errors
+        // But when the program is just started, the configuration file has not been updated, and the new connection will read an empty configuration
         HwCodecConfig::remove();
         if let Ok(exe) = std::env::current_exe() {
             if let Some(file_name) = exe.file_name().to_owned() {
@@ -339,9 +341,16 @@ pub fn check_config_process() {
                     }
                 }
                 if let Ok(mut child) = std::process::Command::new(exe).arg(arg).spawn() {
-                    let second = 3;
-                    std::thread::sleep(std::time::Duration::from_secs(second));
-                    // kill: Different platforms have different results
+                    // wait up to 10 seconds
+                    for _ in 0..10 {
+                        std::thread::sleep(std::time::Duration::from_secs(1));
+                        if let Ok(Some(status)) = child.try_wait() {
+                            if status.success() {
+                                HwCodecConfig::refresh();
+                            }
+                            break;
+                        }
+                    }
                     allow_err!(child.kill());
                     std::thread::sleep(std::time::Duration::from_millis(30));
                     match child.try_wait() {


### PR DESCRIPTION
1. Use nv12 for hwcodec, because nv12 is native surface format and intel qsv use nv12 only,  tested on windows.
2. Wait up to 10 seconds before terminating the checking process.