### PR TITLE
upgrade desktop_drop to fix windows crash on close on flutter 3.13

### DIFF
--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -325,12 +325,11 @@ packages:
   desktop_drop:
     dependency: "direct main"
     description:
-      path: "packages/desktop_drop"
-      ref: HEAD
-      resolved-ref: "21725af7fd5be4e928acfb84146ebd10d1364a97"
-      url: "https://github.com/rustdesk-org/flutter-plugins"
-    source: git
-    version: "0.4.1"
+      name: desktop_drop
+      sha256: d55a010fe46c8e8fcff4ea4b451a9ff84a162217bdb3b2a0aa1479776205e15d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.4"
   desktop_multi_window:
     dependency: "direct main"
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -67,10 +67,7 @@ dependencies:
   get: ^4.6.5
   visibility_detector: ^0.4.0+2
   contextmenu: ^3.0.0
-  desktop_drop:
-    git:
-      url: https://github.com/rustdesk-org/flutter-plugins
-      path: ./packages/desktop_drop
+  desktop_drop: ^0.4.4
   scroll_pos: ^0.4.0
   debounce_throttle: ^2.0.0
   file_picker: ^5.1.0


### PR DESCRIPTION
https://github.com/MixinNetwork/flutter-plugins/pull/276

Since based on macos 10.14 now, we can use the one on pub.dev
https://github.com/MixinNetwork/flutter-plugins/compare/main...rustdesk-org:flutter-plugins:main