### PR TITLE
Remove dup maximized state

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1699,7 +1699,10 @@ Future<bool> restoreWindowPosition(WindowType type,
       }
       if (lpos.isMaximized == true) {
         await restoreFrame();
-        await wc.maximize();
+        // An duration is needed to avoid the window being restored after maximized.
+        Future.delayed(Duration(milliseconds: 300), () async {
+          await wc.maximize();
+        });
       } else {
         await restoreFrame();
       }

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -106,7 +106,8 @@ class _ConnectionPageState extends State<ConnectionPage>
   @override
   void onWindowLeaveFullScreen() {
     // Restore edge border to default edge size.
-    stateGlobal.resizeEdgeSize.value = kWindowEdgeSize;
+    stateGlobal.resizeEdgeSize.value =
+        stateGlobal.isMaximized.isTrue ? kMaximizeEdgeSize : kWindowEdgeSize;
   }
 
   @override


### PR DESCRIPTION
1. Remove dup maximized state.  Fix the cursor on the edge of the remote window, if the remote window is maximized on start.
2. Restore remote window. Add an duration delay (300 milliseconds) after restore the window frame size and position. To avoid 
applying first `maximize` then `restore`.
