### PR TITLE
Fix xdg portal verison check for persist_mode

### DIFF
--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -563,7 +563,16 @@ fn on_create_session_response(
     move |r: OrgFreedesktopPortalRequestResponse, c, _| {
         let portal = get_portal(c);
         let mut args: PropMap = HashMap::new();
-
+        if let Ok(version) = remote_desktop_portal::version(&portal) {
+            if version >= 2 {
+                let restore_token = config::LocalConfig::get_option(RESTORE_TOKEN_CONF_KEY);
+                if !restore_token.is_empty() {
+                    args.insert(RESTORE_TOKEN.to_string(), Variant(Box::new(restore_token)));
+                }
+                // persist_mode may be configured by the user.
+                args.insert("persist_mode".to_string(), Variant(Box::new(2u32)));
+            }
+        }
         args.insert(
             "handle_token".to_string(),
             Variant(Box::new("u2".to_string())),
@@ -620,16 +629,6 @@ fn on_select_devices_response(
     move |_: OrgFreedesktopPortalRequestResponse, c, _| {
         let portal = get_portal(c);
         let mut args: PropMap = HashMap::new();
-        if let Ok(version) = remote_desktop_portal::version(&portal) {
-            if version >= 4 {
-                let restore_token = config::LocalConfig::get_option(RESTORE_TOKEN_CONF_KEY);
-                if !restore_token.is_empty() {
-                    args.insert(RESTORE_TOKEN.to_string(), Variant(Box::new(restore_token)));
-                }
-                // persist_mode may be configured by the user.
-                args.insert("persist_mode".to_string(), Variant(Box::new(2u32)));
-            }
-        }
         args.insert(
             "handle_token".to_string(),
             Variant(Box::new("u3".to_string())),
@@ -697,7 +696,7 @@ fn on_start_response(
     move |r: OrgFreedesktopPortalRequestResponse, c, _| {
         let portal = get_portal(c);
         if let Ok(version) = remote_desktop_portal::version(&portal) {
-            if version >= 4 {
+            if version >= 2 {
                 if let Some(restore_token) = r.results.get(RESTORE_TOKEN) {
                     if let Some(restore_token) = restore_token.as_str() {
                         config::LocalConfig::set_option(


### PR DESCRIPTION
fixes #6741 on Fedora 39.

- version check mixed up `ScreenCast` and `RemoteDesktop` which added `persist_mode` and `restore_token` on versions `4` and `2`, respectively.
- injection of `persist_mode` and `restore_token` happened in a too late step of setting up the session