### PR TITLE
log nothing if config file not found

### DIFF
--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -52,7 +52,6 @@ lazy_static::lazy_static! {
     pub static ref EXE_RENDEZVOUS_SERVER: Arc<RwLock<String>> = Default::default();
     pub static ref APP_NAME: Arc<RwLock<String>> = Arc::new(RwLock::new("RustDesk".to_owned()));
     static ref KEY_PAIR: Arc<Mutex<Option<KeyPair>>> = Default::default();
-    static ref HW_CODEC_CONFIG: Arc<RwLock<HwCodecConfig>> = Arc::new(RwLock::new(HwCodecConfig::load()));
     static ref USER_DEFAULT_CONFIG: Arc<RwLock<(UserDefaultConfig, Instant)>> = Arc::new(RwLock::new((UserDefaultConfig::load(), Instant::now())));
 }
 
@@ -400,6 +399,11 @@ pub fn load_path<T: serde::Serialize + serde::de::DeserializeOwned + Default + s
     let cfg = match confy::load_path(&file) {
         Ok(config) => config,
         Err(err) => {
+            if let confy::ConfyError::GeneralLoadError(err) = &err {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    return T::default();
+                }
+            }
             log::error!("Failed to load config '{}': {}", file.display(), err);
             T::default()
         }
@@ -1357,16 +1361,6 @@ impl HwCodecConfig {
 
     pub fn clear() {
         HwCodecConfig::default().store();
-    }
-
-    /// refresh current global HW_CODEC_CONFIG, usually uesd after HwCodecConfig::remove()
-    pub fn refresh() {
-        *HW_CODEC_CONFIG.write().unwrap() = HwCodecConfig::load();
-        log::debug!("HW_CODEC_CONFIG refreshed successfully");
-    }
-
-    pub fn get() -> HwCodecConfig {
-        return HW_CODEC_CONFIG.read().unwrap().clone();
     }
 }
 

--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -314,7 +314,7 @@ impl HwDecoderImage<'_> {
 }
 
 fn get_config(k: &str) -> ResultType<CodecInfos> {
-    let v = HwCodecConfig::get()
+    let v = HwCodecConfig::load()
         .options
         .get(k)
         .unwrap_or(&"".to_owned())
@@ -375,10 +375,7 @@ pub fn check_config_process() {
                     // wait up to 10 seconds
                     for _ in 0..10 {
                         std::thread::sleep(std::time::Duration::from_secs(1));
-                        if let Ok(Some(status)) = child.try_wait() {
-                            if status.success() {
-                                HwCodecConfig::refresh();
-                            }
+                        if let Ok(Some(_)) = child.try_wait() {
                             break;
                         }
                     }
@@ -399,7 +396,6 @@ pub fn check_config_process() {
                             log::error!("Check hwcodec config, error attempting to wait: {e}")
                         }
                     }
-                    HwCodecConfig::refresh();
                 }
             }
         };

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -77,7 +77,7 @@ pub fn core_main() -> Option<Vec<String>> {
     #[cfg(target_os = "linux")]
     #[cfg(feature = "flutter")]
     {
-        let (k, v) = ("LIBGL_ALWAYS_SOFTWARE", "true");
+        let (k, v) = ("LIBGL_ALWAYS_SOFTWARE", "1");
         if !hbb_common::config::Config::get_option("allow-always-software-render").is_empty() {
             std::env::set_var(k, v);
         } else {


### PR DESCRIPTION
1. log nothing if err is std::io::ErrorKind::NotFound when loading config https://github.com/rustdesk/rustdesk/issues/5192#issuecomment-1656991230
2. remove global var HW_CODEC_CONFIG
3. use LIBGL_ALWAYS_SOFTWARE=1 , which is more common, rather than LIBGL_ALWAYS_SOFTWARE=true