### PR TITLE
Update Italian language

### DIFF
--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -526,7 +526,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Sort tags", "Ordina etichette"),
         ("Open connection in new tab", "Apri connessione in una nuova scheda"),
         ("Move tab to new window", "Sposta scheda nella finestra successiva"),
-        ("Can not be empty", ""),
-        ("Already exists", ""),
+        ("Can not be empty", "Non può essere vuoto"),
+        ("Already exists", "Esiste già"),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
@rustdesk 

Please merge. Thanks.

In the string it's important that is always included the subject.
String like "Can not be empty" is not clear what's the subject that can be male/female then the translation can be different.
Please describe strings always with subject.
Thanks.