### PR TITLE
try fix remote tab label update

### DIFF
--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -1100,7 +1100,7 @@ class MyGroupPeerCard extends BasePeerCard {
     if (Platform.isWindows) {
       menuItems.add(_createShortCutAction(peer.id));
     }
-    menuItems.add(MenuEntryDivider());
+    // menuItems.add(MenuEntryDivider());
     // menuItems.add(_renameAction(peer.id));
     // if (await bind.mainPeerHasPassword(id: peer.id)) {
     //   menuItems.add(_unrememberPasswordAction(peer.id));

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -269,11 +269,8 @@ class DesktopTab extends StatelessWidget {
   }
 
   static RxString tablabelGetter(String peerId) {
-    PeerStringOption.init(peerId, 'tabLabel', () {
-      final alias = bind.mainGetPeerOptionSync(id: peerId, key: 'alias');
-      return getDesktopTabLabel(peerId, alias);
-    });
-    return PeerStringOption.find(peerId, 'tabLabel');
+    final alias = bind.mainGetPeerOptionSync(id: peerId, key: 'alias');
+    return RxString(getDesktopTabLabel(peerId, alias));
   }
 
   @override

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -266,8 +266,6 @@ class FfiModel with ChangeNotifier {
         updateBlockInputState(evt, peerId);
       } else if (name == 'update_privacy_mode') {
         updatePrivacyMode(evt, sessionId, peerId);
-      } else if (name == 'alias') {
-        handleAliasChanged(evt);
       } else if (name == 'show_elevation') {
         final show = evt['show'].toString() == 'true';
         parent.target?.serverModel.setShowElevation(show);
@@ -351,17 +349,6 @@ class FfiModel with ChangeNotifier {
   /// Bind the event listener to receive events from the Rust core.
   updateEventListener(SessionID sessionId, String peerId) {
     platformFFI.setEventCallback(startEventListener(sessionId, peerId));
-  }
-
-  handleAliasChanged(Map<String, dynamic> evt) {
-    if (!isDesktop) return;
-    final String peerId = evt['id'];
-    final String alias = evt['alias'];
-    String label = getDesktopTabLabel(peerId, alias);
-    final rxTabLabel = PeerStringOption.find(evt['id'], 'tabLabel');
-    if (rxTabLabel.value != label) {
-      rxTabLabel.value = label;
-    }
   }
 
   _updateCurDisplay(SessionID sessionId, Display newDisplay) {

--- a/flutter/test/cm_test.dart
+++ b/flutter/test/cm_test.dart
@@ -16,7 +16,7 @@ final testClients = [
   Client(3, false, false, "UserDDDDDDDDDDDd", "441123123", true, false, false)
 ];
 
-/// flutter run -d {platform} -t lib/cm_test.dart to test cm
+/// flutter run -d {platform} -t test/cm_test.dart to test cm
 void main(List<String> args) async {
   isTest = true;
   WidgetsFlutterBinding.ensureInitialized();

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -823,11 +823,6 @@ pub fn main_set_peer_option_sync(id: String, key: String, value: String) -> Sync
 }
 
 pub fn main_set_peer_alias(id: String, alias: String) {
-    main_broadcast_message(&HashMap::from([
-        ("name", "alias"),
-        ("id", &id),
-        ("alias", &alias),
-    ]));
     set_peer_option(id, "alias".to_owned(), alias)
 }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/5820#discussioncomment-7123492

In the old implementation, `Get.find` always returns the first instance registered with `Get.put` (I'll find the reason for this behavior later). Then, updates are achieved by broadcasting alias changing events (which might cause the failing in the discussion). Now, construct a new RxString instance every time.