### PR TITLE
flutter: file transfer/port forward/rdp command line support

### DIFF
--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -52,10 +52,12 @@ class FileManagerPage extends StatefulWidget {
   const FileManagerPage(
       {Key? key,
       required this.id,
+      required this.password,
       required this.tabController,
       this.forceRelay})
       : super(key: key);
   final String id;
+  final String? password;
   final bool? forceRelay;
   final DesktopTabController tabController;
 
@@ -79,7 +81,10 @@ class _FileManagerPageState extends State<FileManagerPage>
   void initState() {
     super.initState();
     _ffi = FFI();
-    _ffi.start(widget.id, isFileTransfer: true, forceRelay: widget.forceRelay);
+    _ffi.start(widget.id,
+        isFileTransfer: true,
+        password: widget.password,
+        forceRelay: widget.forceRelay);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _ffi.dialogManager
           .showLoading(translate('Connecting...'), onCancel: closeConnection);

--- a/flutter/lib/desktop/pages/file_manager_tab_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_tab_page.dart
@@ -44,6 +44,7 @@ class _FileManagerTabPageState extends State<FileManagerTabPage> {
         page: FileManagerPage(
           key: ValueKey(params['id']),
           id: params['id'],
+          password: params['password'],
           tabController: tabController,
           forceRelay: params['forceRelay'],
         )));
@@ -72,6 +73,7 @@ class _FileManagerTabPageState extends State<FileManagerTabPage> {
             page: FileManagerPage(
               key: ValueKey(id),
               id: id,
+              password: args['password'],
               tabController: tabController,
               forceRelay: args['forceRelay'],
             )));

--- a/flutter/lib/desktop/pages/port_forward_page.dart
+++ b/flutter/lib/desktop/pages/port_forward_page.dart
@@ -28,11 +28,13 @@ class PortForwardPage extends StatefulWidget {
   const PortForwardPage(
       {Key? key,
       required this.id,
+      required this.password,
       required this.tabController,
       required this.isRDP,
       this.forceRelay})
       : super(key: key);
   final String id;
+  final String password;
   final DesktopTabController tabController;
   final bool isRDP;
   final bool? forceRelay;
@@ -55,6 +57,7 @@ class _PortForwardPageState extends State<PortForwardPage>
     _ffi = FFI();
     _ffi.start(widget.id,
         isPortForward: true,
+        password: widget.password,
         forceRelay: widget.forceRelay,
         isRdp: widget.isRDP);
     Get.put(_ffi, tag: 'pf_${widget.id}');

--- a/flutter/lib/desktop/pages/port_forward_tab_page.dart
+++ b/flutter/lib/desktop/pages/port_forward_tab_page.dart
@@ -43,6 +43,7 @@ class _PortForwardTabPageState extends State<PortForwardTabPage> {
         page: PortForwardPage(
           key: ValueKey(params['id']),
           id: params['id'],
+          password: params['password'],
           tabController: tabController,
           isRDP: isRDP,
           forceRelay: params['forceRelay'],
@@ -77,6 +78,7 @@ class _PortForwardTabPageState extends State<PortForwardTabPage> {
             page: PortForwardPage(
               key: ValueKey(args['id']),
               id: id,
+              password: args['password'],
               isRDP: isRDP,
               tabController: tabController,
               forceRelay: args['forceRelay'],

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -134,7 +134,7 @@ void runMainApp(bool startService) async {
     // Check the startup argument, if we successfully handle the argument, we keep the main window hidden.
     final handledByUniLinks = await initUniLinks();
     debugPrint("handled by uni links: $handledByUniLinks");
-    if (handledByUniLinks || checkArguments()) {
+    if (handledByUniLinks || handleUriLink(cmdArgs: kBootArgs)) {
       windowManager.hide();
     } else {
       windowManager.show();

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -248,7 +248,7 @@ class FfiModel with ChangeNotifier {
 
   onUrlSchemeReceived(Map<String, dynamic> evt) {
     final url = evt['url'].toString().trim();
-    if (url.startsWith(kUniLinksPrefix) && parseRustdeskUri(url)) {
+    if (url.startsWith(kUniLinksPrefix) && handleUriLink(uriString: url)) {
       return;
     }
     switch (url) {

--- a/flutter/lib/utils/multi_window_manager.dart
+++ b/flutter/lib/utils/multi_window_manager.dart
@@ -84,10 +84,12 @@ class RustDeskMultiWindowManager {
     }
   }
 
-  Future<dynamic> newFileTransfer(String remoteId, {bool? forceRelay}) async {
+  Future<dynamic> newFileTransfer(String remoteId,
+      {String? password, bool? forceRelay}) async {
     var msg = jsonEncode({
       "type": WindowType.FileTransfer.index,
       "id": remoteId,
+      "password": password,
       "forceRelay": forceRelay,
     });
 
@@ -117,11 +119,12 @@ class RustDeskMultiWindowManager {
   }
 
   Future<dynamic> newPortForward(String remoteId, bool isRDP,
-      {bool? forceRelay}) async {
+      {String? password, bool? forceRelay}) async {
     final msg = jsonEncode({
       "type": WindowType.PortForward.index,
       "id": remoteId,
       "isRDP": isRDP,
+      "password": password,
       "forceRelay": forceRelay,
     });
 


### PR DESCRIPTION
#4890
1. flutter add file-transfer/port forward/rdp command line/uri link support
2. put uri link handling to one function.

Tested on windows/linux
cmd: 
**rustdesk --connect \<id\> [--password \<password\>] [--relay]**
**rustdesk \<uri link\>**
uni link:
**rustdesk://connection/new/\<id\>?password=\<password\>&relay=true**
**rustdesk://connect/\<id\>?password=\<password\>&relay=true**

`connect` can be replaced by `file-transfer`/`port-forward`/`rdp`
