### PR TITLE
Fix chat

### DIFF
--- a/flutter/lib/desktop/pages/server_page.dart
+++ b/flutter/lib/desktop/pages/server_page.dart
@@ -104,6 +104,12 @@ class ConnectionManagerState extends State<ConnectionManager> {
         final client =
             gFFI.serverModel.clients.firstWhereOrNull((e) => e.id == client_id);
         if (client != null) {
+          if (client.unreadChatMessageCount.value > 0) {
+            Future.delayed(Duration.zero, () {
+              client.unreadChatMessageCount.value = 0;
+              gFFI.chatModel.showChatPage(client.id);
+            });
+          }
           windowManager.setTitle(getWindowNameWithId(client.peerId));
         }
       }
@@ -168,7 +174,13 @@ class ConnectionManagerState extends State<ConnectionManager> {
                     builder: (_, model, child) => model.isShowCMChatPage
                         ? Expanded(
                             child: buildRemoteBlock(
-                              child: ChatPage(),
+                              child: Container(
+                                  decoration: BoxDecoration(
+                                      border: Border(
+                                          right: BorderSide(
+                                              color: Theme.of(context)
+                                                  .dividerColor))),
+                                  child: ChatPage()),
                             ),
                             flex: (kConnectionManagerWindowSizeOpenChat.width -
                                     kConnectionManagerWindowSizeClosedChat

--- a/flutter/lib/models/chat_model.dart
+++ b/flutter/lib/models/chat_model.dart
@@ -234,13 +234,21 @@ class ChatModel with ChangeNotifier {
   }
 
   showChatPage(int id) async {
-    if (isConnManager) {
-      if (!_isShowCMChatPage) {
-        await toggleCMChatPage(id);
+    if (isDesktop) {
+      if (isConnManager) {
+        if (!_isShowCMChatPage) {
+          await toggleCMChatPage(id);
+        }
+      } else {
+        if (_isChatOverlayHide()) {
+          await toggleChatOverlay();
+        }
       }
     } else {
-      if (_isChatOverlayHide()) {
-        await toggleChatOverlay();
+      if (id == clientModeID) {
+        if (_isChatOverlayHide()) {
+          await toggleChatOverlay();
+        }
       }
     }
   }

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -462,13 +462,7 @@ class ServerModel with ChangeNotifier {
         key: client.id.toString(),
         label: client.name,
         closable: false,
-        onTap: () {
-          if (client.unreadChatMessageCount.value > 0) {
-            client.unreadChatMessageCount.value = 0;
-            final chatModel = parent.target!.chatModel;
-            chatModel.showChatPage(client.id);
-          }
-        },
+        onTap: () {},
         page: desktop.buildConnectionCard(client)));
     Future.delayed(Duration.zero, () async {
       if (!hideCm) window_on_top(null);


### PR DESCRIPTION
1. Fix the problem that cm unread messages are still displayed after label switching.
2. Add a vertical divider between the desktop cm permission page and the chat page
3. Fix the mobile display chat overlay outside the remote page

![1688805299708](https://github.com/rustdesk/rustdesk/assets/14891774/edd802ed-546d-44a1-b513-36507327549e)
