### PR TITLE
android video service wakelock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
+name = "android-wakelock"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "296e5b7c23adb32743194b1810604b772f2be10f0b0387365cb3ba09cd5c1851"
+dependencies = [
+ "jni 0.21.1",
+ "log",
+ "ndk-context",
+]
+
+[[package]]
 name = "android_log-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5197,6 +5208,7 @@ dependencies = [
 name = "rustdesk"
 version = "1.2.4"
 dependencies = [
+ "android-wakelock",
  "android_logger",
  "arboard",
  "async-process",
@@ -5487,6 +5499,7 @@ dependencies = [
  "lazy_static",
  "log",
  "ndk",
+ "ndk-context",
  "num_cpus",
  "pkg-config",
  "quest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ once_cell = {version = "1.18", optional = true}
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.13"
 jni = "0.21"
+android-wakelock = "0.1"
 
 [workspace]
 members = ["libs/scrap", "libs/hbb_common", "libs/enigo", "libs/clipboard", "libs/virtual_display", "libs/virtual_display/dylib", "libs/portable"]

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -211,6 +211,7 @@ class MainService : Service() {
     override fun onCreate() {
         super.onCreate()
         Log.d(logTag,"MainService onCreate")
+        init(this)
         HandlerThread("Service", Process.THREAD_PRIORITY_BACKGROUND).apply {
             start()
             serviceLooper = looper
@@ -315,7 +316,6 @@ class MainService : Service() {
                 mediaProjection =
                     mediaProjectionManager.getMediaProjection(Activity.RESULT_OK, it)
                 checkMediaPermission()
-                init(this)
                 _isReady = true
             } ?: let {
                 Log.d(logTag, "getParcelableExtra intent null, invoke requestMediaProjection")

--- a/libs/scrap/Cargo.toml
+++ b/libs/scrap/Cargo.toml
@@ -36,6 +36,7 @@ lazy_static = "1.4"
 log = "0.4"
 serde_json = "1.0"
 ndk = { version = "0.7", features = ["media"], optional = true}
+ndk-context = "0.1"
 
 [target.'cfg(not(target_os = "android"))'.dev-dependencies]
 repng = "0.2"

--- a/libs/scrap/src/android/ffi.rs
+++ b/libs/scrap/src/android/ffi.rs
@@ -19,6 +19,7 @@ lazy_static! {
     static ref MAIN_SERVICE_CTX: RwLock<Option<GlobalRef>> = RwLock::new(None); // MainService -> video service / audio service / info
     static ref VIDEO_RAW: Mutex<FrameRaw> = Mutex::new(FrameRaw::new("video", MAX_VIDEO_FRAME_TIMEOUT));
     static ref AUDIO_RAW: Mutex<FrameRaw> = Mutex::new(FrameRaw::new("audio", MAX_AUDIO_FRAME_TIMEOUT));
+    static ref NDK_CONTEXT_INITED: Mutex<bool> = Default::default();
 }
 
 const MAX_VIDEO_FRAME_TIMEOUT: Duration = Duration::from_millis(100);
@@ -150,6 +151,7 @@ pub extern "system" fn Java_com_carriez_flutter_1hbb_MainService_init(
         *JVM.write().unwrap() = Some(jvm);
         if let Ok(context) = env.new_global_ref(ctx) {
             *MAIN_SERVICE_CTX.write().unwrap() = Some(context);
+            init_ndk_context().ok();
         }
     }
 }
@@ -165,7 +167,12 @@ pub fn call_main_service_pointer_input(kind: &str, mask: i32, x: i32, y: i32) ->
             ctx,
             "rustPointerInput",
             "(Ljava/lang/String;III)V",
-            &[JValue::Object(&JObject::from(kind)), JValue::Int(mask), JValue::Int(x), JValue::Int(y)],
+            &[
+                JValue::Object(&JObject::from(kind)),
+                JValue::Int(mask),
+                JValue::Int(x),
+                JValue::Int(y),
+            ],
         )?;
         return Ok(());
     } else {
@@ -245,4 +252,27 @@ pub fn call_main_service_set_by_name(
     } else {
         return Err(JniError::ThrowFailed(-1));
     }
+}
+
+fn init_ndk_context() -> JniResult<()> {
+    let mut lock = NDK_CONTEXT_INITED.lock().unwrap();
+    if *lock {
+        unsafe {
+            ndk_context::release_android_context();
+        }
+    }
+    if let (Some(jvm), Some(ctx)) = (
+        JVM.read().unwrap().as_ref(),
+        MAIN_SERVICE_CTX.read().unwrap().as_ref(),
+    ) {
+        unsafe {
+            ndk_context::initialize_android_context(
+                jvm.get_java_vm_pointer() as _,
+                ctx.as_obj().as_raw() as _,
+            );
+        }
+        *lock = true;
+        return Ok(());
+    }
+    Err(JniError::ThrowFailed(-1))
 }


### PR DESCRIPTION
#6192
Without using battery optimization,  without using lock to avoid background killing,  after screen off
* without wakelock: disconnect after 3 minutes 
* with wakelock: stay connected for 20 minutes  (maybe never disconnect, test later).

The android_context used by android-wakelock needs to be initialized and it should be managed in only one place, otherwise there is a risk of crash. `cpal` and `oboe` also use it,  and there is no context management in them, which is expected. 
https://github.com/sagebind/android-wakelock/blob/master/src/lib.rs#L252
https://github.com/rust-mobile/ndk-context/blob/0eb252bf2306f6ca477430a35e88298e634c0b24/ndk-context/src/lib.rs#L84

move `init(this)` from `onStartCommand` to `onCreate` to look more reasonable, because there is no function like `uninit()` 

