### PR TITLE
fix macos and linux vm reboot

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2130,11 +2130,17 @@ impl Connection {
                         return false;
                     }
 
-                    Some(misc::Union::RestartRemoteDevice(_)) =>
-                    {
+                    Some(misc::Union::RestartRemoteDevice(_)) => {
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         if self.restart {
+                            // force_reboot, not work on linux vm and macos 14
+                            #[cfg(any(target_os = "linux", target_os = "windows"))]
                             match system_shutdown::force_reboot() {
+                                Ok(_) => log::info!("Restart by the peer"),
+                                Err(e) => log::error!("Failed to restart: {}", e),
+                            }
+                            #[cfg(any(target_os = "linux", target_os = "macos"))]
+                            match system_shutdown::reboot() {
                                 Ok(_) => log::info!("Restart by the peer"),
                                 Err(e) => log::error!("Failed to restart: {}", e),
                             }


### PR DESCRIPTION
macos / linux vm doesn't support force_reboot.
linux vm doesn't support the interrupt, macos doesn't have that directory.

![5e36d2de4e56224b55b1393e0ef7384](https://github.com/rustdesk/rustdesk/assets/14891774/8943c7b4-1a77-409a-8b97-c2c896017d46)

ubuntu 22.04 vm can reboot with `reboot` function, but some applications like terminal ssh may block macos reboot, need to find other api.
![83a8b27cd5c1a1807fc9ba7e5388d5e](https://github.com/rustdesk/rustdesk/assets/14891774/6837db5a-867e-4551-85a1-52136f84794c)

