### PR TITLE
fix, android rotate screen

### DIFF
--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -4,8 +4,10 @@ use std::{
     sync::{Arc, Mutex, RwLock},
 };
 
+#[cfg(any(target_os = "windows", feature = "unix-file-copy-paste",))]
+use hbb_common::allow_err;
 use hbb_common::{
-    allow_err, lazy_static, log,
+    lazy_static,
     tokio::sync::{
         mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
         Mutex as TokioMutex,

--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste",))]
-use hbb_common::allow_err;
+use hbb_common::{allow_err, log};
 use hbb_common::{
     lazy_static,
     tokio::sync::{

--- a/libs/clipboard/src/platform/windows.rs
+++ b/libs/clipboard/src/platform/windows.rs
@@ -10,11 +10,11 @@ use std::{
     ffi::{CStr, CString},
     result::Result,
 };
-
 use crate::{
-    allow_err, log, send_data, ClipboardFile, CliprdrError, CliprdrServiceContext, ResultType,
+    allow_err, send_data, ClipboardFile, CliprdrError, CliprdrServiceContext, ResultType,
     ERR_CODE_INVALID_PARAMETER, ERR_CODE_SERVER_FUNCTION_NONE, VEC_MSG_CHANNEL,
 };
+use hbb_common::log;
 
 // only used error code will be recorded here
 /// success

--- a/src/server.rs
+++ b/src/server.rs
@@ -95,7 +95,7 @@ pub fn new() -> ServerPtr {
         id_count: hbb_common::rand::random::<i32>() % 1000 + 1000, // ensure positive
     };
     server.add_service(Box::new(audio_service::new()));
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    #[cfg(not(target_os = "ios"))]
     server.add_service(Box::new(display_service::new()));
     server.add_service(Box::new(video_service::new(
         *display_service::PRIMARY_DISPLAY_IDX,

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -12,6 +12,7 @@ use scrap::Display;
 
 pub const NAME: &'static str = "display";
 
+#[cfg(all(windows, feature = "virtual_display_driver"))]
 const DUMMY_DISPLAY_SIDE_MAX_SIZE: usize = 1024;
 
 struct ChangedResolution {


### PR DESCRIPTION
Fix, rotate android, then the image is distorted. This bug on Android is introduced since "1.2.4", "1.2.3" works fine.


https://github.com/rustdesk/rustdesk/assets/136106582/5bf0b7c4-1418-451c-8e0b-4701b4c67f32


```rust
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+   #[cfg(not(target_os = "ios"))]
     server.add_service(Box::new(display_service::new()));
```


https://github.com/rustdesk/rustdesk/assets/136106582/95409895-a709-43e5-8df2-0653624eac5d

