### PR TITLE
Fix/dialog button reconnect cancel

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -996,11 +996,20 @@ void msgBox(SessionID sessionId, String type, String title, String text,
         }));
   }
   if (reconnect != null && title == "Connection Error") {
-    buttons.insert(
-        0,
-        dialogButton('Reconnect', isOutline: true, onPressed: () {
-          reconnect(dialogManager, sessionId, false);
-        }));
+    final enabled = true.obs;
+    final button = Obx(
+      () => dialogButton(
+        'Reconnect',
+        isOutline: true,
+        onPressed: enabled.isTrue
+            ? () {
+                enabled.value = false;
+                reconnect(dialogManager, sessionId, false);
+              }
+            : null,
+      ),
+    );
+    buttons.insert(0, button);
   }
   if (link.isNotEmpty) {
     buttons.insert(0, dialogButton('JumpLink', onPressed: jumplink));

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -996,6 +996,7 @@ void msgBox(SessionID sessionId, String type, String title, String text,
         }));
   }
   if (reconnect != null && title == "Connection Error") {
+    // `enabled` is used to disable the dialog button once the button is clicked.
     final enabled = true.obs;
     final button = Obx(
       () => dialogButton(
@@ -1003,6 +1004,7 @@ void msgBox(SessionID sessionId, String type, String title, String text,
         isOutline: true,
         onPressed: enabled.isTrue
             ? () {
+                // Disable the button
                 enabled.value = false;
                 reconnect(dialogManager, sessionId, false);
               }

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hbb/consts.dart';
-import 'package:flutter_hbb/desktop/widgets/scroll_wrapper.dart';
 import 'package:flutter_hbb/models/state_model.dart';
 import 'package:get/get.dart';
 import 'package:url_launcher/url_launcher_string.dart';

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -415,8 +415,24 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
 
   void onRemoveId(String id) async {
     if (tabController.state.value.tabs.isEmpty) {
-      await WindowController.fromWindowId(windowId()).close();
       stateGlobal.setFullscreen(false, procWnd: false);
+      // Keep calling until the window status is hidden.
+      //
+      // Workaround for Windows:
+      // If you click other buttons and close in msgbox within a very short period of time, the close may fail.
+      // `await WindowController.fromWindowId(windowId()).close();`.
+      Future<void> loopCloseWindow() async {
+        int c = 0;
+        final windowController = WindowController.fromWindowId(windowId());
+        while (c < 100 &&
+            tabController.state.value.tabs.isEmpty &&
+            (!await windowController.isHidden())) {
+          await windowController.close();
+          await Future.delayed(Duration(milliseconds: 50));
+          c++;
+        }
+      }
+      loopCloseWindow();
     }
     ConnectionTypeState.delete(id);
     _update_remote_count();

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -424,11 +424,11 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
       Future<void> loopCloseWindow() async {
         int c = 0;
         final windowController = WindowController.fromWindowId(windowId());
-        while (c < 100 &&
+        while (c < 20 &&
             tabController.state.value.tabs.isEmpty &&
             (!await windowController.isHidden())) {
           await windowController.close();
-          await Future.delayed(Duration(milliseconds: 50));
+          await Future.delayed(Duration(milliseconds: 100));
           c++;
         }
       }

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 import 'dart:ui' as ui;
@@ -9,7 +8,6 @@ import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' hide TabBarTheme;
 import 'package:flutter_hbb/common.dart';
-import 'package:flutter_hbb/common/shared_state.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/main.dart';
 import 'package:flutter_hbb/models/platform_model.dart';

--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hbb/common/widgets/peers_view.dart';
 import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/peer_model.dart';
-import 'package:flutter_hbb/models/peer_tab_model.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:get/get.dart';
 import 'package:bot_toast/bot_toast.dart';

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -8,7 +8,6 @@ import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hbb/consts.dart';
-import 'package:flutter_hbb/desktop/widgets/tabbar_widget.dart';
 import 'package:flutter_hbb/generated_bridge.dart';
 import 'package:flutter_hbb/models/ab_model.dart';
 import 'package:flutter_hbb/models/chat_model.dart';

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -328,7 +328,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: ba5de698dbe51a961d16ede8a94331d594873e62
+      resolved-ref: ef03db52a20a7899da135d694c071fa3866c8fb1
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1078,7 +1078,8 @@ pub fn session_next_rgba(session_id: SessionID) {
 pub fn session_register_texture(_session_id: SessionID, _ptr: usize) {
     #[cfg(feature = "flutter_texture_render")]
     if let Some(session) = SESSIONS.write().unwrap().get_mut(&_session_id) {
-        return session.register_texture(_ptr);
+        session.register_texture(_ptr);
+        return;
     }
 }
 


### PR DESCRIPTION
1. Fix double "Reconnect". The bug is Windows only.


https://github.com/rustdesk/rustdesk/assets/136106582/56d8410e-a97d-4b47-ba2c-b6a4dabb018c



2. `loopCloseWindow` until the window is closed. `remote_tab_page.dart`
    If click "Reconnect" and "Cancel" in a short period of time, the window may not be closed even `PostMessage(handle, WM_SYSCOMMAND, SC_CLOSE, 0)` is sent. The bug is also Windows only.  

**NOTE**:

This PR does not fix https://github.com/rustdesk/rustdesk/issues/5849 .

## TODOs

I'll sumbit other PRs for:

1. Dead lock RwLock in `reconnect`.
2. Do not start new session when connecting.
