### PR TITLE
Fix/query onlines block thread

### DIFF
--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -82,7 +82,7 @@ class _PeersViewState extends State<_PeersView> with WindowListener {
   final _curPeers = <String>{};
   var _lastChangeTime = DateTime.now();
   var _lastQueryPeers = <String>{};
-  var _lastQueryTime = DateTime.now().subtract(const Duration(hours: 1));
+  var _lastQueryTime = DateTime.now().add(const Duration(seconds: 30));
   var _queryCount = 0;
   var _exit = false;
 
@@ -272,8 +272,7 @@ class _PeersViewState extends State<_PeersView> with WindowListener {
           if (_queryCount < _maxQueryCount) {
             if (now.difference(_lastQueryTime) >= _queryInterval) {
               if (_curPeers.isNotEmpty) {
-                platformFFI.ffiBind
-                    .queryOnlines(ids: _curPeers.toList(growable: false));
+                bind.queryOnlines(ids: _curPeers.toList(growable: false));
                 _lastQueryTime = DateTime.now();
                 _queryCount += 1;
               }
@@ -287,7 +286,7 @@ class _PeersViewState extends State<_PeersView> with WindowListener {
 
   _queryOnlines(bool isLoadEvent) {
     if (_curPeers.isNotEmpty) {
-      platformFFI.ffiBind.queryOnlines(ids: _curPeers.toList(growable: false));
+      bind.queryOnlines(ids: _curPeers.toList(growable: false));
       _lastQueryPeers = {..._curPeers};
       if (isLoadEvent) {
         _lastChangeTime = DateTime.now();

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -36,6 +36,7 @@ lazy_static::lazy_static! {
 }
 
 fn initialize(app_dir: &str) {
+    flutter::async_tasks::start_flutter_async_runner();
     *config::APP_DIR.write().unwrap() = app_dir.to_owned();
     #[cfg(target_os = "android")]
     {
@@ -1554,18 +1555,6 @@ pub fn main_get_build_date() -> String {
     crate::BUILD_DATE.to_string()
 }
 
-fn handle_query_onlines(onlines: Vec<String>, offlines: Vec<String>) {
-    let data = HashMap::from([
-        ("name", "callback_query_onlines".to_owned()),
-        ("onlines", onlines.join(",")),
-        ("offlines", offlines.join(",")),
-    ]);
-    let _res = flutter::push_global_event(
-        flutter::APP_TYPE_MAIN,
-        serde_json::ser::to_string(&data).unwrap_or("".to_owned()),
-    );
-}
-
 pub fn translate(name: String, locale: String) -> SyncReturn<String> {
     SyncReturn(crate::client::translate_locale(name, &locale))
 }
@@ -1589,8 +1578,7 @@ pub fn session_register_texture(
 }
 
 pub fn query_onlines(ids: Vec<String>) {
-    #[cfg(not(any(target_os = "ios")))]
-    crate::rendezvous_mediator::query_online_states(ids, handle_query_onlines)
+    let _ = flutter::async_tasks::query_onlines(ids);
 }
 
 pub fn version_to_number(v: String) -> SyncReturn<i64> {

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -598,7 +598,7 @@ pub async fn query_online_states<F: FnOnce(Vec<String>, Vec<String>)>(ids: Vec<S
             }
 
             if query_begin.elapsed() > query_timeout {
-                log::debug!("query onlines timeout {:?}", query_timeout);
+                log::debug!("query onlines timeout {:?} ({:?})", query_begin.elapsed(), query_timeout);
                 break;
             }
 

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -572,7 +572,6 @@ async fn direct_server(server: ServerPtr) {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
 pub async fn query_online_states<F: FnOnce(Vec<String>, Vec<String>)>(ids: Vec<String>, f: F) {
     let test = false;
     if test {
@@ -598,7 +597,11 @@ pub async fn query_online_states<F: FnOnce(Vec<String>, Vec<String>)>(ids: Vec<S
             }
 
             if query_begin.elapsed() > query_timeout {
-                log::debug!("query onlines timeout {:?} ({:?})", query_begin.elapsed(), query_timeout);
+                log::debug!(
+                    "query onlines timeout {:?} ({:?})",
+                    query_begin.elapsed(),
+                    query_timeout
+                );
                 break;
             }
 
@@ -679,8 +682,10 @@ async fn query_online_states_(
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn test_query_onlines() {
+    use hbb_common::tokio;
+
+    #[tokio::test]
+    async fn test_query_onlines() {
         super::query_online_states(
             vec![
                 "152183996".to_owned(),
@@ -691,6 +696,7 @@ mod tests {
             |onlines: Vec<String>, offlines: Vec<String>| {
                 println!("onlines: {:?}, offlines: {:?}", &onlines, &offlines);
             },
-        );
+        )
+        .await;
     }
 }


### PR DESCRIPTION
`query_onlines()` will block current thread.

The thread will block for a long time if the server is unreachable.

Fix by creating a task thread for querying, and sending ids to query through the `UnboundedSender`.

https://github.com/rustdesk/rustdesk/assets/136106582/4623b335-fa88-4614-9248-7a501568c3a9

