### PR TITLE
Fix. sciter, switch display. Unsubscribe unused display services after switching

### DIFF
--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -723,6 +723,11 @@ impl<T: InvokeUiSession> Session<T> {
         let mut msg_out = Message::new();
         msg_out.set_misc(misc);
         self.send(Data::Message(msg_out));
+
+        #[cfg(not(feature = "flutter"))]
+        {
+            self.capture_displays(vec![], vec![], vec![display]);
+        }
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]


### PR DESCRIPTION
Use `capture_displays` to sync current display index for sciter version.
So the remote side can unsubscribe unused display services.


 ## Bug

https://github.com/rustdesk/rustdesk/assets/13586388/ac9685fd-eaa3-4dd6-8a32-2f800b6936ee

## Fixed


https://github.com/rustdesk/rustdesk/assets/13586388/3071c9ec-c932-486e-b3f3-07e35cced596

