### PR TITLE
Cleanup page install

### DIFF
--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -251,7 +251,7 @@ class _InstallPageBodyState extends State<_InstallPageBody>
                 ],
               )
             ],
-          ).paddingSymmetric(horizontal: 8 * em, vertical: 2 * em),
+          ).paddingSymmetric(horizontal: 4 * em, vertical: 3 * em),
         ));
   }
 

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -149,62 +149,59 @@ class _InstallPageBodyState extends State<_InstallPageBody>
                       .marginOnly(left: em))
                 ],
               ).marginSymmetric(vertical: 2 * em),
-              TextButton(
-                onPressed: () => startmenu.value = !startmenu.value,
+              InkWell(
+                borderRadius: BorderRadius.circular(6),
+                onTap: () => startmenu.value = !startmenu.value,
                 child: Row(
                   children: [
                     Obx(() => Checkbox(
+                        visualDensity:
+                            VisualDensity(horizontal: -4, vertical: -4),
                         value: startmenu.value,
                         onChanged: (b) {
                           if (b != null) startmenu.value = b;
-                        })),
-                    RichText(
-                      text: TextSpan(
-                        text: translate('Create start menu shortcuts'),
-                        style: DefaultTextStyle.of(context).style,
-                      ),
-                    ),
+                        }).marginOnly(right: 8)),
+                    Expanded(
+                        child: Text(translate('Create start menu shortcuts'))),
                   ],
                 ),
-              ),
-              TextButton(
-                onPressed: () => desktopicon.value = !desktopicon.value,
+              ).marginOnly(bottom: 7),
+              InkWell(
+                borderRadius: BorderRadius.circular(6),
+                onTap: () => desktopicon.value = !desktopicon.value,
                 child: Row(
                   children: [
                     Obx(() => Checkbox(
+                        visualDensity:
+                            VisualDensity(horizontal: -4, vertical: -4),
                         value: desktopicon.value,
                         onChanged: (b) {
                           if (b != null) desktopicon.value = b;
-                        })),
-                    RichText(
-                      text: TextSpan(
-                        text: translate('Create desktop icon'),
-                        style: DefaultTextStyle.of(context).style,
-                      ),
-                    ),
+                        }).marginOnly(right: 8)),
+                    Expanded(child: Text(translate('Create desktop icon'))),
                   ],
                 ),
               ),
               Offstage(
                 offstage: !Platform.isWindows,
-                child: TextButton(
-                  onPressed: () => driverCert.value = !driverCert.value,
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(6),
+                  onTap: () => driverCert.value = !driverCert.value,
                   child: Row(
                     children: [
                       Obx(() => Checkbox(
+                          visualDensity:
+                              VisualDensity(horizontal: -4, vertical: -4),
                           value: driverCert.value,
                           onChanged: (b) {
                             if (b != null) driverCert.value = b;
-                          })),
-                      RichText(
-                        text: TextSpan(
-                          text: translate('idd_driver_tip'),
-                          style: DefaultTextStyle.of(context).style,
-                        ),
+                          }).marginOnly(right: 8)),
+                      Expanded(
+                        child: Text(translate('idd_driver_tip')),
                       ),
                     ],
                   ),
-                ),
+                ).marginOnly(top: 7),
               ),
               InkWell(
                   hoverColor: Colors.transparent,

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -97,6 +97,29 @@ class _InstallPageBodyState extends State<_InstallPageBody>
     windowManager.close();
   }
 
+  InkWell Option(RxBool option, {String label = ''}) {
+    return InkWell(
+      // todo mouseCursor: "SystemMouseCursors.forbidden" or no cursor on btnEnabled == false
+      borderRadius: BorderRadius.circular(6),
+      onTap: () => btnEnabled.value ? option.value = !option.value : null,
+      child: Row(
+        children: [
+          Obx(
+            () => Checkbox(
+              visualDensity: VisualDensity(horizontal: -4, vertical: -4),
+              value: option.value,
+              onChanged: (v) =>
+                  btnEnabled.value ? option.value = !option.value : null,
+            ).marginOnly(right: 8),
+          ),
+          Expanded(
+            child: Text(translate(label)),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final double em = 13;
@@ -132,60 +155,13 @@ class _InstallPageBodyState extends State<_InstallPageBody>
                   )
                 ],
               ).marginSymmetric(vertical: 2 * em),
-              InkWell(
-                borderRadius: BorderRadius.circular(6),
-                onTap: () => startmenu.value = !startmenu.value,
-                child: Row(
-                  children: [
-                    Obx(() => Checkbox(
-                        visualDensity:
-                            VisualDensity(horizontal: -4, vertical: -4),
-                        value: startmenu.value,
-                        onChanged: (b) {
-                          if (b != null) startmenu.value = b;
-                        }).marginOnly(right: 8)),
-                    Expanded(
-                        child: Text(translate('Create start menu shortcuts'))),
-                  ],
-                ),
-              ).marginOnly(bottom: 7),
-              InkWell(
-                borderRadius: BorderRadius.circular(6),
-                onTap: () => desktopicon.value = !desktopicon.value,
-                child: Row(
-                  children: [
-                    Obx(() => Checkbox(
-                        visualDensity:
-                            VisualDensity(horizontal: -4, vertical: -4),
-                        value: desktopicon.value,
-                        onChanged: (b) {
-                          if (b != null) desktopicon.value = b;
-                        }).marginOnly(right: 8)),
-                    Expanded(child: Text(translate('Create desktop icon'))),
-                  ],
-                ),
-              ),
+              Option(startmenu, label: 'Create start menu shortcuts')
+                  .marginOnly(bottom: 7),
+              Option(desktopicon, label: 'Create desktop icon'),
               Offstage(
                 offstage: !Platform.isWindows,
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(6),
-                  onTap: () => driverCert.value = !driverCert.value,
-                  child: Row(
-                    children: [
-                      Obx(() => Checkbox(
-                          visualDensity:
-                              VisualDensity(horizontal: -4, vertical: -4),
-                          value: driverCert.value,
-                          onChanged: (b) {
-                            if (b != null) driverCert.value = b;
-                          }).marginOnly(right: 8)),
-                      Expanded(
-                        child: Text(translate('idd_driver_tip')),
-                      ),
-                    ],
-                  ),
-                ).marginOnly(top: 7),
-              ),
+                child: Option(driverCert, label: 'idd_driver_tip'),
+              ).marginOnly(top: 7),
               Container(
                   padding: EdgeInsets.all(12),
                   decoration: BoxDecoration(

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -70,6 +70,12 @@ class _InstallPageBodyState extends State<_InstallPageBody>
   final RxBool showProgress = false.obs;
   final RxBool btnEnabled = true.obs;
 
+  // todo move to theme.
+  final buttonStyle = OutlinedButton.styleFrom(
+    textStyle: TextStyle(fontSize: 14, fontWeight: FontWeight.normal),
+    padding: EdgeInsets.symmetric(vertical: 15, horizontal: 12),
+  );
+
   @override
   void initState() {
     windowManager.addListener(this);
@@ -94,14 +100,7 @@ class _InstallPageBodyState extends State<_InstallPageBody>
   @override
   Widget build(BuildContext context) {
     final double em = 13;
-    final btnFontSize = 0.9 * em;
-    final double button_radius = 6;
     final isDarkTheme = MyTheme.currentThemeMode() == ThemeMode.dark;
-    final buttonStyle = OutlinedButton.styleFrom(
-        shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(Radius.circular(button_radius)),
-    ));
-    final textColor = isDarkTheme ? null : Colors.black87;
     final dividerColor = isDarkTheme ? Colors.white70 : Colors.black87;
     return Scaffold(
         backgroundColor: null,
@@ -130,12 +129,14 @@ class _InstallPageBodyState extends State<_InstallPageBody>
                       ),
                     ).marginOnly(right: 10),
                   ),
-                  Obx(() => OutlinedButton(
+                  Obx(
+                    () => OutlinedButton.icon(
+                      icon: Icon(Icons.folder_outlined, size: 16),
                       onPressed: btnEnabled.value ? selectInstallPath : null,
                       style: buttonStyle,
-                      child: Text(translate('Change Path'),
-                          style: TextStyle(
-                              color: textColor, fontSize: btnFontSize))))
+                      label: Text(translate('Change Path')),
+                    ),
+                  )
                 ],
               ).marginSymmetric(vertical: 2 * em),
               InkWell(
@@ -217,38 +218,35 @@ class _InstallPageBodyState extends State<_InstallPageBody>
                             offstage: !showProgress.value,
                             child: LinearProgressIndicator(),
                           ))),
-                  Obx(() => OutlinedButton(
-                          onPressed: btnEnabled.value
-                              ? () => windowManager.close()
-                              : null,
-                          style: buttonStyle,
-                          child: Text(translate('Cancel'),
-                              style: TextStyle(
-                                  color: textColor, fontSize: btnFontSize)))
-                      .marginSymmetric(horizontal: 2 * em)),
-                  Obx(() => ElevatedButton(
+                  Obx(
+                    () => OutlinedButton.icon(
+                      icon: Icon(Icons.close_rounded, size: 16),
+                      label: Text(translate('Cancel')),
+                      onPressed:
+                          btnEnabled.value ? () => windowManager.close() : null,
+                      style: buttonStyle,
+                    ).marginOnly(right: 10),
+                  ),
+                  Obx(
+                    () => ElevatedButton.icon(
+                      icon: Icon(Icons.done_rounded, size: 16),
+                      label: Text(translate('Accept and Install')),
                       onPressed: btnEnabled.value ? install : null,
-                      style: ElevatedButton.styleFrom(
-                          primary: MyTheme.button,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.all(
-                                Radius.circular(button_radius)),
-                          )),
-                      child: Text(
-                        translate('Accept and Install'),
-                        style: TextStyle(fontSize: btnFontSize),
-                      ))),
+                      style: buttonStyle,
+                    ),
+                  ),
                   Offstage(
                     offstage: bind.installShowRunWithoutInstall(),
-                    child: Obx(() => OutlinedButton(
-                            onPressed: btnEnabled.value
-                                ? () => bind.installRunWithoutInstall()
-                                : null,
-                            style: buttonStyle,
-                            child: Text(translate('Run without install'),
-                                style: TextStyle(
-                                    color: textColor, fontSize: btnFontSize)))
-                        .marginOnly(left: 2 * em)),
+                    child: Obx(
+                      () => OutlinedButton.icon(
+                        icon: Icon(Icons.screen_share_outlined, size: 16),
+                        label: Text(translate('Run without install')),
+                        onPressed: btnEnabled.value
+                            ? () => bind.installRunWithoutInstall()
+                            : null,
+                        style: buttonStyle,
+                      ).marginOnly(left: 10),
+                    ),
                   ),
                 ],
               )
@@ -271,21 +269,21 @@ class _InstallPageBodyState extends State<_InstallPageBody>
     if (driverCert.isTrue) {
       final tag = 'install-info-install-cert-confirm';
       final btns = [
-        dialogButton(
-          'Cancel',
-          icon: Icon(Icons.close_rounded),
+        OutlinedButton.icon(
+          icon: Icon(Icons.close_rounded, size: 16),
+          label: Text(translate('Cancel')),
           onPressed: () => gFFI.dialogManager.dismissByTag(tag),
-          isOutline: true,
+          style: buttonStyle,
         ),
-        dialogButton(
-          'OK',
-          icon: Icon(Icons.done_rounded),
+        ElevatedButton.icon(
+          icon: Icon(Icons.done_rounded, size: 16),
+          label: Text(translate('OK')),
           onPressed: () {
             gFFI.dialogManager.dismissByTag(tag);
             do_install();
           },
-          isOutline: false,
-        ),
+          style: buttonStyle,
+        )
       ];
       gFFI.dialogManager.show(
         (setState, close, context) => CustomAlertDialog(

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -208,10 +208,12 @@ class _InstallPageBodyState extends State<_InstallPageBody>
               Row(
                 children: [
                   Expanded(
-                      child: Obx(() => Offstage(
-                            offstage: !showProgress.value,
-                            child: LinearProgressIndicator(),
-                          ))),
+                    child: Obx(() => Offstage(
+                          offstage: !showProgress.value,
+                          child:
+                              LinearProgressIndicator().marginOnly(right: 10),
+                        )),
+                  ),
                   Obx(
                     () => OutlinedButton.icon(
                       icon: Icon(Icons.close_rounded, size: 16),

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -287,11 +287,13 @@ class _InstallPageBodyState extends State<_InstallPageBody>
       final btns = [
         dialogButton(
           'Cancel',
+          icon: Icon(Icons.close_rounded),
           onPressed: () => gFFI.dialogManager.dismissByTag(tag),
           isOutline: true,
         ),
         dialogButton(
           'OK',
+          icon: Icon(Icons.done_rounded),
           onPressed: () {
             gFFI.dialogManager.dismissByTag(tag);
             do_install();

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -106,16 +106,10 @@ class _InstallPageBodyState extends State<_InstallPageBody>
         backgroundColor: null,
         body: SingleChildScrollView(
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
-                children: [
-                  Text(
-                    translate('Installation'),
-                    style: TextStyle(
-                        fontSize: 2 * em, fontWeight: FontWeight.w500),
-                  ),
-                ],
-              ),
+              Text(translate('Installation'),
+                  style: Theme.of(context).textTheme.headlineMedium),
               Row(
                 children: [
                   Text('${translate('Installation Path')}:')

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_hbb/desktop/widgets/tabbar_widget.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
 import 'package:get/get.dart';
+import 'package:path/path.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -312,8 +313,7 @@ class _InstallPageBodyState extends State<_InstallPageBody>
     String? install_path = await FilePicker.platform
         .getDirectoryPath(initialDirectory: controller.text);
     if (install_path != null) {
-      install_path = '$install_path\\${await bind.mainGetAppName()}';
-      controller.text = install_path;
+      controller.text = join(install_path, await bind.mainGetAppName());
     }
   }
 }

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -206,14 +206,20 @@ class _InstallPageBodyState extends State<_InstallPageBody>
                   ),
                 ),
               ),
-              GestureDetector(
-                  onTap: () => launchUrlString('http://rustdesk.com/privacy'),
-                  child: Row(
-                    children: [
-                      Text(translate('End-user license agreement'),
-                          style: const TextStyle(
-                              decoration: TextDecoration.underline))
-                    ],
+              InkWell(
+                  hoverColor: Colors.transparent,
+                  onTap: () => launchUrlString('https://rustdesk.com/privacy'),
+                  child: Tooltip(
+                    message: 'https://rustdesk.com/privacy',
+                    child: Row(children: [
+                      Icon(Icons.launch_outlined, size: 16)
+                          .marginOnly(right: 5),
+                      Text(
+                        translate('End-user license agreement'),
+                        style: const TextStyle(
+                            decoration: TextDecoration.underline),
+                      )
+                    ]),
                   )).marginOnly(top: 2 * em),
               Row(children: [Text(translate('agreement_tip'))])
                   .marginOnly(top: em),

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -101,7 +101,6 @@ class _InstallPageBodyState extends State<_InstallPageBody>
   Widget build(BuildContext context) {
     final double em = 13;
     final isDarkTheme = MyTheme.currentThemeMode() == ThemeMode.dark;
-    final dividerColor = isDarkTheme ? Colors.white70 : Colors.black87;
     return Scaffold(
         backgroundColor: null,
         body: SingleChildScrollView(
@@ -187,24 +186,45 @@ class _InstallPageBodyState extends State<_InstallPageBody>
                   ),
                 ).marginOnly(top: 7),
               ),
-              InkWell(
-                  hoverColor: Colors.transparent,
-                  onTap: () => launchUrlString('https://rustdesk.com/privacy'),
-                  child: Tooltip(
-                    message: 'https://rustdesk.com/privacy',
-                    child: Row(children: [
-                      Icon(Icons.launch_outlined, size: 16)
-                          .marginOnly(right: 5),
-                      Text(
-                        translate('End-user license agreement'),
-                        style: const TextStyle(
-                            decoration: TextDecoration.underline),
+              Container(
+                  padding: EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: isDarkTheme
+                        ? Color.fromARGB(135, 87, 87, 90)
+                        : Colors.grey[100],
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Colors.grey),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(Icons.info_outline_rounded, size: 32)
+                          .marginOnly(right: 16),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(translate('agreement_tip'))
+                              .marginOnly(bottom: em),
+                          InkWell(
+                            hoverColor: Colors.transparent,
+                            onTap: () =>
+                                launchUrlString('https://rustdesk.com/privacy'),
+                            child: Tooltip(
+                              message: 'https://rustdesk.com/privacy',
+                              child: Row(children: [
+                                Icon(Icons.launch_outlined, size: 16)
+                                    .marginOnly(right: 5),
+                                Text(
+                                  translate('End-user license agreement'),
+                                  style: const TextStyle(
+                                      decoration: TextDecoration.underline),
+                                )
+                              ]),
+                            ),
+                          ),
+                        ],
                       )
-                    ]),
-                  )).marginOnly(top: 2 * em),
-              Row(children: [Text(translate('agreement_tip'))])
-                  .marginOnly(top: em),
-              Divider(color: dividerColor).marginSymmetric(vertical: 0.5 * em),
+                    ],
+                  )).marginSymmetric(vertical: 2 * em),
               Row(
                 children: [
                   Expanded(

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -101,10 +101,6 @@ class _InstallPageBodyState extends State<_InstallPageBody>
         shape: RoundedRectangleBorder(
       borderRadius: BorderRadius.all(Radius.circular(button_radius)),
     ));
-    final inputBorder = OutlineInputBorder(
-        borderRadius: BorderRadius.zero,
-        borderSide:
-            BorderSide(color: isDarkTheme ? Colors.white70 : Colors.black12));
     final textColor = isDarkTheme ? null : Colors.black87;
     final dividerColor = isDarkTheme ? Colors.white70 : Colors.black87;
     return Scaffold(
@@ -123,30 +119,23 @@ class _InstallPageBodyState extends State<_InstallPageBody>
               ),
               Row(
                 children: [
-                  Text('${translate('Installation Path')}: '),
+                  Text('${translate('Installation Path')}:')
+                      .marginOnly(right: 10),
                   Expanded(
-                      child: TextField(
-                    controller: controller,
-                    readOnly: true,
-                    style: TextStyle(
-                        fontSize: 1.5 * em, fontWeight: FontWeight.w400),
-                    decoration: InputDecoration(
-                      isDense: true,
-                      contentPadding: EdgeInsets.all(0.75 * em),
-                      enabledBorder: inputBorder,
-                      border: inputBorder,
-                      focusedBorder: inputBorder,
-                      constraints: BoxConstraints(maxHeight: 3 * em),
-                    ),
-                  )),
+                    child: TextField(
+                      controller: controller,
+                      readOnly: true,
+                      decoration: InputDecoration(
+                        contentPadding: EdgeInsets.all(0.75 * em),
+                      ),
+                    ).marginOnly(right: 10),
+                  ),
                   Obx(() => OutlinedButton(
-                          onPressed:
-                              btnEnabled.value ? selectInstallPath : null,
-                          style: buttonStyle,
-                          child: Text(translate('Change Path'),
-                              style: TextStyle(
-                                  color: textColor, fontSize: btnFontSize)))
-                      .marginOnly(left: em))
+                      onPressed: btnEnabled.value ? selectInstallPath : null,
+                      style: buttonStyle,
+                      child: Text(translate('Change Path'),
+                          style: TextStyle(
+                              color: textColor, fontSize: btnFontSize))))
                 ],
               ).marginSymmetric(vertical: 2 * em),
               InkWell(


### PR DESCRIPTION
### Fixes:

- Overflow at checkbox label 
- Checkboxes are still changeable when the installation has been started.


### Changes:

- Use path.join instead of string contact to create install path 
- Reset styles for input/buttons/headline to default/theme
- Alignment of checkboxes
- Progressindicator space to buttons
- Cursor pointer, icon, tooltip, https for outgoing link.  
- Make "Agreement" section more visible


### before

|![before-light](https://github.com/rustdesk/rustdesk/assets/67791701/185b5a2e-b129-4eb1-a5e9-52cbbedcc492)

### after

![after-light](https://github.com/rustdesk/rustdesk/assets/67791701/32f539a5-3a1a-4b3c-a4a6-e1a72a1808c8)

### before 
![before-dark](https://github.com/rustdesk/rustdesk/assets/67791701/5633b241-99e4-4d90-8343-b8d62a817be8)

### after

![after-dark](https://github.com/rustdesk/rustdesk/assets/67791701/f3f1275e-3af0-4c1b-921c-14115845613b)

### Dialog buttons

|before | after |
|-- |-- |
|![before-dialog](https://github.com/rustdesk/rustdesk/assets/67791701/34157e80-1169-417a-846b-3896496b5982)|![after-light-dialog](https://github.com/rustdesk/rustdesk/assets/67791701/579d65cc-4550-4434-8440-4cf97c877471)|



