### PR TITLE
opt remote chat page

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2140,3 +2140,20 @@ Widget buildRemoteBlock({required Widget child, WhetherUseRemoteBlock? use}) {
         ]),
       ));
 }
+
+Widget unreadMessageCountBuilder(RxInt? count) {
+  return Obx(() => Offstage(
+      offstage: !((count?.value ?? 0) > 0),
+      child: Container(
+        width: 16,
+        height: 16,
+        decoration: BoxDecoration(
+          color: Colors.red,
+          shape: BoxShape.circle,
+        ),
+        child: Center(
+          child: Text("${count?.value ?? 0}",
+              maxLines: 1, style: TextStyle(color: Colors.white, fontSize: 10)),
+        ),
+      ).marginOnly(left: 4)));
+}

--- a/flutter/lib/common/shared_state.dart
+++ b/flutter/lib/common/shared_state.dart
@@ -285,6 +285,29 @@ class PeerStringOption {
       Get.find<RxString>(tag: tag(id, opt));
 }
 
+class UnreadChatCountState {
+  static String tag(id) => 'unread_chat_count_$id';
+
+  static void init(String id) {
+    final key = tag(id);
+    if (!Get.isRegistered(tag: key)) {
+      final RxInt state = RxInt(0);
+      Get.put(state, tag: key);
+    } else {
+      Get.find<RxInt>(tag: key).value = 0;
+    }
+  }
+
+  static void delete(String id) {
+    final key = tag(id);
+    if (Get.isRegistered(tag: key)) {
+      Get.delete(tag: key);
+    }
+  }
+
+  static RxInt find(String id) => Get.find<RxInt>(tag: tag(id));
+}
+
 initSharedStates(String id) {
   PrivacyModeState.init(id);
   BlockInputState.init(id);
@@ -294,6 +317,7 @@ initSharedStates(String id) {
   RemoteCursorMovedState.init(id);
   FingerprintState.init(id);
   PeerBoolOption.init(id, 'zoom-cursor', () => false);
+  UnreadChatCountState.init(id);
 }
 
 removeSharedStates(String id) {
@@ -305,4 +329,5 @@ removeSharedStates(String id) {
   RemoteCursorMovedState.delete(id);
   FingerprintState.delete(id);
   PeerBoolOption.delete(id, 'zoom-cursor');
+  UnreadChatCountState.delete(id);
 }

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -56,15 +56,14 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
     if (peerId != null) {
       ConnectionTypeState.init(peerId);
       tabController.onSelected = (id) {
-        final remotePage = tabController.state.value.tabs
-            .firstWhereOrNull((tab) => tab.key == id)
-            ?.page;
+        final remotePage = tabController.widget(id);
         if (remotePage is RemotePage) {
           final ffi = remotePage.ffi;
           bind.setCurSessionId(sessionId: ffi.sessionId);
         }
         WindowController.fromWindowId(windowId())
             .setTitle(getWindowNameWithId(id));
+        UnreadChatCountState.find(id).value = 0;
       };
       tabController.add(TabInfo(
         key: peerId,
@@ -206,6 +205,7 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
                       ).paddingOnly(right: 5),
                     ),
                     label,
+                    unreadMessageCountBuilder(UnreadChatCountState.find(key)),
                   ],
                 );
 

--- a/flutter/lib/desktop/pages/server_page.dart
+++ b/flutter/lib/desktop/pages/server_page.dart
@@ -158,24 +158,7 @@ class ConnectionManagerState extends State<ConnectionManager> {
                         message: key,
                         waitDuration: Duration(seconds: 1),
                         child: label),
-                    Obx(() => Offstage(
-                        offstage:
-                            !((client?.unreadChatMessageCount.value ?? 0) > 0),
-                        child: Container(
-                          width: 16,
-                          height: 16,
-                          decoration: BoxDecoration(
-                            color: Colors.red,
-                            shape: BoxShape.circle,
-                          ),
-                          child: Center(
-                            child: Text(
-                                "${client?.unreadChatMessageCount.value ?? 0}",
-                                maxLines: 1,
-                                style: TextStyle(
-                                    color: Colors.white, fontSize: 10)),
-                          ),
-                        ).marginOnly(left: 4)))
+                    unreadMessageCountBuilder(client?.unreadChatMessageCount),
                   ],
                 );
               },

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -187,6 +187,10 @@ class DesktopTabController {
     state.value.tabs.clear();
     state.refresh();
   }
+
+  Widget? widget(String key) {
+    return state.value.tabs.firstWhereOrNull((tab) => tab.key == key)?.page;
+  }
 }
 
 class TabThemeConf {

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -319,7 +319,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "30518303e28702bf6b8110465293c05d21bc4cd2"
+      resolved-ref: aee670819f5fe7e8b0f05e0239dafb5c62f7a84b
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"


### PR DESCRIPTION
If the remote page is minimized: bring it to the top and switch to the current tab.
if not minimized and not current tab, add the unread message count. 
The case that the remote page is behind another window is not handled.
Test on windows/linux.
![bd1ee495bd8153ea7b8da804d60fa16](https://github.com/rustdesk/rustdesk/assets/14891774/0760a619-3414-48cf-92c1-125800bc5e25)
