### PR TITLE
fix, cursor (hotx,hoty) mismatch sometimes

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -614,7 +614,7 @@ class _ImagePaintState extends State<ImagePaint> {
     } else {
       final key = cache.updateGetKey(scale);
       if (!cursor.cachedKeys.contains(key)) {
-        debugPrint("Register custom cursor with key $key");
+        debugPrint("Register custom cursor with key $key (${cache.hotx},${cache.hoty})");
         // [Safety]
         // It's ok to call async registerCursor in current synchronous context,
         // because activating the cursor is also an async call and will always

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1457,7 +1457,7 @@ class CursorModel with ChangeNotifier {
 
     // Update last cursor data.
     // Do not use the previous `image` and `id`, because `_id` may be changed.
-    _updateCursorIdData(_id);
+    _updateCurData();
   }
 
   Future<bool> _updateCache(
@@ -1497,9 +1497,9 @@ class CursorModel with ChangeNotifier {
     return true;
   }
 
-  bool _updateCursorIdData(int id) {
-    _cache = _cacheMap[id];
-    final tmp = _images[id];
+  bool _updateCurData() {
+    _cache = _cacheMap[_id];
+    final tmp = _images[_id];
     if (tmp != null) {
       _image = tmp.item1;
       _hotx = tmp.item2;
@@ -1509,7 +1509,7 @@ class CursorModel with ChangeNotifier {
         notifyListeners();
       } catch (e) {
         debugPrint(
-            'WARNING: updateCursorId $id, without notifyListeners(). $e');
+            'WARNING: updateCursorId $_id, without notifyListeners(). $e');
       }
       return true;
     } else {
@@ -1518,10 +1518,10 @@ class CursorModel with ChangeNotifier {
   }
 
   updateCursorId(Map<String, dynamic> evt) async {
-    final id = int.parse(evt['id']);
-    if (!_updateCursorIdData(id)) {
+    _id = int.parse(evt['id']);
+    if (!_updateCurData()) {
       debugPrint(
-          'WARNING: updateCursorId $id, cache is ${_cache == null ? "null" : "not null"}. without notifyListeners()');
+          'WARNING: updateCursorId $_id, cache is ${_cache == null ? "null" : "not null"}. without notifyListeners()');
     }
   }
 


### PR DESCRIPTION
Fix cursor (hotx,hoty) mismatch sometimes.

1. The Main changes is in the `updateCursorData` function.
Use local variables instead of the class member. Because the class members are shared across the async tasks.
2. Use class member `_id` to hold the last cursor id. The `_id` is updated in a sync function `updateLastCursorId`.


## How to reproduce more easily

1. Add a class member `int ct = 0` in `class CursorModel`.
2. Add the following sleep in `updateCursorData`.
<img width="528" alt="1696340591594" src="https://github.com/rustdesk/rustdesk/assets/13586388/593c28ab-491d-4558-b28c-b5f36a267c3e">

