### PR TITLE
android add approve mode

### DIFF
--- a/flutter/lib/mobile/pages/server_page.dart
+++ b/flutter/lib/mobile/pages/server_page.dart
@@ -25,6 +25,18 @@ class ServerPage extends StatefulWidget implements PageShape {
     PopupMenuButton<String>(
         icon: const Icon(Icons.more_vert),
         itemBuilder: (context) {
+          listTile(String text, bool checked) {
+            return ListTile(
+                title: Text(translate(text)),
+                trailing: Icon(
+                  Icons.check,
+                  color: checked ? null : Colors.transparent,
+                ));
+          }
+
+          final approveMode = gFFI.serverModel.approveMode;
+          final verificationMethod = gFFI.serverModel.verificationMethod;
+          final showPasswordOption = approveMode != 'click';
           return [
             PopupMenuItem(
               enabled: gFFI.serverModel.connectStatus > 0,
@@ -32,62 +44,64 @@ class ServerPage extends StatefulWidget implements PageShape {
               value: "changeID",
               child: Text(translate("Change ID")),
             ),
-            PopupMenuItem(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              value: "setPermanentPassword",
-              enabled:
-                  gFFI.serverModel.verificationMethod != kUseTemporaryPassword,
-              child: Text(translate("Set permanent password")),
-            ),
-            PopupMenuItem(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              value: "setTemporaryPasswordLength",
-              enabled:
-                  gFFI.serverModel.verificationMethod != kUsePermanentPassword,
-              child: Text(translate("One-time password length")),
-            ),
             const PopupMenuDivider(),
             PopupMenuItem(
               padding: const EdgeInsets.symmetric(horizontal: 0.0),
-              value: kUseTemporaryPassword,
-              child: ListTile(
-                  title: Text(translate("Use one-time password")),
-                  trailing: Icon(
-                    Icons.check,
-                    color: gFFI.serverModel.verificationMethod ==
-                            kUseTemporaryPassword
-                        ? null
-                        : Colors.transparent,
-                  )),
+              value: 'AcceptSessionsViaPassword',
+              child: listTile(
+                  'Accept sessions via password', approveMode == 'password'),
             ),
             PopupMenuItem(
               padding: const EdgeInsets.symmetric(horizontal: 0.0),
-              value: kUsePermanentPassword,
-              child: ListTile(
-                  title: Text(translate("Use permanent password")),
-                  trailing: Icon(
-                    Icons.check,
-                    color: gFFI.serverModel.verificationMethod ==
-                            kUsePermanentPassword
-                        ? null
-                        : Colors.transparent,
-                  )),
+              value: 'AcceptSessionsViaClick',
+              child:
+                  listTile('Accept sessions via click', approveMode == 'click'),
             ),
             PopupMenuItem(
               padding: const EdgeInsets.symmetric(horizontal: 0.0),
-              value: kUseBothPasswords,
-              child: ListTile(
-                  title: Text(translate("Use both passwords")),
-                  trailing: Icon(
-                    Icons.check,
-                    color: gFFI.serverModel.verificationMethod !=
-                                kUseTemporaryPassword &&
-                            gFFI.serverModel.verificationMethod !=
-                                kUsePermanentPassword
-                        ? null
-                        : Colors.transparent,
-                  )),
+              value: "AcceptSessionsViaBoth",
+              child: listTile("Accept sessions via both",
+                  approveMode != 'password' && approveMode != 'click'),
             ),
+            if (showPasswordOption) const PopupMenuDivider(),
+            if (showPasswordOption &&
+                verificationMethod != kUseTemporaryPassword)
+              PopupMenuItem(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                value: "setPermanentPassword",
+                child: Text(translate("Set permanent password")),
+              ),
+            if (showPasswordOption &&
+                verificationMethod != kUsePermanentPassword)
+              PopupMenuItem(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                value: "setTemporaryPasswordLength",
+                child: Text(translate("One-time password length")),
+              ),
+            if (showPasswordOption) const PopupMenuDivider(),
+            if (showPasswordOption)
+              PopupMenuItem(
+                padding: const EdgeInsets.symmetric(horizontal: 0.0),
+                value: kUseTemporaryPassword,
+                child: listTile('Use one-time password',
+                    verificationMethod == kUseTemporaryPassword),
+              ),
+            if (showPasswordOption)
+              PopupMenuItem(
+                padding: const EdgeInsets.symmetric(horizontal: 0.0),
+                value: kUsePermanentPassword,
+                child: listTile('Use permanent password',
+                    verificationMethod == kUsePermanentPassword),
+              ),
+            if (showPasswordOption)
+              PopupMenuItem(
+                padding: const EdgeInsets.symmetric(horizontal: 0.0),
+                value: kUseBothPasswords,
+                child: listTile(
+                    'Use both passwords',
+                    verificationMethod != kUseTemporaryPassword &&
+                        verificationMethod != kUsePermanentPassword),
+              ),
           ];
         },
         onSelected: (value) {
@@ -102,6 +116,15 @@ class ServerPage extends StatefulWidget implements PageShape {
               value == kUseBothPasswords) {
             bind.mainSetOption(key: "verification-method", value: value);
             gFFI.serverModel.updatePasswordModel();
+          } else if (value.startsWith("AcceptSessionsVia")) {
+            value = value.substring("AcceptSessionsVia".length);
+            if (value == "Password") {
+              gFFI.serverModel.setApproveMode('password');
+            } else if (value == "Click") {
+              gFFI.serverModel.setApproveMode('click');
+            } else {
+              gFFI.serverModel.setApproveMode('');
+            }
           }
         })
   ];
@@ -434,12 +457,14 @@ class ConnectionManager extends StatelessWidget {
                                     serverModel.sendLoginResponse(
                                         client, false);
                                   }).marginOnly(right: 15),
-                              ElevatedButton.icon(
-                                  icon: const Icon(Icons.check),
-                                  label: Text(translate("Accept")),
-                                  onPressed: () {
-                                    serverModel.sendLoginResponse(client, true);
-                                  }),
+                              if (serverModel.approveMode != 'password')
+                                ElevatedButton.icon(
+                                    icon: const Icon(Icons.check),
+                                    label: Text(translate("Accept")),
+                                    onPressed: () {
+                                      serverModel.sendLoginResponse(
+                                          client, true);
+                                    }),
                             ]),
                 ])))
             .toList());

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -520,7 +520,8 @@ class ServerModel with ChangeNotifier {
         ),
         actions: [
           dialogButton("Dismiss", onPressed: cancel, isOutline: true),
-          dialogButton("Accept", onPressed: submit),
+          if (approveMode != 'password')
+            dialogButton("Accept", onPressed: submit),
         ],
         onSubmit: submit,
         onCancel: cancel,


### PR DESCRIPTION
1. add approve mode options in top right menu, hide others if "accept sessions via click"
![580ab3743fb61a7b713f71486c279ec](https://github.com/rustdesk/rustdesk/assets/14891774/f446b0b9-1f27-4c20-a77d-ef31436291ad)

2. when "accept sessions via click", behave same with desktop,  when "accept sessions via password", remove "accept" button in login dialog and connection manager.
![66ddb46e7ee1a2adda51bbb6ecd2062](https://github.com/rustdesk/rustdesk/assets/14891774/733f0ac5-d3fa-4e67-92b8-e78a95d62c3c)
![7c3284f4b0448d6cc31ffdd2e85e13f](https://github.com/rustdesk/rustdesk/assets/14891774/02758a75-6529-4b4f-b82e-aafe739bf2ed)

