### PR TITLE
Fix/win privacy broker

### DIFF
--- a/flutter/lib/desktop/pages/server_page.dart
+++ b/flutter/lib/desktop/pages/server_page.dart
@@ -40,6 +40,7 @@ class _DesktopServerPageState extends State<DesktopServerPage>
 
   @override
   void dispose() {
+    bind.cmClear();
     windowManager.removeListener(this);
     super.dispose();
   }

--- a/flutter/lib/desktop/pages/server_page.dart
+++ b/flutter/lib/desktop/pages/server_page.dart
@@ -40,7 +40,6 @@ class _DesktopServerPageState extends State<DesktopServerPage>
 
   @override
   void dispose() {
-    bind.cmClear();
     windowManager.removeListener(this);
     super.dispose();
   }

--- a/flutter/lib/models/native_model.dart
+++ b/flutter/lib/models/native_model.dart
@@ -233,7 +233,7 @@ class PlatformFFI {
             '_appType:$_appType,info1-id:$id,info2-name:$name,dir:$_dir');
       }
       if (desktopType == DesktopType.cm) {
-        await _ffiBind.cmStartListenIpcThread();
+        await _ffiBind.cmInit();
       }
       await _ffiBind.mainDeviceId(id: id);
       await _ffiBind.mainDeviceName(name: name);

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -931,23 +931,10 @@ pub mod connection_manager {
         }
     }
 
-    extern "C" fn cm_clear_hook() {
-        #[cfg(target_os = "windows")]
-        crate::privacy_win_mag::stop();
-    }
-
     #[inline]
     pub fn cm_init() {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         start_listen_ipc_thread();
-        #[cfg(target_os = "windows")]
-        shutdown_hooks::add_shutdown_hook(cm_clear_hook);
-    }
-
-    #[inline]
-    pub fn cm_clear() {
-        #[cfg(target_os = "windows")]
-        crate::privacy_win_mag::stop();
     }
 
     #[cfg(target_os = "android")]

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -910,7 +910,7 @@ pub mod connection_manager {
 
     #[inline]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    pub fn start_listen_ipc_thread() {
+    fn start_listen_ipc_thread() {
         start_listen_ipc(true);
     }
 
@@ -931,8 +931,22 @@ pub mod connection_manager {
         }
     }
 
-    #[cfg(target_os = "windows")]
+    extern "C" fn cm_clear_hook() {
+        #[cfg(target_os = "windows")]
+        crate::privacy_win_mag::stop();
+    }
+
+    #[inline]
+    pub fn cm_init() {
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        start_listen_ipc_thread();
+        #[cfg(target_os = "windows")]
+        shutdown_hooks::add_shutdown_hook(cm_clear_hook);
+    }
+
+    #[inline]
     pub fn cm_clear() {
+        #[cfg(target_os = "windows")]
         crate::privacy_win_mag::stop();
     }
 

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -931,6 +931,11 @@ pub mod connection_manager {
         }
     }
 
+    #[cfg(target_os = "windows")]
+    pub fn cm_clear() {
+        crate::privacy_win_mag::stop();
+    }
+
     #[cfg(target_os = "android")]
     use hbb_common::tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1453,6 +1453,11 @@ pub fn cm_start_listen_ipc_thread() {
     crate::flutter::connection_manager::start_listen_ipc_thread();
 }
 
+pub fn cm_clear() {
+    #[cfg(target_os = "windows")]
+    crate::flutter::connection_manager::cm_clear();
+}
+
 /// Start an ipc server for receiving the url scheme.
 ///
 /// * Should only be called in the main flutter window.

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1453,11 +1453,6 @@ pub fn cm_init() {
     crate::flutter::connection_manager::cm_init();
 }
 
-pub fn cm_clear() {
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    crate::flutter::connection_manager::cm_clear();
-}
-
 /// Start an ipc server for receiving the url scheme.
 ///
 /// * Should only be called in the main flutter window.

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1448,13 +1448,13 @@ pub fn main_use_texture_render() -> SyncReturn<bool> {
     }
 }
 
-pub fn cm_start_listen_ipc_thread() {
+pub fn cm_init() {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    crate::flutter::connection_manager::start_listen_ipc_thread();
+    crate::flutter::connection_manager::cm_init();
 }
 
 pub fn cm_clear() {
-    #[cfg(target_os = "windows")]
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     crate::flutter::connection_manager::cm_clear();
 }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2161,9 +2161,11 @@ pub fn uninstall_service(show_new_window: bool) -> bool {
     sc stop {app_name}
     sc delete {app_name}
     if exist \"%PROGRAMDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\{app_name} Tray.lnk\" del /f /q \"%PROGRAMDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\{app_name} Tray.lnk\"
+    taskkill /F /IM {broker_exe}
     taskkill /F /IM {app_name}.exe{filter}
     ",
         app_name = crate::get_app_name(),
+        broker_exe = WIN_MAG_INJECTED_PROCESS_EXE,
     );
     if let Err(err) = run_cmds(cmds, false, "uninstall") {
         Config::set_option("stop-service".into(), "".into());

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2273,6 +2273,15 @@ fn run_after_run_cmds(silent: bool) {
     std::thread::sleep(std::time::Duration::from_millis(300));
 }
 
+#[inline]
+pub fn try_kill_broker() {
+    allow_err!(run_cmds(
+        format!("taskkill /F /IM {}", WIN_MAG_INJECTED_PROCESS_EXE),
+        false,
+        "kill_broker"
+    ));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/privacy_win_mag.rs
+++ b/src/privacy_win_mag.rs
@@ -59,6 +59,12 @@ struct WindowHandlers {
 
 impl Drop for WindowHandlers {
     fn drop(&mut self) {
+        self.reset();
+    }
+}
+
+impl WindowHandlers {
+    fn reset(&mut self) {
         unsafe {
             if self.hthread != 0 {
                 CloseHandle(self.hthread as _);
@@ -255,6 +261,10 @@ pub fn start() -> ResultType<()> {
     }
 
     Ok(())
+}
+
+pub fn stop() {
+    WND_HANDLERS.lock().unwrap().reset();
 }
 
 unsafe fn inject_dll<'a>(hproc: HANDLE, hthread: HANDLE, dll_file: &'a str) -> ResultType<()> {

--- a/src/privacy_win_mag.rs
+++ b/src/privacy_win_mag.rs
@@ -21,7 +21,7 @@ use winapi::{
         libloaderapi::{GetModuleHandleA, GetModuleHandleExA, GetProcAddress},
         memoryapi::{VirtualAllocEx, WriteProcessMemory},
         processthreadsapi::{
-            CreateProcessAsUserW, GetCurrentThreadId, QueueUserAPC, ResumeThread,
+            CreateProcessAsUserW, GetCurrentThreadId, QueueUserAPC, ResumeThread, TerminateProcess,
             PROCESS_INFORMATION, STARTUPINFOW,
         },
         winbase::{WTSGetActiveConsoleSessionId, CREATE_SUSPENDED, DETACHED_PROCESS},
@@ -46,7 +46,6 @@ pub const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: u32 = 4;
 const WM_USER_EXIT_HOOK: u32 = WM_USER + 1;
 
 lazy_static::lazy_static! {
-    static ref DLL_FOUND: Mutex<bool> = Mutex::new(false);
     static ref CONN_ID: Mutex<i32> = Mutex::new(0);
     static ref CUR_HOOK_THREAD_ID: Mutex<DWORD> = Mutex::new(0);
     static ref WND_HANDLERS: Mutex<WindowHandlers> = Mutex::new(WindowHandlers{hthread: 0, hprocess: 0});
@@ -66,15 +65,20 @@ impl Drop for WindowHandlers {
 impl WindowHandlers {
     fn reset(&mut self) {
         unsafe {
+            if self.hprocess != 0 {
+                let _res = TerminateProcess(self.hprocess as _, 0);
+                CloseHandle(self.hprocess as _);
+            }
+            self.hprocess = 0;
             if self.hthread != 0 {
                 CloseHandle(self.hthread as _);
             }
             self.hthread = 0;
-            if self.hprocess != 0 {
-                CloseHandle(self.hprocess as _);
-            }
-            self.hprocess = 0;
         }
+    }
+
+    fn is_default(&self) -> bool {
+        self.hthread == 0 && self.hprocess == 0
     }
 }
 
@@ -91,7 +95,7 @@ pub fn turn_on_privacy(conn_id: i32) -> ResultType<bool> {
         );
     }
 
-    if !*DLL_FOUND.lock().unwrap() {
+    if WND_HANDLERS.lock().unwrap().is_default() {
         log::info!("turn_on_privacy, dll not found when started, try start");
         start()?;
         std::thread::sleep(std::time::Duration::from_millis(1_000));
@@ -161,8 +165,6 @@ pub fn start() -> ResultType<()> {
             dll_file.to_string_lossy().as_ref()
         );
     }
-
-    *DLL_FOUND.lock().unwrap() = true;
 
     let hwnd = wait_find_privacy_hwnd(1_000)?;
     if !hwnd.is_null() {
@@ -263,6 +265,7 @@ pub fn start() -> ResultType<()> {
     Ok(())
 }
 
+#[inline]
 pub fn stop() {
     WND_HANDLERS.lock().unwrap().reset();
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -303,7 +303,7 @@ impl Server {
     // get a new unique id
     pub fn get_new_id(&mut self) -> i32 {
         self.id_count += 1;
-        self.id_count 
+        self.id_count
     }
 }
 
@@ -389,6 +389,8 @@ pub async fn start_server(is_server: bool) {
         }
         #[cfg(any(target_os = "macos", target_os = "linux"))]
         tokio::spawn(async { sync_and_watch_config_dir().await });
+        #[cfg(target_os = "windows")]
+        crate::platform::try_kill_broker();
         crate::RendezvousMediator::start_all().await;
     } else {
         match crate::ipc::connect(1000, "").await {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2559,6 +2559,10 @@ mod raii {
             if active_conns_lock.is_empty() {
                 video_service::try_plug_out_virtual_display();
             }
+            #[cfg(all(windows))]
+            if active_conns_lock.is_empty() {
+                crate::privacy_win_mag::stop();
+            }
         }
     }
 }

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -533,7 +533,6 @@ pub async fn start_ipc<T: InvokeUiCM>(cm: ConnectionManager<T>) {
                 e
             );
         }
-        allow_err!(crate::privacy_win_mag::start());
     });
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
1. Do not start broker.exe on create cm.
    In the past, when the cm process was started, the broker process was started, because it was relatively slow to create a window in privacy mode, which took about 2 seconds. This window was created in advance.
2. Kill broker.exe on start server.
3. Kill broker.exe on tray "Exit".
5. Kill reset privacy mag window on all sessions end. The broker.exe is terminated.
