### PR TITLE
fix, texture render widget, blurry image

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -409,7 +409,7 @@ class _RemotePageState extends State<RemotePage>
           keyboardEnabled: _keyboardEnabled,
           remoteCursorMoved: _remoteCursorMoved,
           textureId: _renderTexture.textureId,
-          useTextureRender: _renderTexture.useTextureRender,
+          useTextureRender: RenderTexture.useTextureRender,
           listenerBuilder: (child) =>
               _buildRawTouchAndPointerRegion(child, enterView, leaveView),
         );
@@ -539,7 +539,10 @@ class _ImagePaintState extends State<ImagePaint> {
         imageWidget = SizedBox(
           width: imageWidth,
           height: imageHeight,
-          child: Obx(() => Texture(textureId: widget.textureId.value)),
+          child: Obx(() => Texture(
+                textureId: widget.textureId.value,
+                filterQuality: FilterQuality.none,
+              )),
         );
       } else {
         imageWidget = CustomPaint(
@@ -576,11 +579,14 @@ class _ImagePaintState extends State<ImagePaint> {
           imageWidget = Stack(
             children: [
               Positioned(
-                left: c.x.toInt().toDouble(),
-                top: c.y.toInt().toDouble(),
+                left: c.x,
+                top: c.y,
                 width: c.getDisplayWidth() * s,
                 height: c.getDisplayHeight() * s,
-                child: Texture(textureId: widget.textureId.value),
+                child: Texture(
+                  textureId: widget.textureId.value,
+                  filterQuality: FilterQuality.none,
+                ),
               )
             ],
           );

--- a/flutter/lib/models/desktop_render_texture.dart
+++ b/flutter/lib/models/desktop_render_texture.dart
@@ -8,7 +8,7 @@ class RenderTexture {
   final RxInt textureId = RxInt(-1);
   int _textureKey = -1;
   SessionID? _sessionId;
-  final useTextureRender = bind.mainUseTextureRender();
+  static final useTextureRender = bind.mainUseTextureRender();
 
   final textureRenderer = TextureRgbaRenderer();
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/5717

Fix blurry image by add `filterQuality: FilterQuality.none` to the `Texture` widget.
But I don't know why this parameter can fix the issue.

## the issue
1. Scale original.
2. Resize the window if the remote image is smaller than current window. Or scroll the image if the remote image is bigger than current window.

https://github.com/rustdesk/rustdesk/assets/136106582/05bc29d9-a0d2-432e-81ff-c63d6d64771c

