### PR TITLE
fix: ci for bridge not fully support dart 3.x yet

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   FLUTTER_VERSION: "3.10.1"
+  FLUTTER_RUST_BRIDGE_VERSION: "1.75.3"
   
 jobs:
   generate_bridge:
@@ -60,7 +61,7 @@ jobs:
       - name: Install flutter rust bridge deps
         shell: bash
         run: |
-          cargo install flutter_rust_bridge_codegen
+          cargo install flutter_rust_bridge_codegen --version ${{ env.FLUTTER_RUST_BRIDGE_VERSION }}
           pushd flutter && flutter pub get && popd
 
       - name: Run flutter rust bridge

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -10,6 +10,7 @@ on:
 env:
   LLVM_VERSION: "15.0.6"
   FLUTTER_VERSION: "3.10.1"
+  FLUTTER_RUST_BRIDGE_VERSION: "1.75.3"
   # for arm64 linux
   FLUTTER_ELINUX_VERSION: "3.10.1"
   FLUTTER_ELINUX_COMMIT_ID: "410b3ca42f2cd0c485edf517a1666652bab442d4"
@@ -77,7 +78,7 @@ jobs:
 
       - name: Install flutter rust bridge deps
         run: |
-          cargo install flutter_rust_bridge_codegen
+          cargo install flutter_rust_bridge_codegen --version ${{ env.FLUTTER_RUST_BRIDGE_VERSION }}
           Push-Location flutter ; flutter pub get ; Pop-Location
           ~/.cargo/bin/flutter_rust_bridge_codegen --rust-input ./src/flutter_ffi.rs --dart-output ./flutter/lib/generated_bridge.dart
 
@@ -310,7 +311,7 @@ jobs:
       - name: Install flutter rust bridge deps
         shell: bash
         run: |
-          cargo install flutter_rust_bridge_codegen
+          cargo install flutter_rust_bridge_codegen --version ${{ env.FLUTTER_RUST_BRIDGE_VERSION }}
           pushd flutter && flutter pub get && popd
           ~/.cargo/bin/flutter_rust_bridge_codegen --rust-input ./src/flutter_ffi.rs --dart-output ./flutter/lib/generated_bridge.dart
 

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -579,10 +579,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_rust_bridge
-      sha256: "5aea0f3980dcd314f1890ef0d2392263817899cc15e543734b5d4dbe66b761eb"
+      sha256: "36e11b79ac7011d9203313468c5827fe1215b0fa03df384cfe2891a68ed74ed5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.62.0"
+    version: "1.75.3"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   image_picker: ^0.8.5
   image: ^4.0.17
   back_button_interceptor: ^6.0.1
-  flutter_rust_bridge: ^1.61.1
+  flutter_rust_bridge: "<1.76.0"
   window_manager:
     git:
       url: https://github.com/Kingtous/rustdesk_window_manager


### PR DESCRIPTION
Currently, flutter_rust_bridge has implemented  flutter 3.10.0 support particially and released a release, which has some issues for now. This PR fixes the bridge to the version without partial Dart 3.0.0 support.