### PR TITLE
rustdesk-v.1.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rustdesk"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["rustdesk <info@rustdesk.com>"]
-edition = "2021"
+edition = "2023"
 build= "build.rs"
 description = "A remote control software."
 default-run = "rustdesk"


### PR DESCRIPTION
Modifications in Cargo.toml:
version = 1.2.1 
edition = 2023

Reason:
version 1.2.0 already released 4 days ago