### PR TITLE
fix, set texture widget offset to int on linux

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -576,11 +576,13 @@ class _ImagePaintState extends State<ImagePaint> {
       late final Widget imageWidget;
       if (c.size.width > 0 && c.size.height > 0) {
         if (widget.useTextureRender) {
+          final x = Platform.isLinux ? c.x.toInt().toDouble() : c.x;
+          final y = Platform.isLinux ? c.y.toInt().toDouble() : c.y;
           imageWidget = Stack(
             children: [
               Positioned(
-                left: c.x,
-                top: c.y,
+                left: x,
+                top: y,
                 width: c.getDisplayWidth() * s,
                 height: c.getDisplayHeight() * s,
                 child: Texture(


### PR DESCRIPTION
Linux requires the `Texture` widget offset to be integers.

TODOs:

I'll push other PRs.

1. Resizing window is not smooth. Recent commits.


https://github.com/rustdesk/rustdesk/assets/136106582/37e0c593-7757-4be2-a250-a29e1add3cab



2. "Scale adaptive" blurry image, `Texture` widget.


https://github.com/rustdesk/rustdesk/assets/136106582/c59a2bb1-f814-4891-9c65-4c1d09071d76

