### PR TITLE
Change the maximized state on 'Adjust Window'

### DIFF
--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -775,6 +775,7 @@ class ScreenAdjustor {
       }
       await WindowController.fromWindowId(windowId)
           .setFrame(Rect.fromLTWH(left, top, width, height));
+      stateGlobal.setMaximized(false);
     }
   }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/5717

Please merge https://github.com/rustdesk-org/rustdesk_desktop_multi_window/pull/4 first.

Because double tap toggles maximize:
```dart
Future<bool> toggleMaximize(bool isMainWindow) async {
  if (isMainWindow) {
    if (await windowManager.isMaximized()) {
      windowManager.unmaximize();
      return false;
    } else {
      windowManager.maximize();
      return true;
    }
  } else {
    final wc = WindowController.fromWindowId(kWindowId!);
    if (await wc.isMaximized()) {
      wc.unmaximize();
      return false;
    } else {
      wc.maximize();
      return true;
    }
  }
}
```

`isMaximized()` in the [rustdesk_desktop_multi_window](https://github.com/rustdesk-org/rustdesk_desktop_multi_window) need to be fixed first.
