### PR TITLE
Refact/verification code input check

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -442,6 +442,7 @@ class Dialog2FaField extends ValidationField {
   final String? errorText;
   final VoidCallback? readyCallback;
   final VoidCallback? onChanged;
+  final errMsg = translate('2FA code must be 6 digits.');
 
   @override
   Widget build(BuildContext context) {
@@ -468,20 +469,18 @@ class Dialog2FaField extends ValidationField {
   bool get isReady => text.length == 6 && isAllDigits;
 
   @override
-  String? validate() =>
-      isReady ? null : translate('2FA code must be 6 digits.');
+  String? validate() => isReady ? null : errMsg;
 
   _onChanged(StateSetter setState, SimpleWrapper<String?> errText) {
     onChanged?.call();
 
     if (text.length > 6) {
-      setState(() => errText.value =
-          translate('Email verification code must be 6 characters.'));
+      setState(() => errText.value = errMsg);
       return;
     }
 
     if (!isAllDigits) {
-      setState(() => errText.value = translate('2FA code must be 6 digits.'));
+      setState(() => errText.value = errMsg);
       return;
     }
 
@@ -515,6 +514,7 @@ class DialogEmailCodeField extends ValidationField {
   final String? errorText;
   final VoidCallback? readyCallback;
   final VoidCallback? onChanged;
+  final errMsg = translate('Email verification code must be 6 characters.');
 
   @override
   Widget build(BuildContext context) {
@@ -537,16 +537,13 @@ class DialogEmailCodeField extends ValidationField {
   bool get isReady => text.length == 6;
 
   @override
-  String? validate() => isReady
-      ? null
-      : translate('Email verification code must be 6 characters.');
+  String? validate() => isReady ? null : errMsg;
 
   _onChanged(StateSetter setState, SimpleWrapper<String?> errText) {
     onChanged?.call();
 
     if (text.length > 6) {
-      setState(() => errText.value =
-          translate('Email verification code must be 6 characters.'));
+      setState(() => errText.value = errMsg);
       return;
     }
 

--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -363,6 +363,7 @@ class DialogTextField extends StatelessWidget {
   final Widget? suffixIcon;
   final TextEditingController controller;
   final FocusNode? focusNode;
+  final List<TextInputFormatter>? inputFormatters;
 
   static const kUsernameTitle = 'Username';
   static const kUsernameIcon = Icon(Icons.account_circle_outlined);
@@ -378,6 +379,7 @@ class DialogTextField extends StatelessWidget {
       this.prefixIcon,
       this.suffixIcon,
       this.hintText,
+      this.inputFormatters,
       required this.title,
       required this.controller})
       : super(key: key);
@@ -402,6 +404,7 @@ class DialogTextField extends StatelessWidget {
             focusNode: focusNode,
             autofocus: true,
             obscureText: obscureText,
+            inputFormatters: inputFormatters,
           ),
         ),
       ],
@@ -452,6 +455,9 @@ class Dialog2FaField extends ValidationField {
       readyCallback: readyCallback,
       helperText: helperText ?? translate('2fa_tip'),
       onChanged: _onChanged,
+      inputFormatters: [
+        FilteringTextInputFormatter.allow(RegExp(r'[0-9]')),
+      ],
     );
   }
 
@@ -568,6 +574,7 @@ class DialogVerificationCodeField extends StatefulWidget {
     this.textLength,
     this.readyCallback,
     this.onChanged,
+    this.inputFormatters,
   }) : super(key: key);
 
   final TextEditingController controller;
@@ -581,6 +588,7 @@ class DialogVerificationCodeField extends StatefulWidget {
   final VoidCallback? readyCallback;
   final Function(StateSetter setState, SimpleWrapper<String?> errText)?
       onChanged;
+  final List<TextInputFormatter>? inputFormatters;
 
   @override
   State<DialogVerificationCodeField> createState() =>
@@ -637,6 +645,7 @@ class _DialogVerificationCodeField extends State<DialogVerificationCodeField> {
       errorText: widget.errorText ?? errorText.value,
       focusNode: _focusNode,
       helperText: widget.helperText,
+      inputFormatters: widget.inputFormatters,
     );
   }
 }

--- a/flutter/lib/common/widgets/login.dart
+++ b/flutter/lib/common/widgets/login.dart
@@ -619,14 +619,7 @@ Future<bool?> verificationCodeDialog(
   final code = TextEditingController();
 
   final res = await gFFI.dialogManager.show<bool>((setState, close, context) {
-    late ValidationField codeField;
-
     void onVerify() async {
-      errorText = codeField.validate();
-      if (errorText != null) {
-        setState(() {});
-        return;
-      }
       setState(() => isInProgress = true);
 
       try {
@@ -661,17 +654,17 @@ Future<bool?> verificationCodeDialog(
       setState(() => isInProgress = false);
     }
 
-    codeField = isEmailVerification
+    final codeField = isEmailVerification
         ? DialogEmailCodeField(
             controller: code,
             errorText: errorText,
-            isReadyCallback: onVerify,
+            readyCallback: onVerify,
             onChanged: () => errorText = null,
           )
         : Dialog2FaField(
             controller: code,
             errorText: errorText,
-            isReadyCallback: onVerify,
+            readyCallback: onVerify,
             onChanged: () => errorText = null,
           );
 

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", "Email 验证码必须是 6 个字符。"),
+        ("2FA code must be 6 digits.", "2FA 码必须是6位数字。"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", "Bitte richten Sie jetzt Ihren Authentifikator ein. Sie können eine Authentifizierungs-App wie Authy, Microsoft oder Google Authenticator auf Ihrem Telefon oder Desktop verwenden.\n\nScannen Sie den QR-Code mit Ihrer App und geben Sie den Code ein, den Ihre App anzeigt, um die Zwei-Faktor-Authentifizierung zu aktivieren."),
         ("wrong-2fa-code", "Der Code kann nicht verifiziert werden. Prüfen Sie, ob der Code und die lokalen Zeiteinstellungen korrekt sind."),
         ("enter-2fa-title", "Zwei-Faktor-Authentifizierung"),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -585,5 +585,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("enable-2fa-desc", ""),
         ("wrong-2fa-code", ""),
         ("enter-2fa-title", ""),
+        ("Email verification code must be 6 characters.", ""),
+        ("2FA code must be 6 digits.", ""),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
1. Refactor, unify 2FA verification code input.
2. Fix adding listener for `TextEditingController` multiple times.

![image](https://github.com/rustdesk/rustdesk/assets/13586388/011b6e43-8de5-4dd7-806b-af904e40e2e6)


## Preview

### login, email verification code

https://github.com/rustdesk/rustdesk/assets/13586388/8c720487-694f-4f70-ab8b-02a485a0689f

### login, 2FA code

https://github.com/rustdesk/rustdesk/assets/13586388/23cfc3b7-6a9b-4807-8934-614287349934

### connection, 2FA code

https://github.com/rustdesk/rustdesk/assets/13586388/37251f80-bfc4-4092-af3b-8e9b9b90ac75

