### PR TITLE
fix move tab to new window

### DIFF
--- a/flutter/lib/utils/multi_window_manager.dart
+++ b/flutter/lib/utils/multi_window_manager.dart
@@ -50,7 +50,7 @@ class RustDeskMultiWindowManager {
       'session_id': sessionId,
     };
     await _newSession(
-      true,
+      false,
       WindowType.RemoteDesktop,
       kWindowEventNewRemoteDesktop,
       peerId,


### PR DESCRIPTION
`openInSeparateWindow` is changed to `openInTabs` while the caller does not change the parameter.