### PR TITLE
Feat: mobile uni link support (android + ios)

### DIFF
--- a/flutter/android/app/src/main/AndroidManifest.xml
+++ b/flutter/android/app/src/main/AndroidManifest.xml
@@ -61,6 +61,14 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Intent for deep linking-->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="rustdesk" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/flutter/ios/Runner/Info.plist
+++ b/flutter/ios/Runner/Info.plist
@@ -34,7 +34,7 @@
 			<key>CFBundleURLName</key>
 			<string>com.carriez.rustdesk</string>
 			<key>CFBundleURLSchemes</key>
-		<array>
+			<array>
 				<string>rustdesk</string>
 			</array>
 		</dict>

--- a/flutter/ios/Runner/Info.plist
+++ b/flutter/ios/Runner/Info.plist
@@ -24,6 +24,21 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLIconFile</key>
+			<string></string>
+			<key>CFBundleURLName</key>
+			<string>com.carriez.rustdesk</string>
+			<key>CFBundleURLSchemes</key>
+		<array>
+				<string>rustdesk</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1803,6 +1803,10 @@ Future<bool> initUniLinks() async {
     if (initialLink == null) {
       return false;
     }
+    if (isMobile){
+      handleUriLinkMobile(initialLink);
+      return true;
+    }
     return handleUriLink(uriString: initialLink);
   } catch (err) {
     debugPrintStack(label: "$err");

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1823,10 +1823,15 @@ StreamSubscription? listenUniLinks({handleByFlutter = true}) {
   final sub = uriLinkStream.listen((Uri? uri) {
     debugPrint("A uri was received: $uri. handleByFlutter $handleByFlutter");
     if (uri != null) {
-      if (handleByFlutter) {
-        handleUriLink(uri: uri);
-      } else {
-        bind.sendUrlScheme(url: uri.toString());
+      if (!isMobile){
+        if (handleByFlutter) {
+          handleUriLink(uri: uri);
+        } else {
+          bind.sendUrlScheme(url: uri.toString());
+        }
+      }
+      else {
+        handleUriLinkMobile(uri.toString());
       }
     } else {
       print("uni listen error: uri is empty.");
@@ -1842,6 +1847,14 @@ enum UriLinkType {
   fileTransfer,
   portForward,
   rdp,
+}
+
+void handleUriLinkMobile(String uri) {
+  var context = Get.context;
+  var uri_id = uri.split("//").last;
+  if (context != null && uri_id.isNotEmpty){
+    connect(context, uri_id);
+  }
 }
 
 // uri link handler

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1828,8 +1828,7 @@ StreamSubscription? listenUniLinks({handleByFlutter = true}) {
       } else {
         bind.sendUrlScheme(url: uri.toString());
       }
-    }
-    else {
+    } else {
       print("uni listen error: uri is empty.");
     }
   }, onError: (err) {

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1955,6 +1955,7 @@ bool handleUriLink({List<String>? cmdArgs, Uri? uri, String? uriString}) {
 List<String>? urlLinkToCmdArgs(Uri uri) {
   String? command;
   String? id;
+  final options = ["connect", "play", "file-transfer", "port-forward", "rdp"];
   if (uri.authority.isEmpty &&
       uri.path.split('').every((char) => char == '/')) {
     return [];
@@ -1962,11 +1963,19 @@ List<String>? urlLinkToCmdArgs(Uri uri) {
     // For compatibility
     command = '--connect';
     id = uri.path.substring("/new/".length);
-  } else if (['connect', "play", 'file-transfer', 'port-forward', 'rdp']
-      .contains(uri.authority) && !isMobile) {
+  } else if (options.contains(uri.authority)) {
+    final optionIndex = options.indexOf(uri.authority);
     command = '--${uri.authority}';
     if (uri.path.length > 1) {
       id = uri.path.substring(1);
+    }
+    if (isMobile && id != null) {
+      if (optionIndex == 0 || optionIndex == 1) {
+        connect(Get.context!, id);
+      } else if (optionIndex == 2) {
+        connect(Get.context!, id, isFileTransfer: true);
+      }
+      return null;
     }
   } else if (uri.authority.length > 2 && uri.path.length <= 1) {
     // rustdesk://<connect-id>

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -156,6 +156,7 @@ void runMobileApp() async {
   await Future.wait([gFFI.abModel.loadCache(), gFFI.groupModel.loadCache()]);
   gFFI.userModel.refreshCurrentUser();
   runApp(App());
+  await initUniLinks();
 }
 
 void runMultiWindow(

--- a/flutter/lib/mobile/pages/connection_page.dart
+++ b/flutter/lib/mobile/pages/connection_page.dart
@@ -54,10 +54,12 @@ class _ConnectionPageState extends State<ConnectionPage> {
   }
   bool isPeersLoading = false;
   bool isPeersLoaded = false;
+  StreamSubscription? _uniLinksSubscription;
 
   @override
   void initState() {
     super.initState();
+    _uniLinksSubscription = listenUniLinks();
     if (_idController.text.isEmpty) {
       () async {
         final lastRemoteId = await bind.mainGetLastRemoteId();
@@ -312,6 +314,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
 
   @override
   void dispose() {
+    _uniLinksSubscription?.cancel();
     _idController.dispose();
     if (Get.isRegistered<IDTextEditingController>()) {
       Get.delete<IDTextEditingController>();


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/4669
Connect to ID using uni/deep link on mobile

Format: `rustdesk://[id]` or `rustdesk://connection/new/[id]` or `rustdesk://connect/[id]` or `rustdesk://play/[id]`
Ex: `rustdesk://13423325234` or `rustdesk://connection/new/13423325234`...

**File transfer:**
Format: `rustdesk://file-transfer/[id]`
Ex: `rustdesk://file-transfer/13423325234`

Works on cold boot as well as when the app is running in the background.


https://github.com/rustdesk/rustdesk/assets/73148455/acc800f1-8e6a-44ee-8f90-937ba6991b6f


https://github.com/rustdesk/rustdesk/assets/73148455/206397fc-e1fb-46df-a19b-128572ae8968

https://github.com/rustdesk/rustdesk/assets/73148455/39148305-58e1-48f0-93f4-ce449bdba0ab