### PR TITLE
Fix/restore resolution

### DIFF
--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -995,7 +995,7 @@ class _ResolutionsMenu extends StatefulWidget {
   State<_ResolutionsMenu> createState() => _ResolutionsMenuState();
 }
 
-const double _kCustonResolutionEditingWidth = 42;
+const double _kCustomResolutionEditingWidth = 42;
 const _kCustomResolutionValue = 'custom';
 
 class _ResolutionsMenuState extends State<_ResolutionsMenu> {
@@ -1102,6 +1102,7 @@ class _ResolutionsMenuState extends State<_ResolutionsMenu> {
   _changeResolution(int w, int h) async {
     await bind.sessionChangeResolution(
       id: widget.id,
+      display: pi.currentDisplay,
       width: w,
       height: h,
     );
@@ -1157,12 +1158,12 @@ class _ResolutionsMenuState extends State<_ResolutionsMenu> {
           children: [
             Text('${translate('resolution_custom_tip')} '),
             SizedBox(
-              width: _kCustonResolutionEditingWidth,
+              width: _kCustomResolutionEditingWidth,
               child: _resolutionInput(_customWidth),
             ),
             Text(' x '),
             SizedBox(
-              width: _kCustonResolutionEditingWidth,
+              width: _kCustomResolutionEditingWidth,
               child: _resolutionInput(_customHeight),
             ),
           ],

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -508,7 +508,8 @@ message OptionMessage {
   SupportedDecoding supported_decoding = 10;
   int32 custom_fps = 11;
   BoolOption disable_keyboard = 12;
-  Resolution custom_resolution = 13;
+// Position 13 is used for Resolution. Remove later.
+// Resolution custom_resolution = 13;
 }
 
 message TestDelay {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -262,10 +262,10 @@ pub struct PeerConfig {
 
     #[serde(
         default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_option_resolution"
+        deserialize_with = "deserialize_hashmap_resolutions",
+        skip_serializing_if = "HashMap::is_empty",
     )]
-    pub custom_resolution: Option<Resolution>,
+    pub custom_resolutions: HashMap<i32, Resolution>,
 
     // The other scalar value must before this
     #[serde(default, deserialize_with = "PeerConfig::deserialize_options")]
@@ -1509,7 +1509,7 @@ deserialize_default!(deserialize_option_string, Option<String>);
 deserialize_default!(deserialize_hashmap_string_string,  HashMap<String, String>);
 deserialize_default!(deserialize_hashmap_string_bool,  HashMap<String, bool>);
 deserialize_default!(deserialize_hashmap_string_configoidcprovider,  HashMap<String, ConfigOidcProvider>);
-deserialize_default!(deserialize_option_resolution, Option<Resolution>);
+deserialize_default!(deserialize_hashmap_resolutions, HashMap<i32, Resolution>);
 
 #[cfg(test)]
 mod tests {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1567,7 +1567,20 @@ mod tests {
             let wrong_type_str = r#"
             view_style = "adaptive"
             scroll_style = "scrollbar"
-            custom_resolution = true
+            custom_resolutions = true
+            "#;
+            let mut cfg_to_compare = default_peer_config.clone();
+            cfg_to_compare.view_style = "adaptive".to_string();
+            cfg_to_compare.scroll_style = "scrollbar".to_string();
+            let cfg = toml::from_str::<PeerConfig>(wrong_type_str);
+            assert_eq!(cfg, Ok(cfg_to_compare), "Failed to test wrong_type_str");
+
+            let wrong_type_str = r#"
+            view_style = "adaptive"
+            scroll_style = "scrollbar"
+            [custom_resolutions.0]
+            w = "1920"
+            h = 1080
             "#;
             let mut cfg_to_compare = default_peer_config.clone();
             cfg_to_compare.view_style = "adaptive".to_string();
@@ -1576,14 +1589,15 @@ mod tests {
             assert_eq!(cfg, Ok(cfg_to_compare), "Failed to test wrong_type_str");
 
             let wrong_field_str = r#"
-            [custom_resolution]
+            [custom_resolutions.0]
             w = 1920
             h = 1080
             hello = "world"
             [ui_flutter]
             "#;
             let mut cfg_to_compare = default_peer_config.clone();
-            cfg_to_compare.custom_resolution = Some(Resolution { w: 1920, h: 1080 });
+            cfg_to_compare.custom_resolutions =
+                HashMap::from([("0".to_string(), Resolution { w: 1920, h: 1080 })]);
             let cfg = toml::from_str::<PeerConfig>(wrong_field_str);
             assert_eq!(cfg, Ok(cfg_to_compare), "Failed to test wrong_field_str");
         }

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -263,9 +263,9 @@ pub struct PeerConfig {
     #[serde(
         default,
         deserialize_with = "deserialize_hashmap_resolutions",
-        skip_serializing_if = "HashMap::is_empty",
+        skip_serializing_if = "HashMap::is_empty"
     )]
-    pub custom_resolutions: HashMap<i32, Resolution>,
+    pub custom_resolutions: HashMap<String, Resolution>,
 
     // The other scalar value must before this
     #[serde(default, deserialize_with = "PeerConfig::deserialize_options")]
@@ -1509,7 +1509,7 @@ deserialize_default!(deserialize_option_string, Option<String>);
 deserialize_default!(deserialize_hashmap_string_string,  HashMap<String, String>);
 deserialize_default!(deserialize_hashmap_string_bool,  HashMap<String, bool>);
 deserialize_default!(deserialize_hashmap_string_configoidcprovider,  HashMap<String, ConfigOidcProvider>);
-deserialize_default!(deserialize_hashmap_resolutions, HashMap<i32, Resolution>);
+deserialize_default!(deserialize_hashmap_resolutions, HashMap<String, Resolution>);
 
 #[cfg(test)]
 mod tests {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1353,7 +1353,9 @@ impl LoginConfigHandler {
     ///
     /// * `ignore_default` - If `true`, ignore the default value of the option.
     fn get_option_message(&self, ignore_default: bool) -> Option<OptionMessage> {
-        if self.conn_type.eq(&ConnType::FILE_TRANSFER) || self.conn_type.eq(&ConnType::PORT_FORWARD) || self.conn_type.eq(&ConnType::RDP)
+        if self.conn_type.eq(&ConnType::FILE_TRANSFER)
+            || self.conn_type.eq(&ConnType::PORT_FORWARD)
+            || self.conn_type.eq(&ConnType::RDP)
         {
             return None;
         }
@@ -1402,7 +1404,7 @@ impl LoginConfigHandler {
             msg.disable_clipboard = BoolOption::Yes.into();
             n += 1;
         }
-        if let Some(r) = self.get_custom_resolution() {
+        if let Some(r) = self.get_custom_resolution(0) {
             if r.0 > 0 && r.1 > 0 {
                 msg.custom_resolution = Some(ProtoResolution {
                     width: r.0,
@@ -1424,7 +1426,9 @@ impl LoginConfigHandler {
     }
 
     pub fn get_option_message_after_login(&self) -> Option<OptionMessage> {
-        if self.conn_type.eq(&ConnType::FILE_TRANSFER) || self.conn_type.eq(&ConnType::PORT_FORWARD) || self.conn_type.eq(&ConnType::RDP)
+        if self.conn_type.eq(&ConnType::FILE_TRANSFER)
+            || self.conn_type.eq(&ConnType::PORT_FORWARD)
+            || self.conn_type.eq(&ConnType::RDP)
         {
             return None;
         }
@@ -1584,14 +1588,26 @@ impl LoginConfigHandler {
     }
 
     #[inline]
-    pub fn get_custom_resolution(&self) -> Option<(i32, i32)> {
-        self.config.custom_resolution.as_ref().map(|r| (r.w, r.h))
+    pub fn get_custom_resolution(&self, display: i32) -> Option<(i32, i32)> {
+        self.config
+            .custom_resolutions
+            .get(&display)
+            .map(|r| (r.w, r.h))
     }
 
     #[inline]
-    pub fn set_custom_resolution(&mut self, wh: Option<(i32, i32)>) {
+    pub fn set_custom_resolution(&mut self, display: i32, wh: Option<(i32, i32)>) {
         let mut config = self.load_config();
-        config.custom_resolution = wh.map(|r| Resolution { w: r.0, h: r.1 });
+        match wh {
+            Some((w, h)) => {
+                config
+                    .custom_resolutions
+                    .insert(display, Resolution { w, h });
+            }
+            None => {
+                config.custom_resolutions.remove(&display);
+            }
+        }
         self.save_config(config);
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -35,7 +35,7 @@ use hbb_common::{
         Config, PeerConfig, PeerInfoSerde, Resolution, CONNECT_TIMEOUT, READ_TIMEOUT, RELAY_PORT,
     },
     get_version_number, log,
-    message_proto::{option_message::BoolOption, Resolution as ProtoResolution, *},
+    message_proto::{option_message::BoolOption, *},
     protobuf::Message as _,
     rand,
     rendezvous_proto::*,
@@ -1403,16 +1403,6 @@ impl LoginConfigHandler {
         if view_only || self.get_toggle_option("disable-clipboard") {
             msg.disable_clipboard = BoolOption::Yes.into();
             n += 1;
-        }
-        if let Some(r) = self.get_custom_resolution(0) {
-            if r.0 > 0 && r.1 > 0 {
-                msg.custom_resolution = Some(ProtoResolution {
-                    width: r.0,
-                    height: r.1,
-                    ..Default::default()
-                })
-                .into();
-            }
         }
         msg.supported_decoding =
             hbb_common::protobuf::MessageField::some(Decoder::supported_decodings(Some(&self.id)));

--- a/src/client.rs
+++ b/src/client.rs
@@ -1591,12 +1591,13 @@ impl LoginConfigHandler {
     pub fn get_custom_resolution(&self, display: i32) -> Option<(i32, i32)> {
         self.config
             .custom_resolutions
-            .get(&display)
+            .get(&display.to_string())
             .map(|r| (r.w, r.h))
     }
 
     #[inline]
     pub fn set_custom_resolution(&mut self, display: i32, wh: Option<(i32, i32)>) {
+        let display = display.to_string();
         let mut config = self.load_config();
         match wh {
             Some((w, h)) => {

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1201,7 +1201,7 @@ impl<T: InvokeUiSession> Remote<T> {
                         }
                     }
                     Some(misc::Union::SwitchDisplay(s)) => {
-                        self.handler.ui_handler.switch_display(&s);
+                        self.handler.handle_peer_switch_display(&s);
                         self.video_sender.send(MediaData::Reset).ok();
                         if s.width > 0 && s.height > 0 {
                             self.handler.set_display(
@@ -1212,14 +1212,6 @@ impl<T: InvokeUiSession> Remote<T> {
                                 s.cursor_embedded,
                             );
                         }
-                        let custom_resolution = if s.width != s.original_resolution.width
-                            || s.height != s.original_resolution.height
-                        {
-                            Some((s.width, s.height))
-                        } else {
-                            None
-                        };
-                        self.handler.set_custom_resolution(custom_resolution);
                     }
                     Some(misc::Union::CloseReason(c)) => {
                         self.handler.msgbox("error", "Connection Error", &c, "");

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -535,9 +535,9 @@ pub fn session_switch_sides(id: String) {
     }
 }
 
-pub fn session_change_resolution(id: String, width: i32, height: i32) {
+pub fn session_change_resolution(id: String, display: i32, width: i32, height: i32) {
     if let Some(session) = SESSIONS.read().unwrap().get(&id) {
-        session.change_resolution(width, height);
+        session.change_resolution(display, width, height);
     }
 }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1795,14 +1795,11 @@ impl Connection {
                         video_service::switch_display(s.display).await;
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         if s.width != 0 && s.height != 0 {
-                            self.change_resolution(
-                                &Resolution {
-                                    width: s.width,
-                                    height: s.height,
-                                    ..Default::default()
-                                },
-                                false,
-                            );
+                            self.change_resolution(&Resolution {
+                                width: s.width,
+                                height: s.height,
+                                ..Default::default()
+                            });
                         }
                     }
                     Some(misc::Union::ChatMessage(c)) => {
@@ -1905,7 +1902,7 @@ impl Connection {
                         }
                     }
                     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                    Some(misc::Union::ChangeResolution(r)) => self.change_resolution(&r, false),
+                    Some(misc::Union::ChangeResolution(r)) => self.change_resolution(&r),
                     #[cfg(all(feature = "flutter", feature = "plugin_framework"))]
                     #[cfg(not(any(target_os = "android", target_os = "ios")))]
                     Some(misc::Union::PluginRequest(p)) => {
@@ -1948,13 +1945,9 @@ impl Connection {
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    fn change_resolution(&mut self, r: &Resolution, first_display: bool) {
+    fn change_resolution(&mut self, r: &Resolution) {
         if self.keyboard {
-            if let Ok((_, current, display)) = video_service::get_current_display() {
-                if first_display && current != 0 {
-                    return;
-                }
-                let name = display.name();
+            if let Ok(name) = video_service::get_current_display_name() {
                 #[cfg(all(windows, feature = "virtual_display_driver"))]
                 if let Some(_ok) =
                     crate::virtual_display_manager::change_resolution_if_is_virtual_display(
@@ -2180,7 +2173,7 @@ impl Connection {
         if let Some(custom_resolution) = o.custom_resolution.as_ref() {
             if Self::alive_conns().len() > 0 {
                 if custom_resolution.width > 0 && custom_resolution.height > 0 {
-                    self.change_resolution(&custom_resolution, true);
+                    self.change_resolution(&custom_resolution);
                 }
             }
         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2167,16 +2167,6 @@ impl Connection {
                 }
             }
         }
-        // Custom resolution here is only valid in the process of establishing a connection.
-        // After the connection is established, the resolution is changed by another message.
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        if let Some(custom_resolution) = o.custom_resolution.as_ref() {
-            if Self::alive_conns().len() == 1 {
-                if custom_resolution.width > 0 && custom_resolution.height > 0 {
-                    self.change_resolution(&custom_resolution);
-                }
-            }
-        }
         if self.keyboard {
             if let Ok(q) = o.block_input.enum_value() {
                 match q {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2171,7 +2171,7 @@ impl Connection {
         // After the connection is established, the resolution is changed by another message.
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         if let Some(custom_resolution) = o.custom_resolution.as_ref() {
-            if Self::alive_conns().len() > 0 {
+            if Self::alive_conns().len() == 1 {
                 if custom_resolution.width > 0 && custom_resolution.height > 0 {
                     self.change_resolution(&custom_resolution);
                 }

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -1029,12 +1029,14 @@ pub(super) fn get_current_display_2(mut all: Vec<Display>) -> ResultType<(usize,
     return Ok((n, current, all.remove(current)));
 }
 
+#[inline]
 pub fn get_current_display() -> ResultType<(usize, usize, Display)> {
     get_current_display_2(try_get_displays()?)
 }
 
 // `try_reset_current_display` is needed because `get_displays` may change the current display,
 // which may cause the mismatch of current display and the current display name.
+#[inline]
 pub fn get_current_display_name() -> ResultType<String> {
     Ok(get_current_display_2(try_get_displays()?)?.2.name())
 }


### PR DESCRIPTION
1. Remove `custom_resolution` in the `option` of `LoginRequest`.
2. Remove `custom_resolution` from peer config, `custom_resolutions` is added.
```
[custom_resolutions.0]
w = 1920
h = 1080

[custom_resolutions.1]
w = 1024
h = 768
```
3. Add `w` & `h` in session `switch_display`.
4. Remember last change of the custom resolution, `last_change_display`.