### PR TITLE
install service period protection 

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -101,6 +101,7 @@ class ColorThemeExtension extends ThemeExtension<ColorThemeExtension> {
     required this.highlight,
     required this.drag_indicator,
     required this.shadow,
+    required this.errorBannerBg,
   });
 
   final Color? border;
@@ -108,6 +109,7 @@ class ColorThemeExtension extends ThemeExtension<ColorThemeExtension> {
   final Color? highlight;
   final Color? drag_indicator;
   final Color? shadow;
+  final Color? errorBannerBg;
 
   static final light = ColorThemeExtension(
     border: Color(0xFFCCCCCC),
@@ -115,6 +117,7 @@ class ColorThemeExtension extends ThemeExtension<ColorThemeExtension> {
     highlight: Color(0xFFE5E5E5),
     drag_indicator: Colors.grey[800],
     shadow: Colors.black,
+    errorBannerBg: Color(0xFFFDEEEB),
   );
 
   static final dark = ColorThemeExtension(
@@ -123,6 +126,7 @@ class ColorThemeExtension extends ThemeExtension<ColorThemeExtension> {
     highlight: Color(0xFF3F3F3F),
     drag_indicator: Colors.grey,
     shadow: Colors.grey,
+    errorBannerBg: Color(0xFF470F2D),
   );
 
   @override
@@ -132,6 +136,7 @@ class ColorThemeExtension extends ThemeExtension<ColorThemeExtension> {
     Color? highlight,
     Color? drag_indicator,
     Color? shadow,
+    Color? errorBannerBg,
   }) {
     return ColorThemeExtension(
       border: border ?? this.border,
@@ -139,6 +144,7 @@ class ColorThemeExtension extends ThemeExtension<ColorThemeExtension> {
       highlight: highlight ?? this.highlight,
       drag_indicator: drag_indicator ?? this.drag_indicator,
       shadow: shadow ?? this.shadow,
+      errorBannerBg: errorBannerBg ?? this.errorBannerBg,
     );
   }
 
@@ -154,6 +160,7 @@ class ColorThemeExtension extends ThemeExtension<ColorThemeExtension> {
       highlight: Color.lerp(highlight, other.highlight, t),
       drag_indicator: Color.lerp(drag_indicator, other.drag_indicator, t),
       shadow: Color.lerp(shadow, other.shadow, t),
+      errorBannerBg: Color.lerp(shadow, other.errorBannerBg, t),
     );
   }
 }

--- a/flutter/lib/common/widgets/address_book.dart
+++ b/flutter/lib/common/widgets/address_book.dart
@@ -76,7 +76,7 @@ class _AddressBookState extends State<AddressBook> {
           child: Center(
               child: Container(
             height: height,
-            color: Color.fromARGB(255, 253, 238, 235),
+            color: MyTheme.color(context).errorBannerBg,
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.center,

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1537,9 +1537,14 @@ Widget _OptionCheckBox(BuildContext context, String label, String key,
       isServer
           ? await mainSetBoolOption(key, option)
           : await mainSetLocalBoolOption(key, option);
-      ref.value = isServer
+      final readOption = isServer
           ? mainGetBoolOptionSync(key)
           : mainGetLocalBoolOptionSync(key);
+      if (reverse) {
+        ref.value = !readOption;
+      } else {
+        ref.value = readOption;
+      }
       update?.call();
     }
   }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1074,7 +1074,7 @@ mod desktop {
 
         pub fn refresh(&mut self) {
             if !self.sid.is_empty() && is_active_and_seat0(&self.sid) {
-                     return;
+                return;
             }
 
             let seat0_values = get_values_of_seat0(&[0, 1, 2]);
@@ -1183,6 +1183,7 @@ pub fn uninstall_service(show_new_window: bool) -> bool {
 }
 
 pub fn install_service() -> bool {
+    let _installing = crate::platform::InstallingService::new();
     if !has_cmd("systemctl") {
         return false;
     }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -23,8 +23,17 @@ pub mod linux_desktop_manager;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use hbb_common::{message_proto::CursorData, ResultType};
+use std::sync::{Arc, Mutex};
 #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "ios")))]
 const SERVICE_INTERVAL: u64 = 300;
+
+lazy_static::lazy_static! {
+    static ref INSTALLING_SERVICE: Arc<Mutex<bool>>= Default::default();
+}
+
+pub fn installing_service() -> bool {
+    INSTALLING_SERVICE.lock().unwrap().clone()
+}
 
 pub fn is_xfce() -> bool {
     #[cfg(target_os = "linux")]
@@ -70,6 +79,21 @@ pub fn get_active_username() -> String {
 
 #[cfg(target_os = "android")]
 pub const PA_SAMPLE_RATE: u32 = 48000;
+
+pub(crate) struct InstallingService; // please use new
+
+impl InstallingService {
+    pub fn new() -> Self {
+        *INSTALLING_SERVICE.lock().unwrap() = true;
+        Self
+    }
+}
+
+impl Drop for InstallingService {
+    fn drop(&mut self) {
+        *INSTALLING_SERVICE.lock().unwrap() = false;
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2167,6 +2167,7 @@ pub fn uninstall_service(show_new_window: bool) -> bool {
 
 pub fn install_service() -> bool {
     log::info!("Installing service...");
+    let _installing = crate::platform::InstallingService::new();
     let (_, _, _, exe) = get_install_info();
     let tmp_path = std::env::temp_dir().to_string_lossy().to_string();
     let tray_shortcut = get_tray_shortcut(&exe, &tmp_path).unwrap_or_default();

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -79,7 +79,9 @@ impl RendezvousMediator {
         crate::platform::linux_desktop_manager::start_xdesktop();
         loop {
             Config::reset_online();
-            if Config::get_option("stop-service").is_empty() {
+            if Config::get_option("stop-service").is_empty()
+                && !crate::platform::installing_service()
+            {
                 if !nat_tested {
                     crate::test_nat_type();
                     nat_tested = true;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2278,7 +2278,7 @@ impl Connection {
             lock_screen().await;
         }
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        let data = if self.chat_unanswered || self.file_transferred {
+        let data = if self.chat_unanswered || self.file_transferred && cfg!(feature = "flutter") {
             ipc::Data::Disconnected
         } else {
             ipc::Data::Close


### PR DESCRIPTION
1. fix dark theme error banner background color

| before | after |
| :----: | :---: |
|   ![13aeee63bfbbd03a8b550b7bfb31994](https://github.com/rustdesk/rustdesk/assets/14891774/aa2a4360-1dd5-4c3e-bdda-97536a122ff3)  |   ![3ba416f4386ea9cdc33e3b7857dae6b](https://github.com/rustdesk/rustdesk/assets/14891774/4f4ea067-2503-4c38-b5cb-c8f4753832f8)  |
2. remove keep cm open when there is file log in sciter version, because sciter version doesn't support
3. install service period protection, used and tested on windows/linux
* how to reproduce:
install, click stop service, click start service, uac pop up, wait for one second, click cancel on uac, it'll show "Service is not running" but can be connected. because the value of "stop-service" is temporarily reversed.
https://github.com/rustdesk/rustdesk/blob/96215d32b76f4bdc629e98b7f02e0039664e57da/src/rendezvous_mediator.rs#L82
4. fix lan option reaction