### PR TITLE
Fix/win file clipboard

### DIFF
--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -181,32 +181,37 @@ pub fn server_clip_file(
         ClipboardFile::MonitorReady => {
             log::debug!("server_monitor_ready called");
             ret = server_monitor_ready(context, conn_id);
-            log::debug!("server_monitor_ready called, return {}", ret);
+            log::debug!("server_monitor_ready called, conn_id {}, return {}", conn_id, ret);
         }
         ClipboardFile::FormatList { format_list } => {
-            log::debug!("server_format_list called");
+            log::debug!("server_format_list called, conn_id {}, format_list: {:?}", conn_id, &format_list);
             ret = server_format_list(context, conn_id, format_list);
-            log::debug!("server_format_list called, return {}", ret);
+            log::debug!("server_format_list called, conn_id {}, return {}", conn_id, ret);
         }
         ClipboardFile::FormatListResponse { msg_flags } => {
-            log::debug!("format_list_response called");
+            log::debug!("server_format_list_response called");
             ret = server_format_list_response(context, conn_id, msg_flags);
-            log::debug!("server_format_list_response called, return {}", ret);
+            log::debug!("server_format_list_response called, conn_id {}, msg_flags {}, return {}", conn_id, msg_flags, ret);
         }
         ClipboardFile::FormatDataRequest {
             requested_format_id,
         } => {
-            log::debug!("format_data_request called");
+            log::debug!("server_format_data_request called");
             ret = server_format_data_request(context, conn_id, requested_format_id);
-            log::debug!("server_format_data_request called, return {}", ret);
+            log::debug!("server_format_data_request called, conn_id {}, requested_format_id {}, return {}", conn_id, requested_format_id, ret);
         }
         ClipboardFile::FormatDataResponse {
             msg_flags,
             format_data,
         } => {
-            log::debug!("format_data_response called");
+            log::debug!("server_format_data_response called");
             ret = server_format_data_response(context, conn_id, msg_flags, format_data);
-            log::debug!("server_format_data_response called, return {}", ret);
+            log::debug!(
+                "server_format_data_response called, conn_id {}, msg_flags: {}, return {}",
+                conn_id,
+                msg_flags,
+                ret
+            );
         }
         ClipboardFile::FileContentsRequest {
             stream_id,
@@ -218,7 +223,7 @@ pub fn server_clip_file(
             have_clip_data_id,
             clip_data_id,
         } => {
-            log::debug!("file_contents_request called");
+            log::debug!("server_file_contents_request called");
             ret = server_file_contents_request(
                 context,
                 conn_id,
@@ -231,14 +236,24 @@ pub fn server_clip_file(
                 have_clip_data_id,
                 clip_data_id,
             );
-            log::debug!("server_file_contents_request called, return {}", ret);
+            log::debug!("server_file_contents_request called, conn_id {}, stream_id: {}, list_index {}, dw_flags {}, n_position_low {}, n_position_high {}, cb_requested {}, have_clip_data_id {}, clip_data_id {}, return {}",                 conn_id,
+                stream_id,
+                list_index,
+                dw_flags,
+                n_position_low,
+                n_position_high,
+                cb_requested,
+                have_clip_data_id,
+                clip_data_id,
+                ret
+            );
         }
         ClipboardFile::FileContentsResponse {
             msg_flags,
             stream_id,
             requested_data,
         } => {
-            log::debug!("file_contents_response called");
+            log::debug!("server_file_contents_response called");
             ret = server_file_contents_response(
                 context,
                 conn_id,
@@ -246,7 +261,12 @@ pub fn server_clip_file(
                 stream_id,
                 requested_data,
             );
-            log::debug!("server_file_contents_response called, return {}", ret);
+            log::debug!("server_file_contents_response called, conn_id {}, msg_flags {}, stream_id {}, return {}",
+                conn_id,
+                msg_flags,
+                stream_id,
+                ret
+            );
         }
     }
     ret
@@ -578,8 +598,6 @@ extern "C" fn client_format_data_request(
     _context: *mut CliprdrClientContext,
     format_data_request: *const CLIPRDR_FORMAT_DATA_REQUEST,
 ) -> UINT {
-    log::debug!("client_format_data_request called");
-
     let conn_id;
     let requested_format_id;
     unsafe {
@@ -589,6 +607,7 @@ extern "C" fn client_format_data_request(
     let data = ClipboardFile::FormatDataRequest {
         requested_format_id,
     };
+    log::debug!("client_format_data_request called, conn_id: {}, requested_format_id: {}", conn_id, requested_format_id);
     // no need to handle result here
     send_data(conn_id, data);
 

--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -535,8 +535,6 @@ extern "C" fn client_format_list(
     _context: *mut CliprdrClientContext,
     clip_format_list: *const CLIPRDR_FORMAT_LIST,
 ) -> UINT {
-    log::debug!("client_format_list called");
-
     let conn_id;
     let mut format_list: Vec<(i32, String)> = Vec::new();
     unsafe {
@@ -561,6 +559,8 @@ extern "C" fn client_format_list(
         }
         conn_id = (*clip_format_list).connID as i32;
     }
+    log::debug!("client_format_list called, client id: {}, format_list: {:?}", conn_id, &format_list);
+
     let data = ClipboardFile::FormatList { format_list };
     // no need to handle result here
     if conn_id == 0 {
@@ -580,14 +580,13 @@ extern "C" fn client_format_list_response(
     _context: *mut CliprdrClientContext,
     format_list_response: *const CLIPRDR_FORMAT_LIST_RESPONSE,
 ) -> UINT {
-    log::debug!("client_format_list_response called");
-
     let conn_id;
     let msg_flags;
     unsafe {
         conn_id = (*format_list_response).connID as i32;
         msg_flags = (*format_list_response).msgFlags as i32;
     }
+    log::debug!("client_format_list_response called, client id: {}, msg_flags: {}", conn_id, msg_flags);
     let data = ClipboardFile::FormatListResponse { msg_flags };
     send_data(conn_id, data);
 
@@ -618,8 +617,6 @@ extern "C" fn client_format_data_response(
     _context: *mut CliprdrClientContext,
     format_data_response: *const CLIPRDR_FORMAT_DATA_RESPONSE,
 ) -> UINT {
-    log::debug!("cconn_idlient_format_data_response called");
-
     let conn_id;
     let msg_flags;
     let format_data;
@@ -636,6 +633,7 @@ extern "C" fn client_format_data_response(
             .to_vec();
         }
     }
+    log::debug!("client_format_data_response called, client id: {}, msg_flags: {}", conn_id, msg_flags);
     let data = ClipboardFile::FormatDataResponse {
         msg_flags,
         format_data,
@@ -649,8 +647,6 @@ extern "C" fn client_file_contents_request(
     _context: *mut CliprdrClientContext,
     file_contents_request: *const CLIPRDR_FILE_CONTENTS_REQUEST,
 ) -> UINT {
-    log::debug!("client_file_contents_request called");
-
     // TODO: support huge file?
     // if (!cliprdr->hasHugeFileSupport)
     // {
@@ -692,6 +688,8 @@ extern "C" fn client_file_contents_request(
         have_clip_data_id,
         clip_data_id,
     };
+    log::debug!("client_file_contents_request called, data: {:?}", &data);
+
     send_data(conn_id, data);
 
     0
@@ -701,8 +699,6 @@ extern "C" fn client_file_contents_response(
     _context: *mut CliprdrClientContext,
     file_contents_response: *const CLIPRDR_FILE_CONTENTS_RESPONSE,
 ) -> UINT {
-    log::debug!("client_file_contents_response called");
-
     let conn_id;
     let msg_flags;
     let stream_id;
@@ -726,6 +722,7 @@ extern "C" fn client_file_contents_response(
         stream_id,
         requested_data,
     };
+    log::debug!("client_file_contents_response called, conn_id: {}, msg_flags: {}, stream_id: {}", conn_id, msg_flags, stream_id);
     send_data(conn_id, data);
 
     0

--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -560,7 +560,6 @@ extern "C" fn client_format_list(
         conn_id = (*clip_format_list).connID as i32;
     }
     log::debug!("client_format_list called, client id: {}, format_list: {:?}", conn_id, &format_list);
-
     let data = ClipboardFile::FormatList { format_list };
     // no need to handle result here
     if conn_id == 0 {
@@ -677,7 +676,6 @@ extern "C" fn client_file_contents_request(
         have_clip_data_id = (*file_contents_request).haveClipDataId == TRUE;
         clip_data_id = (*file_contents_request).clipDataId as i32;
     }
-
     let data = ClipboardFile::FileContentsRequest {
         stream_id,
         list_index,
@@ -689,7 +687,6 @@ extern "C" fn client_file_contents_request(
         clip_data_id,
     };
     log::debug!("client_file_contents_request called, data: {:?}", &data);
-
     send_data(conn_id, data);
 
     0

--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -1367,6 +1367,11 @@ static UINT cliprdr_send_format_list(wfClipboard *clipboard, UINT32 connID)
 	if (!clipboard)
 		return ERROR_INTERNAL_ERROR;
 
+	if (!IsClipboardFormatAvailable(CF_HDROP))
+	{
+		return ERROR_SUCCESS;
+	}
+
 	ZeroMemory(&formatList, sizeof(CLIPRDR_FORMAT_LIST));
 
 	/* Ignore if other app is holding clipboard */
@@ -1392,21 +1397,11 @@ static UINT cliprdr_send_format_list(wfClipboard *clipboard, UINT32 connID)
 		}
 
 		index = 0;
-
-		if (IsClipboardFormatAvailable(CF_HDROP))
-		{
-			UINT fsid = RegisterClipboardFormat(CFSTR_FILEDESCRIPTORW);
-			UINT fcid = RegisterClipboardFormat(CFSTR_FILECONTENTS);
-
-			formats[index++].formatId = fsid;
-			formats[index++].formatId = fcid;
-		}
-		else
-		{
-			while (formatId = EnumClipboardFormats(formatId) && index < numFormats)
-				formats[index++].formatId = formatId;
-		}
-
+		// IsClipboardFormatAvailable(CF_HDROP) is checked above
+		UINT fsid = RegisterClipboardFormat(CFSTR_FILEDESCRIPTORW);
+		UINT fcid = RegisterClipboardFormat(CFSTR_FILECONTENTS);
+		formats[index++].formatId = fsid;
+		formats[index++].formatId = fcid;
 		numFormats = index;
 
 		if (!CloseClipboard())
@@ -2215,6 +2210,7 @@ static UINT wf_cliprdr_server_format_list(CliprdrClientContext *context,
 
 	for (i = 0; i < formatList->numFormats; i++)
 	{
+		printf("REMOVE ME ========================== idx: %d, format id: %d\n", i, formatList->formats[i].formatId);
 		format = &(formatList->formats[i]);
 		mapping = &(clipboard->format_mappings[i]);
 		mapping->remote_format_id = format->formatId;
@@ -2594,6 +2590,7 @@ wf_cliprdr_server_format_data_response(CliprdrClientContext *context,
 		{
 			// BOOL emptyRes = wf_do_empty_cliprdr((wfClipboard *)context->custom);
 			// (void)emptyRes;
+			printf("REMOVE ME ================================= msg flags: %d\n", formatDataResponse->msgFlags);
 			rc = E_FAIL;
 			break;
 		}

--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -2210,7 +2210,6 @@ static UINT wf_cliprdr_server_format_list(CliprdrClientContext *context,
 
 	for (i = 0; i < formatList->numFormats; i++)
 	{
-		printf("REMOVE ME ========================== idx: %d, format id: %d\n", i, formatList->formats[i].formatId);
 		format = &(formatList->formats[i]);
 		mapping = &(clipboard->format_mappings[i]);
 		mapping->remote_format_id = format->formatId;
@@ -2590,7 +2589,6 @@ wf_cliprdr_server_format_data_response(CliprdrClientContext *context,
 		{
 			// BOOL emptyRes = wf_do_empty_cliprdr((wfClipboard *)context->custom);
 			// (void)emptyRes;
-			printf("REMOVE ME ================================= msg flags: %d\n", formatDataResponse->msgFlags);
 			rc = E_FAIL;
 			break;
 		}


### PR DESCRIPTION
This PR do not fix the common "file copy&patest" issues.


It fix the following "File copy&paste" cases.

<img width="518" alt="image" src="https://github.com/rustdesk/rustdesk/assets/136106582/b795cad5-e6e6-4438-9b74-2008d4d3aefa">


<img width="495" alt="image" src="https://github.com/rustdesk/rustdesk/assets/136106582/5704e872-4153-4955-b44e-85042125df05">





The only change is `libs/clipboard/src/windows/wf_cliprdr.c`.
The others are debug log lines.

```C
	if (!IsClipboardFormatAvailable(CF_HDROP))
	{
		return ERROR_SUCCESS;
	}
```
