### PR TITLE
fix windows wakelock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "keepawake"
 version = "0.4.3"
-source = "git+https://github.com/rustdesk-org/keepawake-rs#ac395ef826b32a077bc5d2fe108cf71fde8fe2e6"
+source = "git+https://github.com/rustdesk-org/keepawake-rs#ad94454a75cf1ff9e95e217dee9dd6a378bf625e"
 dependencies = [
  "anyhow",
  "apple-sys",

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -733,4 +733,11 @@ impl WakeLock {
                 .ok(),
         )
     }
+
+    pub fn set_display(&mut self, display: bool) -> ResultType<()> {
+        self.0
+            .as_mut()
+            .map(|h| h.set_display(display))
+            .ok_or(anyhow!("no AwakeHandle"))?
+    }
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -98,7 +98,7 @@ impl WakeLock {
     }
 }
 
-pub fn get_wake_lock(_display: bool) -> WakeLock {
+pub fn get_wakelock(_display: bool) -> WakeLock {
     hbb_common::log::info!("new wakelock, require display on: {_display}");
     #[cfg(target_os = "android")]
     return crate::platform::WakeLock::new("server");

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2109,7 +2109,7 @@ pub fn is_process_consent_running() -> ResultType<bool> {
         .output()?;
     Ok(output.status.success() && !output.stdout.is_empty())
 }
-pub struct WakeLock;
+pub struct WakeLock(u32);
 // Failed to compile keepawake-rs on i686
 impl WakeLock {
     pub fn new(display: bool, idle: bool, sleep: bool) -> Self {
@@ -2124,7 +2124,20 @@ impl WakeLock {
             flag |= ES_AWAYMODE_REQUIRED;
         }
         unsafe { SetThreadExecutionState(flag) };
-        WakeLock {}
+        WakeLock(flag)
+    }
+
+    pub fn set_display(&mut self, display: bool) -> ResultType<()> {
+        let flag = if display {
+            self.0 | ES_DISPLAY_REQUIRED
+        } else {
+            self.0 & !ES_DISPLAY_REQUIRED
+        };
+        if flag != self.0 {
+            unsafe { SetThreadExecutionState(flag) };
+            self.0 = flag;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
#6615
1. Fix windows wakelock not work introduced by #6520,  set and clear the wakelock flag within a single thread, https://stackoverflow.com/questions/48142101/setthreadexecutionstate-for-another-thread, tested on macos/android. On Ubuntu 22.04, the display flag does not work, and the operating system is not able to enter sleep mode, same as before.
![1701774080419](https://github.com/rustdesk/rustdesk/assets/14891774/507e1378-f228-4229-a2f0-ca80ef6d884c)
2. There is a possibility that the CPU will immediately stop working when dropping the previous wakelock, although it has never happened in tests. Windows/macOS change the display flag instead of dropping it, and Linux also uses display=true for file transfer, android doesn't use display flag.