### PR TITLE
Fix/clipboard flutter

### DIFF
--- a/libs/clipboard/src/cliprdr.h
+++ b/libs/clipboard/src/cliprdr.h
@@ -191,8 +191,6 @@ extern "C"
     typedef UINT (*pcCliprdrServerFileContentsResponse)(
         CliprdrClientContext *context, const CLIPRDR_FILE_CONTENTS_RESPONSE *fileContentsResponse);
 
-    typedef BOOL (*pcCheckEnabled)(UINT32 connID);
-
     // TODO: hide more members of clipboard context
     struct _cliprdr_client_context
     {
@@ -200,7 +198,6 @@ extern "C"
         BOOL enableFiles;
         BOOL enableOthers;
 
-        pcCheckEnabled CheckEnabled;
         pcCliprdrServerCapabilities ServerCapabilities;
         pcCliprdrClientCapabilities ClientCapabilities;
         pcCliprdrMonitorReady MonitorReady;

--- a/libs/clipboard/src/cliprdr.h
+++ b/libs/clipboard/src/cliprdr.h
@@ -194,10 +194,11 @@ extern "C"
     // TODO: hide more members of clipboard context
     struct _cliprdr_client_context
     {
-        void *custom;
-        BOOL enableFiles;
-        BOOL enableOthers;
+        void *Custom;
+        BOOL EnableFiles;
+        BOOL EnableOthers;
 
+        BOOL IsStopped;
         pcCliprdrServerCapabilities ServerCapabilities;
         pcCliprdrClientCapabilities ClientCapabilities;
         pcCliprdrMonitorReady MonitorReady;
@@ -219,7 +220,7 @@ extern "C"
         pcCliprdrClientFileContentsResponse ClientFileContentsResponse;
         pcCliprdrServerFileContentsResponse ServerFileContentsResponse;
 
-        UINT32 lastRequestedFormatId;
+        UINT32 LastRequestedFormatId;
     };
 
 #ifdef __cplusplus

--- a/libs/clipboard/src/cliprdr.rs
+++ b/libs/clipboard/src/cliprdr.rs
@@ -449,9 +449,10 @@ pub type pcCliprdrServerFileContentsResponse = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct _cliprdr_client_context {
-    pub custom: *mut ::std::os::raw::c_void,
-    pub enableFiles: BOOL,
-    pub enableOthers: BOOL,
+    pub Custom: *mut ::std::os::raw::c_void,
+    pub EnableFiles: BOOL,
+    pub EnableOthers: BOOL,
+    pub IsStopped: BOOL,
     pub ServerCapabilities: pcCliprdrServerCapabilities,
     pub ClientCapabilities: pcCliprdrClientCapabilities,
     pub MonitorReady: pcCliprdrMonitorReady,
@@ -472,7 +473,7 @@ pub struct _cliprdr_client_context {
     pub ServerFileContentsRequest: pcCliprdrServerFileContentsRequest,
     pub ClientFileContentsResponse: pcCliprdrClientFileContentsResponse,
     pub ServerFileContentsResponse: pcCliprdrServerFileContentsResponse,
-    pub lastRequestedFormatId: UINT32,
+    pub LastRequestedFormatId: UINT32,
 }
 
 // #[link(name = "user32")]
@@ -480,10 +481,7 @@ pub struct _cliprdr_client_context {
 extern "C" {
     pub(crate) fn init_cliprdr(context: *mut CliprdrClientContext) -> BOOL;
     pub(crate) fn uninit_cliprdr(context: *mut CliprdrClientContext) -> BOOL;
-    pub(crate) fn empty_cliprdr(
-        context: *mut CliprdrClientContext,
-        connID: UINT32,
-    ) -> BOOL;
+    pub(crate) fn empty_cliprdr(context: *mut CliprdrClientContext, connID: UINT32) -> BOOL;
 }
 
 #[derive(Error, Debug)]
@@ -508,9 +506,10 @@ impl CliprdrClientContext {
         client_file_contents_response: pcCliprdrClientFileContentsResponse,
     ) -> Result<Box<Self>, CliprdrError> {
         let context = CliprdrClientContext {
-            custom: 0 as *mut _,
-            enableFiles: if enable_files { TRUE } else { FALSE },
-            enableOthers: if enable_others { TRUE } else { FALSE },
+            Custom: 0 as *mut _,
+            EnableFiles: if enable_files { TRUE } else { FALSE },
+            EnableOthers: if enable_others { TRUE } else { FALSE },
+            IsStopped: FALSE,
             ServerCapabilities: None,
             ClientCapabilities: None,
             MonitorReady: None,
@@ -531,7 +530,7 @@ impl CliprdrClientContext {
             ServerFileContentsRequest: None,
             ClientFileContentsResponse: client_file_contents_response,
             ServerFileContentsResponse: None,
-            lastRequestedFormatId: 0,
+            LastRequestedFormatId: 0,
         };
         let mut context = Box::new(context);
         unsafe {

--- a/libs/clipboard/src/cliprdr.rs
+++ b/libs/clipboard/src/cliprdr.rs
@@ -444,9 +444,6 @@ pub type pcCliprdrServerFileContentsResponse = ::std::option::Option<
         fileContentsResponse: *const CLIPRDR_FILE_CONTENTS_RESPONSE,
     ) -> UINT,
 >;
-pub type pcCheckEnabled = ::std::option::Option<
-    unsafe extern "C" fn(connID: UINT32) -> BOOL,
->;
 
 // TODO: hide more members of clipboard context
 #[repr(C)]
@@ -455,7 +452,6 @@ pub struct _cliprdr_client_context {
     pub custom: *mut ::std::os::raw::c_void,
     pub enableFiles: BOOL,
     pub enableOthers: BOOL,
-    pub CheckEnabled: pcCheckEnabled,
     pub ServerCapabilities: pcCliprdrServerCapabilities,
     pub ClientCapabilities: pcCliprdrClientCapabilities,
     pub MonitorReady: pcCliprdrMonitorReady,
@@ -504,7 +500,6 @@ impl CliprdrClientContext {
     pub fn create(
         enable_files: bool,
         enable_others: bool,
-        check_enabled: pcCheckEnabled,
         client_format_list: pcCliprdrClientFormatList,
         client_format_list_response: pcCliprdrClientFormatListResponse,
         client_format_data_request: pcCliprdrClientFormatDataRequest,
@@ -516,7 +511,6 @@ impl CliprdrClientContext {
             custom: 0 as *mut _,
             enableFiles: if enable_files { TRUE } else { FALSE },
             enableOthers: if enable_others { TRUE } else { FALSE },
-            CheckEnabled: check_enabled,
             ServerCapabilities: None,
             ClientCapabilities: None,
             MonitorReady: None,

--- a/libs/clipboard/src/context_send.rs
+++ b/libs/clipboard/src/context_send.rs
@@ -7,24 +7,24 @@ lazy_static::lazy_static! {
 }
 
 pub struct ContextSend {
-    server_enabled: bool,
+    cm_enabled: bool,
     addr: u64,
 }
 
 impl ContextSend {
     fn new() -> Self {
         Self {
-            server_enabled: false,
+            cm_enabled: false,
             addr: 0,
         }
     }
 
     #[inline]
-    pub fn is_server_enabled() -> bool {
-        CONTEXT_SEND.lock().unwrap().server_enabled
+    pub fn is_cm_enabled() -> bool {
+        CONTEXT_SEND.lock().unwrap().cm_enabled
     }
 
-    pub fn enable(enabled: bool, is_server_side: bool, is_server_process: bool) {
+    pub fn enable(enabled: bool, is_cm_side: bool, is_server_process: bool) {
         let mut lock = CONTEXT_SEND.lock().unwrap();
         if enabled {
             if lock.addr == 0 {
@@ -41,8 +41,8 @@ impl ContextSend {
                     }
                 }
             }
-            if is_server_side {
-                lock.server_enabled = true;
+            if is_cm_side {
+                lock.cm_enabled = true;
             }
         } else {
             if lock.addr != 0 {
@@ -53,7 +53,7 @@ impl ContextSend {
                     log::info!("clipboard context for file transfer destroyed.");
                     lock.addr = 0;
                 }
-                lock.server_enabled = false;
+                lock.cm_enabled = false;
             }
         }
     }

--- a/libs/clipboard/src/context_send.rs
+++ b/libs/clipboard/src/context_send.rs
@@ -19,6 +19,7 @@ impl ContextSend {
         }
     }
 
+    #[inline]
     pub fn is_server_enabled() -> bool {
         CONTEXT_SEND.lock().unwrap().server_enabled
     }

--- a/libs/clipboard/src/context_send.rs
+++ b/libs/clipboard/src/context_send.rs
@@ -62,7 +62,9 @@ impl ContextSend {
         if lock.addr != 0 {
             unsafe {
                 let mut context = Box::from_raw(lock.addr as *mut CliprdrClientContext);
-                f(&mut context)
+                let code = f(&mut context);
+                std::mem::forget(context);
+                code
             }
         } else {
             0

--- a/libs/clipboard/src/context_send.rs
+++ b/libs/clipboard/src/context_send.rs
@@ -24,6 +24,13 @@ impl ContextSend {
         CONTEXT_SEND.lock().unwrap().cm_enabled
     }
 
+    pub fn set_is_stopped() {
+        let _res = Self::proc(|c| {
+            c.IsStopped = TRUE;
+            0
+        });
+    }
+
     pub fn enable(enabled: bool, is_cm_side: bool, is_server_process: bool) {
         let mut lock = CONTEXT_SEND.lock().unwrap();
         if enabled {

--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -485,9 +485,9 @@ extern "C" fn client_format_list(
     let data = ClipboardFile::FormatList { format_list };
     // no need to handle result here
     if conn_id == 0 {
-        VEC_MSG_CHANNEL
-            .read()
-            .unwrap()
+        // msg_channel is used for debug, VEC_MSG_CHANNEL cannot be inspected by the debugger.
+        let msg_channel = VEC_MSG_CHANNEL.read().unwrap();
+        msg_channel
             .iter()
             .for_each(|msg_channel| allow_err!(msg_channel.sender.send(data.clone())));
     } else {

--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -18,6 +18,8 @@ pub mod cliprdr;
 pub mod context_send;
 pub use context_send::*;
 
+const ERR_CODE_SERVER_FUNCTION_NONE: u32 = 0x00000001;
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "t", content = "c")]
 pub enum ClipboardFile {
@@ -247,8 +249,12 @@ pub fn server_monitor_ready(context: &mut Box<CliprdrClientContext>, conn_id: i3
             msgFlags: 0 as UINT16,
             dataLen: 0 as UINT32,
         };
-        let ret = ((**context).MonitorReady.unwrap())(&mut (**context), &monitor_ready);
-        ret as u32
+        if let Some(f) = (**context).MonitorReady {
+            let ret = f(&mut (**context), &monitor_ready);
+            ret as u32
+        } else {
+            ERR_CODE_SERVER_FUNCTION_NONE
+        }
     }
 }
 
@@ -289,7 +295,11 @@ pub fn server_format_list(
             formats: formats.as_mut_ptr(),
         };
 
-        let ret = ((**context).ServerFormatList.unwrap())(&mut (**context), &format_list);
+        let ret = if let Some(f) = (**context).ServerFormatList {
+            f(&mut (**context), &format_list)
+        } else {
+            ERR_CODE_SERVER_FUNCTION_NONE
+        };
 
         for f in formats {
             if !f.formatName.is_null() {
@@ -315,10 +325,11 @@ pub fn server_format_list_response(
             dataLen: 0 as UINT32,
         };
 
-        let ret =
-            (**context).ServerFormatListResponse.unwrap()(&mut (**context), &format_list_response);
-
-        ret as u32
+        if let Some(f) = (**context).ServerFormatListResponse {
+            f(&mut (**context), &format_list_response)
+        } else {
+            ERR_CODE_SERVER_FUNCTION_NONE
+        }
     }
 }
 
@@ -335,9 +346,11 @@ pub fn server_format_data_request(
             dataLen: 0 as UINT32,
             requestedFormatId: requested_format_id as UINT32,
         };
-        let ret =
-            ((**context).ServerFormatDataRequest.unwrap())(&mut (**context), &format_data_request);
-        ret as u32
+        if let Some(f) = (**context).ServerFormatDataRequest {
+            f(&mut (**context), &format_data_request)
+        } else {
+            ERR_CODE_SERVER_FUNCTION_NONE
+        }
     }
 }
 
@@ -355,11 +368,11 @@ pub fn server_format_data_response(
             dataLen: format_data.len() as UINT32,
             requestedFormatData: format_data.as_mut_ptr(),
         };
-        let ret = ((**context).ServerFormatDataResponse.unwrap())(
-            &mut (**context),
-            &format_data_response,
-        );
-        ret as u32
+        if let Some(f) = (**context).ServerFormatDataResponse {
+            f(&mut (**context), &format_data_response)
+        } else {
+            ERR_CODE_SERVER_FUNCTION_NONE
+        }
     }
 }
 
@@ -390,11 +403,11 @@ pub fn server_file_contents_request(
             haveClipDataId: if have_clip_data_id { TRUE } else { FALSE },
             clipDataId: clip_data_id as UINT32,
         };
-        let ret = ((**context).ServerFileContentsRequest.unwrap())(
-            &mut (**context),
-            &file_contents_request,
-        );
-        ret as u32
+        if let Some(f) = (**context).ServerFileContentsRequest {
+            f(&mut (**context), &file_contents_request)
+        } else {
+            ERR_CODE_SERVER_FUNCTION_NONE
+        }
     }
 }
 
@@ -415,11 +428,11 @@ pub fn server_file_contents_response(
             cbRequested: requested_data.len() as UINT32,
             requestedData: requested_data.as_mut_ptr(),
         };
-        let ret = ((**context).ServerFileContentsResponse.unwrap())(
-            &mut (**context),
-            &file_contents_response,
-        );
-        ret as u32
+        if let Some(f) = (**context).ServerFileContentsResponse {
+            f(&mut (**context), &file_contents_response)
+        } else {
+            ERR_CODE_SERVER_FUNCTION_NONE
+        }
     }
 }
 

--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -75,6 +75,13 @@ impl ClipboardFile {
             _ => false,
         }
     }
+
+    pub fn is_stopping_allowed_from_peer(&self) -> bool {
+        match self {
+            ClipboardFile::MonitorReady | ClipboardFile::FormatList { .. } => true,
+            _ => false,
+        }
+    }
 }
 
 pub fn get_client_conn_id(session_uuid: &SessionID) -> Option<i32> {

--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -1446,7 +1446,7 @@ static UINT cliprdr_send_format_list(wfClipboard *clipboard, UINT32 connID)
 
 UINT wait_response_event(wfClipboard *clipboard, HANDLE event, void *data)
 {
-	UINT rc = ERROR_INTERNAL_ERROR;
+	UINT rc = ERROR_SUCCESS;
 	clipboard->context->IsStopped = FALSE;
 	// with default 3min timeout
 	for (int i = 0; i < 20 * 60 * 3; i++)
@@ -1460,6 +1460,7 @@ UINT wait_response_event(wfClipboard *clipboard, HANDLE event, void *data)
 		if (clipboard->context->IsStopped == TRUE)
 		{
 			wf_do_empty_cliprdr(clipboard);
+			rc = ERROR_INTERNAL_ERROR;
 		}
 
 		if (waitRes != WAIT_OBJECT_0)

--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -681,10 +681,6 @@ static HRESULT STDMETHODCALLTYPE CliprdrDataObject_GetData(IDataObject *This, FO
 	}
 
 	clipboard = (wfClipboard *)instance->m_pData;
-	if (!clipboard->context->CheckEnabled(instance->m_connID))
-	{
-		return E_INVALIDARG;
-	}
 
 	if (!clipboard)
 		return E_INVALIDARG;
@@ -1470,14 +1466,7 @@ static UINT cliprdr_send_data_request(UINT32 connID, wfClipboard *clipboard, UIN
 		DWORD waitRes = WaitForSingleObject(clipboard->response_data_event, 50);
 		if (waitRes == WAIT_TIMEOUT)
 		{
-			if (clipboard->context->CheckEnabled(connID))
-			{
-				continue;
-			}
-			else
-			{
-				break;
-			}
+			continue;
 		}
 
 		if (waitRes != WAIT_OBJECT_0)
@@ -1542,14 +1531,7 @@ UINT cliprdr_send_request_filecontents(wfClipboard *clipboard, UINT32 connID, co
 		DWORD waitRes = WaitForSingleObject(clipboard->req_fevent, 50);
 		if (waitRes == WAIT_TIMEOUT)
 		{
-			if (clipboard->context->CheckEnabled(connID))
-			{
-				continue;
-			}
-			else
-			{
-				break;
-			}
+			continue;
 		}
 
 		if (waitRes != WAIT_OBJECT_0)

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     fs,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    ops::{Deref, DerefMut},
     path::{Path, PathBuf},
     sync::{Arc, Mutex, RwLock},
     time::{Duration, Instant, SystemTime},
@@ -130,6 +131,18 @@ macro_rules! serde_field_bool {
         impl $struct_name {
             pub fn $func() -> bool {
                 UserDefaultConfig::read().get($field_name) == "Y"
+            }
+        }
+        impl Deref for $struct_name {
+            type Target = bool;
+
+            fn deref(&self) -> &Self::Target {
+                &self.v
+            }
+        }
+        impl DerefMut for $struct_name {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.v
             }
         }
     };

--- a/src/client.rs
+++ b/src/client.rs
@@ -2336,6 +2336,7 @@ pub enum Data {
     CancelJob(i32),
     RemovePortForward(i32),
     AddPortForward((i32, String, i32)),
+    #[cfg(not(feature = "flutter"))]
     ToggleClipboardFile,
     NewRDP,
     SetConfirmOverrideFile((i32, i32, bool, bool, bool)),

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -209,8 +209,8 @@ impl<T: InvokeUiSession> Remote<T> {
                                 Some(clip) => {
                                     let is_stopping_allowed = clip.is_stopping_allowed();
                                     let server_file_transfer_enabled = *self.handler.server_file_transfer_enabled.read().unwrap();
-                                    let enable_file_transfer = self.handler.lc.read().unwrap().enable_file_transfer.v;
-                                    let stop = is_stopping_allowed && !(server_file_transfer_enabled && enable_file_transfer);
+                                    let file_transfer_enabled = self.handler.lc.read().unwrap().enable_file_transfer.v;
+                                    let stop = is_stopping_allowed && !(server_file_transfer_enabled && file_transfer_enabled);
                                     log::debug!("Process clipboard message from system, stop: {}, is_stopping_allowed: {}, server_file_transfer_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, server_file_transfer_enabled, file_transfer_enabled);
                                     if !stop {
                                         allow_err!(peer.send(&crate::clipboard_file::clip_2_msg(clip)).await);

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1550,7 +1550,7 @@ impl<T: InvokeUiSession> Remote<T> {
         {
             let enabled = *self.handler.server_file_transfer_enabled.read().unwrap()
                 && self.handler.lc.read().unwrap().enable_file_transfer.v;
-            ContextSend::enable(enabled, false, false);
+            ContextSend::enable(enabled);
         }
     }
 

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -212,7 +212,9 @@ impl<T: InvokeUiSession> Remote<T> {
                                     let file_transfer_enabled = self.handler.lc.read().unwrap().enable_file_transfer.v;
                                     let stop = is_stopping_allowed && !(server_file_transfer_enabled && file_transfer_enabled);
                                     log::debug!("Process clipboard message from system, stop: {}, is_stopping_allowed: {}, server_file_transfer_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, server_file_transfer_enabled, file_transfer_enabled);
-                                    if !stop {
+                                    if stop {
+                                        ContextSend::set_is_stopped();
+                                    } else {
                                         allow_err!(peer.send(&crate::clipboard_file::clip_2_msg(clip)).await);
                                     }
                                 }

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -207,13 +207,12 @@ impl<T: InvokeUiSession> Remote<T> {
                             #[cfg(windows)]
                             match _msg {
                                 Some(clip) => {
-                                    let mut send_msg = true;
-                                    if clip.is_stopping_allowed() {
-                                        if !(*self.handler.server_file_transfer_enabled.read().unwrap() && self.handler.lc.read().unwrap().enable_file_transfer.v) {
-                                            send_msg = false;
-                                        }
-                                    }
-                                    if send_msg {
+                                    let is_stopping_allowed = clip.is_stopping_allowed();
+                                    let server_file_transfer_enabled = *self.handler.server_file_transfer_enabled.read().unwrap();
+                                    let enable_file_transfer = self.handler.lc.read().unwrap().enable_file_transfer.v;
+                                    let stop = is_stopping_allowed && !(server_file_transfer_enabled && enable_file_transfer);
+                                    log::debug!("Process clipboard message from system, stop: {}, is_stopping_allowed: {}, server_file_transfer_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, server_file_transfer_enabled, file_transfer_enabled);
+                                    if !stop {
                                         allow_err!(peer.send(&crate::clipboard_file::clip_2_msg(clip)).await);
                                     }
                                 }

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -6,7 +6,7 @@ use std::sync::{
 };
 
 #[cfg(windows)]
-use clipboard::{cliprdr::CliprdrClientContext, ClipboardFile, ContextSend};
+use clipboard::{cliprdr::CliprdrClientContext, empty_clipboard, ContextSend};
 use crossbeam_queue::ArrayQueue;
 use hbb_common::config::{PeerConfig, TransferSerde};
 use hbb_common::fs::{
@@ -270,6 +270,15 @@ impl<T: InvokeUiSession> Remote<T> {
         }
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         Client::try_stop_clipboard(&self.handler.session_id);
+
+        #[cfg(windows)]
+        {
+            let conn_id = self.client_conn_id;
+            ContextSend::proc(|context: &mut Box<CliprdrClientContext>| -> u32 {
+                empty_clipboard(context, conn_id);
+                0
+            });
+        }
     }
 
     fn handle_job_status(&mut self, id: i32, file_num: i32, err: Option<String>) {

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -123,7 +123,7 @@ pub fn core_main() -> Option<Vec<String>> {
     init_plugins(&args);
     if args.is_empty() {
         #[cfg(windows)]
-        clipboard::ContextSend::enable(true, false, false);
+        clipboard::ContextSend::enable(true);
         std::thread::spawn(move || crate::start_server(false));
     } else {
         #[cfg(windows)]

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -122,6 +122,8 @@ pub fn core_main() -> Option<Vec<String>> {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     init_plugins(&args);
     if args.is_empty() {
+        #[cfg(windows)]
+        clipboard::ContextSend::enable(true, false, false);
         std::thread::spawn(move || crate::start_server(false));
     } else {
         #[cfg(windows)]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -202,6 +202,7 @@ pub enum Data {
     SyncConfig(Option<Box<(Config, Config2)>>),
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     ClipboardFile(ClipboardFile),
+    ClipboardFileEnabled(bool),
     PrivacyModeState((i32, PrivacyModeState)),
     TestRendezvousServer,
     #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -202,7 +202,6 @@ pub enum Data {
     SyncConfig(Option<Box<(Config, Config2)>>),
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     ClipboardFile(ClipboardFile),
-    ClipboardFileEnabled(bool),
     PrivacyModeState((i32, PrivacyModeState)),
     TestRendezvousServer,
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -242,7 +241,7 @@ pub async fn start(postfix: &str) -> ResultType<()> {
                         loop {
                             match stream.next().await {
                                 Err(err) => {
-                                    log::trace!("ipc{} connection closed: {}", postfix, err);
+                                    log::trace!("ipc '{}' connection closed: {}", postfix, err);
                                     break;
                                 }
                                 Ok(Some(data)) => {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -438,7 +438,11 @@ impl Connection {
                         }
                         #[cfg(windows)]
                         ipc::Data::ClipboardFile(clip) => {
-                            if !clip.is_stopping_allowed() || conn.file_transfer_enabled() {
+                            let is_stopping_allowed = clip.is_stopping_allowed();
+                            let enable_file_transfer = conn.file_transfer_enabled();
+                            let stop = is_stopping_allowed && !enable_file_transfer;
+                            log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, file_transfer_enabled);
+                            if !stop {
                                 allow_err!(conn.stream.send(&clip_2_msg(clip)).await);
                             }
                         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -439,10 +439,9 @@ impl Connection {
                         #[cfg(windows)]
                         ipc::Data::ClipboardFile(clip) => {
                             let is_stopping_allowed = clip.is_stopping_allowed();
-                            let is_clipboard_enabled = clipboard::ContextSend::is_server_enabled();
                             let file_transfer_enabled = conn.file_transfer_enabled();
-                            let stop = is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled);
-                            log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, is_clipboard_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, is_clipboard_enabled, file_transfer_enabled);
+                            let stop = is_stopping_allowed && !file_transfer_enabled;
+                            log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, file_transfer_enabled);
                             if !stop {
                                 allow_err!(conn.stream.send(&clip_2_msg(clip)).await);
                             }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -439,8 +439,8 @@ impl Connection {
                         #[cfg(windows)]
                         ipc::Data::ClipboardFile(clip) => {
                             let is_stopping_allowed = clip.is_stopping_allowed();
-                            let enable_file_transfer = conn.file_transfer_enabled();
-                            let stop = is_stopping_allowed && !enable_file_transfer;
+                            let file_transfer_enabled = conn.file_transfer_enabled();
+                            let stop = is_stopping_allowed && !file_transfer_enabled;
                             log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, file_transfer_enabled);
                             if !stop {
                                 allow_err!(conn.stream.send(&clip_2_msg(clip)).await);

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -438,15 +438,7 @@ impl Connection {
                         }
                         #[cfg(windows)]
                         ipc::Data::ClipboardFile(clip) => {
-                            let is_stopping_allowed = clip.is_stopping_allowed();
-                            let file_transfer_enabled = conn.file_transfer_enabled();
-                            let stop = is_stopping_allowed && !file_transfer_enabled;
-                            log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, file_transfer_enabled);
-                            if stop {
-                                clipboard::ContextSend::set_is_stopped();
-                            } else {
-                                allow_err!(conn.stream.send(&clip_2_msg(clip)).await);
-                            }
+                            allow_err!(conn.stream.send(&clip_2_msg(clip)).await);
                         }
                         ipc::Data::PrivacyModeState((_, state)) => {
                             let msg_out = match state {
@@ -2078,6 +2070,9 @@ impl Connection {
         if let Ok(q) = o.enable_file_transfer.enum_value() {
             if q != BoolOption::NotSet {
                 self.enable_file_transfer = q == BoolOption::Yes;
+                self.send_to_cm(ipc::Data::ClipboardFileEnabled(
+                    self.file_transfer_enabled(),
+                ));
             }
         }
         if let Ok(q) = o.disable_clipboard.enum_value() {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -442,7 +442,9 @@ impl Connection {
                             let file_transfer_enabled = conn.file_transfer_enabled();
                             let stop = is_stopping_allowed && !file_transfer_enabled;
                             log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, file_transfer_enabled);
-                            if !stop {
+                            if stop {
+                                clipboard::ContextSend::set_is_stopped();
+                            } else {
                                 allow_err!(conn.stream.send(&clip_2_msg(clip)).await);
                             }
                         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -439,9 +439,10 @@ impl Connection {
                         #[cfg(windows)]
                         ipc::Data::ClipboardFile(clip) => {
                             let is_stopping_allowed = clip.is_stopping_allowed();
+                            let is_clipboard_enabled = clipboard::ContextSend::is_server_enabled();
                             let file_transfer_enabled = conn.file_transfer_enabled();
-                            let stop = is_stopping_allowed && !file_transfer_enabled;
-                            log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, file_transfer_enabled);
+                            let stop = is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled);
+                            log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, is_clipboard_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, is_clipboard_enabled, file_transfer_enabled);
                             if !stop {
                                 allow_err!(conn.stream.send(&clip_2_msg(clip)).await);
                             }
@@ -1639,7 +1640,8 @@ impl Connection {
                         update_clipboard(_cb, None);
                     }
                 }
-                Some(message::Union::Cliprdr(_clip)) => {
+                Some(message::Union::Cliprdr(_clip)) =>
+                {
                     #[cfg(windows)]
                     if let Some(clip) = msg_2_clip(_clip) {
                         self.send_to_cm(ipc::Data::ClipboardFile(clip))

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -16,7 +16,7 @@ use crate::ipc::Connection;
 #[cfg(not(any(target_os = "ios")))]
 use crate::ipc::{self, Data};
 #[cfg(windows)]
-use clipboard::{cliprdr::CliprdrClientContext, ContextSend};
+use clipboard::{cliprdr::CliprdrClientContext, empty_clipboard, ContextSend};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use hbb_common::tokio::sync::mpsc::unbounded_channel;
 #[cfg(windows)]
@@ -169,6 +169,14 @@ impl<T: InvokeUiCM> ConnectionManager<T> {
                 .unwrap()
                 .get_mut(&id)
                 .map(|c| c.disconnected = true);
+        }
+
+        #[cfg(windows)]
+        {
+            ContextSend::proc(|context: &mut Box<CliprdrClientContext>| -> u32 {
+                empty_clipboard(context, id);
+                0
+            });
         }
 
         #[cfg(any(target_os = "android"))]

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -406,7 +406,9 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                                         let file_transfer_enabled = self.file_transfer_enabled;
                                         let stop = !is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled);
                                         log::debug!("Process clipboard message from peer, stop: {}, is_stopping_allowed: {}, is_clipboard_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, is_clipboard_enabled, file_transfer_enabled);
-                                        if !stop {
+                                        if stop {
+                                            ContextSend::set_is_stopped();
+                                        } else {
                                             let conn_id = self.conn_id;
                                             ContextSend::proc(|context: &mut Box<CliprdrClientContext>| -> u32 {
                                                 clipboard::server_clip_file(context, conn_id, _clip)
@@ -461,7 +463,9 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                             let file_transfer_enabled = self.file_transfer_enabled;
                             let stop = is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled);
                             log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, is_clipboard_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, is_clipboard_enabled, file_transfer_enabled);
-                            if !stop {
+                            if stop {
+                                ContextSend::set_is_stopped();
+                            } else {
                                 allow_err!(self.tx.send(Data::ClipboardFile(_clip)));
                             }
                         }

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -419,6 +419,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                 }
                 Some(data) = self.rx.recv() => {
                     if let Data::SwitchPermission{name, enabled} = &data {
+                        #[cfg(windows)]
                         if name == "file" {
                             self.file_transfer_enabled = *enabled;
                         }

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -326,6 +326,17 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
             (_tx_clip, rx_clip) = unbounded_channel::<i32>();
         }
 
+        #[cfg(windows)]
+        {
+            if ContextSend::is_server_enabled() {
+                allow_err!(
+                    self.stream
+                        .send(&Data::ClipboardFile(clipboard::ClipboardFile::MonitorReady))
+                        .await
+                );
+            }
+        }
+
         self.running = false;
         loop {
             tokio::select! {

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -402,9 +402,10 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                                     #[cfg(windows)]
                                     {
                                         let is_stopping_allowed = _clip.is_stopping_allowed();
+                                        let is_clipboard_enabled = ContextSend::is_server_enabled();
                                         let file_transfer_enabled = self.file_transfer_enabled;
-                                        let stop = is_stopping_allowed && !file_transfer_enabled;
-                                        log::debug!("Process clipboard message from peer, stop: {}, is_stopping_allowed: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, file_transfer_enabled);
+                                        let stop = !is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled);
+                                        log::debug!("Process clipboard message from peer, stop: {}, is_stopping_allowed: {}, is_clipboard_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, is_clipboard_enabled, file_transfer_enabled);
                                         if !stop {
                                             let conn_id = self.conn_id;
                                             ContextSend::proc(|context: &mut Box<CliprdrClientContext>| -> u32 {
@@ -456,9 +457,10 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                         #[cfg(windows)]
                         {
                             let is_stopping_allowed = _clip.is_stopping_allowed();
+                            let is_clipboard_enabled = ContextSend::is_server_enabled();
                             let file_transfer_enabled = self.file_transfer_enabled;
-                            let stop = is_stopping_allowed && !file_transfer_enabled;
-                            log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, file_transfer_enabled);
+                            let stop = is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled);
+                            log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, is_clipboard_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, is_clipboard_enabled, file_transfer_enabled);
                             if !stop {
                                 allow_err!(self.tx.send(Data::ClipboardFile(_clip)));
                             }

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -336,7 +336,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
 
         #[cfg(windows)]
         {
-            if ContextSend::is_server_enabled() {
+            if ContextSend::is_cm_enabled() {
                 allow_err!(
                     self.stream
                         .send(&Data::ClipboardFile(clipboard::ClipboardFile::MonitorReady))
@@ -402,7 +402,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                                     #[cfg(windows)]
                                     {
                                         let is_stopping_allowed = _clip.is_stopping_allowed();
-                                        let is_clipboard_enabled = ContextSend::is_server_enabled();
+                                        let is_clipboard_enabled = ContextSend::is_cm_enabled();
                                         let file_transfer_enabled = self.file_transfer_enabled;
                                         let stop = !is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled);
                                         log::debug!("Process clipboard message from peer, stop: {}, is_stopping_allowed: {}, is_clipboard_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, is_clipboard_enabled, file_transfer_enabled);
@@ -457,7 +457,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                         #[cfg(windows)]
                         {
                             let is_stopping_allowed = _clip.is_stopping_allowed();
-                            let is_clipboard_enabled = ContextSend::is_server_enabled();
+                            let is_clipboard_enabled = ContextSend::is_cm_enabled();
                             let file_transfer_enabled = self.file_transfer_enabled;
                             let stop = is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled);
                             log::debug!("Process clipboard message from cm, stop: {}, is_stopping_allowed: {}, is_clipboard_enabled: {}, file_transfer_enabled: {}", stop, is_stopping_allowed, is_clipboard_enabled, file_transfer_enabled);

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -338,7 +338,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
 
         #[cfg(windows)]
         {
-            if ContextSend::is_cm_enabled() {
+            if ContextSend::is_enabled() {
                 allow_err!(
                     self.stream
                         .send(&Data::ClipboardFile(clipboard::ClipboardFile::MonitorReady))
@@ -404,7 +404,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                                     #[cfg(windows)]
                                     {
                                         let is_stopping_allowed = _clip.is_stopping_allowed_from_peer();
-                                        let is_clipboard_enabled = ContextSend::is_cm_enabled();
+                                        let is_clipboard_enabled = ContextSend::is_enabled();
                                         let file_transfer_enabled = self.file_transfer_enabled;
                                         let stop = !is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled);
                                         log::debug!(
@@ -469,7 +469,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                         #[cfg(windows)]
                         {
                             let is_stopping_allowed = _clip.is_stopping_allowed();
-                            let is_clipboard_enabled = ContextSend::is_cm_enabled();
+                            let is_clipboard_enabled = ContextSend::is_enabled();
                             let file_transfer_enabled = self.file_transfer_enabled;
                             let file_transfer_enabled_peer = self.file_transfer_enabled_peer;
                             let stop = is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled && file_transfer_enabled_peer);
@@ -537,11 +537,7 @@ pub async fn start_ipc<T: InvokeUiCM>(cm: ConnectionManager<T>) {
     });
 
     #[cfg(target_os = "windows")]
-    ContextSend::enable(
-        Config::get_option("enable-file-transfer").is_empty(),
-        true,
-        crate::is_server(),
-    );
+    ContextSend::enable(Config::get_option("enable-file-transfer").is_empty());
 
     match ipc::new_listener("_cm").await {
         Ok(mut incoming) => {

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -882,11 +882,7 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
                                 {
                                     let b = OPTIONS.lock().unwrap().get("enable-file-transfer").map(|x| x.to_string()).unwrap_or_default();
                                     if b != enable_file_transfer {
-                                        clipboard::ContextSend::enable(
-                                            b.is_empty(),
-                                            true,
-                                            crate::is_server(),
-                                        );
+                                        clipboard::ContextSend::enable(b.is_empty());
                                         enable_file_transfer = b;
                                     }
                                 }

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -857,6 +857,8 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
     let mut rx = rx;
     let mut mouse_time = 0;
     let mut id = "".to_owned();
+    let mut enable_file_transfer = "".to_owned();
+
     loop {
         if let Ok(mut c) = ipc::connect(1000, "").await {
             let mut timer = time::interval(time::Duration::from_secs(1));
@@ -875,6 +877,19 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
                             Ok(Some(ipc::Data::Options(Some(v)))) => {
                                 *OPTIONS.lock().unwrap() = v;
                                 *OPTION_SYNCED.lock().unwrap() = true;
+
+                                #[cfg(target_os="windows")]
+                                {
+                                    let b = OPTIONS.lock().unwrap().get("enable-file-transfer").map(|x| x.to_string()).unwrap_or_default();
+                                    if b != enable_file_transfer {
+                                        clipboard::ContextSend::enable(
+                                            b.is_empty(),
+                                            true,
+                                            crate::is_server(),
+                                        );
+                                        enable_file_transfer = b;
+                                    }
+                                }
                             }
                             Ok(Some(ipc::Data::Config((name, Some(value))))) => {
                                 if name == "id" {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -198,6 +198,7 @@ impl<T: InvokeUiSession> Session<T> {
 
     pub fn toggle_option(&mut self, name: String) {
         let msg = self.lc.write().unwrap().toggle_option(name.clone());
+        #[cfg(not(feature = "flutter"))]
         if name == "enable-file-transfer" {
             self.send(Data::ToggleClipboardFile);
         }


### PR DESCRIPTION
Refactor windows clipboard (file).

![image](https://github.com/rustdesk/rustdesk/assets/13586388/4031dce6-c705-4144-8100-01842cc2b4ee)

![image](https://github.com/rustdesk/rustdesk/assets/13586388/07c8f4b0-5b18-4750-9f9d-309e758cf276)

![image](https://github.com/rustdesk/rustdesk/assets/13586388/8bbd0b3b-0bfc-4f12-90a7-2a4d5669275f)

A small part of the logic is modified in the `C` code.
It is mainly to modify the control logic of the `Rust` code.

Current changes may break clipboard in sciter version.  I'll modify the code in sciter version based on this code.

1. When passing messages, if the clipboard message is `MonitorReady`, `FormatList`, or `FormatDataRequest`, the message should be blocked according to the configuration. Blocking the message should notify the clipboard to avoid waiting for the message until timeout.
2. When disconnecting, both the client and server will clear the clipboard. However, only the clipboard contents created in their own session will be cleared.
3. For the Flutter version, more accurate clipboard control is provided.


TODOs (I'll fix with another PR):
1. The following system error.  `A --> B`. If `A` copies `a.txt`, B want to copy and paste it's `a.txt` to `A`, or vice versa.
![1687220293075](https://github.com/rustdesk/rustdesk/assets/13586388/f3ee312f-94c4-482f-a176-7b9b04897686)

https://github.com/rustdesk/rustdesk/assets/13586388/d677a506-b3d1-44e1-9ac8-ba75212fcd8c

2. Sciter version.
3. Check again whether the related issues are still there.
4. Pass the file information of the clipboard to `Rust`.
