### PR TITLE
Allow to explicitly increase the bitrate massively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "android_logger",
  "arboard",

--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -1220,7 +1220,8 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
   qualityInitValue =
       quality != null && quality.isNotEmpty ? quality[0].toDouble() : 50.0;
   const qualityMinValue = 10.0;
-  const qualityMaxValue = 100.0;
+  const qualityMoreThresholdValue = 100.0;
+  const qualityMaxValue = 4000.0;
   if (qualityInitValue < qualityMinValue) {
     qualityInitValue = qualityMinValue;
   }
@@ -1228,6 +1229,8 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
     qualityInitValue = qualityMaxValue;
   }
   final RxDouble qualitySliderValue = RxDouble(qualityInitValue);
+  final moreQualityInitValue = qualityInitValue > qualityMoreThresholdValue;
+  final RxBool moreQualityChecked = RxBool(moreQualityInitValue);
   final debouncerQuality = Debouncer<double>(
     Duration(milliseconds: 1000),
     onChanged: (double v) {
@@ -1242,7 +1245,9 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
               child: Slider(
                 value: qualitySliderValue.value,
                 min: qualityMinValue,
-                max: qualityMaxValue,
+                max: moreQualityChecked.value
+                    ? qualityMaxValue
+                    : qualityMoreThresholdValue,
                 divisions: 18,
                 onChanged: (double value) {
                   qualitySliderValue.value = value;
@@ -1256,10 +1261,30 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
                 style: const TextStyle(fontSize: 15),
               )),
           Expanded(
-              flex: 2,
+              flex: 1,
               child: Text(
                 translate('Bitrate'),
                 style: const TextStyle(fontSize: 15),
+              )),
+          Expanded(
+              flex: 1,
+              child: Row(
+                 children: [
+                   Checkbox(
+                     value: moreQualityChecked.value,
+                     onChanged: (bool? value) {
+                       moreQualityChecked.value = value!;
+                       if (!value &&
+                         qualitySliderValue.value > qualityMoreThresholdValue) {
+                         qualitySliderValue.value = qualityMoreThresholdValue;
+                         debouncerQuality.value = qualityMoreThresholdValue;
+                       }
+                     },
+                   ).marginOnly(right: 5),
+                   Expanded(
+                     child: Text(translate('More')),
+                   )
+                 ],
               )),
         ],
       ));

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1078,7 +1078,7 @@ impl PeerConfig {
         D: de::Deserializer<'de>,
     {
         let v: Vec<i32> = de::Deserialize::deserialize(deserializer)?;
-        if v.len() == 1 && v[0] >= 10 && v[0] <= 100 {
+        if v.len() == 1 && v[0] >= 10 && v[0] <= 0xFFF {
             Ok(v)
         } else {
             Ok(Self::default_custom_image_quality())
@@ -1402,7 +1402,7 @@ impl UserDefaultConfig {
             "codec-preference" => {
                 self.get_string(key, "auto", vec!["vp8", "vp9", "av1", "h264", "h265"])
             }
-            "custom_image_quality" => self.get_double_string(key, 50.0, 10.0, 100.0),
+            "custom_image_quality" => self.get_double_string(key, 50.0, 10.0, 0xFFF as f64),
             "custom-fps" => self.get_double_string(key, 30.0, 5.0, 120.0),
             _ => self
                 .options

--- a/src/server/video_qos.rs
+++ b/src/server/video_qos.rs
@@ -299,9 +299,9 @@ impl VideoQoS {
             } else if q == ImageQuality::Best.value() {
                 Quality::Best
             } else {
-                let mut b = (q >> 8 & 0xFF) * 2;
-                b = std::cmp::max(b, 10);
-                b = std::cmp::min(b, 200);
+                let mut b = (q >> 8 & 0xFFF) * 2;
+                b = std::cmp::max(b, 20);
+                b = std::cmp::min(b, 8000);
                 Quality::Custom(b as u32)
             }
         };

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -424,10 +424,17 @@ class Header: Reactor.Component {
 function handle_custom_image_quality() {
     var tmp = handler.get_custom_image_quality();
     var bitrate = (tmp[0] || 50);
-    msgbox("custom", "Custom Image Quality", "<div .form> \
-          <div><input type=\"hslider\" style=\"width: 50%\" name=\"bitrate\" max=\"100\" min=\"10\" value=\"" + bitrate + "\"/ buddy=\"bitrate-buddy\"><b #bitrate-buddy>x</b>% Bitrate</div> \
+    var extendedBitrate = bitrate > 100;
+    var maxRate = extendedBitrate ? 4000 : 100;
+    msgbox("custom-image-quality", "Custom Image Quality", "<div .form> \
+          <div><input #bitrate-slider type=\"hslider\" style=\"width: 50%\" name=\"bitrate\" max=\"" + maxRate + "\" min=\"10\" value=\"" + bitrate + "\"/ buddy=\"bitrate-buddy\"><b #bitrate-buddy>x</b>% Bitrate <button|checkbox #extended-slider .custom-event " + (extendedBitrate ? "checked" : "") + ">More</button></div> \
       </div>", "", function(res=null) {
         if (!res) return;
+        if (res.id === "extended-slider") {
+            var slider = res.parent.$(#bitrate-slider)
+            slider.slider.max = res.checked ? 4000 : 100;
+            return;
+        }
         if (!res.bitrate) return;
         handler.save_custom_image_quality(res.bitrate);
         toggleMenuState();


### PR DESCRIPTION
This has the benefit - over direct connections - to be able to send a lot more data. In particular fast moving frames may avoid fps drops (or short stutter) with a higher target bitrate.

See also: #4682

I'm currently hiding the functionality well behind an extra checkbox you need to tick to be able to select up to 40x the bitrate. Not sure on the proper UI, but I'm open to any suggestions, maybe also some hint in a tooltip that this should only be used on peer to peer connections or dedicated servers?