### PR TITLE
Fix, windows display orders

### DIFF
--- a/libs/scrap/src/common/dxgi.rs
+++ b/libs/scrap/src/common/dxgi.rs
@@ -111,16 +111,23 @@ impl Display {
         let tmp = Self::all_().unwrap_or(Default::default());
         if tmp.is_empty() {
             println!("Display got from gdi");
-            return Ok(dxgi::Displays::get_from_gdi()
-                .drain(..)
-                .map(Display)
-                .collect::<Vec<_>>());
+            return Ok(Self::displays_from_dxgi_displays(
+                dxgi::Displays::get_from_gdi().drain(..),
+            ));
         }
         Ok(tmp)
     }
 
+    #[inline]
+    pub fn displays_from_dxgi_displays<I>(displays: I) -> Vec<Display>
+    where
+        I: Iterator<Item = dxgi::Display>,
+    {
+        displays.map(Display).collect::<Vec<_>>()
+    }
+
     fn all_() -> io::Result<Vec<Display>> {
-        Ok(dxgi::Displays::new()?.map(Display).collect::<Vec<_>>())
+        Ok(Self::displays_from_dxgi_displays(dxgi::Displays::new()?))
     }
 
     pub fn width(&self) -> usize {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1098,7 +1098,7 @@ pub fn main_get_main_display() -> SyncReturn<String> {
     #[cfg(not(target_os = "ios"))]
     let mut display_info = "".to_owned();
     #[cfg(not(target_os = "ios"))]
-    if let Ok(displays) = crate::display_service::try_get_displays() {
+    if let Ok(displays) = crate::display_service::try_get_displays(false) {
         // to-do: Need to detect current display index.
         if let Some(display) = displays.iter().next() {
             display_info = serde_json::to_string(&HashMap::from([
@@ -1117,7 +1117,7 @@ pub fn main_get_displays() -> SyncReturn<String> {
     #[cfg(not(target_os = "ios"))]
     let mut display_info = "".to_owned();
     #[cfg(not(target_os = "ios"))]
-    if let Ok(displays) = crate::display_service::try_get_displays() {
+    if let Ok(displays) = crate::display_service::try_get_displays(false) {
         let displays = displays
             .iter()
             .map(|d| {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1165,7 +1165,7 @@ impl Connection {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
             pi.resolutions = Some(SupportedResolutions {
-                resolutions: display_service::try_get_displays()
+                resolutions: display_service::try_get_displays(true)
                     .map(|displays| {
                         displays
                             .get(self.display_idx)
@@ -2366,7 +2366,7 @@ impl Connection {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     fn change_resolution(&mut self, r: &Resolution) {
         if self.keyboard {
-            if let Ok(displays) = display_service::try_get_displays() {
+            if let Ok(displays) = display_service::try_get_displays(true) {
                 if let Some(display) = displays.get(self.display_idx) {
                     let name = display.name();
                     #[cfg(all(windows, feature = "virtual_display_driver"))]

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -180,7 +180,7 @@ fn displays_to_msg(displays: Vec<DisplayInfo>) -> Message {
 }
 
 fn check_get_displays_changed_msg() -> Option<Message> {
-    check_update_displays(&try_get_displays().ok()?);
+    check_update_displays(&try_get_displays(true).ok()?);
     let displays = SYNC_DISPLAYS.lock().unwrap().get_update_sync_displays()?;
     Some(displays_to_msg(displays))
 }
@@ -292,7 +292,7 @@ pub async fn update_get_sync_displays() -> ResultType<Vec<DisplayInfo>> {
             return super::wayland::get_displays().await;
         }
     }
-    check_update_displays(&try_get_displays()?);
+    check_update_displays(&try_get_displays(true)?);
     Ok(SYNC_DISPLAYS.lock().unwrap().displays.clone())
 }
 
@@ -308,7 +308,9 @@ pub fn get_primary() -> usize {
         }
     }
 
-    try_get_displays().map(|d| get_primary_2(&d)).unwrap_or(0)
+    try_get_displays(false)
+        .map(|d| get_primary_2(&d))
+        .unwrap_or(0)
 }
 
 #[inline]
@@ -343,20 +345,41 @@ fn no_displays(displays: &Vec<Display>) -> bool {
 
 #[inline]
 #[cfg(not(all(windows, feature = "virtual_display_driver")))]
-pub fn try_get_displays() -> ResultType<Vec<Display>> {
-    Ok(Display::all()?)
+pub fn try_get_displays(_order: bool) -> ResultType<Vec<Display>> {
+    Ok(get_displays(_order)?)
 }
 
 #[cfg(all(windows, feature = "virtual_display_driver"))]
-pub fn try_get_displays() -> ResultType<Vec<Display>> {
-    let mut displays = Display::all()?;
+pub fn try_get_displays(order: bool) -> ResultType<Vec<Display>> {
+    let mut displays = get_displays(order)?;
     if crate::platform::is_installed() && no_displays(&displays) {
         log::debug!("no displays, create virtual display");
         if let Err(e) = virtual_display_manager::plug_in_headless() {
             log::error!("plug in headless failed {}", e);
         } else {
-            displays = Display::all()?;
+            displays = get_displays(order)?;
         }
     }
     Ok(displays)
+}
+
+// Note: Do not use `Display::all()` to get displays.
+// Use `get_displays()` instead.
+
+#[cfg(not(windows))]
+pub fn get_displays(_order: bool) -> ResultType<Vec<Display>> {
+    Ok(Display::all()?)
+}
+
+// get_from_gdi() returns the displays in the same order of the windows display settings.
+// dxgi does not guarantee the order of displays.
+#[cfg(windows)]
+pub fn get_displays(order: bool) -> ResultType<Vec<Display>> {
+    if !order {
+        Ok(Display::all()?)
+    } else {
+        Ok(Display::displays_from_dxgi_displays(
+            scrap::dxgi::Displays::get_from_gdi().drain(..),
+        ))
+    }
 }

--- a/src/server/portable_service.rs
+++ b/src/server/portable_service.rs
@@ -317,7 +317,7 @@ pub mod server {
                 let current_display = (*para).current_display;
                 let timeout_ms = (*para).timeout_ms;
                 if c.is_none() {
-                    let Ok(mut displays) = display_service::try_get_displays() else {
+                    let Ok(mut displays) = display_service::try_get_displays(true) else {
                         log::error!("Failed to get displays");
                         *EXIT.lock().unwrap() = true;
                         return;
@@ -534,7 +534,7 @@ pub mod client {
             bail!("already running");
         }
         if SHMEM.lock().unwrap().is_none() {
-            let displays = scrap::Display::all()?;
+            let displays = crate::display_service::get_displays(false)?;
             if displays.is_empty() {
                 bail!("no display available!");
             }
@@ -655,7 +655,7 @@ pub mod client {
                 shmem.write(ADDR_CAPTURE_WOULDBLOCK, &utils::i32_to_vec(TRUE));
             }
             let (mut width, mut height) = (0, 0);
-            if let Ok(displays) = display_service::try_get_displays() {
+            if let Ok(displays) = display_service::try_get_displays(true) {
                 if let Some(display) = displays.get(current_display) {
                     width = display.width();
                     height = display.height();

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -249,7 +249,7 @@ pub fn test_create_capturer(
 ) -> String {
     let test_begin = Instant::now();
     loop {
-        let err = match Display::all() {
+        let err = match super::display_service::get_displays(true) {
             Ok(mut displays) => {
                 if displays.len() <= display_idx {
                     anyhow!(
@@ -322,7 +322,7 @@ fn get_capturer(current: usize, portable_service_running: bool) -> ResultType<Ca
         }
     }
 
-    let mut displays = Display::all()?;
+    let mut displays = super::display_service::get_displays(true)?;
     let ndisplay = displays.len();
     if ndisplay <= current {
         bail!(

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -139,7 +139,7 @@ pub(super) async fn check_init() -> ResultType<()> {
         if *CAP_DISPLAY_INFO.read().unwrap() == 0 {
             let mut lock = CAP_DISPLAY_INFO.write().unwrap();
             if *lock == 0 {
-                let mut all = Display::all()?;
+                let mut all = super::display_service::get_displays(true)?;
                 let num = all.len();
                 let primary = super::display_service::get_primary_2(&all);
                 let current = primary;

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -1,6 +1,6 @@
 use super::*;
 use hbb_common::{allow_err, platform::linux::DISTRO};
-use scrap::{is_cursor_embedded, set_map_err, Capturer, Display, Frame, TraitCapturer};
+use scrap::{is_cursor_embedded, set_map_err, Capturer, Frame, TraitCapturer};
 use std::io;
 use std::process::{Command, Output};
 
@@ -186,8 +186,7 @@ pub(super) async fn check_init() -> ResultType<()> {
                 maxy = max_height;
 
                 let capturer = Box::into_raw(Box::new(
-                    Capturer::new(display)
-                        .with_context(|| "Failed to create capturer")?,
+                    Capturer::new(display).with_context(|| "Failed to create capturer")?,
                 ));
                 let capturer = CapturerPtr(capturer);
                 let cap_display_info = Box::into_raw(Box::new(CapDisplayInfo {


### PR DESCRIPTION
![image](https://github.com/rustdesk/rustdesk/assets/13586388/ca5448cf-9202-4460-8285-d578af9639a6)

Displays' order returned from the dxgi method does not match the order of the system dispay settings.

I could not find a way to keep the order from dxgi method.

Displays' order returned from the gdi method matches the order.

So, I introduce a new method `fn get_displays(_order: bool) -> ResultType<Vec<Display>>`, and replace all direct call of `Display::all()`.

The disadvantage is that almost everywhere uses `scrap::dxgi::Displays::get_from_gdi()` to keep the order.




