### PR TITLE
Fix/desktop touchpad scale

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/gestures.dart';
@@ -230,10 +232,18 @@ class _RawTouchGestureDetectorRegionState
       return;
     }
     if (isDesktop) {
-      // to-do
+      final scale = ((d.scale - _scale) * 1000).toInt();
+      _scale = d.scale;
+
+      if (scale != 0) {
+        bind.sessionSendPointer(
+            sessionId: sessionId,
+            msg: json.encode({
+              'touch': {'scale': scale}
+            }));
+      }
     } else {
       // mobile
-      // to-do: Is this correct?
       ffi.canvasModel.updateScale(d.scale / _scale);
       _scale = d.scale;
       ffi.canvasModel.panX(d.focalPointDelta.dx);
@@ -246,14 +256,17 @@ class _RawTouchGestureDetectorRegionState
       return;
     }
     if (isDesktop) {
-      // to-do
+      bind.sessionSendPointer(
+          sessionId: sessionId,
+          msg: json.encode({
+            'touch': {'scale': 0}
+          }));
     } else {
       // mobile
-      // to-do: Is this correct?
       _scale = 1;
       bind.sessionSetViewStyle(sessionId: sessionId, value: "");
     }
-     inputModel.sendMouse('up', MouseButtons.left);
+    inputModel.sendMouse('up', MouseButtons.left);
   }
 
   get onHoldDragCancel => null;

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -55,6 +55,8 @@ class InputModel {
   final _trackpadSpeed = 0.06;
   var _trackpadScrollUnsent = Offset.zero;
 
+  var _lastScale = 1.0;
+
   // mouse
   final isPhysicalMouse = false.obs;
   int _lastButtons = 0;
@@ -272,7 +274,7 @@ class InputModel {
     sendMouse('down', button);
   }
 
-    void tapUp(MouseButtons button) {
+  void tapUp(MouseButtons button) {
     sendMouse('up', button);
   }
 
@@ -337,12 +339,15 @@ class InputModel {
   }
 
   void onPointerPanZoomStart(PointerPanZoomStartEvent e) {
+    _lastScale = 1.0;
     _stopFling = true;
   }
 
   // https://docs.flutter.dev/release/breaking-changes/trackpad-gestures
-  // TODO(support zoom in/out)
   void onPointerPanZoomUpdate(PointerPanZoomUpdateEvent e) {
+    final scale = ((e.scale - _lastScale) * 100).toInt();
+    _lastScale = e.scale;
+
     final delta = e.panDelta;
     _trackpadLastDelta = delta;
 
@@ -366,7 +371,7 @@ class InputModel {
     if (x != 0 || y != 0) {
       bind.sessionSendMouse(
           sessionId: sessionId,
-          msg: '{"type": "trackpad", "x": "$x", "y": "$y"}');
+          msg: '{"type": "trackpad", "x": "$x", "y": "$y", "scale": "$scale"}');
     }
   }
 

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -345,8 +345,19 @@ class InputModel {
 
   // https://docs.flutter.dev/release/breaking-changes/trackpad-gestures
   void onPointerPanZoomUpdate(PointerPanZoomUpdateEvent e) {
-    final scale = ((e.scale - _lastScale) * 100).toInt();
+    debugPrint(
+        'REMOVE ME =============================== onPointerPanZoomUpdate ${e.scale}');
+    final scale = ((e.scale - _lastScale) * 1000).toInt();
     _lastScale = e.scale;
+
+    if (scale != 0) {
+      bind.sessionSendPointer(
+          sessionId: sessionId,
+          msg: json.encode({
+            'touch': {'scale': scale}
+          }));
+      return;
+    }
 
     final delta = e.panDelta;
     _trackpadLastDelta = delta;
@@ -371,7 +382,7 @@ class InputModel {
     if (x != 0 || y != 0) {
       bind.sessionSendMouse(
           sessionId: sessionId,
-          msg: '{"type": "trackpad", "x": "$x", "y": "$y", "scale": "$scale"}');
+          msg: '{"type": "trackpad", "x": "$x", "y": "$y"}');
     }
   }
 
@@ -427,6 +438,12 @@ class InputModel {
   }
 
   void onPointerPanZoomEnd(PointerPanZoomEndEvent e) {
+    bind.sessionSendPointer(
+        sessionId: sessionId,
+        msg: json.encode({
+          'touch': {'scale': 0}
+        }));
+
     waitLastFlingDone();
     _stopFling = false;
 

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -345,8 +345,6 @@ class InputModel {
 
   // https://docs.flutter.dev/release/breaking-changes/trackpad-gestures
   void onPointerPanZoomUpdate(PointerPanZoomUpdateEvent e) {
-    debugPrint(
-        'REMOVE ME =============================== onPointerPanZoomUpdate ${e.scale}');
     final scale = ((e.scale - _lastScale) * 1000).toInt();
     _lastScale = e.scale;
 

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -122,13 +122,13 @@ message TouchEvent {
   oneof union {
     TouchScaleUpdate scale_update = 1;
   }
-  repeated ControlKey modifiers = 2;
 }
 
 message PointerDeviceEvent {
   oneof union {
     TouchEvent touch_event = 1;
   }
+  repeated ControlKey modifiers = 2;
 }
 
 message MouseEvent {

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -116,6 +116,7 @@ message MouseEvent {
   sint32 x = 2;
   sint32 y = 3;
   repeated ControlKey modifiers = 4;
+  sint32 scale = 5;
 }
 
 enum KeyboardMode{

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -111,12 +111,31 @@ message LoginResponse {
   }
 }
 
+message TouchScaleUpdate {
+  // The delta scale factor relative to the previous scale.
+  // delta * 1000
+  // 0 means scale end
+  int32 scale = 1;
+}
+
+message TouchEvent {
+  oneof union {
+    TouchScaleUpdate scale_update = 1;
+  }
+  repeated ControlKey modifiers = 2;
+}
+
+message PointerDeviceEvent {
+  oneof union {
+    TouchEvent touch_event = 1;
+  }
+}
+
 message MouseEvent {
   int32 mask = 1;
   sint32 x = 2;
   sint32 y = 3;
   repeated ControlKey modifiers = 4;
-  sint32 scale = 5;
 }
 
 enum KeyboardMode{
@@ -683,5 +702,6 @@ message Message {
     VoiceCallRequest voice_call_request = 23;
     VoiceCallResponse voice_call_response = 24;
     PeerInfo peer_info = 25;
+    PointerDeviceEvent pointer_device_event = 26;
   }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1109,7 +1109,8 @@ impl LoginConfigHandler {
         self.remember = !config.password.is_empty();
         self.config = config;
         let mut sid = rand::random();
-        if sid == 0 { // you won the lottery
+        if sid == 0 {
+            // you won the lottery
             sid = 1;
         }
         self.session_id = sid;
@@ -1928,6 +1929,7 @@ pub fn send_mouse(
     mask: i32,
     x: i32,
     y: i32,
+    scale: i32,
     alt: bool,
     ctrl: bool,
     shift: bool,
@@ -1939,6 +1941,7 @@ pub fn send_mouse(
         mask,
         x,
         y,
+        scale,
         ..Default::default()
     };
     if alt {
@@ -1971,12 +1974,12 @@ pub fn send_mouse(
 ///
 /// * `interface` - The interface for sending data.
 fn activate_os(interface: &impl Interface) {
-    send_mouse(0, 0, 0, false, false, false, false, interface);
+    send_mouse(0, 0, 0, 0, false, false, false, false, interface);
     std::thread::sleep(Duration::from_millis(50));
-    send_mouse(0, 3, 3, false, false, false, false, interface);
+    send_mouse(0, 3, 3, 0, false, false, false, false, interface);
     std::thread::sleep(Duration::from_millis(50));
-    send_mouse(1 | 1 << 3, 0, 0, false, false, false, false, interface);
-    send_mouse(2 | 1 << 3, 0, 0, false, false, false, false, interface);
+    send_mouse(1 | 1 << 3, 0, 0, 0, false, false, false, false, interface);
+    send_mouse(2 | 1 << 3, 0, 0, 0, false, false, false, false, interface);
     /*
     let mut key_event = KeyEvent::new();
     // do not use Esc, which has problem with Linux

--- a/src/client.rs
+++ b/src/client.rs
@@ -1967,8 +1967,8 @@ pub fn send_mouse(
 }
 
 #[inline]
-pub fn send_touch(
-    mut evt: TouchEvent,
+pub fn send_pointer_device_event(
+    mut evt: PointerDeviceEvent,
     alt: bool,
     ctrl: bool,
     shift: bool,
@@ -1995,10 +1995,7 @@ pub fn send_touch(
         mouse_event.x *= factor;
         mouse_event.y *= factor;
     }
-    msg_out.set_pointer_device_event(PointerDeviceEvent {
-        union: Some(pointer_device_event::Union::TouchEvent(evt)),
-        ..Default::default()
-    });
+    msg_out.set_pointer_device_event(evt);
     interface.send(Data::Message(msg_out));
 }
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1103,8 +1103,12 @@ pub fn session_send_mouse(session_id: SessionID, msg: String) {
                 _ => 0,
             } << 3;
         }
+        let scale = m
+            .get("scale")
+            .map(|x| x.parse::<i32>().unwrap_or(0))
+            .unwrap_or(0);
         if let Some(session) = SESSIONS.read().unwrap().get(&session_id) {
-            session.send_mouse(mask, x, y, alt, ctrl, shift, command);
+            session.send_mouse(mask, x, y, scale, alt, ctrl, shift, command);
         }
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -152,6 +152,7 @@ pub enum DataPortableService {
     Pong,
     ConnCount(Option<usize>),
     Mouse((Vec<u8>, i32)),
+    Pointer((Vec<u8>, i32)),
     Key(Vec<u8>),
     RequestStart,
     WillClose,

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1,9 +1,9 @@
 use super::*;
-use crate::input::*;
 #[cfg(target_os = "macos")]
 use crate::common::is_server;
 #[cfg(target_os = "linux")]
 use crate::common::IS_X11;
+use crate::input::*;
 #[cfg(target_os = "macos")]
 use dispatch::Queue;
 use enigo::{Enigo, Key, KeyboardControllable, MouseButton, MouseControllable};
@@ -752,6 +752,14 @@ pub fn handle_mouse_(evt: &MouseEvent, conn: i32) {
         return;
     }
 
+    if evt.scale != 0 {
+        #[cfg(target_os = "windows")]
+        {
+            handle_scale(evt.scale);
+            return;
+        }
+    }
+
     #[cfg(windows)]
     crate::platform::windows::try_change_desktop();
     let buttons = evt.mask >> 3;
@@ -883,14 +891,14 @@ pub fn handle_mouse_(evt: &MouseEvent, conn: i32) {
     for key in to_release {
         en.key_up(key.clone());
     }
-    handle_mouse_scale(evt.scale);
 }
 
 #[cfg(target_os = "windows")]
-fn handle_mouse_scale(scale: i32) {
+fn handle_scale(scale: i32) {
     let mut en = ENIGO.lock().unwrap();
-    en.key_down(Key::Control);
-    en.mouse_scroll_y(scale);
+    if en.key_down(Key::Control).is_ok() {
+        en.mouse_scroll_y(scale);
+    }
     en.key_up(Key::Control);
 }
 

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -759,7 +759,7 @@ pub fn handle_mouse_(evt: &MouseEvent, conn: i32) {
     let mut en = ENIGO.lock().unwrap();
     #[cfg(not(target_os = "macos"))]
     let mut to_release = Vec::new();
-    if evt_type == 1 {
+    if evt_type == MOUSE_TYPE_DOWN {
         fix_modifiers(&evt.modifiers[..], &mut en, 0);
         #[cfg(target_os = "macos")]
         en.reset_flag();
@@ -883,6 +883,15 @@ pub fn handle_mouse_(evt: &MouseEvent, conn: i32) {
     for key in to_release {
         en.key_up(key.clone());
     }
+    handle_mouse_scale(evt.scale);
+}
+
+#[cfg(target_os = "windows")]
+fn handle_mouse_scale(scale: i32) {
+    let mut en = ENIGO.lock().unwrap();
+    en.key_down(Key::Control);
+    en.mouse_scroll_y(scale);
+    en.key_up(Key::Control);
 }
 
 pub fn is_enter(evt: &KeyEvent) -> bool {

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -7,7 +7,11 @@ use crate::input::*;
 #[cfg(target_os = "macos")]
 use dispatch::Queue;
 use enigo::{Enigo, Key, KeyboardControllable, MouseButton, MouseControllable};
-use hbb_common::{get_time, protobuf::EnumOrUnknown};
+use hbb_common::{
+    get_time,
+    message_proto::{pointer_device_event::Union::TouchEvent, touch_event::Union::ScaleUpdate},
+    protobuf::EnumOrUnknown,
+};
 use rdev::{self, EventType, Key as RdevKey, KeyCode, RawKey};
 #[cfg(target_os = "macos")]
 use rdev::{CGEventSourceStateID, CGEventTapLocation, VirtualInput};
@@ -523,6 +527,21 @@ pub fn handle_mouse(evt: &MouseEvent, conn: i32) {
     handle_mouse_(evt, conn);
 }
 
+// to-do: merge handle_mouse and handle_pointer
+pub fn handle_pointer(evt: &PointerDeviceEvent, conn: i32) {
+    #[cfg(target_os = "macos")]
+    if !is_server() {
+        // having GUI, run main GUI thread, otherwise crash
+        let evt = evt.clone();
+        QUEUE.exec_async(move || handle_pointer_(&evt, conn));
+        return;
+    }
+    #[cfg(windows)]
+    crate::portable_service::client::handle_pointer(evt, conn);
+    #[cfg(not(windows))]
+    handle_pointer_(evt, conn);
+}
+
 pub fn fix_key_down_timeout_loop() {
     std::thread::spawn(move || loop {
         std::thread::sleep(std::time::Duration::from_millis(10_000));
@@ -743,7 +762,7 @@ fn active_mouse_(conn: i32) -> bool {
     }
 }
 
-pub fn handle_mouse_(evt: &MouseEvent, conn: i32) {
+pub fn handle_pointer_(evt: &PointerDeviceEvent, conn: i32) {
     if !active_mouse_(conn) {
         return;
     }
@@ -752,12 +771,25 @@ pub fn handle_mouse_(evt: &MouseEvent, conn: i32) {
         return;
     }
 
-    if evt.scale != 0 {
-        #[cfg(target_os = "windows")]
-        {
-            handle_scale(evt.scale);
-            return;
-        }
+    match &evt.union {
+        Some(TouchEvent(evt)) => match &evt.union {
+            Some(ScaleUpdate(_scale_evt)) => {
+                #[cfg(target_os = "windows")]
+                handle_scale(_scale_evt.scale);
+            }
+            _ => {}
+        },
+        _ => {}
+    }
+}
+
+pub fn handle_mouse_(evt: &MouseEvent, conn: i32) {
+    if !active_mouse_(conn) {
+        return;
+    }
+
+    if EXITING.load(Ordering::SeqCst) {
+        return;
     }
 
     #[cfg(windows)]
@@ -896,10 +928,13 @@ pub fn handle_mouse_(evt: &MouseEvent, conn: i32) {
 #[cfg(target_os = "windows")]
 fn handle_scale(scale: i32) {
     let mut en = ENIGO.lock().unwrap();
-    if en.key_down(Key::Control).is_ok() {
-        en.mouse_scroll_y(scale);
+    if scale == 0 {
+        en.key_up(Key::Control);
+    } else {
+        if en.key_down(Key::Control).is_ok() {
+            en.mouse_scroll_y(scale);
+        }
     }
-    en.key_up(Key::Control);
 }
 
 pub fn is_enter(evt: &KeyEvent) -> bool {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -35,8 +35,8 @@ use hbb_common::{
 use crate::client::io_loop::Remote;
 use crate::client::{
     check_if_retry, handle_hash, handle_login_error, handle_login_from_ui, handle_test_delay,
-    input_os_password, load_config, send_mouse, send_touch, start_video_audio_threads, FileManager,
-    Key, LoginConfigHandler, QualityStatus, KEY_MAP,
+    input_os_password, load_config, send_mouse, send_pointer_device_event,
+    start_video_audio_threads, FileManager, Key, LoginConfigHandler, QualityStatus, KEY_MAP,
 };
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::common::GrabState;
@@ -695,11 +695,11 @@ impl<T: InvokeUiSession> Session<T> {
             scale,
             ..Default::default()
         };
-        let evt = TouchEvent {
-            union: Some(touch_event::Union::ScaleUpdate(scale_evt)),
-            ..Default::default()
-        };
-        send_touch(evt, alt, ctrl, shift, command, self);
+        let mut touch_evt = TouchEvent::new();
+        touch_evt.set_scale_update(scale_evt);
+        let mut evt = PointerDeviceEvent::new();
+        evt.set_touch_event(touch_evt);
+        send_pointer_device_event(evt, alt, ctrl, shift, command, self);
     }
 
     pub fn send_mouse(


### PR DESCRIPTION
1. Add pointer device event. Superset of mouse and touch event.
2. Support zoom of touchpad and touchscreen on desktop. (Win only)

Zooming is simulated by "Ctrl" + "mouse scroll" on Windows.

TODOs:
- [ ] Merge mouse event to pointer device event.
- [ ] Scale on Linux and macOS ?