### PR TITLE
fix, mobile, init server connection status

### DIFF
--- a/flutter/lib/mobile/pages/home_page.dart
+++ b/flutter/lib/mobile/pages/home_page.dart
@@ -98,7 +98,7 @@ class WebHomePage extends StatelessWidget {
       // backgroundColor: MyTheme.grayBg,
       appBar: AppBar(
         centerTitle: true,
-        title: Text("RustDesk" + (isWeb ? " (Beta) " : "")),
+        title: Text("RustDesk${isWeb ? " (Beta) " : ""}"),
         actions: connectionPage.appBarActions,
       ),
       body: connectionPage,

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -40,7 +40,6 @@ fn initialize(app_dir: &str) {
         );
         #[cfg(feature = "mediacodec")]
         scrap::mediacodec::check_mediacodec();
-        crate::common::test_rendezvous_server();
         crate::common::test_nat_type();
         crate::common::check_software_update();
     }


### PR DESCRIPTION
Remove  `test_rendezvous_server` call for mobile version.
Because mobile version do not start service on startup.