### PR TITLE
not show remove wallpaper option if unsupported

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6602,7 +6602,7 @@ dependencies = [
 [[package]]
 name = "wallpaper"
 version = "3.2.0"
-source = "git+https://github.com/21pages/wallpaper.rs#2bbb70acd93be179c69cb96cb8c3dda487e6f5fd"
+source = "git+https://github.com/21pages/wallpaper.rs#ce4a0cd3f58327c7cc44d15a63706fb0c022bacf"
 dependencies = [
  "dirs 5.0.1",
  "enquote",

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -323,24 +323,7 @@ class _GeneralState extends State<_General> {
           'enable-confirm-closing-tabs',
           isServer: false),
       _OptionCheckBox(context, 'Adaptive bitrate', 'enable-abr'),
-      if (Platform.isWindows || Platform.isLinux)
-        Row(
-          children: [
-            Flexible(
-              child: _OptionCheckBox(
-                  context,
-                  'Remove wallpaper during incoming sessions',
-                  'allow-remove-wallpaper'),
-            ),
-            _CountDownButton(
-              text: 'Test',
-              second: 5,
-              onPressed: () {
-                bind.mainTestWallpaper(second: 5);
-              },
-            )
-          ],
-        ),
+      wallpaper(),
       _OptionCheckBox(
         context,
         'Open connection in new tab',
@@ -365,6 +348,42 @@ class _GeneralState extends State<_General> {
           context, 'Allow linux headless', 'allow-linux-headless'));
     }
     return _Card(title: 'Other', children: children);
+  }
+
+  Widget wallpaper() {
+    return futureBuilder(future: () async {
+      final support = await bind.mainSupportRemoveWallpaper();
+      return support;
+    }(), hasData: (data) {
+      if (data is bool && data == true) {
+        final option = 'allow-remove-wallpaper';
+        bool value = mainGetBoolOptionSync(option);
+        return Row(
+          children: [
+            Flexible(
+              child: _OptionCheckBox(
+                context,
+                'Remove wallpaper during incoming sessions',
+                option,
+                update: () {
+                  setState(() {});
+                },
+              ),
+            ),
+            if (value)
+              _CountDownButton(
+                text: 'Test',
+                second: 5,
+                onPressed: () {
+                  bind.mainTestWallpaper(second: 5);
+                },
+              )
+          ],
+        );
+      }
+
+      return Offstage();
+    });
   }
 
   Widget hwcodec() {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1625,6 +1625,10 @@ pub fn main_test_wallpaper(_second: u64) {
     });
 }
 
+pub fn main_support_remove_wallpaper() -> bool {
+    support_remove_wallpaper()
+}
+
 /// Send a url scheme throught the ipc.
 ///
 /// * macOS only

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1341,6 +1341,14 @@ impl WallPaperRemover {
             old_path_dark,
         })
     }
+
+    pub fn support() -> bool {
+        let desktop = std::env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
+        if wallpaper::gnome::is_compliant(&desktop) || desktop.as_str() == "XFCE" {
+            return wallpaper::get().is_ok();
+        }
+        false
+    }
 }
 
 impl Drop for WallPaperRemover {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2392,6 +2392,10 @@ impl WallPaperRemover {
         Ok(Self { old_path })
     }
 
+    pub fn support() -> bool {
+        wallpaper::get().is_ok() || !Self::get_recent_wallpaper().unwrap_or_default().is_empty()
+    }
+
     fn get_recent_wallpaper() -> ResultType<String> {
         // SystemParametersInfoW may return %appdata%\Microsoft\Windows\Themes\TranscodedWallpaper, not real path and may not real cache
         // https://www.makeuseof.com/find-desktop-wallpapers-file-location-windows-11/

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -598,6 +598,10 @@ impl UI {
     fn get_login_device_info(&self) -> String {
         get_login_device_info_json()
     }
+
+    fn support_remove_wallpaper(&self) -> bool {
+        support_remove_wallpaper()
+    }
 }
 
 impl sciter::EventHandler for UI {
@@ -683,6 +687,7 @@ impl sciter::EventHandler for UI {
         fn default_video_save_directory();
         fn handle_relay_id(String);
         fn get_login_device_info();
+        fn support_remove_wallpaper();
     }
 }
 

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -210,6 +210,7 @@ class Enhancements: Reactor.Component {
 
     function render() {
         var has_hwcodec = handler.has_hwcodec();
+        var support_remove_wallpaper = handler.support_remove_wallpaper();
         var me = this;
         self.timer(1ms, function() { me.toggleMenuState() });
         return <li>{translate('Enhancements')}
@@ -217,7 +218,7 @@ class Enhancements: Reactor.Component {
                 {has_hwcodec ? <li #enable-hwcodec><span>{svg_checkmark}</span>{translate("Hardware Codec")} (beta)</li> : ""}
                 <li #enable-abr><span>{svg_checkmark}</span>{translate("Adaptive bitrate")} (beta)</li>
                 <li #screen-recording>{translate("Recording")}</li>
-                {is_osx ? "" : <li #allow-remove-wallpaper><span>{svg_checkmark}</span>{translate("Remove wallpaper during incoming sessions")}</li>}
+                {support_remove_wallpaper ? <li #allow-remove-wallpaper><span>{svg_checkmark}</span>{translate("Remove wallpaper during incoming sessions")}</li> : ""}
             </menu>
         </li>;
     }

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -594,7 +594,13 @@ pub fn current_is_wayland() -> bool {
 
 #[inline]
 pub fn get_new_version() -> String {
-    (*SOFTWARE_UPDATE_URL.lock().unwrap().rsplit('/').next().unwrap_or("")).to_string()
+    (*SOFTWARE_UPDATE_URL
+        .lock()
+        .unwrap()
+        .rsplit('/')
+        .next()
+        .unwrap_or(""))
+    .to_string()
 }
 
 #[inline]
@@ -1247,4 +1253,11 @@ pub fn handle_relay_id(id: String) -> String {
     } else {
         id
     }
+}
+
+pub fn support_remove_wallpaper() -> bool {
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    return crate::platform::WallPaperRemover::support();
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    return false;
 }


### PR DESCRIPTION
1. Show the option only when
* windows (test on win7, 10, 11),  gnome (test on ubuntu 22.04) and xfce (test on xubuntu 23.04)
* able to obtain wallpaper
2. Show the "Test" button only when the option is checked.