### PR TITLE
Do not unregister texture if move to new window

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -204,7 +204,7 @@ class _RemotePageState extends State<RemotePage>
     // https://github.com/flutter/flutter/issues/64935
     super.dispose();
     debugPrint("REMOTE PAGE dispose session $sessionId ${widget.id}");
-    await _renderTexture.destroy();
+    await _renderTexture.destroy(closeSession);
     // ensure we leave this session, this is a double check
     bind.sessionEnterOrLeave(sessionId: sessionId, enter: false);
     DesktopMultiWindow.removeListener(this);

--- a/flutter/lib/models/desktop_render_texture.dart
+++ b/flutter/lib/models/desktop_render_texture.dart
@@ -31,9 +31,11 @@ class RenderTexture {
     }
   }
 
-  destroy() async {
+  destroy(bool unregisterTexture) async {
     if (useTextureRender && _textureKey != -1 && _sessionId != null) {
-      platformFFI.registerTexture(_sessionId!, 0);
+      if (unregisterTexture) {
+        platformFFI.registerTexture(_sessionId!, 0);
+      }
       await textureRenderer.closeTexture(_textureKey);
       _textureKey = -1;
     }


### PR DESCRIPTION
```dart
platformFFI.registerTexture(_sessionId!, 0);
```
may causes black screen if it is called after the new window is ready. Because it set the `on_rgba_func` to initial invalid ptr.