### PR TITLE
try fix macos convertion key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4894,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#9bee1317f96110dad89117d83a4a736575109bcf"
+source = "git+https://github.com/fufesou/rdev#66c55439b0daf8836b188ddff47a497711cf164e"
 dependencies = [
  "cocoa",
  "core-foundation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4894,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#ab48d5798c86303b9398727684509b1b43ecfdab"
+source = "git+https://github.com/fufesou/rdev#9bee1317f96110dad89117d83a4a736575109bcf"
 dependencies = [
  "cocoa",
  "core-foundation",

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -708,7 +708,7 @@ pub fn legacy_keyboard_mode(event: &Event, mut key_event: KeyEvent) -> Vec<KeyEv
         Key::Final => Some(ControlKey::Final),
         Key::Hanja => Some(ControlKey::Hanja),
         Key::Hanji => Some(ControlKey::Hanja),
-        Key::Convert => Some(ControlKey::Convert),
+        Key::Lang2 => Some(ControlKey::Convert),
         Key::Print => Some(ControlKey::Print),
         Key::Select => Some(ControlKey::Select),
         Key::Execute => Some(ControlKey::Execute),


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/5027

https://github.com/fufesou/rdev/compare/3b98973b7ff4109c39f6619eb2d69e231e3f7371...66c55439b0daf8836b188ddff47a497711cf164e

1. Remove rdev `Convert` and `NonConvert` key, use `Lang1` and `Lang2` instead.
2. The commit may affect previous behavior when map `Lang1` and `Lang2`. But as the maps are wrong, the keys may not be tested and used before.

Win:
```
-    Lang1, 0x0000, 0x0072,
-    Lang2, 0x0000, 0x0071,
+    Lang1, 0x1D, 0x007b,
+    Lang2, 0x1C, 0x0079,
```

Linux:
```
-    Lang1, 0x0082,
-    Lang2, 0x0083,
+    Lang1, 0x0066,
+    Lang2, 0x0064,
```
