### PR TITLE
Fix russian translation

### DIFF
--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -5,7 +5,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your Desktop", "Ваш рабочий стол"),
         ("desk_tip", "Ваш рабочий стол доступен с этим ID и паролем"),
         ("Password", "Пароль"),
-        ("Ready", "Готово"),
+        ("Ready", "Готов"),
         ("Established", "Установлено"),
         ("connecting_status", "Подключение к сети RustDesk..."),
         ("Enable service", "Включить службу"),


### PR DESCRIPTION
Fix russian translation of "Ready" line. 

It was more like "The job is done. Results are ready". Now it's more like "I am ready".

Possible improvement: Maybe we should write here "Ready to connection" ? To make it clear, what we are ready to?