### PR TITLE
macos, fix input crash

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -62,7 +62,9 @@ lazy_static::lazy_static! {
 }
 
 lazy_static::lazy_static! {
+    // Is server process, with "--server" args
     static ref IS_SERVER: bool = std::env::args().nth(1) == Some("--server".to_owned());
+    // Is server logic running. The server code can invoked to run by the main process if --server is not running.
     static ref SERVER_RUNNING: Arc<RwLock<bool>> = Default::default();
 }
 
@@ -101,9 +103,16 @@ pub fn set_server_running(b: bool) {
     *SERVER_RUNNING.write().unwrap() = b;
 }
 
+// is server process, with "--server" args
 #[inline]
 pub fn is_server() -> bool {
-    *IS_SERVER || *SERVER_RUNNING.read().unwrap()
+    *IS_SERVER
+}
+
+// Is server logic running. 
+#[inline]
+pub fn is_server_running() -> bool {
+    *SERVER_RUNNING.read().unwrap()
 }
 
 #[inline]

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -321,7 +321,7 @@ pub fn uninstall_plugin(id: &str, called_by_ui: bool) {
         }
     }
 
-    if is_server() {
+    if super::is_server_running() {
         super::plugins::unload_plugin(&id);
     }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -42,8 +42,6 @@ static PLUGIN_SOURCE_LOCAL_DIR: &str = "plugins";
 
 pub use config::{ManagerConfig, PeerConfig, SharedConfig};
 
-use crate::common::is_server;
-
 /// Common plugin return.
 ///
 /// [Note]
@@ -96,8 +94,12 @@ impl PluginReturn {
     }
 }
 
+fn is_server_running() -> bool {
+    crate::common::is_server() || crate::common::is_server_running()
+}
+
 pub fn init() {
-    if !is_server() {
+    if !is_server_running() {
         std::thread::spawn(move || manager::start_ipc());
     } else {
         if let Err(e) = remove_uninstalled() {

--- a/src/plugin/plugins.rs
+++ b/src/plugin/plugins.rs
@@ -371,7 +371,7 @@ fn load_plugin_path(path: &str) -> ResultType<()> {
     PLUGIN_INFO.write().unwrap().insert(id.clone(), plugin_info);
 
     let init_info = serde_json::to_string(&InitInfo {
-        is_server: crate::common::is_server(),
+        is_server: super::is_server_running(),
     })?;
     let init_data = InitData {
         version: str_to_cstr_ret(crate::VERSION),
@@ -389,7 +389,7 @@ fn load_plugin_path(path: &str) -> ResultType<()> {
         log::error!("Failed to init plugin '{}', {}", desc.meta().id, e);
     }
 
-    if is_server() {
+    if super::is_server_running() {
         super::config::ManagerConfig::add_plugin(&desc.meta().id)?;
     }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/4520

It was my fault.
I modified `is_server` function two weeks ago.
