### PR TITLE
Fix/macos close sesions

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1495,7 +1495,7 @@ Future<void> saveWindowPosition(WindowType type, {int? windowId}) async {
   late Size sz;
   late bool isMaximized;
   bool isFullscreen = stateGlobal.fullscreen.isTrue ||
-      (Platform.isMacOS && stateGlobal.closeOnFullscreen);
+      (Platform.isMacOS && stateGlobal.closeOnFullscreen == true);
   setFrameIfMaximized() {
     if (isMaximized) {
       final pos = bind.getLocalFlutterOption(k: kWindowPrefix + type.name);

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -125,9 +125,12 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
         windowOnTop(windowId());
         tryMoveToScreenAndSetFullscreen(screenRect);
         if (tabController.length == 0) {
-          if (Platform.isMacOS && stateGlobal.closeOnFullscreen) {
+          // Show the hidden window.
+          if (Platform.isMacOS && stateGlobal.closeOnFullscreen == true) {
             stateGlobal.setFullscreen(true);
           }
+          // Reset the state
+          stateGlobal.closeOnFullscreen = null;
         }
         ConnectionTypeState.init(id);
         _toolbarState.setShow(

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -20,7 +20,6 @@ import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:window_size/window_size.dart' as window_size;
 
 import '../../common.dart';
-import '../../common/widgets/dialog.dart';
 import '../../models/model.dart';
 import '../../models/platform_model.dart';
 import '../../common/shared_state.dart';
@@ -1683,7 +1682,7 @@ class _CloseMenu extends StatelessWidget {
     return _IconMenuButton(
       assetName: 'assets/close.svg',
       tooltip: 'Close',
-      onPressed: () => clientClose(ffi.sessionId, ffi.dialogManager),
+      onPressed: () => closeConnection(id: id),
       color: _ToolbarTheme.redColor,
       hoverColor: _ToolbarTheme.hoverRedColor,
     );

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -581,18 +581,14 @@ class WindowActionPanelState extends State<WindowActionPanel>
     mainWindowClose() async => await windowManager.hide();
     notMainWindowClose(WindowController controller) async {
       await controller.hide();
-      await Future.wait([
-        rustDeskWinManager
-            .call(WindowType.Main, kWindowEventHide, {"id": kWindowId!}),
-        widget.onClose?.call() ?? Future.microtask(() => null)
-      ]);
+      await rustDeskWinManager
+          .call(WindowType.Main, kWindowEventHide, {"id": kWindowId!});
     }
 
     macOSWindowClose(
-        Future<void> Function() restoreFunc,
-        Future<bool> Function() checkFullscreen,
-        Future<void> Function() closeFunc) async {
-      await restoreFunc();
+      Future<bool> Function() checkFullscreen,
+      Future<void> Function() closeFunc,
+    ) async {
       _macOSCheckRestoreCounter = 0;
       _macOSCheckRestoreTimer =
           Timer.periodic(Duration(milliseconds: 30), (timer) async {
@@ -612,26 +608,38 @@ class WindowActionPanelState extends State<WindowActionPanel>
       }
       // macOS specific workaround, the window is not hiding when in fullscreen.
       if (Platform.isMacOS && await windowManager.isFullScreen()) {
-        stateGlobal.closeOnFullscreen = true;
+        stateGlobal.closeOnFullscreen ??= true;
+        await windowManager.setFullScreen(false);
         await macOSWindowClose(
-            () async => await windowManager.setFullScreen(false),
-            () async => await windowManager.isFullScreen(),
-            mainWindowClose);
+          () async => await windowManager.isFullScreen(),
+          mainWindowClose,
+        );
       } else {
-        stateGlobal.closeOnFullscreen = false;
+        stateGlobal.closeOnFullscreen ??= false;
         await mainWindowClose();
       }
     } else {
       // it's safe to hide the subwindow
       final controller = WindowController.fromWindowId(kWindowId!);
-      if (Platform.isMacOS && await controller.isFullScreen()) {
-        stateGlobal.closeOnFullscreen = true;
-        await macOSWindowClose(
-            () async => await controller.setFullscreen(false),
-            () async => await controller.isFullScreen(),
-            () async => await notMainWindowClose(controller));
+      if (Platform.isMacOS) {
+        // onWindowClose() maybe called multiple times as loopCloseWindow() in remote_tab_page.dart.
+        // use ??=  to make sure the value is set on first call.
+
+        if (await widget.onClose?.call() ?? true) {
+          if (await controller.isFullScreen()) {
+            stateGlobal.closeOnFullscreen ??= true;
+            await controller.setFullscreen(false);
+            stateGlobal.setFullscreen(false, procWnd: false);
+            await macOSWindowClose(
+              () async => await controller.isFullScreen(),
+              () async => await notMainWindowClose(controller),
+            );
+          } else {
+            stateGlobal.closeOnFullscreen ??= false;
+            await notMainWindowClose(controller);
+          }
+        }
       } else {
-        stateGlobal.closeOnFullscreen = false;
         await notMainWindowClose(controller);
       }
     }

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -622,7 +622,7 @@ class WindowActionPanelState extends State<WindowActionPanel>
       // it's safe to hide the subwindow
       final controller = WindowController.fromWindowId(kWindowId!);
       if (Platform.isMacOS) {
-        // onWindowClose() maybe called multiple times as loopCloseWindow() in remote_tab_page.dart.
+        // onWindowClose() maybe called multiple times because of loopCloseWindow() in remote_tab_page.dart.
         // use ??=  to make sure the value is set on first call.
 
         if (await widget.onClose?.call() ?? true) {

--- a/flutter/lib/models/state_model.dart
+++ b/flutter/lib/models/state_model.dart
@@ -20,7 +20,7 @@ class StateGlobal {
   final RxBool showRemoteToolBar = false.obs;
   final svcStatus = SvcStatus.notReady.obs;
   // Only used for macOS
-  bool closeOnFullscreen = false;
+  bool? closeOnFullscreen;
 
   // Use for desktop -> remote toolbar -> resolution
   final Map<String, Map<int, String?>> _lastResolutionGroupValues = {};


### PR DESCRIPTION
1. Remove the confirm dialog on desktop when closing one session.

https://github.com/rustdesk/rustdesk/discussions/6091

2. The confirm dialog must be choosed before the window is closed(hidden) on macos.


https://github.com/rustdesk/rustdesk/assets/136106582/b62e5362-5b1c-4e8e-93fe-93b762aca1e6

