### PR TITLE
fix: update version of zbus to build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ lib/generated_bridge.dart
 .devcontainer/.*
 # build cache in examples
 examples/**/target/
+# ===
+vcpkg_installed

--- a/vdi/host/Cargo.toml
+++ b/vdi/host/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 qemu-display = { git = "https://github.com/rustdesk/qemu-display" }
 hbb_common = { path = "../../libs/hbb_common" }
 clap = { version = "4.1", features = ["derive"] }
-zbus = { version = "3.0" }
+zbus = { version = "3.14.1" }
 image = "0.24"
 async-trait = "0.1"


### PR DESCRIPTION
After many trials to build the system found below error after installing dependencies:

```
   Compiling jpeg-decoder v0.3.0
error: rustc interrupted by SIGSEGV, printing backtrace

/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/librustc_driver-5aef5f09b8575cae.so(+0x2b51e36)[0x7fcf87b51e36]
/lib/x86_64-linux-gnu/libc.so.6(+0x42520)[0x7fcf84c42520]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc(+0x6c0da)[0x55fc0821f0da]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc(+0x6bc2b)[0x55fc0821ec2b]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc(+0x70045)[0x55fc08223045]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc(+0x1c57b)[0x55fc081cf57b]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/libLLVM-17-rust-1.75.0-stable.so(+0x6729324)[0x7fcf83929324]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/libLLVM-17-rust-1.75.0-stable.so(_ZN4llvm9MCContext5resetEv+0xba)[0x7fcf83928b58]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/libLLVM-17-rust-1.75.0-stable.so(_ZN4llvm28MachineModuleInfoWrapperPass14doFinalizationERNS_6ModuleE+0xd)[0x7fcf8331874f]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/libLLVM-17-rust-1.75.0-stable.so(_ZN4llvm6legacy15PassManagerImpl3runERNS_6ModuleE+0x422)[0x7fcf83318676]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/librustc_driver-5aef5f09b8575cae.so(+0x4ac7250)[0x7fcf89ac7250]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/librustc_driver-5aef5f09b8575cae.so(+0x4ac6e8c)[0x7fcf89ac6e8c]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/librustc_driver-5aef5f09b8575cae.so(+0x4ac47a3)[0x7fcf89ac47a3]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/librustc_driver-5aef5f09b8575cae.so(+0x4ac443f)[0x7fcf89ac443f]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/librustc_driver-5aef5f09b8575cae.so(+0x4ac7a5c)[0x7fcf89ac7a5c]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/librustc_driver-5aef5f09b8575cae.so(+0x4ac7540)[0x7fcf89ac7540]
/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/libstd-90f6ddbf82de36ec.so(rust_metadata_std_409886f6357001f0+0xb96a5)[0x7fcf84f986a5]
/lib/x86_64-linux-gnu/libc.so.6(+0x94ac3)[0x7fcf84c94ac3]
/lib/x86_64-linux-gnu/libc.so.6(+0x126660)[0x7fcf84d26660]

note: we would appreciate a report at https://github.com/rust-lang/rust
error: could not compile `zbus` (lib)

Caused by:
  process didn't exit successfully: `/home/moaz/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name zbus --edition=2018 /home/moaz/.cargo/registry/src/index.crates.io-6f17d22bba15001f/zbus-3.14.1/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=88 --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="async-executor"' --cfg 'feature="async-fs"' --cfg 'feature="async-io"' --cfg 'feature="async-lock"' --cfg 'feature="async-task"' --cfg 'feature="blocking"' --cfg 'feature="default"' -C metadata=c653630722d5d4ce -C extra-filename=-c653630722d5d4ce --out-dir /home/moaz/dev/_identity/talha/rustdesk/target/debug/deps -L dependency=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps --extern async_broadcast=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libasync_broadcast-fdf27001944da803.rmeta --extern async_executor=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libasync_executor-941e45bb3ed0f00e.rmeta --extern async_fs=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libasync_fs-c618075b58c48a7d.rmeta --extern async_io=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libasync_io-61f765f78918b081.rmeta --extern async_lock=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libasync_lock-f13fee641d1bcecb.rmeta --extern async_recursion=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libasync_recursion-679089a4909d5615.so --extern async_task=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libasync_task-e0dcfed2727a384a.rmeta --extern async_trait=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libasync_trait-97745e194fbf22ae.so --extern blocking=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libblocking-304f3c28ac611340.rmeta --extern byteorder=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libbyteorder-e9468b374a0c0c11.rmeta --extern derivative=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libderivative-e5c2d2edb18aeb81.so --extern enumflags2=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libenumflags2-42198c6e3e9089e0.rmeta --extern event_listener=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libevent_listener-c4b6b56059522037.rmeta --extern futures_core=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libfutures_core-17b45303463871aa.rmeta --extern futures_sink=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libfutures_sink-ca415c0607e47a6c.rmeta --extern futures_util=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libfutures_util-26435935d1b743d9.rmeta --extern hex=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libhex-05644b5497b79c5b.rmeta --extern nix=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libnix-acf96ec554fe243a.rmeta --extern once_cell=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libonce_cell-865e1c5018a0303a.rmeta --extern ordered_stream=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libordered_stream-86d3c1206c082586.rmeta --extern rand=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/librand-58af96db0efb05e4.rmeta --extern serde=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libserde-183538cdf870ae08.rmeta --extern serde_repr=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libserde_repr-09196369387364c9.so --extern sha1=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libsha1-d20bad8e931e3714.rmeta --extern static_assertions=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libstatic_assertions-06b6572b5d394a0a.rmeta --extern tracing=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libtracing-7d251ac35fd6045b.rmeta --extern xdg_home=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libxdg_home-8bdb31cd1a0a779e.rmeta --extern zbus_macros=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libzbus_macros-79464551d24f7d83.so --extern zbus_names=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libzbus_names-8d093c566ac801fb.rmeta --extern zvariant=/home/moaz/dev/_identity/talha/rustdesk/target/debug/deps/libzvariant-2d416eddbd4ca14c.rmeta --cap-lints allow` (signal: 11, SIGSEGV: invalid memory reference)
warning: build failed, waiting for other jobs to finish...

```

Issue fixed by update version of library `zbus`. Now it is: `zbus = { version = "3.14.1" }`


