### PR TITLE
better conditional compilation

### DIFF
--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -120,12 +120,11 @@ class ServerModel with ChangeNotifier {
     _serverId = IDTextEditingController(text: _emptyIdShow);
 
     timerCallback() async {
-      var status = await bind.mainGetOnlineStatue();
-      if (status > 0) {
-        status = 1;
-      }
-      if (status != _connectStatus) {
-        _connectStatus = status;
+      final connectionStatus =
+          jsonDecode(await bind.mainGetConnectStatus()) as Map<String, dynamic>;
+      final statusNum = connectionStatus['status_num'] as int;
+      if (statusNum != _connectStatus) {
+        _connectStatus = statusNum;
         notifyListeners();
       }
 

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -44,7 +44,7 @@ lazy_static::lazy_static! {
     static ref CONFIG: Arc<RwLock<Config>> = Arc::new(RwLock::new(Config::load()));
     static ref CONFIG2: Arc<RwLock<Config2>> = Arc::new(RwLock::new(Config2::load()));
     static ref LOCAL_CONFIG: Arc<RwLock<LocalConfig>> = Arc::new(RwLock::new(LocalConfig::load()));
-    pub static ref ONLINE: Arc<Mutex<HashMap<String, i64>>> = Default::default();
+    static ref ONLINE: Arc<Mutex<HashMap<String, i64>>> = Default::default();
     pub static ref PROD_RENDEZVOUS_SERVER: Arc<RwLock<String>> = Arc::new(RwLock::new(match option_env!("RENDEZVOUS_SERVER") {
         Some(key) if !key.is_empty() => key,
         _ => "",
@@ -307,6 +307,11 @@ pub struct TransferSerde {
     pub write_jobs: Vec<String>,
     #[serde(default, deserialize_with = "deserialize_vec_string")]
     pub read_jobs: Vec<String>,
+}
+
+#[inline]
+pub fn get_online_statue() -> i64 {
+    *ONLINE.lock().unwrap().values().max().unwrap_or(&0)
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/libs/scrap/examples/capture_mag.rs
+++ b/libs/scrap/examples/capture_mag.rs
@@ -1,20 +1,21 @@
 extern crate repng;
 extern crate scrap;
 
-use std::fs::File;
-
-use scrap::{i420_to_rgb, Display};
+use scrap::Display;
 #[cfg(windows)]
-use scrap::{CapturerMag, TraitCapturer};
+use scrap::{i420_to_rgb, CapturerMag, TraitCapturer};
+#[cfg(windows)]
+use std::fs::File;
 
 fn main() {
     let n = Display::all().unwrap().len();
-    for i in 0..n {
+    for _i in 0..n {
         #[cfg(windows)]
-        record(i);
+        record(_i);
     }
 }
 
+#[cfg(windows)]
 fn get_display(i: usize) -> Display {
     Display::all().unwrap().remove(i)
 }

--- a/libs/virtual_display/dylib/src/lib.rs
+++ b/libs/virtual_display/dylib/src/lib.rs
@@ -1,7 +1,8 @@
 #[cfg(windows)]
 pub mod win10;
-
-use hbb_common::{bail, lazy_static, ResultType};
+#[cfg(windows)]
+use hbb_common::lazy_static;
+use hbb_common::{bail, ResultType};
 use std::path::Path;
 
 #[cfg(windows)]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -186,6 +186,7 @@ pub enum Data {
     },
     SystemInfo(Option<String>),
     ClickTime(i64),
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     MouseMoveTime(i64),
     Authorize,
     Close,
@@ -332,6 +333,7 @@ async fn handle(data: Data, stream: &mut Connection) {
             let t = crate::server::CLICK_TIME.load(Ordering::SeqCst);
             allow_err!(stream.send(&Data::ClickTime(t)).await);
         }
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         Data::MouseMoveTime(_) => {
             let t = crate::server::MOUSE_MOVE_TIME.load(Ordering::SeqCst);
             allow_err!(stream.send(&Data::MouseMoveTime(t)).await);
@@ -345,13 +347,7 @@ async fn handle(data: Data, stream: &mut Connection) {
             }
         }
         Data::OnlineStatus(_) => {
-            let x = config::ONLINE
-                .lock()
-                .unwrap()
-                .values()
-                .max()
-                .unwrap_or(&0)
-                .clone();
+            let x = config::get_online_statue();
             let confirmed = Config::get_key_confirmed();
             allow_err!(stream.send(&Data::OnlineStatus(Some((x, confirmed)))).await);
         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -63,6 +63,7 @@ lazy_static::lazy_static! {
     static ref SWITCH_SIDES_UUID: Arc::<Mutex<HashMap<String, (Instant, uuid::Uuid)>>> = Default::default();
 }
 pub static CLICK_TIME: AtomicI64 = AtomicI64::new(0);
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub static MOUSE_MOVE_TIME: AtomicI64 = AtomicI64::new(0);
 
 #[cfg(all(feature = "flutter", feature = "plugin_framework"))]
@@ -163,6 +164,7 @@ pub struct Connection {
     // by peer
     disable_audio: bool,
     // by peer
+    #[cfg(windows)]
     enable_file_transfer: bool,
     // by peer
     audio_sender: Option<MediaSender>,
@@ -291,6 +293,7 @@ impl Connection {
             show_remote_cursor: false,
             ip: "".to_owned(),
             disable_audio: false,
+            #[cfg(windows)]
             enable_file_transfer: false,
             disable_clipboard: false,
             disable_keyboard: false,
@@ -1112,6 +1115,7 @@ impl Connection {
         self.audio && !self.disable_audio
     }
 
+    #[cfg(windows)]
     fn file_transfer_enabled(&self) -> bool {
         self.file && self.enable_file_transfer
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -362,9 +362,9 @@ impl UI {
     fn get_connect_status(&mut self) -> Value {
         let mut v = Value::array(0);
         let x = get_connect_status();
-        v.push(x.0);
-        v.push(x.1);
-        v.push(x.3);
+        v.push(x.status_num);
+        v.push(x.key_confirmed);
+        v.push(x.id);
         v
     }
 

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -454,10 +454,10 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                     }
                 }
                 Some(data) = self.rx.recv() => {
-                    if let Data::SwitchPermission{name, enabled} = &data {
+                    if let Data::SwitchPermission{name: _name, enabled: _enabled} = &data {
                         #[cfg(windows)]
-                        if name == "file" {
-                            self.file_transfer_enabled = *enabled;
+                        if _name == "file" {
+                            self.file_transfer_enabled = *_enabled;
                         }
                     }
                     if self.stream.send(&data).await.is_err() {


### PR DESCRIPTION
This PR is part of https://github.com/rustdesk/rustdesk/pull/4747.

1. Remove ffi method `main_get_online_statue`, use `main_get_connect_status` instead.
2. Refactor structure.
```rust
type Status = (i32, bool, i64, String); // (status_num, key_confirmed, mouse_time, id)
```
to
```rust
#[derive(Clone, Debug, Serialize)]
pub struct UiStatus {
    pub status_num: i32,
    #[cfg(not(feature = "flutter"))]
    pub key_confirmed: bool,
    #[cfg(not(any(target_os = "android", target_os = "ios")))]
    pub mouse_time: i64,
    #[cfg(not(feature = "flutter"))]
    pub id: String,
}
```
3. Remove some warns and better  conditional compilation.