### PR TITLE
not show waitingForImage dialog when already get first image

### DIFF
--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -262,6 +262,7 @@ class _PeerTabPageState extends State<PeerTabPage>
   Widget _createMultiSelection() {
     final textColor = Theme.of(context).textTheme.titleLarge?.color;
     final model = Provider.of<PeerTabModel>(context);
+    if (model.currentTabCachedPeers.isEmpty) return Offstage();
     return Container(
       padding: EdgeInsets.all(4.0),
       child: InkWell(

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -124,31 +124,34 @@ class _PeersViewState extends State<_PeersView> with WindowListener {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<Peers>(
       create: (context) => widget.peers,
-      child: Consumer<Peers>(
-        builder: (context, peers, child) => peers.peers.isEmpty
-            ? Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      Icons.sentiment_very_dissatisfied_rounded,
-                      color: Theme.of(context).tabBarTheme.labelColor,
-                      size: 40,
-                    ).paddingOnly(bottom: 10),
-                    Text(
-                      translate(
-                        _emptyMessages[widget.peers.loadEvent] ?? 'Empty',
-                      ),
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        color: Theme.of(context).tabBarTheme.labelColor,
-                      ),
-                    ),
-                  ],
+      child: Consumer<Peers>(builder: (context, peers, child) {
+        if (peers.peers.isEmpty) {
+          gFFI.peerTabModel.setCurrentTabCachedPeers([]);
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.sentiment_very_dissatisfied_rounded,
+                  color: Theme.of(context).tabBarTheme.labelColor,
+                  size: 40,
+                ).paddingOnly(bottom: 10),
+                Text(
+                  translate(
+                    _emptyMessages[widget.peers.loadEvent] ?? 'Empty',
+                  ),
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Theme.of(context).tabBarTheme.labelColor,
+                  ),
                 ),
-              )
-            : _buildPeersView(peers),
-      ),
+              ],
+            ),
+          );
+        } else {
+          return _buildPeersView(peers);
+        }
+      }),
     );
   }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -425,6 +425,7 @@ class FfiModel with ChangeNotifier {
       closeConnection();
     }
 
+    if (_waitForFirstImage[sessionId] == false) return;
     dialogManager.show(
       (setState, close, context) => CustomAlertDialog(
           title: null,


### PR DESCRIPTION
1. not show waitingForImage dialog when already get first image for insurance.
2. hide multiselect icon if peers is empty
