### PR TITLE
Refact/plug in virtual display

### DIFF
--- a/libs/virtual_display/dylib/examples/idd_controller.rs
+++ b/libs/virtual_display/dylib/examples/idd_controller.rs
@@ -16,8 +16,8 @@ fn prompt_input() -> u8 {
     println!("       3. 'u'               3. uninstall driver");
     println!("       4. 'c'               4. create device");
     println!("       5. 'd'               5. destroy device");
-    println!("       6. '1','2','3'       6. plug in monitor 0,1,2");
-    println!("       7. '4','5','6'       7. plug out monitor 0,1,2");
+    println!("       6. 'a'               6. plug in monitor");
+    println!("       7. 'b'               7. plug out monitor");
 
     io::stdin()
         .bytes()
@@ -79,6 +79,7 @@ unsafe fn plug_out(index: idd::UINT) {
 fn main() {
     #[cfg(windows)]
     {
+        let mut idx = 0;
         let abs_path = match Path::new(DRIVER_INSTALL_PATH).canonicalize() {
             Ok(p) => p,
             Err(e) => {
@@ -172,12 +173,19 @@ fn main() {
                         h_sw_device = invalid_device;
                         println!("Close device done");
                     }
-                    '1' => plug_in(0, 0),
-                    '2' => plug_in(1, 0),
-                    '3' => plug_in(2, 0),
-                    '4' => plug_out(0),
-                    '5' => plug_out(1),
-                    '6' => plug_out(2),
+                    'a' => {
+                        plug_in(idx, 0);
+                        idx += 1;
+                    },
+                    'b' => {
+                        if idx == 0 {
+                            println!("No virtual monitors\n");
+                            break;
+                        } else {
+                            idx -= 1;
+                            plug_out(idx);
+                        }
+                    },
                     _ => {}
                 }
             }

--- a/libs/virtual_display/dylib/src/win10/IddController.c
+++ b/libs/virtual_display/dylib/src/win10/IddController.c
@@ -9,41 +9,37 @@
 
 #include "./Public.h"
 
-
-const GUID GUID_DEVINTERFACE_IDD_DRIVER_DEVICE = \
-{ 0x781EF630, 0x72B2, 0x11d2, { 0xB8, 0x52,  0x00,  0xC0,  0x4E,  0xAF,  0x52,  0x72 } };
+const GUID GUID_DEVINTERFACE_IDD_DRIVER_DEVICE =
+    {0x781EF630, 0x72B2, 0x11d2, {0xB8, 0x52, 0x00, 0xC0, 0x4E, 0xAF, 0x52, 0x72}};
 //{781EF630-72B2-11d2-B852-00C04EAF5272}
 
 BOOL g_printMsg = TRUE;
 char g_lastMsg[1024];
-const char* g_msgHeader = "RustDeskIdd: ";
+const char *g_msgHeader = "RustDeskIdd: ";
 
 VOID WINAPI
 CreationCallback(
     _In_ HSWDEVICE hSwDevice,
     _In_ HRESULT hrCreateResult,
     _In_opt_ PVOID pContext,
-    _In_opt_ PCWSTR pszDeviceInstanceId
-);
+    _In_opt_ PCWSTR pszDeviceInstanceId);
 // https://github.com/microsoft/Windows-driver-samples/blob/9f03207ae1e8df83325f067de84494ae55ab5e97/general/DCHU/osrfx2_DCHU_base/osrfx2_DCHU_testapp/testapp.c#L88
 // Not a good way for this device, I don't not why. I'm not familiar with dirver.
 BOOLEAN GetDevicePath(
     _In_ LPCGUID InterfaceGuid,
     _Out_writes_(BufLen) PTCHAR DevicePath,
-    _In_ size_t BufLen
-);
+    _In_ size_t BufLen);
 // https://github.com/microsoft/Windows-driver-samples/blob/9f03207ae1e8df83325f067de84494ae55ab5e97/usb/umdf_fx2/exe/testapp.c#L90
 // Works good to check whether device is created before.
 BOOLEAN GetDevicePath2(
     _In_ LPCGUID InterfaceGuid,
     _Out_writes_(BufLen) PTCHAR DevicePath,
-    _In_ size_t BufLen
-);
+    _In_ size_t BufLen);
 
 HANDLE DeviceOpenHandle();
 VOID DeviceCloseHandle(HANDLE handle);
 
-void SetLastMsg(const char* format, ...)
+void SetLastMsg(const char *format, ...)
 {
     memset(g_lastMsg, 0, sizeof(g_lastMsg));
     memcpy_s(g_lastMsg, sizeof(g_lastMsg), g_msgHeader, strlen(g_msgHeader));
@@ -59,7 +55,7 @@ void SetLastMsg(const char* format, ...)
     va_end(args);
 }
 
-const char* GetLastMsg()
+const char *GetLastMsg()
 {
     return g_lastMsg;
 }
@@ -70,14 +66,13 @@ BOOL InstallUpdate(LPCWSTR fullInfPath, PBOOL rebootRequired)
 
     // UpdateDriverForPlugAndPlayDevicesW may return FALSE while driver was successfully installed...
     if (FALSE == UpdateDriverForPlugAndPlayDevicesW(
-        NULL,
-        L"RustDeskIddDriver",    // match hardware id in the inf file
-        fullInfPath,
-        INSTALLFLAG_FORCE
-            // | INSTALLFLAG_NONINTERACTIVE  // INSTALLFLAG_NONINTERACTIVE may cause error 0xe0000247
-        ,
-        rebootRequired
-    ))
+                     NULL,
+                     L"RustDeskIddDriver", // match hardware id in the inf file
+                     fullInfPath,
+                     INSTALLFLAG_FORCE
+                     // | INSTALLFLAG_NONINTERACTIVE  // INSTALLFLAG_NONINTERACTIVE may cause error 0xe0000247
+                     ,
+                     rebootRequired))
     {
         DWORD error = GetLastError();
         if (error != 0)
@@ -99,11 +94,10 @@ BOOL Uninstall(LPCWSTR fullInfPath, PBOOL rebootRequired)
     SetLastMsg("Success");
 
     if (FALSE == DiUninstallDriverW(
-        NULL,
-        fullInfPath,
-        0,
-        rebootRequired
-    ))
+                     NULL,
+                     fullInfPath,
+                     0,
+                     rebootRequired))
     {
         DWORD error = GetLastError();
         if (error != 0)
@@ -126,10 +120,10 @@ BOOL IsDeviceCreated(PBOOL created)
 
     HDEVINFO hardwareDeviceInfo = SetupDiGetClassDevs(
         &GUID_DEVINTERFACE_IDD_DRIVER_DEVICE,
-        NULL, // Define no enumerator (global)
-        NULL, // Define no
-        (DIGCF_PRESENT | // Only Devices present
-            DIGCF_DEVICEINTERFACE)); // Function class devices.
+        NULL,                     // Define no enumerator (global)
+        NULL,                     // Define no
+        (DIGCF_PRESENT |          // Only Devices present
+         DIGCF_DEVICEINTERFACE)); // Function class devices.
     if (INVALID_HANDLE_VALUE == hardwareDeviceInfo)
     {
         SetLastMsg("Idd device: Failed IsDeviceCreated SetupDiGetClassDevs, last error 0x%x\n", GetLastError());
@@ -140,17 +134,17 @@ BOOL IsDeviceCreated(PBOOL created)
         return FALSE;
     }
 
-    SP_DEVICE_INTERFACE_DATA            deviceInterfaceData;
+    SP_DEVICE_INTERFACE_DATA deviceInterfaceData;
     deviceInterfaceData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
 
     BOOL ret = FALSE;
     do
     {
         if (TRUE == SetupDiEnumDeviceInterfaces(hardwareDeviceInfo,
-            0, // No care about specific PDOs
-            &GUID_DEVINTERFACE_IDD_DRIVER_DEVICE,
-            0, //
-            &deviceInterfaceData))
+                                                0, // No care about specific PDOs
+                                                &GUID_DEVINTERFACE_IDD_DRIVER_DEVICE,
+                                                0, //
+                                                &deviceInterfaceData))
         {
             *created = TRUE;
             ret = TRUE;
@@ -175,7 +169,7 @@ BOOL IsDeviceCreated(PBOOL created)
 
     } while (0);
 
-    (VOID)SetupDiDestroyDeviceInfoList(hardwareDeviceInfo);
+    (VOID) SetupDiDestroyDeviceInfoList(hardwareDeviceInfo);
     return ret;
 }
 
@@ -218,7 +212,7 @@ BOOL DeviceCreate(PHSWDEVICE hSwDevice)
         return FALSE;
     }
 
-    SW_DEVICE_CREATE_INFO createInfo = { 0 };
+    SW_DEVICE_CREATE_INFO createInfo = {0};
     PCWSTR description = L"RustDesk Idd Driver";
 
     // These match the Pnp id's in the inf file so OS will load the driver when the device is created
@@ -233,18 +227,18 @@ BOOL DeviceCreate(PHSWDEVICE hSwDevice)
     createInfo.pszDeviceDescription = description;
 
     createInfo.CapabilityFlags = SWDeviceCapabilitiesRemovable |
-        SWDeviceCapabilitiesSilentInstall |
-        SWDeviceCapabilitiesDriverRequired;
+                                 SWDeviceCapabilitiesSilentInstall |
+                                 SWDeviceCapabilitiesDriverRequired;
 
     // Create the device
     HRESULT hr = SwDeviceCreate(L"RustDeskIddDriver",
-        L"HTREE\\ROOT\\0",
-        &createInfo,
-        0,
-        NULL,
-        CreationCallback,
-        &hEvent,
-        hSwDevice);
+                                L"HTREE\\ROOT\\0",
+                                &createInfo,
+                                0,
+                                NULL,
+                                CreationCallback,
+                                &hEvent,
+                                hSwDevice);
     if (FAILED(hr))
     {
         SetLastMsg("Failed DeviceCreate SwDeviceCreate 0x%lx\n", hr);
@@ -297,10 +291,15 @@ BOOL MonitorPlugIn(UINT index, UINT edid, INT retries)
     }
 
     HANDLE hDevice = INVALID_HANDLE_VALUE;
-    for (; retries >= 0; --retries)
+    while (TRUE)
     {
         hDevice = DeviceOpenHandle();
         if (hDevice != INVALID_HANDLE_VALUE && hDevice != NULL)
+        {
+            break;
+        }
+        --retries;
+        if (retries < 0)
         {
             break;
         }
@@ -332,14 +331,14 @@ BOOL MonitorPlugIn(UINT index, UINT edid, INT retries)
         for (; retries >= 0; --retries)
         {
             if (TRUE == DeviceIoControl(
-                hDevice,
-                IOCTL_CHANGER_IDD_PLUG_IN,
-                &plugIn,                    // Ptr to InBuffer
-                sizeof(CtlPlugIn),          // Length of InBuffer
-                NULL,                       // Ptr to OutBuffer
-                0,                          // Length of OutBuffer
-                &junk,                      // BytesReturned
-                0))                         // Ptr to Overlapped structure
+                            hDevice,
+                            IOCTL_CHANGER_IDD_PLUG_IN,
+                            &plugIn,           // Ptr to InBuffer
+                            sizeof(CtlPlugIn), // Length of InBuffer
+                            NULL,              // Ptr to OutBuffer
+                            0,                 // Length of OutBuffer
+                            &junk,             // BytesReturned
+                            0))                // Ptr to Overlapped structure
             {
                 ret = TRUE;
                 break;
@@ -372,14 +371,14 @@ BOOL MonitorPlugOut(UINT index)
     CtlPlugOut plugOut;
     plugOut.ConnectorIndex = index;
     if (!DeviceIoControl(
-        hDevice,
-        IOCTL_CHANGER_IDD_PLUG_OUT,
-        &plugOut,               // Ptr to InBuffer
-        sizeof(CtlPlugOut),     // Length of InBuffer
-        NULL,                   // Ptr to OutBuffer
-        0,                      // Length of OutBuffer
-        &junk,                  // BytesReturned
-        0))                     // Ptr to Overlapped structure
+            hDevice,
+            IOCTL_CHANGER_IDD_PLUG_OUT,
+            &plugOut,           // Ptr to InBuffer
+            sizeof(CtlPlugOut), // Length of InBuffer
+            NULL,               // Ptr to OutBuffer
+            0,                  // Length of OutBuffer
+            &junk,              // BytesReturned
+            0))                 // Ptr to Overlapped structure
     {
         DWORD error = GetLastError();
         SetLastMsg("Failed MonitorPlugOut DeviceIoControl 0x%lx\n", error);
@@ -431,14 +430,14 @@ BOOL MonitorModesUpdate(UINT index, UINT modeCount, PMonitorMode modes)
         pMonitorModes->Modes[i].Sync = modes[i].sync;
     }
     if (!DeviceIoControl(
-        hDevice,
-        IOCTL_CHANGER_IDD_UPDATE_MONITOR_MODE,
-        pMonitorModes,               // Ptr to InBuffer
-        buflen,                     // Length of InBuffer
-        NULL,                       // Ptr to OutBuffer
-        0,                          // Length of OutBuffer
-        &junk,                      // BytesReturned
-        0))                         // Ptr to Overlapped structure
+            hDevice,
+            IOCTL_CHANGER_IDD_UPDATE_MONITOR_MODE,
+            pMonitorModes, // Ptr to InBuffer
+            buflen,        // Length of InBuffer
+            NULL,          // Ptr to OutBuffer
+            0,             // Length of OutBuffer
+            &junk,         // BytesReturned
+            0))            // Ptr to Overlapped structure
     {
         DWORD error = GetLastError();
         SetLastMsg("Failed MonitorModesUpdate DeviceIoControl 0x%lx\n", error);
@@ -463,10 +462,9 @@ CreationCallback(
     _In_ HSWDEVICE hSwDevice,
     _In_ HRESULT hrCreateResult,
     _In_opt_ PVOID pContext,
-    _In_opt_ PCWSTR pszDeviceInstanceId
-)
+    _In_opt_ PCWSTR pszDeviceInstanceId)
 {
-    HANDLE hEvent = *(HANDLE*)pContext;
+    HANDLE hEvent = *(HANDLE *)pContext;
 
     SetEvent(hEvent);
     UNREFERENCED_PARAMETER(hSwDevice);
@@ -478,8 +476,7 @@ BOOLEAN
 GetDevicePath(
     _In_ LPCGUID InterfaceGuid,
     _Out_writes_(BufLen) PTCHAR DevicePath,
-    _In_ size_t BufLen
-)
+    _In_ size_t BufLen)
 {
     CONFIGRET cr = CR_SUCCESS;
     PTSTR deviceInterfaceList = NULL;
@@ -553,12 +550,14 @@ GetDevicePath(
 
     nextInterface = deviceInterfaceList + _tcslen(deviceInterfaceList) + 1;
 #ifdef UNICODE
-    if (*nextInterface != UNICODE_NULL) {
+    if (*nextInterface != UNICODE_NULL)
+    {
 #else
-    if (*nextInterface != ANSI_NULL) {
+    if (*nextInterface != ANSI_NULL)
+    {
 #endif
         printf("Warning: More than one device interface instance found. \n"
-            "Selecting first matching device.\n\n");
+               "Selecting first matching device.\n\n");
     }
 
     printf("begin copy device path\n");
@@ -590,25 +589,24 @@ clean0:
 BOOLEAN GetDevicePath2(
     _In_ LPCGUID InterfaceGuid,
     _Out_writes_(BufLen) PTCHAR DevicePath,
-    _In_ size_t BufLen
-)
+    _In_ size_t BufLen)
 {
-    HANDLE                              hDevice = INVALID_HANDLE_VALUE;
-    PSP_DEVICE_INTERFACE_DETAIL_DATA    deviceInterfaceDetailData = NULL;
-    ULONG                               predictedLength = 0;
-    ULONG                               requiredLength = 0;
-    ULONG                               bytes;
-    HDEVINFO                            hardwareDeviceInfo;
-    SP_DEVICE_INTERFACE_DATA            deviceInterfaceData;
-    BOOLEAN                             status = FALSE;
-    HRESULT                             hr;
+    HANDLE hDevice = INVALID_HANDLE_VALUE;
+    PSP_DEVICE_INTERFACE_DETAIL_DATA deviceInterfaceDetailData = NULL;
+    ULONG predictedLength = 0;
+    ULONG requiredLength = 0;
+    ULONG bytes;
+    HDEVINFO hardwareDeviceInfo;
+    SP_DEVICE_INTERFACE_DATA deviceInterfaceData;
+    BOOLEAN status = FALSE;
+    HRESULT hr;
 
     hardwareDeviceInfo = SetupDiGetClassDevs(
         InterfaceGuid,
-        NULL, // Define no enumerator (global)
-        NULL, // Define no
-        (DIGCF_PRESENT | // Only Devices present
-            DIGCF_DEVICEINTERFACE)); // Function class devices.
+        NULL,                     // Define no enumerator (global)
+        NULL,                     // Define no
+        (DIGCF_PRESENT |          // Only Devices present
+         DIGCF_DEVICEINTERFACE)); // Function class devices.
     if (INVALID_HANDLE_VALUE == hardwareDeviceInfo)
     {
         SetLastMsg("Idd device: GetDevicePath2 SetupDiGetClassDevs failed, last error 0x%x\n", GetLastError());
@@ -622,10 +620,10 @@ BOOLEAN GetDevicePath2(
     deviceInterfaceData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
 
     if (!SetupDiEnumDeviceInterfaces(hardwareDeviceInfo,
-        0, // No care about specific PDOs
-        InterfaceGuid,
-        0, //
-        &deviceInterfaceData))
+                                     0, // No care about specific PDOs
+                                     InterfaceGuid,
+                                     0, //
+                                     &deviceInterfaceData))
     {
         SetLastMsg("Idd device: GetDevicePath2 SetupDiEnumDeviceInterfaces failed, last error 0x%x\n", GetLastError());
         if (g_printMsg)
@@ -643,9 +641,9 @@ BOOLEAN GetDevicePath2(
         hardwareDeviceInfo,
         &deviceInterfaceData,
         NULL, // probing so no output buffer yet
-        0, // probing so output buffer length of zero
+        0,    // probing so output buffer length of zero
         &requiredLength,
-        NULL);//not interested in the specific dev-node
+        NULL); // not interested in the specific dev-node
 
     if (ERROR_INSUFFICIENT_BUFFER != GetLastError())
     {
@@ -661,8 +659,7 @@ BOOLEAN GetDevicePath2(
     deviceInterfaceDetailData = (PSP_DEVICE_INTERFACE_DETAIL_DATA)HeapAlloc(
         GetProcessHeap(),
         HEAP_ZERO_MEMORY,
-        predictedLength
-    );
+        predictedLength);
 
     if (deviceInterfaceDetailData)
     {
@@ -680,12 +677,12 @@ BOOLEAN GetDevicePath2(
     }
 
     if (!SetupDiGetDeviceInterfaceDetail(
-        hardwareDeviceInfo,
-        &deviceInterfaceData,
-        deviceInterfaceDetailData,
-        predictedLength,
-        &requiredLength,
-        NULL))
+            hardwareDeviceInfo,
+            &deviceInterfaceData,
+            deviceInterfaceDetailData,
+            predictedLength,
+            &requiredLength,
+            NULL))
     {
         SetLastMsg("Idd device: Failed GetDevicePath2 SetupDiGetDeviceInterfaceDetail, last error 0x%x\n", GetLastError());
         if (g_printMsg)
@@ -712,9 +709,9 @@ BOOLEAN GetDevicePath2(
     }
 
 Clean1:
-    (VOID)HeapFree(GetProcessHeap(), 0, deviceInterfaceDetailData);
+    (VOID) HeapFree(GetProcessHeap(), 0, deviceInterfaceDetailData);
 Clean0:
-    (VOID)SetupDiDestroyDeviceInfoList(hardwareDeviceInfo);
+    (VOID) SetupDiDestroyDeviceInfoList(hardwareDeviceInfo);
     return status;
 }
 
@@ -724,14 +721,14 @@ HANDLE DeviceOpenHandle()
     SetLastMsg("Success");
 
     // const int maxDevPathLen = 256;
-    TCHAR devicePath[256] = { 0 };
+    TCHAR devicePath[256] = {0};
     HANDLE hDevice = INVALID_HANDLE_VALUE;
     do
     {
         if (FALSE == GetDevicePath2(
-            &GUID_DEVINTERFACE_IDD_DRIVER_DEVICE,
-            devicePath,
-            sizeof(devicePath) / sizeof(devicePath[0])))
+                         &GUID_DEVINTERFACE_IDD_DRIVER_DEVICE,
+                         devicePath,
+                         sizeof(devicePath) / sizeof(devicePath[0])))
         {
             break;
         }
@@ -751,11 +748,10 @@ HANDLE DeviceOpenHandle()
             GENERIC_READ | GENERIC_WRITE,
             // FILE_SHARE_READ | FILE_SHARE_WRITE,
             0,
-            NULL, // no SECURITY_ATTRIBUTES structure
+            NULL,          // no SECURITY_ATTRIBUTES structure
             OPEN_EXISTING, // No special create flags
-            0, // No special attributes
-            NULL
-        );
+            0,             // No special attributes
+            NULL);
         if (hDevice == INVALID_HANDLE_VALUE || hDevice == NULL)
         {
             DWORD error = GetLastError();

--- a/libs/virtual_display/examples/virtual_display_1.rs
+++ b/libs/virtual_display/examples/virtual_display_1.rs
@@ -10,8 +10,8 @@ fn prompt_input() -> u8 {
     println!("       3. 'u'       3. uninstall driver");
     println!("       4. 'c'       4. create device");
     println!("       5. 'd'       5. destroy device");
-    println!("       6. '1'       6. plug in monitor 0,1,2");
-    println!("       7. '4'       7. plug out monitor 0,1,2");
+    println!("       6. 'a'       6. plug in monitor");
+    println!("       7. 'b'       7. plug out monitor");
 
     io::stdin()
         .bytes()
@@ -42,6 +42,7 @@ fn plug_out(monitor_index: u32) {
 
 #[cfg(windows)]
 fn main() {
+    let mut idx = 0;
     loop {
         let chr = prompt_input();
         match chr as char {
@@ -87,12 +88,19 @@ fn main() {
                 virtual_display::close_device();
                 println!("Close device done");
             }
-            '1' => plug_in(0),
-            '2' => plug_in(1),
-            '3' => plug_in(2),
-            '4' => plug_out(0),
-            '5' => plug_out(1),
-            '6' => plug_out(2),
+            'a' => {
+                plug_in(idx);
+                idx += 1;
+            }
+            'b' => {
+                if idx == 0 {
+                    println!("No virtual monitors\n");
+                    break;
+                } else {
+                    idx -= 1;
+                    plug_out(idx);
+                }
+            }
             _ => {}
         }
     }

--- a/libs/virtual_display/examples/virtual_display_1.rs
+++ b/libs/virtual_display/examples/virtual_display_1.rs
@@ -23,7 +23,7 @@ fn prompt_input() -> u8 {
 #[cfg(windows)]
 fn plug_in(monitor_index: u32) {
     println!("Plug in monitor begin");
-    if let Err(e) = virtual_display::plug_in_monitor(monitor_index as _) {
+    if let Err(e) = virtual_display::plug_in_monitor(monitor_index as _, 10) {
         println!("{}", e);
     } else {
         println!("Plug in monitor done");

--- a/libs/virtual_display/src/lib.rs
+++ b/libs/virtual_display/src/lib.rs
@@ -159,7 +159,7 @@ pub fn uninstall_driver(reboot_required: &mut bool) -> ResultType<()> {
 }
 
 #[cfg(windows)]
-pub fn plug_in_monitor(monitor_index: u32) -> ResultType<()> {
+pub fn plug_in_monitor(monitor_index: u32, retries: u32) -> ResultType<()> {
     let mut lock = MONITOR_INDICES.lock().unwrap();
     if lock.contains(&monitor_index) {
         return Ok(());
@@ -169,20 +169,21 @@ pub fn plug_in_monitor(monitor_index: u32) -> ResultType<()> {
         .unwrap()
         .plug_in_monitor
         .ok_or(anyhow::Error::msg("plug_in_monitor method not found"))?;
-    f(monitor_index, 0, 20)?;
+    f(monitor_index, 0, retries)?;
     lock.insert(monitor_index);
     Ok(())
 }
 
 #[cfg(windows)]
 pub fn plug_out_monitor(monitor_index: u32) -> ResultType<()> {
+    let mut lock = MONITOR_INDICES.lock().unwrap();
     let f = LIB_WRAPPER
         .lock()
         .unwrap()
         .plug_out_monitor
         .ok_or(anyhow::Error::msg("plug_out_monitor method not found"))?;
     f(monitor_index)?;
-    MONITOR_INDICES.lock().unwrap().remove(&monitor_index);
+    lock.remove(&monitor_index);
     Ok(())
 }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1857,7 +1857,7 @@ pub fn uninstall_cert() -> ResultType<()> {
     cert::uninstall_cert()
 }
 
-mod cert {
+pub mod cert {
     use hbb_common::{allow_err, bail, log, ResultType};
     use std::{path::Path, str::from_utf8};
     use winapi::{
@@ -1887,7 +1887,7 @@ mod cert {
     const THUMBPRINT_ALG: ALG_ID = CALG_SHA1;
     const THUMBPRINT_LEN: DWORD = 20;
 
-    const CERT_ISSUER_1: &str = "CN=\"WDKTestCert admin,133225435702113567\"\0";
+    pub const CERT_ISSUER_1: &str = "CN=\"WDKTestCert admin,133225435702113567\"\0";
 
     #[inline]
     unsafe fn compute_thumbprint(pb_encoded: *const BYTE, cb_encoded: DWORD) -> (Vec<u8>, String) {
@@ -1994,9 +1994,7 @@ mod cert {
         Ok(())
     }
 
-    fn get_thumbprints_to_rm() -> ResultType<Vec<String>> {
-        let issuers_to_rm = [CERT_ISSUER_1];
-
+    pub fn get_thumbprints_of_issuers(issuers: &[&str]) -> ResultType<Vec<String>> {
         let mut thumbprints = Vec::new();
         let mut buf = [0u8; 1024];
 
@@ -2020,7 +2018,7 @@ mod cert {
                 if cb_size != 1 {
                     let mut add_ctx = false;
                     if let Ok(issuer) = from_utf8(&buf[..cb_size as _]) {
-                        for iss in issuers_to_rm.iter() {
+                        for iss in issuers.iter() {
                             if issuer == *iss {
                                 add_ctx = true;
                                 let (_, thumbprint) = compute_thumbprint(
@@ -2046,6 +2044,11 @@ mod cert {
         }
 
         Ok(thumbprints)
+    }
+
+    #[inline]
+    fn get_thumbprints_to_rm() -> ResultType<Vec<String>> {
+        get_thumbprints_of_issuers(&[CERT_ISSUER_1])
     }
 
     pub fn uninstall_cert() -> ResultType<()> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -380,6 +380,8 @@ pub async fn start_server(is_server: bool) {
         if crate::platform::current_is_wayland() {
             allow_err!(input_service::setup_uinput(0, 1920, 0, 1080).await);
         }
+        #[cfg(all(windows, feature = "virtual_display_driver"))]
+        let _r = crate::virtual_display_manager::prepare_driver();
         #[cfg(any(target_os = "macos", target_os = "linux"))]
         tokio::spawn(async { sync_and_watch_config_dir().await });
         #[cfg(target_os = "windows")]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1064,6 +1064,8 @@ impl Connection {
         // which may cause the mismatch of current display and the current display name.
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         video_service::try_reset_current_display();
+        #[cfg(all(windows, feature = "virtual_display_driver"))]
+        let _r = video_service::try_plug_in_virtual_display(10);
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
             pi.resolutions = Some(SupportedResolutions {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1065,7 +1065,7 @@ impl Connection {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         video_service::try_reset_current_display();
         #[cfg(all(windows, feature = "virtual_display_driver"))]
-        let _r = video_service::try_plug_in_virtual_display(10);
+        let _r = video_service::try_plug_in_virtual_display(9);
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
             pi.resolutions = Some(SupportedResolutions {

--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -46,6 +46,11 @@ impl VirtualDisplayManager {
     }
 }
 
+#[inline]
+pub fn prepare_driver() -> ResultType<()> {
+    VirtualDisplayManager::prepare_driver()
+}
+
 pub fn plug_in_headless(retries: u32) -> ResultType<()> {
     let mut manager = VIRTUAL_DISPLAY_MANAGER.lock().unwrap();
     VirtualDisplayManager::prepare_driver()?;


### PR DESCRIPTION
Refact virtual display.

1. Plugin retry at most 10 times after the authentication check. The interval is 1 second.
2. Remove plug in operation when querying the displays. This is why the connection cannot be established when the virtual dislay driver is not correctly installed.
3. Check if cert is installed before plugging in virtual display.

The "the exclamation of driver" issue is hard to reproduce for me, and is still not fixed.