### PR TITLE
feature: support building with msys2 toolchains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3091,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "impersonate_system"
 version = "0.1.0"
-source = "git+https://github.com/21pages/impersonate-system#84b401893d5b6628c8b33b295328d13fbbe2674b"
+source = "git+https://github.com/21pages/impersonate-system#2f429010a5a10b1fe5eceb553c6672fd53d20167"
 dependencies = [
  "cc",
 ]
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "magnum-opus"
 version = "0.4.0"
-source = "git+https://github.com/rustdesk/magnum-opus#5cd2bf989c148662fa3a2d9d539a71d71fd1d256"
+source = "git+https://github.com/clslaid/magnum-opus?branch=msys2-build-support#325da906c2c0668978851cf1fd49661bdd0a075c"
 dependencies = [
  "bindgen 0.59.2",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ mediacodec = ["scrap/mediacodec"]
 linux_headless = ["pam" ]
 virtual_display_driver = ["virtual_display"]
 plugin_framework = []
+pkg-config = ["msys2-pkg-config", "linux-pkg-config"]
+msys2-pkg-config = ["magnum-opus/msys2-pkg-config", "scrap/msys2-pkg-config"]
 linux-pkg-config = ["magnum-opus/linux-pkg-config", "scrap/linux-pkg-config"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -49,7 +51,7 @@ sha2 = "0.10"
 repng = "0.2"
 parity-tokio-ipc = { git = "https://github.com/open-trade/parity-tokio-ipc" }
 runas = "1.0"
-magnum-opus = { git = "https://github.com/rustdesk/magnum-opus" }
+magnum-opus = { git = "https://github.com/clslaid/magnum-opus", branch = "msys2-build-support" }
 dasp = { version = "0.11", features = ["signal", "interpolate-linear", "interpolate"], optional = true }
 rubato = { version = "0.12", optional = true }
 samplerate = { version = "0.2", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,11 @@
 #[cfg(windows)]
 fn build_windows() {
     let file = "src/platform/windows.cc";
-    cc::Build::new().file(file).compile("windows");
+    let mut builder = cc::Build::new();
+    builder.cpp(true)
+        .flag_if_supported("-std=c++11")
+        .file(file);
+    builder.compile("windows");
     println!("cargo:rustc-link-lib=WtsApi32");
     println!("cargo:rerun-if-changed={}", file);
 }

--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -25,6 +25,12 @@
 #define CINTERFACE
 #define COBJMACROS
 
+#ifndef INITGUID
+#define INITGUID
+#endif
+
+#include <wincodec.h>
+#include <objidl.h>
 #include <ole2.h>
 #include <shlobj.h>
 #include <windows.h>

--- a/libs/scrap/Cargo.toml
+++ b/libs/scrap/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 wayland = ["gstreamer", "gstreamer-app", "gstreamer-video", "dbus", "tracing"]
 mediacodec = ["ndk"]
 linux-pkg-config = ["dep:pkg-config"]
+msys2-pkg-config = ["dep:pkg-config"]
 
 [dependencies]
 block = "0.1"

--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -4,7 +4,10 @@ use std::{
     println,
 };
 
-#[cfg(all(target_os = "linux", feature = "linux-pkg-config"))]
+#[cfg(
+    any(
+        all(target_os = "linux", feature = "linux-pkg-config")
+        ,all(target_os = "windows", feature = "msys2-pkg-config")))]
 fn link_pkg_config(name: &str) -> Vec<PathBuf> {
     // sometimes an override is needed
     let pc_name = match name {
@@ -15,10 +18,12 @@ fn link_pkg_config(name: &str) -> Vec<PathBuf> {
         .expect(format!(
             "unable to find '{pc_name}' development headers with pkg-config (feature linux-pkg-config is enabled).
             try installing '{pc_name}-dev' from your system package manager.").as_str());
-
     lib.include_paths
 }
-#[cfg(not(all(target_os = "linux", feature = "linux-pkg-config")))]
+#[cfg(
+    not(any(
+        all(target_os = "linux", feature = "linux-pkg-config")
+        ,all(target_os = "windows", feature = "msys2-pkg-config"))))]
 fn link_pkg_config(_name: &str) -> Vec<PathBuf> {
     unimplemented!()
 }
@@ -127,7 +132,9 @@ fn link_homebrew_m1(name: &str) -> PathBuf {
 fn find_package(name: &str) -> Vec<PathBuf> {
     let no_pkg_config_var_name = format!("NO_PKG_CONFIG_{name}");
     println!("cargo:rerun-if-env-changed={no_pkg_config_var_name}");
-    if cfg!(all(target_os = "linux", feature = "linux-pkg-config"))
+    if cfg!(any(
+                all(target_os = "linux", feature = "linux-pkg-config")
+                ,all(target_os = "windows", feature = "msys2-pkg-config")))
         && std::env::var(no_pkg_config_var_name).as_deref() != Ok("1")
     {
         link_pkg_config(name)

--- a/src/platform/windows.cc
+++ b/src/platform/windows.cc
@@ -9,6 +9,11 @@
 #include <shlobj.h> // NOLINT(build/include_order)
 #include <userenv.h>
 #include <versionhelpers.h>
+// msys2 build support
+#ifdef __MINGW64__
+#include <algorithm>
+#include <sas.h>
+#endif
 
 void flog(char const *fmt, ...)
 {
@@ -425,7 +430,7 @@ extern "C"
         {
             if (buf)
             {
-                nout = min(nin, n);
+                nout = std::min(static_cast<DWORD>(nin), n);
                 memcpy(bufin, buf, nout);
                 WTSFreeMemory(buf);
             }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -639,6 +639,13 @@ async fn send_close_async(postfix: &str) -> ResultType<()> {
 // https://docs.microsoft.com/en-us/windows/win32/api/sas/nf-sas-sendsas
 // https://www.cnblogs.com/doutu/p/4892726.html
 fn send_sas() {
+    #[cfg(feature = "msys2-pkg-config")]
+    // Sas.h is included in windows.cc, so just link to it.
+    #[link(name = "windows")]
+    extern "C" {
+        pub fn SendSAS(AsUser: BOOL);
+    }
+    #[cfg(not(feature = "msys2-pkg-config"))]
     #[link(name = "sas")]
     extern "system" {
         pub fn SendSAS(AsUser: BOOL);


### PR DESCRIPTION
Related: https://github.com/rustdesk-org/magnum-opus/pull/2

This PR should add build support for msys2 toolchains under Windows system. This PR may also benefit trials for getting rid of `vcpkgs` and cross compiling. 

No `vcpkgs` and VS toolchains required to build the software. You need to got msys2 toolchains installed in your path, and acquire related packages like build-essentials, `pkgconf`, `libyuv`, `opus`, etc, on your msys2 toolchain. Its `pkg-config` fits well with `build.rs` and can handle dependencies perfectly.

I've built with the `ucrt64` toolchain and successes.

```bash
# on windows machine
# targetting x86_64-pc-windows-gnu
# don't forget this feature
cargo build --features="msys2-pkg-config"
wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.win/x64/sciter.dll
mv sciter.dll target/debug
cargo run --features="msys2-pkg-config"
```

Showcases:

- starting up
![图片](https://github.com/rustdesk/rustdesk/assets/44747719/23d0f785-7882-4c77-a9df-216209097ef2)

- controled via android phone
![图片](https://github.com/rustdesk/rustdesk/assets/44747719/3d5d477b-3c26-4b4f-9af9-717c982d6f20)
