### PR TITLE
fix, virtual dislay reset

### DIFF
--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -139,12 +139,10 @@ pub fn plug_in_index_modes(
 }
 
 pub fn reset_all() -> ResultType<()> {
-    let mut manager = VIRTUAL_DISPLAY_MANAGER.lock().unwrap();
-    if !manager.peer_index_name.is_empty() || manager.headless_index_name.is_some() {
-        manager.install_update_driver()?;
-        manager.peer_index_name.clear();
-        manager.headless_index_name = None;
+    if let Err(e) = plug_out_peer_request(&get_virtual_displays()) {
+        log::error!("Failed to plug out virtual displays: {}", e);
     }
+    let _ = plug_out_headless();
     Ok(())
 }
 


### PR DESCRIPTION
Reset virtual display on disconn.

Just plug out all displays, do not call `manager.install_update_driver()?;`, which will not reset inner data.


