### PR TITLE
windows, try use dxgi display when creating capturer

### DIFF
--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -383,3 +383,11 @@ pub fn get_displays(order: bool) -> ResultType<Vec<Display>> {
         ))
     }
 }
+
+#[inline]
+#[cfg(windows)]
+pub fn try_get_dxgi_display(display: Display) -> ResultType<Option<Display>> {
+    Ok(Display::all()?
+        .into_iter()
+        .find(|d| d.name() == display.name()))
+}

--- a/src/server/portable_service.rs
+++ b/src/server/portable_service.rs
@@ -329,10 +329,18 @@ pub mod server {
                     }
                     let display = displays.remove(current_display);
                     #[cfg(windows)]
-                    let Ok(Some(display)) = display_service::try_get_dxgi_display(display) else {
-                        log::error!("Failed to try get dxgi display");
-                        *EXIT.lock().unwrap() = true;
-                        return;
+                    let display = match display_service::try_get_dxgi_display(display) {
+                        Ok(Some(d)) => d,
+                        Ok(None) => {
+                            log::error!("Failed to try get dxgi display");
+                            *EXIT.lock().unwrap() = true;
+                            return;
+                        }
+                        Err(e) => {
+                            log::error!("Failed to try get dxgi display:{:?}", e);
+                            *EXIT.lock().unwrap() = true;
+                            return;
+                        }
                     };
                     display_width = display.width();
                     display_height = display.height();

--- a/src/server/portable_service.rs
+++ b/src/server/portable_service.rs
@@ -328,6 +328,12 @@ pub mod server {
                         return;
                     }
                     let display = displays.remove(current_display);
+                    #[cfg(windows)]
+                    let Ok(Some(display)) = display_service::try_get_dxgi_display(display) else {
+                        log::error!("Failed to try get dxgi display");
+                        *EXIT.lock().unwrap() = true;
+                        return;
+                    };
                     display_width = display.width();
                     display_height = display.height();
                     match Capturer::new(display) {

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -332,6 +332,14 @@ fn get_capturer(current: usize, portable_service_running: bool) -> ResultType<Ca
         );
     }
     let display = displays.remove(current);
+    #[cfg(windows)]
+    let Ok(Some(display)) = display_service::try_get_dxgi_display(display) else {
+        bail!(
+            "Failed to try get display {}, displays len: {}",
+            current,
+            ndisplay
+        );
+    };
     let (origin, width, height) = (display.origin(), display.width(), display.height());
     let name = display.name();
     log::debug!(

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -333,7 +333,7 @@ fn get_capturer(current: usize, portable_service_running: bool) -> ResultType<Ca
     }
     let display = displays.remove(current);
     #[cfg(windows)]
-    let Ok(Some(display)) = display_service::try_get_dxgi_display(display) else {
+    let Some(display) = display_service::try_get_dxgi_display(display)? else {
         bail!(
             "Failed to try get display {}, displays len: {}",
             current,


### PR DESCRIPTION
Gdi is always used on windows since https://github.com/rustdesk/rustdesk/pull/6379 .

Try use the  correspoding dxgi display for capturing.
