### PR TITLE
Show relay hint regardless of whether data is received or not

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -512,7 +512,7 @@ class FfiModel with ChangeNotifier {
       showWaitUacDialog(sessionId, dialogManager, type);
     } else if (type == 'elevation-error') {
       showElevationError(sessionId, type, title, text, dialogManager);
-    } else if (type == 'relay-hint') {
+    } else if (type == 'relay-hint' || type == 'relay-hint2') {
       showRelayHintDialog(sessionId, type, title, text, dialogManager, peerId);
     } else if (text == 'Connected, waiting for image...') {
       showConnectedWaitingForImage(dialogManager, sessionId, type, title, text);
@@ -564,17 +564,19 @@ class FfiModel with ChangeNotifier {
       if (text.contains("10054") || text.contains("104")) {
         hint = "";
       }
-      final alreadyForceAlwaysRelay = bind
-          .mainGetPeerOptionSync(id: peerId, key: 'force-always-relay')
-          .isNotEmpty;
       return CustomAlertDialog(
         title: null,
         content: msgboxContent(type, title, "${translate(text)}$hint"),
         actions: [
           dialogButton('Close', onPressed: onClose, isOutline: true),
+          if (type == 'relay-hint')
+            dialogButton('Connect via relay',
+                onPressed: () => reconnect(dialogManager, sessionId, true),
+                buttonStyle: style,
+                isOutline: true),
           dialogButton('Retry',
               onPressed: () => reconnect(dialogManager, sessionId, false)),
-          if (!alreadyForceAlwaysRelay)
+          if (type == 'relay-hint2')
             dialogButton('Connect via relay',
                 onPressed: () => reconnect(dialogManager, sessionId, true),
                 buttonStyle: style),

--- a/src/client.rs
+++ b/src/client.rs
@@ -1801,7 +1801,11 @@ impl LoginConfigHandler {
             crate::flutter::push_global_event(crate::flutter::APP_TYPE_MAIN, evt);
         }
         if config.keyboard_mode.is_empty() {
-            if is_keyboard_mode_supported(&KeyboardMode::Map, get_version_number(&pi.version), &pi.platform) {
+            if is_keyboard_mode_supported(
+                &KeyboardMode::Map,
+                get_version_number(&pi.version),
+                &pi.platform,
+            ) {
                 config.keyboard_mode = KeyboardMode::Map.to_string();
             } else {
                 config.keyboard_mode = KeyboardMode::Legacy.to_string();
@@ -2670,21 +2674,25 @@ pub trait Interface: Send + Clone + 'static + Sized {
         let lc = self.get_lch();
         let direct = lc.read().unwrap().direct;
         let received = lc.read().unwrap().received;
-        let relay_condition = direct == Some(true) && !received;
 
+        let mut relay_hint = false;
+        let mut relay_hint_type = "relay-hint";
         // force relay
         let errno = errno::errno().0;
         log::error!("Connection closed: {err}({errno})");
-        if relay_condition
-            && (cfg!(windows) && (errno == 10054 || err.contains("10054"))
-                || !cfg!(windows) && (errno == 104 || err.contains("104")))
+        if direct == Some(true)
+            && ((cfg!(windows) && (errno == 10054 || err.contains("10054")))
+                || (!cfg!(windows) && (errno == 104 || err.contains("104"))))
         {
-            lc.write().unwrap().force_relay = true;
+            relay_hint = true;
+            if !received {
+                relay_hint_type = "relay-hint2"
+            }
         }
 
         // relay-hint
-        if cfg!(feature = "flutter") && relay_condition {
-            self.msgbox("relay-hint", title, &text, "");
+        if cfg!(feature = "flutter") && relay_hint {
+            self.msgbox(relay_hint_type, title, &text, "");
         } else {
             self.msgbox("error", title, &text, "");
         }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/1113#issuecomment-1803912235

`relay-hint2` is receiving data and puts more emphasis on relay.


https://github.com/rustdesk/rustdesk/assets/14891774/c95691ec-da15-4309-8f4e-57d26373f7c5

