### PR TITLE
fix request elevation menu not displayed when reconnect

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1660,6 +1660,7 @@ class ElevationModel with ChangeNotifier {
   bool get showRequestMenu => _canElevate && !_running;
   onPeerInfo(PeerInfo pi) {
     _canElevate = pi.platform == kPeerPlatformWindows && pi.sasEnabled == false;
+    _running = false;
   }
 
   onPortableServiceRunning(Map<String, dynamic> evt) {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2379,8 +2379,8 @@ impl Connection {
         ));
         if self.authorized {
             let p = &mut self.portable;
-            if running != p.last_running {
-                p.last_running = running;
+            if Some(running) != p.last_running {
+                p.last_running = Some(running);
                 let mut misc = Misc::new();
                 misc.set_portable_service_running(running);
                 let mut msg = Message::new();
@@ -2660,7 +2660,7 @@ pub enum FileAuditType {
 pub struct PortableState {
     pub last_uac: bool,
     pub last_foreground_window_elevated: bool,
-    pub last_running: bool,
+    pub last_running: Option<bool>,
     pub is_installed: bool,
 }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/5864

When reconnecting, FFI will not be reset, leaving portable service running flag to be true, which causes the problem.

For client side, reset running to false when receive peer info. Receiving peer info will always be ahead of receiving running status, so it is no harm.
For server side, always send the running status to client at start, this ensures that older version clients can correctly display the request menu.