### PR TITLE
mobile scrollable peers view

### DIFF
--- a/flutter/lib/common/widgets/address_book.dart
+++ b/flutter/lib/common/widgets/address_book.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:dynamic_layouts/dynamic_layouts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hbb/common/formatter/id_formatter.dart';
@@ -170,16 +172,18 @@ class _AddressBookState extends State<AddressBook> {
             });
       }
 
+      final gridView = DynamicGridView.builder(
+          shrinkWrap: isMobile,
+          gridDelegate: SliverGridDelegateWithWrapping(),
+          itemCount: tags.length,
+          itemBuilder: (BuildContext context, int index) {
+            final e = tags[index];
+            return tagBuilder(e);
+          });
+      final maxHeight = max(MediaQuery.of(context).size.height / 6, 100.0);
       return isDesktop
-          ? DynamicGridView.builder(
-              gridDelegate: SliverGridDelegateWithWrapping(
-                  mainAxisSpacing: 0, crossAxisSpacing: 0),
-              itemCount: tags.length,
-              itemBuilder: (BuildContext context, int index) {
-                final e = tags[index];
-                return tagBuilder(e);
-              })
-          : Wrap(children: tags.map((e) => tagBuilder(e)).toList());
+          ? gridView
+          : LimitedBox(maxHeight: maxHeight, child: gridView);
     });
   }
 

--- a/flutter/lib/common/widgets/my_group.dart
+++ b/flutter/lib/common/widgets/my_group.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hbb/common/hbbs/hbbs.dart';
 import 'package:flutter_hbb/common/widgets/login.dart';
@@ -157,11 +159,14 @@ class _MyGroupState extends State<MyGroup> {
         }
         return true;
       }).toList();
+      final listView = ListView.builder(
+          shrinkWrap: isMobile,
+          itemCount: items.length,
+          itemBuilder: (context, index) => _buildUserItem(items[index]));
+      var maxHeight = max(MediaQuery.of(context).size.height / 6, 100.0);
       return isDesktop
-          ? ListView.builder(
-              itemCount: items.length,
-              itemBuilder: (context, index) => _buildUserItem(items[index]))
-          : Column(children: items.map((e) => _buildUserItem(e)).toList());
+          ? listView
+          : LimitedBox(maxHeight: maxHeight, child: listView);
     });
   }
 

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -197,23 +197,14 @@ class _PeersViewState extends State<_PeersView> with WindowListener {
                   : SizedBox(width: mobileWidth, child: visibilityChild);
             }
 
-            final Widget child;
-            if (isDesktop) {
-              child = DynamicGridView.builder(
-                gridDelegate: SliverGridDelegateWithWrapping(
-                    mainAxisSpacing: space / 2, crossAxisSpacing: space),
-                itemCount: peers.length,
-                itemBuilder: (BuildContext context, int index) {
-                  return buildOnePeer(peers[index]);
-                },
-              );
-            } else {
-              child = Wrap(
-                  spacing: space,
-                  runSpacing: space,
-                  children: peers.map((e) => buildOnePeer(e)).toList());
-            }
-
+            final child = DynamicGridView.builder(
+              gridDelegate: SliverGridDelegateWithWrapping(
+                  mainAxisSpacing: space / 2, crossAxisSpacing: space),
+              itemCount: peers.length,
+              itemBuilder: (BuildContext context, int index) {
+                return buildOnePeer(peers[index]);
+              },
+            );
             if (updateEvent == UpdateEvent.load) {
               _curPeers.clear();
               _curPeers.addAll(peers.map((e) => e.id));

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -176,7 +176,8 @@ class _PeersViewState extends State<_PeersView> with WindowListener {
       return FutureBuilder<List<Peer>>(
         builder: (context, snapshot) {
           if (snapshot.hasData) {
-            final peers = snapshot.data!;
+            var peers = snapshot.data!;
+            if (peers.length > 1000) peers = peers.sublist(0, 1000);
             gFFI.peerTabModel.setCurrentTabCachedPeers(peers);
             buildOnePeer(Peer peer) {
               final visibilityChild = VisibilityDetector(

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -125,8 +125,7 @@ void runMainApp(bool startService) async {
     bind.pluginSyncUi(syncTo: kAppTypeMain);
     bind.pluginListReload();
   }
-  gFFI.abModel.loadCache();
-  gFFI.groupModel.loadCache();
+  await Future.wait([gFFI.abModel.loadCache(), gFFI.groupModel.loadCache()]);
   gFFI.userModel.refreshCurrentUser();
   runApp(App());
   // Set window option.
@@ -154,8 +153,7 @@ void runMobileApp() async {
   await initEnv(kAppTypeMain);
   if (isAndroid) androidChannelInit();
   platformFFI.syncAndroidServiceAppDirConfigPath();
-  gFFI.abModel.loadCache();
-  gFFI.groupModel.loadCache();
+  await Future.wait([gFFI.abModel.loadCache(), gFFI.groupModel.loadCache()]);
   gFFI.userModel.refreshCurrentUser();
   runApp(App());
 }

--- a/flutter/lib/mobile/pages/connection_page.dart
+++ b/flutter/lib/mobile/pages/connection_page.dart
@@ -80,7 +80,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
           _buildRemoteIDTextField(),
         ])),
         SliverFillRemaining(
-          hasScrollBody: false,
+          hasScrollBody: true,
           child: PeerTabPage(),
         )
       ],

--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -478,7 +478,7 @@ class AbModel {
     }
   }
 
-  loadCache() async {
+  Future<void> loadCache() async {
     try {
       if (_cacheLoadOnceFlag || abLoading.value || initialized) return;
       _cacheLoadOnceFlag = true;

--- a/flutter/lib/models/group_model.dart
+++ b/flutter/lib/models/group_model.dart
@@ -173,9 +173,6 @@ class GroupModel {
         }
         if (json.containsKey('total')) {
           if (total == 0) total = json['total'];
-          if (total > 1000) {
-            total = 1000;
-          }
           if (json.containsKey('data')) {
             final data = json['data'];
             if (data is List) {
@@ -187,9 +184,6 @@ class GroupModel {
                   tmpPeers.add(peer);
                 } else {
                   tmpPeers[index] = peer;
-                }
-                if (tmpPeers.length >= 1000) {
-                  break;
                 }
               }
             }

--- a/flutter/lib/models/group_model.dart
+++ b/flutter/lib/models/group_model.dart
@@ -231,7 +231,7 @@ class GroupModel {
     }
   }
 
-  loadCache() async {
+  Future<void> loadCache() async {
     try {
       if (_cacheLoadOnceFlag || groupLoading.value || initialized) return;
       _cacheLoadOnceFlag = true;

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -400,11 +400,11 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/dynamic_layouts"
-      ref: "0023d01996576e494094793a6552463f01c5627a"
-      resolved-ref: "0023d01996576e494094793a6552463f01c5627a"
-      url: "https://github.com/flutter/packages.git"
+      ref: "74cc4b495dcf3a4cb8df38d9ecc89f53f074a2c6"
+      resolved-ref: "74cc4b495dcf3a4cb8df38d9ecc89f53f074a2c6"
+      url: "https://github.com/21pages/packages.git"
     source: git
-    version: "0.0.1+1"
+    version: "0.0.1+2"
   event_bus:
     dependency: transitive
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -102,9 +102,9 @@ dependencies:
   flex_color_picker: ^3.3.0
   dynamic_layouts:
     git:
-      url: https://github.com/flutter/packages.git
+      url: https://github.com/21pages/packages.git
       path: packages/dynamic_layouts
-      ref: 0023d01996576e494094793a6552463f01c5627a
+      ref: 74cc4b495dcf3a4cb8df38d9ecc89f53f074a2c6
 
 dev_dependencies:
   icons_launcher: ^2.0.4


### PR DESCRIPTION
1.Use `await loadCach`e to ensure that the group/ab peers view is not empty at startup. While it may not be the actual reason, as in some tests the user is shown before the peers, it still works effectively.
2.Truncate the peers list to display a maximum of 1000 peers after applying any filters. When selecting all peers, show "1000 selected" and perform operations on these 1000 peers.
3. Mobile: the height of scroll tags/users is limited to at most one-sixth of the screen height, make the peers view scrollable.



https://github.com/rustdesk/rustdesk/assets/14891774/182d3dab-4f86-4a19-a6fa-21d319eb5533

