### PR TITLE
not use max fps by default

### DIFF
--- a/flutter/lib/common/widgets/setting_widgets.dart
+++ b/flutter/lib/common/widgets/setting_widgets.dart
@@ -2,6 +2,7 @@ import 'package:debounce_throttle/debounce_throttle.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hbb/common.dart';
+import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:get/get.dart';
 
@@ -12,13 +13,17 @@ customImageQualityWidget(
     required Function(double) setFps,
     required bool showFps,
     required bool showMoreQuality}) {
-  if (!showMoreQuality && initQuality > 100) {
-    initQuality = 50;
+  if (initQuality < kMinQuality ||
+      initQuality > (showMoreQuality ? kMaxMoreQuality : kMaxQuality)) {
+    initQuality = kDefaultQuality;
+  }
+  if (initFps < kMinFps || initFps > kMaxFps) {
+    initFps = kDefaultFps;
   }
   final qualityValue = initQuality.obs;
   final fpsValue = initFps.obs;
 
-  final RxBool moreQualityChecked = RxBool(qualityValue.value > 100);
+  final RxBool moreQualityChecked = RxBool(qualityValue.value > kMaxQuality);
   final debouncerQuality = Debouncer<double>(
     Duration(milliseconds: 1000),
     onChanged: (double v) {
@@ -51,9 +56,11 @@ customImageQualityWidget(
                 flex: 3,
                 child: Slider(
                   value: qualityValue.value,
-                  min: 10.0,
-                  max: moreQualityChecked.value ? 2000 : 100,
-                  divisions: moreQualityChecked.value ? 199 : 18,
+                  min: kMinQuality,
+                  max: moreQualityChecked.value ? kMaxMoreQuality : kMaxQuality,
+                  divisions: moreQualityChecked.value
+                      ? ((kMaxMoreQuality - kMinQuality) / 10).round()
+                      : ((kMaxQuality - kMinQuality) / 5).round(),
                   onChanged: (double value) async {
                     qualityValue.value = value;
                     debouncerQuality.value = value;
@@ -113,9 +120,9 @@ customImageQualityWidget(
                   flex: 3,
                   child: Slider(
                     value: fpsValue.value,
-                    min: 5.0,
-                    max: 120.0,
-                    divisions: 23,
+                    min: kMinFps,
+                    max: kMaxFps,
+                    divisions: ((kMaxFps - kMinFps) / 5).round(),
                     onChanged: (double value) async {
                       fpsValue.value = value;
                       debouncerFps.value = value;
@@ -145,15 +152,10 @@ customImageQualitySetting() {
   final fpsKey = 'custom-fps';
 
   var initQuality =
-      (double.tryParse(bind.mainGetUserDefaultOption(key: qualityKey)) ?? 50.0);
-  if (initQuality < 10 || initQuality > 2000) {
-    initQuality = 50;
-  }
-  var initFps =
-      (double.tryParse(bind.mainGetUserDefaultOption(key: fpsKey)) ?? 30.0);
-  if (initFps < 5 || initFps > 120) {
-    initFps = 30;
-  }
+      (double.tryParse(bind.mainGetUserDefaultOption(key: qualityKey)) ??
+          kDefaultQuality);
+  var initFps = (double.tryParse(bind.mainGetUserDefaultOption(key: fpsKey)) ??
+      kDefaultFps);
 
   return customImageQualityWidget(
       initQuality: initQuality,

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -102,6 +102,15 @@ const int kDesktopMaxDisplaySize = 3840;
 const double kDesktopFileTransferRowHeight = 30.0;
 const double kDesktopFileTransferHeaderHeight = 25.0;
 
+const double kMinFps = 5;
+const double kDefaultFps = 30;
+const double kMaxFps = 120;
+
+const double kMinQuality = 10;
+const double kDefaultQuality = 50;
+const double kMaxQuality = 100;
+const double kMaxMoreQuality = 2000;
+
 double kNewWindowOffset = Platform.isWindows
     ? 56.0
     : Platform.isLinux

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -715,7 +715,7 @@ message Misc {
     Resolution change_resolution = 24;
     PluginRequest plugin_request = 25;
     PluginFailure plugin_failure = 26;
-    uint32 full_speed_fps = 27;
+    uint32 full_speed_fps = 27; // deprecated
     uint32 auto_adjust_fps = 28;
     bool client_record_status = 29;
     CaptureDisplays capture_displays = 30;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2179,10 +2179,6 @@ impl Connection {
                             crate::plugin::handle_client_event(&p.id, &self.lr.my_id, &p.content);
                         self.send(msg).await;
                     }
-                    Some(misc::Union::FullSpeedFps(fps)) => video_service::VIDEO_QOS
-                        .lock()
-                        .unwrap()
-                        .user_full_speed_fps(self.inner.id(), fps),
                     Some(misc::Union::AutoAdjustFps(fps)) => video_service::VIDEO_QOS
                         .lock()
                         .unwrap()

--- a/src/server/video_qos.rs
+++ b/src/server/video_qos.rs
@@ -30,8 +30,7 @@ struct Delay {
 
 #[derive(Default, Debug, Copy, Clone)]
 struct UserData {
-    full_speed_fps: Option<u32>,
-    auto_adjust_fps: Option<u32>,
+    auto_adjust_fps: Option<u32>, // reserve for compatibility
     custom_fps: Option<u32>,
     quality: Option<(i64, Quality)>, // (time, quality)
     delay: Option<Delay>,
@@ -126,18 +125,12 @@ impl VideoQoS {
     pub fn refresh(&mut self, typ: Option<RefreshType>) {
         // fps
         let user_fps = |u: &UserData| {
-            // full_speed_fps
-            let mut fps = u.full_speed_fps.unwrap_or_default() * 9 / 10;
+            // custom_fps
+            let mut fps = u.custom_fps.unwrap_or(FPS);
             // auto adjust fps
             if let Some(auto_adjust_fps) = u.auto_adjust_fps {
                 if fps == 0 || auto_adjust_fps < fps {
                     fps = auto_adjust_fps;
-                }
-            }
-            // custom_fps
-            if let Some(custom_fps) = u.custom_fps {
-                if fps == 0 || custom_fps < fps {
-                    fps = custom_fps;
                 }
             }
             // delay
@@ -257,21 +250,6 @@ impl VideoQoS {
                 id,
                 UserData {
                     custom_fps: Some(fps),
-                    ..Default::default()
-                },
-            );
-        }
-        self.refresh(None);
-    }
-
-    pub fn user_full_speed_fps(&mut self, id: i32, full_speed_fps: u32) {
-        if let Some(user) = self.users.get_mut(&id) {
-            user.full_speed_fps = Some(full_speed_fps);
-        } else {
-            self.users.insert(
-                id,
-                UserData {
-                    full_speed_fps: Some(full_speed_fps),
                     ..Default::default()
                 },
             );

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1,4 +1,7 @@
-use crate::{input::{MOUSE_BUTTON_LEFT, MOUSE_TYPE_DOWN, MOUSE_TYPE_UP, MOUSE_TYPE_WHEEL}, common::{is_keyboard_mode_supported, get_supported_keyboard_modes}};
+use crate::{
+    common::{get_supported_keyboard_modes, is_keyboard_mode_supported},
+    input::{MOUSE_BUTTON_LEFT, MOUSE_TYPE_DOWN, MOUSE_TYPE_UP, MOUSE_TYPE_WHEEL},
+};
 use async_trait::async_trait;
 use bytes::Bytes;
 use rdev::{Event, EventType::*, KeyCode};
@@ -213,7 +216,7 @@ impl<T: InvokeUiSession> Session<T> {
         self.lc.read().unwrap().version.clone()
     }
 
-    pub fn fallback_keyboard_mode(&self) -> String { 
+    pub fn fallback_keyboard_mode(&self) -> String {
         let peer_version = self.get_peer_version();
         let platform = self.peer_platform();
 
@@ -386,14 +389,19 @@ impl<T: InvokeUiSession> Session<T> {
     }
 
     pub fn save_image_quality(&self, value: String) {
-        let msg = self.lc.write().unwrap().save_image_quality(value);
+        let msg = self.lc.write().unwrap().save_image_quality(value.clone());
         if let Some(msg) = msg {
+            self.send(Data::Message(msg));
+        }
+        if value != "custom" {
+            // non custom quality use 30 fps
+            let msg = self.lc.write().unwrap().set_custom_fps(30, false);
             self.send(Data::Message(msg));
         }
     }
 
     pub fn set_custom_fps(&self, custom_fps: i32) {
-        let msg = self.lc.write().unwrap().set_custom_fps(custom_fps);
+        let msg = self.lc.write().unwrap().set_custom_fps(custom_fps, true);
         self.send(Data::Message(msg));
     }
 


### PR DESCRIPTION
1. Not use max fps by default, fps will never exceed max fps,  remove full speed fps, client adjust fps with custom_fps (rather than auto_fps, because one value is sufficient to express the max fps), server still reserve auto_fps for compatibility. 
2. Only the Custom image quality option allows users to set a custom FPS. For other image qualities, the maximum FPS will be set to 30.
3. Make the automatic adjustment of FPS more responsive
4. Fix  custom_fps/custom_quality in login request, which doesn't check public or selfhost, direct or relay.

