### PR TITLE
Adding support MacPorts and /usr/local/ opus library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,45 @@
-/build
-/target
-.vscode
-.idea
-.DS_Store
-libsciter-gtk.so
-src/ui/inline.rs
-extractor
-__pycache__
+# Rust & Cargo
+debug/
+target/
+Cargo.lock
+**/*.rs.bk
 src/version.rs
-*dmg
-*exe
-*tgz
-cert.pfx
-*.bak
-*png
-*svg
-*jpg
-sciter.dll
-**pdb
+src/ui/inline.rs
 src/bridge_generated.rs
 src/bridge_generated.io.rs
-*deb
-rustdesk
-*.cache
-# appimage
-appimage/AppDir
-appimage/*.AppImage
-appimage/appimage-build
-appimage/*.xz
-# flutter
-flutter/linux/build/**
-flutter/linux/cmake-build-debug/**
-# flatpak
+
+# Apple (General)
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# IDE
+.idea
+.vscode
+
+# Flatpak
 flatpak/.flatpak-builder/**
 flatpak/ccache/**
 flatpak/.flatpak-builder/build/**
@@ -41,12 +49,55 @@ flatpak/.flatpak-builder/debian-binary
 flatpak/build/**
 flatpak/repo/**
 flatpak/*.flatpak
-# bridge file
-lib/generated_bridge.dart
-# vscode devcontainer
-.gitconfig
+
+# Flutter
+flutter/linux/build/**
+flutter/linux/cmake-build-debug/**
+
+# VSCode devcontainer
 .vscode-server/
-.ssh
 .devcontainer/.*
-# build cache in examples
+
+# Git
+.gitconfig
+
+# SSH
+.ssh
+
+# Images
+*png
+*svg
+*jpg
+
+# Appimage
+appimage/AppDir
+appimage/*.AppImage
+appimage/appimage-build
+appimage/*.xz
+
+# Bridge file
+lib/generated_bridge.dart
+
+# Build cache in examples
 examples/**/target/
+
+# Libs & Debug
+libsciter-gtk.so
+sciter.dll
+**pdb
+
+# Images & Executable & Archive
+extractor
+rustdesk
+*dmg
+*exe
+*deb
+*tgz
+
+# Python
+__pycache__
+
+# Other
+cert.pfx
+*.bak
+*.cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ sha2 = "0.10"
 repng = "0.2"
 parity-tokio-ipc = { git = "https://github.com/open-trade/parity-tokio-ipc" }
 runas = "=1.0" # https://github.com/mitsuhiko/rust-runas/issues/13
-magnum-opus = { git = "https://github.com/rustdesk/magnum-opus" }
+magnum-opus = { git = "https://github.com/rustdesk-org/magnum-opus" }
 dasp = { version = "0.11", features = ["signal", "interpolate-linear", "interpolate"], optional = true }
 rubato = { version = "0.12", optional = true }
 samplerate = { version = "0.2", optional = true }


### PR DESCRIPTION
I didn't end up getting rustdesk to work with sciter. I saw in the documentation that now for macOS you need to build together with Flutter. These commits will work on macOS if sciter works, which doesn't work on macOS 13.5.1 and possibly some versions below. Sciter definitely supports OSX, but I get:

![1](https://github.com/rustdesk/rustdesk/assets/52722847/2e7a6dc1-b0c0-425b-a9ad-acbc98868e34)

[Log](https://pastebin.com/ZkmHKsMj)

For this commit to work, you need to add this [commit](https://github.com/rustdesk-org/magnum-opus/pull/4).