### PR TITLE
Fix/render texture instance

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -117,9 +117,9 @@ class _RemotePageState extends State<RemotePage>
     }
     // Register texture.
     if (mainGetLocalBoolOptionSync(kOptionOpenNewConnInTabs)) {
-      _renderTexture = renderTexture;
-    } else {
       _renderTexture = RenderTexture();
+    } else {
+      _renderTexture = renderTexture;
     }
     _renderTexture.create(sessionId);
 

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -116,11 +116,7 @@ class _RemotePageState extends State<RemotePage>
       Wakelock.enable();
     }
     // Register texture.
-    if (mainGetLocalBoolOptionSync(kOptionOpenNewConnInTabs)) {
-      _renderTexture = RenderTexture();
-    } else {
-      _renderTexture = renderTexture;
-    }
+    _renderTexture = RenderTexture();
     _renderTexture.create(sessionId);
 
     _ffi.ffiModel.updateEventListener(sessionId, widget.id);

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -582,8 +582,6 @@ class WindowActionPanelState extends State<WindowActionPanel>
       }
       await windowManager.hide();
     } else {
-      renderTexture.destroy();
-
       // it's safe to hide the subwindow
       final controller = WindowController.fromWindowId(kWindowId!);
       if (Platform.isMacOS && await controller.isFullScreen()) {

--- a/flutter/lib/models/desktop_render_texture.dart
+++ b/flutter/lib/models/desktop_render_texture.dart
@@ -38,9 +38,4 @@ class RenderTexture {
       _textureKey = -1;
     }
   }
-
-  static final RenderTexture instance = RenderTexture();
 }
-
-// Global instance for separate texture
-final renderTexture = RenderTexture.instance;


### PR DESCRIPTION
Remove global render texture instance.

The logic of this code is reversed. 
```dart
    if (mainGetLocalBoolOptionSync(kOptionOpenNewConnInTabs)) {
      _renderTexture = renderTexture;
    } else {
      _renderTexture = RenderTexture();
    }
```

And there is no need to create a global texture instance for each separate window at all.
