### PR TITLE
fix waiting for image, should not await dialogManager.show

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -425,19 +425,18 @@ class FfiModel with ChangeNotifier {
       closeConnection();
     }
 
-    Future.delayed(Duration.zero, () async {
-      await dialogManager.show(
-        (setState, close, context) => CustomAlertDialog(
-            title: null,
-            content: SelectionArea(child: msgboxContent(type, title, text)),
-            actions: [
-              dialogButton("Cancel", onPressed: onClose, isOutline: true)
-            ],
-            onCancel: onClose),
-        tag: '$sessionId-waiting-for-image',
-      );
-      _waitForImageDialogShow[sessionId] = true;
-    });
+    dialogManager.show(
+      (setState, close, context) => CustomAlertDialog(
+          title: null,
+          content: SelectionArea(child: msgboxContent(type, title, text)),
+          actions: [
+            dialogButton("Cancel", onPressed: onClose, isOutline: true)
+          ],
+          onCancel: onClose),
+      tag: '$sessionId-waiting-for-image',
+    );
+    _waitForImageDialogShow[sessionId] = true;
+    bind.sessionOnWaitingForImageDialogShow(sessionId: sessionId);
   }
 
   _updateSessionWidthHeight(SessionID sessionId) {
@@ -1902,7 +1901,7 @@ Future<void> initializeCursorAndCanvas(FFI ffi) async {
 }
 
 clearWaitingForImage(OverlayDialogManager? dialogManager, SessionID sessionId) {
-  final durations = [100, 500, 1000, 2000];
+  final durations = [0, 100, 500, 1000, 2000];
   for (var duration in durations) {
     Future.delayed(Duration(milliseconds: duration), () {
       dialogManager?.dismissByTag('$sessionId-waiting-for-image');

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -345,6 +345,14 @@ impl FlutterHandler {
         *self.notify_rendered.write().unwrap() = false;
         self.renderer.write().unwrap().set_size(width, height);
     }
+
+    pub fn on_waiting_for_image_dialog_show(&self) {
+        #[cfg(any(feature = "flutter_texture_render"))]
+        {
+            *self.notify_rendered.write().unwrap() = false;
+        }
+        // rgba array render will notify every frame
+    }
 }
 
 impl InvokeUiSession for FlutterHandler {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1266,6 +1266,12 @@ pub fn session_change_prefer_codec(session_id: SessionID) {
     }
 }
 
+pub fn session_on_waiting_for_image_dialog_show(session_id: SessionID) {
+    if let Some(session) = SESSIONS.read().unwrap().get(&session_id) {
+        session.ui_handler.on_waiting_for_image_dialog_show();
+    }
+}
+
 pub fn main_set_home_dir(_home: String) {
     #[cfg(any(target_os = "android", target_os = "ios"))]
     {


### PR DESCRIPTION
dialogManager.show is a sync function which returns a future, await dialogManager.show will wait until dialog complete.
sessionOnWaitingForImageDialogShow can make it notify RgbaEvent again, and will not effect _waitForFirstImage.