### PR TITLE
fix, macos as the controlled side, crash on disconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4881,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/fufesou/rdev#bec664ee8743ade8d2fdd099b114c9eeacd9cfba"
+source = "git+https://github.com/fufesou/rdev#2e8221d653f4995c831ad52966e79a514516b1fa"
 dependencies = [
  "cocoa",
  "core-foundation",

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -380,9 +380,6 @@ pub fn try_stop_record_cursor_pos() {
         return;
     }
     RECORD_CURSOR_POS_RUNNING.store(false, Ordering::SeqCst);
-
-    #[cfg(any(target_os = "windows", target_os = "macos"))]
-    let _r = rdev::exit_grab();
 }
 
 // mac key input must be run in main thread, otherwise crash on >= osx 10.15


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/5712

1. Remove `rdev::exit_grab();`. `rdev::grab()` is never called in the "--server" process. The `rdev::grab()` works on the portable process, but it's not necessary to call `rdev::exit_grab();`.
2. Check null ptr before operating. https://github.com/fufesou/rdev/commit/2e8221d653f4995c831ad52966e79a514516b1fa

