### PR TITLE
Fix. Do not get displays on server start.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -77,7 +77,6 @@ lazy_static::lazy_static! {
     // Now we use this [`CLIENT_SERVER`] to do following operations:
     // - record local audio, and send to remote
     pub static ref CLIENT_SERVER: ServerPtr = new();
-    static ref PRIMARY_VIDEO_SERVICE_LOCK: Arc<Mutex<()>> = Default::default();
 }
 
 pub struct Server {
@@ -260,8 +259,7 @@ impl Server {
         name.starts_with(video_service::NAME)
     }
 
-    pub fn try_add_privay_video_service(&mut self) {
-        let _lock = PRIMARY_VIDEO_SERVICE_LOCK.lock().unwrap();
+    pub fn try_add_primay_video_service(&mut self) {
         let primary_video_service_name =
             video_service::get_service_name(*display_service::PRIMARY_DISPLAY_IDX);
         if !self.contains(&primary_video_service_name) {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1244,7 +1244,7 @@ impl Connection {
                 #[cfg(not(any(target_os = "android", target_os = "ios")))]
                 let _h = try_start_record_cursor_pos();
                 self.auto_disconnect_timer = Self::get_auto_disconenct_timer();
-                s.try_add_privay_video_service();
+                s.try_add_primay_video_service();
                 s.add_connection(self.inner.clone(), &noperms);
             }
         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1244,6 +1244,7 @@ impl Connection {
                 #[cfg(not(any(target_os = "android", target_os = "ios")))]
                 let _h = try_start_record_cursor_pos();
                 self.auto_disconnect_timer = Self::get_auto_disconenct_timer();
+                s.try_add_privay_video_service();
                 s.add_connection(self.inner.clone(), &noperms);
             }
         }

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -24,7 +24,7 @@ lazy_static::lazy_static! {
     static ref IS_CAPTURER_MAGNIFIER_SUPPORTED: bool = is_capturer_mag_supported();
     static ref CHANGED_RESOLUTIONS: Arc<RwLock<HashMap<String, ChangedResolution>>> = Default::default();
     // Initial primary display index.
-    // It should only be updated when the rustdesk server is started, and should not be updated when displays changed.
+    // It should should not be updated when displays changed.
     pub static ref PRIMARY_DISPLAY_IDX: usize = get_primary();
     static ref SYNC_DISPLAYS: Arc<Mutex<SyncDisplaysInfo>> = Default::default();
 }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/6280#issuecomment-1815887300

Do not detect displays (or primary display) on server start.

RustDesk use the primary display as the default display.
The video service of the primary display should be added immediately after the first connection is ready.

