### PR TITLE
video handler holds only one decoder of the current codec format

### DIFF
--- a/libs/scrap/src/common/mediacodec.rs
+++ b/libs/scrap/src/common/mediacodec.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::ImageFormat;
 use crate::{
     codec::{EncoderApi, EncoderCfg},
-    I420ToABGR, I420ToARGB, ImageRgb,
+    CodecFormat, I420ToABGR, I420ToARGB, ImageRgb,
 };
 
 /// MediaCodec mime type name
@@ -37,17 +37,16 @@ impl Deref for MediaCodecDecoder {
     }
 }
 
-#[derive(Default)]
-pub struct MediaCodecDecoders {
-    pub h264: Option<MediaCodecDecoder>,
-    pub h265: Option<MediaCodecDecoder>,
-}
-
 impl MediaCodecDecoder {
-    pub fn new_decoders() -> MediaCodecDecoders {
-        let h264 = create_media_codec(H264_MIME_TYPE, MediaCodecDirection::Decoder);
-        let h265 = create_media_codec(H265_MIME_TYPE, MediaCodecDirection::Decoder);
-        MediaCodecDecoders { h264, h265 }
+    pub fn new(format: CodecFormat) -> Option<MediaCodecDecoder> {
+        match format {
+            CodecFormat::H264 => create_media_codec(H264_MIME_TYPE, MediaCodecDirection::Decoder),
+            CodecFormat::H265 => create_media_codec(H265_MIME_TYPE, MediaCodecDirection::Decoder),
+            _ => {
+                log::error!("Unsupported codec format: {}", format);
+                None
+            }
+        }
     }
 
     // rgb [in/out] fmt and stride must be set in ImageRgb

--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -251,7 +251,7 @@ pub enum CodecName {
     H265GPU,
 }
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum CodecFormat {
     VP8,
     VP9,

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,7 +51,7 @@ pub use helper::*;
 use scrap::{
     codec::Decoder,
     record::{Recorder, RecorderContext},
-    ImageFormat, ImageRgb,
+    CodecFormat, ImageFormat, ImageRgb,
 };
 
 use crate::{
@@ -76,6 +76,7 @@ pub mod io_loop;
 pub const MILLI1: Duration = Duration::from_millis(1);
 pub const SEC30: Duration = Duration::from_secs(30);
 pub const VIDEO_QUEUE_SIZE: usize = 120;
+const MAX_DECODE_FAIL_COUNTER: usize = 10; // Currently, failed decode cause refresh_video, so make it small
 
 #[cfg(all(target_os = "linux", feature = "linux_headless"))]
 #[cfg(not(any(feature = "flatpak", feature = "appimage")))]
@@ -1027,24 +1028,25 @@ pub struct VideoHandler {
     recorder: Arc<Mutex<Option<Recorder>>>,
     record: bool,
     _display: usize, // useful for debug
+    fail_counter: usize,
 }
 
 impl VideoHandler {
     /// Create a new video handler.
-    pub fn new(_display: usize) -> Self {
+    pub fn new(format: CodecFormat, _display: usize) -> Self {
         #[cfg(all(feature = "gpucodec", feature = "flutter"))]
         let luid = crate::flutter::get_adapter_luid();
         #[cfg(not(all(feature = "gpucodec", feature = "flutter")))]
         let luid = Default::default();
-        println!("new session_get_adapter_luid: {:?}", luid);
-        log::info!("new video handler for display #{_display}");
+        log::info!("new video handler for display #{_display}, format: {format:?}, luid: {luid:?}");
         VideoHandler {
-            decoder: Decoder::new(luid),
+            decoder: Decoder::new(format, luid),
             rgb: ImageRgb::new(ImageFormat::ARGB, crate::DST_STRIDE_RGBA),
             texture: std::ptr::null_mut(),
             recorder: Default::default(),
             record: false,
             _display,
+            fail_counter: 0,
         }
     }
 
@@ -1056,6 +1058,10 @@ impl VideoHandler {
         pixelbuffer: &mut bool,
         chroma: &mut Option<Chroma>,
     ) -> ResultType<bool> {
+        let format = CodecFormat::from(&vf);
+        if format != self.decoder.format() {
+            self.reset(Some(format));
+        }
         match &vf.union {
             Some(frame) => {
                 let res = self.decoder.handle_video_frame(
@@ -1065,6 +1071,13 @@ impl VideoHandler {
                     pixelbuffer,
                     chroma,
                 );
+                if res.as_ref().is_ok_and(|x| *x) {
+                    self.fail_counter = 0;
+                } else {
+                    if self.fail_counter < usize::MAX {
+                        self.fail_counter += 1
+                    }
+                }
                 if self.record {
                     self.recorder
                         .lock()
@@ -1078,13 +1091,15 @@ impl VideoHandler {
         }
     }
 
-    /// Reset the decoder.
-    pub fn reset(&mut self) {
+    /// Reset the decoder, change format if it is Some
+    pub fn reset(&mut self, format: Option<CodecFormat>) {
         #[cfg(all(feature = "flutter", feature = "gpucodec"))]
         let luid = crate::flutter::get_adapter_luid();
         #[cfg(not(all(feature = "flutter", feature = "gpucodec")))]
         let luid = None;
-        self.decoder = Decoder::new(luid);
+        let format = format.unwrap_or(self.decoder.format());
+        self.decoder = Decoder::new(format, luid);
+        self.fail_counter = 0;
     }
 
     /// Start or stop screen record.
@@ -1133,6 +1148,7 @@ pub struct LoginConfigHandler {
     pub other_server: Option<(String, String, String)>,
     pub custom_fps: Arc<Mutex<Option<usize>>>,
     pub adapter_luid: Option<i64>,
+    pub mark_unsupported: Vec<CodecFormat>,
 }
 
 impl Deref for LoginConfigHandler {
@@ -1562,6 +1578,7 @@ impl LoginConfigHandler {
                 Some(&self.id),
                 cfg!(feature = "flutter"),
                 self.adapter_luid,
+                &self.mark_unsupported,
             ));
         n += 1;
 
@@ -1947,6 +1964,7 @@ impl LoginConfigHandler {
             Some(&self.id),
             cfg!(feature = "flutter"),
             self.adapter_luid,
+            &self.mark_unsupported,
         );
         let mut misc = Misc::new();
         misc.set_option(OptionMessage {
@@ -1956,44 +1974,6 @@ impl LoginConfigHandler {
         let mut msg_out = Message::new();
         msg_out.set_misc(misc);
         msg_out
-    }
-
-    fn real_supported_decodings(
-        &self,
-        handler_controller_map: &Vec<VideoHandlerController>,
-    ) -> Data {
-        let abilities: Vec<CodecAbility> = handler_controller_map
-            .iter()
-            .map(|h| h.handler.decoder.exist_codecs(cfg!(feature = "flutter")))
-            .collect();
-        let all = |ability: fn(&CodecAbility) -> bool| -> i32 {
-            if abilities.iter().all(|d| ability(d)) {
-                1
-            } else {
-                0
-            }
-        };
-        let decoding = scrap::codec::Decoder::supported_decodings(
-            Some(&self.id),
-            cfg!(feature = "flutter"),
-            self.adapter_luid,
-        );
-        let decoding = SupportedDecoding {
-            ability_vp8: all(|e| e.vp8),
-            ability_vp9: all(|e| e.vp9),
-            ability_av1: all(|e| e.av1),
-            ability_h264: all(|e| e.h264),
-            ability_h265: all(|e| e.h265),
-            ..decoding
-        };
-        let mut misc = Misc::new();
-        misc.set_option(OptionMessage {
-            supported_decoding: hbb_common::protobuf::MessageField::some(decoding),
-            ..Default::default()
-        });
-        let mut msg_out = Message::new();
-        msg_out.set_misc(misc);
-        Data::Message(msg_out)
     }
 
     pub fn restart_remote_device(&self) -> Message {
@@ -2088,26 +2068,16 @@ where
                         };
                         let display = vf.display as usize;
                         let start = std::time::Instant::now();
-                        let mut created_new_handler = false;
+                        let format = CodecFormat::from(&vf);
                         if handler_controller_map.len() <= display {
                             for _i in handler_controller_map.len()..=display {
                                 handler_controller_map.push(VideoHandlerController {
-                                    handler: VideoHandler::new(_i),
+                                    handler: VideoHandler::new(format, _i),
                                     count: 0,
                                     duration: std::time::Duration::ZERO,
                                     skip_beginning: 0,
                                 });
-                                created_new_handler = true;
                             }
-                        }
-                        if created_new_handler {
-                            session.send(
-                                session
-                                    .lc
-                                    .read()
-                                    .unwrap()
-                                    .real_supported_decodings(&handler_controller_map),
-                            );
                         }
                         if let Some(handler_controller) = handler_controller_map.get_mut(display) {
                             let mut pixelbuffer = true;
@@ -2172,17 +2142,32 @@ where
                                 _ => {}
                             }
                         }
+
+                        // check invalid decoders
+                        let mut should_update_supported = false;
+                        handler_controller_map
+                            .iter()
+                            .map(|h| {
+                                if !h.handler.decoder.valid() || h.handler.fail_counter >= MAX_DECODE_FAIL_COUNTER {
+                                    let mut lc = session.lc.write().unwrap();
+                                    let format = h.handler.decoder.format();
+                                    if !lc.mark_unsupported.contains(&format) {
+                                        lc.mark_unsupported.push(format);
+                                        should_update_supported = true;
+                                        log::info!("mark {format:?} decoder as unsupported, valid:{}, fail_counter:{}, all unsupported:{:?}", h.handler.decoder.valid(), h.handler.fail_counter, lc.mark_unsupported);
+                                    }
+                                }
+                            })
+                            .count();
+                        if should_update_supported {
+                            session.send(Data::Message(
+                                session.lc.read().unwrap().update_supported_decodings(),
+                            ));
+                        }
                     }
                     MediaData::Reset(display) => {
                         if let Some(handler_controler) = handler_controller_map.get_mut(display) {
-                            handler_controler.handler.reset();
-                            session.send(
-                                session
-                                    .lc
-                                    .read()
-                                    .unwrap()
-                                    .real_supported_decodings(&handler_controller_map),
-                            );
+                            handler_controler.handler.reset(None);
                         }
                     }
                     MediaData::RecordScreen(start, display, w, h, id) => {

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -846,7 +846,7 @@ pub fn has_gpucodec() -> bool {
 #[cfg(feature = "flutter")]
 #[inline]
 pub fn supported_hwdecodings() -> (bool, bool) {
-    let decoding = scrap::codec::Decoder::supported_decodings(None, true, None);
+    let decoding = scrap::codec::Decoder::supported_decodings(None, true, None, &vec![]);
     #[allow(unused_mut)]
     let (mut h264, mut h265) = (decoding.ability_h264 > 0, decoding.ability_h265 > 0);
     #[cfg(feature = "gpucodec")]

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -437,8 +437,13 @@ impl<T: InvokeUiSession> Session<T> {
 
     pub fn alternative_codecs(&self) -> (bool, bool, bool, bool) {
         let luid = self.lc.read().unwrap().adapter_luid;
-        let decoder =
-            scrap::codec::Decoder::supported_decodings(None, cfg!(feature = "flutter"), luid);
+        let mark_unsupported = self.lc.read().unwrap().mark_unsupported.clone();
+        let decoder = scrap::codec::Decoder::supported_decodings(
+            None,
+            cfg!(feature = "flutter"),
+            luid,
+            &mark_unsupported,
+        );
         let mut vp8 = decoder.ability_vp8 > 0;
         let mut av1 = decoder.ability_av1 > 0;
         let mut h264 = decoder.ability_h264 > 0;


### PR DESCRIPTION
1. For example: when receiving h264 video frames, only one h264 decoder is created, priority: vram > ram
2. For creation and decoding failed:

  * Remove real_supported_decodings, this will update real existing decoders, replace it with the `mark_unsupported` vector. After creating the decoder failure, marks the codec as unsupported and updates supported decoding to the controlled side
  *  Add `fail_counter` in the decoder. When decoding 10 consecutive frames failed, adding codec type to `mark_unsupported` vector
  *  The controlled end always ignores the unavailability of VP9

test:
* 1.2.4 control 1.1.9~1.2.4
* In this test video, the default codec  is AV1, let AV1 and H264 fail to be created, and let H265 fail to decode after 100 frames.

https://github.com/rustdesk/rustdesk/assets/14891774/4f033b03-33b0-4c19-b340-731b1842900d

