### PR TITLE
opt bitrate change

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -947,7 +947,9 @@ showSetOSPassword(
   Function()? closeCallback,
 ) async {
   final controller = TextEditingController();
-  osPassword ??= await bind.sessionGetOption(sessionId: sessionId, arg: 'os-password') ?? '';
+  osPassword ??=
+      await bind.sessionGetOption(sessionId: sessionId, arg: 'os-password') ??
+          '';
   var autoLogin =
       await bind.sessionGetOption(sessionId: sessionId, arg: 'auto-login') !=
           '';
@@ -957,6 +959,7 @@ showSetOSPassword(
       close();
       if (closeCallback != null) closeCallback();
     }
+
     submit() {
       var text = controller.text.trim();
       bind.sessionPeerOption(
@@ -1221,7 +1224,7 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
       quality != null && quality.isNotEmpty ? quality[0].toDouble() : 50.0;
   const qualityMinValue = 10.0;
   const qualityMoreThresholdValue = 100.0;
-  const qualityMaxValue = 4000.0;
+  const qualityMaxValue = 2000.0;
   if (qualityInitValue < qualityMinValue) {
     qualityInitValue = qualityMinValue;
   }
@@ -1269,22 +1272,23 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
           Expanded(
               flex: 1,
               child: Row(
-                 children: [
-                   Checkbox(
-                     value: moreQualityChecked.value,
-                     onChanged: (bool? value) {
-                       moreQualityChecked.value = value!;
-                       if (!value &&
-                         qualitySliderValue.value > qualityMoreThresholdValue) {
-                         qualitySliderValue.value = qualityMoreThresholdValue;
-                         debouncerQuality.value = qualityMoreThresholdValue;
-                       }
-                     },
-                   ).marginOnly(right: 5),
-                   Expanded(
-                     child: Text(translate('More')),
-                   )
-                 ],
+                children: [
+                  Checkbox(
+                    value: moreQualityChecked.value,
+                    onChanged: (bool? value) {
+                      moreQualityChecked.value = value!;
+                      if (!value &&
+                          qualitySliderValue.value >
+                              qualityMoreThresholdValue) {
+                        qualitySliderValue.value = qualityMoreThresholdValue;
+                        debouncerQuality.value = qualityMoreThresholdValue;
+                      }
+                    },
+                  ).marginOnly(right: 5),
+                  Expanded(
+                    child: Text(translate('More')),
+                  )
+                ],
               )),
         ],
       ));

--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -1220,7 +1220,8 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
   qualityInitValue =
       quality != null && quality.isNotEmpty ? quality[0].toDouble() : 50.0;
   const qualityMinValue = 10.0;
-  const qualityMaxValue = 100.0;
+  const qualityMoreThresholdValue = 100.0;
+  const qualityMaxValue = 4000.0;
   if (qualityInitValue < qualityMinValue) {
     qualityInitValue = qualityMinValue;
   }
@@ -1228,6 +1229,8 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
     qualityInitValue = qualityMaxValue;
   }
   final RxDouble qualitySliderValue = RxDouble(qualityInitValue);
+  final moreQualityInitValue = qualityInitValue > qualityMoreThresholdValue;
+  final RxBool moreQualityChecked = RxBool(moreQualityInitValue);
   final debouncerQuality = Debouncer<double>(
     Duration(milliseconds: 1000),
     onChanged: (double v) {
@@ -1242,7 +1245,9 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
               child: Slider(
                 value: qualitySliderValue.value,
                 min: qualityMinValue,
-                max: qualityMaxValue,
+                max: moreQualityChecked.value
+                    ? qualityMaxValue
+                    : qualityMoreThresholdValue,
                 divisions: 18,
                 onChanged: (double value) {
                   qualitySliderValue.value = value;
@@ -1256,10 +1261,30 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
                 style: const TextStyle(fontSize: 15),
               )),
           Expanded(
-              flex: 2,
+              flex: 1,
               child: Text(
                 translate('Bitrate'),
                 style: const TextStyle(fontSize: 15),
+              )),
+          Expanded(
+              flex: 1,
+              child: Row(
+                 children: [
+                   Checkbox(
+                     value: moreQualityChecked.value,
+                     onChanged: (bool? value) {
+                       moreQualityChecked.value = value!;
+                       if (!value &&
+                         qualitySliderValue.value > qualityMoreThresholdValue) {
+                         qualitySliderValue.value = qualityMoreThresholdValue;
+                         debouncerQuality.value = qualityMoreThresholdValue;
+                       }
+                     },
+                   ).marginOnly(right: 5),
+                   Expanded(
+                     child: Text(translate('More')),
+                   )
+                 ],
               )),
         ],
       ));

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1078,7 +1078,7 @@ impl PeerConfig {
         D: de::Deserializer<'de>,
     {
         let v: Vec<i32> = de::Deserialize::deserialize(deserializer)?;
-        if v.len() == 1 && v[0] >= 10 && v[0] <= 100 {
+        if v.len() == 1 && v[0] >= 10 && v[0] <= 0xFFF {
             Ok(v)
         } else {
             Ok(Self::default_custom_image_quality())
@@ -1402,7 +1402,7 @@ impl UserDefaultConfig {
             "codec-preference" => {
                 self.get_string(key, "auto", vec!["vp8", "vp9", "av1", "h264", "h265"])
             }
-            "custom_image_quality" => self.get_double_string(key, 50.0, 10.0, 100.0),
+            "custom_image_quality" => self.get_double_string(key, 50.0, 10.0, 0xFFF as f64),
             "custom-fps" => self.get_double_string(key, 30.0, 5.0, 120.0),
             _ => self
                 .options

--- a/libs/scrap/src/common/aom.rs
+++ b/libs/scrap/src/common/aom.rs
@@ -344,7 +344,7 @@ impl AomEncoder {
     fn calc_q_values(b: u32) -> (u32, u32) {
         let b = std::cmp::min(b, 200);
         let q_min1: i32 = 24;
-        let q_min2 = 12;
+        let q_min2 = 5;
         let q_max1 = 45;
         let q_max2 = 25;
 

--- a/libs/scrap/src/common/vpxcodec.rs
+++ b/libs/scrap/src/common/vpxcodec.rs
@@ -303,7 +303,7 @@ impl VpxEncoder {
     fn calc_q_values(b: u32) -> (u32, u32) {
         let b = std::cmp::min(b, 200);
         let q_min1: i32 = 36;
-        let q_min2 = 12;
+        let q_min2 = 0;
         let q_max1 = 56;
         let q_max2 = 37;
 

--- a/src/server/video_qos.rs
+++ b/src/server/video_qos.rs
@@ -299,9 +299,9 @@ impl VideoQoS {
             } else if q == ImageQuality::Best.value() {
                 Quality::Best
             } else {
-                let mut b = (q >> 8 & 0xFF) * 2;
-                b = std::cmp::max(b, 10);
-                b = std::cmp::min(b, 200);
+                let mut b = (q >> 8 & 0xFFF) * 2;
+                b = std::cmp::max(b, 20);
+                b = std::cmp::min(b, 8000);
                 Quality::Custom(b as u32)
             }
         };

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -425,14 +425,19 @@ function handle_custom_image_quality() {
     var tmp = handler.get_custom_image_quality();
     var bitrate = (tmp[0] || 50);
     var extendedBitrate = bitrate > 100;
-    var maxRate = extendedBitrate ? 4000 : 100;
+    var maxRate = extendedBitrate ? 2000 : 100;
     msgbox("custom-image-quality", "Custom Image Quality", "<div .form> \
           <div><input #bitrate-slider type=\"hslider\" style=\"width: 50%\" name=\"bitrate\" max=\"" + maxRate + "\" min=\"10\" value=\"" + bitrate + "\"/ buddy=\"bitrate-buddy\"><b #bitrate-buddy>x</b>% Bitrate <button|checkbox #extended-slider .custom-event " + (extendedBitrate ? "checked" : "") + ">More</button></div> \
       </div>", "", function(res=null) {
         if (!res) return;
         if (res.id === "extended-slider") {
             var slider = res.parent.$(#bitrate-slider)
-            slider.slider.max = res.checked ? 4000 : 100;
+            slider.slider.max = res.checked ? 2000 : 100;
+            if (slider.value > slider.slider.max) {
+                slider.value = slider.slider.max;
+            }
+            var buddy = res.parent.$(#bitrate-buddy);
+            buddy.value = slider.value;
             return;
         }
         if (!res.bitrate) return;

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -424,10 +424,17 @@ class Header: Reactor.Component {
 function handle_custom_image_quality() {
     var tmp = handler.get_custom_image_quality();
     var bitrate = (tmp[0] || 50);
-    msgbox("custom", "Custom Image Quality", "<div .form> \
-          <div><input type=\"hslider\" style=\"width: 50%\" name=\"bitrate\" max=\"100\" min=\"10\" value=\"" + bitrate + "\"/ buddy=\"bitrate-buddy\"><b #bitrate-buddy>x</b>% Bitrate</div> \
+    var extendedBitrate = bitrate > 100;
+    var maxRate = extendedBitrate ? 4000 : 100;
+    msgbox("custom-image-quality", "Custom Image Quality", "<div .form> \
+          <div><input #bitrate-slider type=\"hslider\" style=\"width: 50%\" name=\"bitrate\" max=\"" + maxRate + "\" min=\"10\" value=\"" + bitrate + "\"/ buddy=\"bitrate-buddy\"><b #bitrate-buddy>x</b>% Bitrate <button|checkbox #extended-slider .custom-event " + (extendedBitrate ? "checked" : "") + ">More</button></div> \
       </div>", "", function(res=null) {
         if (!res) return;
+        if (res.id === "extended-slider") {
+            var slider = res.parent.$(#bitrate-slider)
+            slider.slider.max = res.checked ? 4000 : 100;
+            return;
+        }
         if (!res.bitrate) return;
         handler.save_custom_image_quality(res.bitrate);
         toggleMenuState();


### PR DESCRIPTION
1. For bitrate bigger than 200%, vpx use q_min=0, aom use q_min=5
2. Allow to increase bitrate massively, change max to 2000%, because vp8 encode failed when the bitrate is close to 4000% on my computer. There may be a maximum supported bitrate for each codec. #4976