### PR TITLE
Update Freedesktop runtime to 23.08 for Flatpak.

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -1614,8 +1614,8 @@ jobs:
   #           apt install -y flatpak flatpak-builder cmake g++ gcc git curl wget nasm yasm libgtk-3-dev git
   #           # flatpak deps
   #           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-  #           flatpak --user install -y flathub org.freedesktop.Platform/${{ matrix.job.arch }}/21.08
-  #           flatpak --user install -y flathub org.freedesktop.Sdk/${{ matrix.job.arch }}/21.08
+  #           flatpak --user install -y flathub org.freedesktop.Platform/${{ matrix.job.arch }}/23.08
+  #           flatpak --user install -y flathub org.freedesktop.Sdk/${{ matrix.job.arch }}/23.08
   #           # package
   #           pushd flatpak
   #           git clone https://github.com/flathub/shared-modules.git --depth=1
@@ -1677,8 +1677,8 @@ jobs:
             apt install -y flatpak flatpak-builder cmake g++ gcc git curl wget nasm yasm libgtk-3-dev git
             # flatpak deps
             flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-            flatpak --user install -y flathub org.freedesktop.Platform/${{ matrix.job.arch }}/21.08
-            flatpak --user install -y flathub org.freedesktop.Sdk/${{ matrix.job.arch }}/21.08
+            flatpak --user install -y flathub org.freedesktop.Platform/${{ matrix.job.arch }}/23.08
+            flatpak --user install -y flathub org.freedesktop.Sdk/${{ matrix.job.arch }}/23.08
             # package
             pushd flatpak
             git clone https://github.com/flathub/shared-modules.git --depth=1

--- a/flatpak/rustdesk.json
+++ b/flatpak/rustdesk.json
@@ -1,7 +1,7 @@
 {
   "id": "com.rustdesk.RustDesk",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "21.08",
+  "runtime-version": "23.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "rustdesk",
   "icon": "share/icons/hicolor/scalable/apps/rustdesk.svg",


### PR DESCRIPTION
I bumped the Freedesktop runtime to the newest 23.08 version to make sure this issue does not immediately arise again in another year. I tested the changes locally, and it seems fine, so I also bumped the CI pipeline, and now I am waiting for the build to finish testing the generated artefact as well. This progress can be tracked [here](https://github.com/RayJW/rustdesk/actions/runs/6429905863).

/claim #5889