### PR TITLE
fix, android soft keyboard, 'delete input' on conn password

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -275,7 +275,9 @@ class _RemotePageState extends State<RemotePage> {
                           return Offstage();
                         }(),
                   _bottomWidget(),
-                  gFFI.ffiModel.pi.isSet.isFalse ? emptyOverlay(MyTheme.canvasColor) : Offstage(),
+                  gFFI.ffiModel.pi.isSet.isFalse
+                      ? emptyOverlay(MyTheme.canvasColor)
+                      : Offstage(),
                 ],
               )),
           body: Overlay(
@@ -316,12 +318,15 @@ class _RemotePageState extends State<RemotePage> {
   Widget getRawPointerAndKeyBody(Widget child) {
     final keyboard = gFFI.ffiModel.permissions['keyboard'] != false;
     return RawPointerMouseRegion(
-        cursor: keyboard ? SystemMouseCursors.none : MouseCursor.defer,
-        inputModel: inputModel,
-        child: RawKeyFocusScope(
-            focusNode: _physicalFocusNode,
-            inputModel: inputModel,
-            child: child));
+      cursor: keyboard ? SystemMouseCursors.none : MouseCursor.defer,
+      inputModel: inputModel,
+      child: gFFI.ffiModel.pi.isSet.isTrue
+          ? RawKeyFocusScope(
+              focusNode: _physicalFocusNode,
+              inputModel: inputModel,
+              child: child)
+          : child,
+    );
   }
 
   Widget getBottomAppBar(bool keyboard) {

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -320,6 +320,8 @@ class _RemotePageState extends State<RemotePage> {
     return RawPointerMouseRegion(
       cursor: keyboard ? SystemMouseCursors.none : MouseCursor.defer,
       inputModel: inputModel,
+      // Disable RawKeyFocusScope before the connecting is established.
+      // The "Delete" key on the soft keyboard may be grabbed when inputting the password dialog.
       child: gFFI.ffiModel.pi.isSet.isTrue
           ? RawKeyFocusScope(
               focusNode: _physicalFocusNode,


### PR DESCRIPTION
"Delete" on soft keyboard has no effect, on password dialog when connecting.

Because "Delete" is grabbed by https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/models/input_model.dart#L93

But it's strange that the dialog is grabbed and only the "Delete" key is grabbed.

Now try to disable the key grabbing before the connecting is established.

