### PR TITLE
Fix, check if is cached peer info when handle_peer_info

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2366,7 +2366,7 @@ pub trait Interface: Send + Clone + 'static + Sized {
     fn send(&self, data: Data);
     fn msgbox(&self, msgtype: &str, title: &str, text: &str, link: &str);
     fn handle_login_error(&mut self, err: &str) -> bool;
-    fn handle_peer_info(&mut self, pi: PeerInfo);
+    fn handle_peer_info(&mut self, pi: PeerInfo, is_cached_pi: bool);
     fn on_error(&self, err: &str) {
         self.msgbox("error", "Error", err, "");
     }

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1026,7 +1026,7 @@ impl<T: InvokeUiSession> Remote<T> {
                         {
                             self.handler.cache_flutter.write().unwrap().pi = pi.clone();
                         }
-                        self.handler.handle_peer_info(pi);
+                        self.handler.handle_peer_info(pi, false);
                         #[cfg(not(feature = "flutter"))]
                         self.check_clipboard_file_context();
                         if !(self.handler.is_file_transfer() || self.handler.is_port_forward()) {

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1506,6 +1506,12 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                 }
                 Some(message::Union::PeerInfo(pi)) => {
+                    #[cfg(feature = "flutter")]
+                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                    {
+                        self.handler.cache_flutter.write().unwrap().pi.displays =
+                            pi.displays.clone();
+                    }
                     self.handler.set_displays(&pi.displays);
                 }
                 _ => {}

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -146,7 +146,7 @@ async fn connect_and_login(
                                 return Ok(None);
                             }
                             Some(login_response::Union::PeerInfo(pi)) => {
-                                interface.handle_peer_info(pi);
+                                interface.handle_peer_info(pi, false);
                                 break;
                             }
                             _ => {}

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1078,7 +1078,7 @@ impl<T: InvokeUiSession> Interface for Session<T> {
         handle_login_error(self.lc.clone(), err, self)
     }
 
-    fn handle_peer_info(&mut self, mut pi: PeerInfo) {
+    fn handle_peer_info(&mut self, mut pi: PeerInfo, is_cached_pi: bool) {
         log::debug!("handle_peer_info :{:?}", pi);
         pi.username = self.lc.read().unwrap().get_username(&pi);
         if pi.current_display as usize >= pi.displays.len() {
@@ -1099,10 +1099,12 @@ impl<T: InvokeUiSession> Interface for Session<T> {
                 self.msgbox("error", "Remote Error", "No Display", "");
                 return;
             }
-            self.try_change_init_resolution(pi.current_display);
-            let p = self.lc.read().unwrap().should_auto_login();
-            if !p.is_empty() {
-                input_os_password(p, true, self.clone());
+            if !is_cached_pi {
+                self.try_change_init_resolution(pi.current_display);
+                let p = self.lc.read().unwrap().should_auto_login();
+                if !p.is_empty() {
+                    input_os_password(p, true, self.clone());
+                }
             }
             let current = &pi.displays[pi.current_display as usize];
             self.set_display(
@@ -1211,7 +1213,7 @@ impl<T: InvokeUiSession> Session<T> {
             self.set_connection_type(is_secured, direct);
         }
         let pi = self.cache_flutter.read().unwrap().pi.clone();
-        self.handle_peer_info(pi);
+        self.handle_peer_info(pi, true);
         if let Some(sp) = self.cache_flutter.read().unwrap().sp.as_ref() {
             self.handle_peer_switch_display(sp);
         }


### PR DESCRIPTION
Avoid repeated run of the following code, when the tab is moving to a new window. (Same session, but peer info is needed.)

Maybe a better way is needed.

```rust
                self.try_change_init_resolution(pi.current_display);
                let p = self.lc.read().unwrap().should_auto_login();
                if !p.is_empty() {
                    input_os_password(p, true, self.clone());
                }
```