### PR TITLE
use full range by default for yuv420p if supported

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,7 +3013,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "hwcodec"
 version = "0.1.3"
-source = "git+https://github.com/21pages/hwcodec?branch=stable#83300549075158e5a3fa6c59ea527af3330e48ff"
+source = "git+https://github.com/21pages/hwcodec?branch=stable#12fcf7208a2972050e2343a90eaea6e97d21beb0"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -522,8 +522,9 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
 
   // 444
   final codec_format = ffi.qualityMonitorModel.data.codecFormat;
-  if (versionCmp(pi.version, "1.2.4") >= 0 &&
-      (codec_format == "AV1" || codec_format == "VP9")) {
+  if (codec_format != null &&
+      bind.sessionIsCodecSupport444(
+          sessionId: sessionId, codec: codec_format)) {
     final option = 'i444';
     final value =
         bind.sessionGetToggleOptionSync(sessionId: sessionId, arg: option);

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -18,8 +18,8 @@ message YUV {
 }
 
 enum Chroma {
-  I420 = 0;
-  I444 = 1;
+  C420 = 0;
+  C444 = 1;
 }
 
 message VideoFrame {
@@ -96,12 +96,28 @@ message CodecAbility {
   bool h265 = 5;
 }
 
+// vpx, aom have yuv420p_bt601_studio by default
+// h26x have nv12_bt601_studio by default
+message ColorAbility {
+  bool yuv420p_bt601_full = 1;
+  bool yuv444p_bt601_studio = 2;
+}
+
+message ColorAbilities {
+  ColorAbility vp8 = 1;
+  ColorAbility vp9 = 2;
+  ColorAbility av1 = 3;
+  ColorAbility h264 = 4;
+  ColorAbility h265 = 5;
+}
+
 message SupportedEncoding {
   bool h264 = 1;
   bool h265 = 2;
   bool vp8 = 3;
   bool av1 = 4;
-  CodecAbility i444 = 5;
+  CodecAbility i444 = 5; // deprecated, use color_abilities instead
+  ColorAbilities color_abilities = 6;
 }
 
 message PeerInfo {
@@ -563,6 +579,7 @@ message SupportedDecoding {
   int32 ability_av1 = 6;
   CodecAbility i444 = 7;
   Chroma prefer_chroma = 8;
+  ColorAbilities color_abilities = 9;
 }
 
 message OptionMessage {

--- a/libs/scrap/examples/benchmark.rs
+++ b/libs/scrap/examples/benchmark.rs
@@ -5,9 +5,9 @@ use hbb_common::{
 };
 use scrap::{
     aom::{AomDecoder, AomEncoder, AomEncoderConfig},
-    codec::{EncoderApi, EncoderCfg, Quality as Q},
-    convert_to_yuv, Capturer, Display, TraitCapturer, VpxDecoder, VpxDecoderConfig, VpxEncoder,
-    VpxEncoderConfig,
+    codec::{EncoderApi, EncoderCfg, ExtraEncoderCfg, Quality as Q},
+    convert_to_yuv, Capturer, ColorRange, Display, TraitCapturer, VpxDecoder, VpxDecoderConfig,
+    VpxEncoder, VpxEncoderConfig,
     VpxVideoCodecId::{self, *},
     STRIDE_ALIGN,
 };
@@ -110,7 +110,15 @@ fn test_vpx(
         codec: codec_id,
         keyframe_interval: None,
     });
-    let mut encoder = VpxEncoder::new(config, i444).unwrap();
+    let extra = ExtraEncoderCfg {
+        pixfmt: if i444 {
+            scrap::Pixfmt::YUV444P
+        } else {
+            scrap::Pixfmt::YUV420P
+        },
+        range: ColorRange::Studio,
+    };
+    let mut encoder = VpxEncoder::new(config, extra).unwrap();
     let mut vpxs = vec![];
     let start = Instant::now();
     let mut size = 0;
@@ -122,7 +130,7 @@ fn test_vpx(
         match c.frame(std::time::Duration::from_millis(30)) {
             Ok(frame) => {
                 let tmp_timer = Instant::now();
-                convert_to_yuv(&frame, encoder.yuvfmt(), &mut yuv, &mut mid_data);
+                convert_to_yuv(&frame, encoder.yuvfmt(), &mut yuv, &mut mid_data).unwrap();
                 for ref frame in encoder
                     .encode(start.elapsed().as_millis() as _, &yuv, STRIDE_ALIGN)
                     .unwrap()
@@ -187,7 +195,15 @@ fn test_av1(
         quality,
         keyframe_interval: None,
     });
-    let mut encoder = AomEncoder::new(config, i444).unwrap();
+    let extra = ExtraEncoderCfg {
+        pixfmt: if i444 {
+            scrap::Pixfmt::YUV444P
+        } else {
+            scrap::Pixfmt::YUV420P
+        },
+        range: ColorRange::Studio,
+    };
+    let mut encoder = AomEncoder::new(config, extra).unwrap();
     let start = Instant::now();
     let mut size = 0;
     let mut av1s: Vec<Vec<u8>> = vec![];
@@ -199,7 +215,7 @@ fn test_av1(
         match c.frame(std::time::Duration::from_millis(30)) {
             Ok(frame) => {
                 let tmp_timer = Instant::now();
-                convert_to_yuv(&frame, encoder.yuvfmt(), &mut yuv, &mut mid_data);
+                convert_to_yuv(&frame, encoder.yuvfmt(), &mut yuv, &mut mid_data).unwrap();
                 for ref frame in encoder
                     .encode(start.elapsed().as_millis() as _, &yuv, STRIDE_ALIGN)
                     .unwrap()
@@ -274,6 +290,10 @@ mod hw {
         yuv_count: usize,
         h26xs: &mut Vec<Vec<u8>>,
     ) {
+        let extra = ExtraEncoderCfg {
+            pixfmt: scrap::Pixfmt::NV12,
+            range: ColorRange::Studio,
+        };
         let mut encoder = HwEncoder::new(
             EncoderCfg::HW(HwEncoderConfig {
                 name: info.name.clone(),
@@ -282,7 +302,7 @@ mod hw {
                 quality,
                 keyframe_interval: None,
             }),
-            false,
+            extra,
         )
         .unwrap();
         let mut size = 0;
@@ -295,7 +315,7 @@ mod hw {
             match c.frame(std::time::Duration::from_millis(30)) {
                 Ok(frame) => {
                     let tmp_timer = Instant::now();
-                    convert_to_yuv(&frame, encoder.yuvfmt(), &mut yuv, &mut mid_data);
+                    convert_to_yuv(&frame, encoder.yuvfmt(), &mut yuv, &mut mid_data).unwrap();
                     for ref frame in encoder.encode(&yuv).unwrap() {
                         size += frame.data.len();
 

--- a/libs/scrap/src/common/aom.rs
+++ b/libs/scrap/src/common/aom.rs
@@ -6,10 +6,10 @@
 
 include!(concat!(env!("OUT_DIR"), "/aom_ffi.rs"));
 
-use crate::codec::{base_bitrate, codec_thread_num, Quality};
+use crate::codec::{base_bitrate, codec_thread_num, ExtraEncoderCfg, Quality};
 use crate::{codec::EncoderApi, EncodeFrame, STRIDE_ALIGN};
 use crate::{common::GoogleImage, generate_call_macro, generate_call_ptr_macro, Error, Result};
-use crate::{EncodeYuvFormat, Pixfmt};
+use crate::{ColorRange, EncodeYuvFormat, Pixfmt};
 use hbb_common::{
     anyhow::{anyhow, Context},
     bytes::Bytes,
@@ -53,7 +53,7 @@ pub struct AomEncoder {
     ctx: aom_codec_ctx_t,
     width: usize,
     height: usize,
-    i444: bool,
+    extra: ExtraEncoderCfg,
     yuvfmt: EncodeYuvFormat,
 }
 
@@ -98,7 +98,7 @@ mod webrtc {
     pub fn enc_cfg(
         i: *const aom_codec_iface,
         cfg: AomEncoderConfig,
-        i444: bool,
+        extra: &ExtraEncoderCfg,
     ) -> ResultType<aom_codec_enc_cfg> {
         let mut c = unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
         call_aom!(aom_codec_enc_config_default(i, &mut c, kUsageProfile));
@@ -144,12 +144,20 @@ mod webrtc {
         c.g_lag_in_frames = kLagInFrames; // No look ahead when lag equals 0.
 
         // https://aomedia.googlesource.com/aom/+/refs/tags/v3.6.0/av1/common/enums.h#82
-        c.g_profile = if i444 { 1 } else { 0 };
+        c.g_profile = if extra.pixfmt == Pixfmt::YUV444P {
+            1
+        } else {
+            0
+        };
 
         Ok(c)
     }
 
-    pub fn set_controls(ctx: *mut aom_codec_ctx_t, cfg: &aom_codec_enc_cfg) -> ResultType<()> {
+    pub fn set_controls(
+        ctx: *mut aom_codec_ctx_t,
+        cfg: &aom_codec_enc_cfg,
+        extra: ExtraEncoderCfg,
+    ) -> ResultType<()> {
         use aom_tune_content::*;
         use aome_enc_control_id::*;
         macro_rules! call_ctl {
@@ -211,20 +219,45 @@ mod webrtc {
         call_ctl!(ctx, AV1E_SET_ENABLE_SMOOTH_INTERINTRA, 0);
         call_ctl!(ctx, AV1E_SET_ENABLE_TX64, 0);
         call_ctl!(ctx, AV1E_SET_MAX_REFERENCE_FRAMES, 3);
+        // https://github.com/chromium/chromium/blob/327564a4861822c816d35395dfb54d7e5039e6ea/media/video/av1_video_encoder.cc#L662
+        call_ctl!(
+            ctx,
+            AV1E_SET_COLOR_RANGE,
+            if extra.range == ColorRange::Full {
+                aom_color_range::AOM_CR_FULL_RANGE
+            } else {
+                aom_color_range::AOM_CR_STUDIO_RANGE
+            }
+        );
+        call_ctl!(
+            ctx,
+            AV1E_SET_COLOR_PRIMARIES,
+            aom_color_primaries::AOM_CICP_CP_BT_601
+        );
+        call_ctl!(
+            ctx,
+            AV1E_SET_TRANSFER_CHARACTERISTICS,
+            aom_transfer_characteristics::AOM_CICP_TC_BT_601
+        );
+        call_ctl!(
+            ctx,
+            AV1E_SET_MATRIX_COEFFICIENTS,
+            aom_matrix_coefficients::AOM_CICP_MC_BT_601
+        );
 
         Ok(())
     }
 }
 
 impl EncoderApi for AomEncoder {
-    fn new(cfg: crate::codec::EncoderCfg, i444: bool) -> ResultType<Self>
+    fn new(cfg: crate::codec::EncoderCfg, extra: ExtraEncoderCfg) -> ResultType<Self>
     where
         Self: Sized,
     {
         match cfg {
             crate::codec::EncoderCfg::AOM(config) => {
                 let i = call_aom_ptr!(aom_codec_av1_cx());
-                let c = webrtc::enc_cfg(i, config, i444)?;
+                let c = webrtc::enc_cfg(i, config, &extra)?;
 
                 let mut ctx = Default::default();
                 // Flag options: AOM_CODEC_USE_PSNR and AOM_CODEC_USE_HIGHBITDEPTH
@@ -236,13 +269,13 @@ impl EncoderApi for AomEncoder {
                     flags,
                     AOM_ENCODER_ABI_VERSION as _
                 ));
-                webrtc::set_controls(&mut ctx, &c)?;
+                webrtc::set_controls(&mut ctx, &c, extra)?;
                 Ok(Self {
                     ctx,
                     width: config.width as _,
                     height: config.height as _,
-                    i444,
-                    yuvfmt: Self::get_yuvfmt(config.width, config.height, i444),
+                    extra,
+                    yuvfmt: Self::get_yuvfmt(config.width, config.height, &extra),
                 })
             }
             _ => Err(anyhow!("encoder type mismatch")),
@@ -291,16 +324,13 @@ impl EncoderApi for AomEncoder {
 
 impl AomEncoder {
     pub fn encode(&mut self, pts: i64, data: &[u8], stride_align: usize) -> Result<EncodeFrames> {
-        let bpp = if self.i444 { 24 } else { 12 };
+        let (fmt, bpp) = match self.extra.pixfmt {
+            Pixfmt::YUV444P => (aom_img_fmt::AOM_IMG_FMT_I444, 24),
+            _ => (aom_img_fmt::AOM_IMG_FMT_I420, 12),
+        };
         if data.len() < self.width * self.height * bpp / 8 {
             return Err(Error::FailedCall("len not enough".to_string()));
         }
-        let fmt = if self.i444 {
-            aom_img_fmt::AOM_IMG_FMT_I444
-        } else {
-            aom_img_fmt::AOM_IMG_FMT_I420
-        };
-
         let mut image = Default::default();
         call_aom_ptr!(aom_img_wrap(
             &mut image,
@@ -375,12 +405,11 @@ impl AomEncoder {
         (q_min, q_max)
     }
 
-    fn get_yuvfmt(width: u32, height: u32, i444: bool) -> EncodeYuvFormat {
+    fn get_yuvfmt(width: u32, height: u32, extra: &ExtraEncoderCfg) -> EncodeYuvFormat {
         let mut img = Default::default();
-        let fmt = if i444 {
-            aom_img_fmt::AOM_IMG_FMT_I444
-        } else {
-            aom_img_fmt::AOM_IMG_FMT_I420
+        let fmt = match extra.pixfmt {
+            Pixfmt::YUV444P => aom_img_fmt::AOM_IMG_FMT_I444,
+            _ => aom_img_fmt::AOM_IMG_FMT_I420,
         };
         unsafe {
             aom_img_wrap(
@@ -392,9 +421,9 @@ impl AomEncoder {
                 0x1 as _,
             );
         }
-        let pixfmt = if i444 { Pixfmt::I444 } else { Pixfmt::I420 };
         EncodeYuvFormat {
-            pixfmt,
+            pixfmt: extra.pixfmt,
+            range: extra.range,
             w: img.w as _,
             h: img.h as _,
             stride: img.stride.map(|s| s as usize).to_vec(),
@@ -570,8 +599,22 @@ impl GoogleImage for Image {
 
     fn chroma(&self) -> Chroma {
         match self.inner().fmt {
-            aom_img_fmt::AOM_IMG_FMT_I444 => Chroma::I444,
-            _ => Chroma::I420,
+            aom_img_fmt::AOM_IMG_FMT_I444 => Chroma::C444,
+            _ => Chroma::C420,
+        }
+    }
+
+    fn pixfmt(&self) -> Pixfmt {
+        match self.inner().fmt {
+            aom_img_fmt::AOM_IMG_FMT_I444 => Pixfmt::YUV444P,
+            _ => Pixfmt::YUV420P,
+        }
+    }
+
+    fn range(&self) -> ColorRange {
+        match self.inner().range {
+            aom_color_range::AOM_CR_STUDIO_RANGE => ColorRange::Studio,
+            aom_color_range::AOM_CR_FULL_RANGE => ColorRange::Full,
         }
     }
 }

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -14,7 +14,7 @@ use crate::{
     aom::{self, AomDecoder, AomEncoder, AomEncoderConfig},
     common::GoogleImage,
     vpxcodec::{self, VpxDecoder, VpxDecoderConfig, VpxEncoder, VpxEncoderConfig, VpxVideoCodecId},
-    CodecName, EncodeYuvFormat, ImageRgb,
+    CodecName, ColorRange, EncodeYuvFormat, ImageRgb, Pixfmt,
 };
 
 use hbb_common::{
@@ -23,8 +23,8 @@ use hbb_common::{
     config::PeerConfig,
     log,
     message_proto::{
-        supported_decoding::PreferCodec, video_frame, Chroma, CodecAbility, EncodedVideoFrames,
-        SupportedDecoding, SupportedEncoding, VideoFrame,
+        supported_decoding::PreferCodec, video_frame, Chroma, CodecAbility, ColorAbilities,
+        ColorAbility, EncodedVideoFrames, SupportedDecoding, SupportedEncoding, VideoFrame,
     },
     sysinfo::System,
     tokio::time::Instant,
@@ -55,8 +55,14 @@ pub enum EncoderCfg {
     HW(HwEncoderConfig),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExtraEncoderCfg {
+    pub pixfmt: Pixfmt,
+    pub range: ColorRange,
+}
+
 pub trait EncoderApi {
-    fn new(cfg: EncoderCfg, i444: bool) -> ResultType<Self>
+    fn new(cfg: EncoderCfg, extra: ExtraEncoderCfg) -> ResultType<Self>
     where
         Self: Sized;
 
@@ -107,18 +113,18 @@ pub enum EncodingUpdate {
 }
 
 impl Encoder {
-    pub fn new(config: EncoderCfg, i444: bool) -> ResultType<Encoder> {
-        log::info!("new encoder: {config:?}, i444: {i444}");
+    pub fn new(config: EncoderCfg, extra: ExtraEncoderCfg) -> ResultType<Encoder> {
+        log::info!("new encoder: {config:?}, extra: {extra:?}");
         match config {
             EncoderCfg::VPX(_) => Ok(Encoder {
-                codec: Box::new(VpxEncoder::new(config, i444)?),
+                codec: Box::new(VpxEncoder::new(config, extra)?),
             }),
             EncoderCfg::AOM(_) => Ok(Encoder {
-                codec: Box::new(AomEncoder::new(config, i444)?),
+                codec: Box::new(AomEncoder::new(config, extra)?),
             }),
 
             #[cfg(feature = "hwcodec")]
-            EncoderCfg::HW(_) => match HwEncoder::new(config, i444) {
+            EncoderCfg::HW(_) => match HwEncoder::new(config, extra) {
                 Ok(hw) => Ok(Encoder {
                     codec: Box::new(hw),
                 }),
@@ -238,6 +244,22 @@ impl Encoder {
                 ..Default::default()
             })
             .into(),
+            color_abilities: Some(ColorAbilities {
+                vp9: Some(ColorAbility {
+                    yuv420p_bt601_full: true,
+                    yuv444p_bt601_studio: true,
+                    ..Default::default()
+                })
+                .into(),
+                av1: Some(ColorAbility {
+                    yuv420p_bt601_full: true,
+                    yuv444p_bt601_studio: true,
+                    ..Default::default()
+                })
+                .into(),
+                ..Default::default()
+            })
+            .into(),
             ..Default::default()
         };
         #[cfg(feature = "hwcodec")]
@@ -249,20 +271,54 @@ impl Encoder {
         encoding
     }
 
-    pub fn use_i444(config: &EncoderCfg) -> bool {
+    pub fn extra(config: &EncoderCfg) -> ExtraEncoderCfg {
         let decodings = PEER_DECODINGS.lock().unwrap().clone();
         let prefer_i444 = decodings
             .iter()
-            .all(|d| d.1.prefer_chroma == Chroma::I444.into());
-        let i444_useable = match config {
+            .any(|d| d.1.prefer_chroma == Chroma::C444.into());
+        let (pixfmt, range) = match config {
             EncoderCfg::VPX(vpx) => match vpx.codec {
-                VpxVideoCodecId::VP8 => false,
-                VpxVideoCodecId::VP9 => decodings.iter().all(|d| d.1.i444.vp9),
+                VpxVideoCodecId::VP8 => (Pixfmt::YUV420P, ColorRange::Studio),
+                VpxVideoCodecId::VP9 => {
+                    if prefer_i444
+                        && decodings.len() > 0
+                        && decodings
+                            .iter()
+                            .all(|d| d.1.color_abilities.vp9.yuv444p_bt601_studio)
+                    {
+                        (Pixfmt::YUV444P, ColorRange::Studio)
+                    } else if decodings.len() > 0
+                        && decodings
+                            .iter()
+                            .all(|d| d.1.color_abilities.vp9.yuv420p_bt601_full)
+                    {
+                        (Pixfmt::YUV420P, ColorRange::Full)
+                    } else {
+                        (Pixfmt::YUV420P, ColorRange::Studio)
+                    }
+                }
             },
-            EncoderCfg::AOM(_) => decodings.iter().all(|d| d.1.i444.av1),
-            EncoderCfg::HW(_) => false,
+            EncoderCfg::AOM(_) => {
+                if prefer_i444
+                    && decodings.len() > 0
+                    && decodings
+                        .iter()
+                        .all(|d| d.1.color_abilities.av1.yuv444p_bt601_studio)
+                {
+                    (Pixfmt::YUV444P, ColorRange::Studio)
+                } else if decodings.len() > 0
+                    && decodings
+                        .iter()
+                        .all(|d| d.1.color_abilities.av1.yuv420p_bt601_full)
+                {
+                    (Pixfmt::YUV420P, ColorRange::Full)
+                } else {
+                    (Pixfmt::YUV420P, ColorRange::Studio)
+                }
+            }
+            EncoderCfg::HW(_) => (Pixfmt::NV12, ColorRange::Studio),
         };
-        prefer_i444 && i444_useable && !decodings.is_empty()
+        ExtraEncoderCfg { pixfmt, range }
     }
 }
 
@@ -275,12 +331,7 @@ impl Decoder {
             ability_vp8: 1,
             ability_vp9: 1,
             ability_av1: 1,
-            i444: Some(CodecAbility {
-                vp9: true,
-                av1: true,
-                ..Default::default()
-            })
-            .into(),
+            color_abilities: Some(Self::color_abilities()).into(),
             prefer: prefer.into(),
             prefer_chroma: prefer_chroma.into(),
             ..Default::default()
@@ -371,7 +422,7 @@ impl Decoder {
             }
             #[cfg(feature = "hwcodec")]
             video_frame::Union::H264s(h264s) => {
-                *chroma = Some(Chroma::I420);
+                *chroma = Some(Chroma::C420);
                 if let Some(decoder) = &mut self.hw.h264 {
                     Decoder::handle_hw_video_frame(decoder, h264s, rgb, &mut self.i420)
                 } else {
@@ -380,7 +431,7 @@ impl Decoder {
             }
             #[cfg(feature = "hwcodec")]
             video_frame::Union::H265s(h265s) => {
-                *chroma = Some(Chroma::I420);
+                *chroma = Some(Chroma::C420);
                 if let Some(decoder) = &mut self.hw.h265 {
                     Decoder::handle_hw_video_frame(decoder, h265s, rgb, &mut self.i420)
                 } else {
@@ -389,7 +440,7 @@ impl Decoder {
             }
             #[cfg(feature = "mediacodec")]
             video_frame::Union::H264s(h264s) => {
-                *chroma = Some(Chroma::I420);
+                *chroma = Some(Chroma::C420);
                 if let Some(decoder) = &mut self.media_codec.h264 {
                     Decoder::handle_mediacodec_video_frame(decoder, h264s, rgb)
                 } else {
@@ -398,7 +449,7 @@ impl Decoder {
             }
             #[cfg(feature = "mediacodec")]
             video_frame::Union::H265s(h265s) => {
-                *chroma = Some(Chroma::I420);
+                *chroma = Some(Chroma::C420);
                 if let Some(decoder) = &mut self.media_codec.h265 {
                     Decoder::handle_mediacodec_video_frame(decoder, h265s, rgb)
                 } else {
@@ -500,7 +551,7 @@ impl Decoder {
     fn preference(id: Option<&str>) -> (PreferCodec, Chroma) {
         let id = id.unwrap_or_default();
         if id.is_empty() {
-            return (PreferCodec::Auto, Chroma::I420);
+            return (PreferCodec::Auto, Chroma::C420);
         }
         let options = PeerConfig::load(id).options;
         let codec = options
@@ -520,11 +571,29 @@ impl Decoder {
             PreferCodec::Auto
         };
         let chroma = if options.get("i444") == Some(&"Y".to_string()) {
-            Chroma::I444
+            Chroma::C444
         } else {
-            Chroma::I420
+            Chroma::C420
         };
         (codec, chroma)
+    }
+
+    fn color_abilities() -> ColorAbilities {
+        ColorAbilities {
+            vp9: Some(ColorAbility {
+                yuv420p_bt601_full: true,
+                yuv444p_bt601_studio: true,
+                ..Default::default()
+            })
+            .into(),
+            av1: Some(ColorAbility {
+                yuv420p_bt601_full: true,
+                yuv444p_bt601_studio: true,
+                ..Default::default()
+            })
+            .into(),
+            ..Default::default()
+        }
     }
 }
 

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -252,8 +252,8 @@ impl<T: InvokeUiSession> Remote<T> {
                             }).collect::<HashMap<usize, i32>>();
                             let chroma = self.chroma.read().unwrap().clone();
                             let chroma = match chroma {
-                                Some(Chroma::I444) => "4:4:4",
-                                Some(Chroma::I420) => "4:2:0",
+                                Some(Chroma::C444) => "4:4:4",
+                                Some(Chroma::C420) => "4:2:0",
                                 None => "-",
                             };
                             let chroma = Some(chroma.to_string());

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1416,6 +1416,15 @@ pub fn session_change_prefer_codec(session_id: SessionID) {
     }
 }
 
+pub fn session_is_codec_support_444(session_id: SessionID, codec: String) -> SyncReturn<bool> {
+    let res = if let Some(session) = sessions::get_session_by_session_id(&session_id) {
+        session.is_codec_support_444(codec)
+    } else {
+        false
+    };
+    SyncReturn(res)
+}
+
 pub fn session_on_waiting_for_image_dialog_show(session_id: SessionID) {
     super::flutter::session_on_waiting_for_image_dialog_show(session_id);
 }

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -400,8 +400,8 @@ fn run(vs: VideoService) -> ResultType<()> {
     let encoder_cfg = get_encoder_config(&c, quality, last_recording);
 
     let mut encoder;
-    let use_i444 = Encoder::use_i444(&encoder_cfg);
-    match Encoder::new(encoder_cfg.clone(), use_i444) {
+    let extra = Encoder::extra(&encoder_cfg);
+    match Encoder::new(encoder_cfg.clone(), extra) {
         Ok(x) => encoder = x,
         Err(err) => bail!("Failed to create encoder: {}", err),
     }
@@ -456,7 +456,7 @@ fn run(vs: VideoService) -> ResultType<()> {
         if last_portable_service_running != crate::portable_service::client::running() {
             bail!("SWITCH");
         }
-        if Encoder::use_i444(&encoder_cfg) != use_i444 {
+        if Encoder::extra(&encoder_cfg) != extra {
             bail!("SWITCH");
         }
         check_privacy_mode_changed(&sp, c.privacy_mode_id)?;

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1230,6 +1230,17 @@ impl<T: InvokeUiSession> Session<T> {
     pub fn close_voice_call(&self) {
         self.send(Data::CloseVoiceCall);
     }
+
+    pub fn is_codec_support_444(&self, codec: String) -> bool {
+        let codec = codec.to_uppercase();
+        let encoding = self.lc.read().unwrap().supported_encoding.clone();
+        // decoding support following
+        match codec.as_str() {
+            "VP9" => encoding.color_abilities.vp9.yuv444p_bt601_studio,
+            "AV1" => encoding.color_abilities.av1.yuv444p_bt601_studio,
+            _ => false,
+        }
+    }
 }
 
 pub trait InvokeUiSession: Send + Sync + Clone + 'static + Sized + Default {


### PR DESCRIPTION
#6518
1. Explicitly specify the color space as bt601
2. Use fullrange by default for yuv420p if supported
3. Use the pixfmt-space-range format to identify codec capabilities, make i444 proto field deprecated, and cause the non-release version of 444 true color to fail.

After the change, all colors in the image below are accurate for VP9 420 and AV1 420, but still inaccurate when r,g,b are not equal.
The conversion between yuv and rgb is irreversible, so there will be a loss of accuracy.
Teamviewer and parsec are inaccurate in both cases, anydesk accurate in both cases.
tested all codecs, 1.2.4->1.2.3, 1.2.3->1.2.4 on windows.
![image](https://github.com/rustdesk/rustdesk/assets/14891774/f732a5a0-8cd2-42b7-b2ee-e063f9845476)

