### PR TITLE
opt cm ui

### DIFF
--- a/flutter/lib/desktop/pages/server_page.dart
+++ b/flutter/lib/desktop/pages/server_page.dart
@@ -459,7 +459,7 @@ class _PrivilegeBoardState extends State<_PrivilegeBoard> {
   Widget buildPermissionIcon(bool enabled, IconData iconData,
       Function(bool)? onTap, String tooltipText) {
     return Tooltip(
-      message: tooltipText,
+      message: "$tooltipText: ${enabled ? "ON" : "OFF"}",
       child: Container(
         decoration: BoxDecoration(
           color: enabled ? MyTheme.accent : Colors.grey[700],
@@ -476,17 +476,9 @@ class _PrivilegeBoardState extends State<_PrivilegeBoard> {
                 child: Icon(
                   iconData,
                   color: Colors.white,
+                  size: 32,
                 ),
               ),
-              Text(
-                enabled ? "ON" : "OFF",
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontWeight: FontWeight.w200,
-                  color: Colors.white,
-                  fontSize: 10.0,
-                ),
-              )
             ],
           ),
         ),
@@ -829,13 +821,13 @@ class _CmControlPanel extends StatelessWidget {
         ),
       );
     }
+    final borderRadius = BorderRadius.circular(10.0);
     return Container(
       height: 28,
       decoration: BoxDecoration(
-          color: color,
-          borderRadius: BorderRadius.circular(10.0),
-          border: border),
+          color: color, borderRadius: borderRadius, border: border),
       child: InkWell(
+        borderRadius: borderRadius,
         onTap: () => checkClickTime(client.id, onClick),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
1. Put ON/OFF to the tooltip, make permission icon bigger
2. Opt cm control button border

Did not optimize the margin between permission icons and the control buttons.

![rustdesk_1MsbQUgXgu](https://github.com/rustdesk/rustdesk/assets/14891774/edd9bd39-0e21-4f5b-b0a2-100e148f8e6f)
