### PR TITLE
fix, win crash, tokio 1.28.1 to 1.33.0, revert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5719,16 +5719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "sodiumoxide"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6185,11 +6175,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
- "backtrace",
+ "autocfg 1.1.0",
  "bytes",
  "libc",
  "mio",
@@ -6197,7 +6187,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2 0.4.10",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]

--- a/libs/hbb_common/Cargo.toml
+++ b/libs/hbb_common/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 flexi_logger = { version = "0.25", features = ["async"] }
 protobuf = { version = "3.2", features = ["with-bytes"] }
-tokio = { version = "1.28", features = ["full"] }
+tokio = { version = "=1.28.1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 futures = "0.3"
 bytes = { version = "1.4", features = ["serde"] }


### PR DESCRIPTION
Crate `tokio 1.33.1` causes crash on Windows sometimes on startup.

![cafc7a717a07a8ff33ec32ff38268bb](https://github.com/rustdesk/rustdesk/assets/13586388/2b38779a-df50-42c7-8dab-7d8ba571998f)


https://github.com/rustdesk/rustdesk/blob/8e0bce4da4b8f05b5e91feb7c57002b8621cb8ce/src/ipc.rs#L249
 