### PR TITLE
Feat/format idd error message

### DIFF
--- a/libs/scrap/src/dxgi/mag.rs
+++ b/libs/scrap/src/dxgi/mag.rs
@@ -173,7 +173,10 @@ impl MagInterface {
                 if FALSE == init_func() {
                     return Err(Error::new(
                         ErrorKind::Other,
-                        format!("Failed to MagInitialize, error: {:?}", Error::last_os_error()),
+                        format!(
+                            "Failed to MagInitialize, error: {:?}",
+                            Error::last_os_error()
+                        ),
                     ));
                 } else {
                     s.init_succeeded = true;
@@ -315,7 +318,10 @@ impl CapturerMag {
             ) {
                 return Err(Error::new(
                     ErrorKind::Other,
-                    format!("Failed to GetModuleHandleExA, error {:?}", Error::last_os_error()),
+                    format!(
+                        "Failed to GetModuleHandleExA, error {:?}",
+                        Error::last_os_error()
+                    ),
                 ));
             }
 
@@ -342,7 +348,10 @@ impl CapturerMag {
                 if code != ERROR_CLASS_ALREADY_EXISTS {
                     return Err(Error::new(
                         ErrorKind::Other,
-                        format!("Failed to RegisterClassExA, error: {}", code),
+                        format!(
+                            "Failed to RegisterClassExA, error {:?}",
+                            Error::from_raw_os_error(code as _)
+                        ),
                     ));
                 }
             }
@@ -546,7 +555,10 @@ impl CapturerMag {
                 if FALSE == set_window_source_func(self.magnifier_window, self.rect) {
                     return Err(Error::new(
                         ErrorKind::Other,
-                        format!("Failed to MagSetWindowSource, error {:?}", Error::last_os_error()),
+                        format!(
+                            "Failed to MagSetWindowSource, error {:?}",
+                            Error::last_os_error()
+                        ),
                     ));
                 }
             } else {
@@ -578,7 +590,10 @@ impl CapturerMag {
             unsafe {
                 if FALSE == DestroyWindow(self.magnifier_window) {
                     //
-                    println!("Failed DestroyWindow magnifier window, error {:?}", Error::last_os_error())
+                    println!(
+                        "Failed DestroyWindow magnifier window, error {:?}",
+                        Error::last_os_error()
+                    )
                 }
             }
         }
@@ -588,7 +603,10 @@ impl CapturerMag {
             unsafe {
                 if FALSE == DestroyWindow(self.host_window) {
                     //
-                    println!("Failed DestroyWindow host window, error {:?}", Error::last_os_error())
+                    println!(
+                        "Failed DestroyWindow host window, error {:?}",
+                        Error::last_os_error()
+                    )
                 }
             }
         }

--- a/libs/scrap/src/dxgi/mag.rs
+++ b/libs/scrap/src/dxgi/mag.rs
@@ -139,7 +139,7 @@ impl MagInterface {
                 return Err(Error::new(
                     ErrorKind::Other,
                     format!(
-                        "Failed to LoadLibraryExA {}, error: {:?}",
+                        "Failed to LoadLibraryExA {}, error: {}",
                         lib_file_name,
                         Error::last_os_error()
                     ),
@@ -173,10 +173,7 @@ impl MagInterface {
                 if FALSE == init_func() {
                     return Err(Error::new(
                         ErrorKind::Other,
-                        format!(
-                            "Failed to MagInitialize, error: {:?}",
-                            Error::last_os_error()
-                        ),
+                        format!("Failed to MagInitialize, error: {}", Error::last_os_error()),
                     ));
                 } else {
                     s.init_succeeded = true;
@@ -198,7 +195,7 @@ impl MagInterface {
             return Err(Error::new(
                 ErrorKind::Other,
                 format!(
-                    "Failed to GetProcAddress {}, error {:?}",
+                    "Failed to GetProcAddress {}, error {}",
                     func_name,
                     Error::last_os_error()
                 ),
@@ -212,14 +209,14 @@ impl MagInterface {
             if let Some(uninit_func) = self.mag_uninitialize_func {
                 unsafe {
                     if FALSE == uninit_func() {
-                        println!("Failed MagUninitialize, error {:?}", Error::last_os_error())
+                        println!("Failed MagUninitialize, error {}", Error::last_os_error())
                     }
                 }
             }
             if !self.lib_handle.is_null() {
                 unsafe {
                     if FALSE == FreeLibrary(self.lib_handle) {
-                        println!("Failed FreeLibrary, error {:?}", Error::last_os_error())
+                        println!("Failed FreeLibrary, error {}", Error::last_os_error())
                     }
                 }
                 self.lib_handle = NULL as _;
@@ -319,7 +316,7 @@ impl CapturerMag {
                 return Err(Error::new(
                     ErrorKind::Other,
                     format!(
-                        "Failed to GetModuleHandleExA, error {:?}",
+                        "Failed to GetModuleHandleExA, error {}",
                         Error::last_os_error()
                     ),
                 ));
@@ -375,7 +372,7 @@ impl CapturerMag {
                 return Err(Error::new(
                     ErrorKind::Other,
                     format!(
-                        "Failed to CreateWindowExA host_window, error {:?}",
+                        "Failed to CreateWindowExA host_window, error {}",
                         Error::last_os_error()
                     ),
                 ));
@@ -400,7 +397,7 @@ impl CapturerMag {
                 return Err(Error::new(
                     ErrorKind::Other,
                     format!(
-                        "Failed CreateWindowA magnifier_window, error {:?}",
+                        "Failed CreateWindowA magnifier_window, error {}",
                         Error::last_os_error()
                     ),
                 ));
@@ -420,7 +417,7 @@ impl CapturerMag {
                     return Err(Error::new(
                         ErrorKind::Other,
                         format!(
-                            "Failed to MagSetImageScalingCallback, error {:?}",
+                            "Failed to MagSetImageScalingCallback, error {}",
                             Error::last_os_error()
                         ),
                     ));
@@ -464,7 +461,7 @@ impl CapturerMag {
                     return Err(Error::new(
                         ErrorKind::Other,
                         format!(
-                            "Failed MagSetWindowFilterList for cls {} name {}, error {:?}",
+                            "Failed MagSetWindowFilterList for cls {} name {}, error {}",
                             cls,
                             name,
                             Error::last_os_error()
@@ -539,7 +536,7 @@ impl CapturerMag {
                 return Err(Error::new(
                     ErrorKind::Other,
                     format!(
-                        "Failed SetWindowPos (x, y, w , h) - ({}, {}, {}, {}), error {:?}",
+                        "Failed SetWindowPos (x, y, w , h) - ({}, {}, {}, {}), error {}",
                         self.rect.left,
                         self.rect.top,
                         self.rect.right - self.rect.left,
@@ -556,7 +553,7 @@ impl CapturerMag {
                     return Err(Error::new(
                         ErrorKind::Other,
                         format!(
-                            "Failed to MagSetWindowSource, error {:?}",
+                            "Failed to MagSetWindowSource, error {}",
                             Error::last_os_error()
                         ),
                     ));
@@ -591,7 +588,7 @@ impl CapturerMag {
                 if FALSE == DestroyWindow(self.magnifier_window) {
                     //
                     println!(
-                        "Failed DestroyWindow magnifier window, error {:?}",
+                        "Failed DestroyWindow magnifier window, error {}",
                         Error::last_os_error()
                     )
                 }
@@ -604,7 +601,7 @@ impl CapturerMag {
                 if FALSE == DestroyWindow(self.host_window) {
                     //
                     println!(
-                        "Failed DestroyWindow host window, error {:?}",
+                        "Failed DestroyWindow host window, error {}",
                         Error::last_os_error()
                     )
                 }

--- a/libs/scrap/src/dxgi/mag.rs
+++ b/libs/scrap/src/dxgi/mag.rs
@@ -139,7 +139,7 @@ impl MagInterface {
                 return Err(Error::new(
                     ErrorKind::Other,
                     format!(
-                        "Failed to LoadLibraryExA {}, error: {}",
+                        "Failed to LoadLibraryExA {}, error {}",
                         lib_file_name,
                         Error::last_os_error()
                     ),
@@ -173,7 +173,7 @@ impl MagInterface {
                 if FALSE == init_func() {
                     return Err(Error::new(
                         ErrorKind::Other,
-                        format!("Failed to MagInitialize, error: {}", Error::last_os_error()),
+                        format!("Failed to MagInitialize, error {}", Error::last_os_error()),
                     ));
                 } else {
                     s.init_succeeded = true;
@@ -346,7 +346,7 @@ impl CapturerMag {
                     return Err(Error::new(
                         ErrorKind::Other,
                         format!(
-                            "Failed to RegisterClassExA, error {:?}",
+                            "Failed to RegisterClassExA, error {}",
                             Error::from_raw_os_error(code as _)
                         ),
                     ));

--- a/libs/scrap/src/dxgi/mag.rs
+++ b/libs/scrap/src/dxgi/mag.rs
@@ -139,9 +139,9 @@ impl MagInterface {
                 return Err(Error::new(
                     ErrorKind::Other,
                     format!(
-                        "Failed to LoadLibraryExA {}, error: {}",
+                        "Failed to LoadLibraryExA {}, error: {:?}",
                         lib_file_name,
-                        GetLastError()
+                        Error::last_os_error()
                     ),
                 ));
             };
@@ -173,7 +173,7 @@ impl MagInterface {
                 if FALSE == init_func() {
                     return Err(Error::new(
                         ErrorKind::Other,
-                        format!("Failed to MagInitialize, error: {}", GetLastError()),
+                        format!("Failed to MagInitialize, error: {:?}", Error::last_os_error()),
                     ));
                 } else {
                     s.init_succeeded = true;
@@ -195,9 +195,9 @@ impl MagInterface {
             return Err(Error::new(
                 ErrorKind::Other,
                 format!(
-                    "Failed to GetProcAddress {}, error: {}",
+                    "Failed to GetProcAddress {}, error {:?}",
                     func_name,
-                    GetLastError()
+                    Error::last_os_error()
                 ),
             ));
         }
@@ -209,14 +209,14 @@ impl MagInterface {
             if let Some(uninit_func) = self.mag_uninitialize_func {
                 unsafe {
                     if FALSE == uninit_func() {
-                        println!("Failed MagUninitialize {}", GetLastError())
+                        println!("Failed MagUninitialize, error {:?}", Error::last_os_error())
                     }
                 }
             }
             if !self.lib_handle.is_null() {
                 unsafe {
                     if FALSE == FreeLibrary(self.lib_handle) {
-                        println!("Failed FreeLibrary {}", GetLastError())
+                        println!("Failed FreeLibrary, error {:?}", Error::last_os_error())
                     }
                 }
                 self.lib_handle = NULL as _;
@@ -315,7 +315,7 @@ impl CapturerMag {
             ) {
                 return Err(Error::new(
                     ErrorKind::Other,
-                    format!("Failed to GetModuleHandleExA, error: {}", GetLastError()),
+                    format!("Failed to GetModuleHandleExA, error {:?}", Error::last_os_error()),
                 ));
             }
 
@@ -366,8 +366,8 @@ impl CapturerMag {
                 return Err(Error::new(
                     ErrorKind::Other,
                     format!(
-                        "Failed to CreateWindowExA host_window, error: {}",
-                        GetLastError()
+                        "Failed to CreateWindowExA host_window, error {:?}",
+                        Error::last_os_error()
                     ),
                 ));
             }
@@ -391,8 +391,8 @@ impl CapturerMag {
                 return Err(Error::new(
                     ErrorKind::Other,
                     format!(
-                        "Failed CreateWindowA magnifier_window, error: {}",
-                        GetLastError()
+                        "Failed CreateWindowA magnifier_window, error {:?}",
+                        Error::last_os_error()
                     ),
                 ));
             }
@@ -411,8 +411,8 @@ impl CapturerMag {
                     return Err(Error::new(
                         ErrorKind::Other,
                         format!(
-                            "Failed to MagSetImageScalingCallback, error: {}",
-                            GetLastError()
+                            "Failed to MagSetImageScalingCallback, error {:?}",
+                            Error::last_os_error()
                         ),
                     ));
                 }
@@ -455,10 +455,10 @@ impl CapturerMag {
                     return Err(Error::new(
                         ErrorKind::Other,
                         format!(
-                            "Failed MagSetWindowFilterList for cls {} name {}, err: {}",
+                            "Failed MagSetWindowFilterList for cls {} name {}, error {:?}",
                             cls,
                             name,
-                            GetLastError()
+                            Error::last_os_error()
                         ),
                     ));
                 }
@@ -530,12 +530,12 @@ impl CapturerMag {
                 return Err(Error::new(
                     ErrorKind::Other,
                     format!(
-                        "Failed SetWindowPos (x, y, w , h) - ({}, {}, {}, {}), error {}",
+                        "Failed SetWindowPos (x, y, w , h) - ({}, {}, {}, {}), error {:?}",
                         self.rect.left,
                         self.rect.top,
                         self.rect.right - self.rect.left,
                         self.rect.bottom - self.rect.top,
-                        GetLastError()
+                        Error::last_os_error()
                     ),
                 ));
             }
@@ -546,7 +546,7 @@ impl CapturerMag {
                 if FALSE == set_window_source_func(self.magnifier_window, self.rect) {
                     return Err(Error::new(
                         ErrorKind::Other,
-                        format!("Failed to MagSetWindowSource, error: {}", GetLastError()),
+                        format!("Failed to MagSetWindowSource, error {:?}", Error::last_os_error()),
                     ));
                 }
             } else {
@@ -578,7 +578,7 @@ impl CapturerMag {
             unsafe {
                 if FALSE == DestroyWindow(self.magnifier_window) {
                     //
-                    println!("Failed DestroyWindow magnifier window {}", GetLastError())
+                    println!("Failed DestroyWindow magnifier window, error {:?}", Error::last_os_error())
                 }
             }
         }
@@ -588,7 +588,7 @@ impl CapturerMag {
             unsafe {
                 if FALSE == DestroyWindow(self.host_window) {
                     //
-                    println!("Failed DestroyWindow host window {}", GetLastError())
+                    println!("Failed DestroyWindow host window, error {:?}", Error::last_os_error())
                 }
             }
         }

--- a/libs/virtual_display/dylib/src/win10/IddController.c
+++ b/libs/virtual_display/dylib/src/win10/IddController.c
@@ -97,7 +97,7 @@ BOOL InstallUpdate(LPCWSTR fullInfPath, PBOOL rebootRequired)
                 SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: Install the cert.\n", error, errorString == NULL ? "(NULL)\n" : errorString);
                 break;
             case 0xe0000247:
-                SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: \n1. Uninstall the driver first.\n2. Install the cert.\n3. Check the device manager and event viewer.\n", error, errorString == NULL ? "(NULL)\n" : errorString);
+                SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: \n1. Check the device manager and event viewer.\n2. Uninstall the driver, install the cert, then try again.\n", error, errorString == NULL ? "(NULL)\n" : errorString);
                 break;
             default:
                 SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: Check the device manager and event viewer.\n", error, errorString == NULL ? "(NULL)\n" : errorString);

--- a/libs/virtual_display/dylib/src/win10/IddController.c
+++ b/libs/virtual_display/dylib/src/win10/IddController.c
@@ -94,10 +94,10 @@ BOOL InstallUpdate(LPCWSTR fullInfPath, PBOOL rebootRequired)
             switch (error)
             {
             case 0x109:
-                SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: Install the cert.\n", error, errorString == NULL ? "(NULL)\n" : errorString);
+                SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: Reinstall RustDesk with the cert option.\n", error, errorString == NULL ? "(NULL)\n" : errorString);
                 break;
             case 0xe0000247:
-                SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: \n1. Check the device manager and event viewer.\n2. Uninstall the driver, install the cert, then try again.\n", error, errorString == NULL ? "(NULL)\n" : errorString);
+                SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: \n1. Check the device manager and event viewer.\n2. Uninstall \"RustDeskIddDriver Device\" in device manager, then reinstall RustDesk with the cert option.\n", error, errorString == NULL ? "(NULL)\n" : errorString);
                 break;
             default:
                 SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: Check the device manager and event viewer.\n", error, errorString == NULL ? "(NULL)\n" : errorString);

--- a/libs/virtual_display/dylib/src/win10/IddController.c
+++ b/libs/virtual_display/dylib/src/win10/IddController.c
@@ -293,7 +293,12 @@ BOOL DeviceCreateWithLifetime(SW_DEVICE_LIFETIME *lifetime, PHSWDEVICE hSwDevice
         hSwDevice);
     if (FAILED(hr))
     {
-        SetLastMsg("Failed DeviceCreate SwDeviceCreate 0x%lx\n", hr);
+        LPSTR errorString = formatErrorString((DWORD)hr);
+        SetLastMsg("Failed DeviceCreate SwDeviceCreate, hresult 0x%lx, %s\n", hr, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -308,7 +313,29 @@ BOOL DeviceCreateWithLifetime(SW_DEVICE_LIFETIME *lifetime, PHSWDEVICE hSwDevice
     CloseHandle(hEvent);
     if (waitResult != WAIT_OBJECT_0)
     {
-        SetLastMsg("Failed DeviceCreate wait for device creation 0x%d\n", waitResult);
+        DWORD error = 0;
+        LPSTR errorString = NULL;
+        switch (waitResult)
+        {
+            case WAIT_ABANDONED:
+                SetLastMsg("Failed DeviceCreate wait for device creation 0x%d, WAIT_ABANDONED\n", waitResult);
+                break;
+            case WAIT_TIMEOUT:
+                SetLastMsg("Failed DeviceCreate wait for device creation 0x%d, WAIT_TIMEOUT\n", waitResult);
+                break;
+            default:
+                error = GetLastError();
+                if (error != 0)
+                {
+                    errorString = formatErrorString(error);
+                    SetLastMsg("Failed DeviceCreate wait for device creation, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+                    if (errorString != NULL)
+                    {
+                        LocalFree(errorString);
+                    }
+                }
+                break;
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -323,7 +350,12 @@ BOOL DeviceCreateWithLifetime(SW_DEVICE_LIFETIME *lifetime, PHSWDEVICE hSwDevice
     }
     else
     {
-        SetLastMsg("Failed DeviceCreate SwDeviceCreate, hrCreateResult 0x%lx\n", callbackContext.hrCreateResult);
+        LPSTR errorString = formatErrorString((DWORD)callbackContext.hrCreateResult);
+        SetLastMsg("Failed DeviceCreate SwDeviceCreate, hrCreateResult 0x%lx, %s", callbackContext.hrCreateResult, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         return FALSE;
     }
 }
@@ -405,7 +437,12 @@ BOOL MonitorPlugIn(UINT index, UINT edid, INT retries)
     HRESULT hr = CoCreateGuid(&plugIn.ContainerId);
     if (!SUCCEEDED(hr))
     {
-        SetLastMsg("Failed MonitorPlugIn CoCreateGuid %d\n", hr);
+        LPSTR errorString = formatErrorString((DWORD)hr);
+        SetLastMsg("Failed MonitorPlugIn CoCreateGuid, hresult 0x%lx, %s\n", hr, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -513,7 +550,7 @@ BOOL MonitorModesUpdate(UINT index, UINT modeCount, PMonitorMode modes)
     PCtlMonitorModes pMonitorModes = (PCtlMonitorModes)malloc(buflen);
     if (pMonitorModes == NULL)
     {
-        SetLastMsg("Failed MonitorModesUpdate CtlMonitorModes malloc 0x%lx\n");
+        SetLastMsg("Failed MonitorModesUpdate CtlMonitorModes malloc\n");
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -618,7 +655,7 @@ GetDevicePath(
         CM_GET_DEVICE_INTERFACE_LIST_ALL_DEVICES);
     if (cr != CR_SUCCESS)
     {
-        SetLastMsg("Failed GetDevicePath 0x%x retrieving device interface list size.\n", cr);
+        SetLastMsg("Failed GetDevicePath 0x%x, retrieving device interface list size.\n", cr);
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -688,7 +725,12 @@ GetDevicePath(
     hr = StringCchCopy(DevicePath, BufLen, deviceInterfaceList);
     if (FAILED(hr))
     {
-        SetLastMsg("Error: GetDevicePath StringCchCopy failed with HRESULT 0x%x", hr);
+        LPSTR errorString = formatErrorString((DWORD)hr);
+        SetLastMsg("Failed GetDevicePath StringCchCopy, hresult 0x%lx, %s\n", hr, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -851,7 +893,12 @@ BOOLEAN GetDevicePath2(
     hr = StringCchCopy(DevicePath, BufLen, deviceInterfaceDetailData->DevicePath);
     if (FAILED(hr))
     {
-        SetLastMsg("Failed GetDevicePath2 StringCchCopy, HRESULT 0x%x", hr);
+        LPSTR errorString = formatErrorString((DWORD)hr);
+        SetLastMsg("Failed GetDevicePath2 StringCchCopy, hresult 0x%lx, %s\n", hr, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);

--- a/libs/virtual_display/dylib/src/win10/IddController.c
+++ b/libs/virtual_display/dylib/src/win10/IddController.c
@@ -294,7 +294,7 @@ BOOL DeviceCreateWithLifetime(SW_DEVICE_LIFETIME *lifetime, PHSWDEVICE hSwDevice
     if (FAILED(hr))
     {
         LPSTR errorString = formatErrorString((DWORD)hr);
-        SetLastMsg("Failed DeviceCreate SwDeviceCreate, hresult 0x%lx, %s\n", hr, errorString == NULL ? "(NULL)\n" : errorString);
+        SetLastMsg("Failed DeviceCreate SwDeviceCreate, hresult 0x%lx, %s", hr, errorString == NULL ? "(NULL)\n" : errorString);
         if (errorString != NULL)
         {
             LocalFree(errorString);
@@ -438,7 +438,7 @@ BOOL MonitorPlugIn(UINT index, UINT edid, INT retries)
     if (!SUCCEEDED(hr))
     {
         LPSTR errorString = formatErrorString((DWORD)hr);
-        SetLastMsg("Failed MonitorPlugIn CoCreateGuid, hresult 0x%lx, %s\n", hr, errorString == NULL ? "(NULL)\n" : errorString);
+        SetLastMsg("Failed MonitorPlugIn CoCreateGuid, hresult 0x%lx, %s", hr, errorString == NULL ? "(NULL)\n" : errorString);
         if (errorString != NULL)
         {
             LocalFree(errorString);
@@ -726,7 +726,7 @@ GetDevicePath(
     if (FAILED(hr))
     {
         LPSTR errorString = formatErrorString((DWORD)hr);
-        SetLastMsg("Failed GetDevicePath StringCchCopy, hresult 0x%lx, %s\n", hr, errorString == NULL ? "(NULL)\n" : errorString);
+        SetLastMsg("Failed GetDevicePath StringCchCopy, hresult 0x%lx, %s", hr, errorString == NULL ? "(NULL)\n" : errorString);
         if (errorString != NULL)
         {
             LocalFree(errorString);
@@ -894,7 +894,7 @@ BOOLEAN GetDevicePath2(
     if (FAILED(hr))
     {
         LPSTR errorString = formatErrorString((DWORD)hr);
-        SetLastMsg("Failed GetDevicePath2 StringCchCopy, hresult 0x%lx, %s\n", hr, errorString == NULL ? "(NULL)\n" : errorString);
+        SetLastMsg("Failed GetDevicePath2 StringCchCopy, hresult 0x%lx, %s", hr, errorString == NULL ? "(NULL)\n" : errorString);
         if (errorString != NULL)
         {
             LocalFree(errorString);

--- a/libs/virtual_display/dylib/src/win10/IddController.c
+++ b/libs/virtual_display/dylib/src/win10/IddController.c
@@ -9,6 +9,12 @@
 
 #include "./Public.h"
 
+typedef struct DeviceCreateCallbackContext
+{
+    HANDLE hEvent;
+    SW_DEVICE_LIFETIME* lifetime;
+    HRESULT hrCreateResult;
+} DeviceCreateCallbackContext;
 
 const GUID GUID_DEVINTERFACE_IDD_DRIVER_DEVICE = \
 { 0x781EF630, 0x72B2, 0x11d2, { 0xB8, 0x52,  0x00,  0xC0,  0x4E,  0xAF,  0x52,  0x72 } };
@@ -42,6 +48,8 @@ BOOLEAN GetDevicePath2(
 
 HANDLE DeviceOpenHandle();
 VOID DeviceCloseHandle(HANDLE handle);
+
+LPSTR formatErrorString(DWORD error);
 
 void SetLastMsg(const char* format, ...)
 {
@@ -82,7 +90,23 @@ BOOL InstallUpdate(LPCWSTR fullInfPath, PBOOL rebootRequired)
         DWORD error = GetLastError();
         if (error != 0)
         {
-            SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, last error 0x%x\n", error);
+            LPSTR errorString = formatErrorString(error);
+            switch (error)
+            {
+            case 0x109:
+                SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: Install the cert.\n", error, errorString == NULL ? "(NULL)\n" : errorString);
+                break;
+            case 0xe0000247:
+                SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: \n1. Uninstall the driver first.\n2. Install the cert.\n3. Check the device manager and event viewer.\n", error, errorString == NULL ? "(NULL)\n" : errorString);
+                break;
+            default:
+                SetLastMsg("Failed InstallUpdate UpdateDriverForPlugAndPlayDevicesW, error: 0x%x, %s  Please try: Check the device manager and event viewer.\n", error, errorString == NULL ? "(NULL)\n" : errorString);
+                break;
+            }
+            if (errorString != NULL)
+            {
+                LocalFree(errorString);
+            }
             if (g_printMsg)
             {
                 printf(g_lastMsg);
@@ -108,7 +132,12 @@ BOOL Uninstall(LPCWSTR fullInfPath, PBOOL rebootRequired)
         DWORD error = GetLastError();
         if (error != 0)
         {
-            SetLastMsg("Failed Uninstall DiUninstallDriverW, last error 0x%x\n", error);
+            LPSTR errorString = formatErrorString(error);
+            SetLastMsg("Failed Uninstall DiUninstallDriverW, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+            if (errorString != NULL)
+            {
+                LocalFree(errorString);
+            }
             if (g_printMsg)
             {
                 printf(g_lastMsg);
@@ -132,7 +161,13 @@ BOOL IsDeviceCreated(PBOOL created)
             DIGCF_DEVICEINTERFACE)); // Function class devices.
     if (INVALID_HANDLE_VALUE == hardwareDeviceInfo)
     {
-        SetLastMsg("Idd device: Failed IsDeviceCreated SetupDiGetClassDevs, last error 0x%x\n", GetLastError());
+        DWORD error = GetLastError();
+        LPSTR errorString = formatErrorString(error);
+        SetLastMsg("Idd device: Failed IsDeviceCreated SetupDiGetClassDevs, error 0x%x (%s)\n", error, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -165,7 +200,12 @@ BOOL IsDeviceCreated(PBOOL created)
             break;
         }
 
-        SetLastMsg("Idd device: Failed IsDeviceCreated SetupDiEnumDeviceInterfaces, last error 0x%x\n", error);
+        LPSTR errorString = formatErrorString(error);
+        SetLastMsg("Idd device: Failed IsDeviceCreated SetupDiEnumDeviceInterfaces, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -181,35 +221,39 @@ BOOL IsDeviceCreated(PBOOL created)
 
 BOOL DeviceCreate(PHSWDEVICE hSwDevice)
 {
+    SW_DEVICE_LIFETIME lifetime = SWDeviceLifetimeHandle;
+    return DeviceCreateWithLifetime(&lifetime, hSwDevice);
+}
+
+BOOL DeviceCreateWithLifetime(SW_DEVICE_LIFETIME *lifetime, PHSWDEVICE hSwDevice)
+{
     SetLastMsg("Success");
 
     if (*hSwDevice != NULL)
     {
-        SetLastMsg("Device handler is not NULL\n");
+        SetLastMsg("Device handle is not NULL\n");
         return FALSE;
     }
 
-    BOOL created = TRUE;
-    if (FALSE == IsDeviceCreated(&created))
-    {
-        return FALSE;
-    }
-    if (created == TRUE)
-    {
-        SetLastMsg("Device is already created, please destroy it first\n");
-        if (g_printMsg)
-        {
-            printf(g_lastMsg);
-        }
-        return FALSE;
-    }
+    // No need to check if the device is previous created.
+    // https://learn.microsoft.com/en-us/windows/win32/api/swdevice/nf-swdevice-swdevicesetlifetime
+    // When a client app calls SwDeviceCreate for a software device that was previously marked for 
+    // SwDeviceLifetimeParentPresent, SwDeviceCreate succeeds if there are no open software device handles for the device 
+    // (only one handle can be open for a device). A client app can then regain control over a persistent software device 
+    // for the purposes of updating properties and interfaces or changing the lifetime.
+    //
 
     // create device
     HANDLE hEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
     if (hEvent == INVALID_HANDLE_VALUE || hEvent == NULL)
     {
         DWORD error = GetLastError();
-        SetLastMsg("Failed DeviceCreate CreateEvent 0x%lx\n", error);
+        LPSTR errorString = formatErrorString(error);
+        SetLastMsg("Failed DeviceCreate CreateEvent, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -217,6 +261,8 @@ BOOL DeviceCreate(PHSWDEVICE hSwDevice)
 
         return FALSE;
     }
+
+    DeviceCreateCallbackContext callbackContext = { hEvent, lifetime, E_FAIL, };
 
     SW_DEVICE_CREATE_INFO createInfo = { 0 };
     PCWSTR description = L"RustDesk Idd Driver";
@@ -243,7 +289,7 @@ BOOL DeviceCreate(PHSWDEVICE hSwDevice)
         0,
         NULL,
         CreationCallback,
-        &hEvent,
+        &callbackContext,
         hSwDevice);
     if (FAILED(hr))
     {
@@ -259,6 +305,7 @@ BOOL DeviceCreate(PHSWDEVICE hSwDevice)
     // Wait for callback to signal that the device has been created
     printf("Waiting for device to be created....\n");
     DWORD waitResult = WaitForSingleObject(hEvent, 10 * 1000);
+    CloseHandle(hEvent);
     if (waitResult != WAIT_OBJECT_0)
     {
         SetLastMsg("Failed DeviceCreate wait for device creation 0x%d\n", waitResult);
@@ -268,8 +315,17 @@ BOOL DeviceCreate(PHSWDEVICE hSwDevice)
         }
         return FALSE;
     }
-    // printf("Device created\n\n");
-    return TRUE;
+
+    if (SUCCEEDED(callbackContext.hrCreateResult))
+    {
+        // printf("Device created\n\n");
+        return TRUE;
+    }
+    else
+    {
+        SetLastMsg("Failed DeviceCreate SwDeviceCreate, hrCreateResult 0x%lx\n", callbackContext.hrCreateResult);
+        return FALSE;
+    }
 }
 
 VOID DeviceClose(HSWDEVICE hSwDevice)
@@ -278,7 +334,37 @@ VOID DeviceClose(HSWDEVICE hSwDevice)
 
     if (hSwDevice != INVALID_HANDLE_VALUE && hSwDevice != NULL)
     {
+        HRESULT result = SwDeviceSetLifetime(hSwDevice, SWDeviceLifetimeHandle);
         SwDeviceClose(hSwDevice);
+    }
+    else
+    {
+        BOOL created = TRUE;
+        if (TRUE == IsDeviceCreated(&created))
+        {
+            if (created == FALSE)
+            {
+                return;
+            }
+        }
+        else
+        {
+            // Try crete sw device, and close
+        }
+
+        HSWDEVICE hSwDevice2 = NULL;
+        if (DeviceCreateWithLifetime(NULL, &hSwDevice2))
+        {
+            if (hSwDevice2 != NULL)
+            {
+                HRESULT result = SwDeviceSetLifetime(hSwDevice2, SWDeviceLifetimeHandle);
+                SwDeviceClose(hSwDevice2);
+            }
+        }
+        else
+        {
+            //
+        }
     }
 }
 
@@ -348,8 +434,16 @@ BOOL MonitorPlugIn(UINT index, UINT edid, INT retries)
         if (ret == FALSE)
         {
             DWORD error = GetLastError();
-            SetLastMsg("Failed MonitorPlugIn DeviceIoControl 0x%lx\n", error);
-            printf(g_lastMsg);
+            LPSTR errorString = formatErrorString(error);
+            SetLastMsg("Failed MonitorPlugIn DeviceIoControl, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+            if (errorString != NULL)
+            {
+                LocalFree(errorString);
+            }
+            if (g_printMsg)
+            {
+                printf(g_lastMsg);
+            }
         }
     }
 
@@ -382,7 +476,12 @@ BOOL MonitorPlugOut(UINT index)
         0))                     // Ptr to Overlapped structure
     {
         DWORD error = GetLastError();
-        SetLastMsg("Failed MonitorPlugOut DeviceIoControl 0x%lx\n", error);
+        LPSTR errorString = formatErrorString(error);
+        SetLastMsg("Failed MonitorPlugOut DeviceIoControl, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -441,7 +540,12 @@ BOOL MonitorModesUpdate(UINT index, UINT modeCount, PMonitorMode modes)
         0))                         // Ptr to Overlapped structure
     {
         DWORD error = GetLastError();
-        SetLastMsg("Failed MonitorModesUpdate DeviceIoControl 0x%lx\n", error);
+        LPSTR errorString = formatErrorString(error);
+        SetLastMsg("Failed MonitorModesUpdate DeviceIoControl, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -466,11 +570,30 @@ CreationCallback(
     _In_opt_ PCWSTR pszDeviceInstanceId
 )
 {
-    HANDLE hEvent = *(HANDLE*)pContext;
+    DeviceCreateCallbackContext* callbackContext = NULL;
 
-    SetEvent(hEvent);
-    UNREFERENCED_PARAMETER(hSwDevice);
-    UNREFERENCED_PARAMETER(hrCreateResult);
+    if (pContext != NULL)
+    {
+        callbackContext = (DeviceCreateCallbackContext*)pContext;
+        callbackContext->hrCreateResult = hrCreateResult;
+        if (SUCCEEDED(hrCreateResult))
+        {
+            if (callbackContext->lifetime)
+            {
+                HRESULT result = SwDeviceSetLifetime(hSwDevice, *callbackContext->lifetime);
+                if (FAILED(result))
+                {
+                    // TODO: debug log error here
+                }
+            }
+        }
+
+        if (callbackContext->hEvent != NULL)
+        {
+            SetEvent(callbackContext->hEvent);
+        }
+    }
+
     // printf("Idd device %ls created\n", pszDeviceInstanceId);
 }
 
@@ -611,7 +734,13 @@ BOOLEAN GetDevicePath2(
             DIGCF_DEVICEINTERFACE)); // Function class devices.
     if (INVALID_HANDLE_VALUE == hardwareDeviceInfo)
     {
-        SetLastMsg("Idd device: GetDevicePath2 SetupDiGetClassDevs failed, last error 0x%x\n", GetLastError());
+        DWORD error = GetLastError();
+        LPSTR errorString = formatErrorString(error);
+        SetLastMsg("Failed GetDevicePath2 SetupDiGetClassDevs, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -627,7 +756,13 @@ BOOLEAN GetDevicePath2(
         0, //
         &deviceInterfaceData))
     {
-        SetLastMsg("Idd device: GetDevicePath2 SetupDiEnumDeviceInterfaces failed, last error 0x%x\n", GetLastError());
+        DWORD error = GetLastError();
+        LPSTR errorString = formatErrorString(error);
+        SetLastMsg("Failed GetDevicePath2 SetupDiEnumDeviceInterfaces, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -647,9 +782,15 @@ BOOLEAN GetDevicePath2(
         &requiredLength,
         NULL);//not interested in the specific dev-node
 
-    if (ERROR_INSUFFICIENT_BUFFER != GetLastError())
+    DWORD error = GetLastError();
+    if (ERROR_INSUFFICIENT_BUFFER != error)
     {
-        SetLastMsg("Idd device: GetDevicePath2 SetupDiGetDeviceInterfaceDetail failed, last error 0x%x\n", GetLastError());
+        LPSTR errorString = formatErrorString(error);
+        SetLastMsg("GetDevicePath2 SetupDiGetDeviceInterfaceDetail failed, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -671,7 +812,13 @@ BOOLEAN GetDevicePath2(
     }
     else
     {
-        SetLastMsg("Idd device: Failed GetDevicePath2 HeapAlloc, last error 0x%x\n", GetLastError());
+        DWORD error = GetLastError();
+        LPSTR errorString = formatErrorString(error);
+        SetLastMsg("Failed GetDevicePath2 HeapAlloc, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -687,7 +834,13 @@ BOOLEAN GetDevicePath2(
         &requiredLength,
         NULL))
     {
-        SetLastMsg("Idd device: Failed GetDevicePath2 SetupDiGetDeviceInterfaceDetail, last error 0x%x\n", GetLastError());
+        DWORD error = GetLastError();
+        LPSTR errorString = formatErrorString(error);
+        SetLastMsg("Failed GetDevicePath2 SetupDiGetDeviceInterfaceDetail, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+        if (errorString != NULL)
+        {
+            LocalFree(errorString);
+        }
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -698,7 +851,7 @@ BOOLEAN GetDevicePath2(
     hr = StringCchCopy(DevicePath, BufLen, deviceInterfaceDetailData->DevicePath);
     if (FAILED(hr))
     {
-        SetLastMsg("Error: Failed GetDevicePath2 StringCchCopy HRESULT 0x%x", hr);
+        SetLastMsg("Failed GetDevicePath2 StringCchCopy, HRESULT 0x%x", hr);
         if (g_printMsg)
         {
             printf(g_lastMsg);
@@ -759,7 +912,12 @@ HANDLE DeviceOpenHandle()
         if (hDevice == INVALID_HANDLE_VALUE || hDevice == NULL)
         {
             DWORD error = GetLastError();
-            SetLastMsg("Failed DeviceOpenHandle CreateFile 0x%lx\n", error);
+            LPSTR errorString = formatErrorString(error);
+            SetLastMsg("Failed DeviceOpenHandle CreateFile, error: 0x%x, %s", error, errorString == NULL ? "(NULL)\n" : errorString);
+            if (errorString != NULL)
+            {
+                LocalFree(errorString);
+            }
             if (g_printMsg)
             {
                 printf(g_lastMsg);
@@ -782,3 +940,20 @@ VOID SetPrintErrMsg(BOOL b)
 {
     g_printMsg = (b == TRUE);
 }
+
+// Use en-us for simple, or we may need to handle wide string.
+LPSTR formatErrorString(DWORD error)
+{
+    LPSTR errorString = NULL;
+    FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        error,
+        MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US),
+        (LPSTR)&errorString,
+        0,
+        NULL
+    );
+    return errorString;
+}
+

--- a/libs/virtual_display/dylib/src/win10/IddController.h
+++ b/libs/virtual_display/dylib/src/win10/IddController.h
@@ -59,9 +59,26 @@ BOOL IsDeviceCreated(PBOOL created);
 BOOL DeviceCreate(PHSWDEVICE hSwDevice);
 
 /**
+ * @brief Create device and set the lifetime.
+ *        Only one device should be created.
+ *        If device is installed ealier, this function returns FALSE.
+ *
+ * @param lifetime [in] The lifetime to set after creating the device. NULL means do not set the lifetime.
+ *                      https://learn.microsoft.com/en-us/windows/win32/api/swdevice/nf-swdevice-swdevicesetlifetime
+ * @param hSwDevice [out] Handler of software device, used by DeviceCreate(). Should be **NULL**.
+ *
+ * @return TRUE/FALSE. If FALSE returned, error message can be retrieved by GetLastMsg()
+ *
+ * @see GetLastMsg#GetLastMsg
+ *
+ */
+BOOL DeviceCreateWithLifetime(SW_DEVICE_LIFETIME * lifetime, PHSWDEVICE hSwDevice);
+
+/**
  * @brief Close device.
  *
  * @param hSwDevice Handler of software device, used by SwDeviceClose().
+ *                  If hSwDevice is INVALID_HANDLE_VALUE or NULL, try find and close the device.
  *
  */
 VOID DeviceClose(HSWDEVICE hSwDevice);

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1738,11 +1738,11 @@ pub fn create_process_with_logon(user: &str, pwd: &str, exe: &str, arg: &str) ->
         {
             let last_error = GetLastError();
             bail!(
-                "CreateProcessWithLogonW failed : \"{}\", errno={}",
+                "CreateProcessWithLogonW failed : \"{}\", error {:?}",
                 last_error_table
                     .get(&last_error)
                     .unwrap_or(&"Unknown error"),
-                last_error
+                io::Error::from_raw_os_error(last_error as _)
             );
         }
     }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1700,7 +1700,7 @@ pub fn create_process_with_logon(user: &str, pwd: &str, exe: &str, arg: &str) ->
         {
             let last_error = GetLastError();
             bail!(
-                "CreateProcessWithLogonW failed : \"{}\", error {:?}",
+                "CreateProcessWithLogonW failed : \"{}\", error {}",
                 last_error_table
                     .get(&last_error)
                     .unwrap_or(&"Unknown error"),

--- a/src/privacy_mode/win_input.rs
+++ b/src/privacy_mode/win_input.rs
@@ -1,7 +1,10 @@
 use hbb_common::{allow_err, bail, lazy_static, log, ResultType};
-use std::sync::{
-    mpsc::{channel, Sender},
-    Mutex,
+use std::{
+    io::Error,
+    sync::{
+        mpsc::{channel, Sender},
+        Mutex,
+    },
 };
 use winapi::{
     ctypes::c_int,
@@ -10,10 +13,7 @@ use winapi::{
         ntdef::NULL,
         windef::{HHOOK, POINT},
     },
-    um::{
-        errhandlingapi::GetLastError, libloaderapi::GetModuleHandleExA,
-        processthreadsapi::GetCurrentThreadId, winuser::*,
-    },
+    um::{libloaderapi::GetModuleHandleExA, processthreadsapi::GetCurrentThreadId, winuser::*},
 };
 
 const GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT: u32 = 2;
@@ -43,8 +43,8 @@ fn do_hook(tx: Sender<String>) -> ResultType<(HHOOK, HHOOK)> {
             &mut hm_keyboard as _,
         ) {
             tx.send(format!(
-                "Failed to GetModuleHandleExA, error: {}",
-                GetLastError()
+                "Failed to GetModuleHandleExA, error: {:?}",
+                Error::last_os_error()
             ))?;
             return Ok(invalid_ret);
         }
@@ -55,8 +55,8 @@ fn do_hook(tx: Sender<String>) -> ResultType<(HHOOK, HHOOK)> {
             &mut hm_mouse as _,
         ) {
             tx.send(format!(
-                "Failed to GetModuleHandleExA, error: {}",
-                GetLastError()
+                "Failed to GetModuleHandleExA, error: {:?}",
+                Error::last_os_error()
             ))?;
             return Ok(invalid_ret);
         }
@@ -68,7 +68,10 @@ fn do_hook(tx: Sender<String>) -> ResultType<(HHOOK, HHOOK)> {
             0,
         );
         if hook_keyboard.is_null() {
-            tx.send(format!(" SetWindowsHookExA keyboard {}", GetLastError()))?;
+            tx.send(format!(
+                " SetWindowsHookExA keyboard, error {:?}",
+                Error::last_os_error()
+            ))?;
             return Ok(invalid_ret);
         }
 
@@ -76,9 +79,15 @@ fn do_hook(tx: Sender<String>) -> ResultType<(HHOOK, HHOOK)> {
         if hook_mouse.is_null() {
             if FALSE == UnhookWindowsHookEx(hook_keyboard) {
                 // Fatal error
-                log::error!(" UnhookWindowsHookEx keyboard {}", GetLastError());
+                log::error!(
+                    " UnhookWindowsHookEx keyboard, error {:?}",
+                    Error::last_os_error()
+                );
             }
-            tx.send(format!(" SetWindowsHookExA mouse {}", GetLastError()))?;
+            tx.send(format!(
+                " SetWindowsHookExA mouse, error {:?}",
+                Error::last_os_error()
+            ))?;
             return Ok(invalid_ret);
         }
 
@@ -131,12 +140,18 @@ pub fn hook() -> ResultType<()> {
 
             if FALSE == UnhookWindowsHookEx(hook_keyboard as _) {
                 // Fatal error
-                log::error!("Failed UnhookWindowsHookEx keyboard {}", GetLastError());
+                log::error!(
+                    "Failed UnhookWindowsHookEx keyboard, error {:?}",
+                    Error::last_os_error()
+                );
             }
 
             if FALSE == UnhookWindowsHookEx(hook_mouse as _) {
                 // Fatal error
-                log::error!("Failed UnhookWindowsHookEx mouse {}", GetLastError());
+                log::error!(
+                    "Failed UnhookWindowsHookEx mouse, error {:?}",
+                    Error::last_os_error()
+                );
             }
 
             *CUR_HOOK_THREAD_ID.lock().unwrap() = 0;
@@ -162,7 +177,10 @@ pub fn unhook() -> ResultType<()> {
         let cur_hook_thread_id = CUR_HOOK_THREAD_ID.lock().unwrap();
         if *cur_hook_thread_id != 0 {
             if FALSE == PostThreadMessageA(*cur_hook_thread_id, WM_USER_EXIT_HOOK, 0, 0) {
-                bail!("Failed to post message to exit hook, {}", GetLastError());
+                bail!(
+                    "Failed to post message to exit hook, error {:?}",
+                    Error::last_os_error()
+                );
             }
         }
     }

--- a/src/privacy_mode/win_input.rs
+++ b/src/privacy_mode/win_input.rs
@@ -43,7 +43,7 @@ fn do_hook(tx: Sender<String>) -> ResultType<(HHOOK, HHOOK)> {
             &mut hm_keyboard as _,
         ) {
             tx.send(format!(
-                "Failed to GetModuleHandleExA, error: {:?}",
+                "Failed to GetModuleHandleExA, error: {}",
                 Error::last_os_error()
             ))?;
             return Ok(invalid_ret);
@@ -55,7 +55,7 @@ fn do_hook(tx: Sender<String>) -> ResultType<(HHOOK, HHOOK)> {
             &mut hm_mouse as _,
         ) {
             tx.send(format!(
-                "Failed to GetModuleHandleExA, error: {:?}",
+                "Failed to GetModuleHandleExA, error: {}",
                 Error::last_os_error()
             ))?;
             return Ok(invalid_ret);
@@ -69,7 +69,7 @@ fn do_hook(tx: Sender<String>) -> ResultType<(HHOOK, HHOOK)> {
         );
         if hook_keyboard.is_null() {
             tx.send(format!(
-                " SetWindowsHookExA keyboard, error {:?}",
+                " SetWindowsHookExA keyboard, error {}",
                 Error::last_os_error()
             ))?;
             return Ok(invalid_ret);
@@ -80,12 +80,12 @@ fn do_hook(tx: Sender<String>) -> ResultType<(HHOOK, HHOOK)> {
             if FALSE == UnhookWindowsHookEx(hook_keyboard) {
                 // Fatal error
                 log::error!(
-                    " UnhookWindowsHookEx keyboard, error {:?}",
+                    " UnhookWindowsHookEx keyboard, error {}",
                     Error::last_os_error()
                 );
             }
             tx.send(format!(
-                " SetWindowsHookExA mouse, error {:?}",
+                " SetWindowsHookExA mouse, error {}",
                 Error::last_os_error()
             ))?;
             return Ok(invalid_ret);
@@ -141,7 +141,7 @@ pub fn hook() -> ResultType<()> {
             if FALSE == UnhookWindowsHookEx(hook_keyboard as _) {
                 // Fatal error
                 log::error!(
-                    "Failed UnhookWindowsHookEx keyboard, error {:?}",
+                    "Failed UnhookWindowsHookEx keyboard, error {}",
                     Error::last_os_error()
                 );
             }
@@ -149,7 +149,7 @@ pub fn hook() -> ResultType<()> {
             if FALSE == UnhookWindowsHookEx(hook_mouse as _) {
                 // Fatal error
                 log::error!(
-                    "Failed UnhookWindowsHookEx mouse, error {:?}",
+                    "Failed UnhookWindowsHookEx mouse, error {}",
                     Error::last_os_error()
                 );
             }
@@ -178,7 +178,7 @@ pub fn unhook() -> ResultType<()> {
         if *cur_hook_thread_id != 0 {
             if FALSE == PostThreadMessageA(*cur_hook_thread_id, WM_USER_EXIT_HOOK, 0, 0) {
                 bail!(
-                    "Failed to post message to exit hook, error {:?}",
+                    "Failed to post message to exit hook, error {}",
                     Error::last_os_error()
                 );
             }

--- a/src/privacy_mode/win_topmost_window.rs
+++ b/src/privacy_mode/win_topmost_window.rs
@@ -3,6 +3,7 @@ use crate::{platform::windows::get_user_token, privacy_mode::PrivacyModeState};
 use hbb_common::{allow_err, bail, log, ResultType};
 use std::{
     ffi::CString,
+    io::Error,
     time::{Duration, Instant},
 };
 use winapi::{
@@ -12,7 +13,6 @@ use winapi::{
         windef::HWND,
     },
     um::{
-        errhandlingapi::GetLastError,
         handleapi::CloseHandle,
         libloaderapi::{GetModuleHandleA, GetProcAddress},
         memoryapi::{VirtualAllocEx, WriteProcessMemory},
@@ -266,9 +266,9 @@ impl PrivacyModeImpl {
             CloseHandle(token);
             if 0 == create_res {
                 bail!(
-                    "Failed to create privacy window process {}, code {}",
+                    "Failed to create privacy window process {}, error {:?}",
                     cmdline,
-                    GetLastError()
+                    Error::last_os_error()
                 );
             };
 
@@ -284,8 +284,8 @@ impl PrivacyModeImpl {
                 CloseHandle(proc_info.hProcess);
 
                 bail!(
-                    "Failed to create privacy window process, {}",
-                    GetLastError()
+                    "Failed to create privacy window process, error {:?}",
+                    Error::last_os_error()
                 );
             }
 

--- a/src/privacy_mode/win_topmost_window.rs
+++ b/src/privacy_mode/win_topmost_window.rs
@@ -266,7 +266,7 @@ impl PrivacyModeImpl {
             CloseHandle(token);
             if 0 == create_res {
                 bail!(
-                    "Failed to create privacy window process {}, error {:?}",
+                    "Failed to create privacy window process {}, error {}",
                     cmdline,
                     Error::last_os_error()
                 );
@@ -284,7 +284,7 @@ impl PrivacyModeImpl {
                 CloseHandle(proc_info.hProcess);
 
                 bail!(
-                    "Failed to create privacy window process, error {:?}",
+                    "Failed to create privacy window process, error {}",
                     Error::last_os_error()
                 );
             }

--- a/src/privacy_mode/win_virtual_display.rs
+++ b/src/privacy_mode/win_virtual_display.rs
@@ -1,7 +1,10 @@
 use super::{PrivacyMode, PrivacyModeState, INVALID_PRIVACY_MODE_CONN_ID, NO_DISPLAYS};
 use crate::virtual_display_manager;
 use hbb_common::{allow_err, bail, config::Config, log, ResultType};
-use std::ops::{Deref, DerefMut};
+use std::{
+    io::Error,
+    ops::{Deref, DerefMut},
+};
 use virtual_display::MonitorMode;
 use winapi::{
     shared::{
@@ -9,7 +12,6 @@ use winapi::{
         ntdef::{NULL, WCHAR},
     },
     um::{
-        errhandlingapi::GetLastError,
         wingdi::{
             DEVMODEW, DISPLAY_DEVICEW, DISPLAY_DEVICE_ACTIVE, DISPLAY_DEVICE_ATTACHED_TO_DESKTOP,
             DISPLAY_DEVICE_MIRRORING_DRIVER, DISPLAY_DEVICE_PRIMARY_DEVICE, DM_POSITION,
@@ -193,9 +195,9 @@ impl PrivacyModeImpl {
                 )
             {
                 bail!(
-                    "Failed EnumDisplaySettingsW, device name: {:?}, error code: {}",
+                    "Failed EnumDisplaySettingsW, device name: {:?}, error: {:?}",
                     std::string::String::from_utf16(&display.name),
-                    GetLastError()
+                    Error::last_os_error()
                 );
             }
 
@@ -227,9 +229,9 @@ impl PrivacyModeImpl {
                     == EnumDisplaySettingsW(dd.DeviceName.as_ptr(), ENUM_CURRENT_SETTINGS, &mut dm)
                 {
                     bail!(
-                        "Failed EnumDisplaySettingsW, device name: {:?}, error code: {}",
+                        "Failed EnumDisplaySettingsW, device name: {:?}, error: {:?}",
                         std::string::String::from_utf16(&dd.DeviceName),
-                        GetLastError()
+                        Error::last_os_error()
                     );
                 }
 

--- a/src/privacy_mode/win_virtual_display.rs
+++ b/src/privacy_mode/win_virtual_display.rs
@@ -195,7 +195,7 @@ impl PrivacyModeImpl {
                 )
             {
                 bail!(
-                    "Failed EnumDisplaySettingsW, device name: {:?}, error: {:?}",
+                    "Failed EnumDisplaySettingsW, device name: {:?}, error: {}",
                     std::string::String::from_utf16(&display.name),
                     Error::last_os_error()
                 );
@@ -229,7 +229,7 @@ impl PrivacyModeImpl {
                     == EnumDisplaySettingsW(dd.DeviceName.as_ptr(), ENUM_CURRENT_SETTINGS, &mut dm)
                 {
                     bail!(
-                        "Failed EnumDisplaySettingsW, device name: {:?}, error: {:?}",
+                        "Failed EnumDisplaySettingsW, device name: {:?}, error: {}",
                         std::string::String::from_utf16(&dd.DeviceName),
                         Error::last_os_error()
                     );


### PR DESCRIPTION
1. Format error message.  https://github.com/rustdesk/rustdesk/issues/6472#issuecomment-1818179586
2. Send a "message box" when failed to plug in/out a virtual display.
3. Replace `GetLastError()` with `std::io::Error::last_os_error()`  in rust source.


## Examples

### SwDevice handle is held by another process

Format `HRESULT`

<img width="506" alt="1700468138865" src="https://github.com/rustdesk/rustdesk/assets/13586388/fec3a2c4-f5aa-434e-82c5-74fb4b2d05a8">


### No cert

Format `GetLastError`

<img width="506" alt="1700468138865" src="https://github.com/rustdesk/rustdesk/assets/13586388/1a7a3391-379f-425c-86ca-4da1ae0ae849">

