### PR TITLE
hwcodec check wait more time

### DIFF
--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -569,7 +569,7 @@ impl Config {
 
     pub fn get_home() -> PathBuf {
         #[cfg(any(target_os = "android", target_os = "ios"))]
-        return Self::path(APP_HOME_DIR.read().unwrap().as_str());
+        return PathBuf::from(APP_HOME_DIR.read().unwrap().as_str());
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
             if let Some(path) = dirs_next::home_dir() {

--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -362,13 +362,14 @@ pub fn check_config_process() {
     let f = || {
         // Clear to avoid checking process errors
         // But when the program is just started, the configuration file has not been updated, and the new connection will read an empty configuration
+        // TODO: --server start multi times on windows startup, which will clear the last config and cause concurrent file writing
         HwCodecConfig::clear();
         if let Ok(exe) = std::env::current_exe() {
             if let Some(_) = exe.file_name().to_owned() {
                 let arg = "--check-hwcodec-config";
                 if let Ok(mut child) = std::process::Command::new(exe).arg(arg).spawn() {
-                    // wait up to 10 seconds
-                    for _ in 0..10 {
+                    // wait up to 30 seconds, it maybe slow on windows startup for poorly performing machines
+                    for _ in 0..30 {
                         std::thread::sleep(std::time::Duration::from_secs(1));
                         if let Ok(Some(_)) = child.try_wait() {
                             break;


### PR DESCRIPTION
1. android get_home, bad code get corrent result, file transfer and log are still ok after modification.
This is how it works:
![dad77670a43ab65b2c47125fb331798](https://github.com/rustdesk/rustdesk/assets/14891774/667d937e-de1c-46f1-b1ca-417619025637)

2. The hwcodec check may be slow on poor performance computer on system startup, give more wait time to let it finish the check.