### PR TITLE
Fix/change resolutions

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,8 +79,8 @@ impl Interface for Session {
         handle_login_error(self.lc.clone(), err, self)
     }
 
-    fn handle_peer_info(&mut self, pi: PeerInfo) {
-        self.lc.write().unwrap().handle_peer_info(&pi);
+    fn handle_peer_info(&mut self, pi: PeerInfo, is_cached_pi: bool) {
+        self.lc.write().unwrap().handle_peer_info(&pi, is_cached_pi);
     }
 
     async fn handle_hash(&mut self, pass: &str, hash: Hash, peer: &mut Stream) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1590,13 +1590,6 @@ impl LoginConfigHandler {
     }
 
     #[inline]
-    pub fn clear_custom_resolutions(&mut self) {
-        let mut config = self.load_config();
-        config.custom_resolutions.clear();
-        self.save_config(config);
-    }
-
-    #[inline]
     pub fn set_custom_resolution(&mut self, display: i32, wh: Option<(i32, i32)>) {
         let display = display.to_string();
         let mut config = self.load_config();

--- a/src/client.rs
+++ b/src/client.rs
@@ -1590,6 +1590,13 @@ impl LoginConfigHandler {
     }
 
     #[inline]
+    pub fn clear_custom_resolutions(&mut self) {
+        let mut config = self.load_config();
+        config.custom_resolutions.clear();
+        self.save_config(config);
+    }
+
+    #[inline]
     pub fn set_custom_resolution(&mut self, display: i32, wh: Option<(i32, i32)>) {
         let display = display.to_string();
         let mut config = self.load_config();

--- a/src/client.rs
+++ b/src/client.rs
@@ -1590,6 +1590,13 @@ impl LoginConfigHandler {
     }
 
     #[inline]
+    pub fn clear_custom_resolutions(&self) {
+        let mut config = self.load_config();
+        config.custom_resolutions.clear();
+        self.save_config(config);
+    }
+
+    #[inline]
     pub fn set_custom_resolution(&mut self, display: i32, wh: Option<(i32, i32)>) {
         let display = display.to_string();
         let mut config = self.load_config();
@@ -2366,7 +2373,7 @@ pub trait Interface: Send + Clone + 'static + Sized {
     fn send(&self, data: Data);
     fn msgbox(&self, msgtype: &str, title: &str, text: &str, link: &str);
     fn handle_login_error(&mut self, err: &str) -> bool;
-    fn handle_peer_info(&mut self, pi: PeerInfo);
+    fn handle_peer_info(&mut self, pi: PeerInfo, is_cached_pi: bool);
     fn on_error(&self, err: &str) {
         self.msgbox("error", "Error", err, "");
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1590,7 +1590,7 @@ impl LoginConfigHandler {
     }
 
     #[inline]
-    pub fn clear_custom_resolutions(&self) {
+    pub fn clear_custom_resolutions(&mut self) {
         let mut config = self.load_config();
         config.custom_resolutions.clear();
         self.save_config(config);

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1529,8 +1529,8 @@ impl<T: InvokeUiSession> Remote<T> {
                 return;
             }
 
-            let cached_origin_res = cached_displays[i].original_resolution;
-            let cur_origin_res = cur_displays[i].original_resolution;
+            let cached_origin_res = &*cached_displays[i].original_resolution;
+            let cur_origin_res = &*cur_displays[i].original_resolution;
 
             // If the original resolution is changed, just clear the custom resolution.
             if cached_origin_res.width != cur_origin_res.width

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1502,47 +1502,12 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                 }
                 Some(message::Union::PeerInfo(pi)) => {
-                    self.update_custom_resolutions(&pi.displays);
                     self.handler.set_displays(&pi.displays);
                 }
                 _ => {}
             }
         }
         true
-    }
-
-    fn update_custom_resolutions(&self, cur_displays: &Vec<DisplayInfo>) {
-        let cached_displays = &self.handler.cache_pi.read().unwrap().displays;
-
-        // It does not distinguish which display's custom resolution needs to be updated based on the name.
-        // Because name is index under macos, it will be confusing.
-        // It's possible to do different processing according to the OS, but there is no need to do complex logic here.
-        if cached_displays.len() != cur_displays.len() {
-            self.handler.lc.write().unwrap().clear_custom_resolutions();
-            return;
-        }
-
-        for i in 0..cur_displays.len() {
-            // Not work on macOS
-            if cur_displays[i].name != cached_displays[i].name {
-                self.handler.lc.write().unwrap().clear_custom_resolutions();
-                return;
-            }
-
-            let cached_origin_res = &*cached_displays[i].original_resolution;
-            let cur_origin_res = &*cur_displays[i].original_resolution;
-
-            // If the original resolution is changed, just clear the custom resolution.
-            if cached_origin_res.width != cur_origin_res.width
-                || cached_origin_res.height != cur_origin_res.height
-            {
-                self.handler
-                    .lc
-                    .write()
-                    .unwrap()
-                    .set_custom_resolution(i as _, None);
-            }
-        }
     }
 
     async fn handle_back_notification(&mut self, notification: BackNotification) -> bool {

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1021,12 +1021,8 @@ impl<T: InvokeUiSession> Remote<T> {
                         }
                     }
                     Some(login_response::Union::PeerInfo(pi)) => {
-                        #[cfg(feature = "flutter")]
-                        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                        {
-                            self.handler.cache_flutter.write().unwrap().pi = pi.clone();
-                        }
-                        self.handler.handle_peer_info(pi);
+                        *self.handler.cache_pi.write().unwrap() = pi.clone();
+                        self.handler.handle_peer_info(pi, false);
                         #[cfg(not(feature = "flutter"))]
                         self.check_clipboard_file_context();
                         if !(self.handler.is_file_transfer() || self.handler.is_port_forward()) {
@@ -1506,12 +1502,47 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                 }
                 Some(message::Union::PeerInfo(pi)) => {
+                    self.update_custom_resolutions(&pi.displays);
                     self.handler.set_displays(&pi.displays);
                 }
                 _ => {}
             }
         }
         true
+    }
+
+    fn update_custom_resolutions(&self, cur_displays: &Vec<DisplayInfo>) {
+        let cached_displays = &self.handler.cache_pi.read().unwrap().displays;
+
+        // It does not distinguish which display's custom resolution needs to be updated based on the name.
+        // Because name is index under macos, it will be confusing.
+        // It's possible to do different processing according to the OS, but there is no need to do complex logic here.
+        if cached_displays.len() != cur_displays.len() {
+            self.handler.lc.write().unwrap().clear_custom_resolutions();
+            return;
+        }
+
+        for i in 0..cur_displays.len() {
+            // Not work on macOS
+            if cur_displays[i].name != cached_displays[i].name {
+                self.handler.lc.write().unwrap().clear_custom_resolutions();
+                return;
+            }
+
+            let cached_origin_res = cached_displays[i].original_resolution;
+            let cur_origin_res = cur_displays[i].original_resolution;
+
+            // If the original resolution is changed, just clear the custom resolution.
+            if cached_origin_res.width != cur_origin_res.width
+                || cached_origin_res.height != cur_origin_res.height
+            {
+                self.handler
+                    .lc
+                    .write()
+                    .unwrap()
+                    .set_custom_resolution(i as _, None);
+            }
+        }
     }
 
     async fn handle_back_notification(&mut self, notification: BackNotification) -> bool {

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1021,11 +1021,7 @@ impl<T: InvokeUiSession> Remote<T> {
                         }
                     }
                     Some(login_response::Union::PeerInfo(pi)) => {
-                        #[cfg(feature = "flutter")]
-                        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                        {
-                            self.handler.cache_flutter.write().unwrap().pi = pi.clone();
-                        }
+                        *self.handler.cache_pi.write().unwrap() = pi.clone();
                         self.handler.handle_peer_info(pi, false);
                         #[cfg(not(feature = "flutter"))]
                         self.check_clipboard_file_context();
@@ -1506,12 +1502,47 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                 }
                 Some(message::Union::PeerInfo(pi)) => {
+                    self.update_custom_resolutions(&pi.displays);
                     self.handler.set_displays(&pi.displays);
                 }
                 _ => {}
             }
         }
         true
+    }
+
+    fn update_custom_resolutions(&self, cur_displays: &Vec<DisplayInfo>) {
+        let cached_displays = &self.handler.cache_pi.read().unwrap().displays;
+
+        // It does not distinguish which display's custom resolution needs to be updated based on the name.
+        // Because name is index under macos, it will be confusing.
+        // It's possible to do different processing according to the OS, but there is no need to do complex logic here.
+        if cached_displays.len() != cur_displays.len() {
+            self.handler.lc.write().unwrap().clear_custom_resolutions();
+            return;
+        }
+
+        for i in 0..cur_displays.len() {
+            // Not work on macOS
+            if cur_displays[i].name != cached_displays[i].name {
+                self.handler.lc.write().unwrap().clear_custom_resolutions();
+                return;
+            }
+
+            let cached_origin_res = &*cached_displays[i].original_resolution;
+            let cur_origin_res = &*cur_displays[i].original_resolution;
+
+            // If the original resolution is changed, just clear the custom resolution.
+            if cached_origin_res.width != cur_origin_res.width
+                || cached_origin_res.height != cur_origin_res.height
+            {
+                self.handler
+                    .lc
+                    .write()
+                    .unwrap()
+                    .set_custom_resolution(i as _, None);
+            }
+        }
     }
 
     async fn handle_back_notification(&mut self, notification: BackNotification) -> bool {

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1021,7 +1021,11 @@ impl<T: InvokeUiSession> Remote<T> {
                         }
                     }
                     Some(login_response::Union::PeerInfo(pi)) => {
-                        *self.handler.cache_pi.write().unwrap() = pi.clone();
+                        #[cfg(feature = "flutter")]
+                        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                        {
+                            self.handler.cache_flutter.write().unwrap().pi = pi.clone();
+                        }
                         self.handler.handle_peer_info(pi, false);
                         #[cfg(not(feature = "flutter"))]
                         self.check_clipboard_file_context();

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -36,9 +36,11 @@ pub(crate) const APP_TYPE_CM: &str = "cm";
 #[cfg(any(target_os = "android", target_os = "ios"))]
 pub(crate) const APP_TYPE_CM: &str = "main";
 
-pub(crate) const APP_TYPE_DESKTOP_REMOTE: &str = "remote";
-pub(crate) const APP_TYPE_DESKTOP_FILE_TRANSFER: &str = "file transfer";
-pub(crate) const APP_TYPE_DESKTOP_PORT_FORWARD: &str = "port forward";
+// Do not remove the following definitions.
+// Uncomment the code if they are used later.
+// pub(crate) const APP_TYPE_DESKTOP_REMOTE: &str = "remote";
+// pub(crate) const APP_TYPE_DESKTOP_FILE_TRANSFER: &str = "file transfer";
+// pub(crate) const APP_TYPE_DESKTOP_PORT_FORWARD: &str = "port forward";
 
 lazy_static::lazy_static! {
     pub(crate) static ref CUR_SESSION_ID: RwLock<SessionID> = Default::default();

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -146,7 +146,7 @@ async fn connect_and_login(
                                 return Ok(None);
                             }
                             Some(login_response::Union::PeerInfo(pi)) => {
-                                interface.handle_peer_info(pi);
+                                interface.handle_peer_info(pi, false);
                                 break;
                             }
                             _ => {}

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1959,6 +1959,7 @@ impl Connection {
                 {
                     return;
                 }
+                video_service::set_last_changed_resolution(&name, (r.width, r.height));
                 if let Err(e) =
                     crate::platform::change_resolution(&name, r.width as _, r.height as _)
                 {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1959,7 +1959,16 @@ impl Connection {
                 {
                     return;
                 }
-                video_service::set_last_changed_resolution(&name, (r.width, r.height));
+                if let Err(e) =
+                    video_service::set_last_changed_resolution(&name, (r.width, r.height))
+                {
+                    log::error!(
+                        "Failed to record the changing display resolution '{}': {:?}",
+                        &name,
+                        e
+                    );
+                    return;
+                }
                 if let Err(e) =
                     crate::platform::change_resolution(&name, r.width as _, r.height as _)
                 {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1051,13 +1051,15 @@ impl Connection {
             ..Default::default()
         })
         .into();
+        // `try_reset_current_display` is needed because `get_displays` may change the current display,
+        // which may cause the mismatch of current display and the current display name.
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         video_service::try_reset_current_display();
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
             pi.resolutions = Some(SupportedResolutions {
-                resolutions: video_service::get_current_display_name()
-                    .map(|name| crate::platform::resolutions(&name))
+                resolutions: video_service::get_current_display()
+                    .map(|(_, _, d)| crate::platform::resolutions(&d.name()))
                     .unwrap_or(vec![]),
                 ..Default::default()
             })
@@ -1948,7 +1950,8 @@ impl Connection {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     fn change_resolution(&mut self, r: &Resolution) {
         if self.keyboard {
-            if let Ok(name) = video_service::get_current_display_name() {
+            if let Ok((_, _, display)) = video_service::get_current_display() {
+                let name = display.name();
                 #[cfg(all(windows, feature = "virtual_display_driver"))]
                 if let Some(_ok) =
                     crate::virtual_display_manager::change_resolution_if_is_virtual_display(
@@ -1959,16 +1962,11 @@ impl Connection {
                 {
                     return;
                 }
-                if let Err(e) =
-                    video_service::set_last_changed_resolution(&name, (r.width, r.height))
-                {
-                    log::error!(
-                        "Failed to record the changing display resolution '{}': {:?}",
-                        &name,
-                        e
-                    );
-                    return;
-                }
+                video_service::set_last_changed_resolution(
+                    &name,
+                    (display.width() as _, display.height() as _),
+                    (r.width, r.height),
+                );
                 if let Err(e) =
                     crate::platform::change_resolution(&name, r.width as _, r.height as _)
                 {

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -325,6 +325,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
 
         // for tmp use, without real conn id
         let mut write_jobs: Vec<fs::TransferJob> = Vec::new();
+        #[cfg(windows)]
         let is_authorized = self.cm.is_authorized(self.conn_id);
 
         #[cfg(windows)]

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -52,7 +52,6 @@ const CHANGE_RESOLUTION_VALID_TIMEOUT_SECS: u64 = 15;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 #[derive(Default)]
 pub struct CacheFlutter {
-    pub pi: PeerInfo,
     pub sp: Option<SwitchDisplay>,
     pub cursor_data: HashMap<u64, CursorData>,
     pub cursor_id: u64,
@@ -76,6 +75,7 @@ pub struct Session<T: InvokeUiSession> {
     #[cfg(feature = "flutter")]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub cache_flutter: Arc<RwLock<CacheFlutter>>,
+    pub cache_pi: Arc<RwLock<PeerInfo>>,
 }
 
 #[derive(Clone)]
@@ -927,34 +927,42 @@ impl<T: InvokeUiSession> Session<T> {
         }
     }
 
-    pub fn handle_peer_switch_display(&self, display: &SwitchDisplay) {
-        self.ui_handler.switch_display(display);
-
-        if self.last_change_display.lock().unwrap().is_the_same_record(
+    fn set_custom_resolution(&self, display: &SwitchDisplay) {
+        let custom_resolution = if self.last_change_display.lock().unwrap().is_the_same_record(
             display.display,
             display.width,
             display.height,
         ) {
-            let custom_resolution = if display.width != display.original_resolution.width
+            if display.width != display.original_resolution.width
                 || display.height != display.original_resolution.height
             {
                 Some((display.width, display.height))
             } else {
                 None
-            };
-            self.lc
-                .write()
-                .unwrap()
-                .set_custom_resolution(display.display, custom_resolution);
-        }
+            }
+        } else {
+            None
+        };
+        self.lc
+            .write()
+            .unwrap()
+            .set_custom_resolution(display.display, custom_resolution);
     }
 
+    #[inline]
+    pub fn handle_peer_switch_display(&self, display: &SwitchDisplay) {
+        self.ui_handler.switch_display(display);
+        self.set_custom_resolution(display);
+    }
+
+    #[inline]
     pub fn change_resolution(&self, display: i32, width: i32, height: i32) {
         *self.last_change_display.lock().unwrap() =
             ChangeDisplayRecord::new(display, width, height);
         self.do_change_resolution(width, height);
     }
 
+    #[inline]
     fn try_change_init_resolution(&self, display: i32) {
         if let Some((w, h)) = self.lc.read().unwrap().get_custom_resolution(display) {
             self.do_change_resolution(w, h);
@@ -973,10 +981,12 @@ impl<T: InvokeUiSession> Session<T> {
         self.send(Data::Message(msg));
     }
 
+    #[inline]
     pub fn request_voice_call(&self) {
         self.send(Data::NewVoiceCall);
     }
 
+    #[inline]
     pub fn close_voice_call(&self) {
         self.send(Data::CloseVoiceCall);
     }
@@ -1078,7 +1088,7 @@ impl<T: InvokeUiSession> Interface for Session<T> {
         handle_login_error(self.lc.clone(), err, self)
     }
 
-    fn handle_peer_info(&mut self, mut pi: PeerInfo) {
+    fn handle_peer_info(&mut self, mut pi: PeerInfo, is_cached_pi: bool) {
         log::debug!("handle_peer_info :{:?}", pi);
         pi.username = self.lc.read().unwrap().get_username(&pi);
         if pi.current_display as usize >= pi.displays.len() {
@@ -1099,10 +1109,12 @@ impl<T: InvokeUiSession> Interface for Session<T> {
                 self.msgbox("error", "Remote Error", "No Display", "");
                 return;
             }
-            self.try_change_init_resolution(pi.current_display);
-            let p = self.lc.read().unwrap().should_auto_login();
-            if !p.is_empty() {
-                input_os_password(p, true, self.clone());
+            if !is_cached_pi {
+                self.try_change_init_resolution(pi.current_display);
+                let p = self.lc.read().unwrap().should_auto_login();
+                if !p.is_empty() {
+                    input_os_password(p, true, self.clone());
+                }
             }
             let current = &pi.displays[pi.current_display as usize];
             self.set_display(
@@ -1210,8 +1222,8 @@ impl<T: InvokeUiSession> Session<T> {
         if let Some((is_secured, direct)) = self.cache_flutter.read().unwrap().is_secured_direct {
             self.set_connection_type(is_secured, direct);
         }
-        let pi = self.cache_flutter.read().unwrap().pi.clone();
-        self.handle_peer_info(pi);
+        let pi = self.cache_pi.read().unwrap().clone();
+        self.handle_peer_info(pi, true);
         if let Some(sp) = self.cache_flutter.read().unwrap().sp.as_ref() {
             self.handle_peer_switch_display(sp);
         }

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -52,6 +52,7 @@ const CHANGE_RESOLUTION_VALID_TIMEOUT_SECS: u64 = 15;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 #[derive(Default)]
 pub struct CacheFlutter {
+    pub pi: PeerInfo,
     pub sp: Option<SwitchDisplay>,
     pub cursor_data: HashMap<u64, CursorData>,
     pub cursor_id: u64,
@@ -75,7 +76,6 @@ pub struct Session<T: InvokeUiSession> {
     #[cfg(feature = "flutter")]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub cache_flutter: Arc<RwLock<CacheFlutter>>,
-    pub cache_pi: Arc<RwLock<PeerInfo>>,
 }
 
 #[derive(Clone)]
@@ -1220,7 +1220,7 @@ impl<T: InvokeUiSession> Session<T> {
         if let Some((is_secured, direct)) = self.cache_flutter.read().unwrap().is_secured_direct {
             self.set_connection_type(is_secured, direct);
         }
-        let pi = self.cache_pi.read().unwrap().clone();
+        let pi = self.cache_flutter.read().unwrap().pi.clone();
         self.handle_peer_info(pi, true);
         if let Some(sp) = self.cache_flutter.read().unwrap().sp.as_ref() {
             self.handle_peer_switch_display(sp);

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -928,25 +928,23 @@ impl<T: InvokeUiSession> Session<T> {
     }
 
     fn set_custom_resolution(&self, display: &SwitchDisplay) {
-        let custom_resolution = if self.last_change_display.lock().unwrap().is_the_same_record(
+        if self.last_change_display.lock().unwrap().is_the_same_record(
             display.display,
             display.width,
             display.height,
         ) {
-            if display.width != display.original_resolution.width
+            let custom_resolution = if display.width != display.original_resolution.width
                 || display.height != display.original_resolution.height
             {
                 Some((display.width, display.height))
             } else {
                 None
-            }
-        } else {
-            None
-        };
-        self.lc
-            .write()
-            .unwrap()
-            .set_custom_resolution(display.display, custom_resolution);
+            };
+            self.lc
+                .write()
+                .unwrap()
+                .set_custom_resolution(display.display, custom_resolution);
+        }
     }
 
     #[inline]


### PR DESCRIPTION
1. If the remote resolution is changed by a third process other than RustDesk.
The original resolution is then set to the new one.
https://github.com/rustdesk/rustdesk/issues/5361
2. Remove peer custom resolution if the remote resolution is not changed by the control side(session).
3. Add `is_cached_pi` for `handle_peer_info`, to avoid meaningless call of
```rust
                self.try_change_init_resolution(pi.current_display);
                let p = self.lc.read().unwrap().should_auto_login();
                if !p.is_empty() {
                    input_os_password(p, true, self.clone());
                }
```
when try to set peer info when `restore_flutter_cache` in a separate window session.

https://github.com/rustdesk/rustdesk/assets/136106582/6c33e06f-e6ac-4013-895e-34a7b3e8010b


TODOs:
1. Add resolution options for the mobile version.
