### PR TITLE
fix encrypt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,9 +3598,10 @@ dependencies = [
 [[package]]
 name = "machine-uid"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26141aceb9f046065617266f41a4a652e4583da643472a10a89b4b3664d99eb6"
+source = "git+https://github.com/21pages/machine-uid#381ff579c1dc3a6c54db9dfec47c44bcb0246542"
 dependencies = [
+ "bindgen 0.59.2",
+ "cc",
  "winreg 0.11.0",
 ]
 
@@ -5191,7 +5192,6 @@ dependencies = [
  "libpulse-binding",
  "libpulse-simple-binding",
  "mac_address",
- "machine-uid",
  "magnum-opus",
  "mouce",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ cpal = "0.15"
 ringbuf = "0.3"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
-machine-uid = "0.3"
 mac_address = "1.1"
 sciter-rs = { git = "https://github.com/open-trade/rust-sciter", branch = "dyn" }
 sys-locale = "0.3"

--- a/libs/hbb_common/Cargo.toml
+++ b/libs/hbb_common/Cargo.toml
@@ -40,7 +40,7 @@ uuid = { version = "1.3", features = ["v4"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 mac_address = "1.1"
-machine-uid = "0.3"
+machine-uid = { git = "https://github.com/21pages/machine-uid" }
 sysinfo = "0.29"
 
 [features]

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1031,12 +1031,8 @@ impl PeerConfig {
                         };
 
                         let c = PeerConfig::load(&id_decoded_string);
-                        if c.info.platform.is_empty() {
-                            fs::remove_file(p).ok();
-                        }
                         (id_decoded_string, t, c)
                     })
-                    .filter(|p| !p.2.info.platform.is_empty())
                     .collect();
                 peers.sort_unstable_by(|a, b| b.1.cmp(&a.1));
                 return peers;

--- a/libs/hbb_common/src/lib.rs
+++ b/libs/hbb_common/src/lib.rs
@@ -45,6 +45,8 @@ pub mod keyboard;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use dlopen;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub use machine_uid;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use sysinfo;
 pub use toml;
 pub use uuid;

--- a/libs/hbb_common/src/password_security.rs
+++ b/libs/hbb_common/src/password_security.rs
@@ -149,7 +149,7 @@ pub fn decrypt_vec_or_original(v: &[u8], current_version: &str) -> (Vec<u8>, boo
 }
 
 fn encrypt(v: &[u8]) -> Result<String, ()> {
-    if !v.is_empty() {
+    if !v.is_empty() && v.len() <= 128 {
         symmetric_crypt(v, true).map(|v| base64::encode(v, base64::Variant::Original))
     } else {
         Err(())

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -552,7 +552,7 @@ impl UI {
     }
 
     fn is_ok_change_id(&self) -> bool {
-        machine_uid::get().is_ok()
+        hbb_common::machine_uid::get().is_ok()
     }
 
     fn get_async_job_status(&self) -> String {

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -1037,7 +1037,12 @@ pub async fn change_id_shared_(id: String, old_id: String) -> &'static str {
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    let uuid = Bytes::from(machine_uid::get().unwrap_or("".to_owned()).as_bytes().to_vec());
+    let uuid = Bytes::from(
+        hbb_common::machine_uid::get()
+            .unwrap_or("".to_owned())
+            .as_bytes()
+            .to_vec(),
+    );
     #[cfg(any(target_os = "android", target_os = "ios"))]
     let uuid = Bytes::from(hbb_common::get_uuid());
 


### PR DESCRIPTION
1. remove peers platform filter
2. set the maximum encrypted input length to 128 bytes, because the length of the sha256 hash result is 256 bits, and the length of other string passwords is generally not greater than 128 bytes.
3. update machine-uid, let x86 sciter program can read x64's machine id, so they can share the encrypted data.  https://github.com/Hanaasagi/machine-uid/pull/4