### PR TITLE
feat: Support new tcp-mq rendezvous protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6175,11 +6175,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg 1.1.0",
+ "backtrace",
  "bytes",
  "libc",
  "mio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc1f1a75fd07f0f517322d103211f12d757658e91676def9a2e688774656c60"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "http",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "rand 0.8.5",
+ "regex",
+ "ring 0.17.5",
+ "rustls 0.21.8",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.101.7",
+ "serde 1.0.190",
+ "serde_json 1.0.107",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror",
+ "time 0.3.30",
+ "tokio",
+ "tokio-retry",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "async-process"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1097,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1364,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "dark-light"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1549,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
 name = "dbus"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,12 +1604,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -1756,7 +1841,29 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519 2.2.3",
+ "sha2",
+ "signature 2.2.0",
+ "subtle",
 ]
 
 [[package]]
@@ -1982,6 +2089,12 @@ checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
 
 [[package]]
 name = "field-offset"
@@ -3856,6 +3969,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad178aad32087b19042ee36dfd450b73f5f934fbfb058b59b198684dfec4c47"
+dependencies = [
+ "byteorder",
+ "data-encoding",
+ "ed25519 2.2.3",
+ "ed25519-dalek",
+ "getrandom",
+ "log",
+ "rand 0.8.5",
+ "signatory",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,6 +4019,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4329,6 +4467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4416,10 +4563,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "platforms"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 
 [[package]]
 name = "plist"
@@ -5175,6 +5338,7 @@ version = "1.2.4"
 dependencies = [
  "android_logger",
  "arboard",
+ "async-nats",
  "async-process",
  "async-trait",
  "base64",
@@ -5564,6 +5728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae801b7733ca8d6a2b580debe99f67f36826a0f5b8a36055dc6bc40f8d6bc71"
+dependencies = [
+ "serde 1.0.190",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5665,10 +5838,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "zeroize",
+]
+
+[[package]]
 name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -5724,7 +5919,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
 dependencies = [
- "ed25519",
+ "ed25519 1.5.3",
  "libc",
  "libsodium-sys",
  "serde 1.0.190",
@@ -5743,6 +5938,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -6202,6 +6407,17 @@ dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 2.0.38",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -7476,6 +7692,12 @@ dependencies = [
  "quote 1.0.33",
  "syn 2.0.38",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ cidr-utils = "0.5"
 libloading = "0.8"
 fon = "0.6"
 zip = "0.6"
+async-nats = "0.33.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "linux")))'.dependencies]
 cpal = "0.15"

--- a/libs/hbb_common/Cargo.toml
+++ b/libs/hbb_common/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 flexi_logger = { version = "0.25", features = ["async"] }
 protobuf = { version = "3.2", features = ["with-bytes"] }
-tokio = { version = "=1.28.1", features = ["full"] }
+tokio = { version = "=1.29.1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 futures = "0.3"
 bytes = { version = "1.4", features = ["serde"] }

--- a/libs/hbb_common/protos/rendezvous.proto
+++ b/libs/hbb_common/protos/rendezvous.proto
@@ -73,6 +73,7 @@ message RegisterPkResponse {
     SERVER_ERROR = 7;
   }
   Result result = 1;
+  string mq_token = 2;
 }
 
 message PunchHoleResponse {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -100,6 +100,8 @@ pub const RS_PUB_KEY: &str = match option_env!("RS_PUB_KEY") {
 pub const RENDEZVOUS_PORT: i32 = 21116;
 pub const RELAY_PORT: i32 = 21117;
 
+pub const RS_TOPIC_REGISTER: &str = "api.register";
+
 macro_rules! serde_field_string {
     ($default_func:ident, $de_func:ident, $default_expr:expr) => {
         fn $default_func() -> String {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -989,6 +989,10 @@ impl Config {
         }
     }
 
+    pub fn get_push_topic(id: &str) -> String {
+        format!("push.{}", id)
+    }
+
     pub fn get() -> Config {
         return CONFIG.read().unwrap().clone();
     }

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -993,6 +993,10 @@ impl Config {
         format!("push.{}", id)
     }
 
+    pub fn get_ping_topic(id: &str) -> String {
+        format!("ping.{}", id)
+    }
+
     pub fn get() -> Config {
         return CONFIG.read().unwrap().clone();
     }

--- a/libs/hbb_common/src/socket_client.rs
+++ b/libs/hbb_common/src/socket_client.rs
@@ -154,7 +154,7 @@ pub fn ipv4_to_ipv6(addr: String, ipv4: bool) -> String {
     addr
 }
 
-async fn test_target(target: &str) -> ResultType<SocketAddr> {
+pub async fn test_target(target: &str) -> ResultType<SocketAddr> {
     if let Ok(Ok(s)) = super::timeout(1000, tokio::net::TcpStream::connect(target)).await {
         if let Ok(addr) = s.peer_addr() {
             return Ok(addr);

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -648,8 +648,8 @@ impl RendezvousMediator {
                     let last_ping_too_old = elapse_since_last_resp > REG_INTERVAL;
 
                     let mut ping_latency = match (time_last_register_sent, time_last_register_resp) {
-                        (Some(sent), Some(resp)) => resp.duration_since(sent).as_micros() as i64,
-                        (Some(sent), None) => sent.elapsed().as_micros() as i64,
+                        (Some(sent), Some(resp)) => resp.duration_since(sent).as_millis() as i64,
+                        (Some(sent), None) => sent.elapsed().as_millis() as i64,
                         _ => 0,
                     };
                     let timeout = ping_latency > REG_TIMEOUT;
@@ -665,6 +665,7 @@ impl RendezvousMediator {
                         // Send ping message
                         allow_err!(rz.register_peer_mq(&mq_client).await);
                         time_last_register_sent = now;
+                        time_last_register_resp = None;
                     }
                     if timeout {
                         fails += 1;

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -577,6 +577,35 @@ impl RendezvousMediator {
                                     continue;
                                 }
                             }
+                            Some(rendezvous_message::Union::PunchHole(ph)) => {
+                                let rz = rz.clone();
+                                let server = server.clone();
+                                tokio::spawn(async move {
+                                    allow_err!(rz.handle_punch_hole(ph, server).await);
+                                });
+                            }
+                            Some(rendezvous_message::Union::RequestRelay(rr)) => {
+                                let rz = rz.clone();
+                                let server = server.clone();
+                                tokio::spawn(async move {
+                                    allow_err!(rz.handle_request_relay(rr, server).await);
+                                });
+                            }
+                            Some(rendezvous_message::Union::FetchLocalAddr(fla)) => {
+                                let rz = rz.clone();
+                                let server = server.clone();
+                                tokio::spawn(async move {
+                                    allow_err!(rz.handle_intranet(fla, server).await);
+                                });
+                            }
+                            Some(rendezvous_message::Union::ConfigureUpdate(cu)) => {
+                                let v0 = Config::get_rendezvous_servers();
+                                Config::set_option("rendezvous-servers".to_owned(), cu.rendezvous_servers.join(","));
+                                Config::set_serial(cu.serial);
+                                if v0 != Config::get_rendezvous_servers() {
+                                    Self::restart();
+                                }
+                            }
                             _ => {}
                         }
                     } else {


### PR DESCRIPTION
This PR provides client-side support for the new tcp-mq rendezvous protocol. The purpose of the new tcp-mq rendezvous protocol is to offer a rendezvous messaging communication method that doesn't require UDP, while maintaining support for the existing tcp-udp rendezvous protocol. Specifically, this PR implements client-side support for the following messages:

- TCP Messages
  - `RegisterPk` and `RegisterPkResponse`
    - Request-response type messages, previously sent by hbbs using UDP protocol. In tcp-mq protocol, these messages will be sent using a short TCP connection, i.e., a TCP connection is opened to the hbbs server for sending, and it is disconnected after receiving the expected response message.
    - `RegisterPk` message sent using TCP carries the semantics of a "handshake" for establishing a connection between the client and the server. The server's response message, `RegisterPkResponse`, now includes an extra `mq_token` field. The client will use the `mq_token` as an authentication credential to establish a connection with the mq server (Using port `21120/tcp`). This is expected to avoid abusing of mq server.

- MQ Messages
  - `RegisterPeer`, `RegisterPeerResponse`
    - Request-response type messages, previously sent by hbbs using UDP protocol. In tcp-mq protocol, these messages will be sent using mq, utilizing the topic `ping.[node_id]`. The direction of message sending remains the same as existing messages. That is, `RegisterPeer` is sent from the client to the server via topic `ping.[node_id]`, after which server sends `RegisterPeerResponse` to client using topic `push.[node_id]`.

  - `PunchHole`, `RequestRelay`, `FetchLocalAddr`
      - Previously pushed actively to the client by hbbs using the UDP protocol. In tcp-mq protocol, these messages will be sent using mq, utilizing the topic `push.[node_id]`.

  - `ConfigureUpdate`
     - This message is an optional response to the `RegisterPeer` message, previously sent by hbbs using UDP protocol after `RegisterPeerResponse`. In tcp-mq protocol, these messages will be sent using mq, utilizing the topic `push.[node_id]`.

## Limitations

1. The ability to establish a NATS MQ connection via a user-specified socks5 proxy has not yet been implemented.
2. The implementation of JWT token authentication on a per-peer basis is still pending. Currently, only a version based on token authentication has been implemented. Although this coarser-grained authentication method can prevent attackers from abusing the MQ for message passing (as long as the admin and regular user accounts are not compromised simultaneously), it still does not restrict peers from listening to messages from other peers. It is necessary to employ JWT tokens for fine-grained ACL (Access Control List) access control for different peers.

## Tests

- ✅ New Client → New Client, local network (Both clients using TCP + NATS, trying to establish remote control session)
- ✅ New Client → Old Client, hole punching (TCP + NATS client send remote control request to UDP client)
- ✅ Old Client → New Client, hole punching
- ✅ New Client → Old Client, relay
- ✅ Old Client → New Client, relay
- ✅ New Client connects to Old Server
- ✅ New Client change ID
- ✅ Old Client change ID
- ✅ When hbbs server restarts, new client should be able to reconnect
- ⏳ Online config update for new client