### PR TITLE
Specify cmd.exe explicitly to avoid the replacement of cmd commands

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1222,8 +1222,9 @@ fn run_cmds(cmds: String, show: bool, tip: &str) -> ResultType<()> {
     let tmp2 = get_undone_file(&tmp)?;
     let tmp_fn = tmp.to_str().unwrap_or("");
     // https://github.com/rustdesk/rustdesk/issues/6786#issuecomment-1879655410
-    // Execute the .bat file directly to avoid the replacement of cmd
-    let res = runas::Command::new(&tmp_fn)
+    // Specify cmd.exe explicitly to avoid the replacement of cmd commands.
+    let res = runas::Command::new("cmd.exe")
+        .args(&["/C", &tmp_fn])
         .show(show)
         .force_prompt(true)
         .status();


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/6786
https://github.com/rustdesk/rustdesk/pull/6817

![1704545817076](https://github.com/rustdesk/rustdesk/assets/14891774/3d1ec9f8-967b-4e6d-82e5-d07899832f62)
