### PR TITLE
Cleanup dialogs

### DIFF
--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -1136,9 +1136,6 @@ void _rdpDialog(String id) async {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const SizedBox(
-              height: 8.0,
-            ),
             Row(
               children: [
                 isDesktop
@@ -1207,7 +1204,7 @@ void _rdpDialog(String id) async {
                       )),
                 ),
               ],
-            ).marginOnly(bottom: isDesktop ? 8 : 0),
+            )
           ],
         ),
       ),

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1976,9 +1976,6 @@ void changeSocks5Proxy() async {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const SizedBox(
-              height: 8.0,
-            ),
             Row(
               children: [
                 ConstrainedBox(
@@ -2033,9 +2030,10 @@ void changeSocks5Proxy() async {
                       )),
                 ),
               ],
-            ).marginOnly(bottom: 8),
+            ),
             Offstage(
-                offstage: !isInProgress, child: const LinearProgressIndicator())
+                offstage: !isInProgress,
+                child: const LinearProgressIndicator().marginOnly(top: 8))
           ],
         ),
       ),


### PR DESCRIPTION
- RDP Dialog. Remove extra space
- Proxy dialog. Space to progressbar only if it is visible

| ||
|-- |-- |
|![proxy-before](https://github.com/rustdesk/rustdesk/assets/67791701/33d746f1-2dba-4e58-b620-7599b8981f3a)|![rdp-before](https://github.com/rustdesk/rustdesk/assets/67791701/6a071d3c-64af-4fe4-948a-181c25d3a8c3)|
