### PR TITLE
Refact/displays arrangement

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -138,8 +138,9 @@ class FfiModel with ChangeNotifier {
     sessionId = parent.target!.sessionId;
   }
 
-  Rect? displaysRect() {
-    final displays = _pi.getCurDisplays();
+  Rect? globalDisplaysRect() => _getDisplaysRect(_pi.displays);
+  Rect? displaysRect() => _getDisplaysRect(_pi.getCurDisplays());
+  Rect? _getDisplaysRect(List<Display> displays) {
     if (displays.isEmpty) {
       return null;
     }

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -667,11 +667,12 @@ class FfiModel with ChangeNotifier {
     if (connType == ConnType.fileTransfer) {
       parent.target?.fileModel.onReady();
     } else if (connType == ConnType.defaultConn) {
-      _pi.displays = [];
+      List<Display> newDisplays = [];
       List<dynamic> displays = json.decode(evt['displays']);
       for (int i = 0; i < displays.length; ++i) {
-        _pi.displays.add(evtToDisplay(displays[i]));
+        newDisplays.add(evtToDisplay(displays[i]));
       }
+      _pi.displays.value = newDisplays;
       _pi.displaysCount.value = _pi.displays.length;
       if (_pi.currentDisplay < _pi.displays.length) {
         // now replaced to _updateCurDisplay
@@ -861,7 +862,7 @@ class FfiModel with ChangeNotifier {
       for (int i = 0; i < displays.length; ++i) {
         newDisplays.add(evtToDisplay(displays[i]));
       }
-      _pi.displays = newDisplays;
+      _pi.displays.value = newDisplays;
       _pi.displaysCount.value = _pi.displays.length;
 
       if (_pi.currentDisplay == kAllDisplayValue) {
@@ -909,11 +910,11 @@ class FfiModel with ChangeNotifier {
       _pi.platformAdditions.remove(kPlatformAdditionsVirtualDisplays);
     } else {
       try {
-        final updateJson = json.decode(updateData);
+        final updateJson = json.decode(updateData) as Map<String, dynamic>;
         for (final key in updateJson.keys) {
           _pi.platformAdditions[key] = updateJson[key];
         }
-        if (!updateJson.contains(kPlatformAdditionsVirtualDisplays)) {
+        if (!updateJson.containsKey(kPlatformAdditionsVirtualDisplays)) {
           _pi.platformAdditions.remove(kPlatformAdditionsVirtualDisplays);
         }
       } catch (e) {
@@ -2322,7 +2323,7 @@ class PeerInfo with ChangeNotifier {
   bool isSupportMultiUiSession = false;
   int currentDisplay = 0;
   int primaryDisplay = kInvalidDisplayIndex;
-  List<Display> displays = [];
+  RxList<Display> displays = <Display>[].obs;
   Features features = Features();
   List<Resolution> resolutions = [];
   Map<String, dynamic> platformAdditions = {};

--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -142,6 +142,8 @@ pub fn reset_all() -> ResultType<()> {
     let mut manager = VIRTUAL_DISPLAY_MANAGER.lock().unwrap();
     if !manager.peer_index_name.is_empty() || manager.headless_index_name.is_some() {
         manager.install_update_driver()?;
+        manager.peer_index_name.clear();
+        manager.headless_index_name = None;
     }
     Ok(())
 }


### PR DESCRIPTION
1. Fix. Clear plugged virtual display map.
```rust
        manager.peer_index_name.clear();
        manager.headless_index_name = None;
```
2. Fix. Use `containsKey()` for map instead of `contains()`.
3. Show global displays' arrangement.


https://github.com/rustdesk/rustdesk/assets/13586388/336c6fd8-08e8-478c-9289-76cdbaf022b1

