### PR TITLE
Set mouse position before sending 'down' event and after entering remote page 

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -181,6 +181,8 @@ class InputModel {
 
   var _lastScale = 1.0;
 
+  bool _pointerMovedAfterEnter = false;
+
   // mouse
   final isPhysicalMouse = false.obs;
   int _lastButtons = 0;
@@ -441,6 +443,7 @@ class InputModel {
 
   void enterOrLeave(bool enter) {
     toReleaseKeys.release(handleRawKeyEvent);
+    _pointerMovedAfterEnter = false;
 
     // Fix status
     if (!enter) {
@@ -778,12 +781,19 @@ class InputModel {
         type = 'up';
         break;
       case _kMouseEventMove:
+        _pointerMovedAfterEnter = true;
         isMove = true;
         break;
       default:
         return;
     }
     evt['type'] = type;
+
+    if (type == 'down' && !_pointerMovedAfterEnter) {
+      // Move mouse to the position of the down event first.
+      lastMousePos = ui.Offset(x, y);
+      refreshMousePos();
+    }
 
     final pos = handlePointerDevicePos(
       kPointerEventKindMouse,


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/6686


## Reason

Current implementations of window event grabbing are different.

For MacOS, if the remote window is not active. No 'enter' or 'leave' event will be triggered.


https://github.com/rustdesk/rustdesk/assets/13586388/96e6f7bf-ae9f-4280-8a4a-b603b4a9107a

For Windows and Linux, event will be grabbed event the window is not active.


https://github.com/rustdesk/rustdesk/assets/13586388/099a46e4-2e4e-451c-b16d-bb4df9edd770



### Bug

macOS -> Win

https://github.com/rustdesk/rustdesk/assets/13586388/6b9febc5-231b-46d9-a661-673a3165b5f7

### Fixed

Send `RefreshMousePos()` before sending click down event.

https://github.com/rustdesk/rustdesk/assets/13586388/69c962a2-2a65-42ed-a733-0b5fa8c6a646





