### PR TITLE
Refact/touchpad scroll

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -51,6 +51,9 @@ class InputModel {
   var _fling = false;
   Timer? _flingTimer;
   final _flingBaseDelay = 30;
+  // trackpad, peer linux
+  final _trackpadSpeed = 0.06;
+  var _trackpadScrollUnsent = Offset.zero;
 
   // mouse
   final isPhysicalMouse = false.obs;
@@ -332,16 +335,24 @@ class InputModel {
   // https://docs.flutter.dev/release/breaking-changes/trackpad-gestures
   // TODO(support zoom in/out)
   void onPointerPanZoomUpdate(PointerPanZoomUpdateEvent e) {
-    final delta = e.panDelta;
+    var delta = e.panDelta;
     _trackpadLastDelta = delta;
+
     var x = delta.dx.toInt();
     var y = delta.dy.toInt();
-    if (x == 0 && y == 0) {
-      final thr = 0.1;
-      if (delta.dx.abs() > delta.dy.abs()) {
-        x = delta.dx > thr ? 1 : (delta.dx < -thr ? -1 : 0);
-      } else {
-        y = delta.dy > thr ? 1 : (delta.dy < -thr ? -1 : 0);
+    if (parent.target?.ffiModel.pi.platform == kPeerPlatformLinux) {
+      _trackpadScrollUnsent += (delta * _trackpadSpeed);
+      x = _trackpadScrollUnsent.dx.truncate();
+      y = _trackpadScrollUnsent.dy.truncate();
+      _trackpadScrollUnsent -= Offset(x.toDouble(), y.toDouble());
+    } else {
+      if (x == 0 && y == 0) {
+        final thr = 0.1;
+        if (delta.dx.abs() > delta.dy.abs()) {
+          x = delta.dx > thr ? 1 : (delta.dx < -thr ? -1 : 0);
+        } else {
+          y = delta.dy > thr ? 1 : (delta.dy < -thr ? -1 : 0);
+        }
       }
     }
     if (x != 0 || y != 0) {
@@ -370,6 +381,11 @@ class InputModel {
       // Try set delta (x,y) and delay.
       var dx = x.toInt();
       var dy = y.toInt();
+      if (parent.target?.ffiModel.pi.platform == kPeerPlatformLinux) {
+        dx = (x * _trackpadSpeed).toInt();
+        dy = (y * _trackpadSpeed).toInt();
+      }
+
       var delay = _flingBaseDelay;
 
       if (dx == 0 && dy == 0) {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -336,6 +336,14 @@ class InputModel {
     _trackpadLastDelta = delta;
     var x = delta.dx.toInt();
     var y = delta.dy.toInt();
+    if (x == 0 && y == 0) {
+      final thr = 0.1;
+      if (delta.dx.abs() > delta.dy.abs()) {
+        x = delta.dx > thr ? 1 : (delta.dx < -thr ? -1 : 0);
+      } else {
+        y = delta.dy > thr ? 1 : (delta.dy < -thr ? -1 : 0);
+      }
+    }
     if (x != 0 || y != 0) {
       bind.sessionSendMouse(
           sessionId: sessionId,

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -335,7 +335,7 @@ class InputModel {
   // https://docs.flutter.dev/release/breaking-changes/trackpad-gestures
   // TODO(support zoom in/out)
   void onPointerPanZoomUpdate(PointerPanZoomUpdateEvent e) {
-    var delta = e.panDelta;
+    final delta = e.panDelta;
     _trackpadLastDelta = delta;
 
     var x = delta.dx.toInt();


### PR DESCRIPTION
1. A slight swipe can also trigger a scroll event.
```rust
      if (x == 0 && y == 0) {
        final thr = 0.1;
        if (delta.dx.abs() > delta.dy.abs()) {
          x = delta.dx > thr ? 1 : (delta.dx < -thr ? -1 : 0);
        } else {
          y = delta.dy > thr ? 1 : (delta.dy < -thr ? -1 : 0);
        }
      }
```
2. If the controlled side is Linux, superimpose the scrolling value and reduce it by a certain factor.

