### PR TITLE
Fix: wayland repeated share screen prompts

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1237,6 +1237,8 @@ impl Connection {
     }
 
     fn get_supported_resolutions(display_idx: usize) -> Option<SupportedResolutions> {
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        return None;
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
             #[cfg(target_os = "linux")]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -12,12 +12,14 @@ use crate::platform::linux_desktop_manager;
 use crate::platform::WallPaperRemover;
 #[cfg(windows)]
 use crate::portable_service::client as portable_client;
+#[cfg(target_os = "linux")]
+use crate::platform::linux::is_x11;
 use crate::{
     client::{
         new_voice_call_request, new_voice_call_response, start_audio_thread, MediaData, MediaSender,
     },
     common::{get_default_sound_input, set_sound_input},
-    display_service, ipc, privacy_mode, video_service, VERSION, platform::is_x11,
+    display_service, ipc, privacy_mode, video_service, VERSION,
 };
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use crate::{common::DEVICE_NAME, flutter::connection_manager::start_channel};

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1172,10 +1172,7 @@ impl Connection {
             ..Default::default()
         })
         .into();
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        {
-            pi.resolutions = Self::get_supported_resolutions(self.display_idx).into();
-        }
+        pi.resolutions = Self::get_supported_resolutions(self.display_idx).into();
 
         let mut sub_service = false;
         if self.file_transfer.is_some() {
@@ -1240,23 +1237,26 @@ impl Connection {
     }
 
     fn get_supported_resolutions(display_idx: usize) -> Option<SupportedResolutions> {
-        #[cfg(target_os = "linux")]
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
-            if !is_x11() {
-                return None;
+            #[cfg(target_os = "linux")]
+            {
+                if !is_x11() {
+                    return None;
+                }
             }
+            Some(SupportedResolutions {
+                resolutions: display_service::try_get_displays()
+                    .map(|displays| {
+                        displays
+                            .get(display_idx)
+                            .map(|d| crate::platform::resolutions(&d.name()))
+                            .unwrap_or(vec![])
+                    })
+                    .unwrap_or(vec![]),
+                ..Default::default()
+            })
         }
-        Some(SupportedResolutions {
-            resolutions: display_service::try_get_displays()
-                .map(|displays| {
-                    displays
-                        .get(display_idx)
-                        .map(|d| crate::platform::resolutions(&d.name()))
-                        .unwrap_or(vec![])
-                })
-                .unwrap_or(vec![]),
-            ..Default::default()
-        })
     }
 
     fn on_remote_authorized(&self) {

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -178,7 +178,17 @@ fn displays_to_msg(displays: Vec<DisplayInfo>) -> Message {
 }
 
 fn check_get_displays_changed_msg() -> Option<Message> {
+    #[cfg(target_os = "linux")]
+    {
+        if !is_x11() {
+            return get_displays_msg();
+        }
+    }
     check_update_displays(&try_get_displays().ok()?);
+    get_displays_msg()
+}
+
+fn get_displays_msg() -> Option<Message> {
     let displays = SYNC_DISPLAYS.lock().unwrap().get_update_sync_displays()?;
     Some(displays_to_msg(displays))
 }


### PR DESCRIPTION
Fixes: https://github.com/rustdesk/rustdesk/pull/5900#issuecomment-1751999206

The check for 'supported resolutions' and 'change in displays' does not work on wayland.
These were making unnecessary calls to get display on wayland. The implementation for getting display on wayland requests the user for screen share permission hence causing infinite share screen prompts.
I have skipped these two functionalities specific for wayland.

We got away with it on gnome because of 'Remember selection' option but this option is not available on some kde environments such as ubuntu 22.04 kde.
On a side note as I'm working on implementing remote desktop portal for https://github.com/rustdesk/rustdesk/issues/5949, it does not have the 'Remember selection' option so it was required to fix this issue first.

Tested: gnome + kde on arch, ubuntu
Also tested x11, windows and android to ensure they are unaffected