### PR TITLE
desktop touch pad scroll

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -273,11 +273,29 @@ class MyTheme {
       : EdgeInsets.only(left: dialogPadding / 3);
 
   static ScrollbarThemeData scrollbarTheme = ScrollbarThemeData(
-    thickness: MaterialStateProperty.all(kScrollbarThickness),
+    thickness: MaterialStateProperty.all(6),
+    thumbColor: MaterialStateProperty.resolveWith<Color?>((states) {
+      if (states.contains(MaterialState.dragged)) {
+        return Colors.grey[900];
+      } else if (states.contains(MaterialState.hovered)) {
+        return Colors.grey[700];
+      } else {
+        return Colors.grey[500];
+      }
+    }),
+    crossAxisMargin: 4,
   );
 
   static ScrollbarThemeData scrollbarThemeDark = scrollbarTheme.copyWith(
-    thumbColor: MaterialStateProperty.all(Colors.grey[500]),
+    thumbColor: MaterialStateProperty.resolveWith<Color?>((states) {
+      if (states.contains(MaterialState.dragged)) {
+        return Colors.grey[100];
+      } else if (states.contains(MaterialState.hovered)) {
+        return Colors.grey[300];
+      } else {
+        return Colors.grey[500];
+      }
+    }),
   );
 
   static ThemeData lightTheme = ThemeData(

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -4,6 +4,7 @@ import 'dart:collection';
 import 'package:dynamic_layouts/dynamic_layouts.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hbb/desktop/widgets/scroll_wrapper.dart';
 import 'package:get/get.dart';
 import 'package:provider/provider.dart';
 import 'package:visibility_detector/visibility_detector.dart';
@@ -94,6 +95,8 @@ class _PeersViewState extends State<_PeersView> with WindowListener {
     }
     return width;
   }();
+
+  final _scrollController = ScrollController();
 
   _PeersViewState() {
     _startCheckOnlines();
@@ -197,14 +200,31 @@ class _PeersViewState extends State<_PeersView> with WindowListener {
                   : SizedBox(width: mobileWidth, child: visibilityChild);
             }
 
-            final child = DynamicGridView.builder(
-              gridDelegate: SliverGridDelegateWithWrapping(
-                  mainAxisSpacing: space / 2, crossAxisSpacing: space),
-              itemCount: peers.length,
-              itemBuilder: (BuildContext context, int index) {
-                return buildOnePeer(peers[index]);
-              },
-            );
+            final Widget child;
+            if (isMobile) {
+              child = DynamicGridView.builder(
+                gridDelegate: SliverGridDelegateWithWrapping(
+                    mainAxisSpacing: space / 2, crossAxisSpacing: space),
+                itemCount: peers.length,
+                itemBuilder: (BuildContext context, int index) {
+                  return buildOnePeer(peers[index]);
+                },
+              );
+            } else {
+              child = DesktopScrollWrapper(
+                scrollController: _scrollController,
+                child: DynamicGridView.builder(
+                    controller: _scrollController,
+                    physics: DraggableNeverScrollableScrollPhysics(),
+                    gridDelegate: SliverGridDelegateWithWrapping(
+                        mainAxisSpacing: space / 2, crossAxisSpacing: space),
+                    itemCount: peers.length,
+                    itemBuilder: (BuildContext context, int index) {
+                      return buildOnePeer(peers[index]);
+                    }),
+              );
+            }
+
             if (updateEvent == UpdateEvent.load) {
               _curPeers.clear();
               _curPeers.addAll(peers.map((e) => e.id));

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -88,6 +88,11 @@ class _DesktopSettingPageState extends State<DesktopSettingPage>
     Get.put<RxInt>(selectedIndex, tag: _kSettingPageIndexTag);
     controller = PageController(initialPage: widget.initialPage);
     Get.put<PageController>(controller, tag: _kSettingPageControllerTag);
+    controller.addListener(() {
+      if (controller.page != null) {
+        selectedIndex.value = controller.page!.toInt();
+      }
+    });
   }
 
   @override
@@ -154,7 +159,7 @@ class _DesktopSettingPageState extends State<DesktopSettingPage>
                   scrollController: controller,
                   child: PageView(
                     controller: controller,
-                    physics: DraggableNeverScrollableScrollPhysics(),
+                    physics: NeverScrollableScrollPhysics(),
                     children: _children(),
                   )),
             ),
@@ -330,9 +335,11 @@ class _GeneralState extends State<_General> {
       child: _OptionCheckBox(context, "Always use software rendering",
           'allow-always-software-render'),
     ));
-     children.add(
-        _OptionCheckBox(context, 'Check for software update on startup','enable-check-update',
-        isServer: false,
+    children.add(_OptionCheckBox(
+      context,
+      'Check for software update on startup',
+      'enable-check-update',
+      isServer: false,
     ));
     if (bind.mainShowOption(key: 'allow-linux-headless')) {
       children.add(_OptionCheckBox(

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -399,12 +399,12 @@ packages:
   dynamic_layouts:
     dependency: "direct main"
     description:
-      path: "packages/dynamic_layouts"
-      ref: "74cc4b495dcf3a4cb8df38d9ecc89f53f074a2c6"
-      resolved-ref: "74cc4b495dcf3a4cb8df38d9ecc89f53f074a2c6"
-      url: "https://github.com/21pages/packages.git"
+      path: "."
+      ref: "24cb88413fa5181d949ddacbb30a65d5c459e7d9"
+      resolved-ref: "24cb88413fa5181d949ddacbb30a65d5c459e7d9"
+      url: "https://github.com/21pages/dynamic_layouts.git"
     source: git
-    version: "0.0.1+2"
+    version: "0.0.1+1"
   event_bus:
     dependency: transitive
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -102,9 +102,8 @@ dependencies:
   flex_color_picker: ^3.3.0
   dynamic_layouts:
     git:
-      url: https://github.com/21pages/packages.git
-      path: packages/dynamic_layouts
-      ref: 74cc4b495dcf3a4cb8df38d9ecc89f53f074a2c6
+      url: https://github.com/21pages/dynamic_layouts.git
+      ref: 24cb88413fa5181d949ddacbb30a65d5c459e7d9
 
 dev_dependencies:
   icons_launcher: ^2.0.4


### PR DESCRIPTION
1. Set default scrollbar thickness to 6, margin 4, not follow system behavior because scrollbar thinkness of different app in the same system can be various. 
2. Enable touchpad scroll for peer views.
3. Disable horizontal touchpad scrolling on the settings page to prevent unintended tab switching.


https://github.com/rustdesk/rustdesk/assets/14891774/418e5de1-3e8d-4f45-9444-639542ccc236




