### PR TITLE
Remove splash for radio/switches on Desktop

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -183,7 +183,13 @@ class MyTheme {
     ),
   );
 
-  static const SwitchThemeData switchTheme = SwitchThemeData(splashRadius: 0);
+  static SwitchThemeData switchTheme() {
+    return SwitchThemeData(splashRadius: isDesktop ? 0 : kRadialReactionRadius);
+  }
+
+  static RadioThemeData radioTheme() {
+    return RadioThemeData(splashRadius: isDesktop ? 0 : kRadialReactionRadius);
+  }
 
   // Checkbox
   static const CheckboxThemeData checkboxTheme = CheckboxThemeData(
@@ -309,7 +315,8 @@ class MyTheme {
         ),
       ),
     ),
-    switchTheme: switchTheme,
+    switchTheme: switchTheme(),
+    radioTheme: radioTheme(),
     checkboxTheme: checkboxTheme,
     listTileTheme: listTileTheme,
     menuBarTheme: MenuBarThemeData(
@@ -404,7 +411,8 @@ class MyTheme {
         ),
       ),
     ),
-    switchTheme: switchTheme,
+    switchTheme: switchTheme(),
+    radioTheme: radioTheme(),
     checkboxTheme: checkboxTheme,
     listTileTheme: listTileTheme,
     menuBarTheme: MenuBarThemeData(


### PR DESCRIPTION
Remove splash for radio/switch on Desktop, but keep for mobile.