### PR TITLE
fix is x11, on conn

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -108,7 +108,7 @@ impl Drop for SimpleCallOnReturn {
 pub fn global_init() -> bool {
     #[cfg(target_os = "linux")]
     {
-        if !*IS_X11 {
+        if !crate::platform::linux::is_x11() {
             crate::server::wayland::init();
         }
     }
@@ -956,7 +956,10 @@ pub async fn post_request_sync(url: String, body: String, header: &str) -> Resul
 }
 
 #[inline]
-pub fn make_privacy_mode_msg_with_details(state: back_notification::PrivacyModeState, details: String) -> Message {
+pub fn make_privacy_mode_msg_with_details(
+    state: back_notification::PrivacyModeState,
+    details: String,
+) -> Message {
     let mut misc = Misc::new();
     let mut back_notification = BackNotification {
         details,
@@ -988,17 +991,6 @@ pub fn get_supported_keyboard_modes(version: i64) -> Vec<KeyboardMode> {
         .filter(|&mode| is_keyboard_mode_supported(mode, version))
         .map(|&mode| mode)
         .collect::<Vec<_>>()
-}
-
-#[cfg(not(target_os = "linux"))]
-lazy_static::lazy_static! {
-    pub static ref IS_X11: bool = false;
-
-}
-
-#[cfg(target_os = "linux")]
-lazy_static::lazy_static! {
-    pub static ref IS_X11: bool = hbb_common::platform::linux::is_x11_or_headless();
 }
 
 pub fn make_fd_to_json(id: i32, path: String, entries: &Vec<FileEntry>) -> String {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1584,7 +1584,7 @@ pub fn main_is_installed() -> SyncReturn<bool> {
 
 pub fn main_start_grab_keyboard() -> SyncReturn<bool> {
     #[cfg(target_os = "linux")]
-    if !*crate::common::IS_X11 {
+    if !crate::platform::linux::is_x11() {
         return SyncReturn(false);
     }
     crate::keyboard::client::start_grab_loop();

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -35,6 +35,10 @@ type Xdo = *const c_void;
 pub const PA_SAMPLE_RATE: u32 = 48000;
 static mut UNMODIFIED: bool = true;
 
+lazy_static::lazy_static! {
+    pub static ref IS_X11: bool = hbb_common::platform::linux::is_x11_or_headless();
+}
+
 thread_local! {
     static XDO: RefCell<Xdo> = RefCell::new(unsafe { xdo_new(std::ptr::null()) });
     static DISPLAY: RefCell<*mut c_void> = RefCell::new(unsafe { XOpenDisplay(std::ptr::null())});
@@ -1359,4 +1363,9 @@ impl Drop for WallPaperRemover {
                 .map_err(|e| anyhow!(e.to_string())));
         }
     }
+}
+
+#[inline]
+pub fn is_x11() -> bool {
+    *IS_X11
 }

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1,8 +1,6 @@
 use super::*;
 #[cfg(target_os = "macos")]
 use crate::common::is_server;
-#[cfg(target_os = "linux")]
-use crate::common::IS_X11;
 use crate::input::*;
 #[cfg(target_os = "macos")]
 use dispatch::Queue;
@@ -1152,7 +1150,7 @@ fn map_keyboard_mode(evt: &KeyEvent) {
 
     // Wayland
     #[cfg(target_os = "linux")]
-    if !*IS_X11 {
+    if !crate::platform::linux::is_x11() {
         let mut en = ENIGO.lock().unwrap();
         let code = evt.chr() as u16;
 

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -18,8 +18,6 @@
 // to-do:
 // https://slhck.info/video/2017/03/01/rate-control.html
 
-#[cfg(target_os = "linux")]
-use super::display_service::IS_X11;
 use super::{
     display_service::{check_display_changed, get_display_info},
     service::ServiceTmpl,
@@ -28,6 +26,8 @@ use super::{
 };
 #[cfg(target_os = "linux")]
 use crate::common::SimpleCallOnReturn;
+#[cfg(target_os = "linux")]
+use crate::platform::linux::is_x11;
 #[cfg(windows)]
 use crate::{platform::windows::is_process_consent_running, privacy_win_mag};
 use hbb_common::{
@@ -46,8 +46,6 @@ use scrap::{
     vpxcodec::{VpxEncoderConfig, VpxVideoCodecId},
     CodecName, Display, TraitCapturer,
 };
-#[cfg(target_os = "linux")]
-use std::sync::atomic::Ordering;
 #[cfg(windows)]
 use std::sync::Once;
 use std::{
@@ -329,7 +327,7 @@ fn get_capturer(
 ) -> ResultType<CapturerInfo> {
     #[cfg(target_os = "linux")]
     {
-        if !IS_X11.load(Ordering::SeqCst) {
+        if !is_x11() {
             return super::wayland::get_capturer();
         }
     }
@@ -571,7 +569,7 @@ fn run(vs: VideoService) -> ResultType<()> {
                 #[cfg(target_os = "linux")]
                 {
                     would_block_count += 1;
-                    if !IS_X11.load(Ordering::SeqCst) {
+                    if !is_x11() {
                         if would_block_count >= 100 {
                             // to-do: Unknown reason for WouldBlock 100 times (seconds = 100 * 1 / fps)
                             // https://github.com/rustdesk/rustdesk/blob/63e6b2f8ab51743e77a151e2b7ff18816f5fa2fb/libs/scrap/src/common/wayland.rs#L81
@@ -751,7 +749,7 @@ fn handle_one_frame(
 
 pub fn is_inited_msg() -> Option<Message> {
     #[cfg(target_os = "linux")]
-    if !IS_X11.load(Ordering::SeqCst) {
+    if !is_x11() {
         return super::wayland::is_inited();
     }
     None

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -4,8 +4,11 @@ use scrap::{is_cursor_embedded, set_map_err, Capturer, Display, Frame, TraitCapt
 use std::io;
 use std::process::{Command, Output};
 
-use crate::client::{
-    SCRAP_OTHER_VERSION_OR_X11_REQUIRED, SCRAP_UBUNTU_HIGHER_REQUIRED, SCRAP_X11_REQUIRED,
+use crate::{
+    client::{
+        SCRAP_OTHER_VERSION_OR_X11_REQUIRED, SCRAP_UBUNTU_HIGHER_REQUIRED, SCRAP_X11_REQUIRED,
+    },
+    platform::linux::is_x11,
 };
 
 lazy_static::lazy_static! {
@@ -96,7 +99,7 @@ pub(super) async fn ensure_inited() -> ResultType<()> {
 }
 
 pub(super) fn is_inited() -> Option<Message> {
-    if scrap::is_x11() {
+    if is_x11() {
         None
     } else {
         if *CAP_DISPLAY_INFO.read().unwrap() == 0 {
@@ -133,7 +136,7 @@ fn get_max_desktop_resolution() -> Option<String> {
 }
 
 pub(super) async fn check_init() -> ResultType<()> {
-    if !scrap::is_x11() {
+    if !is_x11() {
         let mut minx = 0;
         let mut maxx = 0;
         let mut miny = 0;
@@ -246,7 +249,7 @@ pub(super) fn get_primary() -> ResultType<usize> {
 }
 
 pub fn clear() {
-    if scrap::is_x11() {
+    if is_x11() {
         return;
     }
     let mut write_lock = CAP_DISPLAY_INFO.write().unwrap();
@@ -261,7 +264,7 @@ pub fn clear() {
 }
 
 pub(super) fn get_capturer() -> ResultType<super::video_service::CapturerInfo> {
-    if scrap::is_x11() {
+    if is_x11() {
         bail!("Do not call this function if not wayland");
     }
     let addr = *CAP_DISPLAY_INFO.read().unwrap();


### PR DESCRIPTION
Move the global `IS_X11` to `linux.rs`.

The `IS_X11` var is inited only after the service running.

It is incorrect when connecting, and syncronizing the displays info. 

https://github.com/rustdesk/rustdesk/blob/9ee1261204004a20e609a1e0930549c4847b9155/src/server/connection.rs#L1135

