### PR TITLE
fix, reconnect deadlock, introduce connection round control

### DIFF
--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -251,7 +251,7 @@ impl<T: InvokeUiSession> Remote<T> {
             }
         }
         // set_disconnected_ok is used to check if new connection round is started.
-        let set_disconnected_ok = self
+        let _set_disconnected_ok = self
             .handler
             .connection_round_state
             .lock()
@@ -259,12 +259,12 @@ impl<T: InvokeUiSession> Remote<T> {
             .set_disconnected(round);
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        if set_disconnected_ok {
+        if _set_disconnected_ok {
             Client::try_stop_clipboard(&self.handler.session_id);
         }
 
         #[cfg(windows)]
-        if set_disconnected_ok {
+        if _set_disconnected_ok {
             let conn_id = self.client_conn_id;
             ContextSend::proc(|context: &mut CliprdrClientContext| -> u32 {
                 empty_clipboard(context, conn_id);

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -805,7 +805,8 @@ pub fn session_start_(
         if !is_pre_added {
             let session = session.clone();
             std::thread::spawn(move || {
-                io_loop(session);
+                let round = session.connection_round_state.lock().unwrap().new_round();
+                io_loop(session, round);
             });
         }
         Ok(())

--- a/src/plugin/native_handlers/session.rs
+++ b/src/plugin/native_handlers/session.rs
@@ -8,8 +8,10 @@ use std::{
 use flutter_rust_bridge::StreamSink;
 
 use crate::{
-    define_method_prefix, flutter::FlutterHandler, flutter_ffi::EventToUI,
-    plugin::MSG_TO_UI_TYPE_PLUGIN_EVENT, ui_session_interface::Session,
+    define_method_prefix,
+    flutter::FlutterHandler,
+    flutter_ffi::EventToUI,
+    ui_session_interface::{ConnectionState, Session},
 };
 
 const MSG_TO_UI_TYPE_SESSION_CREATED: &str = "session_created";
@@ -61,7 +63,8 @@ impl PluginNativeHandler for PluginNativeSessionHandler {
                         let sessions = SESSION_HANDLER.sessions.read().unwrap();
                         for session in sessions.iter() {
                             if session.id == id {
-                                crate::ui_session_interface::io_loop(session.clone());
+                                let round = session.connection_round_state.lock().unwrap().new_round();
+                                crate::ui_session_interface::io_loop(session.clone(), round);
                             }
                         }
                     }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/5849

Fix deadlock.

Introduce the connection state in `reconnect`:
1. If current session is connecting, do not reconnect.
2. If the connection is established, send `Data::Close`.
3. If the connection is disconnected, do nothing.

Use connection round to update the connection state.

https://github.com/rustdesk/rustdesk/assets/136106582/84d96252-3dad-4eaa-ba24-7f2e640f26e0

