### PR TITLE
Fix remote home button in file transfer

### DIFF
--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -261,6 +261,7 @@ class FileController {
       required this.getOtherSideDirectoryData});
 
   String get homePath => options.value.home;
+  void set homePath(String path) => options.value.home = path;
   OverlayDialogManager? get dialogManager => rootState.target?.dialogManager;
 
   String get shortPath {
@@ -376,6 +377,11 @@ class FileController {
   }
 
   void goToHomeDirectory() {
+    if (isLocal) {
+      openDirectory(homePath);
+      return;
+    }
+    homePath = "";
     openDirectory(homePath);
   }
 

--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -375,14 +375,8 @@ class FileController {
     history.add(directory.value.path);
   }
 
-  void goToHomeDirectory() async {
-    if (isLocal) {
-      openDirectory(homePath);
-      return;
-    }
-    final homeDir = (await bind.sessionGetPeerOption(
-        sessionId: sessionId, name: "remote_home_dir"));
-        openDirectory(homeDir);
+  void goToHomeDirectory() {
+    openDirectory(homePath);
   }
 
   void goBack() {
@@ -409,7 +403,7 @@ class FileController {
   }
 
   // TODO deprecated this
-  void initDirAndHome(Map<String, dynamic> evt) async {
+  void initDirAndHome(Map<String, dynamic> evt) {
     try {
       final fd = FileDirectory.fromJson(jsonDecode(evt['value']));
       fd.format(options.value.isWindows, sort: sortBy.value);
@@ -429,14 +423,6 @@ class FileController {
         }
       } else if (options.value.home.isEmpty) {
         options.value.home = fd.path;
-
-        final homeDir = ( await bind.sessionGetPeerOption(
-          sessionId: sessionId, name: "remote_home_dir"));
-
-        if (homeDir.isEmpty){
-          bind.sessionPeerOption(
-            sessionId: sessionId, name: "remote_home_dir", value: fd.path);
-        }
         debugPrint("init remote home: ${fd.path}");
         directory.value = fd;
       }

--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -375,8 +375,14 @@ class FileController {
     history.add(directory.value.path);
   }
 
-  void goToHomeDirectory() {
-    openDirectory(homePath);
+  void goToHomeDirectory() async {
+    if (isLocal) {
+      openDirectory(homePath);
+      return;
+    }
+    final homeDir = (await bind.sessionGetPeerOption(
+        sessionId: sessionId, name: "remote_home_dir"));
+        openDirectory(homeDir);
   }
 
   void goBack() {
@@ -403,7 +409,7 @@ class FileController {
   }
 
   // TODO deprecated this
-  void initDirAndHome(Map<String, dynamic> evt) {
+  void initDirAndHome(Map<String, dynamic> evt) async {
     try {
       final fd = FileDirectory.fromJson(jsonDecode(evt['value']));
       fd.format(options.value.isWindows, sort: sortBy.value);
@@ -423,6 +429,14 @@ class FileController {
         }
       } else if (options.value.home.isEmpty) {
         options.value.home = fd.path;
+
+        final homeDir = ( await bind.sessionGetPeerOption(
+          sessionId: sessionId, name: "remote_home_dir"));
+
+        if (homeDir.isEmpty){
+          bind.sessionPeerOption(
+            sessionId: sessionId, name: "remote_home_dir", value: fd.path);
+        }
         debugPrint("init remote home: ${fd.path}");
         directory.value = fd;
       }


### PR DESCRIPTION
fixes https://github.com/rustdesk/rustdesk/issues/3508#issuecomment-1758746599
The original issue of #3508 has been already fixed (confirmed by OP and me).

~~Storing and fetching remote home directory for remote home button.~~
Setting the directory as empty is opening home directory.
Rest implementation is unchanged. Local remote home button is working the same as before.

https://github.com/rustdesk/rustdesk/assets/73148455/15103ad5-a035-4ead-9773-bb163c2ce3db

