### PR TITLE
fix windows build, add winapi features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "sysinfo"
 version = "0.29.10"
-source = "git+https://github.com/GuillaumeGomez/sysinfo#f45dcc6510d48c3a1401c5a33eedccc8899f67b2"
+source = "git+https://github.com/rustdesk-org/sysinfo#f45dcc6510d48c3a1401c5a33eedccc8899f67b2"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys 0.8.4",

--- a/libs/hbb_common/Cargo.toml
+++ b/libs/hbb_common/Cargo.toml
@@ -53,7 +53,7 @@ flatpak = []
 protobuf-codegen = { version = "3.2" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["winuser"] }
+winapi = { version = "0.3", features = ["winuser", "synchapi", "pdh", "memoryapi"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 osascript = "0.3"


### PR DESCRIPTION
winapi version has not changed, don’t know why no error was reported before.

![7a9c2d1bd10120c211f28fbc75bad3f](https://github.com/rustdesk/rustdesk/assets/14891774/02b55a1b-d519-4ff4-870d-e49e2ae17889)
