### PR TITLE
fix, sciter, reconnect, check thread running before the state

### DIFF
--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -888,10 +888,12 @@ impl<T: InvokeUiSession> Session<T> {
         // 2. If the connection is established, send `Data::Close`.
         // 3. If the connection is disconnected, do nothing.
         let mut connection_round_state_lock = self.connection_round_state.lock().unwrap();
-        match connection_round_state_lock.state {
-            ConnectionState::Connecting => return,
-            ConnectionState::Connected => self.send(Data::Close),
-            ConnectionState::Disconnected => {}
+        if self.thread.lock().unwrap().is_some() {
+            match connection_round_state_lock.state {
+                ConnectionState::Connecting => return,
+                ConnectionState::Connected => self.send(Data::Close),
+                ConnectionState::Disconnected => {}
+            }
         }
         let round = connection_round_state_lock.new_round();
         drop(connection_round_state_lock);


### PR DESCRIPTION
Sicter version calls `reconnect` on the first time.
Checking `ConnectionState::Connecting` will make `reconnect` return without further process.