### PR TITLE
Update cn.rs “或 IP”

### DIFF
--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -188,7 +188,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relayed and encrypted connection", "加密中继连接"),
         ("Direct and unencrypted connection", "非加密直连"),
         ("Relayed and unencrypted connection", "非加密中继连接"),
-        ("Enter Remote ID", "输入对方 ID"),
+        ("Enter Remote ID", "输入对方 ID 或 IP"),
         ("Enter your password", "输入密码"),
         ("Logging in...", "正在登录..."),
         ("Enable RDP session sharing", "允许 RDP 会话共享"),


### PR DESCRIPTION
记得之前是支持 IP 直连的，但是一直没找到输入的地方。最后发现，首页输入框原来是可以直接填 IP。

把翻译加上 “或 IP” 就直观了。