### PR TITLE
fix close on taskbar

### DIFF
--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -448,6 +448,7 @@ class DesktopTab extends StatelessWidget {
           isMainWindow: isMainWindow,
           tabType: tabType,
           state: state,
+          tabController: controller,
           tail: tail,
           showMinimize: showMinimize,
           showMaximize: showMaximize,
@@ -463,6 +464,7 @@ class WindowActionPanel extends StatefulWidget {
   final bool isMainWindow;
   final DesktopTabType tabType;
   final Rx<DesktopTabState> state;
+  final DesktopTabController tabController;
 
   final bool showMinimize;
   final bool showMaximize;
@@ -475,6 +477,7 @@ class WindowActionPanel extends StatefulWidget {
       required this.isMainWindow,
       required this.tabType,
       required this.state,
+      required this.tabController,
       this.tail,
       this.showMinimize = true,
       this.showMaximize = true,
@@ -580,9 +583,32 @@ class WindowActionPanelState extends State<WindowActionPanel>
   void onWindowClose() async {
     mainWindowClose() async => await windowManager.hide();
     notMainWindowClose(WindowController controller) async {
-      await controller.hide();
-      await rustDeskWinManager
-          .call(WindowType.Main, kWindowEventHide, {"id": kWindowId!});
+      if (widget.tabController.length == 0) {
+        debugPrint("close emtpy multiwindow, hide");
+        await controller.hide();
+        await rustDeskWinManager
+            .call(WindowType.Main, kWindowEventHide, {"id": kWindowId!});
+      } else {
+        debugPrint("close not emtpy multiwindow from taskbar");
+        if (Platform.isWindows) {
+          await controller.show();
+          await controller.focus();
+          final res = await widget.onClose?.call() ?? true;
+          if (res) {
+            Future.delayed(Duration.zero, () async {
+              // onWindowClose will be called again to hide
+              await WindowController.fromWindowId(kWindowId!).close();
+            });
+          }
+        } else {
+          // ubuntu22.04 windowOnTop not work from taskbar
+          widget.tabController.clear();
+          Future.delayed(Duration.zero, () async {
+            // onWindowClose will be called again to hide
+            await WindowController.fromWindowId(kWindowId!).close();
+          });
+        }
+      }
     }
 
     macOSWindowClose(


### PR DESCRIPTION
old implement just hide it without closing the connection when closed on taskbar, for this pr when closed on the taskbar:
* Windows behaves as if clicked on the close button in the top right. 
* Linux simply close all tabs since it lacks the ability to top from taskbar. 
* MacOS can't close applications directly from the taskbar

tested remote/file transfer/port forward



https://github.com/rustdesk/rustdesk/assets/14891774/cf26f6d8-7492-4ba5-a4fc-bbb55e9c623d


https://github.com/rustdesk/rustdesk/assets/14891774/5663620a-b5f3-45d0-8da8-30d9409d58fe

