### PR TITLE
save ab password to recent PeerConfig when connected with it

### DIFF
--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -895,7 +895,7 @@ pub fn main_load_recent_peers_for_ab(filter: String) -> String {
     if !config::APP_DIR.read().unwrap().is_empty() {
         let peers: Vec<HashMap<&str, String>> = PeerConfig::peers(id_filters)
             .drain(..)
-            .map(|(id, _, p)| peer_to_map_ab(id, p))
+            .map(|(id, _, p)| peer_to_map(id, p))
             .collect();
         return serde_json::ser::to_string(&peers).unwrap_or("".to_owned());
     }

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -625,6 +625,7 @@ pub fn discover() {
 
 #[cfg(feature = "flutter")]
 pub fn peer_to_map(id: String, p: PeerConfig) -> HashMap<&'static str, String> {
+    use hbb_common::sodiumoxide::base64;
     HashMap::<&str, String>::from_iter([
         ("id", id),
         ("username", p.info.username.clone()),
@@ -634,18 +635,11 @@ pub fn peer_to_map(id: String, p: PeerConfig) -> HashMap<&'static str, String> {
             "alias",
             p.options.get("alias").unwrap_or(&"".to_owned()).to_owned(),
         ),
+        (
+            "hash",
+            base64::encode(p.password, base64::Variant::Original),
+        ),
     ])
-}
-
-#[cfg(feature = "flutter")]
-pub fn peer_to_map_ab(id: String, p: PeerConfig) -> HashMap<&'static str, String> {
-    use hbb_common::sodiumoxide::base64;
-    let mut m = peer_to_map(id, p.clone());
-    m.insert(
-        "hash",
-        base64::encode(p.password, base64::Variant::Original),
-    );
-    m
 }
 
 #[cfg(feature = "flutter")]


### PR DESCRIPTION
1. fix passwords were not synced to address book when adding to address book from recent session without selecting "Sync from recent sessions"
2. save password to PeerConfig if connected with adressbook password. If the password is not correct, it won't be saved. 