### PR TITLE
Fix sciter build on MacOS

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2025,13 +2025,6 @@ pub fn send_pointer_device_event(
     if command {
         evt.modifiers.push(ControlKey::Meta.into());
     }
-    #[cfg(all(target_os = "macos", not(feature = "flutter")))]
-    if check_scroll_on_mac(mask, x, y) {
-        let factor = 3;
-        mouse_event.mask = crate::input::MOUSE_TYPE_TRACKPAD;
-        mouse_event.x *= factor;
-        mouse_event.y *= factor;
-    }
     msg_out.set_pointer_device_event(evt);
     interface.send(Data::Message(msg_out));
 }


### PR DESCRIPTION
c86a8fff034c7dd3b3ddf4f33d69eaee5c3538b0 accidentally duplicated that part of the code from send_mouse (the function just above). Removing it.