### PR TITLE
fix, window maximized state

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -562,7 +562,7 @@ void windowOnTop(int? id) async {
   print("Bring window '$id' on top");
   if (id == null) {
     // main window
-    if (stateGlobal.minimized) {
+    if (stateGlobal.isMinimized) {
       await windowManager.restore();
     }
     await windowManager.show();

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -77,7 +77,7 @@ const double kDesktopFileTransferHeaderHeight = 25.0;
 
 EdgeInsets get kDragToResizeAreaPadding =>
     !kUseCompatibleUiMode && Platform.isLinux
-        ? stateGlobal.fullscreen || stateGlobal.maximized
+        ? stateGlobal.fullscreen || stateGlobal.isMaximized.value
             ? EdgeInsets.zero
             : EdgeInsets.all(5.0)
         : EdgeInsets.zero;

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -237,7 +237,6 @@ class DesktopTab extends StatelessWidget {
   final DesktopTabController controller;
 
   Rx<DesktopTabState> get state => controller.state;
-  final isMaximized = false.obs;
   final _scrollDebounce = Debouncer(delay: Duration(milliseconds: 50));
 
   late final DesktopTabType tabType;
@@ -373,7 +372,7 @@ class DesktopTab extends StatelessWidget {
                         if (elapsed < bind.getDoubleClickTime()) {
                           // onDoubleTap
                           toggleMaximize(isMainWindow)
-                              .then((value) => isMaximized.value = value);
+                              .then((value) => stateGlobal.setMaximized(value));
                         }
                       }
                     : null,
@@ -441,7 +440,7 @@ class DesktopTab extends StatelessWidget {
           tabType: tabType,
           state: state,
           tail: tail,
-          isMaximized: isMaximized,
+          isMaximized: stateGlobal.isMaximized,
           showMinimize: showMinimize,
           showMaximize: showMaximize,
           showClose: showClose,

--- a/flutter/lib/models/state_model.dart
+++ b/flutter/lib/models/state_model.dart
@@ -10,10 +10,10 @@ enum SvcStatus { notReady, connecting, ready }
 
 class StateGlobal {
   int _windowId = -1;
-  bool _fullscreen = false;
-  bool _maximized = false;
-  bool _minimized = false;
   bool grabKeyboard = false;
+  bool _fullscreen = false;
+  bool _isMinimized = false;
+  final RxBool isMaximized = false.obs;
   final RxBool _showTabBar = true.obs;
   final RxDouble _resizeEdgeSize = RxDouble(kWindowEdgeSize);
   final RxDouble _windowBorderWidth = RxDouble(kWindowBorderWidth);
@@ -26,8 +26,7 @@ class StateGlobal {
 
   int get windowId => _windowId;
   bool get fullscreen => _fullscreen;
-  bool get maximized => _maximized;
-  bool get minimized => _minimized;
+  bool get isMinimized => _isMinimized;
   double get tabBarHeight => fullscreen ? 0 : kDesktopRemoteTabBarHeight;
   RxBool get showTabBar => _showTabBar;
   RxDouble get resizeEdgeSize => _resizeEdgeSize;
@@ -51,12 +50,12 @@ class StateGlobal {
 
   setWindowId(int id) => _windowId = id;
   setMaximized(bool v) {
-    if (_maximized != v && !_fullscreen) {
-      _maximized = v;
-      _resizeEdgeSize.value = _maximized ? kMaximizeEdgeSize : kWindowEdgeSize;
+    if (isMaximized.value != v && !_fullscreen) {
+      isMaximized.value = v;
+      _resizeEdgeSize.value = isMaximized.isTrue ? kMaximizeEdgeSize : kWindowEdgeSize;
     }
   }
-  setMinimized(bool v) => _minimized = v;
+  setMinimized(bool v) => _isMinimized = v;
 
   setFullscreen(bool v) {
     if (_fullscreen != v) {
@@ -64,7 +63,7 @@ class StateGlobal {
       _showTabBar.value = !_fullscreen;
       _resizeEdgeSize.value = fullscreen
           ? kFullScreenEdgeSize
-          : _maximized
+          : isMaximized.isTrue
               ? kMaximizeEdgeSize
               : kWindowEdgeSize;
       print(


### PR DESCRIPTION
Fix this issue.

https://github.com/rustdesk/rustdesk/assets/136106582/02dab3cc-5a29-4964-ab7e-25d191579cb6

Remove member `final isMaximized = false.obs;` in `DesktopTab`. As `DesktopTab` is rebuilt when the window is from minimized to restore.

Use global state instead.



