### PR TITLE
Fix. Do not update cursor pos when switching display on toolbar when "Show monitors on toolbar"

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2698,7 +2698,7 @@ Future<List<Rect>> getScreenRectList() async {
       : await getScreenListNotWayland();
 }
 
-openMonitorInTheSameTab(int i, FFI ffi, PeerInfo pi, bool updateCursorPos) {
+openMonitorInTheSameTab(int i, FFI ffi, PeerInfo pi, {bool updateCursorPos = true}) {
   final displays = i == kAllDisplayValue
       ? List.generate(pi.displays.length, (index) => index)
       : [i];
@@ -2707,7 +2707,7 @@ openMonitorInTheSameTab(int i, FFI ffi, PeerInfo pi, bool updateCursorPos) {
     sessionId: ffi.sessionId,
     value: Int32List.fromList(displays),
   );
-  ffi.ffiModel.switchToNewDisplay(i, ffi.sessionId, ffi.id, updateCursorPos);
+  ffi.ffiModel.switchToNewDisplay(i, ffi.sessionId, ffi.id, updateCursorPos: updateCursorPos);
 }
 
 // Open new tab or window to show this monitor.

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2698,7 +2698,7 @@ Future<List<Rect>> getScreenRectList() async {
       : await getScreenListNotWayland();
 }
 
-openMonitorInTheSameTab(int i, FFI ffi, PeerInfo pi) {
+openMonitorInTheSameTab(int i, FFI ffi, PeerInfo pi, bool updateCursorPos) {
   final displays = i == kAllDisplayValue
       ? List.generate(pi.displays.length, (index) => index)
       : [i];
@@ -2707,7 +2707,7 @@ openMonitorInTheSameTab(int i, FFI ffi, PeerInfo pi) {
     sessionId: ffi.sessionId,
     value: Int32List.fromList(displays),
   );
-  ffi.ffiModel.switchToNewDisplay(i, ffi.sessionId, ffi.id);
+  ffi.ffiModel.switchToNewDisplay(i, ffi.sessionId, ffi.id, updateCursorPos);
 }
 
 // Open new tab or window to show this monitor.

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -730,7 +730,7 @@ class _MonitorMenu extends StatelessWidget {
                       ],
                     ),
                   ),
-            onPressed: () => onPressed(i, pi),
+            onPressed: () => onPressed(i, pi, isMulti),
           );
         });
 
@@ -810,14 +810,18 @@ class _MonitorMenu extends StatelessWidget {
     );
   }
 
-  onPressed(int i, PeerInfo pi) {
-    _menuDismissCallback(ffi);
+  onPressed(int i, PeerInfo pi, bool isMulti) {
+    if (!isMulti) {
+      // If show monitors in toolbar(`buildMultiMonitorMenu()`), then the menu will dismiss automatically.
+      _menuDismissCallback(ffi);
+    }
     RxInt display = CurrentDisplayState.find(id);
     if (display.value != i) {
       if (isChooseDisplayToOpenInNewWindow(pi, ffi.sessionId)) {
         openMonitorInNewTabOrWindow(i, ffi.id, pi);
       } else {
-        openMonitorInTheSameTab(i, ffi, pi);
+        final updateCursorPos = !isMulti;
+        openMonitorInTheSameTab(i, ffi, pi, updateCursorPos);
       }
     }
   }

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -820,8 +820,7 @@ class _MonitorMenu extends StatelessWidget {
       if (isChooseDisplayToOpenInNewWindow(pi, ffi.sessionId)) {
         openMonitorInNewTabOrWindow(i, ffi.id, pi);
       } else {
-        final updateCursorPos = !isMulti;
-        openMonitorInTheSameTab(i, ffi, pi, updateCursorPos);
+        openMonitorInTheSameTab(i, ffi, pi, updateCursorPos: !isMulti);
       }
     }
   }

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -787,7 +787,7 @@ void showOptions(
       children.add(InkWell(
           onTap: () {
             if (i == cur) return;
-            openMonitorInTheSameTab(i, gFFI, pi, false);
+            openMonitorInTheSameTab(i, gFFI, pi, true);
             gFFI.dialogManager.dismissAll();
           },
           child: Ink(

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -787,7 +787,7 @@ void showOptions(
       children.add(InkWell(
           onTap: () {
             if (i == cur) return;
-            openMonitorInTheSameTab(i, gFFI, pi);
+            openMonitorInTheSameTab(i, gFFI, pi, false);
             gFFI.dialogManager.dismissAll();
           },
           child: Ink(

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -787,7 +787,7 @@ void showOptions(
       children.add(InkWell(
           onTap: () {
             if (i == cur) return;
-            openMonitorInTheSameTab(i, gFFI, pi, true);
+            openMonitorInTheSameTab(i, gFFI, pi);
             gFFI.dialogManager.dismissAll();
           },
           child: Ink(

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -915,7 +915,7 @@ class FfiModel with ChangeNotifier {
             if (_pi.isSupportMultiUiSession) {
               // If the peer supports multi-ui-session, no switch display message will be send back.
               // We need to update the display manually.
-              switchToNewDisplay(newDisplay, sessionId, peerId, true);
+              switchToNewDisplay(newDisplay, sessionId, peerId);
             }
           } else {
             msgBox(sessionId, 'nocancel-error', 'Prompt', 'No Displays', '',
@@ -955,12 +955,8 @@ class FfiModel with ChangeNotifier {
   }
 
   // Directly switch to the new display without waiting for the response.
-  switchToNewDisplay(
-    int display,
-    SessionID sessionId,
-    String peerId,
-    bool updateCursorPos,
-  ) {
+  switchToNewDisplay(int display, SessionID sessionId, String peerId,
+      {bool updateCursorPos = true}) {
     // VideoHandler creation is upon when video frames are received, so either caching commands(don't know next width/height) or stopping recording when switching displays.
     parent.target?.recordingModel.onClose();
     // no need to wait for the response


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/6453

Add an optional argument to check if should update current cursor position in `updateViewStyle()` and `updateCurDisplay()`.

Do not call `_menuDismissCallback()` and update cursor position when "Show monitors on toolbar" is true and switching display on the toolbar.

