### PR TITLE
disable ffmpeg ram codec temporarily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3079,7 +3079,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "hwcodec"
 version = "0.2.0"
-source = "git+https://github.com/21pages/hwcodec?branch=stable#da8aec8e8abb6a5506e027484023e6e2ad1f47eb"
+source = "git+https://github.com/21pages/hwcodec?branch=stable#42cfa3f9e5138d3dbdea83ea87d4c4bf798fef51"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -708,10 +708,17 @@ impl Decoder {
 
 #[cfg(any(feature = "hwcodec", feature = "mediacodec"))]
 pub fn enable_hwcodec_option() -> bool {
-    if let Some(v) = Config2::get().options.get("enable-hwcodec") {
-        return v != "N";
+    #[cfg(feature = "hwcodec")]
+    {
+        return false;
     }
-    return true; // default is true
+    #[cfg(feature = "mediacodec")]
+    {
+        if let Some(v) = Config2::get().options.get("enable-hwcodec") {
+            return v != "N";
+        }
+        return true; // default is true
+    }
 }
 #[cfg(feature = "gpucodec")]
 pub fn enable_gpucodec_option() -> bool {

--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -381,6 +381,7 @@ pub fn check_available_hwcodec() {
 }
 
 pub fn hwcodec_new_check_process() {
+    /*
     use std::sync::Once;
     let f = || {
         // Clear to avoid checking process errors
@@ -423,4 +424,5 @@ pub fn hwcodec_new_check_process() {
     ONCE.call_once(|| {
         std::thread::spawn(f);
     });
+    */
 }


### PR DESCRIPTION
On my desktop computer, i5 12400, gtx 1650, the old ffmpeg hardware codec can freeze the cpu when closing the remote page, temporarily disabling it. New hardware codecs are available for Windows platforms and I will be testing it on Linux on the same computer soon.