### PR TITLE
feat: Support new http-mq rendezvous protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6175,11 +6175,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg 1.1.0",
+ "backtrace",
  "bytes",
  "libc",
  "mio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,19 +3136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3856,24 +3843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0419348c027fa7be448d2ae7ea0e4e04c2334c31dc4e74ab29f00a2a7ca69204"
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,48 +4255,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "openssl"
-version = "0.10.62"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
-dependencies = [
- "bitflags 2.4.1",
- "cfg-if 1.0.0",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -5247,12 +5178,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5262,7 +5191,6 @@ dependencies = [
  "serde_json 1.0.107",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -6479,16 +6407,6 @@ dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 2.0.38",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc1f1a75fd07f0f517322d103211f12d757658e91676def9a2e688774656c60"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "http",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "rand 0.8.5",
+ "regex",
+ "ring 0.17.5",
+ "rustls 0.21.8",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.101.7",
+ "serde 1.0.190",
+ "serde_json 1.0.107",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror",
+ "time 0.3.30",
+ "tokio",
+ "tokio-retry",
+ "tokio-rustls",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "async-process"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1097,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1364,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "dark-light"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1549,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
 name = "dbus"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,12 +1604,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
+ "serde 1.0.190",
 ]
 
 [[package]]
@@ -1756,7 +1841,29 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519 2.2.3",
+ "sha2",
+ "signature 2.2.0",
+ "subtle",
 ]
 
 [[package]]
@@ -1982,6 +2089,12 @@ checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
 
 [[package]]
 name = "field-offset"
@@ -3856,6 +3969,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad178aad32087b19042ee36dfd450b73f5f934fbfb058b59b198684dfec4c47"
+dependencies = [
+ "byteorder",
+ "data-encoding",
+ "ed25519 2.2.3",
+ "ed25519-dalek",
+ "getrandom",
+ "log",
+ "rand 0.8.5",
+ "signatory",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,6 +4019,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4329,6 +4467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4416,10 +4563,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "platforms"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
 
 [[package]]
 name = "plist"
@@ -5175,6 +5338,7 @@ version = "1.2.4"
 dependencies = [
  "android_logger",
  "arboard",
+ "async-nats",
  "async-process",
  "async-trait",
  "base64",
@@ -5564,6 +5728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae801b7733ca8d6a2b580debe99f67f36826a0f5b8a36055dc6bc40f8d6bc71"
+dependencies = [
+ "serde 1.0.190",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5665,10 +5838,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "zeroize",
+]
+
+[[package]]
 name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -5724,7 +5919,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
 dependencies = [
- "ed25519",
+ "ed25519 1.5.3",
  "libc",
  "libsodium-sys",
  "serde 1.0.190",
@@ -5743,6 +5938,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -6202,6 +6407,17 @@ dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 2.0.38",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -7476,6 +7692,12 @@ dependencies = [
  "quote 1.0.33",
  "syn 2.0.38",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,6 +3136,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,6 +3856,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0419348c027fa7be448d2ae7ea0e4e04c2334c31dc4e74ab29f00a2a7ca69204"
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4255,10 +4286,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "openssl"
+version = "0.10.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if 1.0.0",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -5178,10 +5247,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5191,6 +5262,7 @@ dependencies = [
  "serde_json 1.0.107",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -6407,6 +6479,16 @@ dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 2.0.38",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ cidr-utils = "0.5"
 libloading = "0.8"
 fon = "0.6"
 zip = "0.6"
+async-nats = "0.33.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "linux")))'.dependencies]
 cpal = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ rdev = { git = "https://github.com/fufesou/rdev" }
 url = { version = "2.3", features = ["serde"] }
 crossbeam-queue = "0.3"
 hex = "0.4"
-reqwest = { git = "https://github.com/rustdesk-org/reqwest", features = ["blocking", "json", "rustls-tls"], default-features=false }
+reqwest = { git = "https://github.com/rustdesk-org/reqwest", features = ["blocking", "json", "rustls-tls", "native-tls"], default-features=false }
 chrono = "0.4"
 cidr-utils = "0.5"
 libloading = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ rdev = { git = "https://github.com/fufesou/rdev" }
 url = { version = "2.3", features = ["serde"] }
 crossbeam-queue = "0.3"
 hex = "0.4"
-reqwest = { git = "https://github.com/rustdesk-org/reqwest", features = ["blocking", "json", "rustls-tls", "native-tls"], default-features=false }
+reqwest = { git = "https://github.com/rustdesk-org/reqwest", features = ["blocking", "json", "rustls-tls"], default-features=false }
 chrono = "0.4"
 cidr-utils = "0.5"
 libloading = "0.8"

--- a/libs/hbb_common/Cargo.toml
+++ b/libs/hbb_common/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 flexi_logger = { version = "0.25", features = ["async"] }
 protobuf = { version = "3.2", features = ["with-bytes"] }
-tokio = { version = "=1.28.1", features = ["full"] }
+tokio = { version = "=1.29.1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 futures = "0.3"
 bytes = { version = "1.4", features = ["serde"] }

--- a/libs/hbb_common/protos/rendezvous.proto
+++ b/libs/hbb_common/protos/rendezvous.proto
@@ -74,6 +74,7 @@ message RegisterPkResponse {
   }
   Result result = 1;
   string mq_token = 2;
+  int64 mq_token_expire = 3;
 }
 
 message PunchHoleResponse {

--- a/libs/hbb_common/protos/rendezvous.proto
+++ b/libs/hbb_common/protos/rendezvous.proto
@@ -73,6 +73,7 @@ message RegisterPkResponse {
     SERVER_ERROR = 7;
   }
   Result result = 1;
+  string mq_token = 2;
 }
 
 message PunchHoleResponse {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -100,6 +100,8 @@ pub const RS_PUB_KEY: &str = match option_env!("RS_PUB_KEY") {
 pub const RENDEZVOUS_PORT: i32 = 21116;
 pub const RELAY_PORT: i32 = 21117;
 
+pub const RS_TOPIC_REGISTER: &str = "api.register";
+
 macro_rules! serde_field_string {
     ($default_func:ident, $de_func:ident, $default_expr:expr) => {
         fn $default_func() -> String {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -99,6 +99,9 @@ pub const RS_PUB_KEY: &str = match option_env!("RS_PUB_KEY") {
 
 pub const RENDEZVOUS_PORT: i32 = 21116;
 pub const RELAY_PORT: i32 = 21117;
+pub const DEFAULT_MQ_PORT: i32 = 4222;
+pub const TOKEN_SERVER_PORT: i32 = 443;
+pub const INSECURE_TOKEN_SERVER_PORT: i32 = 80;
 
 pub const RS_TOPIC_REGISTER: &str = "api.register";
 
@@ -997,6 +1000,10 @@ impl Config {
 
     pub fn get_ping_topic(id: &str) -> String {
         format!("ping.{}", id)
+    }
+
+    pub fn get_inbox_prefix(id: &str) -> String {
+        format!("_INBOX_{}", id)
     }
 
     pub fn get() -> Config {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -989,6 +989,10 @@ impl Config {
         }
     }
 
+    pub fn get_push_topic(id: &str) -> String {
+        format!("push.{}", id)
+    }
+
     pub fn get() -> Config {
         return CONFIG.read().unwrap().clone();
     }

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -993,6 +993,10 @@ impl Config {
         format!("push.{}", id)
     }
 
+    pub fn get_ping_topic(id: &str) -> String {
+        format!("ping.{}", id)
+    }
+
     pub fn get() -> Config {
         return CONFIG.read().unwrap().clone();
     }

--- a/libs/hbb_common/src/socket_client.rs
+++ b/libs/hbb_common/src/socket_client.rs
@@ -154,7 +154,7 @@ pub fn ipv4_to_ipv6(addr: String, ipv4: bool) -> String {
     addr
 }
 
-async fn test_target(target: &str) -> ResultType<SocketAddr> {
+pub async fn test_target(target: &str) -> ResultType<SocketAddr> {
     if let Ok(Ok(s)) = super::timeout(1000, tokio::net::TcpStream::connect(target)).await {
         if let Ok(addr) = s.peer_addr() {
             return Ok(addr);

--- a/libs/hbb_common/src/socket_client.rs
+++ b/libs/hbb_common/src/socket_client.rs
@@ -49,6 +49,27 @@ pub fn increase_port<T: std::string::ToString>(host: T, offset: i32) -> String {
     host
 }
 
+#[inline]
+pub fn replace_port<T: std::string::ToString>(host: T, port: i32) -> String {
+    let host = host.to_string();
+    if crate::is_ipv6_str(&host) {
+        if host.starts_with('[') {
+            let tmp: Vec<&str> = host.split("]:").collect();
+            if tmp.len() == 2 {
+                return format!("{}]:{}", tmp[0], port);
+            }
+        } else {
+            return format!("[{}]:{}", host, port);
+        }
+    } else if host.contains(':') {
+        let tmp: Vec<&str> = host.split(':').collect();
+        if tmp.len() == 2 {
+            return format!("{}:{}", tmp[0], port);
+        }
+    }
+    format!("{}:{}", host, port)
+}
+
 pub fn test_if_valid_server(host: &str) -> String {
     let host = check_port(host, 0);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2828,7 +2828,7 @@ fn create_symmetric_key_msg(their_pk_b: [u8; 32]) -> (Bytes, Bytes, secretbox::K
     (Vec::from(our_pk_b.0).into(), sealed_key.into(), key)
 }
 
-async fn secure_punch_connection(conn: &mut FramedStream, key: &str) -> ResultType<()> {
+pub async fn secure_punch_connection(conn: &mut FramedStream, key: &str) -> ResultType<()> {
     let rs_pk = get_rs_pk(key);
     let Some(rs_pk) = rs_pk else {
         bail!("Handshake failed: invalid public key from rendezvous server");

--- a/src/common.rs
+++ b/src/common.rs
@@ -928,6 +928,11 @@ pub fn increase_port<T: std::string::ToString>(host: T, offset: i32) -> String {
     hbb_common::socket_client::increase_port(host, offset)
 }
 
+#[inline]
+pub fn replace_port<T: std::string::ToString>(host: T, port: i32) -> String {
+    hbb_common::socket_client::replace_port(host, port)
+}
+
 pub const POSTFIX_SERVICE: &'static str = "_service";
 
 #[inline]

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -699,7 +699,7 @@ impl RendezvousMediator {
         let mq_url = format!("nats://{}", mq_host);
 
         let options = ConnectOptions::new()
-            .token(mq_token)
+            .credentials(&mq_token)?
             .ping_interval(Duration::from_millis(REG_INTERVAL as u64));
         let client = async_nats::connect_with_options(&mq_url, options).await?;
         log::info!("Connected to mq server at: {}", mq_url);

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -771,17 +771,7 @@ impl RendezvousMediator {
         // Get temporary credential
         let token_server = replace_port(host, TOKEN_SERVER_PORT);
         let token_server_url = format!("https://{}", token_server);
-        let temp_connect_info = match self.get_temp_mq_connect_info(&token_server_url).await {
-            Ok(temp_mq_token) => temp_mq_token,
-            Err(_) => {
-                // If failed, try http protocol
-                let token_server = replace_port(host, INSECURE_TOKEN_SERVER_PORT);
-                let token_server_url = format!("http://{}", token_server);
-                let connect_info = self.get_temp_mq_connect_info(&token_server_url).await?;
-                log::warn!("Token server {} is using http protocol!", token_server);
-                connect_info
-            }
-        };
+        let temp_connect_info = self.get_temp_mq_connect_info(&token_server_url).await?;
         log::debug!("Got temp token from token server");
 
         // Register pk & id using temporary credential

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -645,8 +645,8 @@ impl RendezvousMediator {
                     let last_ping_too_old = elapse_since_last_resp > REG_INTERVAL;
 
                     let mut ping_latency = match (time_last_register_sent, time_last_register_resp) {
-                        (Some(sent), Some(resp)) => resp.duration_since(sent).as_micros() as i64,
-                        (Some(sent), None) => sent.elapsed().as_micros() as i64,
+                        (Some(sent), Some(resp)) => resp.duration_since(sent).as_millis() as i64,
+                        (Some(sent), None) => sent.elapsed().as_millis() as i64,
                         _ => 0,
                     };
                     let timeout = ping_latency > REG_TIMEOUT;
@@ -662,6 +662,7 @@ impl RendezvousMediator {
                         // Send ping message
                         allow_err!(rz.register_peer_mq(&mq_client).await);
                         time_last_register_sent = now;
+                        time_last_register_resp = None;
                     }
                     if timeout {
                         fails += 1;

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -32,6 +32,7 @@ use hbb_common::{
 };
 
 use crate::{
+    client::secure_punch_connection,
     common::increase_port,
     server::{check_zombie, new as new_server, ServerPtr},
 };
@@ -715,6 +716,12 @@ impl RendezvousMediator {
     async fn register_pk_tcp(&mut self) -> ResultType<String> {
         for _ in 0..3 {
             let mut socket = socket_client::connect_tcp(&*self.host, CONNECT_TIMEOUT).await?;
+
+            // Securing connection
+            let key = crate::get_key(false).await;
+            if !key.is_empty() {
+                allow_err!(secure_punch_connection(&mut socket, &key).await);
+            }
 
             // Send RegisterPk
             let mut msg_out = Message::new();

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -815,7 +815,7 @@ impl RendezvousMediator {
         } else {
             // Default mq server is the same as rendzvous server
             let mq_host = replace_port(&self.host, DEFAULT_MQ_PORT);
-            format!("nats://{}", mq_host)
+            format!("tls://{}", mq_host)
         };
 
         let temp_id = data

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -577,6 +577,35 @@ impl RendezvousMediator {
                                     continue;
                                 }
                             }
+                            Some(rendezvous_message::Union::PunchHole(ph)) => {
+                                let rz = rz.clone();
+                                let server = server.clone();
+                                tokio::spawn(async move {
+                                    allow_err!(rz.handle_punch_hole(ph, server).await);
+                                });
+                            }
+                            Some(rendezvous_message::Union::RequestRelay(rr)) => {
+                                let rz = rz.clone();
+                                let server = server.clone();
+                                tokio::spawn(async move {
+                                    allow_err!(rz.handle_request_relay(rr, server).await);
+                                });
+                            }
+                            Some(rendezvous_message::Union::FetchLocalAddr(fla)) => {
+                                let rz = rz.clone();
+                                let server = server.clone();
+                                tokio::spawn(async move {
+                                    allow_err!(rz.handle_intranet(fla, server).await);
+                                });
+                            }
+                            Some(rendezvous_message::Union::ConfigureUpdate(cu)) => {
+                                let v0 = Config::get_rendezvous_servers();
+                                Config::set_option("rendezvous-servers".to_owned(), cu.rendezvous_servers.join(","));
+                                Config::set_serial(cu.serial);
+                                if v0 != Config::get_rendezvous_servers() {
+                                    Self::restart();
+                                }
+                            }
                             _ => {}
                         }
                     } else {


### PR DESCRIPTION
This PR provides client-side support for the new http-mq rendezvous protocol. The purpose of the new http-mq rendezvous protocol is to offer a rendezvous messaging communication method that doesn't require UDP, while maintaining support for the existing tcp-udp rendezvous protocol. Specifically, this PR implements client-side support for the following messages:

- HTTP/HTTPS Request
  - `/api/get_token`
    - Token server and `/api/get_token` endpoint is introduced to solve the authentication problem between Client and MQ server. While handshaking, the Client will send a request to the Token server to get `temp_mq_token`.  The Client will connect to MQ server with `temp_mq_token` to perform other handshake actions.
    - Apart from `temp_mq_token`, the URL of the MQ server and the other connection detail will be retrieved by this.

- MQ Messages
  - `RegisterPk` and `RegisterPkResponse`
    - Request-response type messages, previously sent by hbbs using UDP protocol. In http-mq protocol, these messages will be sent through MQ using NATS's request-reply mode.
    - `RegisterPk` message sent using MQ carries the semantics of a "handshake" for establishing a connection between the client and the server. The server's response message, `RegisterPkResponse`, now includes an extra `mq_token` field. The client will use the `mq_token` as an authentication credential to establish a long connection with the mq server.
    - The `mq_token` has much more permission compared to `temp_mq_token`. This is expected to avoid abusing of mq server.

  - `RegisterPeer`, `RegisterPeerResponse`
    - Request-response type messages, previously sent by hbbs using UDP protocol. In http-mq protocol, these messages will be sent using mq, utilizing the topic `ping.[node_id]`. The direction of message sending remains the same as existing messages. That is, `RegisterPeer` is sent from the client to the server via topic `ping.[node_id]`, after which server sends `RegisterPeerResponse` to client using topic `push.[node_id]`.

  - `PunchHole`, `RequestRelay`, `FetchLocalAddr`
      - Previously pushed actively to the client by hbbs using the UDP protocol. In http-mq protocol, these messages will be sent using mq, utilizing the topic `push.[node_id]`.

  - `ConfigureUpdate`
     - This message is an optional response to the `RegisterPeer` message, previously sent by hbbs using UDP protocol after `RegisterPeerResponse`. In http-mq protocol, these messages will be sent using mq, utilizing the topic `push.[node_id]`.

Apart from the messages mentioned above, there still exists some rendezvous messages sent through TCP protocol in udp-tcp protocol, e.g., `PunchHoleRequest`. These messages are not affected by this PR.

## Limitations

1. The ability to establish a NATS MQ connection via a user-specified socks5 proxy has not yet been implemented.
2. Using specific certification to verify NATS TLS connection hasn't been implemented yet.

## Tests

| Test Function | Test Item                                        | Test Result |
| ------------- | ------------------------------------------------ | ----------- |
| TCP Hole Punching Connection | $C_{new}P_{http-mq} \to C_{old}P_{tcp-udp}$ | ✅ |
|               | $C_{new}P_{tcp-udp} \to C_{old}P_{tcp-udp}$ | ✅ |
|               | $C_{old}P_{tcp-udp} \to C_{new}P_{http-mq}$ | ✅ |
|               | $C_{old}P_{tcp-udp} \to C_{new}P_{tcp-udp}$ | ✅ |
| Relay Connection | $C_{new}P_{http-mq} \to C_{old}P_{tcp-udp}$ | ✅ |
|               | $C_{old}P_{tcp-udp} \to C_{new}P_{http-mq}$ | ✅ |
| Custom ID | $C_{new}P_{http-mq}$ | ✅ |
|               | $C_{old}P_{tcp-udp}$ | ✅ |
| `mq_token` Expire | Able to reconnect after expire | ✅ |
|               | Still http-mq protocol after reconnection | ✅ |
| hbbs Service Restart | Able to reconnect after restart | ✅ |
|               | Still http-mq protocol after reconnection | ✅ |
| MQ Service Restart | Able to reconnect after restart | ✅ |
|               | Still http-mq protocol after reconnection | ✅ |

**Note**: 
- In the notation $C_{new/old}P_{http-mq/tcp-udp}$:
  - $C_{new}$ and $C_{old}$ denote the client using a new version (after this PR) or old version (1.2.3), respectively.
  - $P_{http-mq}$ and $P_{tcp-udp}$ represent using the http-mq protocol or tcp-udp protocol, respectively.
