### PR TITLE
Fix: android scam warning height for small devices

### DIFF
--- a/flutter/lib/mobile/pages/server_page.dart
+++ b/flutter/lib/mobile/pages/server_page.dart
@@ -267,6 +267,7 @@ class _ScamWarningDialogState extends State<ScamWarningDialog> {
   @override
   Widget build(BuildContext context) {
     final isButtonLocked = _countdown > 0;
+    final screenHeight = MediaQuery.of(context).size.height;
 
     return AlertDialog(
       content: Container(
@@ -321,7 +322,7 @@ class _ScamWarningDialogState extends State<ScamWarningDialog> {
             ),
             SizedBox(height: 18),
             SizedBox(
-              height: 220,
+              height: screenHeight * 0.3,
               child: Scrollbar(
                 child: SingleChildScrollView(
                   child: Text(


### PR DESCRIPTION
Fixes: #6812 
No problem with bigger sizes too.

<img width="300" alt="Screenshot 2024-01-10 at 6 20 31 AM" src="https://github.com/rustdesk/rustdesk/assets/73148455/f4930251-b7cd-4762-bb3d-7275dda4265f">


---
Earlier:

<img width="300" alt="Screenshot 2024-01-10 at 6 15 22 AM" src="https://github.com/rustdesk/rustdesk/assets/73148455/c6c2b984-961c-4cee-9b85-d9899506b6bd">
