### PR TITLE
Fix/change display resolution

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2282,7 +2282,7 @@ class PeerInfo with ChangeNotifier {
     if (currentDisplay == kAllDisplayValue) {
       return null;
     }
-    if (currentDisplay > 0 && currentDisplay < displays.length) {
+    if (currentDisplay >= 0 && currentDisplay < displays.length) {
       return displays[currentDisplay];
     } else {
       return null;

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -430,14 +430,12 @@ class FfiModel with ChangeNotifier {
       Map<String, dynamic> evt, SessionID sessionId, String peerId) {
     final curDisplay = int.parse(evt['display']);
 
-    // The message should be handled by the another UI session.
-    if (isChooseDisplayToOpenInNewWindow(_pi, sessionId)) {
-      if (curDisplay != _pi.currentDisplay) {
-        return;
-      }
-    }
-
     if (_pi.currentDisplay != kAllDisplayValue) {
+      if (bind.peerGetDefaultSessionsCount(id: peerId) > 1) {
+        if (curDisplay != _pi.currentDisplay) {
+          return;
+        }
+      }
       _pi.currentDisplay = curDisplay;
     }
 
@@ -825,6 +823,7 @@ class FfiModel with ChangeNotifier {
       }
       _pi.displays = newDisplays;
       _pi.displaysCount.value = _pi.displays.length;
+
       if (_pi.currentDisplay == kAllDisplayValue) {
         updateCurDisplay(sessionId);
         // to-do: What if the displays are changed?

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
+#[cfg(windows)]
 use crate::client::translate;
 #[cfg(not(debug_assertions))]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2142,6 +2142,12 @@ impl Connection {
                     });
                 }
             }
+
+            // Send display changed message.
+            // For compatibility with old versions ( < 1.2.4 ).
+            if let Some(msg_out) = video_service::make_display_changed_msg(self.display_idx, None) {
+                self.send(msg_out).await;
+            }
         }
     }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -611,7 +611,7 @@ impl Connection {
                                 _ => {},
                             }
                         }
-                        Some(message::Union::PeerInfo(_)) => {
+                        Some(message::Union::PeerInfo(..)) => {
                             conn.refresh_video_display(None);
                         }
                         _ => {}
@@ -1132,11 +1132,13 @@ impl Connection {
                 self.send(msg_out).await;
             }
 
-            match super::display_service::get_displays().await {
+            match super::display_service::update_get_sync_displays().await {
                 Err(err) => {
                     res.set_error(format!("{}", err));
                 }
                 Ok(displays) => {
+                    // For compatibility with old versions, we need to send the displays to the peer.
+                    // But the displays may be updated later, before creating the video capturer.
                     pi.displays = displays.clone();
                     pi.current_display = self.display_idx as _;
                     res.set_peer_info(pi);
@@ -2138,13 +2140,6 @@ impl Connection {
                         height: s.height,
                         ..Default::default()
                     });
-                }
-
-                // send display changed message
-                if let Some(msg_out) =
-                    video_service::make_display_changed_msg(self.display_idx, None)
-                {
-                    self.send(msg_out).await;
                 }
             }
         }

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -151,7 +151,7 @@ fn displays_to_msg(displays: Vec<DisplayInfo>) -> Message {
 }
 
 fn check_get_displays_changed_msg() -> Option<Message> {
-    check_update_displays(try_get_displays().ok()?);
+    check_update_displays(&try_get_displays().ok()?);
     let displays = SYNC_DISPLAYS.lock().unwrap().get_update_sync_displays()?;
     Some(displays_to_msg(displays))
 }
@@ -225,9 +225,14 @@ pub(super) fn get_original_resolution(
     .into()
 }
 
+#[cfg(target_os = "linux")]
+pub(super) fn get_sync_displays() -> Vec<DisplayInfo> {
+    SYNC_DISPLAYS.lock().unwrap().displays.clone()
+}
+
 // Display to DisplayInfo
 // The DisplayInfo is be sent to the peer.
-fn check_update_displays(all: Vec<Display>) {
+pub(super) fn check_update_displays(all: &Vec<Display>) {
     let displays = all
         .iter()
         .map(|d| {
@@ -264,7 +269,7 @@ pub async fn update_get_sync_displays() -> ResultType<Vec<DisplayInfo>> {
             return super::wayland::get_displays().await;
         }
     }
-    check_update_displays(try_get_displays()?);
+    check_update_displays(&try_get_displays()?);
     Ok(SYNC_DISPLAYS.lock().unwrap().displays.clone())
 }
 

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -60,7 +60,9 @@ impl SyncDisplaysInfo {
 }
 
 // This function is really useful, though a duplicate check if display changed.
-// Because the video server will send the supported resolutions of the {idx} display to the subscribers.
+// The video server will then send the following messages to the client:
+//  1. the supported resolutions of the {idx} display
+//  2. the switch resolution message, so that the client can record the custom resolution.
 pub(super) fn check_display_changed(
     ndisplay: usize,
     idx: usize,

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -242,6 +242,10 @@ pub(super) fn get_sync_displays() -> Vec<DisplayInfo> {
     SYNC_DISPLAYS.lock().unwrap().displays.clone()
 }
 
+pub(super) fn get_display_info(idx: usize) -> Option<DisplayInfo> {
+    SYNC_DISPLAYS.lock().unwrap().displays.get(idx).cloned()
+}
+
 // Display to DisplayInfo
 // The DisplayInfo is be sent to the peer.
 pub(super) fn check_update_displays(all: &Vec<Display>) {

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -5,6 +5,12 @@ use crate::virtual_display_manager;
 use hbb_common::get_version_number;
 use hbb_common::protobuf::MessageField;
 use scrap::Display;
+#[cfg(target_os = "linux")]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+// https://github.com/rustdesk/rustdesk/discussions/6042, avoiding dbus call
+#[cfg(target_os = "linux")]
+pub(super) static IS_X11: AtomicBool = AtomicBool::new(false);
 
 pub const NAME: &'static str = "display";
 
@@ -19,6 +25,59 @@ lazy_static::lazy_static! {
     // Initial primary display index.
     // It should only be updated when the rustdesk server is started, and should not be updated when displays changed.
     pub static ref PRIMARY_DISPLAY_IDX: usize = get_primary();
+    static ref SYNC_DISPLAYS: Arc<Mutex<SyncDisplaysInfo>> = Default::default();
+}
+
+#[derive(Default)]
+struct SyncDisplaysInfo {
+    displays: Vec<DisplayInfo>,
+    is_synced: bool,
+}
+
+impl SyncDisplaysInfo {
+    fn check_changed(&mut self, displays: Vec<DisplayInfo>) {
+        if self.displays.len() != displays.len() {
+            self.displays = displays;
+            self.is_synced = false;
+            return;
+        }
+        for (i, d) in displays.iter().enumerate() {
+            if d != &self.displays[i] {
+                self.displays = displays;
+                self.is_synced = false;
+                return;
+            }
+        }
+    }
+
+    fn get_update_sync_displays(&mut self) -> Option<Vec<DisplayInfo>> {
+        if self.is_synced {
+            return None;
+        }
+        self.is_synced = true;
+        Some(self.displays.clone())
+    }
+}
+
+pub(super) fn check_display_changed(
+    idx: usize,
+    (x, y, w, h): (i32, i32, usize, usize),
+) -> Option<DisplayInfo> {
+    #[cfg(target_os = "linux")]
+    {
+        // wayland do not support changing display for now
+        if !IS_X11.load(Ordering::SeqCst) {
+            return None;
+        }
+    }
+
+    let lock = SYNC_DISPLAYS.lock().unwrap();
+    let d = lock.displays.get(idx)?;
+    if !(d.x == x && d.y == y && d.width == w as i32 && d.height == h as i32) {
+        Some(d.clone())
+    } else {
+        None
+    }
 }
 
 #[inline]
@@ -74,45 +133,27 @@ pub fn is_privacy_mode_supported() -> bool {
     return false;
 }
 
-#[derive(Default)]
-struct StateDisplay {
-    synced_displays: Vec<DisplayInfo>,
-}
-
-impl super::service::Reset for StateDisplay {
-    fn reset(&mut self) {
-        self.synced_displays.clear();
-    }
-}
-
 pub fn new() -> GenericService {
-    let svc = EmptyExtraFieldService::new(NAME.to_owned(), false);
-    GenericService::repeat::<StateDisplay, _, _>(&svc.clone(), 300, run);
+    let svc = EmptyExtraFieldService::new(NAME.to_owned(), true);
+    GenericService::run(&svc.clone(), run);
     svc.sp
 }
 
-fn check_get_displays_changed_msg(last_synced_displays: &mut Vec<DisplayInfo>) -> Option<Message> {
-    let displays = try_get_displays().ok()?;
-    if displays.len() == last_synced_displays.len() {
-        return None;
-    }
+fn displays_to_msg(displays: Vec<DisplayInfo>) -> Message {
+    let mut pi = PeerInfo {
+        ..Default::default()
+    };
+    pi.displays = displays.clone();
+    pi.current_display = 0;
+    let mut msg_out = Message::new();
+    msg_out.set_peer_info(pi);
+    msg_out
+}
 
-    // Display to DisplayInfo
-    let displays = to_display_info(&displays);
-    if last_synced_displays.len() == 0 {
-        *last_synced_displays = displays;
-        None
-    } else {
-        let mut pi = PeerInfo {
-            ..Default::default()
-        };
-        pi.displays = displays.clone();
-        pi.current_display = 0;
-        let mut msg_out = Message::new();
-        msg_out.set_peer_info(pi);
-        *last_synced_displays = displays;
-        Some(msg_out)
-    }
+fn check_get_displays_changed_msg() -> Option<Message> {
+    check_update_displays(try_get_displays().ok()?);
+    let displays = SYNC_DISPLAYS.lock().unwrap().get_update_sync_displays()?;
+    Some(displays_to_msg(displays))
 }
 
 #[cfg(all(windows, feature = "virtual_display_driver"))]
@@ -120,11 +161,28 @@ pub fn try_plug_out_virtual_display() {
     let _res = virtual_display_manager::plug_out_headless();
 }
 
-fn run(sp: EmptyExtraFieldService, state: &mut StateDisplay) -> ResultType<()> {
-    if let Some(msg_out) = check_get_displays_changed_msg(&mut state.synced_displays) {
-        sp.send(msg_out);
-        log::info!("Displays changed");
+fn run(sp: EmptyExtraFieldService) -> ResultType<()> {
+    #[cfg(target_os = "linux")]
+    {
+        IS_X11.store(scrap::is_x11(), Ordering::SeqCst);
     }
+
+    while sp.ok() {
+        sp.snapshot(|sps| {
+            if sps.has_subscribes() {
+                SYNC_DISPLAYS.lock().unwrap().is_synced = false;
+                bail!("new subscriber");
+            }
+            Ok(())
+        })?;
+
+        if let Some(msg_out) = check_get_displays_changed_msg() {
+            sp.send(msg_out);
+            log::info!("Displays changed");
+        }
+        std::thread::sleep(Duration::from_millis(300));
+    }
+
     Ok(())
 }
 
@@ -167,8 +225,11 @@ pub(super) fn get_original_resolution(
     .into()
 }
 
-pub fn to_display_info(all: &Vec<Display>) -> Vec<DisplayInfo> {
-    all.iter()
+// Display to DisplayInfo
+// The DisplayInfo is be sent to the peer.
+fn check_update_displays(all: Vec<Display>) {
+    let displays = all
+        .iter()
         .map(|d| {
             let display_name = d.name();
             let original_resolution = get_original_resolution(&display_name, d.width(), d.height());
@@ -184,32 +245,34 @@ pub fn to_display_info(all: &Vec<Display>) -> Vec<DisplayInfo> {
                 ..Default::default()
             }
         })
-        .collect::<Vec<DisplayInfo>>()
+        .collect::<Vec<DisplayInfo>>();
+    SYNC_DISPLAYS.lock().unwrap().check_changed(displays);
 }
 
 pub fn is_inited_msg() -> Option<Message> {
     #[cfg(target_os = "linux")]
-    if !scrap::is_x11() {
+    if !IS_X11.load(Ordering::SeqCst) {
         return super::wayland::is_inited();
     }
     None
 }
 
-pub async fn get_displays() -> ResultType<Vec<DisplayInfo>> {
+pub async fn update_get_sync_displays() -> ResultType<Vec<DisplayInfo>> {
     #[cfg(target_os = "linux")]
     {
-        if !scrap::is_x11() {
+        if !IS_X11.load(Ordering::SeqCst) {
             return super::wayland::get_displays().await;
         }
     }
-    Ok(to_display_info(&try_get_displays()?))
+    check_update_displays(try_get_displays()?);
+    Ok(SYNC_DISPLAYS.lock().unwrap().displays.clone())
 }
 
 #[inline]
 pub fn get_primary() -> usize {
     #[cfg(target_os = "linux")]
     {
-        if !scrap::is_x11() {
+        if !IS_X11.load(Ordering::SeqCst) {
             return match super::wayland::get_primary() {
                 Ok(n) => n,
                 Err(_) => 0,

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -407,7 +407,7 @@ fn run(vs: VideoService) -> ResultType<()> {
     #[cfg(target_os = "linux")]
     super::wayland::ensure_inited()?;
     #[cfg(target_os = "linux")]
-    let wayland_call_on_ret = SimpleCallOnReturn {
+    let _wayland_call_on_ret = SimpleCallOnReturn {
         b: true,
         f: Box::new(|| {
             super::wayland::clear();

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -18,7 +18,11 @@
 // to-do:
 // https://slhck.info/video/2017/03/01/rate-control.html
 
-use super::{service::ServiceTmpl, video_qos::VideoQoS, *};
+#[cfg(target_os = "linux")]
+use super::display_service::IS_X11;
+use super::{display_service::check_display_changed, service::ServiceTmpl, video_qos::VideoQoS, *};
+#[cfg(target_os = "linux")]
+use crate::common::SimpleCallOnReturn;
 #[cfg(windows)]
 use crate::{platform::windows::is_process_consent_running, privacy_win_mag};
 use hbb_common::{
@@ -38,7 +42,7 @@ use scrap::{
     CodecName, Display, TraitCapturer,
 };
 #[cfg(target_os = "linux")]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 #[cfg(windows)]
 use std::sync::Once;
 use std::{
@@ -49,7 +53,6 @@ use std::{
 };
 
 pub const NAME: &'static str = "video";
-pub const OPTION_DISPLAY_CHANGED: &'static str = "changed";
 pub const OPTION_REFRESH: &'static str = "refresh";
 
 lazy_static::lazy_static! {
@@ -62,10 +65,6 @@ lazy_static::lazy_static! {
     pub static ref IS_UAC_RUNNING: Arc<Mutex<bool>> = Default::default();
     pub static ref IS_FOREGROUND_WINDOW_ELEVATED: Arc<Mutex<bool>> = Default::default();
 }
-
-// https://github.com/rustdesk/rustdesk/discussions/6042, avoiding dbus call
-#[cfg(target_os = "linux")]
-static IS_X11: AtomicBool = AtomicBool::new(false);
 
 #[inline]
 pub fn notify_video_frame_fetched(conn_id: i32, frame_tm: Option<Instant>) {
@@ -163,35 +162,6 @@ pub fn new(idx: usize) -> GenericService {
     };
     GenericService::run(&vs, run);
     vs.sp
-}
-
-fn check_display_changed(
-    last_n: usize,
-    last_current: usize,
-    last_width: usize,
-    last_height: usize,
-) -> bool {
-    #[cfg(target_os = "linux")]
-    {
-        // wayland do not support changing display for now
-        if !IS_X11.load(Ordering::SeqCst) {
-            return false;
-        }
-    }
-
-    let displays = match try_get_displays() {
-        Ok(d) => d,
-        _ => return false,
-    };
-
-    let n = displays.len();
-    if n != last_n {
-        return true;
-    };
-    match displays.get(last_current) {
-        Some(d) => d.width() != last_width || d.height() != last_height,
-        None => true,
-    }
 }
 
 // Capturer object is expensive, avoiding to create it frequently.
@@ -327,7 +297,6 @@ pub(super) struct CapturerInfo {
     pub origin: (i32, i32),
     pub width: usize,
     pub height: usize,
-    pub ndisplay: usize,
     pub current: usize,
     pub privacy_mode_id: i32,
     pub _capturer_privacy_mode_id: i32,
@@ -419,7 +388,6 @@ fn get_capturer(
         origin,
         width,
         height,
-        ndisplay,
         current,
         privacy_mode_id,
         _capturer_privacy_mode_id: capturer_privacy_mode_id,
@@ -431,16 +399,21 @@ fn run(vs: VideoService) -> ResultType<()> {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     let _wake_lock = get_wake_lock();
 
-    #[cfg(target_os = "linux")]
-    {
-        IS_X11.store(scrap::is_x11(), Ordering::SeqCst);
-    }
-
+    // Wayland only support one video capturer for now. It is ok to call ensure_inited() here.
+    //
     // ensure_inited() is needed because clear() may be called.
     // to-do: wayland ensure_inited should pass current display index.
     // But for now, we do not support multi-screen capture on wayland.
     #[cfg(target_os = "linux")]
     super::wayland::ensure_inited()?;
+    #[cfg(target_os = "linux")]
+    let wayland_call_on_ret = SimpleCallOnReturn {
+        b: true,
+        f: Box::new(|| {
+            super::wayland::clear();
+        }),
+    };
+
     #[cfg(windows)]
     let last_portable_service_running = crate::portable_service::client::running();
     #[cfg(not(windows))]
@@ -470,16 +443,6 @@ fn run(vs: VideoService) -> ResultType<()> {
     }
     c.set_use_yuv(encoder.use_yuv());
     VIDEO_QOS.lock().unwrap().store_bitrate(encoder.bitrate());
-
-    if sp.is_option_true(OPTION_DISPLAY_CHANGED) {
-        log::debug!("Broadcasting display changed");
-        broadcast_display_changed(
-            display_idx,
-            &sp,
-            Some((c.name.clone(), c.origin.clone(), c.width, c.height)),
-        );
-        sp.set_option_bool(OPTION_DISPLAY_CHANGED, false);
-    }
 
     if sp.is_option_true(OPTION_REFRESH) {
         sp.set_option_bool(OPTION_REFRESH, false);
@@ -518,7 +481,7 @@ fn run(vs: VideoService) -> ResultType<()> {
         }
         drop(video_qos);
 
-        if sp.is_option_true(OPTION_DISPLAY_CHANGED) || sp.is_option_true(OPTION_REFRESH) {
+        if sp.is_option_true(OPTION_REFRESH) {
             bail!("SWITCH");
         }
         if codec_name != Encoder::negotiated_codec() {
@@ -540,12 +503,11 @@ fn run(vs: VideoService) -> ResultType<()> {
         let now = time::Instant::now();
         if last_check_displays.elapsed().as_millis() > 1000 {
             last_check_displays = now;
-
-            // Capturer on macos does not return Err event the solution is changed.
-            #[cfg(target_os = "macos")]
-            if check_display_changed(c.ndisplay, c.current, c.width, c.height) {
-                sp.set_option_bool(OPTION_DISPLAY_CHANGED, true);
-                log::info!("Displays changed");
+            if let Some(display) =
+                check_display_changed(c.current, (c.origin.0, c.origin.1, c.width, c.height))
+            {
+                log::info!("Display {} changed", display);
+                broadcast_display_changed(display_idx, &sp, &c.name, display);
                 bail!("SWITCH");
             }
         }
@@ -624,21 +586,12 @@ fn run(vs: VideoService) -> ResultType<()> {
                 }
             }
             Err(err) => {
-                if check_display_changed(c.ndisplay, c.current, c.width, c.height) {
-                    log::info!("Displays changed");
-                    #[cfg(target_os = "linux")]
-                    super::wayland::clear();
-                    sp.set_option_bool(OPTION_DISPLAY_CHANGED, true);
-                    bail!("SWITCH");
-                }
-
                 #[cfg(windows)]
                 if !c.is_gdi() {
                     c.set_gdi();
                     log::info!("dxgi error, fall back to gdi: {:?}", err);
                     continue;
                 }
-
                 return Err(err.into());
             }
             _ => {
@@ -670,9 +623,6 @@ fn run(vs: VideoService) -> ResultType<()> {
             std::thread::sleep(spf - elapsed);
         }
     }
-
-    #[cfg(target_os = "linux")]
-    super::wayland::clear();
 
     Ok(())
 }
@@ -892,9 +842,10 @@ fn get_wake_lock() -> crate::platform::WakeLock {
 fn broadcast_display_changed(
     display_idx: usize,
     sp: &GenericService,
-    display_meta: Option<(String, (i32, i32), usize, usize)>,
+    name: &str,
+    display: DisplayInfo,
 ) {
-    if let Some(msg_out) = make_display_changed_msg(display_idx, display_meta) {
+    if let Some(msg_out) = make_display_changed_msg(display_idx, name, display) {
         sp.send(msg_out);
     }
 }
@@ -913,34 +864,30 @@ fn get_display_info_simple_meta(display_idx: usize) -> Option<(String, (i32, i32
     }
 }
 
-pub fn make_display_changed_msg(
+fn make_display_changed_msg(
     display_idx: usize,
-    display_meta: Option<(String, (i32, i32), usize, usize)>,
+    name: &str,
+    display: DisplayInfo,
 ) -> Option<Message> {
     let mut misc = Misc::new();
-    let (name, origin, width, height) = match display_meta {
-        Some(d) => d,
-        None => get_display_info_simple_meta(display_idx)?,
-    };
-    let original_resolution = display_service::get_original_resolution(&name, width, height);
     misc.set_switch_display(SwitchDisplay {
         display: display_idx as _,
-        x: origin.0,
-        y: origin.1,
-        width: width as _,
-        height: height as _,
+        x: display.x,
+        y: display.y,
+        width: display.width,
+        height: display.height,
         cursor_embedded: display_service::capture_cursor_embedded(),
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         resolutions: Some(SupportedResolutions {
             resolutions: if name.is_empty() {
                 vec![]
             } else {
-                crate::platform::resolutions(&name)
+                crate::platform::resolutions(name)
             },
             ..SupportedResolutions::default()
         })
         .into(),
-        original_resolution,
+        original_resolution: display.original_resolution,
         ..Default::default()
     });
     let mut msg_out = Message::new();

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -509,6 +509,8 @@ fn run(vs: VideoService) -> ResultType<()> {
         let now = time::Instant::now();
         if last_check_displays.elapsed().as_millis() > 1000 {
             last_check_displays = now;
+            // This check may be redundant, but it is better to be safe.
+            // The previous check in `sp.is_option_true(OPTION_REFRESH)` block may be enough.
             try_broadcast_display_changed(&sp, display_idx, &c)?;
         }
 
@@ -586,6 +588,8 @@ fn run(vs: VideoService) -> ResultType<()> {
                 }
             }
             Err(err) => {
+                // This check may be redundant, but it is better to be safe.
+                // The previous check in `sp.is_option_true(OPTION_REFRESH)` block may be enough.
                 try_broadcast_display_changed(&sp, display_idx, &c)?;
 
                 #[cfg(windows)]

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -271,9 +271,6 @@ pub(super) fn get_capturer() -> ResultType<super::video_service::CapturerInfo> {
             let cap_display_info = &*cap_display_info;
             let rect = cap_display_info.rects[cap_display_info.current];
             Ok(super::video_service::CapturerInfo {
-                name: cap_display_info.displays[cap_display_info.current]
-                    .name
-                    .clone(),
                 origin: rect.0,
                 width: rect.1,
                 height: rect.2,

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -84,6 +84,7 @@ impl TraitCapturer for CapturerPtr {
 struct CapDisplayInfo {
     rects: Vec<((i32, i32), usize, usize)>,
     displays: Vec<DisplayInfo>,
+    num: usize,
     primary: usize,
     current: usize,
     capturer: CapturerPtr,
@@ -194,6 +195,7 @@ pub(super) async fn check_init() -> ResultType<()> {
                 let cap_display_info = Box::into_raw(Box::new(CapDisplayInfo {
                     rects,
                     displays,
+                    num,
                     primary,
                     current,
                     capturer,
@@ -275,6 +277,7 @@ pub(super) fn get_capturer() -> ResultType<super::video_service::CapturerInfo> {
                 origin: rect.0,
                 width: rect.1,
                 height: rect.2,
+                ndisplay: cap_display_info.num,
                 current: cap_display_info.current,
                 privacy_mode_id: 0,
                 _capturer_privacy_mode_id: 0,

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -1,9 +1,12 @@
-use crate::{client::translate, ipc::Data};
-use hbb_common::{allow_err, log, tokio};
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use crate::client::translate;
+#[cfg(windows)]
+use crate::ipc::Data;
+#[cfg(windows)]
+use hbb_common::tokio;
+use hbb_common::{allow_err, log};
+use std::sync::{Arc, Mutex};
+#[cfg(windows)]
+use std::time::Duration;
 
 pub fn start_tray() {
     allow_err!(make_tray());


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/6071

https://github.com/rustdesk/rustdesk/assets/136106582/3c7564df-7d98-406b-b741-3860fbdbf3f3

Fixes:
1. In `tryGetDisplayIfNotAllDisplay()` `flutter/lib/models/model.dart`, `currentDisplay > 0` to `currentDisplay >= 0`.
2. Send messages. sync peer info and switch display.

Changes:
1. Record a global displays instance `SYNC_DISPLAYS` in `display_service.rs`.
2. Send sync peer info message when the displays are changed.
3. Send switch display `try_broadcast_display_changed()` in `video_service.rs`.


Changing resolution works fine in "Ver 1.2.2". This commit is also tested with "Ver 1.2.2".
