### PR TITLE
fix: bump winget releaser version & add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pub"
+    directory: "/flutter"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -4,9 +4,9 @@ on:
     types: [released]
 jobs:
   publish:
-    runs-on: windows-latest # action can only be run on windows
+    runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v1
+      - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: RustDesk.RustDesk
           version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
The Winget Releaser action failed (https://github.com/rustdesk/rustdesk/actions/runs/5446780380) for two reasons:
- The action was outdated (`v1`)
- The Windows builds weren't available when the release was made (https://github.com/rustdesk/rustdesk/releases/download/1.2.0/rustdesk-1.2.0-x86_64.exe and https://github.com/rustdesk/rustdesk/releases/download/1.2.0/rustdesk-1.2.0-x86-sciter.exe were added later)

This PR fixes the first issue by updating Winget Releaser to `v2` and adding Dependabot to ensure dependencies are up-to-date. For the second issue, you must **ensure that the Windows builds are available on release**.

For the meanwhile, I have manually created a PR for 1.2.0: https://github.com/microsoft/winget-pkgs/pull/111231