### PR TITLE
opt mobile chat page

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2189,19 +2189,21 @@ Widget buildRemoteBlock({required Widget child, WhetherUseRemoteBlock? use}) {
       ));
 }
 
-Widget unreadMessageCountBuilder(RxInt? count) {
+Widget unreadMessageCountBuilder(RxInt? count,
+    {double? size, double? fontSize, double? marginLeft}) {
   return Obx(() => Offstage(
       offstage: !((count?.value ?? 0) > 0),
       child: Container(
-        width: 16,
-        height: 16,
+        width: size ?? 16,
+        height: size ?? 16,
         decoration: BoxDecoration(
           color: Colors.red,
           shape: BoxShape.circle,
         ),
         child: Center(
           child: Text("${count?.value ?? 0}",
-              maxLines: 1, style: TextStyle(color: Colors.white, fontSize: 10)),
+              maxLines: 1,
+              style: TextStyle(color: Colors.white, fontSize: fontSize ?? 10)),
         ),
-      ).marginOnly(left: 4)));
+      ).marginOnly(left: marginLeft ?? 4)));
 }

--- a/flutter/lib/common/widgets/chat_page.dart
+++ b/flutter/lib/common/widgets/chat_page.dart
@@ -7,10 +7,15 @@ import 'package:provider/provider.dart';
 
 import '../../mobile/pages/home_page.dart';
 
+enum ChatPageType {
+  mobileMain,
+}
+
 class ChatPage extends StatelessWidget implements PageShape {
   late final ChatModel chatModel;
+  final ChatPageType? type;
 
-  ChatPage({ChatModel? chatModel}) {
+  ChatPage({ChatModel? chatModel, this.type}) {
     this.chatModel = chatModel ?? gFFI.chatModel;
   }
 
@@ -22,7 +27,7 @@ class ChatPage extends StatelessWidget implements PageShape {
 
   @override
   final appBarActions = [
-    PopupMenuButton<int>(
+    PopupMenuButton<MessageKey>(
         tooltip: "",
         icon: Icon(Icons.group),
         itemBuilder: (context) {
@@ -31,8 +36,15 @@ class ChatPage extends StatelessWidget implements PageShape {
           return chatModel.messages.entries.map((entry) {
             final id = entry.key;
             final user = entry.value.chatUser;
-            return PopupMenuItem<int>(
-              child: Text("${user.firstName}   ${user.id}"),
+            return PopupMenuItem<MessageKey>(
+              child: Row(
+                children: [
+                  Icon(id.isOut ? Icons.call_made : Icons.call_received,
+                          color: MyTheme.accent)
+                      .marginOnly(right: 6),
+                  Text("${user.firstName}   ${user.id}"),
+                ],
+              ),
               value: id,
             );
           }).toList();
@@ -57,9 +69,9 @@ class ChatPage extends StatelessWidget implements PageShape {
                   final chat = DashChat(
                     onSend: chatModel.send,
                     currentUser: chatModel.me,
-                    messages:
-                        chatModel.messages[chatModel.currentID]?.chatMessages ??
-                            [],
+                    messages: chatModel
+                            .messages[chatModel.currentKey]?.chatMessages ??
+                        [],
                     inputOptions: InputOptions(
                       focusNode: chatModel.inputNode,
                       textController: chatModel.textController,
@@ -128,7 +140,8 @@ class ChatPage extends StatelessWidget implements PageShape {
                   return SelectionArea(child: chat);
                 }),
                 desktopType == DesktopType.cm ||
-                        chatModel.currentID == ChatModel.clientModeID
+                        type != ChatPageType.mobileMain ||
+                        currentUser == null
                     ? SizedBox.shrink()
                     : Padding(
                         padding: EdgeInsets.all(12),

--- a/flutter/lib/common/widgets/overlay.dart
+++ b/flutter/lib/common/widgets/overlay.dart
@@ -32,7 +32,7 @@ class DraggableChatWindow extends StatelessWidget {
         width: width,
         height: height,
         builder: (context, onPanUpdate) {
-          return isIOS
+          final child = isIOS
               ? ChatPage(chatModel: chatModel)
               : Scaffold(
                   resizeToAvoidBottomInset: false,
@@ -44,6 +44,10 @@ class DraggableChatWindow extends StatelessWidget {
                   ),
                   body: ChatPage(chatModel: chatModel),
                 );
+          return Container(
+              decoration:
+                  BoxDecoration(border: Border.all(color: MyTheme.border)),
+              child: child);
         });
   }
 

--- a/flutter/lib/desktop/pages/server_page.dart
+++ b/flutter/lib/desktop/pages/server_page.dart
@@ -100,14 +100,14 @@ class ConnectionManagerState extends State<ConnectionManager> {
     gFFI.serverModel.tabController.onSelected = (client_id_str) {
       final client_id = int.tryParse(client_id_str);
       if (client_id != null) {
-        gFFI.chatModel.changeCurrentID(client_id);
         final client =
             gFFI.serverModel.clients.firstWhereOrNull((e) => e.id == client_id);
         if (client != null) {
+          gFFI.chatModel.changeCurrentID(MessageKey(client.peerId, client.id));
           if (client.unreadChatMessageCount.value > 0) {
             Future.delayed(Duration.zero, () {
               client.unreadChatMessageCount.value = 0;
-              gFFI.chatModel.showChatPage(client.id);
+              gFFI.chatModel.showChatPage(MessageKey(client.peerId, client.id));
             });
           }
           windowManager.setTitle(getWindowNameWithId(client.peerId));
@@ -444,7 +444,8 @@ class _CmHeaderState extends State<_CmHeader>
             child: IconButton(
               onPressed: () => checkClickTime(
                 client.id,
-                () => gFFI.chatModel.toggleCMChatPage(client.id),
+                () => gFFI.chatModel
+                    .toggleCMChatPage(MessageKey(client.peerId, client.id)),
               ),
               icon: SvgPicture.asset('assets/chat2.svg'),
               splashRadius: kDesktopIconButtonSplashRadius,

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1413,7 +1413,8 @@ class _ChatMenuState extends State<_ChatMenu> {
             initPos = Offset(pos.dx, pos.dy + _ToolbarTheme.dividerHeight);
           }
 
-          widget.ffi.chatModel.changeCurrentID(ChatModel.clientModeID);
+          widget.ffi.chatModel.changeCurrentID(
+              MessageKey(widget.ffi.id, ChatModel.clientModeID));
           widget.ffi.chatModel.toggleChatOverlay(chatInitPos: initPos);
         });
   }

--- a/flutter/lib/mobile/pages/connection_page.dart
+++ b/flutter/lib/mobile/pages/connection_page.dart
@@ -37,6 +37,7 @@ class ConnectionPage extends StatefulWidget implements PageShape {
 class _ConnectionPageState extends State<ConnectionPage> {
   /// Controller for the id input bar.
   final _idController = IDTextEditingController();
+  final RxBool _idEmpty = true.obs;
 
   /// Update url. If it's not null, means an update is available.
   var _updateUrl = '';
@@ -60,6 +61,10 @@ class _ConnectionPageState extends State<ConnectionPage> {
         if (_updateUrl.isNotEmpty) setState(() {});
       });
     }
+
+    _idController.addListener(() {
+      _idEmpty.value = _idController.text.isEmpty;
+    });
   }
 
   @override
@@ -158,6 +163,14 @@ class _ConnectionPageState extends State<ConnectionPage> {
                   ),
                 ),
               ),
+              Obx(() => Offstage(
+                    offstage: _idEmpty.value,
+                    child: IconButton(
+                        onPressed: () {
+                          _idController.clear();
+                        },
+                        icon: Icon(Icons.clear, color: MyTheme.darkGray)),
+                  )),
               SizedBox(
                 width: 60,
                 height: 60,

--- a/flutter/lib/mobile/pages/home_page.dart
+++ b/flutter/lib/mobile/pages/home_page.dart
@@ -22,6 +22,7 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   var _selectedIndex = 0;
+  int get selectedIndex => _selectedIndex;
   final List<PageShape> _pages = [];
 
   void refreshPages() {
@@ -82,6 +83,8 @@ class _HomePageState extends State<HomePage> {
                 gFFI.chatModel.hideChatWindowOverlay();
               }
               _selectedIndex = index;
+              gFFI.chatModel
+                  .mobileClearClientUnread(gFFI.chatModel.currentKey.connId);
             }),
           ),
           body: _pages.elementAt(_selectedIndex),

--- a/flutter/lib/mobile/pages/home_page.dart
+++ b/flutter/lib/mobile/pages/home_page.dart
@@ -40,7 +40,7 @@ class _HomePageState extends State<HomePage> {
     _pages.clear();
     _pages.add(ConnectionPage());
     if (isAndroid) {
-      _pages.addAll([ChatPage(), ServerPage()]);
+      _pages.addAll([ChatPage(type: ChatPageType.mobileMain), ServerPage()]);
     }
     _pages.add(SettingsPage());
   }

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -351,8 +351,8 @@ class _RemotePageState extends State<RemotePage> {
                             color: Colors.white,
                             icon: Icon(Icons.message),
                             onPressed: () {
-                              gFFI.chatModel
-                                  .changeCurrentID(ChatModel.clientModeID);
+                              gFFI.chatModel.changeCurrentID(MessageKey(
+                                  widget.id, ChatModel.clientModeID));
                               gFFI.chatModel.toggleChatOverlay();
                             },
                           )

--- a/flutter/lib/mobile/pages/server_page.dart
+++ b/flutter/lib/mobile/pages/server_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hbb/mobile/widgets/dialog.dart';
+import 'package:flutter_hbb/models/chat_model.dart';
 import 'package:get/get.dart';
 import 'package:provider/provider.dart';
 
@@ -419,7 +420,8 @@ class ConnectionManager extends StatelessWidget {
                               ? const SizedBox.shrink()
                               : IconButton(
                                   onPressed: () {
-                                    gFFI.chatModel.changeCurrentID(client.id);
+                                    gFFI.chatModel.changeCurrentID(
+                                        MessageKey(client.peerId, client.id));
                                     final bar = navigationBarKey.currentWidget;
                                     if (bar != null) {
                                       bar as BottomNavigationBar;

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/main.dart';
+import 'package:flutter_hbb/models/chat_model.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:get/get.dart';
 import 'package:wakelock/wakelock.dart';
@@ -474,6 +475,8 @@ class ServerModel with ChangeNotifier {
         cmHiddenTimer = null;
       });
     }
+    parent.target?.chatModel
+        .updateConnIdOfKey(MessageKey(client.peerId, client.id));
   }
 
   void showLoginDialog(Client client) {


### PR DESCRIPTION
1. add border to chatbox
2. add clear button to mobile id input
3. opt mobile chat page menu
   * remove "me"
   * same peer same direction merge chat message
   * same peer different direction show different menu
4. add mobile chat message unread
5. make chat page readOnly if not connected for mobile.
6. mobile not show chat icon overlay on main page 

Test on mobile/desktop, do more test later.

![87fddf3e08e2c40feb9919b6523baeb](https://github.com/rustdesk/rustdesk/assets/14891774/44e77304-c93d-4408-98c4-a83ada488cca)

![b0e9cff3fd04cd20fa16b7f68563589](https://github.com/rustdesk/rustdesk/assets/14891774/984150c0-2b60-4835-9eaf-87266c100e9e)

