### PR TITLE
feat: upgrade flutter to 3.10

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
 
 env:
-  FLUTTER_VERSION: "3.10.0"
+  FLUTTER_VERSION: "3.10.1"
   
 jobs:
   generate_bridge:

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -5,6 +5,9 @@ name: Build flutter-rust-bridge
 on:
   workflow_call:
 
+env:
+  FLUTTER_VERSION: "3.10.0"
+  
 jobs:
   generate_bridge:
     runs-on: ${{ matrix.job.os }}
@@ -51,7 +54,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: "3.7.0"
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
       - name: Install flutter rust bridge deps

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -9,10 +9,10 @@ on:
 
 env:
   LLVM_VERSION: "15.0.6"
-  FLUTTER_VERSION: "3.10.0"
+  FLUTTER_VERSION: "3.10.1"
   # for arm64 linux
-  FLUTTER_ELINUX_VERSION: "3.7.0"
-  FLUTTER_ELINUX_COMMIT_ID: "51a1d685901f79fbac51665a967c3a1a789ecee5"
+  FLUTTER_ELINUX_VERSION: "3.10.1"
+  FLUTTER_ELINUX_COMMIT_ID: "410b3ca42f2cd0c485edf517a1666652bab442d4"
   TAG_NAME: "nightly"
   # vcpkg version: 2023.04.15
   # for multiarch gcc compatibility
@@ -1169,7 +1169,7 @@ jobs:
           # disable git safe.directory
           git config --global --add safe.directory "*"
           pushd /opt
-          # clone repo and reset to flutter 3.7.0
+          # clone repo and reset to flutter ${{ env.FLUTTER_VERSION }}
           git clone https://github.com/sony/flutter-elinux.git || true
           pushd flutter-elinux
             git fetch
@@ -1205,8 +1205,8 @@ jobs:
             # Patch arm64 engine for flutter 3.6.0+
             flutter-elinux precache --linux
             pushd /tmp
-            curl -O https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.0-stable.tar.xz
-            tar -xvf flutter_linux_3.7.0-stable.tar.xz flutter/bin/cache/artifacts/engine/linux-x64/shader_lib
+            curl -O https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${{ env.FLUTTER_ELINUX_VERSION }}-stable.tar.xz
+            tar -xvf flutter_linux_${{ env.FLUTTER_ELINUX_VERSION }}-stable.tar.xz flutter/bin/cache/artifacts/engine/linux-x64/shader_lib
             cp -R flutter/bin/cache/artifacts/engine/linux-x64/shader_lib /opt/flutter-elinux/flutter/bin/cache/artifacts/engine/linux-arm64
             popd
             # edit to corresponding arch

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -10,9 +10,6 @@ on:
 env:
   LLVM_VERSION: "15.0.6"
   FLUTTER_VERSION: "3.10.0"
-  # for arm64 linux
-  FLUTTER_ELINUX_VERSION: "3.7.0"
-  FLUTTER_ELINUX_COMMIT_ID: "51a1d685901f79fbac51665a967c3a1a789ecee5"
   TAG_NAME: "nightly"
   # vcpkg version: 2023.04.15
   # for multiarch gcc compatibility
@@ -1163,18 +1160,18 @@ jobs:
           name: librustdesk-${{ matrix.job.arch }}-${{ matrix.job.extra-build-features }}.so
           path: ./target/release/
 
-      - name: Download Flutter
-        shell: bash
-        run: |
-          # disable git safe.directory
-          git config --global --add safe.directory "*"
-          pushd /opt
-          # clone repo and reset to flutter 3.7.0
-          git clone https://github.com/sony/flutter-elinux.git || true
-          pushd flutter-elinux
-            git fetch
-            git reset --hard ${{ env.FLUTTER_ELINUX_COMMIT_ID }} 
-          popd
+      # - name: Download Flutter
+      #   shell: bash
+      #   run: |
+      #     # disable git safe.directory
+      #     git config --global --add safe.directory "*"
+      #     pushd /opt
+      #     # clone repo and reset to flutter ${{ env.FLUTTER_VERSION }} 
+      #     git clone https://github.com/sony/flutter-elinux.git || true
+      #     pushd flutter-elinux
+      #       git fetch
+      #       git reset --hard ${{ env.FLUTTER_ELINUX_COMMIT_ID }} 
+      #     popd
 
       - uses: Kingtous/run-on-arch-action@amd64-support
         name: Build rustdesk binary for ${{ matrix.job.arch }}
@@ -1188,7 +1185,6 @@ jobs:
           dockerRunArgs: |
             --volume "${PWD}:/workspace"
             --volume "/opt/artifacts:/opt/artifacts"
-            --volume "/opt/flutter-elinux:/opt/flutter-elinux"
           shell: /bin/bash
           install: |
             apt update -y
@@ -1196,19 +1192,20 @@ jobs:
           run: |
             # disable git safe.directory
             git config --global --add safe.directory "*"
-            pushd /workspace
-            # we use flutter-elinux to build our rustdesk
-            export PATH=/opt/flutter-elinux/bin:$PATH
-            sed -i "s/flutter build linux --release/flutter-elinux build linux/g" ./build.py
-            # Setup flutter-elinux. Run doctor to check if issues here.
-            flutter-elinux doctor -v
+            pushd /opt
+            # Setup Flutter
+            wget https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${{ env.FLUTTER_VERSION }}-stable.tar.xz
+            tar xf flutter_linux_${{ env.FLUTTER_VERSION }}-stable.tar.xz
+            ls -l .
+            export PATH=/opt/flutter/bin:$PATH
+            flutter doctor -v
             # Patch arm64 engine for flutter 3.6.0+
-            flutter-elinux precache --linux
-            pushd /tmp
-            curl -O https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.0-stable.tar.xz
-            tar -xvf flutter_linux_3.7.0-stable.tar.xz flutter/bin/cache/artifacts/engine/linux-x64/shader_lib
-            cp -R flutter/bin/cache/artifacts/engine/linux-x64/shader_lib /opt/flutter-elinux/flutter/bin/cache/artifacts/engine/linux-arm64
-            popd
+            flutter precache --linux
+            # pushd /tmp
+            # curl -O https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.0-stable.tar.xz
+            # tar -xvf flutter_linux_3.7.0-stable.tar.xz flutter/bin/cache/artifacts/engine/linux-x64/shader_lib
+            # cp -R flutter/bin/cache/artifacts/engine/linux-x64/shader_lib /opt/flutter-elinux/flutter/bin/cache/artifacts/engine/linux-arm64
+            # popd
             # edit to corresponding arch
             case ${{ matrix.job.arch }} in
               aarch64)

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -9,7 +9,10 @@ on:
 
 env:
   LLVM_VERSION: "15.0.6"
-  FLUTTER_VERSION: "3.7.0"
+  FLUTTER_VERSION: "3.10.0"
+  # for arm64 linux
+  FLUTTER_ELINUX_VERSION: "3.7.0"
+  FLUTTER_ELINUX_COMMIT_ID: "51a1d685901f79fbac51665a967c3a1a789ecee5"
   TAG_NAME: "nightly"
   # vcpkg version: 2023.04.15
   # for multiarch gcc compatibility
@@ -52,13 +55,13 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      - name: Replace engine with rustdesk custom flutter engine
-        run: |
-          flutter doctor -v
-          flutter precache --windows
-          Invoke-WebRequest -Uri https://github.com/Kingtous/engine/releases/download/v3.7.0-rustdesk/windows-x64-release-flutter.zip -OutFile windows-x64-flutter-release.zip
-          Expand-Archive windows-x64-flutter-release.zip -DestinationPath engine
-          mv -Force engine/*  C:/hostedtoolcache/windows/flutter/stable-${{ env.FLUTTER_VERSION }}-x64/bin/cache/artifacts/engine/windows-x64-release/
+      # - name: Replace engine with rustdesk custom flutter engine
+      #   run: |
+      #     flutter doctor -v
+      #     flutter precache --windows
+      #     Invoke-WebRequest -Uri https://github.com/Kingtous/engine/releases/download/v3.7.0-rustdesk/windows-x64-release-flutter.zip -OutFile windows-x64-flutter-release.zip
+      #     Expand-Archive windows-x64-flutter-release.zip -DestinationPath engine
+      #     mv -Force engine/*  C:/hostedtoolcache/windows/flutter/stable-${{ env.FLUTTER_VERSION }}-x64/bin/cache/artifacts/engine/windows-x64-release/
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -1169,9 +1172,8 @@ jobs:
           # clone repo and reset to flutter 3.7.0
           git clone https://github.com/sony/flutter-elinux.git || true
           pushd flutter-elinux
-            # reset to flutter 3.7.0
             git fetch
-            git reset --hard 51a1d685901f79fbac51665a967c3a1a789ecee5 
+            git reset --hard ${{ env.FLUTTER_ELINUX_COMMIT_ID }} 
           popd
 
       - uses: Kingtous/run-on-arch-action@amd64-support

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -10,6 +10,9 @@ on:
 env:
   LLVM_VERSION: "15.0.6"
   FLUTTER_VERSION: "3.10.0"
+  # for arm64 linux
+  FLUTTER_ELINUX_VERSION: "3.7.0"
+  FLUTTER_ELINUX_COMMIT_ID: "51a1d685901f79fbac51665a967c3a1a789ecee5"
   TAG_NAME: "nightly"
   # vcpkg version: 2023.04.15
   # for multiarch gcc compatibility
@@ -1160,18 +1163,18 @@ jobs:
           name: librustdesk-${{ matrix.job.arch }}-${{ matrix.job.extra-build-features }}.so
           path: ./target/release/
 
-      # - name: Download Flutter
-      #   shell: bash
-      #   run: |
-      #     # disable git safe.directory
-      #     git config --global --add safe.directory "*"
-      #     pushd /opt
-      #     # clone repo and reset to flutter ${{ env.FLUTTER_VERSION }} 
-      #     git clone https://github.com/sony/flutter-elinux.git || true
-      #     pushd flutter-elinux
-      #       git fetch
-      #       git reset --hard ${{ env.FLUTTER_ELINUX_COMMIT_ID }} 
-      #     popd
+      - name: Download Flutter
+        shell: bash
+        run: |
+          # disable git safe.directory
+          git config --global --add safe.directory "*"
+          pushd /opt
+          # clone repo and reset to flutter 3.7.0
+          git clone https://github.com/sony/flutter-elinux.git || true
+          pushd flutter-elinux
+            git fetch
+            git reset --hard ${{ env.FLUTTER_ELINUX_COMMIT_ID }} 
+          popd
 
       - uses: Kingtous/run-on-arch-action@amd64-support
         name: Build rustdesk binary for ${{ matrix.job.arch }}
@@ -1185,6 +1188,7 @@ jobs:
           dockerRunArgs: |
             --volume "${PWD}:/workspace"
             --volume "/opt/artifacts:/opt/artifacts"
+            --volume "/opt/flutter-elinux:/opt/flutter-elinux"
           shell: /bin/bash
           install: |
             apt update -y
@@ -1192,20 +1196,19 @@ jobs:
           run: |
             # disable git safe.directory
             git config --global --add safe.directory "*"
-            pushd /opt
-            # Setup Flutter
-            wget https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${{ env.FLUTTER_VERSION }}-stable.tar.xz
-            tar xf flutter_linux_${{ env.FLUTTER_VERSION }}-stable.tar.xz
-            ls -l .
-            export PATH=/opt/flutter/bin:$PATH
-            flutter doctor -v
+            pushd /workspace
+            # we use flutter-elinux to build our rustdesk
+            export PATH=/opt/flutter-elinux/bin:$PATH
+            sed -i "s/flutter build linux --release/flutter-elinux build linux/g" ./build.py
+            # Setup flutter-elinux. Run doctor to check if issues here.
+            flutter-elinux doctor -v
             # Patch arm64 engine for flutter 3.6.0+
-            flutter precache --linux
-            # pushd /tmp
-            # curl -O https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.0-stable.tar.xz
-            # tar -xvf flutter_linux_3.7.0-stable.tar.xz flutter/bin/cache/artifacts/engine/linux-x64/shader_lib
-            # cp -R flutter/bin/cache/artifacts/engine/linux-x64/shader_lib /opt/flutter-elinux/flutter/bin/cache/artifacts/engine/linux-arm64
-            # popd
+            flutter-elinux precache --linux
+            pushd /tmp
+            curl -O https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.0-stable.tar.xz
+            tar -xvf flutter_linux_3.7.0-stable.tar.xz flutter/bin/cache/artifacts/engine/linux-x64/shader_lib
+            cp -R flutter/bin/cache/artifacts/engine/linux-x64/shader_lib /opt/flutter-elinux/flutter/bin/cache/artifacts/engine/linux-arm64
+            popd
             # edit to corresponding arch
             case ${{ matrix.job.arch }} in
               aarch64)

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -27,6 +27,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/flutter/lib/mobile/pages/scan_page.dart
+++ b/flutter/lib/mobile/pages/scan_page.dart
@@ -46,13 +46,13 @@ class _ScanPageState extends State<ScanPage> {
                       await picker.pickImage(source: ImageSource.gallery);
                   if (file != null) {
                     var image = img.decodeNamedImage(
-                        File(file.path).readAsBytesSync(), file.path)!;
+                        file.path, File(file.path).readAsBytesSync())!;
 
                     LuminanceSource source = RGBLuminanceSource(
                         image.width,
                         image.height,
                         image
-                            .getBytes(format: img.Format.abgr)
+                            .getBytes(order: img.ChannelOrder.abgr)
                             .buffer
                             .asInt32List());
                     var bitmap = BinaryBitmap(HybridBinarizer(source));

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -1067,7 +1068,7 @@ class CursorData {
               height: (height * scale).toInt(),
               interpolation: img2.Interpolation.average,
             )
-            .getBytes(format: img2.Format.bgra);
+            .getBytes(order: img2.ChannelOrder.bgra);
       } else {
         data = Uint8List.fromList(
           img2.encodePng(
@@ -1133,13 +1134,13 @@ class PredefinedCursor {
       () async {
         final defaultImg = _image2!;
         // This function is called only one time, no need to care about the performance.
-        Uint8List data = defaultImg.getBytes(format: img2.Format.rgba);
+        Uint8List data = defaultImg.getBytes(order: img2.ChannelOrder.rgba);
         _image = await img.decodeImageFromPixels(
             data, defaultImg.width, defaultImg.height, ui.PixelFormat.rgba8888);
 
         double scale = 1.0;
         if (Platform.isWindows) {
-          data = _image2!.getBytes(format: img2.Format.bgra);
+          data = _image2!.getBytes(order: img2.ChannelOrder.bgra);
         } else {
           data = Uint8List.fromList(img2.encodePng(_image2!));
         }
@@ -1358,9 +1359,9 @@ class CursorModel with ChangeNotifier {
       Uint8List rgba, ui.Image image, int id, int w, int h) async {
     Uint8List? data;
     img2.Image imgOrigin =
-        img2.Image.fromBytes(w, h, rgba, format: img2.Format.rgba);
+        img2.Image.fromBytes(width: w, height:h, bytes: rgba.buffer, order: img2.ChannelOrder.rgba);
     if (Platform.isWindows) {
-      data = imgOrigin.getBytes(format: img2.Format.bgra);
+      data = imgOrigin.getBytes(order: img2.ChannelOrder.bgra);
     } else {
       ByteData? imgBytes =
           await image.toByteData(format: ui.ImageByteFormat.png);

--- a/flutter/macos/Podfile.lock
+++ b/flutter/macos/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - FMDB (2.7.5):
     - FMDB/standard (= 2.7.5)
   - FMDB/standard (2.7.5)
-  - package_info_plus_macos (0.0.1):
+  - package_info_plus (0.0.1):
     - FlutterMacOS
   - path_provider_foundation (0.0.1):
     - Flutter
@@ -40,8 +40,8 @@ DEPENDENCIES:
   - device_info_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus_macos/macos`)
   - flutter_custom_cursor (from `Flutter/ephemeral/.symlinks/plugins/flutter_custom_cursor/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - package_info_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos`)
+  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - screen_retriever (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos`)
   - sqflite (from `Flutter/ephemeral/.symlinks/plugins/sqflite/macos`)
   - texture_rgba_renderer (from `Flutter/ephemeral/.symlinks/plugins/texture_rgba_renderer/macos`)
@@ -66,10 +66,10 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_custom_cursor/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  package_info_plus_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus_macos/macos
+  package_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   screen_retriever:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos
   sqflite:
@@ -94,13 +94,13 @@ SPEC CHECKSUMS:
   flutter_custom_cursor: 629957115075c672287bd0fa979d863ccf6024f7
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  package_info_plus_macos: f010621b07802a241d96d01876d6705f15e77c1c
-  path_provider_foundation: 37748e03f12783f9de2cb2c4eadfaa25fe6d4852
+  package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
+  path_provider_foundation: eaf5b3e458fc0e5fbb9940fb09980e853fe058b8
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
   sqflite: a5789cceda41d54d23f31d6de539d65bb14100ea
   texture_rgba_renderer: cbed959a3c127122194a364e14b8577bd62dc8f2
   uni_links_desktop: 45900fb319df48fcdea2df0756e9c2626696b026
-  url_launcher_macos: c04e4fa86382d4f94f6b38f14625708be3ae52e2
+  url_launcher_macos: 5335912b679c073563f29d89d33d10d459f95451
   wakelock_macos: bc3f2a9bd8d2e6c89fee1e1822e7ddac3bd004a9
   window_manager: 3a1844359a6295ab1e47659b1a777e36773cd6e8
   window_size: 339dafa0b27a95a62a843042038fa6c3c48de195

--- a/flutter/macos/Runner/MainFlutterWindow.swift
+++ b/flutter/macos/Runner/MainFlutterWindow.swift
@@ -7,7 +7,7 @@ import desktop_multi_window
 import desktop_drop
 import device_info_plus_macos
 import flutter_custom_cursor
-import package_info_plus_macos
+import package_info_plus
 import path_provider_foundation
 import screen_retriever
 import sqflite

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -104,6 +104,7 @@ dependencies:
   percent_indicator: ^4.2.2
   dropdown_button2: ^2.0.0
   fluentui_system_icons: ^1.1.201
+  desktop_drop: ^0.4.1
 
 dev_dependencies:
   icons_launcher: ^2.0.4

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -36,9 +36,10 @@ dependencies:
   provider: ^6.0.3
   tuple: ^2.0.0
   wakelock: ^0.6.2
+  # Keep this version for the compatibility of some old systems like win7.
   device_info_plus: ^4.1.2
   #firebase_analytics: ^9.1.5
-  package_info_plus: ^1.4.2
+  package_info_plus: ^3.1.2
   url_launcher: ^6.0.9
   toggle_switch: ^1.4.0
   dash_chat_2: ^0.0.15
@@ -47,9 +48,9 @@ dependencies:
   flutter_breadcrumb: ^1.0.1
   http: ^0.13.4
   qr_code_scanner: ^1.0.0
-  zxing2: ^0.1.0
+  zxing2: ^0.2.0
   image_picker: ^0.8.5
-  image: ^3.1.3
+  image: ^4.0.17
   back_button_interceptor: ^6.0.1
   flutter_rust_bridge: ^1.61.1
   window_manager:
@@ -68,13 +69,14 @@ dependencies:
       path: plugins/window_size
       ref: a738913c8ce2c9f47515382d40827e794a334274
   get: ^4.6.5
-  visibility_detector: ^0.3.3
+  visibility_detector: ^0.4.0+2
   contextmenu: ^3.0.0
-  desktop_drop: ^0.3.3
-  scroll_pos: ^0.3.0
+  # Disable desktop_drop for now, because it may cause crash on Win11 when destructing.
+  # desktop_drop: ^0.4.1
+  scroll_pos: ^0.4.0
   debounce_throttle: ^2.0.0
   file_picker: ^5.1.0
-  flutter_svg: ^1.1.5
+  flutter_svg: ^2.0.5
   flutter_improved_scrolling:
     # currently, we use flutter 3.7.0+.
     #
@@ -94,7 +96,7 @@ dependencies:
   bot_toast: ^4.0.3
   win32: any
   password_strength: ^0.2.0
-  flutter_launcher_icons: ^0.11.0
+  flutter_launcher_icons: ^0.13.1
   flutter_keyboard_visibility: ^5.4.0
   texture_rgba_renderer: ^0.0.16
   percent_indicator: ^4.2.2

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -76,7 +76,7 @@ dependencies:
   desktop_drop: 
     git:
       url: https://github.com/Kingtous/mixin-flutter-plugins.git
-      ref: 5720b83b511d7642ad15908b51d9aba8192528e7
+      ref: ba76531701885d9de8a69ee0167e1610cf76e440
       path: ./packages/desktop_drop
   scroll_pos: ^0.4.0
   debounce_throttle: ^2.0.0

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -56,9 +56,10 @@ dependencies:
   back_button_interceptor: ^6.0.1
   flutter_rust_bridge: ^1.61.1
   window_manager:
-    git:
-      url: https://github.com/Kingtous/rustdesk_window_manager
-      ref: 94ff0eeb7e20e93f50022b2090f0b6ffb725c7df
+    # git:
+    # url: https://github.com/Kingtous/rustdesk_window_manager
+    path: ../../rustdesk_window_manager
+    # ref: 94ff0eeb7e20e93f50022b2090f0b6ffb725c7df
   desktop_multi_window:
     git:
       url: https://github.com/Kingtous/rustdesk_desktop_multi_window
@@ -106,6 +107,7 @@ dependencies:
   texture_rgba_renderer: ^0.0.16
   percent_indicator: ^4.2.2
   dropdown_button2: ^2.0.0
+  fluentui_system_icons: ^1.1.201
 
 dev_dependencies:
   icons_launcher: ^2.0.4

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -73,14 +73,17 @@ dependencies:
   get: ^4.6.5
   visibility_detector: ^0.4.0+2
   contextmenu: ^3.0.0
-  # Disable desktop_drop for now, because it may cause crash on Win11 when destructing.
-  # desktop_drop: ^0.4.1
+  desktop_drop: 
+    git:
+      url: https://github.com/Kingtous/mixin-flutter-plugins.git
+      ref: 5720b83b511d7642ad15908b51d9aba8192528e7
+      path: ./packages/desktop_drop
   scroll_pos: ^0.4.0
   debounce_throttle: ^2.0.0
   file_picker: ^5.1.0
   flutter_svg: ^2.0.5
   flutter_improved_scrolling:
-    # currently, we use flutter 3.7.0+.
+    # currently, we use flutter 3.10.0+.
     #
     # for flutter 3.0.5, please use official version(just comment code below).
     # if build rustdesk by flutter >=3.3, please use our custom pub below (uncomment code below).
@@ -103,8 +106,6 @@ dependencies:
   texture_rgba_renderer: ^0.0.16
   percent_indicator: ^4.2.2
   dropdown_button2: ^2.0.0
-  fluentui_system_icons: ^1.1.201
-  desktop_drop: ^0.4.1
 
 dev_dependencies:
   icons_launcher: ^2.0.4

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -56,14 +56,13 @@ dependencies:
   back_button_interceptor: ^6.0.1
   flutter_rust_bridge: ^1.61.1
   window_manager:
-    # git:
-    # url: https://github.com/Kingtous/rustdesk_window_manager
-    path: ../../rustdesk_window_manager
-    # ref: 94ff0eeb7e20e93f50022b2090f0b6ffb725c7df
+    git:
+      url: https://github.com/Kingtous/rustdesk_window_manager
+      ref: 8cb5bf683e6b7b3f73280449900fe8d2c6bfe011
   desktop_multi_window:
     git:
       url: https://github.com/Kingtous/rustdesk_desktop_multi_window
-      ref: 6cd00db1d68443aeeb13dc89f6a090a0ad5dbb3e
+      ref: 30518303e28702bf6b8110465293c05d21bc4cd2
   freezed_annotation: ^2.0.3
   flutter_custom_cursor: ^0.0.4
   window_size:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -41,8 +41,10 @@ dependencies:
   #firebase_analytics: ^9.1.5
   package_info_plus: ^3.1.2
   url_launcher: ^6.0.9
-  toggle_switch: ^1.4.0
-  dash_chat_2: ^0.0.15
+  toggle_switch: ^2.1.0
+  dash_chat_2: 
+    git:
+      url: https://github.com/Kingtous/Dash-Chat-2.git
   draggable_float_widget: ^0.0.2
   settings_ui: ^2.0.2
   flutter_breadcrumb: ^1.0.1


### PR DESCRIPTION
This PR upgrades all platforms to flutter 3.10.1, which is the latest version of Flutter. Tested on windows, macos, linux. A fix is included for resolving closing issue brought by https://github.com/flutter/engine/pull/40033#discussion_r1200793727. Changes will be needed if a further event changes here.