### PR TITLE
Fix window hide sometimes

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -593,7 +593,7 @@ closeConnection({String? id}) {
   }
 }
 
-void windowOnTop(int? id) async {
+Future<void> windowOnTop(int? id) async {
   if (!isDesktop) {
     return;
   }
@@ -1834,10 +1834,10 @@ enum UriLinkType {
 // uri link handler
 bool handleUriLink({List<String>? cmdArgs, Uri? uri, String? uriString}) {
   List<String>? args;
-  if (cmdArgs != null) {
+  if (cmdArgs != null && cmdArgs.isNotEmpty) {
     args = cmdArgs;
     // rustdesk <uri link>
-    if (args.isNotEmpty && args[0].startsWith(kUniLinksPrefix)) {
+    if (args[0].startsWith(kUniLinksPrefix)) {
       final uri = Uri.tryParse(args[0]);
       if (uri != null) {
         args = urlLinkToCmdArgs(uri);


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/5986

The error: `handleUriLink()` returns `true`, which causes `hide()`.

But "async/await" usually causes the window to show up after `hide()`.