### PR TITLE
add snapshot before sending SwitchDisplay

### DIFF
--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -741,6 +741,14 @@ fn try_broadcast_display_changed(
     ) {
         log::info!("Display {} changed", display);
         if let Some(msg_out) = make_display_changed_msg(display_idx, Some(display)) {
+            // switch display may occur before the first video frame, add snapshot to ensure successful send
+            sp.snapshot(|sps| {
+                // so that new sub and old sub share the same encoder after switch
+                if sps.has_subscribes() {
+                    bail!("SWITCH");
+                }
+                Ok(())
+            })?;
             sp.send(msg_out);
             bail!("SWITCH");
         }


### PR DESCRIPTION
snapshot swap subscribes, which can  make sure `sp.send()` is successful.