### PR TITLE
fix, current user check, ignore '2 sessions listed.'

### DIFF
--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -166,7 +166,9 @@ fn _get_values_of_seat0(indices: &[usize], ignore_gdm_wayland: bool) -> Vec<Stri
                     if d == "tty" {
                         continue;
                     }
-                    return line_values(indices, line);
+                    if !line.contains("sessions listed.") {
+                        return line_values(indices, line);
+                    }
                 }
             }
         }


### PR DESCRIPTION

Avoid the `USER` to be "listed."

```
SESSION  UID USER     SEAT  TTY  
      2 1000 username seat0 tty2
      4 1000 username       pts/0

2 sessions listed.
```