### PR TITLE
opt cm width and elevation requires keyboard permission

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -711,6 +711,13 @@ void showWaitUacDialog(
       (setState, close, context) => CustomAlertDialog(
             title: null,
             content: msgboxContent(type, 'Wait', 'wait_accept_uac_tip'),
+            actions: [
+              dialogButton(
+                'OK',
+                icon: Icon(Icons.done_rounded),
+                onPressed: close,
+              ),
+            ],
           ));
 }
 
@@ -931,7 +938,7 @@ void showElevationError(SessionID sessionId, String type, String title,
         dialogButton('Cancel', onPressed: () {
           close();
         }, isOutline: true),
-        dialogButton('Retry', onPressed: submit),
+        if (text != 'No permission') dialogButton('Retry', onPressed: submit),
       ],
       onSubmit: submit,
       onCancel: close,

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -49,7 +49,8 @@ class TToggleMenu {
 handleOsPasswordEditIcon(
     SessionID sessionId, OverlayDialogManager dialogManager) {
   isEditOsPassword = true;
-  showSetOSPassword(sessionId, false, dialogManager, null, () => isEditOsPassword = false);
+  showSetOSPassword(
+      sessionId, false, dialogManager, null, () => isEditOsPassword = false);
 }
 
 handleOsPasswordAction(
@@ -62,7 +63,8 @@ handleOsPasswordAction(
       await bind.sessionGetOption(sessionId: sessionId, arg: 'os-password') ??
           '';
   if (password.isEmpty) {
-    showSetOSPassword(sessionId, true, dialogManager, password, () => isEditOsPassword = false);
+    showSetOSPassword(sessionId, true, dialogManager, password,
+        () => isEditOsPassword = false);
   } else {
     bind.sessionInputOsPassword(sessionId: sessionId, value: password);
   }
@@ -76,7 +78,7 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
 
   List<TTextMenu> v = [];
   // elevation
-  if (ffi.elevationModel.showRequestMenu) {
+  if (perms['keyboard'] != false && ffi.elevationModel.showRequestMenu) {
     v.add(
       TTextMenu(
           child: Text(translate('Request Elevation')),

--- a/flutter/lib/desktop/pages/server_page.dart
+++ b/flutter/lib/desktop/pages/server_page.dart
@@ -175,34 +175,47 @@ class ConnectionManagerState extends State<ConnectionManager> {
                   ],
                 );
               },
-              pageViewBuilder: (pageView) => Row(
-                children: [
-                  Consumer<ChatModel>(
-                    builder: (_, model, child) => model.isShowCMSidePage
-                        ? Expanded(
-                            child: buildRemoteBlock(
-                              child: Container(
-                                  decoration: BoxDecoration(
-                                      border: Border(
-                                          right: BorderSide(
-                                              color: Theme.of(context)
-                                                  .dividerColor))),
-                                  child: buildSidePage()),
-                            ),
-                            flex: (kConnectionManagerWindowSizeOpenChat.width -
-                                    kConnectionManagerWindowSizeClosedChat
-                                        .width)
-                                .toInt(),
-                          )
-                        : Offstage(),
-                  ),
-                  Expanded(
-                      child: pageView,
-                      flex: kConnectionManagerWindowSizeClosedChat.width
-                              .toInt() -
-                          4 // prevent stretch of the page view when chat is open,
-                      ),
-                ],
+              pageViewBuilder: (pageView) => LayoutBuilder(
+                builder: (context, constrains) {
+                  var borderWidth = 0.0;
+                  if (constrains.maxWidth >
+                      kConnectionManagerWindowSizeClosedChat.width) {
+                    borderWidth = kConnectionManagerWindowSizeOpenChat.width -
+                        constrains.maxWidth;
+                  } else {
+                    borderWidth = kConnectionManagerWindowSizeClosedChat.width -
+                        constrains.maxWidth;
+                  }
+                  if (borderWidth < 0 || borderWidth > 50) {
+                    borderWidth = 0;
+                  }
+                  final realClosedWidth =
+                      kConnectionManagerWindowSizeClosedChat.width -
+                          borderWidth;
+                  final realChatPageWidth =
+                      constrains.maxWidth - realClosedWidth;
+                  return Row(children: [
+                    if (constrains.maxWidth >
+                        kConnectionManagerWindowSizeClosedChat.width)
+                      Consumer<ChatModel>(
+                          builder: (_, model, child) => SizedBox(
+                                width: realChatPageWidth,
+                                child: buildRemoteBlock(
+                                  child: Container(
+                                      decoration: BoxDecoration(
+                                          border: Border(
+                                              right: BorderSide(
+                                                  color: Theme.of(context)
+                                                      .dividerColor))),
+                                      child: buildSidePage()),
+                                ),
+                              )),
+                    SizedBox(
+                        width: realClosedWidth,
+                        child:
+                            SizedBox(width: realClosedWidth, child: pageView)),
+                  ]);
+                },
               ),
             ),
           );
@@ -966,8 +979,7 @@ class __FileTransferLogPageState extends State<_FileTransferLogPage> {
     return PreferredSize(
       preferredSize: const Size(200, double.infinity),
       child: Container(
-          margin: const EdgeInsets.only(top: 16.0, bottom: 16.0, right: 16.0),
-          padding: const EdgeInsets.all(8.0),
+          padding: const EdgeInsets.all(12.0),
           child: Obx(
             () {
               final jobTable = gFFI.cmFileModel.currentJobTable;

--- a/flutter/lib/models/chat_model.dart
+++ b/flutter/lib/models/chat_model.dart
@@ -285,7 +285,10 @@ class ChatModel with ChangeNotifier {
     await toggleCMSidePage();
   }
 
+  var _togglingCMSidePage = false; // protect order for await
   toggleCMSidePage() async {
+    if (_togglingCMSidePage) return false;
+    _togglingCMSidePage = true;
     if (_isShowCMSidePage) {
       _isShowCMSidePage = !_isShowCMSidePage;
       notifyListeners();
@@ -300,6 +303,7 @@ class ChatModel with ChangeNotifier {
       _isShowCMSidePage = !_isShowCMSidePage;
       notifyListeners();
     }
+    _togglingCMSidePage = false;
   }
 
   changeCurrentKey(MessageKey key) {

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1303,9 +1303,10 @@ impl<T: InvokeUiSession> Remote<T> {
                         }
                     }
                     Some(misc::Union::Uac(uac)) => {
+                        let keyboard = self.handler.server_keyboard_enabled.read().unwrap().clone();
                         #[cfg(feature = "flutter")]
                         {
-                            if uac {
+                            if uac && keyboard {
                                 self.handler.msgbox(
                                     "on-uac",
                                     "Prompt",
@@ -1324,7 +1325,7 @@ impl<T: InvokeUiSession> Remote<T> {
                             let title = "Prompt";
                             let text = "Please wait for confirmation of UAC...";
                             let link = "";
-                            if uac {
+                            if uac && keyboard {
                                 self.handler.msgbox(msgtype, title, text, link);
                             } else {
                                 self.handler.cancel_msgbox(&format!(
@@ -1335,9 +1336,10 @@ impl<T: InvokeUiSession> Remote<T> {
                         }
                     }
                     Some(misc::Union::ForegroundWindowElevated(elevated)) => {
+                        let keyboard = self.handler.server_keyboard_enabled.read().unwrap().clone();
                         #[cfg(feature = "flutter")]
                         {
-                            if elevated {
+                            if elevated && keyboard {
                                 self.handler.msgbox(
                                     "on-foreground-elevated",
                                     "Prompt",
@@ -1356,7 +1358,7 @@ impl<T: InvokeUiSession> Remote<T> {
                             let title = "Prompt";
                             let text = "elevated_foreground_window_tip";
                             let link = "";
-                            if elevated {
+                            if elevated && keyboard {
                                 self.handler.msgbox(msgtype, title, text, link);
                             } else {
                                 self.handler.cancel_msgbox(&format!(
@@ -1370,6 +1372,7 @@ impl<T: InvokeUiSession> Remote<T> {
                         if err.is_empty() {
                             self.handler.msgbox("wait-uac", "", "", "");
                         } else {
+                            self.handler.cancel_msgbox("wait-uac");
                             self.handler
                                 .msgbox("elevation-error", "Elevation Error", &err, "");
                         }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", "启动时检查软件更新"),
         ("upgrade_rustdesk_server_pro_to_{}_tip", "请升级专业版服务器到{}或更高版本！"),
         ("pull_group_failed_tip", "获取组信息失败"),
+        ("No permission", "没有权限"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", "Beim Start auf Softwareaktualisierung prüfen"),
         ("upgrade_rustdesk_server_pro_to_{}_tip", "Bitte aktualisieren Sie RustDesk Server Pro auf die Version {} oder neuer!"),
         ("pull_group_failed_tip", "Aktualisierung der Gruppe fehlgeschlagen"),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", "Comprobar actualización al iniciar"),
         ("upgrade_rustdesk_server_pro_to_{}_tip", "¡Por favor, actualiza RustDesk Server Pro a la versión {} o superior"),
         ("pull_group_failed_tip", "No se ha podido refrescar el grupo"),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", "Vérifier la disponibilité des mises à jour au démarrage"),
         ("upgrade_rustdesk_server_pro_to_{}_tip", "Veuillez mettre à jour RustDesk Server Pro avec la version {} ou une version plus récente !"),
         ("pull_group_failed_tip", "Échec de l'actualisation du groupe"),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", "Periksa pembaruan aplikasi saat sistem dinyalakan."),
         ("upgrade_rustdesk_server_pro_to_{}_tip", "Silahkan perbarui RustDesk Server Pro ke versi {} atau yang lebih baru!"),
         ("pull_group_failed_tip", "Gagal memperbarui grup"),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", "All'avvio verifica presenza aggiornamenti programma"),
         ("upgrade_rustdesk_server_pro_to_{}_tip", "Aggiorna RustDesk Server Pro alla versione {} o successiva!"),
         ("pull_group_failed_tip", "Impossibile aggiornare il gruppo"),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -57,7 +57,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("ID Server", "ID serveris"),
         ("Relay Server", "Releja serveris"),
         ("API Server", "API serveris"),
-        ("Key", "Atslēga"),
         ("invalid_http", "jāsākas ar http:// vai https://"),
         ("Invalid IP", "Nederīga IP"),
         ("Invalid format", "Nederīgs formāts"),
@@ -297,7 +296,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("This file exists, skip or overwrite this file?", "Šis fails pastāv, izlaist vai pārrakstīt šo failu?"),
         ("Quit", "Iziet"),
         ("doc_mac_permission", "https://rustdesk.com/docs/en/manual/mac/#enable-permissions"),
-        ("doc_fix_wayland", "https://rustdesk.com/docs/en/manual/linux/#x11-required"),
         ("Help", "Palīdzība"),
         ("Failed", "Neizdevās"),
         ("Succeeded", "Izdevās"),
@@ -481,7 +479,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Me", "Es"),
         ("identical_file_tip", "Šis fails ir identisks sesijas failam."),
         ("show_monitors_tip", "Rādīt monitorus rīkjoslā"),
-        ("enter_rustdesk_passwd_tip", "Ievadiet RustDesk paroli"),
         ("View Mode", "Skatīšanas režīms"),
         ("login_linux_tip", "Jums ir jāpiesakās attālajā Linux kontā, lai iespējotu X darbvirsmas sesiju"),
         ("verify_rustdesk_password_tip", "Pārbaudīt RustDesk paroli"),
@@ -560,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", "Startējot pārbaudīt, vai nav programmatūras atjauninājumu"),
         ("upgrade_rustdesk_server_pro_to_{}_tip", "Lūdzu, jauniniet RustDesk Server Pro uz versiju {} vai jaunāku!"),
         ("pull_group_failed_tip", "Neizdevās atsvaidzināt grupu"),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", "Sprawdź aktualizacje przy starcie programu"),
         ("upgrade_rustdesk_server_pro_to_{}_tip", "Proszę zaktualizować RustDesk Server Pro do wersji {} lub nowszej!"),
         ("pull_group_failed_tip", "Błąd odświeżania grup"),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", "Проверять обновления программы при запуске"),
         ("upgrade_rustdesk_server_pro_to_{}_tip", "Обновите RustDesk Server Pro до версии {} или новее!"),
         ("pull_group_failed_tip", "Невозможно обновить группу"),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -557,5 +557,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Check for software update on startup", ""),
         ("upgrade_rustdesk_server_pro_to_{}_tip", ""),
         ("pull_group_failed_tip", ""),
+        ("No permission", ""),
     ].iter().cloned().collect();
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2047,12 +2047,18 @@ impl Connection {
 
     #[cfg(windows)]
     async fn handle_elevation_request(&mut self, para: portable_client::StartPara) {
-        let mut err = "No need to elevate".to_string();
-        if !crate::platform::is_installed() && !portable_client::running() {
-            err = portable_client::start_portable_service(para)
-                .err()
-                .map_or("".to_string(), |e| e.to_string());
+        let mut err;
+        if !self.keyboard {
+            err = "No permission".to_string();
+        } else {
+            err = "No need to elevate".to_string();
+            if !crate::platform::is_installed() && !portable_client::running() {
+                err = portable_client::start_portable_service(para)
+                    .err()
+                    .map_or("".to_string(), |e| e.to_string());
+            }
         }
+
         let mut misc = Misc::new();
         misc.set_elevation_response(err);
         let mut msg = Message::new();
@@ -2369,6 +2375,7 @@ impl Connection {
         if self.portable.is_installed
             || self.file_transfer.is_some()
             || self.port_forward_socket.is_some()
+            || !self.keyboard
         {
             return;
         }


### PR DESCRIPTION
1. opt cm width
* One-way rendering: Previously, the chat page would appear simultaneously as the window width changed. Now, the chat page's visibility depends on the window width. It will only show up when the window width is greater than 300. I didn't reproduce the error, but this would ensure a one-way rendering order.
* Keep right page size unchanged: The cm window has an invisible border, and the width of the border varies across different systems. The actual rendered width is different from the set width. Noww Ensure that the width of the right page remains unchanged before and after displaying the chat page by using LayoutBuilder.

nightly: right page has a little width change

https://github.com/rustdesk/rustdesk/assets/14891774/c1651aef-3b1b-41ec-869a-243e3fb5c57e

pr

https://github.com/rustdesk/rustdesk/assets/14891774/05732ee1-cb23-499f-ba23-55184ee2f981

* Sometimes setSizeAlignment not work, not fix it yet.

2. elevation 
* let elevation require keyboard permission, and there is no prompt for the user to request elevation when keyboard permission is not available. 
* Previously, when the request failed, the "wai-uac" window would block the main window, and the only way to close the window was through the taskbar. Now, if the request fails, the "wait-uac" window will be closed automatically, and a manual close button will be added on the "wait-uac" window.
* Prompt elevation for any elevated foreground window, remove filter.