### PR TITLE
Fix/window save pos

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1363,15 +1363,19 @@ Future<void> saveWindowPosition(WindowType type, {int? windowId}) async {
     debugPrint(
         "Error: windowId cannot be null when saving positions for sub window");
   }
+
+  late Offset position;
+  late Size sz;
+  late bool isMaximized;
   switch (type) {
     case WindowType.Main:
-      final position = await windowManager.getPosition();
-      final sz = await windowManager.getSize();
-      final isMaximized = await windowManager.isMaximized();
-      final pos = LastWindowPosition(
-          sz.width, sz.height, position.dx, position.dy, isMaximized);
-      await bind.setLocalFlutterConfig(
-          k: kWindowPrefix + type.name, v: pos.toString());
+      position = await windowManager.getPosition();
+      if (position.dx < 0 || position.dy < 0) {
+        debugPrint("Main window is hidden, ignoring position restoration");
+        return;
+      }
+      sz = await windowManager.getSize();
+      isMaximized = await windowManager.isMaximized();
       break;
     default:
       final wc = WindowController.fromWindowId(windowId!);
@@ -1382,22 +1386,22 @@ Future<void> saveWindowPosition(WindowType type, {int? windowId}) async {
         debugPrint("Failed to get frame of window $windowId, it may be hidden");
         return;
       }
-      final position = frame.topLeft;
+      position = frame.topLeft;
       if (position.dx < 0 || position.dy < 0) {
         debugPrint("Window $windowId is hidden, ignoring position restoration");
         return;
       }
-
-      final sz = frame.size;
-      final isMaximized = await wc.isMaximized();
-      final pos = LastWindowPosition(
-          sz.width, sz.height, position.dx, position.dy, isMaximized);
-      debugPrint(
-          "Saving frame: $windowId: ${pos.width}/${pos.height}, offset:${pos.offsetWidth}/${pos.offsetHeight}");
-      await bind.setLocalFlutterConfig(
-          k: kWindowPrefix + type.name, v: pos.toString());
+      sz = frame.size;
+      isMaximized = await wc.isMaximized();
       break;
   }
+
+  final pos = LastWindowPosition(
+      sz.width, sz.height, position.dx, position.dy, isMaximized);
+  debugPrint(
+      "Saving frame: $windowId: ${pos.width}/${pos.height}, offset:${pos.offsetWidth}/${pos.offsetHeight}");
+  await bind.setLocalFlutterConfig(
+      k: kWindowPrefix + type.name, v: pos.toString());
 }
 
 Future<Size> _adjustRestoreMainWindowSize(double? width, double? height) async {
@@ -1869,7 +1873,14 @@ Future<void> onActiveWindowChanged() async {
   if (rustDeskWinManager.getActiveWindows().isEmpty) {
     // close all sub windows
     try {
-      await rustDeskWinManager.closeAllSubWindows();
+      if (Platform.isLinux) {
+        await Future.wait([
+          saveWindowPosition(WindowType.Main),
+          rustDeskWinManager.closeAllSubWindows()
+        ]);
+      } else {
+        await rustDeskWinManager.closeAllSubWindows();
+      }
     } catch (err) {
       debugPrintStack(label: "$err");
     } finally {

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -478,6 +478,8 @@ class WindowActionPanel extends StatefulWidget {
 
 class WindowActionPanelState extends State<WindowActionPanel>
     with MultiWindowListener, WindowListener {
+  final _saveFrameDebounce = Debouncer(delay: Duration(seconds: 1));
+
   @override
   void initState() {
     super.initState();
@@ -535,6 +537,26 @@ class WindowActionPanelState extends State<WindowActionPanel>
     }
     _setMaximize(false);
     super.onWindowUnmaximize();
+  }
+
+  _saveFrame() async {
+    if (widget.tabType == DesktopTabType.main) {
+      await saveWindowPosition(WindowType.Main);
+    } else if (kWindowType != null && kWindowId != null) {
+      await saveWindowPosition(kWindowType!, windowId: kWindowId);
+    }
+  }
+
+  @override
+  void onWindowMoved() {
+    _saveFrameDebounce.call(_saveFrame);
+    super.onWindowMoved();
+  }
+
+  @override
+  void onWindowResized() {
+    _saveFrameDebounce.call(_saveFrame);
+    super.onWindowMoved();
   }
 
   @override

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -327,7 +327,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: aee670819f5fe7e8b0f05e0239dafb5c62f7a84b
+      resolved-ref: 6c4181330f4ed80c1cb5670bd61aa75115f9f748
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/5109

Save the position when the window is moved or resized.

Please merge https://github.com/rustdesk-org/rustdesk_desktop_multi_window/pull/2 first.

Notes:
1. For Windows and MacOS, save the position on moved and resized is enought.
2. For Linux, the main window does not listen the moved and resized events. It should also save the position on close.

Windows will get negative positions if the window is minimized.
While Linux does not.



https://github.com/rustdesk/rustdesk/assets/136106582/cef180fe-679a-4a71-ad7e-8db1df70dc7c

