### PR TITLE
Fix: wayland cursor mismatch on fractional scaling

### DIFF
--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -175,7 +175,12 @@ pub(super) async fn check_init() -> ResultType<()> {
                             .trim_end_matches(",")
                             .parse()
                             .unwrap_or(origin.1 + height as i32);
-                        (w, h)
+                        if w < origin.0 + width as i32 || h < origin.1 + height as i32 {
+                            (origin.0 + width as i32, origin.1 + height as i32)
+                        }
+                        else{
+                            (w, h)
+                        }
                     }
                     _ => (origin.0 + width as i32, origin.1 + height as i32),
                 };


### PR DESCRIPTION
Fixes: https://github.com/rustdesk/rustdesk/pull/6487#issuecomment-1822479852
In the case where xrandr output is not correct use stream resolution instead of xrandr for mouse resolution.
When xrandr is incorrect, it is always less than the stream resolution.
Cursor mismatch on a single screen or a monitor at (0,0) pixel coordinate is solved.

xrandr is only incorrect when fractional scaling(experimental feature) is enabled on gnome on distros like fedora, debian. Ubuntu does not have this issue neither kde, they both support fractional scaling officially.
Currently, the cursor will still be mismatched if the user has **multi-monitor+gnome(other than ubuntu)+wayland+fractional scaling enabled**. It may be a less common scenario but it's worth noting. #5773 #4288 
On the official release of fractional scaling on gnome, if this issue gets addressed and xrandr produces the correct value in that case this particular problem (multi-monitor+fractional scaling) will be solved on its own. I could not find any better way to get max desktop resolution on wayland other than xrandr.

**If you are using **multi-monitor+gnome(other than ubuntu)+wayland+fractional scaling enabled** just turn the scaling back to 100% and the cursor will work perfectly.**