### PR TITLE
fix, non-texture render, next_rgba

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -14,6 +14,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_hbb/common/formatter/id_formatter.dart';
 import 'package:flutter_hbb/desktop/widgets/refresh_wrapper.dart';
 import 'package:flutter_hbb/desktop/widgets/tabbar_widget.dart';
+import 'package:flutter_hbb/models/desktop_render_texture.dart';
 import 'package:flutter_hbb/main.dart';
 import 'package:flutter_hbb/models/peer_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
@@ -2602,5 +2603,5 @@ sessionRefreshVideo(SessionID sessionId, PeerInfo pi) async {
 
 bool isChooseDisplayToOpenInNewWindow(PeerInfo pi, SessionID sessionId) =>
     pi.isSupportMultiDisplay &&
+    useTextureRender &&
     bind.sessionGetDisplaysAsIndividualWindows(sessionId: sessionId) == 'Y';
-

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -9,6 +9,7 @@ import 'package:flutter_hbb/common/widgets/dialog.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
+import 'package:flutter_hbb/models/desktop_render_texture.dart';
 import 'package:get/get.dart';
 
 bool isEditOsPassword = false;
@@ -516,7 +517,8 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
         child: Text(translate('Swap control-command key'))));
   }
 
-  if (pi.isSupportMultiDisplay &&
+  if (useTextureRender &&
+      pi.isSupportMultiDisplay &&
       PrivacyModeState.find(id).isFalse &&
       pi.displaysCount.value > 1 &&
       bind.mainGetUserDefaultOption(key: kKeyShowMonitorsToolbar) == 'Y') {

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -10,6 +10,7 @@ import 'package:flutter_hbb/common/widgets/setting_widgets.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_home_page.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_tab_page.dart';
+import 'package:flutter_hbb/models/desktop_render_texture.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:flutter_hbb/models/server_model.dart';
 import 'package:flutter_hbb/plugin/manager.dart';
@@ -1306,7 +1307,7 @@ class _DisplayState extends State<_Display> {
   }
 
   Widget other(BuildContext context) {
-    return _Card(title: 'Other Default Options', children: [
+    final children = [
       otherRow('View Mode', 'view_only'),
       otherRow('show_monitors_tip', kKeyShowMonitorsToolbar),
       otherRow('Collapse toolbar', 'collapse_toolbar'),
@@ -1319,9 +1320,12 @@ class _DisplayState extends State<_Display> {
       otherRow('Lock after session end', 'lock_after_session_end'),
       otherRow('Privacy mode', 'privacy_mode'),
       otherRow('Reverse mouse wheel', 'reverse_mouse_wheel'),
-      otherRow('Show displays as individual windows',
-          kKeyShowDisplaysAsIndividualWindows),
-    ]);
+    ];
+    if (useTextureRender) {
+      children.add(otherRow('Show displays as individual windows',
+          kKeyShowDisplaysAsIndividualWindows));
+    }
+    return _Card(title: 'Other Default Options', children: children);
   }
 }
 

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -9,6 +9,7 @@ import 'package:flutter_hbb/common/widgets/toolbar.dart';
 import 'package:flutter_hbb/main.dart';
 import 'package:flutter_hbb/models/chat_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
+import 'package:flutter_hbb/models/desktop_render_texture.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/utils/multi_window_manager.dart';
 import 'package:flutter_hbb/plugin/widgets/desc_ui.dart';
@@ -600,6 +601,9 @@ class _MonitorMenu extends StatelessWidget {
   bool get showMonitorsToolbar =>
       bind.mainGetUserDefaultOption(key: kKeyShowMonitorsToolbar) == 'Y';
 
+  bool get supportIndividualWindows =>
+      useTextureRender && ffi.ffiModel.pi.isSupportMultiDisplay;
+
   @override
   Widget build(BuildContext context) =>
       showMonitorsToolbar ? buildMultiMonitorMenu() : buildMonitorMenu();
@@ -622,13 +626,12 @@ class _MonitorMenu extends StatelessWidget {
   }
 
   Widget buildMonitorSubmenuWidget() {
-    final pi = ffi.ffiModel.pi;
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         Row(children: buildMonitorList(false)),
-        pi.isSupportMultiDisplay ? Divider() : Offstage(),
-        pi.isSupportMultiDisplay ? chooseDisplayBehavior() : Offstage(),
+        supportIndividualWindows ? Divider() : Offstage(),
+        supportIndividualWindows ? chooseDisplayBehavior() : Offstage(),
       ],
     );
   }
@@ -711,7 +714,7 @@ class _MonitorMenu extends StatelessWidget {
     for (int i = 0; i < pi.displays.length; i++) {
       monitorList.add(buildMonitorButton(i));
     }
-    if (pi.isSupportMultiUiSession && pi.displays.length > 1) {
+    if (supportIndividualWindows && pi.displays.length > 1) {
       monitorList.add(buildMonitorButton(kAllDisplayValue));
     }
     return monitorList;

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -19,6 +19,7 @@ import 'package:flutter_hbb/models/peer_tab_model.dart';
 import 'package:flutter_hbb/models/server_model.dart';
 import 'package:flutter_hbb/models/user_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
+import 'package:flutter_hbb/models/desktop_render_texture.dart';
 import 'package:flutter_hbb/plugin/event.dart';
 import 'package:flutter_hbb/plugin/manager.dart';
 import 'package:flutter_hbb/plugin/widgets/desc_ui.dart';
@@ -415,11 +416,11 @@ class FfiModel with ChangeNotifier {
       return;
     }
     if (newRect != _rect) {
-      _rect = newRect;
       if (newRect.left != _rect?.left || newRect.top != _rect?.top) {
         parent.target?.cursorModel
             .updateDisplayOrigin(newRect.left, newRect.top);
       }
+      _rect = newRect;
       parent.target?.canvasModel.updateViewStyle();
       _updateSessionWidthHeight(sessionId);
     }
@@ -1991,7 +1992,6 @@ class FFI {
     }
     final stream = bind.sessionStart(sessionId: sessionId, id: id);
     final cb = ffiModel.startEventListener(sessionId, id);
-    final useTextureRender = bind.mainUseTextureRender();
 
     // Force refresh displays.
     // The controlled side may not refresh the image when the (peer,display) is already subscribed.

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -803,7 +803,7 @@ impl InvokeUiSession for FlutterHandler {
     fn next_rgba(&self, _display: usize) {
         #[cfg(not(feature = "flutter_texture_render"))]
         if let Some(rgba_data) = self.display_rgbas.write().unwrap().get_mut(&_display) {
-            rgba_data.valid = true;
+            rgba_data.valid = false;
         }
     }
 }


### PR DESCRIPTION
Fix several bugs, if build without `flutter_texture_render` feature (including Android).

1. `next_rgba()`, set the valid rgba flag to be false. Critical logic error. This will prevent updating the image.
2. `updateCurDisplay()`, move `_rect = newRect;` after updating current display values of cursor model. 2. `updateCurDisplay()`, update the current display value of the cursor model and then move `_rect = newRect;`. This will result in incorrect mouse or touch position handling.
3. Remove the "merged displays image" choise and "Show displays as individual windows" option.