### PR TITLE
Fix frequent loginctl calls

### DIFF
--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -183,6 +183,15 @@ pub fn is_active(sid: &str) -> bool {
     }
 }
 
+pub fn is_active_and_seat0(sid: &str) -> bool {
+    if let Ok(output) = run_loginctl(Some(vec!["show-session", sid])) {
+        String::from_utf8_lossy(&output.stdout).contains("State=active")
+            && String::from_utf8_lossy(&output.stdout).contains("Seat=seat0")
+    } else {
+        false
+    }
+}
+
 pub fn run_cmds(cmds: &str) -> ResultType<String> {
     let output = std::process::Command::new("sh")
         .args(vec!["-c", cmds])

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1073,13 +1073,11 @@ mod desktop {
         }
 
         pub fn refresh(&mut self) {
-            let seat0_values = get_values_of_seat0(&[0, 1, 2]);
-            if !self.sid.is_empty() && is_active(&self.sid) {
-                if self.sid == seat0_values[0] {
+            if !self.sid.is_empty() && is_active_and_seat0(&self.sid) {
                      return;
-                 }
             }
 
+            let seat0_values = get_values_of_seat0(&[0, 1, 2]);
             if seat0_values[0].is_empty() {
                 *self = Self::default();
                 self.is_rustdesk_subprocess = false;


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/3129#issuecomment-1705539631

Tested: Ubuntu, Debian XFCE. Works the same as before. No login error on restart.