### PR TITLE
opt force_relay/relay_hint logic

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -350,7 +350,7 @@ class FfiModel with ChangeNotifier {
     } else if (type == 'elevation-error') {
       showElevationError(sessionId, type, title, text, dialogManager);
     } else if (type == 'relay-hint') {
-      showRelayHintDialog(sessionId, type, title, text, dialogManager);
+      showRelayHintDialog(sessionId, type, title, text, dialogManager, peerId);
     } else {
       var hasRetry = evt['hasRetry'] == 'true';
       showMsgBox(sessionId, type, title, text, link, hasRetry, dialogManager);
@@ -383,7 +383,7 @@ class FfiModel with ChangeNotifier {
   }
 
   void showRelayHintDialog(SessionID sessionId, String type, String title,
-      String text, OverlayDialogManager dialogManager) {
+      String text, OverlayDialogManager dialogManager, String peerId) {
     dialogManager.show(tag: '$sessionId-$type', (setState, close, context) {
       onClose() {
         closeConnection();
@@ -392,25 +392,24 @@ class FfiModel with ChangeNotifier {
 
       final style =
           ElevatedButton.styleFrom(backgroundColor: Colors.green[700]);
+      var hint = "\n\n${translate('relay_hint_tip')}";
+      if (text.contains("10054") || text.contains("104")) {
+        hint = "";
+      }
+      final alreadyForceAlwaysRelay = bind
+          .mainGetPeerOptionSync(id: peerId, key: 'force-always-relay')
+          .isNotEmpty;
       return CustomAlertDialog(
         title: null,
-        content: msgboxContent(type, title,
-            "${translate(text)}\n\n${translate('relay_hint_tip')}"),
+        content: msgboxContent(type, title, "${translate(text)}$hint"),
         actions: [
           dialogButton('Close', onPressed: onClose, isOutline: true),
           dialogButton('Retry',
               onPressed: () => reconnect(dialogManager, sessionId, false)),
-          dialogButton('Connect via relay',
-              onPressed: () => reconnect(dialogManager, sessionId, true),
-              buttonStyle: style),
-          dialogButton('Always connect via relay', onPressed: () {
-            const option = 'force-always-relay';
-            bind.sessionPeerOption(
-                sessionId: sessionId,
-                name: option,
-                value: bool2option(option, true));
-            reconnect(dialogManager, sessionId, true);
-          }, buttonStyle: style),
+          if (!alreadyForceAlwaysRelay)
+            dialogButton('Connect via relay',
+                onPressed: () => reconnect(dialogManager, sessionId, true),
+                buttonStyle: style),
         ],
         onCancel: onClose,
       );

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -44,7 +44,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("wait_accept_uac_tip", "Please wait for the remote user to accept the UAC dialog."),
         ("still_click_uac_tip", "Still requires the remote user to click OK on the UAC window of running RustDesk."),
         ("config_microphone", "In order to speak remotely, you need to grant RustDesk \"Record Audio\" permissions."),
-        ("relay_hint_tip", "It may not be possible to connect directly, you can try to connect via relay. \nIn addition, if you want to use relay on your first try, you can add the \"/r\" suffix to the ID, or select the option \"Always connect via relay\" in the peer card."),
+        ("relay_hint_tip", "It may not be possible to connect directly; you can try connecting via relay. Additionally, if you want to use a relay on your first attempt, you can add the \"/r\" suffix to the ID or select the option \"Always connect via relay\" in the card of recent sessions."),
         ("No transfers in progress", ""),
         ("idd_driver_tip", "Install virtual display driver which is used when you have no physical displays."),
         ("confirm_idd_driver_tip", "The option to install the virtual display driver is checked. Note that a test certificate will be installed to trust the virtual display driver. This test certificate will only be used to trust Rustdesk drivers."),

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -81,7 +81,7 @@ pub async fn listen(
                        });
                     }
                     Err(err) => {
-                        interface.msgbox("error", "Error", &err.to_string(), "");
+                        interface.on_establish_connection_error(err.to_string());
                     }
                     _ => {}
                 }
@@ -113,43 +113,6 @@ async fn connect_and_login(
     token: &str,
     is_rdp: bool,
 ) -> ResultType<Option<Stream>> {
-    let mut res = connect_and_login_2(
-        id,
-        password,
-        ui_receiver,
-        interface.clone(),
-        forward,
-        key,
-        token,
-        is_rdp,
-    )
-    .await;
-    if res.is_err() && interface.is_force_relay() {
-        res = connect_and_login_2(
-            id,
-            password,
-            ui_receiver,
-            interface,
-            forward,
-            key,
-            token,
-            is_rdp,
-        )
-        .await;
-    }
-    res
-}
-
-async fn connect_and_login_2(
-    id: &str,
-    password: &str,
-    ui_receiver: &mut mpsc::UnboundedReceiver<Data>,
-    interface: impl Interface,
-    forward: &mut Framed<TcpStream, BytesCodec>,
-    key: &str,
-    token: &str,
-    is_rdp: bool,
-) -> ResultType<Option<Stream>> {
     let conn_type = if is_rdp {
         ConnType::RDP
     } else {
@@ -157,6 +120,7 @@ async fn connect_and_login_2(
     };
     let (mut stream, direct, _pk) =
         Client::start(id, key, token, conn_type, interface.clone()).await?;
+    interface.update_direct(Some(direct));
     let mut interface = interface;
     let mut buffer = Vec::new();
     let mut received = false;
@@ -167,7 +131,10 @@ async fn connect_and_login_2(
                     bail!("Timeout");
                 }
                 Ok(Some(Ok(bytes))) => {
-                    received = true;
+                    if !received {
+                        received = true;
+                        interface.update_received(true);
+                    }
                     let msg_in = Message::parse_from_bytes(&bytes)?;
                     match msg_in.union {
                         Some(message::Union::Hash(hash)) => {
@@ -191,8 +158,6 @@ async fn connect_and_login_2(
                     }
                 }
                 Ok(Some(Err(err))) => {
-                    log::error!("Connection closed: {}", err);
-                    interface.set_force_relay(direct, received, err.to_string());
                     bail!("Connection closed: {}", err);
                 }
                 _ => {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -146,12 +146,6 @@ impl<T: InvokeUiSession> Session<T> {
         self.lc.read().unwrap().conn_type.eq(&ConnType::RDP)
     }
 
-    pub fn set_connection_info(&mut self, direct: bool, received: bool) {
-        let mut lc = self.lc.write().unwrap();
-        lc.direct = Some(direct);
-        lc.received = received;
-    }
-
     pub fn get_view_style(&self) -> String {
         self.lc.read().unwrap().view_style.clone()
     }
@@ -941,38 +935,6 @@ impl<T: InvokeUiSession> Session<T> {
     pub fn close_voice_call(&self) {
         self.send(Data::CloseVoiceCall);
     }
-
-    pub fn show_relay_hint(
-        &mut self,
-        last_recv_time: tokio::time::Instant,
-        msgtype: &str,
-        title: &str,
-        text: &str,
-    ) -> bool {
-        let duration = Duration::from_secs(3);
-        let counter_interval = 3;
-        let lock = self.lc.read().unwrap();
-        let success_time = lock.success_time;
-        let direct = lock.direct.unwrap_or(false);
-        let received = lock.received;
-        drop(lock);
-        if let Some(success_time) = success_time {
-            if direct && last_recv_time.duration_since(success_time) < duration {
-                let retry_for_relay = direct && !received;
-                let retry = check_if_retry(msgtype, title, text, retry_for_relay);
-                if retry && !retry_for_relay {
-                    self.lc.write().unwrap().direct_error_counter += 1;
-                    if self.lc.read().unwrap().direct_error_counter % counter_interval == 0 {
-                        #[cfg(feature = "flutter")]
-                        return true;
-                    }
-                }
-            } else {
-                self.lc.write().unwrap().direct_error_counter = 0;
-            }
-        }
-        false
-    }
 }
 
 pub trait InvokeUiSession: Send + Sync + Clone + 'static + Sized + Default {
@@ -1060,9 +1022,9 @@ impl<T: InvokeUiSession> Interface for Session<T> {
     }
 
     fn msgbox(&self, msgtype: &str, title: &str, text: &str, link: &str) {
-        let direct = self.lc.read().unwrap().direct.unwrap_or_default();
+        let direct = self.lc.read().unwrap().direct;
         let received = self.lc.read().unwrap().received;
-        let retry_for_relay = direct && !received;
+        let retry_for_relay = direct == Some(true) && !received;
         let retry = check_if_retry(msgtype, title, text, retry_for_relay);
         self.ui_handler.msgbox(msgtype, title, text, link, retry);
     }
@@ -1119,7 +1081,6 @@ impl<T: InvokeUiSession> Interface for Session<T> {
                 "Connected, waiting for image...",
                 "",
             );
-            self.lc.write().unwrap().success_time = Some(tokio::time::Instant::now());
         }
         self.on_connected(self.lc.read().unwrap().conn_type);
         #[cfg(windows)]


### PR DESCRIPTION
#1127 #1113
1. put the logic into one function
2. the relay prompt is easier to trigger, 
3. Includes error handling in Client::start
4. ~save direct failure timestamp to PeerConfig options, and show relay hint if  fail 2 times in 3 minutes~

There are some errors such as Timeout does not use this function, because the connection is considered to have been established.
It has not been tested many times, and some conditions may need adjust,  but I think the logic is relatively clear.
