### PR TITLE
yuv 444

### DIFF
--- a/flutter/lib/common/widgets/overlay.dart
+++ b/flutter/lib/common/widgets/overlay.dart
@@ -27,45 +27,44 @@ class DraggableChatWindow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return isIOS
-    ? IOSDraggable (
-      position: position,
-      chatModel: chatModel,
-      width: width,
-      height: height,
-      builder: (context) {
-    return Column(
-      children: [
-        _buildMobileAppBar(context),
-        Expanded(
-          child: ChatPage(chatModel: chatModel),
-              ),
-            ],
-          );
-        },
-      )
-    : Draggable(
-        checkKeyboard: true,
-        position: position,
-        width: width,
-        height: height,
-        chatModel: chatModel,
-        builder: (context, onPanUpdate) {
-          final child = 
-              Scaffold(
-                  resizeToAvoidBottomInset: false,
-                  appBar: CustomAppBar(
-                    onPanUpdate: onPanUpdate,
-                    appBar: isDesktop
-                        ? _buildDesktopAppBar(context)
-                        : _buildMobileAppBar(context),
+        ? IOSDraggable(
+            position: position,
+            chatModel: chatModel,
+            width: width,
+            height: height,
+            builder: (context) {
+              return Column(
+                children: [
+                  _buildMobileAppBar(context),
+                  Expanded(
+                    child: ChatPage(chatModel: chatModel),
                   ),
-                  body: ChatPage(chatModel: chatModel),
-                );
-          return Container(
-              decoration:
-                  BoxDecoration(border: Border.all(color: MyTheme.border)),
-              child: child);
-        });
+                ],
+              );
+            },
+          )
+        : Draggable(
+            checkKeyboard: true,
+            position: position,
+            width: width,
+            height: height,
+            chatModel: chatModel,
+            builder: (context, onPanUpdate) {
+              final child = Scaffold(
+                resizeToAvoidBottomInset: false,
+                appBar: CustomAppBar(
+                  onPanUpdate: onPanUpdate,
+                  appBar: isDesktop
+                      ? _buildDesktopAppBar(context)
+                      : _buildMobileAppBar(context),
+                ),
+                body: ChatPage(chatModel: chatModel),
+              );
+              return Container(
+                  decoration:
+                      BoxDecoration(border: Border.all(color: MyTheme.border)),
+                  child: child);
+            });
   }
 
   Widget _buildMobileAppBar(BuildContext context) {
@@ -354,14 +353,14 @@ class _DraggableState extends State<Draggable> {
 }
 
 class IOSDraggable extends StatefulWidget {
-  const IOSDraggable({
-    Key? key,
-    this.position = Offset.zero,
-    this.chatModel,
-    required this.width,
-    required this.height,
-    required this.builder})
-    : super(key: key);
+  const IOSDraggable(
+      {Key? key,
+      this.position = Offset.zero,
+      this.chatModel,
+      required this.width,
+      required this.height,
+      required this.builder})
+      : super(key: key);
 
   final Offset position;
   final ChatModel? chatModel;
@@ -423,7 +422,7 @@ class _IOSDraggableState extends State<IOSDraggable> {
     _lastBottomHeight = bottomHeight;
   }
 
-@override
+  @override
   Widget build(BuildContext context) {
     checkKeyboard();
     return Stack(
@@ -439,12 +438,12 @@ class _IOSDraggableState extends State<IOSDraggable> {
               _chatModel?.setChatWindowPosition(_position);
             },
             child: Material(
-              child:
-            Container(
-              width: _width,
-              height: _height,
-              decoration: BoxDecoration(border: Border.all(color: MyTheme.border)),
-              child: widget.builder(context),
+              child: Container(
+                width: _width,
+                height: _height,
+                decoration:
+                    BoxDecoration(border: Border.all(color: MyTheme.border)),
+                child: widget.builder(context),
               ),
             ),
           ),
@@ -499,6 +498,7 @@ class QualityMonitor extends StatelessWidget {
                           "${qualityMonitorModel.data.targetBitrate ?? '-'}kb"),
                       _row(
                           "Codec", qualityMonitorModel.data.codecFormat ?? '-'),
+                      _row("Chroma", qualityMonitorModel.data.chroma ?? '-'),
                     ],
                   ),
                 )

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -547,5 +547,22 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
         child: Text(translate('Use all my displays for the remote session'))));
   }
 
+  // 444
+  final codec_format = ffi.qualityMonitorModel.data.codecFormat;
+  if (versionCmp(pi.version, "1.2.4") >= 0 &&
+      (codec_format == "AV1" || codec_format == "VP9")) {
+    final option = 'i444';
+    final value =
+        bind.sessionGetToggleOptionSync(sessionId: sessionId, arg: option);
+    v.add(TToggleMenu(
+        value: value,
+        onChanged: (value) async {
+          if (value == null) return;
+          await bind.sessionToggleOption(sessionId: sessionId, value: option);
+          bind.sessionChangePreferCodec(sessionId: sessionId);
+        },
+        child: Text(translate('True color(4:4:4)'))));
+  }
+
   return v;
 }

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1320,6 +1320,7 @@ class _DisplayState extends State<_Display> {
       otherRow('Lock after session end', 'lock_after_session_end'),
       otherRow('Privacy mode', 'privacy_mode'),
       otherRow('Reverse mouse wheel', 'reverse_mouse_wheel'),
+      otherRow('True color(4:4:4)', 'i444'),
     ];
     if (useTextureRender) {
       children.add(otherRow('Show displays as individual windows',

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -797,6 +797,7 @@ class __DisplayPageState extends State<_DisplayPage> {
             otherRow('Lock after session end', 'lock_after_session_end'),
             otherRow('Privacy mode', 'privacy_mode'),
             otherRow('Touch mode', 'touch-mode'),
+            otherRow('True color(4:4:4)', 'i444'),
           ],
         ),
       ]),

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1845,6 +1845,7 @@ class QualityMonitorData {
   String? delay;
   String? targetBitrate;
   String? codecFormat;
+  String? chroma;
 }
 
 class QualityMonitorModel with ChangeNotifier {
@@ -1897,6 +1898,9 @@ class QualityMonitorModel with ChangeNotifier {
       }
       if ((evt['codec_format'] as String).isNotEmpty) {
         _data.codecFormat = evt['codec_format'];
+      }
+      if ((evt['chroma'] as String).isNotEmpty) {
+        _data.chroma = evt['chroma'];
       }
       notifyListeners();
     } catch (e) {

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -17,6 +17,11 @@ message YUV {
   int32 stride = 2;
 }
 
+enum Chroma {
+  I420 = 0;
+  I444 = 1;
+}
+
 message VideoFrame {
   oneof union {
     EncodedVideoFrames vp9s = 6;
@@ -83,11 +88,20 @@ message Features {
   bool privacy_mode = 1;
 }
 
+message CodecAbility {
+  bool vp8 = 1;
+  bool vp9 = 2;
+  bool av1 = 3;
+  bool h264 = 4;
+  bool h265 = 5;
+}
+
 message SupportedEncoding {
   bool h264 = 1;
   bool h265 = 2;
   bool vp8 = 3;
   bool av1 = 4;
+  CodecAbility i444 = 5;
 }
 
 message PeerInfo {
@@ -541,6 +555,8 @@ message SupportedDecoding {
   PreferCodec prefer = 4;
   int32 ability_vp8 = 5;
   int32 ability_av1 = 6;
+  CodecAbility i444 = 7;
+  Chroma prefer_chroma = 8;
 }
 
 message OptionMessage {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1229,6 +1229,10 @@ impl PeerConfig {
         if !mp.contains_key(key) {
             mp.insert(key.to_owned(), UserDefaultConfig::read().get(key));
         }
+        key = "i444";
+        if !mp.contains_key(key) {
+            mp.insert(key.to_owned(), UserDefaultConfig::read().get(key));
+        }
     }
 }
 

--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -197,6 +197,7 @@ fn main() {
     find_package("libyuv");
     gen_vcpkg_package("libvpx", "vpx_ffi.h", "vpx_ffi.rs", "^[vV].*");
     gen_vcpkg_package("aom", "aom_ffi.h", "aom_ffi.rs", "^(aom|AOM|OBU|AV1).*");
+    gen_vcpkg_package("libyuv", "yuv_ffi.h", "yuv_ffi.rs", ".*");
 
     // there is problem with cfg(target_os) in build.rs, so use our workaround
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/libs/scrap/examples/capture_mag.rs
+++ b/libs/scrap/examples/capture_mag.rs
@@ -3,7 +3,7 @@ extern crate scrap;
 
 use scrap::Display;
 #[cfg(windows)]
-use scrap::{i420_to_rgb, CapturerMag, TraitCapturer};
+use scrap::{CapturerMag, TraitCapturer};
 #[cfg(windows)]
 use std::fs::File;
 
@@ -24,6 +24,8 @@ fn get_display(i: usize) -> Display {
 fn record(i: usize) {
     use std::time::Duration;
 
+    use scrap::TraitFrame;
+
     for d in Display::all().unwrap() {
         println!("{:?} {} {}", d.origin(), d.width(), d.height());
     }
@@ -32,9 +34,8 @@ fn record(i: usize) {
     let (w, h) = (display.width(), display.height());
 
     {
-        let mut capture_mag =
-            CapturerMag::new(display.origin(), display.width(), display.height(), false)
-                .expect("Couldn't begin capture.");
+        let mut capture_mag = CapturerMag::new(display.origin(), display.width(), display.height())
+            .expect("Couldn't begin capture.");
         let wnd_cls = "";
         let wnd_name = "RustDeskPrivacyWindow";
         if false == capture_mag.exclude(wnd_cls, wnd_name).unwrap() {
@@ -43,7 +44,8 @@ fn record(i: usize) {
             println!("Filter window for cls {} name {}", wnd_cls, wnd_name);
         }
 
-        let frame = capture_mag.frame(Duration::from_millis(0)).unwrap();
+        let captured_frame = capture_mag.frame(Duration::from_millis(0)).unwrap();
+        let frame = captured_frame.data();
         println!("Capture data len: {}, Saving...", frame.len());
 
         let mut bitflipped = Vec::with_capacity(w * h * 4);
@@ -68,9 +70,8 @@ fn record(i: usize) {
     }
 
     {
-        let mut capture_mag =
-            CapturerMag::new(display.origin(), display.width(), display.height(), true)
-                .expect("Couldn't begin capture.");
+        let mut capture_mag = CapturerMag::new(display.origin(), display.width(), display.height())
+            .expect("Couldn't begin capture.");
         let wnd_cls = "";
         let wnd_title = "RustDeskPrivacyWindow";
         if false == capture_mag.exclude(wnd_cls, wnd_title).unwrap() {
@@ -79,19 +80,28 @@ fn record(i: usize) {
             println!("Filter window for cls {} title {}", wnd_cls, wnd_title);
         }
 
-        let buffer = capture_mag.frame(Duration::from_millis(0)).unwrap();
-        println!("Capture data len: {}, Saving...", buffer.len());
+        let frame = capture_mag.frame(Duration::from_millis(0)).unwrap();
+        println!("Capture data len: {}, Saving...", frame.data().len());
 
-        let mut frame = Default::default();
-        i420_to_rgb(w, h, &buffer, &mut frame);
+        let mut raw = Vec::new();
+        unsafe {
+            scrap::ARGBToRAW(
+                frame.data().as_ptr(),
+                frame.stride()[0] as _,
+                (&mut raw).as_mut_ptr(),
+                (w * 3) as _,
+                w as _,
+                h as _,
+            )
+        };
 
         let mut bitflipped = Vec::with_capacity(w * h * 4);
-        let stride = frame.len() / h;
+        let stride = raw.len() / h;
 
         for y in 0..h {
             for x in 0..w {
                 let i = stride * y + 3 * x;
-                bitflipped.extend_from_slice(&[frame[i], frame[i + 1], frame[i + 2], 255]);
+                bitflipped.extend_from_slice(&[raw[i], raw[i + 1], raw[i + 2], 255]);
             }
         }
         let name = format!("capture_mag_{}_2.png", i);

--- a/libs/scrap/examples/ffplay.rs
+++ b/libs/scrap/examples/ffplay.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use scrap::TraitFrame;
+
 extern crate scrap;
 
 fn main() {
@@ -27,16 +29,16 @@ fn main() {
         .spawn()
         .expect("This example requires ffplay.");
 
-    let mut capturer = Capturer::new(d, false).unwrap();
+    let mut capturer = Capturer::new(d).unwrap();
     let mut out = child.stdin.unwrap();
 
     loop {
         match capturer.frame(Duration::from_millis(0)) {
             Ok(frame) => {
                 // Write the frame, removing end-of-row padding.
-                let stride = frame.len() / h;
+                let stride = frame.stride()[0];
                 let rowlen = 4 * w;
-                for row in frame.chunks(stride) {
+                for row in frame.data().chunks(stride) {
                     let row = &row[..rowlen];
                     out.write_all(row).unwrap();
                 }

--- a/libs/scrap/examples/record-screen.rs
+++ b/libs/scrap/examples/record-screen.rs
@@ -17,7 +17,7 @@ use scrap::codec::{EncoderApi, EncoderCfg, Quality as Q};
 use webm::mux;
 use webm::mux::Track;
 
-use scrap::vpxcodec as vpx_encode;
+use scrap::{convert_to_yuv, vpxcodec as vpx_encode};
 use scrap::{Capturer, Display, TraitCapturer, STRIDE_ALIGN};
 
 const USAGE: &'static str = "
@@ -110,13 +110,16 @@ fn main() -> io::Result<()> {
         Quality::Balanced => Q::Balanced,
         Quality::Low => Q::Low,
     };
-    let mut vpx = vpx_encode::VpxEncoder::new(EncoderCfg::VPX(vpx_encode::VpxEncoderConfig {
-        width,
-        height,
-        quality,
-        codec: vpx_codec,
-        keyframe_interval: None,
-    }))
+    let mut vpx = vpx_encode::VpxEncoder::new(
+        EncoderCfg::VPX(vpx_encode::VpxEncoderConfig {
+            width,
+            height,
+            quality,
+            codec: vpx_codec,
+            keyframe_interval: None,
+        }),
+        false,
+    )
     .unwrap();
 
     // Start recording.
@@ -136,7 +139,9 @@ fn main() -> io::Result<()> {
     let spf = Duration::from_nanos(1_000_000_000 / args.flag_fps);
 
     // Capturer object is expensive, avoiding to create it frequently.
-    let mut c = Capturer::new(d, true).unwrap();
+    let mut c = Capturer::new(d).unwrap();
+    let mut yuv = Vec::new();
+    let mut mid_data = Vec::new();
     while !stop.load(Ordering::Acquire) {
         let now = Instant::now();
         let time = now - start;
@@ -147,8 +152,8 @@ fn main() -> io::Result<()> {
 
         if let Ok(frame) = c.frame(Duration::from_millis(0)) {
             let ms = time.as_secs() * 1000 + time.subsec_millis() as u64;
-
-            for frame in vpx.encode(ms as i64, &frame, STRIDE_ALIGN).unwrap() {
+            convert_to_yuv(&frame, vpx.yuvfmt(), &mut yuv, &mut mid_data);
+            for frame in vpx.encode(ms as i64, &yuv, STRIDE_ALIGN).unwrap() {
                 vt.add_frame(frame.data, frame.pts as u64 * 1_000_000, frame.key);
             }
         }

--- a/libs/scrap/src/bindings/yuv_ffi.h
+++ b/libs/scrap/src/bindings/yuv_ffi.h
@@ -1,0 +1,6 @@
+#include <libyuv/convert.h>
+#include <libyuv/convert_argb.h>
+#include <libyuv/convert_from.h>
+#include <libyuv/convert_from_argb.h>
+#include <libyuv/rotate.h>
+#include <libyuv/rotate_argb.h>

--- a/libs/scrap/src/common/android.rs
+++ b/libs/scrap/src/common/android.rs
@@ -1,5 +1,5 @@
 use crate::android::ffi::*;
-use crate::rgba_to_i420;
+use crate::Pixfmt;
 use lazy_static::lazy_static;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -12,15 +12,15 @@ lazy_static! {
 
 pub struct Capturer {
     display: Display,
-    bgra: Vec<u8>,
+    rgba: Vec<u8>,
     saved_raw_data: Vec<u8>, // for faster compare and copy
 }
 
 impl Capturer {
-    pub fn new(display: Display, _yuv: bool) -> io::Result<Capturer> {
+    pub fn new(display: Display) -> io::Result<Capturer> {
         Ok(Capturer {
             display,
-            bgra: Vec::new(),
+            rgba: Vec::new(),
             saved_raw_data: Vec::new(),
         })
     }
@@ -35,22 +35,47 @@ impl Capturer {
 }
 
 impl crate::TraitCapturer for Capturer {
-    fn set_use_yuv(&mut self, _use_yuv: bool) {}
-
     fn frame<'a>(&'a mut self, _timeout: Duration) -> io::Result<Frame<'a>> {
         if let Some(buf) = get_video_raw() {
             crate::would_block_if_equal(&mut self.saved_raw_data, buf)?;
-            rgba_to_i420(self.width(), self.height(), buf, &mut self.bgra);
-            Ok(Frame::RAW(&self.bgra))
+            // Is it safe to directly return buf without copy?
+            self.rgba.resize(buf.len(), 0);
+            unsafe {
+                std::ptr::copy_nonoverlapping(buf.as_ptr(), self.rgba.as_mut_ptr(), buf.len())
+            };
+            Ok(Frame::new(&self.rgba, self.height()))
         } else {
             return Err(io::ErrorKind::WouldBlock.into());
         }
     }
 }
 
-pub enum Frame<'a> {
-    RAW(&'a [u8]),
-    Empty,
+pub struct Frame<'a> {
+    pub data: &'a [u8],
+    pub stride: Vec<usize>,
+}
+
+impl<'a> Frame<'a> {
+    pub fn new(data: &'a [u8], h: usize) -> Self {
+        let stride = data.len() / h;
+        let mut v = Vec::new();
+        v.push(stride);
+        Frame { data, stride: v }
+    }
+}
+
+impl<'a> crate::TraitFrame for Frame<'a> {
+    fn data(&self) -> &[u8] {
+        self.data
+    }
+
+    fn stride(&self) -> Vec<usize> {
+        self.stride.clone()
+    }
+
+    fn pixfmt(&self) -> Pixfmt {
+        Pixfmt::RGBA
+    }
 }
 
 pub struct Display {

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -14,7 +14,7 @@ use crate::{
     aom::{self, AomDecoder, AomEncoder, AomEncoderConfig},
     common::GoogleImage,
     vpxcodec::{self, VpxDecoder, VpxDecoderConfig, VpxEncoder, VpxEncoderConfig, VpxVideoCodecId},
-    CodecName, ImageRgb,
+    CodecName, EncodeYuvFormat, ImageRgb,
 };
 
 use hbb_common::{
@@ -23,7 +23,7 @@ use hbb_common::{
     config::PeerConfig,
     log,
     message_proto::{
-        supported_decoding::PreferCodec, video_frame, EncodedVideoFrames,
+        supported_decoding::PreferCodec, video_frame, Chroma, CodecAbility, EncodedVideoFrames,
         SupportedDecoding, SupportedEncoding, VideoFrame,
     },
     sysinfo::{System, SystemExt},
@@ -56,13 +56,13 @@ pub enum EncoderCfg {
 }
 
 pub trait EncoderApi {
-    fn new(cfg: EncoderCfg) -> ResultType<Self>
+    fn new(cfg: EncoderCfg, i444: bool) -> ResultType<Self>
     where
         Self: Sized;
 
     fn encode_to_message(&mut self, frame: &[u8], ms: i64) -> ResultType<VideoFrame>;
 
-    fn use_yuv(&self) -> bool;
+    fn yuvfmt(&self) -> EncodeYuvFormat;
 
     fn set_quality(&mut self, quality: Quality) -> ResultType<()>;
 
@@ -107,18 +107,18 @@ pub enum EncodingUpdate {
 }
 
 impl Encoder {
-    pub fn new(config: EncoderCfg) -> ResultType<Encoder> {
-        log::info!("new encoder:{:?}", config);
+    pub fn new(config: EncoderCfg, i444: bool) -> ResultType<Encoder> {
+        log::info!("new encoder:{config:?}, i444:{i444}");
         match config {
             EncoderCfg::VPX(_) => Ok(Encoder {
-                codec: Box::new(VpxEncoder::new(config)?),
+                codec: Box::new(VpxEncoder::new(config, i444)?),
             }),
             EncoderCfg::AOM(_) => Ok(Encoder {
-                codec: Box::new(AomEncoder::new(config)?),
+                codec: Box::new(AomEncoder::new(config, i444)?),
             }),
 
             #[cfg(feature = "hwcodec")]
-            EncoderCfg::HW(_) => match HwEncoder::new(config) {
+            EncoderCfg::HW(_) => match HwEncoder::new(config, i444) {
                 Ok(hw) => Ok(Encoder {
                     codec: Box::new(hw),
                 }),
@@ -230,6 +230,12 @@ impl Encoder {
         let mut encoding = SupportedEncoding {
             vp8: true,
             av1: true,
+            i444: Some(CodecAbility {
+                vp9: true,
+                av1: true,
+                ..Default::default()
+            })
+            .into(),
             ..Default::default()
         };
         #[cfg(feature = "hwcodec")]
@@ -240,18 +246,41 @@ impl Encoder {
         }
         encoding
     }
+
+    pub fn use_i444(config: &EncoderCfg) -> bool {
+        let decodings = PEER_DECODINGS.lock().unwrap().clone();
+        let prefer_i444 = decodings
+            .iter()
+            .all(|d| d.1.prefer_chroma == Chroma::I444.into());
+        let i444_useable = match config {
+            EncoderCfg::VPX(vpx) => match vpx.codec {
+                VpxVideoCodecId::VP8 => false,
+                VpxVideoCodecId::VP9 => decodings.iter().all(|d| d.1.i444.vp9),
+            },
+            EncoderCfg::AOM(_) => decodings.iter().all(|d| d.1.i444.av1),
+            EncoderCfg::HW(_) => false,
+        };
+        prefer_i444 && i444_useable && !decodings.is_empty()
+    }
 }
 
 impl Decoder {
     pub fn supported_decodings(id_for_perfer: Option<&str>) -> SupportedDecoding {
+        let (prefer, prefer_chroma) = Self::preference(id_for_perfer);
+
         #[allow(unused_mut)]
         let mut decoding = SupportedDecoding {
             ability_vp8: 1,
             ability_vp9: 1,
             ability_av1: 1,
-            prefer: id_for_perfer
-                .map_or(PreferCodec::Auto, |id| Self::codec_preference(id))
-                .into(),
+            i444: Some(CodecAbility {
+                vp9: true,
+                av1: true,
+                ..Default::default()
+            })
+            .into(),
+            prefer: prefer.into(),
+            prefer_chroma: prefer_chroma.into(),
             ..Default::default()
         };
         #[cfg(feature = "hwcodec")]
@@ -314,31 +343,33 @@ impl Decoder {
         &mut self,
         frame: &video_frame::Union,
         rgb: &mut ImageRgb,
+        chroma: &mut Option<Chroma>,
     ) -> ResultType<bool> {
         match frame {
             video_frame::Union::Vp8s(vp8s) => {
                 if let Some(vp8) = &mut self.vp8 {
-                    Decoder::handle_vpxs_video_frame(vp8, vp8s, rgb)
+                    Decoder::handle_vpxs_video_frame(vp8, vp8s, rgb, chroma)
                 } else {
                     bail!("vp8 decoder not available");
                 }
             }
             video_frame::Union::Vp9s(vp9s) => {
                 if let Some(vp9) = &mut self.vp9 {
-                    Decoder::handle_vpxs_video_frame(vp9, vp9s, rgb)
+                    Decoder::handle_vpxs_video_frame(vp9, vp9s, rgb, chroma)
                 } else {
                     bail!("vp9 decoder not available");
                 }
             }
             video_frame::Union::Av1s(av1s) => {
                 if let Some(av1) = &mut self.av1 {
-                    Decoder::handle_av1s_video_frame(av1, av1s, rgb)
+                    Decoder::handle_av1s_video_frame(av1, av1s, rgb, chroma)
                 } else {
                     bail!("av1 decoder not available");
                 }
             }
             #[cfg(feature = "hwcodec")]
             video_frame::Union::H264s(h264s) => {
+                *chroma = Some(Chroma::I420);
                 if let Some(decoder) = &mut self.hw.h264 {
                     Decoder::handle_hw_video_frame(decoder, h264s, rgb, &mut self.i420)
                 } else {
@@ -347,6 +378,7 @@ impl Decoder {
             }
             #[cfg(feature = "hwcodec")]
             video_frame::Union::H265s(h265s) => {
+                *chroma = Some(Chroma::I420);
                 if let Some(decoder) = &mut self.hw.h265 {
                     Decoder::handle_hw_video_frame(decoder, h265s, rgb, &mut self.i420)
                 } else {
@@ -355,6 +387,7 @@ impl Decoder {
             }
             #[cfg(feature = "mediacodec")]
             video_frame::Union::H264s(h264s) => {
+                *chroma = Some(Chroma::I420);
                 if let Some(decoder) = &mut self.media_codec.h264 {
                     Decoder::handle_mediacodec_video_frame(decoder, h264s, rgb)
                 } else {
@@ -363,6 +396,7 @@ impl Decoder {
             }
             #[cfg(feature = "mediacodec")]
             video_frame::Union::H265s(h265s) => {
+                *chroma = Some(Chroma::I420);
                 if let Some(decoder) = &mut self.media_codec.h265 {
                     Decoder::handle_mediacodec_video_frame(decoder, h265s, rgb)
                 } else {
@@ -378,6 +412,7 @@ impl Decoder {
         decoder: &mut VpxDecoder,
         vpxs: &EncodedVideoFrames,
         rgb: &mut ImageRgb,
+        chroma: &mut Option<Chroma>,
     ) -> ResultType<bool> {
         let mut last_frame = vpxcodec::Image::new();
         for vpx in vpxs.frames.iter() {
@@ -393,6 +428,7 @@ impl Decoder {
         if last_frame.is_null() {
             Ok(false)
         } else {
+            *chroma = Some(last_frame.chroma());
             last_frame.to(rgb);
             Ok(true)
         }
@@ -403,6 +439,7 @@ impl Decoder {
         decoder: &mut AomDecoder,
         av1s: &EncodedVideoFrames,
         rgb: &mut ImageRgb,
+        chroma: &mut Option<Chroma>,
     ) -> ResultType<bool> {
         let mut last_frame = aom::Image::new();
         for av1 in av1s.frames.iter() {
@@ -418,6 +455,7 @@ impl Decoder {
         if last_frame.is_null() {
             Ok(false)
         } else {
+            *chroma = Some(last_frame.chroma());
             last_frame.to(rgb);
             Ok(true)
         }
@@ -457,12 +495,16 @@ impl Decoder {
         return Ok(false);
     }
 
-    fn codec_preference(id: &str) -> PreferCodec {
-        let codec = PeerConfig::load(id)
-            .options
+    fn preference(id: Option<&str>) -> (PreferCodec, Chroma) {
+        let id = id.unwrap_or_default();
+        if id.is_empty() {
+            return (PreferCodec::Auto, Chroma::I420);
+        }
+        let options = PeerConfig::load(id).options;
+        let codec = options
             .get("codec-preference")
             .map_or("".to_owned(), |c| c.to_owned());
-        if codec == "vp8" {
+        let codec = if codec == "vp8" {
             PreferCodec::VP8
         } else if codec == "vp9" {
             PreferCodec::VP9
@@ -474,7 +516,13 @@ impl Decoder {
             PreferCodec::H265
         } else {
             PreferCodec::Auto
-        }
+        };
+        let chroma = if options.get("i444") == Some(&"Y".to_string()) {
+            Chroma::I444
+        } else {
+            Chroma::I420
+        };
+        (codec, chroma)
     }
 }
 

--- a/libs/scrap/src/common/convert.rs
+++ b/libs/scrap/src/common/convert.rs
@@ -1,366 +1,24 @@
-use super::vpx::*;
-use std::os::raw::c_int;
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(improper_ctypes)]
+#![allow(dead_code)]
 
-extern "C" {
-    // seems libyuv uses reverse byte order compared with our view
+include!(concat!(env!("OUT_DIR"), "/yuv_ffi.rs"));
 
-    pub fn ARGBRotate(
-        src_argb: *const u8,
-        src_stride_argb: c_int,
-        dst_argb: *mut u8,
-        dst_stride_argb: c_int,
-        src_width: c_int,
-        src_height: c_int,
-        mode: c_int,
-    ) -> c_int;
+#[cfg(not(target_os = "ios"))]
+use crate::Frame;
+use crate::{generate_call_macro, EncodeYuvFormat, TraitFrame};
+use hbb_common::{bail, log, ResultType};
 
-    pub fn ARGBMirror(
-        src_argb: *const u8,
-        src_stride_argb: c_int,
-        dst_argb: *mut u8,
-        dst_stride_argb: c_int,
-        width: c_int,
-        height: c_int,
-    ) -> c_int;
-
-    pub fn ARGBToI420(
-        src_bgra: *const u8,
-        src_stride_bgra: c_int,
-        dst_y: *mut u8,
-        dst_stride_y: c_int,
-        dst_u: *mut u8,
-        dst_stride_u: c_int,
-        dst_v: *mut u8,
-        dst_stride_v: c_int,
-        width: c_int,
-        height: c_int,
-    ) -> c_int;
-
-    pub fn ABGRToI420(
-        src_rgba: *const u8,
-        src_stride_rgba: c_int,
-        dst_y: *mut u8,
-        dst_stride_y: c_int,
-        dst_u: *mut u8,
-        dst_stride_u: c_int,
-        dst_v: *mut u8,
-        dst_stride_v: c_int,
-        width: c_int,
-        height: c_int,
-    ) -> c_int;
-
-    pub fn ARGBToNV12(
-        src_bgra: *const u8,
-        src_stride_bgra: c_int,
-        dst_y: *mut u8,
-        dst_stride_y: c_int,
-        dst_uv: *mut u8,
-        dst_stride_uv: c_int,
-        width: c_int,
-        height: c_int,
-    ) -> c_int;
-
-    pub fn NV12ToI420(
-        src_y: *const u8,
-        src_stride_y: c_int,
-        src_uv: *const u8,
-        src_stride_uv: c_int,
-        dst_y: *mut u8,
-        dst_stride_y: c_int,
-        dst_u: *mut u8,
-        dst_stride_u: c_int,
-        dst_v: *mut u8,
-        dst_stride_v: c_int,
-        width: c_int,
-        height: c_int,
-    ) -> c_int;
-
-    // I420ToRGB24: RGB little endian (bgr in memory)
-    // I420ToRaw: RGB big endian (rgb in memory) to RGBA.
-    pub fn I420ToRAW(
-        src_y: *const u8,
-        src_stride_y: c_int,
-        src_u: *const u8,
-        src_stride_u: c_int,
-        src_v: *const u8,
-        src_stride_v: c_int,
-        dst_rgba: *mut u8,
-        dst_stride_raw: c_int,
-        width: c_int,
-        height: c_int,
-    ) -> c_int;
-
-    pub fn I420ToARGB(
-        src_y: *const u8,
-        src_stride_y: c_int,
-        src_u: *const u8,
-        src_stride_u: c_int,
-        src_v: *const u8,
-        src_stride_v: c_int,
-        dst_rgba: *mut u8,
-        dst_stride_rgba: c_int,
-        width: c_int,
-        height: c_int,
-    ) -> c_int;
-
-    pub fn I420ToABGR(
-        src_y: *const u8,
-        src_stride_y: c_int,
-        src_u: *const u8,
-        src_stride_u: c_int,
-        src_v: *const u8,
-        src_stride_v: c_int,
-        dst_rgba: *mut u8,
-        dst_stride_rgba: c_int,
-        width: c_int,
-        height: c_int,
-    ) -> c_int;
-
-    pub fn NV12ToARGB(
-        src_y: *const u8,
-        src_stride_y: c_int,
-        src_uv: *const u8,
-        src_stride_uv: c_int,
-        dst_rgba: *mut u8,
-        dst_stride_rgba: c_int,
-        width: c_int,
-        height: c_int,
-    ) -> c_int;
-
-    pub fn NV12ToABGR(
-        src_y: *const u8,
-        src_stride_y: c_int,
-        src_uv: *const u8,
-        src_stride_uv: c_int,
-        dst_rgba: *mut u8,
-        dst_stride_rgba: c_int,
-        width: c_int,
-        height: c_int,
-    ) -> c_int;
-}
-
-// https://github.com/webmproject/libvpx/blob/master/vpx/src/vpx_image.c
-#[inline]
-fn get_vpx_i420_stride(
-    width: usize,
-    height: usize,
-    stride_align: usize,
-) -> (usize, usize, usize, usize, usize, usize) {
-    let mut img = Default::default();
-    unsafe {
-        vpx_img_wrap(
-            &mut img,
-            vpx_img_fmt::VPX_IMG_FMT_I420,
-            width as _,
-            height as _,
-            stride_align as _,
-            0x1 as _,
-        );
-    }
-    (
-        img.w as _,
-        img.h as _,
-        img.stride[0] as _,
-        img.stride[1] as _,
-        img.planes[1] as usize - img.planes[0] as usize,
-        img.planes[2] as usize - img.planes[0] as usize,
-    )
-}
-
-pub fn i420_to_rgb(width: usize, height: usize, src: &[u8], dst: &mut Vec<u8>) {
-    let (_, _, src_stride_y, src_stride_uv, u, v) =
-        get_vpx_i420_stride(width, height, super::STRIDE_ALIGN);
-    let src_y = src.as_ptr();
-    let src_u = src[u..].as_ptr();
-    let src_v = src[v..].as_ptr();
-    dst.resize(width * height * 3, 0);
-    unsafe {
-        super::I420ToRAW(
-            src_y,
-            src_stride_y as _,
-            src_u,
-            src_stride_uv as _,
-            src_v,
-            src_stride_uv as _,
-            dst.as_mut_ptr(),
-            (width * 3) as _,
-            width as _,
-            height as _,
-        );
-    };
-}
-
-pub fn i420_to_bgra(width: usize, height: usize, src: &[u8], dst: &mut Vec<u8>) {
-    let (_, _, src_stride_y, src_stride_uv, u, v) =
-        get_vpx_i420_stride(width, height, super::STRIDE_ALIGN);
-    let src_y = src.as_ptr();
-    let src_u = src[u..].as_ptr();
-    let src_v = src[v..].as_ptr();
-    dst.resize(width * height * 4, 0);
-    unsafe {
-        super::I420ToARGB(
-            src_y,
-            src_stride_y as _,
-            src_u,
-            src_stride_uv as _,
-            src_v,
-            src_stride_uv as _,
-            dst.as_mut_ptr(),
-            (width * 3) as _,
-            width as _,
-            height as _,
-        );
-    };
-}
-
-pub fn bgra_to_i420(width: usize, height: usize, src: &[u8], dst: &mut Vec<u8>) {
-    let (_, h, dst_stride_y, dst_stride_uv, u, v) =
-        get_vpx_i420_stride(width, height, super::STRIDE_ALIGN);
-    dst.resize(h * dst_stride_y * 2, 0); // waste some memory to ensure memory safety
-    let dst_y = dst.as_mut_ptr();
-    let dst_u = dst[u..].as_mut_ptr();
-    let dst_v = dst[v..].as_mut_ptr();
-    unsafe {
-        ARGBToI420(
-            src.as_ptr(),
-            (src.len() / height) as _,
-            dst_y,
-            dst_stride_y as _,
-            dst_u,
-            dst_stride_uv as _,
-            dst_v,
-            dst_stride_uv as _,
-            width as _,
-            height as _,
-        );
-    }
-}
-
-pub fn rgba_to_i420(width: usize, height: usize, src: &[u8], dst: &mut Vec<u8>) {
-    let (_, h, dst_stride_y, dst_stride_uv, u, v) =
-        get_vpx_i420_stride(width, height, super::STRIDE_ALIGN);
-    dst.resize(h * dst_stride_y * 2, 0); // waste some memory to ensure memory safety
-    let dst_y = dst.as_mut_ptr();
-    let dst_u = dst[u..].as_mut_ptr();
-    let dst_v = dst[v..].as_mut_ptr();
-    unsafe {
-        ABGRToI420(
-            src.as_ptr(),
-            (src.len() / height) as _,
-            dst_y,
-            dst_stride_y as _,
-            dst_u,
-            dst_stride_uv as _,
-            dst_v,
-            dst_stride_uv as _,
-            width as _,
-            height as _,
-        );
-    }
-}
-
-pub unsafe fn nv12_to_i420(
-    src_y: *const u8,
-    src_stride_y: c_int,
-    src_uv: *const u8,
-    src_stride_uv: c_int,
-    width: usize,
-    height: usize,
-    dst: &mut Vec<u8>,
-) {
-    let (_, h, dst_stride_y, dst_stride_uv, u, v) =
-        get_vpx_i420_stride(width, height, super::STRIDE_ALIGN);
-    dst.resize(h * dst_stride_y * 2, 0); // waste some memory to ensure memory safety
-    let dst_y = dst.as_mut_ptr();
-    let dst_u = dst[u..].as_mut_ptr();
-    let dst_v = dst[v..].as_mut_ptr();
-    NV12ToI420(
-        src_y,
-        src_stride_y,
-        src_uv,
-        src_stride_uv,
-        dst_y,
-        dst_stride_y as _,
-        dst_u,
-        dst_stride_uv as _,
-        dst_v,
-        dst_stride_uv as _,
-        width as _,
-        height as _,
-    );
-}
+generate_call_macro!(call_yuv, false);
 
 #[cfg(feature = "hwcodec")]
 pub mod hw {
+    use super::*;
     use crate::ImageFormat;
-    use hbb_common::{anyhow::anyhow, ResultType};
     #[cfg(target_os = "windows")]
     use hwcodec::{ffmpeg::ffmpeg_linesize_offset_length, AVPixelFormat};
-
-    pub fn hw_bgra_to_i420(
-        width: usize,
-        height: usize,
-        stride: &[i32],
-        offset: &[i32],
-        length: i32,
-        src: &[u8],
-        dst: &mut Vec<u8>,
-    ) {
-        let stride_y = stride[0] as usize;
-        let stride_u = stride[1] as usize;
-        let stride_v = stride[2] as usize;
-        let offset_u = offset[0] as usize;
-        let offset_v = offset[1] as usize;
-
-        dst.resize(length as _, 0);
-        let dst_y = dst.as_mut_ptr();
-        let dst_u = dst[offset_u..].as_mut_ptr();
-        let dst_v = dst[offset_v..].as_mut_ptr();
-        unsafe {
-            super::ARGBToI420(
-                src.as_ptr(),
-                (src.len() / height) as _,
-                dst_y,
-                stride_y as _,
-                dst_u,
-                stride_u as _,
-                dst_v,
-                stride_v as _,
-                width as _,
-                height as _,
-            );
-        }
-    }
-
-    pub fn hw_bgra_to_nv12(
-        width: usize,
-        height: usize,
-        stride: &[i32],
-        offset: &[i32],
-        length: i32,
-        src: &[u8],
-        dst: &mut Vec<u8>,
-    ) {
-        let stride_y = stride[0] as usize;
-        let stride_uv = stride[1] as usize;
-        let offset_uv = offset[0] as usize;
-
-        dst.resize(length as _, 0);
-        let dst_y = dst.as_mut_ptr();
-        let dst_uv = dst[offset_uv..].as_mut_ptr();
-        unsafe {
-            super::ARGBToNV12(
-                src.as_ptr(),
-                (src.len() / height) as _,
-                dst_y,
-                stride_y as _,
-                dst_uv,
-                stride_uv as _,
-                width as _,
-                height as _,
-            );
-        }
-    }
 
     #[cfg(target_os = "windows")]
     pub fn hw_nv12_to(
@@ -386,61 +44,59 @@ pub mod hw {
             let i420_stride_v = linesize_i420[2];
             i420.resize(i420_len as _, 0);
 
-            unsafe {
-                let i420_offset_y = i420.as_ptr().add(0) as _;
-                let i420_offset_u = i420.as_ptr().add(offset_i420[0] as _) as _;
-                let i420_offset_v = i420.as_ptr().add(offset_i420[1] as _) as _;
-                super::NV12ToI420(
-                    src_y.as_ptr(),
-                    nv12_stride_y as _,
-                    src_uv.as_ptr(),
-                    nv12_stride_uv as _,
-                    i420_offset_y,
-                    i420_stride_y,
-                    i420_offset_u,
-                    i420_stride_u,
-                    i420_offset_v,
-                    i420_stride_v,
-                    width as _,
-                    height as _,
-                );
-                match fmt {
-                    ImageFormat::ARGB => {
-                        super::I420ToARGB(
-                            i420_offset_y,
-                            i420_stride_y,
-                            i420_offset_u,
-                            i420_stride_u,
-                            i420_offset_v,
-                            i420_stride_v,
-                            dst.as_mut_ptr(),
-                            (width * 4) as _,
-                            width as _,
-                            height as _,
-                        );
-                    }
-                    ImageFormat::ABGR => {
-                        super::I420ToABGR(
-                            i420_offset_y,
-                            i420_stride_y,
-                            i420_offset_u,
-                            i420_stride_u,
-                            i420_offset_v,
-                            i420_stride_v,
-                            dst.as_mut_ptr(),
-                            (width * 4) as _,
-                            width as _,
-                            height as _,
-                        );
-                    }
-                    _ => {
-                        return Err(anyhow!("unsupported image format"));
-                    }
+            let i420_offset_y = unsafe { i420.as_ptr().add(0) as _ };
+            let i420_offset_u = unsafe { i420.as_ptr().add(offset_i420[0] as _) as _ };
+            let i420_offset_v = unsafe { i420.as_ptr().add(offset_i420[1] as _) as _ };
+            call_yuv!(NV12ToI420(
+                src_y.as_ptr(),
+                nv12_stride_y as _,
+                src_uv.as_ptr(),
+                nv12_stride_uv as _,
+                i420_offset_y,
+                i420_stride_y,
+                i420_offset_u,
+                i420_stride_u,
+                i420_offset_v,
+                i420_stride_v,
+                width as _,
+                height as _,
+            ));
+            match fmt {
+                ImageFormat::ARGB => {
+                    call_yuv!(I420ToARGB(
+                        i420_offset_y,
+                        i420_stride_y,
+                        i420_offset_u,
+                        i420_stride_u,
+                        i420_offset_v,
+                        i420_stride_v,
+                        dst.as_mut_ptr(),
+                        (width * 4) as _,
+                        width as _,
+                        height as _,
+                    ));
                 }
-                return Ok(());
-            };
+                ImageFormat::ABGR => {
+                    call_yuv!(I420ToABGR(
+                        i420_offset_y,
+                        i420_stride_y,
+                        i420_offset_u,
+                        i420_stride_u,
+                        i420_offset_v,
+                        i420_stride_v,
+                        dst.as_mut_ptr(),
+                        (width * 4) as _,
+                        width as _,
+                        height as _,
+                    ));
+                }
+                _ => {
+                    bail!("unsupported image format");
+                }
+            }
+            return Ok(());
         }
-        return Err(anyhow!("get linesize offset failed"));
+        bail!("get linesize offset failed");
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -457,41 +113,34 @@ pub mod hw {
         _align: usize,
     ) -> ResultType<()> {
         dst.resize(width * height * 4, 0);
-        unsafe {
-            match fmt {
-                ImageFormat::ARGB => {
-                    match super::NV12ToARGB(
-                        src_y.as_ptr(),
-                        src_stride_y as _,
-                        src_uv.as_ptr(),
-                        src_stride_uv as _,
-                        dst.as_mut_ptr(),
-                        (width * 4) as _,
-                        width as _,
-                        height as _,
-                    ) {
-                        0 => Ok(()),
-                        _ => Err(anyhow!("NV12ToARGB failed")),
-                    }
-                }
-                ImageFormat::ABGR => {
-                    match super::NV12ToABGR(
-                        src_y.as_ptr(),
-                        src_stride_y as _,
-                        src_uv.as_ptr(),
-                        src_stride_uv as _,
-                        dst.as_mut_ptr(),
-                        (width * 4) as _,
-                        width as _,
-                        height as _,
-                    ) {
-                        0 => Ok(()),
-                        _ => Err(anyhow!("NV12ToABGR failed")),
-                    }
-                }
-                _ => Err(anyhow!("unsupported image format")),
+        match fmt {
+            ImageFormat::ARGB => {
+                call_yuv!(NV12ToARGB(
+                    src_y.as_ptr(),
+                    src_stride_y as _,
+                    src_uv.as_ptr(),
+                    src_stride_uv as _,
+                    dst.as_mut_ptr(),
+                    (width * 4) as _,
+                    width as _,
+                    height as _,
+                ));
             }
+            ImageFormat::ABGR => {
+                call_yuv!(NV12ToABGR(
+                    src_y.as_ptr(),
+                    src_stride_y as _,
+                    src_uv.as_ptr(),
+                    src_stride_uv as _,
+                    dst.as_mut_ptr(),
+                    (width * 4) as _,
+                    width as _,
+                    height as _,
+                ));
+            }
+            _ => bail!("unsupported image format"),
         }
+        Ok(())
     }
 
     pub fn hw_i420_to(
@@ -505,43 +154,153 @@ pub mod hw {
         src_stride_u: usize,
         src_stride_v: usize,
         dst: &mut Vec<u8>,
-    ) {
+    ) -> ResultType<()> {
         let src_y = src_y.as_ptr();
         let src_u = src_u.as_ptr();
         let src_v = src_v.as_ptr();
         dst.resize(width * height * 4, 0);
-        unsafe {
-            match fmt {
-                ImageFormat::ARGB => {
-                    super::I420ToARGB(
-                        src_y,
-                        src_stride_y as _,
-                        src_u,
-                        src_stride_u as _,
-                        src_v,
-                        src_stride_v as _,
-                        dst.as_mut_ptr(),
-                        (width * 4) as _,
-                        width as _,
-                        height as _,
-                    );
-                }
-                ImageFormat::ABGR => {
-                    super::I420ToABGR(
-                        src_y,
-                        src_stride_y as _,
-                        src_u,
-                        src_stride_u as _,
-                        src_v,
-                        src_stride_v as _,
-                        dst.as_mut_ptr(),
-                        (width * 4) as _,
-                        width as _,
-                        height as _,
-                    );
-                }
-                _ => {}
+        match fmt {
+            ImageFormat::ARGB => {
+                call_yuv!(I420ToARGB(
+                    src_y,
+                    src_stride_y as _,
+                    src_u,
+                    src_stride_u as _,
+                    src_v,
+                    src_stride_v as _,
+                    dst.as_mut_ptr(),
+                    (width * 4) as _,
+                    width as _,
+                    height as _,
+                ));
             }
+            ImageFormat::ABGR => {
+                call_yuv!(I420ToABGR(
+                    src_y,
+                    src_stride_y as _,
+                    src_u,
+                    src_stride_u as _,
+                    src_v,
+                    src_stride_v as _,
+                    dst.as_mut_ptr(),
+                    (width * 4) as _,
+                    width as _,
+                    height as _,
+                ));
+            }
+            _ => bail!("unsupported image format"),
         };
+        Ok(())
     }
+}
+#[cfg(not(target_os = "ios"))]
+pub fn convert_to_yuv(
+    captured: &Frame,
+    dst_fmt: EncodeYuvFormat,
+    dst: &mut Vec<u8>,
+    mid_data: &mut Vec<u8>,
+) -> ResultType<()> {
+    let src = captured.data();
+    let src_stride = captured.stride();
+    let captured_pixfmt = captured.pixfmt();
+    if captured_pixfmt == crate::Pixfmt::BGRA || captured_pixfmt == crate::Pixfmt::RGBA {
+        if src.len() < src_stride[0] * dst_fmt.h {
+            bail!(
+                "length not enough: {} < {}",
+                src.len(),
+                src_stride[0] * dst_fmt.h
+            );
+        }
+    }
+    match (captured_pixfmt, dst_fmt.pixfmt) {
+        (crate::Pixfmt::BGRA, crate::Pixfmt::I420) | (crate::Pixfmt::RGBA, crate::Pixfmt::I420) => {
+            let dst_stride_y = dst_fmt.stride[0];
+            let dst_stride_uv = dst_fmt.stride[1];
+            dst.resize(dst_fmt.h * dst_stride_y * 2, 0); // waste some memory to ensure memory safety
+            let dst_y = dst.as_mut_ptr();
+            let dst_u = dst[dst_fmt.u..].as_mut_ptr();
+            let dst_v = dst[dst_fmt.v..].as_mut_ptr();
+            let f = if captured_pixfmt == crate::Pixfmt::BGRA {
+                ARGBToI420
+            } else {
+                ABGRToI420
+            };
+            call_yuv!(f(
+                src.as_ptr(),
+                src_stride[0] as _,
+                dst_y,
+                dst_stride_y as _,
+                dst_u,
+                dst_stride_uv as _,
+                dst_v,
+                dst_stride_uv as _,
+                dst_fmt.w as _,
+                dst_fmt.h as _,
+            ));
+        }
+        (crate::Pixfmt::BGRA, crate::Pixfmt::NV12) | (crate::Pixfmt::RGBA, crate::Pixfmt::NV12) => {
+            let dst_stride_y = dst_fmt.stride[0];
+            let dst_stride_uv = dst_fmt.stride[1];
+            dst.resize(dst_fmt.h * (dst_stride_y + dst_stride_uv / 2), 0);
+            let dst_y = dst.as_mut_ptr();
+            let dst_uv = dst[dst_fmt.u..].as_mut_ptr();
+            let f = if captured_pixfmt == crate::Pixfmt::BGRA {
+                ARGBToNV12
+            } else {
+                ABGRToNV12
+            };
+            call_yuv!(f(
+                src.as_ptr(),
+                src_stride[0] as _,
+                dst_y,
+                dst_stride_y as _,
+                dst_uv,
+                dst_stride_uv as _,
+                dst_fmt.w as _,
+                dst_fmt.h as _,
+            ));
+        }
+        (crate::Pixfmt::BGRA, crate::Pixfmt::I444) | (crate::Pixfmt::RGBA, crate::Pixfmt::I444) => {
+            let dst_stride_y = dst_fmt.stride[0];
+            let dst_stride_u = dst_fmt.stride[1];
+            let dst_stride_v = dst_fmt.stride[2];
+            dst.resize(dst_fmt.h * (dst_stride_y + dst_stride_u + dst_stride_v), 0);
+            let dst_y = dst.as_mut_ptr();
+            let dst_u = dst[dst_fmt.u..].as_mut_ptr();
+            let dst_v = dst[dst_fmt.v..].as_mut_ptr();
+            let src = if captured_pixfmt == crate::Pixfmt::BGRA {
+                src
+            } else {
+                mid_data.resize(src.len(), 0);
+                call_yuv!(ABGRToARGB(
+                    src.as_ptr(),
+                    src_stride[0] as _,
+                    mid_data.as_mut_ptr(),
+                    src_stride[0] as _,
+                    dst_fmt.w as _,
+                    dst_fmt.h as _,
+                ));
+                mid_data
+            };
+            call_yuv!(ARGBToI444(
+                src.as_ptr(),
+                src_stride[0] as _,
+                dst_y,
+                dst_stride_y as _,
+                dst_u,
+                dst_stride_u as _,
+                dst_v,
+                dst_stride_v as _,
+                dst_fmt.w as _,
+                dst_fmt.h as _,
+            ));
+        }
+        _ => {
+            bail!(
+                "convert not support, {captured_pixfmt:?} -> {:?}",
+                dst_fmt.pixfmt
+            );
+        }
+    }
+    Ok(())
 }

--- a/libs/scrap/src/common/dxgi.rs
+++ b/libs/scrap/src/common/dxgi.rs
@@ -1,10 +1,9 @@
-use crate::{common::TraitCapturer, dxgi};
+use crate::{common::TraitCapturer, dxgi, Pixfmt};
 use std::{
     io::{
         self,
         ErrorKind::{NotFound, TimedOut, WouldBlock},
     },
-    ops,
     time::Duration,
 };
 
@@ -15,10 +14,10 @@ pub struct Capturer {
 }
 
 impl Capturer {
-    pub fn new(display: Display, yuv: bool) -> io::Result<Capturer> {
+    pub fn new(display: Display) -> io::Result<Capturer> {
         let width = display.width();
         let height = display.height();
-        let inner = dxgi::Capturer::new(display.0, yuv)?;
+        let inner = dxgi::Capturer::new(display.0)?;
         Ok(Capturer {
             inner,
             width,
@@ -40,13 +39,9 @@ impl Capturer {
 }
 
 impl TraitCapturer for Capturer {
-    fn set_use_yuv(&mut self, use_yuv: bool) {
-        self.inner.set_use_yuv(use_yuv);
-    }
-
     fn frame<'a>(&'a mut self, timeout: Duration) -> io::Result<Frame<'a>> {
         match self.inner.frame(timeout.as_millis() as _) {
-            Ok(frame) => Ok(Frame(frame)),
+            Ok(frame) => Ok(Frame::new(frame, self.height)),
             Err(ref error) if error.kind() == TimedOut => Err(WouldBlock.into()),
             Err(error) => Err(error),
         }
@@ -61,12 +56,31 @@ impl TraitCapturer for Capturer {
     }
 }
 
-pub struct Frame<'a>(pub &'a [u8]);
+pub struct Frame<'a> {
+    data: &'a [u8],
+    stride: Vec<usize>,
+}
 
-impl<'a> ops::Deref for Frame<'a> {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
-        self.0
+impl<'a> Frame<'a> {
+    pub fn new(data: &'a [u8], h: usize) -> Self {
+        let stride = data.len() / h;
+        let mut v = Vec::new();
+        v.push(stride);
+        Frame { data, stride: v }
+    }
+}
+
+impl<'a> crate::TraitFrame for Frame<'a> {
+    fn data(&self) -> &[u8] {
+        self.data
+    }
+
+    fn stride(&self) -> Vec<usize> {
+        self.stride.clone()
+    }
+
+    fn pixfmt(&self) -> Pixfmt {
+        Pixfmt::BGRA
     }
 }
 
@@ -134,9 +148,9 @@ impl CapturerMag {
         dxgi::mag::CapturerMag::is_supported()
     }
 
-    pub fn new(origin: (i32, i32), width: usize, height: usize, use_yuv: bool) -> io::Result<Self> {
+    pub fn new(origin: (i32, i32), width: usize, height: usize) -> io::Result<Self> {
         Ok(CapturerMag {
-            inner: dxgi::mag::CapturerMag::new(origin, width, height, use_yuv)?,
+            inner: dxgi::mag::CapturerMag::new(origin, width, height)?,
             data: Vec::new(),
         })
     }
@@ -151,13 +165,9 @@ impl CapturerMag {
 }
 
 impl TraitCapturer for CapturerMag {
-    fn set_use_yuv(&mut self, use_yuv: bool) {
-        self.inner.set_use_yuv(use_yuv)
-    }
-
     fn frame<'a>(&'a mut self, _timeout_ms: Duration) -> io::Result<Frame<'a>> {
         self.inner.frame(&mut self.data)?;
-        Ok(Frame(&self.data))
+        Ok(Frame::new(&self.data, self.inner.get_rect().2))
     }
 
     fn is_gdi(&self) -> bool {

--- a/libs/scrap/src/common/linux.rs
+++ b/libs/scrap/src/common/linux.rs
@@ -11,10 +11,10 @@ pub enum Capturer {
 }
 
 impl Capturer {
-    pub fn new(display: Display, yuv: bool) -> io::Result<Capturer> {
+    pub fn new(display: Display) -> io::Result<Capturer> {
         Ok(match display {
-            Display::X11(d) => Capturer::X11(x11::Capturer::new(d, yuv)?),
-            Display::WAYLAND(d) => Capturer::WAYLAND(wayland::Capturer::new(d, yuv)?),
+            Display::X11(d) => Capturer::X11(x11::Capturer::new(d)?),
+            Display::WAYLAND(d) => Capturer::WAYLAND(wayland::Capturer::new(d)?),
         })
     }
 
@@ -34,13 +34,6 @@ impl Capturer {
 }
 
 impl TraitCapturer for Capturer {
-    fn set_use_yuv(&mut self, use_yuv: bool) {
-        match self {
-            Capturer::X11(d) => d.set_use_yuv(use_yuv),
-            Capturer::WAYLAND(d) => d.set_use_yuv(use_yuv),
-        }
-    }
-
     fn frame<'a>(&'a mut self, timeout: Duration) -> io::Result<Frame<'a>> {
         match self {
             Capturer::X11(d) => d.frame(timeout),

--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -1,5 +1,8 @@
 pub use self::vpxcodec::*;
-use hbb_common::message_proto::{video_frame, VideoFrame};
+use hbb_common::{
+    log,
+    message_proto::{video_frame, Chroma, VideoFrame},
+};
 use std::slice;
 
 cfg_if! {
@@ -96,8 +99,6 @@ pub fn would_block_if_equal(old: &mut Vec<u8>, b: &[u8]) -> std::io::Result<()> 
 }
 
 pub trait TraitCapturer {
-    fn set_use_yuv(&mut self, use_yuv: bool);
-
     // We doesn't support
     #[cfg(not(any(target_os = "ios")))]
     fn frame<'a>(&'a mut self, timeout: std::time::Duration) -> std::io::Result<Frame<'a>>;
@@ -106,6 +107,31 @@ pub trait TraitCapturer {
     fn is_gdi(&self) -> bool;
     #[cfg(windows)]
     fn set_gdi(&mut self) -> bool;
+}
+
+pub trait TraitFrame {
+    fn data(&self) -> &[u8];
+
+    fn stride(&self) -> Vec<usize>;
+
+    fn pixfmt(&self) -> Pixfmt;
+}
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Pixfmt {
+    BGRA,
+    RGBA,
+    I420,
+    NV12,
+    I444,
+}
+
+pub struct EncodeYuvFormat {
+    pub pixfmt: Pixfmt,
+    pub w: usize,
+    pub h: usize,
+    pub stride: Vec<usize>,
+    pub u: usize,
+    pub v: usize,
 }
 
 #[cfg(x11)]
@@ -260,6 +286,7 @@ pub trait GoogleImage {
     fn height(&self) -> usize;
     fn stride(&self) -> Vec<i32>;
     fn planes(&self) -> Vec<*mut u8>;
+    fn chroma(&self) -> Chroma;
     fn get_bytes_per_row(w: usize, fmt: ImageFormat, stride: usize) -> usize {
         let bytes_per_pixel = match fmt {
             ImageFormat::Raw => 3,
@@ -278,8 +305,8 @@ pub trait GoogleImage {
         let stride = self.stride();
         let planes = self.planes();
         unsafe {
-            match rgb.fmt() {
-                ImageFormat::Raw => {
+            match (self.chroma(), rgb.fmt()) {
+                (Chroma::I420, ImageFormat::Raw) => {
                     super::I420ToRAW(
                         planes[0],
                         stride[0],
@@ -293,7 +320,7 @@ pub trait GoogleImage {
                         self.height() as _,
                     );
                 }
-                ImageFormat::ARGB => {
+                (Chroma::I420, ImageFormat::ARGB) => {
                     super::I420ToARGB(
                         planes[0],
                         stride[0],
@@ -307,7 +334,7 @@ pub trait GoogleImage {
                         self.height() as _,
                     );
                 }
-                ImageFormat::ABGR => {
+                (Chroma::I420, ImageFormat::ABGR) => {
                     super::I420ToABGR(
                         planes[0],
                         stride[0],
@@ -321,6 +348,36 @@ pub trait GoogleImage {
                         self.height() as _,
                     );
                 }
+                (Chroma::I444, ImageFormat::ARGB) => {
+                    super::I444ToARGB(
+                        planes[0],
+                        stride[0],
+                        planes[1],
+                        stride[1],
+                        planes[2],
+                        stride[2],
+                        rgb.raw.as_mut_ptr(),
+                        bytes_per_row as _,
+                        self.width() as _,
+                        self.height() as _,
+                    );
+                }
+                (Chroma::I444, ImageFormat::ABGR) => {
+                    super::I444ToABGR(
+                        planes[0],
+                        stride[0],
+                        planes[1],
+                        stride[1],
+                        planes[2],
+                        stride[2],
+                        rgb.raw.as_mut_ptr(),
+                        bytes_per_row as _,
+                        self.width() as _,
+                        self.height() as _,
+                    );
+                }
+                // (Chroma::I444, ImageFormat::Raw), new version libyuv have I444ToRAW
+                _ => log::error!("unsupported pixfmt:{:?}", self.chroma()),
             }
         }
     }

--- a/libs/scrap/src/common/quartz.rs
+++ b/libs/scrap/src/common/quartz.rs
@@ -1,18 +1,16 @@
-use crate::quartz;
+use crate::{quartz, Pixfmt};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, TryLockError};
-use std::{io, mem, ops};
+use std::{io, mem};
 
 pub struct Capturer {
     inner: quartz::Capturer,
     frame: Arc<Mutex<Option<quartz::Frame>>>,
-    use_yuv: bool,
-    i420: Vec<u8>,
     saved_raw_data: Vec<u8>, // for faster compare and copy
 }
 
 impl Capturer {
-    pub fn new(display: Display, use_yuv: bool) -> io::Result<Capturer> {
+    pub fn new(display: Display) -> io::Result<Capturer> {
         let frame = Arc::new(Mutex::new(None));
 
         let f = frame.clone();
@@ -20,11 +18,7 @@ impl Capturer {
             display.0,
             display.width(),
             display.height(),
-            if use_yuv {
-                quartz::PixelFormat::YCbCr420Video
-            } else {
-                quartz::PixelFormat::Argb8888
-            },
+            quartz::PixelFormat::Argb8888,
             Default::default(),
             move |inner| {
                 if let Ok(mut f) = f.lock() {
@@ -37,8 +31,6 @@ impl Capturer {
         Ok(Capturer {
             inner,
             frame,
-            use_yuv,
-            i420: Vec::new(),
             saved_raw_data: Vec::new(),
         })
     }
@@ -53,10 +45,6 @@ impl Capturer {
 }
 
 impl crate::TraitCapturer for Capturer {
-    fn set_use_yuv(&mut self, use_yuv: bool) {
-        self.use_yuv = use_yuv;
-    }
-
     fn frame<'a>(&'a mut self, _timeout_ms: std::time::Duration) -> io::Result<Frame<'a>> {
         match self.frame.try_lock() {
             Ok(mut handle) => {
@@ -66,9 +54,7 @@ impl crate::TraitCapturer for Capturer {
                 match frame {
                     Some(mut frame) => {
                         crate::would_block_if_equal(&mut self.saved_raw_data, frame.inner())?;
-                        if self.use_yuv {
-                            frame.nv12_to_i420(self.width(), self.height(), &mut self.i420);
-                        }
+                        frame.surface_to_bgra(self.height());
                         Ok(Frame(frame, PhantomData))
                     }
 
@@ -85,10 +71,19 @@ impl crate::TraitCapturer for Capturer {
 
 pub struct Frame<'a>(pub quartz::Frame, PhantomData<&'a [u8]>);
 
-impl<'a> ops::Deref for Frame<'a> {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
+impl<'a> crate::TraitFrame for Frame<'a> {
+    fn data(&self) -> &[u8] {
         &*self.0
+    }
+
+    fn stride(&self) -> Vec<usize> {
+        let mut v = Vec::new();
+        v.push(self.0.stride());
+        v
+    }
+
+    fn pixfmt(&self) -> Pixfmt {
+        Pixfmt::BGRA
     }
 }
 

--- a/libs/scrap/src/common/wayland.rs
+++ b/libs/scrap/src/common/wayland.rs
@@ -2,7 +2,7 @@ use crate::common::{x11::Frame, TraitCapturer};
 use crate::wayland::{capturable::*, *};
 use std::{io, sync::RwLock, time::Duration};
 
-pub struct Capturer(Display, Box<dyn Recorder>, bool, Vec<u8>);
+pub struct Capturer(Display, Box<dyn Recorder>, Vec<u8>);
 
 static mut IS_CURSOR_EMBEDDED: Option<bool> = None;
 
@@ -45,9 +45,9 @@ fn map_err<E: ToString>(err: E) -> io::Error {
 }
 
 impl Capturer {
-    pub fn new(display: Display, yuv: bool) -> io::Result<Capturer> {
+    pub fn new(display: Display) -> io::Result<Capturer> {
         let r = display.0.recorder(false).map_err(map_err)?;
-        Ok(Capturer(display, r, yuv, Default::default()))
+        Ok(Capturer(display, r, Default::default()))
     }
 
     pub fn width(&self) -> usize {
@@ -60,24 +60,10 @@ impl Capturer {
 }
 
 impl TraitCapturer for Capturer {
-    fn set_use_yuv(&mut self, use_yuv: bool) {
-        self.2 = use_yuv;
-    }
-
     fn frame<'a>(&'a mut self, timeout: Duration) -> io::Result<Frame<'a>> {
         match self.1.capture(timeout.as_millis() as _).map_err(map_err)? {
-            PixelProvider::BGR0(w, h, x) => Ok(Frame(if self.2 {
-                crate::common::bgra_to_i420(w as _, h as _, &x, &mut self.3);
-                &self.3[..]
-            } else {
-                x
-            })),
-            PixelProvider::RGB0(w, h, x) => Ok(Frame(if self.2 {
-                crate::common::rgba_to_i420(w as _, h as _, &x, &mut self.3);
-                &self.3[..]
-            } else {
-                x
-            })),
+            PixelProvider::BGR0(_w, h, x) => Ok(Frame::new(x, crate::Pixfmt::BGRA, h)),
+            PixelProvider::RGB0(_w, h, x) => Ok(Frame::new(x, crate::Pixfmt::RGBA, h)),
             PixelProvider::NONE => Err(std::io::ErrorKind::WouldBlock.into()),
             _ => Err(map_err("Invalid data")),
         }

--- a/libs/scrap/src/common/x11.rs
+++ b/libs/scrap/src/common/x11.rs
@@ -1,13 +1,13 @@
-use crate::{common::TraitCapturer, x11};
-use std::{io, ops, time::Duration};
+use crate::{common::TraitCapturer, x11, TraitFrame, Pixfmt};
+use std::{io, time::Duration};
 
 pub struct Capturer(x11::Capturer);
 
 pub const IS_CURSOR_EMBEDDED: bool = false;
 
 impl Capturer {
-    pub fn new(display: Display, yuv: bool) -> io::Result<Capturer> {
-        x11::Capturer::new(display.0, yuv).map(Capturer)
+    pub fn new(display: Display) -> io::Result<Capturer> {
+        x11::Capturer::new(display.0).map(Capturer)
     }
 
     pub fn width(&self) -> usize {
@@ -20,21 +20,37 @@ impl Capturer {
 }
 
 impl TraitCapturer for Capturer {
-    fn set_use_yuv(&mut self, use_yuv: bool) {
-        self.0.set_use_yuv(use_yuv);
-    }
-
     fn frame<'a>(&'a mut self, _timeout: Duration) -> io::Result<Frame<'a>> {
-        Ok(Frame(self.0.frame()?))
+        Ok(self.0.frame()?)
     }
 }
 
-pub struct Frame<'a>(pub &'a [u8]);
+pub struct Frame<'a>{
+    pub data: &'a [u8],
+    pub pixfmt:Pixfmt,
+    pub stride:Vec<usize>,
+}
 
-impl<'a> ops::Deref for Frame<'a> {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
-        self.0
+impl<'a>  Frame<'a>  {
+    pub fn new(data:&'a [u8], pixfmt:Pixfmt, h:usize) -> Self {
+        let stride = data.len() / h;
+        let mut v = Vec::new();
+        v.push(stride);
+        Self { data, pixfmt, stride: v }
+    }
+}
+
+impl<'a>  TraitFrame for Frame<'a>  {
+    fn data(&self) -> &[u8] {
+        self.data
+    }
+
+    fn stride(&self) -> Vec<usize> {
+        self.stride.clone()
+    }
+
+    fn pixfmt(&self) -> crate::Pixfmt {
+        self.pixfmt
     }
 }
 

--- a/libs/scrap/src/dxgi/gdi.rs
+++ b/libs/scrap/src/dxgi/gdi.rs
@@ -160,7 +160,7 @@ impl CapturerGDI {
                 stride,
                 self.width,
                 self.height,
-                180,
+                crate::RotationMode::kRotate180,
             );
             Ok(())
         }

--- a/libs/scrap/src/dxgi/mod.rs
+++ b/libs/scrap/src/dxgi/mod.rs
@@ -20,6 +20,8 @@ use winapi::{
     },
 };
 
+use crate::RotationMode::*;
+
 pub struct ComPtr<T>(*mut T);
 impl<T> ComPtr<T> {
     fn is_null(&self) -> bool {
@@ -45,8 +47,6 @@ pub struct Capturer {
     surface: ComPtr<IDXGISurface>,
     width: usize,
     height: usize,
-    use_yuv: bool,
-    yuv: Vec<u8>,
     rotated: Vec<u8>,
     gdi_capturer: Option<CapturerGDI>,
     gdi_buffer: Vec<u8>,
@@ -54,7 +54,7 @@ pub struct Capturer {
 }
 
 impl Capturer {
-    pub fn new(display: Display, use_yuv: bool) -> io::Result<Capturer> {
+    pub fn new(display: Display) -> io::Result<Capturer> {
         let mut device = ptr::null_mut();
         let mut context = ptr::null_mut();
         let mut duplication = ptr::null_mut();
@@ -148,17 +148,11 @@ impl Capturer {
             width: display.width() as usize,
             height: display.height() as usize,
             display,
-            use_yuv,
-            yuv: Vec::new(),
             rotated: Vec::new(),
             gdi_capturer,
             gdi_buffer: Vec::new(),
             saved_raw_data: Vec::new(),
         })
-    }
-
-    pub fn set_use_yuv(&mut self, use_yuv: bool) {
-        self.use_yuv = use_yuv;
     }
 
     pub fn is_gdi(&self) -> bool {
@@ -259,10 +253,10 @@ impl Capturer {
                     self.unmap();
                     let r = self.load_frame(timeout)?;
                     let rotate = match self.display.rotation() {
-                        DXGI_MODE_ROTATION_IDENTITY | DXGI_MODE_ROTATION_UNSPECIFIED => 0,
-                        DXGI_MODE_ROTATION_ROTATE90 => 90,
-                        DXGI_MODE_ROTATION_ROTATE180 => 180,
-                        DXGI_MODE_ROTATION_ROTATE270 => 270,
+                        DXGI_MODE_ROTATION_IDENTITY | DXGI_MODE_ROTATION_UNSPECIFIED => kRotate0,
+                        DXGI_MODE_ROTATION_ROTATE90 => kRotate90,
+                        DXGI_MODE_ROTATION_ROTATE180 => kRotate180,
+                        DXGI_MODE_ROTATION_ROTATE270 => kRotate270,
                         _ => {
                             return Err(io::Error::new(
                                 io::ErrorKind::Other,
@@ -270,7 +264,7 @@ impl Capturer {
                             ));
                         }
                     };
-                    if rotate == 0 {
+                    if rotate == kRotate0 {
                         slice::from_raw_parts(r.0, r.1 as usize * self.height)
                     } else {
                         self.rotated.resize(self.width * self.height * 4, 0);
@@ -279,12 +273,12 @@ impl Capturer {
                             r.1,
                             self.rotated.as_mut_ptr(),
                             4 * self.width as i32,
-                            if rotate == 180 {
+                            if rotate == kRotate180 {
                                 self.width
                             } else {
                                 self.height
                             } as _,
-                            if rotate != 180 {
+                            if rotate != kRotate180 {
                                 self.width
                             } else {
                                 self.height
@@ -295,19 +289,7 @@ impl Capturer {
                     }
                 }
             };
-            Ok({
-                if self.use_yuv {
-                    crate::common::bgra_to_i420(
-                        self.width as usize,
-                        self.height as usize,
-                        &result,
-                        &mut self.yuv,
-                    );
-                    &self.yuv[..]
-                } else {
-                    result
-                }
-            })
+            Ok(result)
         }
     }
 

--- a/libs/scrap/src/quartz/frame.rs
+++ b/libs/scrap/src/quartz/frame.rs
@@ -5,8 +5,8 @@ use super::ffi::*;
 pub struct Frame {
     surface: IOSurfaceRef,
     inner: &'static [u8],
-    i420: *mut u8,
-    i420_len: usize,
+    bgra: Vec<u8>,
+    bgra_stride: usize,
 }
 
 impl Frame {
@@ -24,8 +24,8 @@ impl Frame {
         Frame {
             surface,
             inner,
-            i420: ptr::null_mut(),
-            i420_len: 0,
+            bgra: Vec::new(),
+            bgra_stride: 0,
         }
     }
 
@@ -34,23 +34,20 @@ impl Frame {
         self.inner
     }
 
-    pub fn nv12_to_i420<'a>(&'a mut self, w: usize, h: usize, i420: &'a mut Vec<u8>) {
+    pub fn stride(&self) -> usize {
+        self.bgra_stride
+    }
+
+    pub fn surface_to_bgra<'a>(&'a mut self, h: usize) {
         unsafe {
             let plane0 = IOSurfaceGetBaseAddressOfPlane(self.surface, 0);
-            let stride0 = IOSurfaceGetBytesPerRowOfPlane(self.surface, 0);
-            let plane1 = IOSurfaceGetBaseAddressOfPlane(self.surface, 1);
-            let stride1 = IOSurfaceGetBytesPerRowOfPlane(self.surface, 1);
-            crate::common::nv12_to_i420(
+            self.bgra_stride = IOSurfaceGetBytesPerRowOfPlane(self.surface, 0);
+            self.bgra.resize(self.bgra_stride * h, 0);
+            std::ptr::copy_nonoverlapping(
                 plane0 as _,
-                stride0 as _,
-                plane1 as _,
-                stride1 as _,
-                w,
-                h,
-                i420,
+                self.bgra.as_mut_ptr(),
+                self.bgra_stride * h,
             );
-            self.i420 = i420.as_mut_ptr() as _;
-            self.i420_len = i420.len();
         }
     }
 }
@@ -58,14 +55,7 @@ impl Frame {
 impl ops::Deref for Frame {
     type Target = [u8];
     fn deref<'a>(&'a self) -> &'a [u8] {
-        if self.i420.is_null() {
-            self.inner
-        } else {
-            unsafe {
-                let inner = slice::from_raw_parts(self.i420 as *const u8, self.i420_len);
-                inner
-            }
-        }
+        &self.bgra
     }
 }
 

--- a/libs/scrap/src/x11/capturer.rs
+++ b/libs/scrap/src/x11/capturer.rs
@@ -2,6 +2,8 @@ use std::{io, ptr, slice};
 
 use hbb_common::libc;
 
+use crate::Frame;
+
 use super::ffi::*;
 use super::Display;
 
@@ -12,13 +14,11 @@ pub struct Capturer {
     buffer: *const u8,
 
     size: usize,
-    use_yuv: bool,
-    yuv: Vec<u8>,
     saved_raw_data: Vec<u8>, // for faster compare and copy
 }
 
 impl Capturer {
-    pub fn new(display: Display, use_yuv: bool) -> io::Result<Capturer> {
+    pub fn new(display: Display) -> io::Result<Capturer> {
         // Calculate dimensions.
 
         let pixel_width = 4;
@@ -67,15 +67,9 @@ impl Capturer {
             xcbid,
             buffer,
             size,
-            use_yuv,
-            yuv: Vec::new(),
             saved_raw_data: Vec::new(),
         };
         Ok(c)
-    }
-
-    pub fn set_use_yuv(&mut self, use_yuv: bool) {
-        self.use_yuv = use_yuv;
     }
 
     pub fn display(&self) -> &Display {
@@ -103,16 +97,13 @@ impl Capturer {
         }
     }
 
-    pub fn frame<'b>(&'b mut self) -> std::io::Result<&'b [u8]> {
+    pub fn frame<'b>(&'b mut self) -> std::io::Result<Frame> {
         self.get_image();
         let result = unsafe { slice::from_raw_parts(self.buffer, self.size) };
         crate::would_block_if_equal(&mut self.saved_raw_data, result)?;
-        Ok(if self.use_yuv {
-            crate::common::bgra_to_i420(self.display.w(), self.display.h(), &result, &mut self.yuv);
-            &self.yuv[..]
-        } else {
-            result
-        })
+        Ok(
+            Frame::new(result, crate::Pixfmt::BGRA, self.display.h())
+       )
     }
 }
 

--- a/src/client/helper.rs
+++ b/src/client/helper.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
 use hbb_common::{
     get_time,
     message_proto::{Message, VoiceCallRequest, VoiceCallResponse},
 };
 use scrap::CodecFormat;
+use std::collections::HashMap;
 
 #[derive(Debug, Default)]
 pub struct QualityStatus {
@@ -12,6 +12,7 @@ pub struct QualityStatus {
     pub delay: Option<i32>,
     pub target_bitrate: Option<i32>,
     pub codec_format: Option<CodecFormat>,
+    pub chroma: Option<String>,
 }
 
 #[inline]

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -471,6 +471,7 @@ impl InvokeUiSession for FlutterHandler {
                     "codec_format",
                     &status.codec_format.map_or(NULL, |it| it.to_string()),
                 ),
+                ("chroma", &status.chroma.map_or(NULL, |it| it.to_string())),
             ],
         );
     }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", "列表"),
         ("Virtual display", "虚拟显示器"),
         ("Plug out all", "拔出所有"),
+        ("True color(4:4:4)", "真彩模式(4:4:4)"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", "Seznam"),
         ("Virtual display", "Virtuální obrazovka"),
         ("Plug out all", "Odpojit všechny"),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", "Liste"),
         ("Virtual display", "Virtueller Bildschirm"),
         ("Plug out all", "Alle ausschalten"),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -565,13 +565,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Open in new window", "Abrir en una nueva ventana"),
         ("Show displays as individual windows", "Mostrar pantallas como ventanas individuales"),
         ("Use all my displays for the remote session", "Usar todas mis pantallas para la sesión remota"),
-        ("selinux_tip", "SELinux está activado en tu dispositivo, lo que puede hacer que RustDesk no se ejecute correctamente como lado controlado."),
+        ("selinux_tip", ""),
         ("Change view", ""),
         ("Big tiles", ""),
         ("Small tiles", ""),
         ("List", ""),
-        ("selinux_tip", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", "Tampilan virtual"),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", "Elenco"),
         ("Virtual display", "Scehrmo virtuale"),
         ("Plug out all", "Scollega tutto"),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", "Saraksts"),
         ("Virtual display", "Virtuālais displejs"),
         ("Plug out all", "Atvienot visu"),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", "Lista"),
         ("Virtual display", "Witualne ekrany"),
         ("Plug out all", "Odłącz wszystko"),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", "Список"),
         ("Virtual display", "Виртуальный дисплей"),
         ("Plug out all", "Отключить все"),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -572,5 +572,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("List", ""),
         ("Virtual display", ""),
         ("Plug out all", ""),
+        ("True color(4:4:4)", ""),
     ].iter().cloned().collect();
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -126,7 +126,7 @@ pub fn is_can_screen_recording(prompt: bool) -> bool {
     if !can_record_screen && prompt {
         use scrap::{Capturer, Display};
         if let Ok(d) = Display::primary() {
-            Capturer::new(d, true).ok();
+            Capturer::new(d).ok();
         }
     }
     can_record_screen

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1214,7 +1214,7 @@ impl Connection {
 
     fn on_remote_authorized() {
         use std::sync::Once;
-        static ONCE: Once = Once::new();
+        static _ONCE: Once = Once::new();
         #[cfg(any(target_os = "windows", target_os = "linux"))]
         if !Config::get_option("allow-remove-wallpaper").is_empty() {
             // multi connections set once
@@ -1223,7 +1223,7 @@ impl Connection {
                 match crate::platform::WallPaperRemover::new() {
                     Ok(remover) => {
                         *wallpaper = Some(remover);
-                        ONCE.call_once(|| {
+                        _ONCE.call_once(|| {
                             shutdown_hooks::add_shutdown_hook(shutdown_hook);
                         });
                     }

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -76,12 +76,6 @@ impl TraitCapturer for CapturerPtr {
     fn frame<'a>(&'a mut self, timeout: Duration) -> io::Result<Frame<'a>> {
         unsafe { (*self.0).frame(timeout) }
     }
-
-    fn set_use_yuv(&mut self, use_yuv: bool) {
-        unsafe {
-            (*self.0).set_use_yuv(use_yuv);
-        }
-    }
 }
 
 struct CapDisplayInfo {
@@ -192,7 +186,8 @@ pub(super) async fn check_init() -> ResultType<()> {
                 maxy = max_height;
 
                 let capturer = Box::into_raw(Box::new(
-                    Capturer::new(display, true).with_context(|| "Failed to create capturer")?,
+                    Capturer::new(display)
+                        .with_context(|| "Failed to create capturer")?,
                 ));
                 let capturer = CapturerPtr(capturer);
                 let cap_display_info = Box::into_raw(Box::new(CapDisplayInfo {

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -201,6 +201,7 @@ class Header: Reactor.Component {
                 {keyboard_enabled ? <li #lock-after-session-end .toggle-option><span>{svg_checkmark}</span>{translate('Lock after session end')}</li> : ""} 
                 {keyboard_enabled && pi.platform == "Windows" ? <li #privacy-mode><span>{svg_checkmark}</span>{translate('Privacy mode')}</li> : ""}
                 {keyboard_enabled && ((is_osx && pi.platform != "Mac OS") || (!is_osx && pi.platform == "Mac OS")) ? <li #allow_swap_key  .toggle-option><span>{svg_checkmark}</span>{translate('Swap control-command key')}</li> : ""}
+                {handler.version_cmp(pi.version, '1.2.4') >= 0 ? <li #i444><span>{svg_checkmark}</span>{translate('True color(4:4:4)')}</li> : ""}
             </menu>
         </popup>;
     }
@@ -402,6 +403,8 @@ class Header: Reactor.Component {
             togglePrivacyMode(me.id);
         } else if (me.id == "show-quality-monitor") {
             toggleQualityMonitor(me.id);
+        } else if (me.id == "i444") {
+            toggleI444(me.id);
         } else if (me.attributes.hasClass("toggle-option")) {
             handler.toggle_option(me.id);
             toggleMenuState();
@@ -476,7 +479,7 @@ function toggleMenuState() {
     for (var el in $$(menu#keyboard-options>li)) {
         el.attributes.toggleClass("selected", values.indexOf(el.id) >= 0);
     }
-    for (var id in ["show-remote-cursor", "show-quality-monitor", "disable-audio", "enable-file-transfer", "disable-clipboard", "lock-after-session-end", "allow_swap_key"]) {
+    for (var id in ["show-remote-cursor", "show-quality-monitor", "disable-audio", "enable-file-transfer", "disable-clipboard", "lock-after-session-end", "allow_swap_key", "i444"]) {
         var el = self.select('#' + id);
         if (el) {
             var value = handler.get_toggle_option(id);
@@ -560,6 +563,12 @@ function toggleQualityMonitor(name) {
         $(#quality-monitor).style.set{ display: "block" };
     }
     handler.toggle_option(name);
+    toggleMenuState();
+}
+
+function toggleI444(name) {
+    handler.toggle_option(name);
+    handler.change_prefer_codec();
     toggleMenuState();
 }
 

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -131,7 +131,8 @@ impl InvokeUiSession for SciterHandler {
                 status.target_bitrate.map_or(Value::null(), |it| it.into()),
                 status
                     .codec_format
-                    .map_or(Value::null(), |it| it.to_string().into())
+                    .map_or(Value::null(), |it| it.to_string().into()),
+                status.chroma.map_or(Value::null(), |it| it.into())
             ),
         );
     }

--- a/src/ui/remote.tis
+++ b/src/ui/remote.tis
@@ -510,17 +510,21 @@ class QualityMonitor: Reactor.Component
             <div>
                 Codec: {qualityMonitorData[4]}
             </div>
+            <div>
+                Chroma: {qualityMonitorData[5]}
+            </div>
         </div>;
     }
 }
 
 $(#quality-monitor).content(<QualityMonitor />);
-handler.updateQualityStatus = function(speed, fps, delay, bitrate, codec_format) {
+handler.updateQualityStatus = function(speed, fps, delay, bitrate, codec_format, chroma) {
     speed ? qualityMonitorData[0] = speed:null;
     fps ? qualityMonitorData[1] = fps:null;
     delay ? qualityMonitorData[2] = delay:null;
     bitrate ? qualityMonitorData[3] = bitrate:null;
     codec_format ? qualityMonitorData[4] = codec_format:null;
+    chroma ? qualityMonitorData[5] = chroma:null;
     qualityMonitor.update();
 }
 

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1527,16 +1527,17 @@ pub async fn io_loop<T: InvokeUiSession>(handler: Session<T>, round: u32) {
     let frame_count_map: Arc<RwLock<HashMap<usize, usize>>> = Default::default();
     let frame_count_map_cl = frame_count_map.clone();
     let ui_handler = handler.ui_handler.clone();
-    let (video_sender, audio_sender, video_queue_map, decode_fps_map) = start_video_audio_threads(
-        handler.clone(),
-        move |display: usize, data: &mut scrap::ImageRgb| {
-            let mut write_lock = frame_count_map_cl.write().unwrap();
-            let count = write_lock.get(&display).unwrap_or(&0) + 1;
-            write_lock.insert(display, count);
-            drop(write_lock);
-            ui_handler.on_rgba(display, data);
-        },
-    );
+    let (video_sender, audio_sender, video_queue_map, decode_fps_map, chroma) =
+        start_video_audio_threads(
+            handler.clone(),
+            move |display: usize, data: &mut scrap::ImageRgb| {
+                let mut write_lock = frame_count_map_cl.write().unwrap();
+                let count = write_lock.get(&display).unwrap_or(&0) + 1;
+                write_lock.insert(display, count);
+                drop(write_lock);
+                ui_handler.on_rgba(display, data);
+            },
+        );
 
     let mut remote = Remote::new(
         handler,
@@ -1547,6 +1548,7 @@ pub async fn io_loop<T: InvokeUiSession>(handler: Session<T>, round: u32) {
         sender,
         frame_count_map,
         decode_fps_map,
+        chroma,
     );
     remote.io_loop(&key, &token, round).await;
     remote.sync_jobs_status_to_local().await;


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/4952

1. Move convert-to-yuv funciton out of capture, capture only output rgba/bgra, convert to yuv in a specific function, let video service hold the yuv buffer. Tested on windows/macos/wayland/x11/android, and portable service, privacy mode, different resolutions.
2. Add yuv 444 support for vp9 and av1, encode 444 will be a little slower than 420.

https://github.com/rustdesk/rustdesk/assets/14891774/c1c09ded-49f8-4190-86fc-12b52d18a95b

