### PR TITLE
fix: cm await call

### DIFF
--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -234,19 +234,24 @@ void runConnectionManagerScreen(bool hide) async {
   listenUniLinks(handleByFlutter: false);
 }
 
+bool _isCmReadyToShow = false;
+
 showCmWindow({bool isStartup = false}) async {
   if (isStartup) {
     WindowOptions windowOptions = getHiddenTitleBarWindowOptions(
         size: kConnectionManagerWindowSizeClosedChat);
-    windowManager.waitUntilReadyToShow(windowOptions, () async {
-      bind.mainHideDocker();
-      await windowManager.show();
-      await Future.wait([windowManager.focus(), windowManager.setOpacity(1)]);
-      // ensure initial window size to be changed
-      await windowManager.setSizeAlignment(
-          kConnectionManagerWindowSizeClosedChat, Alignment.topRight);
-    });
-  } else {
+    await windowManager.waitUntilReadyToShow(windowOptions, null);
+    bind.mainHideDocker();
+    await Future.wait([
+      windowManager.show(),
+      windowManager.focus(),
+      windowManager.setOpacity(1)
+    ]);
+    // ensure initial window size to be changed
+    await windowManager.setSizeAlignment(
+        kConnectionManagerWindowSizeClosedChat, Alignment.topRight);
+    _isCmReadyToShow = true;
+  } else if (_isCmReadyToShow) {
     if (await windowManager.getOpacity() != 1) {
       await windowManager.setOpacity(1);
       await windowManager.focus();
@@ -263,12 +268,12 @@ hideCmWindow({bool isStartup = false}) async {
     WindowOptions windowOptions = getHiddenTitleBarWindowOptions(
         size: kConnectionManagerWindowSizeClosedChat);
     windowManager.setOpacity(0);
-    windowManager.waitUntilReadyToShow(windowOptions, () async {
-      bind.mainHideDocker();
-      await windowManager.minimize();
-      await windowManager.hide();
-    });
-  } else {
+    await windowManager.waitUntilReadyToShow(windowOptions, null);
+    bind.mainHideDocker();
+    await windowManager.minimize();
+    await windowManager.hide();
+    _isCmReadyToShow = true;
+  } else if (_isCmReadyToShow) {
     if (await windowManager.getOpacity() != 0) {
       await windowManager.setOpacity(0);
       bind.mainHideDocker();


### PR DESCRIPTION
Make sure `windowManager.waitUntilReadyToShow` is called first.
1. Add await to guarantee the calling order.
2. Use `_isCmReadyToShow` to make sure the window is ready.

## Bugs

1. Cm may crash in wrong order.
2. The window may be at the left top.

https://github.com/rustdesk/rustdesk/assets/136106582/09b556ac-72d0-4ad9-912d-39eb6b4a8116

3. The window may be wrong size.
4. The window appears, then minimizes, then restores, then moves to the right.
5. The cm window may also disapear and even crash.

## Fixed



https://github.com/rustdesk/rustdesk/assets/136106582/a7c4b648-9102-46cf-ae41-8c54db48d293


