### PR TITLE
AV1 record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6712,18 +6712,16 @@ dependencies = [
 
 [[package]]
 name = "webm"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb047148a12ef1fd8ab26302bca7e82036f005c3073b48e17cc1b44ec577136"
+version = "1.1.0"
+source = "git+https://github.com/21pages/rust-webm#d2c4d3ac133c7b0e4c0f656da710b48391981e64"
 dependencies = [
  "webm-sys",
 ]
 
 [[package]]
 name = "webm-sys"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ded6ec82ccf51fe265b0b2b1579cac839574ed910c17baac58e807f8a9de7f3"
+version = "1.0.4"
+source = "git+https://github.com/21pages/rust-webm#d2c4d3ac133c7b0e4c0f656da710b48391981e64"
 dependencies = [
  "cc",
 ]

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -224,11 +224,8 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
     ));
   }
   // record
-  var codecFormat = ffi.qualityMonitorModel.data.codecFormat;
   if (!isDesktop &&
-      (ffi.recordingModel.start ||
-          (perms["recording"] != false &&
-              (codecFormat == "VP8" || codecFormat == "VP9")))) {
+      (ffi.recordingModel.start || (perms["recording"] != false))) {
     v.add(TTextMenu(
         child: Row(
           children: [

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -677,7 +677,8 @@ class _ImagePaintState extends State<ImagePaint> {
     } else {
       final key = cache.updateGetKey(scale);
       if (!cursor.cachedKeys.contains(key)) {
-        debugPrint("Register custom cursor with key $key (${cache.hotx},${cache.hoty})");
+        debugPrint(
+            "Register custom cursor with key $key (${cache.hotx},${cache.hoty})");
         // [Safety]
         // It's ok to call async registerCursor in current synchronous context,
         // because activating the cursor is also an async call and will always

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -478,7 +478,7 @@ class _RemoteToolbarState extends State<RemoteToolbar> {
       toolbarItems.add(_ChatMenu(id: widget.id, ffi: widget.ffi));
       toolbarItems.add(_VoiceCallMenu(id: widget.id, ffi: widget.ffi));
     }
-    toolbarItems.add(_RecordMenu(ffi: widget.ffi));
+    toolbarItems.add(_RecordMenu());
     toolbarItems.add(_CloseMenu(id: widget.id, ffi: widget.ffi));
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -1370,12 +1370,11 @@ class _ResolutionsMenuState extends State<_ResolutionsMenu> {
     }
 
     for (final r in resolutions) {
-      if (r.width == _localResolution!.width &&
-          r.height == _localResolution!.height) {
+      if (r.width == _localResolution!.width && r.height == _localResolution!.height) {
         return r;
       }
     }
-
+  
     return null;
   }
 
@@ -1646,17 +1645,16 @@ class _VoiceCallMenu extends StatelessWidget {
 }
 
 class _RecordMenu extends StatelessWidget {
-  final FFI ffi;
-  const _RecordMenu({Key? key, required this.ffi}) : super(key: key);
+  const _RecordMenu({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    var ffiModel = Provider.of<FfiModel>(context);
+    var ffi = Provider.of<FfiModel>(context);
     var recordingModel = Provider.of<RecordingModel>(context);
     final visible =
-        recordingModel.start || ffiModel.permissions['recording'] != false;
+        recordingModel.start || ffi.permissions['recording'] != false;
     if (!visible) return Offstage();
-    final menuButton = _IconMenuButton(
+    return _IconMenuButton(
       assetName: 'assets/rec.svg',
       tooltip: recordingModel.start
           ? 'Stop session recording'
@@ -1669,14 +1667,6 @@ class _RecordMenu extends StatelessWidget {
           ? _ToolbarTheme.hoverRedColor
           : _ToolbarTheme.hoverBlueColor,
     );
-    return ChangeNotifierProvider.value(
-        value: ffi.qualityMonitorModel,
-        child: Consumer<QualityMonitorModel>(
-            builder: (context, model, child) => Offstage(
-                  // If already started, AV1->Hidden/Stop, Other->Start, same as actual
-                  offstage: model.data.codecFormat == 'AV1',
-                  child: menuButton,
-                )));
   }
 }
 

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1370,11 +1370,12 @@ class _ResolutionsMenuState extends State<_ResolutionsMenu> {
     }
 
     for (final r in resolutions) {
-      if (r.width == _localResolution!.width && r.height == _localResolution!.height) {
+      if (r.width == _localResolution!.width &&
+          r.height == _localResolution!.height) {
         return r;
       }
     }
-  
+
     return null;
   }
 
@@ -1652,7 +1653,8 @@ class _RecordMenu extends StatelessWidget {
     var ffi = Provider.of<FfiModel>(context);
     var recordingModel = Provider.of<RecordingModel>(context);
     final visible =
-        recordingModel.start || ffi.permissions['recording'] != false;
+        (recordingModel.start || ffi.permissions['recording'] != false) &&
+            ffi.pi.currentDisplay != kAllDisplayValue;
     if (!visible) return Offstage();
     return _IconMenuButton(
       assetName: 'assets/rec.svg',

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -763,7 +763,9 @@ void showOptions(
       children.add(InkWell(
           onTap: () {
             if (i == cur) return;
-            bind.sessionSwitchDisplay(sessionId: gFFI.sessionId, value: Int32List.fromList([i]));
+            gFFI.recordingModel.onClose();
+            bind.sessionSwitchDisplay(
+                sessionId: gFFI.sessionId, value: Int32List.fromList([i]));
             gFFI.dialogManager.dismissAll();
           },
           child: Ink(

--- a/libs/scrap/Cargo.toml
+++ b/libs/scrap/Cargo.toml
@@ -19,7 +19,7 @@ cfg-if = "1.0"
 num_cpus = "1.15"
 lazy_static = "1.4"
 hbb_common = { path = "../hbb_common" }
-webm = "1.0"
+webm = { git = "https://github.com/21pages/rust-webm" }
 
 [dependencies.winapi]
 version = "0.3"

--- a/libs/scrap/src/common/record.rs
+++ b/libs/scrap/src/common/record.rs
@@ -101,9 +101,6 @@ impl DerefMut for Recorder {
 
 impl Recorder {
     pub fn new(mut ctx: RecorderContext) -> ResultType<Self> {
-        if ctx.format == CodecFormat::AV1 {
-            bail!("not support av1 recording");
-        }
         ctx.set_filename()?;
         let recorder = match ctx.format {
             CodecFormat::VP8 | CodecFormat::VP9 => Recorder {

--- a/src/client.rs
+++ b/src/client.rs
@@ -999,16 +999,19 @@ pub struct VideoHandler {
     pub rgb: ImageRgb,
     recorder: Arc<Mutex<Option<Recorder>>>,
     record: bool,
+    _display: usize, // useful for debug
 }
 
 impl VideoHandler {
     /// Create a new video handler.
-    pub fn new() -> Self {
+    pub fn new(_display: usize) -> Self {
+        log::info!("new video handler for display #{_display}");
         VideoHandler {
             decoder: Decoder::new(),
             rgb: ImageRgb::new(ImageFormat::ARGB, crate::DST_STRIDE_RGBA),
             recorder: Default::default(),
             record: false,
+            _display,
         }
     }
 
@@ -1900,7 +1903,7 @@ where
                         if handler_controller_map.len() <= display {
                             for _i in handler_controller_map.len()..=display {
                                 handler_controller_map.push(VideoHandlerController {
-                                    handler: VideoHandler::new(),
+                                    handler: VideoHandler::new(_i),
                                     count: 0,
                                     duration: std::time::Duration::ZERO,
                                     skip_beginning: 0,
@@ -1960,6 +1963,7 @@ where
                         }
                     }
                     MediaData::RecordScreen(start, display, w, h, id) => {
+                        log::info!("record screen command: start:{start}, display:{display}");
                         if handler_controller_map.len() == 1 {
                             // Compatible with the sciter version(single ui session).
                             // For the sciter version, there're no multi-ui-sessions for one connection.

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2104,7 +2104,7 @@ impl Connection {
                 display,
                 video_service::OPTION_REFRESH,
                 super::service::SERVICE_OPTION_VALUE_TRUE,
-            )
+            );
         });
     }
 
@@ -2145,6 +2145,7 @@ impl Connection {
 
             // Send display changed message.
             // For compatibility with old versions ( < 1.2.4 ).
+            // sciter need it in new version
             if let Some(msg_out) = video_service::make_display_changed_msg(self.display_idx, None) {
                 self.send(msg_out).await;
             }

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -436,8 +436,7 @@ fn run(vs: VideoService) -> ResultType<()> {
     log::info!("init quality={:?}, abr enabled:{}", quality, abr);
     let codec_name = Encoder::negotiated_codec();
     let recorder = get_recorder(c.width, c.height, &codec_name);
-    let last_recording =
-        (recorder.lock().unwrap().is_some() || video_qos.record()) && codec_name != CodecName::AV1;
+    let last_recording = recorder.lock().unwrap().is_some() || video_qos.record();
     drop(video_qos);
     let encoder_cfg = get_encoder_config(&c, quality, last_recording);
 
@@ -479,8 +478,7 @@ fn run(vs: VideoService) -> ResultType<()> {
             allow_err!(encoder.set_quality(quality));
             video_qos.store_bitrate(encoder.bitrate());
         }
-        let recording = (recorder.lock().unwrap().is_some() || video_qos.record())
-            && codec_name != CodecName::AV1;
+        let recording = recorder.lock().unwrap().is_some() || video_qos.record();
         if recording != last_recording {
             bail!("SWITCH");
         }

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -144,7 +144,7 @@ class Header: Reactor.Component {
             <span #action>{svg_action}</span>
             <span #display>{svg_display}</span>
             <span #keyboard>{svg_keyboard}</span>
-            {recording_enabled && qualityMonitorData[4] != "AV1" ? <span #recording>{recording ? svg_recording_on : svg_recording_off}</span> : ""}
+            {recording_enabled ? <span #recording>{recording ? svg_recording_on : svg_recording_off}</span> : ""}
             {this.renderKeyboardPop()}
             {this.renderDisplayPop()}
             {this.renderActionPop()}

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -299,14 +299,22 @@ class Header: Reactor.Component {
         header.update();
         handler.record_status(recording);
         // 0 is just a dummy value. It will be ignored by the handler.
-        if (recording)
+        if (recording) {
             handler.refresh_video(0);
-        else
-            handler.record_screen(false, 0, display_width, display_height);
+            if (handler.version_cmp(pi.version, '1.2.4') >= 0) handler.record_screen(recording, pi.current_display, display_width, display_height);
+        }
+        else {
+            handler.record_screen(recording, pi.current_display, display_width, display_height);
+        }
     }
 
     event click $(#screen) (_, me) {
         if (pi.current_display == me.index) return;
+        if (recording) {
+            recording = false;
+            handler.record_screen(false, pi.current_display, display_width, display_height);
+            handler.record_status(false);
+        }
         handler.switch_display(me.index);
     }
     

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -243,6 +243,7 @@ impl InvokeUiSession for SciterHandler {
         pi_sciter.set_item("sas_enabled", pi.sas_enabled);
         pi_sciter.set_item("displays", Self::make_displays_array(&pi.displays));
         pi_sciter.set_item("current_display", pi.current_display);
+        pi_sciter.set_item("version", pi.version.clone());
         self.call("updatePi", &make_args!(pi_sciter));
     }
 
@@ -469,6 +470,7 @@ impl sciter::EventHandler for SciterSession {
         fn restart_remote_device();
         fn request_voice_call();
         fn close_voice_call();
+        fn version_cmp(String, String);
     }
 }
 
@@ -756,6 +758,10 @@ impl SciterSession {
         if let Err(err) = crate::run_me(args) {
             log::error!("Failed to spawn IP tunneling: {}", err);
         }
+    }
+
+    fn version_cmp(&self, v1: String, v2: String) -> i32 {
+        (hbb_common::get_version_number(&v1) - hbb_common::get_version_number(&v2)) as i32
     }
 }
 

--- a/src/ui/remote.tis
+++ b/src/ui/remote.tis
@@ -522,7 +522,6 @@ handler.updateQualityStatus = function(speed, fps, delay, bitrate, codec_format)
     bitrate ? qualityMonitorData[3] = bitrate:null;
     codec_format ? qualityMonitorData[4] = codec_format:null;
     qualityMonitor.update();
-    if (codec_format) header.update();
 }
 
 handler.setPermission = function(name, enabled) {


### PR DESCRIPTION
1. Support record AV1
AV1's codec private data is from the encode side, use four zero instead works.

2. Fix client side record, test 1.2.4 record 1.1.9~1.2.4 ok, older version can't record 1.2.4 with any codec, update if needed.
* The server side does not send SwitchDisplay on every video_service::run, older versions rely on this message to start recording.  
*  Stop recording when switching the display, because the VideoHandler is created when receiving the frame, later than the switch display command.

https://github.com/rustdesk/rustdesk/assets/14891774/4eb7523b-3ede-457f-96bf-c3e8812d34de
