### PR TITLE
fix, remove unused capturer when switching display

### DIFF
--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1223,8 +1223,9 @@ class _ResolutionsMenuState extends State<_ResolutionsMenu> {
   @override
   Widget build(BuildContext context) {
     final isVirtualDisplay = ffiModel.isVirtualDisplayResolution;
-    final visible =
-        ffiModel.keyboard && (isVirtualDisplay || resolutions.length > 1);
+    final visible = ffiModel.keyboard &&
+        (isVirtualDisplay || resolutions.length > 1) &&
+        pi.currentDisplay != kAllDisplayValue;
     if (!visible) return Offstage();
     final showOriginalBtn =
         ffiModel.isOriginalResolutionSet && !ffiModel.isOriginalResolution;

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1466,25 +1466,7 @@ pub mod sessions {
                     if write_lock.is_empty() {
                         remove_peer_key = Some(peer_key.clone());
                     } else {
-                        // Set capture displays if some are not used any more.
-                        let mut remains_displays = HashSet::new();
-                        for (_, h) in write_lock.iter() {
-                            remains_displays.extend(
-                                h.renderer
-                                    .map_display_sessions
-                                    .read()
-                                    .unwrap()
-                                    .keys()
-                                    .cloned(),
-                            );
-                        }
-                        if !remains_displays.is_empty() {
-                            s.capture_displays(
-                                vec![],
-                                vec![],
-                                remains_displays.iter().map(|d| *d as i32).collect(),
-                            );
-                        }
+                        check_remove_unused_displays(None, id, s, &write_lock);
                     }
                     break;
                 }
@@ -1492,6 +1474,68 @@ pub mod sessions {
             }
         }
         SESSIONS.write().unwrap().remove(&remove_peer_key?)
+    }
+
+    #[cfg(feature = "flutter_texture_render")]
+    fn check_remove_unused_displays(
+        current: Option<usize>,
+        session_id: &SessionID,
+        session: &FlutterSession,
+        handlers: &HashMap<SessionID, SessionHandler>,
+    ) {
+        // Set capture displays if some are not used any more.
+        let mut remains_displays = HashSet::new();
+        if let Some(current) = current {
+            remains_displays.insert(current);
+        }
+        for (k, h) in handlers.iter() {
+            if k == session_id {
+                continue;
+            }
+            remains_displays.extend(
+                h.renderer
+                    .map_display_sessions
+                    .read()
+                    .unwrap()
+                    .keys()
+                    .cloned(),
+            );
+        }
+        if !remains_displays.is_empty() {
+            session.capture_displays(
+                vec![],
+                vec![],
+                remains_displays.iter().map(|d| *d as i32).collect(),
+            );
+        }
+    }
+
+    pub fn session_switch_display(session_id: SessionID, value: Vec<i32>) {
+        for s in SESSIONS.read().unwrap().values() {
+            let read_lock = s.ui_handler.session_handlers.read().unwrap();
+            if read_lock.contains_key(&session_id) {
+                if value.len() == 1 {
+                    // Switch display.
+                    // This operation will also cause the peer to send a switch display message.
+                    // The switch display message will contain `SupportedResolutions`, which is useful when changing resolutions.
+                    s.switch_display(value[0]);
+
+                    // Check if other displays are needed.
+                    if value.len() == 1 {
+                        check_remove_unused_displays(
+                            Some(value[0] as _),
+                            &session_id,
+                            &s,
+                            &read_lock,
+                        );
+                    }
+                } else {
+                    // Try capture all displays.
+                    s.capture_displays(vec![], vec![], value);
+                }
+                break;
+            }
+        }
     }
 
     #[inline]

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -429,13 +429,7 @@ pub fn session_ctrl_alt_del(session_id: SessionID) {
 }
 
 pub fn session_switch_display(session_id: SessionID, value: Vec<i32>) {
-    if let Some(session) = sessions::get_session_by_session_id(&session_id) {
-        if value.len() == 1 {
-            session.switch_display(value[0]);
-        } else {
-            session.capture_displays(vec![], vec![], value);
-        }
-    }
+    sessions::session_switch_display(session_id, value);
 }
 
 pub fn session_handle_flutter_key_event(

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -349,7 +349,7 @@ pub fn try_get_displays() -> ResultType<Vec<Display>> {
 #[cfg(all(windows, feature = "virtual_display_driver"))]
 pub fn try_get_displays() -> ResultType<Vec<Display>> {
     let mut displays = Display::all()?;
-    if no_displays(&displays) {
+    if crate::platform::is_installed() && no_displays(&displays) {
         log::debug!("no displays, create virtual display");
         if let Err(e) = virtual_display_manager::plug_in_headless() {
             log::error!("plug in headless failed {}", e);


### PR DESCRIPTION
1. Fix. Remove unused capturer when switching display.
2. Show "Resolutions" menu when `pi.currentDisplay != kAllDisplayValue`.
3. Refactor "handlePeerInfo()", check if the peer side `isSupportMultiUiSession`.
4. Check is installed before plug in virtual display when detecting no displays.
