### PR TITLE
Delete 'version' key from .desktop file

### DIFF
--- a/res/rustdesk.desktop
+++ b/res/rustdesk.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Version=1.2.0
 Name=RustDesk
 GenericName=Remote Desktop
 Comment=Remote Desktop


### PR DESCRIPTION
Similar to https://github.com/rustdesk/rustdesk/pull/1255 and related to https://github.com/rustdesk/rustdesk/issues/1299, running `desktop-file-validate /usr/share/applications/rustdesk.desktop` on Ubuntu 22.04 returns the following:
```
/usr/share/applications/rustdesk.desktop: error: value "1.2.0" for key "Version" in group "Desktop Entry" is not a known version
```
* "Version" refers to the Freedesktop Specification[1], not the program's one. Given that this was removed from rustdesk-link.desktop, the same should be done here.
[1] https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html