### PR TITLE
modify the env_logger init way,

### DIFF
--- a/libs/hbb_common/src/lib.rs
+++ b/libs/hbb_common/src/lib.rs
@@ -333,7 +333,7 @@ pub fn init_log(_is_async: bool, _name: &str) -> Option<flexi_logger::LoggerHand
     #[cfg(debug_assertions)]
     {
         use env_logger::*;
-        init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info"));
+        let _ = try_init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info"));
         None
     }
     #[cfg(not(debug_assertions))]

--- a/libs/scrap/examples/benchmark.rs
+++ b/libs/scrap/examples/benchmark.rs
@@ -1,5 +1,5 @@
 use docopt::Docopt;
-use hbb_common::env_logger::{init_from_env, Env, DEFAULT_FILTER_ENV};
+use hbb_common::env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
 use scrap::{
     aom::{AomDecoder, AomEncoder, AomEncoderConfig},
     codec::{EncoderApi, EncoderCfg, Quality as Q},
@@ -48,7 +48,7 @@ enum Quality {
 }
 
 fn main() {
-    init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info"));
+    let _ = try_init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info"));
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -55,7 +55,7 @@ fn initialize(app_dir: &str) {
     #[cfg(target_os = "ios")]
     {
         use hbb_common::env_logger::*;
-        init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "debug"));
+        let _ = try_init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "debug"));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
         .args_from_usage(&args)
         .get_matches();
     use hbb_common::{config::LocalConfig, env_logger::*};
-    init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info"));
+    let _ = try_init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info"));
     if let Some(p) = matches.value_of("port-forward") {
         let options: Vec<String> = p.split(":").map(|x| x.to_owned()).collect();
         if options.len() < 3 {


### PR DESCRIPTION
desc: 
using `try_init_from_env` method to initialize the `env_logger`, instead of `init_from_env` otherwise when using `flutter hot restart` the application will crash cos of the initializition operation has performed twice.

development platform: 
```
               .OMMMMo           OS: macOS 13.6 22G120 arm64
               OMMM0,            Host: Mac14,9
     .;loddo:' loolloddol;.      Kernel: 22.6.0
   cKMMMMMMMMMMNWMMMMMMMMMM0:    Uptime: 1 hour, 49 mins
 .KMMMMMMMMMMMMMMMMMMMMMMMWd.    Packages: 108 (brew)
 XMMMMMMMMMMMMMMMMMMMMMMMX.      Shell: zsh 5.9
;MMMMMMMMMMMMMMMMMMMMMMMM:       Resolution: 1512x982, 1920x1080
:MMMMMMMMMMMMMMMMMMMMMMMM:       DE: Aqua
.MMMMMMMMMMMMMMMMMMMMMMMMX.      WM: Quartz Compositor
 kMMMMMMMMMMMMMMMMMMMMMMMMWd.    WM Theme: Blue (Dark)
 .XMMMMMMMMMMMMMMMMMMMMMMMMMMk   Terminal: iTerm2
  .XMMMMMMMMMMMMMMMMMMMMMMMMK.   Terminal Font: HackNF-Regular 14
    kMMMMMMMMMMMMMMMMMMMMMMd     CPU: Apple M2 Pro
     ;KMMMMMMMWXXWMMMMMMMk.      GPU: Apple M2 Pro
       .cooc,.    .,coo:.        Memory: 4124MiB / 32768MiB
```
testing iphone: 
iphone mini 12,ios 16.2

the problem reproduce:

- flutter run the program application
- flutter hot restart 
 
then the application crash..

the cli message show: 
```
Launching lib/main.dart on iPhone (7) in debug mode...
Automatically signing iOS for device deployment using specified development team in Xcode project: xxxxxxxxxxx
Running pod install...                                           1,193ms
Upgrading Pods-Runner-frameworks.sh
Upgrading Pods-Runner.release.xcconfig
Upgrading Pods-Runner.profile.xcconfig
Upgrading Pods-Runner.debug.xcconfig
Running Xcode build...
 └─Compiling, linking and signing...                      2,328ms
Xcode build done.                                            9.2s
(lldb) 2023-10-02 12:10:51.202589+0800 Runner[6059:2655961] [SceneConfiguration] Info.plist contained no UIScene configuration dictionary (looking for configuration named "(no name)")
[SceneConfiguration] Info.plist contained no UIScene configuration dictionary (looking for configuration named "(no name)")
[VERBOSE-2:FlutterDarwinContextMetalImpeller.mm(37)] Using the Impeller rendering backend.
flutter: launch args: []
flutter: initializing FFI main
flutter: _appType:main,info1-id:xxxxxxxxxxxxx,info2-name:xxxxxxxxxx,dir:/var/mobile/Containers/Data/Application/xxxxxxxxxxxxx/Documents,homeDir:data
flutter: _globalFFI init
[2023-10-02T04:10:52Z DEBUG hbb_common::config] Configuration path: /var/mobile/Containers/Data/Application/xxxxxxxxxxxxxxxx/Documents/RustDesk_local.toml
flutter: _globalFFI init end
flutter: pullAb, force:true, quiet:false
Installing and launching...                                        16.3s
[2023-10-02T04:10:52Z DEBUG hbb_common::config] Configuration path: /var/mobile/Containers/Data/Application/xxxxxxxxxxxxx/Documents/RustDesk2.toml
Syncing files to device iPhone (7)...                              120ms

Flutter run key commands.
r Hot reload. 🔥🔥🔥
R Hot restart.
h List all available interactive commands.
d Detach (terminate "flutter run" but leave application running).
c Clear the screen
q Quit (terminate the application on the device).

A Dart VM Service on iPhone (7) is available at: http://127.0.0.1:54303/xxxxxxxxx=/
The Flutter DevTools debugger and profiler on iPhone (7) is available at: http://127.0.0.1:9101?uri=http://127.0.0.1:54303/xxxxxxxxxxx=/

Performing hot restart...
Restarted application in 1,082ms.
flutter: launch args: []
flutter: initializing FFI main
[2023-10-02T04:10:58Z WARN  librustdesk::flutter] Global event stream of type main is started before, but now removed
flutter: _appType:main,info1-id:xxxxxxxxxxx,info2-name:xxxxxxxxxxx,dir:/var/mobile/Containers/Data/Application/xxxxxxxxxxxxxxx/Documents,homeDir:/var/mobile/Containers/Data/Application/xxxxxxxxxxxxx/Documents/data
thread 'frb_workerpool' panicked at 'env_logger::init_from_env should not be called after logger initialized: SetLoggerError(())', /Users/kyros/.cargo/registry/src/index.crates.io-6f17d22bba15001f/env_logger-0.10.0/src/lib.rs:1222:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
* thread #40, name = 'frb_workerpool', stop reason = signal SIGABRT
    frame #0: 0x00000001fd8f7160 libsystem_kernel.dylib`__pthread_kill + 8
libsystem_kernel.dylib`:
->  0x1fd8f7160 <+8>:  b.lo   0x1fd8f7180               ; <+40>
    0x1fd8f7164 <+12>: pacibsp
    0x1fd8f7168 <+16>: stp    x29, x30, [sp, #-0x10]!
    0x1fd8f716c <+20>: mov    x29, sp
Target 0: (Runner) stopped.
Lost connection to device.
```

This pr may not the best way to fix this problem, but this problem seem serious for the flutter develper. Hoping to be fix as soon. 

Best Wish!
