### PR TITLE
wrong verification code

### DIFF
--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Nom d'usuari oblidat"),
         ("Password missed", "Contrasenya oblidada"),
         ("Wrong credentials", "Credencials incorrectes"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Editar tag"),
         ("Unremember Password", "Contrasenya oblidada"),
         ("Favorites", "Preferits"),

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "用户名没有填写"),
         ("Password missed", "密码没有填写"),
         ("Wrong credentials", "提供的登录信息错误"),
+        ("Verification code wrong or timeout", "验证码错误或已超时"),
         ("Edit Tag", "修改标签"),
         ("Unremember Password", "忘记密码"),
         ("Favorites", "收藏"),

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Chybí uživatelské jméno"),
         ("Password missed", "Chybí heslo"),
         ("Wrong credentials", "Nesprávné přihlašovací údaje"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Upravit štítek"),
         ("Unremember Password", "Přestat si heslo pamatovat"),
         ("Favorites", "Oblíbené"),

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Glemt brugernavn"),
         ("Password missed", "Glemt kodeord"),
         ("Wrong credentials", "Forkerte registreringsdata"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Rediger nøgleord"),
         ("Unremember Password", "Glem adgangskoden"),
         ("Favorites", "Favoritter"),

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Benutzername fehlt"),
         ("Password missed", "Passwort fehlt"),
         ("Wrong credentials", "Falsche Anmeldedaten"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Schlagwort bearbeiten"),
         ("Unremember Password", "Gespeichertes Passwort löschen"),
         ("Favorites", "Favoriten"),

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Δεν συμπληρώσατε το όνομα χρήστη"),
         ("Password missed", "Δεν συμπληρώσατε τον κωδικό πρόσβασης"),
         ("Wrong credentials", "Λάθος διαπιστευτήρια"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Επεξεργασία ετικέτας"),
         ("Unremember Password", "Διαγραφή απομνημονευμένου κωδικού"),
         ("Favorites", "Αγαπημένα"),

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -15,6 +15,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("whitelist_tip", "Only whitelisted IP can access me"),
         ("whitelist_sep", "Separated by comma, semicolon, spaces or new line"),
         ("Wrong credentials", "Wrong username or password"),
+        ("Verification code wrong or timeout", "The verification code is wrong or timeout"),
         ("invalid_http", "must start with http:// or https://"),
         ("install_daemon_tip", "For starting on boot, you need to install system service."),
         ("android_input_permission_tip1", "In order for a remote device to control your Android device via mouse or touch, you need to allow RustDesk to use the \"Accessibility\" service."),

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Uzantnomo forgesita"),
         ("Password missed", "Pasvorto forgesita"),
         ("Wrong credentials", "Identigilo aŭ pasvorto erara"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Redakti etikedo"),
         ("Unremember Password", "Forgesi pasvorton"),
         ("Favorites", "Favorataj"),

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Olvidó su nombre de usuario"),
         ("Password missed", "Olvidó su contraseña"),
         ("Wrong credentials", "Credenciales incorrectas"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Editar tag"),
         ("Unremember Password", "Olvidar contraseña"),
         ("Favorites", "Favoritos"),

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "نام کاربری وجود ندارد"),
         ("Password missed", "رمزعبور وجود ندارد"),
         ("Wrong credentials", "اعتبارنامه نادرست است"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "ویرایش برچسب"),
         ("Unremember Password", "رمز عبور ذخیره نشود"),
         ("Favorites", "اتصالات دلخواه"),

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Nom d'utilisateur manquant"),
         ("Password missed", "Mot de passe manquant"),
         ("Wrong credentials", "Identifiant ou mot de passe erroné"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Modifier la balise"),
         ("Unremember Password", "Oublier le Mot de passe"),
         ("Favorites", "Favoris"),

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Üres felhasználónév"),
         ("Password missed", "Üres jelszó"),
         ("Wrong credentials", "Hibás felhasználónév vagy jelszó"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Címke szerkesztése"),
         ("Unremember Password", "A jelszó megjegyzésének törlése"),
         ("Favorites", "Kedvencek"),

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Username tidak sesuai"),
         ("Password missed", "Kata sandi tidak sesuai"),
         ("Wrong credentials", "Username atau password salah"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Ubah Tag"),
         ("Unremember Password", "Lupa Kata Sandi"),
         ("Favorites", "Favorit"),

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Nome utente mancante"),
         ("Password missed", "Password mancante"),
         ("Wrong credentials", "Credenziali errate"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Modifica tag"),
         ("Unremember Password", "Dimentica password"),
         ("Favorites", "Preferiti"),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "ユーザー名がありません"),
         ("Password missed", "パスワードがありません"),
         ("Wrong credentials", "資格情報が間違っています"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "タグを編集"),
         ("Unremember Password", "パスワードの記憶を解除"),
         ("Favorites", "お気に入り"),

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "사용자명 누락"),
         ("Password missed", "비밀번호 누락"),
         ("Wrong credentials", "틀린 인증 정보"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "태그 수정"),
         ("Unremember Password", "패스워드 기억하지 않기"),
         ("Favorites", "즐겨찾기"),

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Қолданушы аты бос"),
         ("Password missed", "Құпия сөз бос"),
         ("Wrong credentials", "Бұрыс тіркелгі деректер"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Тақты Өндеу"),
         ("Unremember Password", "Құпия сөзді Ұмыту"),
         ("Favorites", "Таңдаулылар"),

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Prarastas vartotojo vardas"),
         ("Password missed", "Slaptažodis praleistas"),
         ("Wrong credentials", "Klaidingi kredencialai"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Redaguoti žymą"),
         ("Unremember Password", "Nebeprisiminti slaptažodžio"),
         ("Favorites", "Parankiniai"),

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Gebruikersnaam gemist"),
         ("Password missed", "Wachtwoord vergeten"),
         ("Wrong credentials", "Verkeerde inloggegevens"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Label Bewerken"),
         ("Unremember Password", "Wachtwoord vergeten"),
         ("Favorites", "Favorieten"),

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Nieprawidłowe nazwa użytkownika"),
         ("Password missed", "Nieprawidłowe hasło"),
         ("Wrong credentials", "Błędne dane uwierzytelniające"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Edytuj tag"),
         ("Unremember Password", "Zapomnij hasło"),
         ("Favorites", "Ulubione"),

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Nome de utilizador em falta"),
         ("Password missed", "Palavra-chave em falta"),
         ("Wrong credentials", "Nome de utilizador ou palavra-chave incorrectos"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Editar Tag"),
         ("Unremember Password", "Esquecer Palavra-chave"),
         ("Favorites", "Favoritos"),

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Nome de usuário requerido"),
         ("Password missed", "Senha requerida"),
         ("Wrong credentials", "Nome de usuário ou senha incorretos"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Editar Tag"),
         ("Unremember Password", "Esquecer Senha"),
         ("Favorites", "Favoritos"),

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Lipsește numele de utilizator"),
         ("Password missed", "Lipsește parola"),
         ("Wrong credentials", "Nume sau parolă greșită"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Modifică etichetă"),
         ("Unremember Password", "Uită parola"),
         ("Favorites", "Favorite"),

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Имя пользователя отсутствует"),
         ("Password missed", "Забыли пароль"),
         ("Wrong credentials", "Неправильные учётные данные"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Изменить метку"),
         ("Unremember Password", "Не сохранять пароль"),
         ("Favorites", "Избранное"),

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Chýba užívateľské meno"),
         ("Password missed", "Chýba heslo"),
         ("Wrong credentials", "Nesprávne prihlasovacie údaje"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Upraviť štítok"),
         ("Unremember Password", "Zabudnúť heslo"),
         ("Favorites", "Obľúbené"),

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Up. ime izpuščeno"),
         ("Password missed", "Geslo izpuščeno"),
         ("Wrong credentials", "Napačne poverilnice"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Uredi oznako"),
         ("Unremember Password", "Pozabi geslo"),
         ("Favorites", "Priljubljene"),

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Mungon përdorusesi"),
         ("Password missed", "Mungon fjalëkalimi"),
         ("Wrong credentials", "Kredinciale të gabuara"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Edito tagun"),
         ("Unremember Password", "Fjalëkalim jo i kujtueshëm"),
         ("Favorites", "Te preferuarat"),

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Korisničko ime promašeno"),
         ("Password missed", "Lozinka promašena"),
         ("Wrong credentials", "Pogrešno korisničko ime ili lozinka"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Izmeni oznaku"),
         ("Unremember Password", "Zaboravi lozinku"),
         ("Favorites", "Favoriti"),

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Användarnamn saknas"),
         ("Password missed", "Lösenord saknas"),
         ("Wrong credentials", "Fel användarnamn eller lösenord"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Ändra Tagg"),
         ("Unremember Password", "Glöm lösenord"),
         ("Favorites", "Favoriter"),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", ""),
         ("Password missed", ""),
         ("Wrong credentials", ""),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", ""),
         ("Unremember Password", ""),
         ("Favorites", ""),

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "ไม่พบข้อมูลผู้ใช้งาน"),
         ("Password missed", "ไม่พบรหัสผ่าน"),
         ("Wrong credentials", "ข้อมูลสำหรับเข้าสู่ระบบไม่ถูกต้อง"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "แก้ไขแท็ก"),
         ("Unremember Password", "ยกเลิกการจดจำรหัสผ่าน"),
         ("Favorites", "รายการโปรด"),

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Kullanıcı adı boş"),
         ("Password missed", "Şifre boş"),
         ("Wrong credentials", "Yanlış kimlik bilgileri"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Etiketi düzenle"),
         ("Unremember Password", "Şifreyi Unut"),
         ("Favorites", "Favoriler"),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "缺少使用者名稱"),
         ("Password missed", "缺少密碼"),
         ("Wrong credentials", "提供的登入資訊有誤"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "編輯標籤"),
         ("Unremember Password", "忘掉密碼"),
         ("Favorites", "我的最愛"),

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Імʼя користувача відсутнє"),
         ("Password missed", "Забули пароль"),
         ("Wrong credentials", "Неправильні дані"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Редагувати тег"),
         ("Unremember Password", "Не зберігати пароль"),
         ("Favorites", "Вибране"),

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -233,6 +233,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Username missed", "Mất tên người dùng"),
         ("Password missed", "Mất mật khẩu"),
         ("Wrong credentials", "Chứng danh bị sai"),
+        ("Verification code wrong or timeout", ""),
         ("Edit Tag", "Chỉnh sửa Tag"),
         ("Unremember Password", "Quên mật khẩu"),
         ("Favorites", "Ưa thích"),


### PR DESCRIPTION
If the user has enabled email verification and the verification code is wrong when logging in. The client will get the error "Verification code error or timeout".