### PR TITLE
fix, android_soft_keyboard_input, maybe flutter 3.13.*

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -448,7 +448,8 @@ class _RemotePageState extends State<RemotePage> {
               height: 0,
               child: !_showEdit
                   ? Container()
-                  : TextFormField(
+                  : Container(
+                      child: TextFormField(
                       textInputAction: TextInputAction.newline,
                       autocorrect: false,
                       enableSuggestions: false,
@@ -459,7 +460,7 @@ class _RemotePageState extends State<RemotePage> {
                       // trick way to make backspace work always
                       keyboardType: TextInputType.multiline,
                       onChanged: handleSoftKeyboardInput,
-                    ),
+                    )),
             ),
           ];
           if (showCursorPaint) {

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -448,6 +448,9 @@ class _RemotePageState extends State<RemotePage> {
               height: 0,
               child: !_showEdit
                   ? Container()
+                  // A container wrapper is needed here on some android devices for flutter 3.13.9, otherwise the focusNode will not work.
+                  // But for flutter 3.10.*, the container wrapper is not needed.
+                  // It maybe the flutter compatibility issue.
                   : Container(
                       child: TextFormField(
                       textInputAction: TextInputAction.newline,


### PR DESCRIPTION
Maybe it's a compatibility issue with flutter, I'll confirm.

https://github.com/rustdesk/rustdesk/discussions/6417


Confirmed, after downgrading the version to 3.10.0, the soft keyboard works without the Container wrapper.

