### PR TITLE
Fix ab merge and sync from recent

### DIFF
--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -55,6 +55,7 @@ class AbModel {
       Timer.periodic(Duration(milliseconds: 500), (timer) async {
         if (_timerCounter++ % 6 == 0) {
           if (!gFFI.userModel.isLogin) return;
+          if (!initialized) return;
           syncFromRecent();
         }
       });

--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -378,6 +378,7 @@ class AbModel {
     p.hash = r.hash.isEmpty ? p.hash : r.hash;
     p.username = r.username.isEmpty ? p.username : r.username;
     p.hostname = r.hostname.isEmpty ? p.hostname : r.hostname;
+    p.platform = r.platform.isEmpty ? p.platform : r.platform;
     p.alias = p.alias.isEmpty ? r.alias : p.alias;
     p.forceAlwaysRelay = r.forceAlwaysRelay;
     p.rdpPort = r.rdpPort;


### PR DESCRIPTION
1. Fixed missing "platform" field from recent sync. This issue causes the platform icon to be lost when using Add ID and then syncing from recent. This did not result in multiple pushes.
https://github.com/rustdesk/rustdesk/blob/58fd8780e537239fa07dd877ac48b19e3698d375/flutter/lib/models/ab_model.dart#L455
2. Fix calling the syncFromRecent before ab is initialized. If syncFromRecent option is on, and there are more recent devices than licensed devices, the permitted device count is unknown when calling syncFromRecent , all recent devices are pushed to ab, then after pullAb, the devices are truncated and in front What's in the list is the result.