### PR TITLE
Execute the .bat file directly on install to avoid the replacement of cmd

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1221,8 +1221,9 @@ fn run_cmds(cmds: String, show: bool, tip: &str) -> ResultType<()> {
     let tmp = write_cmds(cmds, "bat", tip)?;
     let tmp2 = get_undone_file(&tmp)?;
     let tmp_fn = tmp.to_str().unwrap_or("");
-    let res = runas::Command::new("cmd")
-        .args(&["/C", &tmp_fn])
+    // https://github.com/rustdesk/rustdesk/issues/6786#issuecomment-1879655410
+    // Execute the .bat file directly to avoid the replacement of cmd
+    let res = runas::Command::new(&tmp_fn)
         .show(show)
         .force_prompt(true)
         .status();


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/6786