### PR TITLE
Few mobile chat window improvements

### DIFF
--- a/flutter/lib/common/widgets/overlay.dart
+++ b/flutter/lib/common/widgets/overlay.dart
@@ -373,7 +373,7 @@ class IOSDraggable extends StatefulWidget {
   _IOSDraggableState createState() => _IOSDraggableState();
 }
 
-class _IOSDraggableState extends State<IOSDraggable> with WidgetsBindingObserver {
+class _IOSDraggableState extends State<IOSDraggable> {
   late Offset _position;
   late ChatModel? _chatModel;
   late double _width;

--- a/flutter/lib/common/widgets/overlay.dart
+++ b/flutter/lib/common/widgets/overlay.dart
@@ -16,7 +16,8 @@ class DraggableChatWindow extends StatelessWidget {
       this.position = Offset.zero,
       required this.width,
       required this.height,
-      required this.chatModel})
+      required this.chatModel
+      })
       : super(key: key);
 
   final Offset position;
@@ -48,6 +49,7 @@ class DraggableChatWindow extends StatelessWidget {
         position: position,
         width: width,
         height: height,
+        chatModel: chatModel,
         builder: (context, onPanUpdate) {
           final child = 
               Scaffold(
@@ -242,6 +244,7 @@ class Draggable extends StatefulWidget {
       this.position = Offset.zero,
       required this.width,
       required this.height,
+      this.chatModel,
       required this.builder})
       : super(key: key);
 
@@ -250,6 +253,7 @@ class Draggable extends StatefulWidget {
   final Offset position;
   final double width;
   final double height;
+  final ChatModel? chatModel;
   final Widget Function(BuildContext, GestureDragUpdateCallback) builder;
 
   @override
@@ -258,6 +262,7 @@ class Draggable extends StatefulWidget {
 
 class _DraggableState extends State<Draggable> {
   late Offset _position;
+  late ChatModel? _chatModel;
   bool _keyboardVisible = false;
   double _saveHeight = 0;
   double _lastBottomHeight = 0;
@@ -266,6 +271,7 @@ class _DraggableState extends State<Draggable> {
   void initState() {
     super.initState();
     _position = widget.position;
+    _chatModel = widget.chatModel??null;
   }
 
   void onPanUpdate(DragUpdateDetails d) {
@@ -292,6 +298,7 @@ class _DraggableState extends State<Draggable> {
     setState(() {
       _position = Offset(x, y);
     });
+      _chatModel?.setChatWindowPosition(_position);
   }
 
   checkScreenSize() {}
@@ -351,14 +358,14 @@ class IOSDraggable extends StatefulWidget {
   const IOSDraggable({
     Key? key,
     this.position = Offset.zero,
-    required this.chatModel, 
+    this.chatModel,
     required this.width,
     required this.height,
     required this.builder})
     : super(key: key);
 
   final Offset position;
-  final ChatModel chatModel;
+  final ChatModel? chatModel;
   final double width;
   final double height;
   final Widget Function(BuildContext) builder;
@@ -369,7 +376,7 @@ class IOSDraggable extends StatefulWidget {
 
 class _IOSDraggableState extends State<IOSDraggable> {
 late Offset _position;
-late ChatModel _chatModel;
+late ChatModel? _chatModel;
 late double _width;
 late double _height;
 
@@ -377,7 +384,7 @@ late double _height;
 void initState() {
   super.initState();
   _position = widget.position;
-  _chatModel = widget.chatModel;
+  _chatModel = widget.chatModel??null;
   _width = widget.width;
   _height = widget.height;
 }
@@ -394,6 +401,7 @@ void initState() {
               setState(() {
                 _position += details.delta;
               });
+              _chatModel?.setChatWindowPosition(_position);
             },
             child: Material(
               child:

--- a/flutter/lib/common/widgets/overlay.dart
+++ b/flutter/lib/common/widgets/overlay.dart
@@ -389,28 +389,27 @@ class _IOSDraggableState extends State<IOSDraggable> with WidgetsBindingObserver
     _chatModel = widget.chatModel;
     _width = widget.width;
     _height = widget.height;
-
-    WidgetsBinding.instance?.addObserver(this);
   }
 
-  @override
-  void dispose() {
-    WidgetsBinding.instance?.removeObserver(this);
-    super.dispose();
-  }
+  checkKeyboard() {
+    final bottomHeight = MediaQuery.of(context).viewInsets.bottom;
+    final currentVisible = bottomHeight != 0;
 
-  @override
-  void didChangeMetrics() {
-    final currentVisible = MediaQuery.of(context).viewInsets.bottom != 0;
-
+    // save
     if (!_keyboardVisible && currentVisible) {
       _saveHeight = _position.dy;
-    } else if (_lastBottomHeight > 0 && !currentVisible) {
+    }
+
+    // reset
+    if (_lastBottomHeight > 0 && bottomHeight == 0) {
       setState(() {
         _position = Offset(_position.dx, _saveHeight);
       });
-    } else if (_keyboardVisible && currentVisible) {
-      final sumHeight = MediaQuery.of(context).viewInsets.bottom + _height;
+    }
+
+    // onKeyboardVisible
+    if (_keyboardVisible && currentVisible) {
+      final sumHeight = bottomHeight + _height;
       final contextHeight = MediaQuery.of(context).size.height;
       if (sumHeight + _position.dy > contextHeight) {
         final y = contextHeight - sumHeight;
@@ -421,11 +420,12 @@ class _IOSDraggableState extends State<IOSDraggable> with WidgetsBindingObserver
     }
 
     _keyboardVisible = currentVisible;
-    _lastBottomHeight = MediaQuery.of(context).viewInsets.bottom;
+    _lastBottomHeight = bottomHeight;
   }
 
 @override
   Widget build(BuildContext context) {
+    checkKeyboard();
     return Stack(
       children: [
         Positioned(

--- a/flutter/lib/common/widgets/overlay.dart
+++ b/flutter/lib/common/widgets/overlay.dart
@@ -400,7 +400,8 @@ void initState() {
             Container(
               width: _width,
               height: _height,
-            child: widget.builder(context),
+              decoration: BoxDecoration(border: Border.all(color: MyTheme.border)),
+              child: widget.builder(context),
               ),
             ),
           ),

--- a/flutter/lib/models/chat_model.dart
+++ b/flutter/lib/models/chat_model.dart
@@ -72,6 +72,13 @@ class ChatModel with ChangeNotifier {
   RxInt mobileUnreadSum = 0.obs;
   MessageKey? latestReceivedKey;
 
+  Offset chatWindowPosition = Offset(20, 80);
+
+   void setChatWindowPosition(Offset position) {
+    chatWindowPosition = position;
+    notifyListeners();
+  }
+
   @override
   void dispose() {
     textController.dispose();
@@ -210,7 +217,7 @@ class ChatModel with ChangeNotifier {
             }
           },
           child: DraggableChatWindow(
-              position: chatInitPos ?? Offset(20, 80),
+              position: chatInitPos ?? chatWindowPosition,
               width: 250,
               height: 350,
               chatModel: this));

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -300,11 +300,12 @@ packages:
   dash_chat_2:
     dependency: "direct main"
     description:
-      name: dash_chat_2
-      sha256: e9e08b2a030d340d60f7adbeb977d3d6481db1f172b51440bfa02488b92fa19c
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.17"
+      path: "."
+      ref: HEAD
+      resolved-ref: bd6b5b41254e57c5bcece202ebfb234de63e6487
+      url: "https://github.com/rustdesk-org/Dash-Chat-2"
+    source: git
+    version: "0.0.18"
   debounce_throttle:
     dependency: "direct main"
     description:
@@ -1398,10 +1399,10 @@ packages:
     dependency: transitive
     description:
       name: video_player
-      sha256: "59f7f31c919c59cbedd37c617317045f5f650dc0eeb568b0b0de9a36472bdb28"
+      sha256: d3910a8cefc0de8a432a4411dcf85030e885d8fef3ddea291f162253a05dbf01
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.1"
+    version: "2.7.1"
   video_player_android:
     dependency: transitive
     description:
@@ -1422,10 +1423,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_platform_interface
-      sha256: "42bb75de5e9b79e1f20f1d95f688fac0f95beac4d89c6eb2cd421724d4432dae"
+      sha256: be72301bf2c0150ab35a8c34d66e5a99de525f6de1e8d27c0672b836fe48f73a
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "6.2.1"
   video_player_web:
     dependency: transitive
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -39,7 +39,9 @@ dependencies:
   package_info_plus: ^3.1.2
   url_launcher: ^6.0.9
   toggle_switch: ^2.1.0
-  dash_chat_2: ^0.0.17
+  dash_chat_2: 
+    git:
+      url: https://github.com/rustdesk-org/Dash-Chat-2
   draggable_float_widget: ^0.0.2
   settings_ui: ^2.0.2
   flutter_breadcrumb: ^1.0.1


### PR DESCRIPTION
- Fixed bottom chat window gap issue (ios). Caused by DashChat's SafeArea, fixed [here](https://github.com/rustdesk-org/Dash-Chat-2/commit/bd6b5b41254e57c5bcece202ebfb234de63e6487).
- Added chat window border (ios).
- Move up chat window on soft keyboard to avoid overlapping (ios).
- Remember the last position of chat window (ios + android).

Tested and working on simulator, let me know if it doesn't work well on a physical device.


https://github.com/rustdesk/rustdesk/assets/73148455/f241a016-61f4-4a5c-ac88-9ffd7a30b449


https://github.com/rustdesk/rustdesk/assets/73148455/310b2175-7032-49d8-88e8-f41015147640

