### PR TITLE
Fix: Mac retina display video blur

### DIFF
--- a/libs/scrap/src/quartz/display.rs
+++ b/libs/scrap/src/quartz/display.rs
@@ -36,8 +36,9 @@ impl Display {
 
     pub fn width(self) -> usize {
         let w = unsafe { CGDisplayPixelsWide(self.0) };
-        if self.is_retina() {
-            w * 2
+        let s = self.scale();
+        if s > 1.0 {
+           ((w as f64) * s) as usize
         } else {
             w
         }
@@ -45,8 +46,9 @@ impl Display {
 
     pub fn height(self) -> usize {
         let h = unsafe { CGDisplayPixelsHigh(self.0) };
-        if self.is_retina() {
-            h * 2
+        let s = self.scale();
+        if s > 1.0 {
+           ((h as f64) * s) as usize
         } else {
             h
         }
@@ -68,8 +70,8 @@ impl Display {
         unsafe { CGDisplayIsOnline(self.0) != 0 }
     }
 
-    pub fn is_retina(self) -> bool {
-        unsafe { BackingScaleFactor() == 2.0 }
+    pub fn scale(self) -> f64 {
+        unsafe { BackingScaleFactor() } as _
     }
 
     pub fn bounds(self) -> CGRect {

--- a/libs/scrap/src/quartz/display.rs
+++ b/libs/scrap/src/quartz/display.rs
@@ -35,11 +35,21 @@ impl Display {
     }
 
     pub fn width(self) -> usize {
-        unsafe { CGDisplayPixelsWide(self.0) }
+        let w = unsafe { CGDisplayPixelsWide(self.0) };
+        if self.is_retina() {
+            w * 2
+        } else {
+            w
+        }
     }
 
     pub fn height(self) -> usize {
-        unsafe { CGDisplayPixelsHigh(self.0) }
+        let h = unsafe { CGDisplayPixelsHigh(self.0) };
+        if self.is_retina() {
+            h * 2
+        } else {
+            h
+        }
     }
 
     pub fn is_builtin(self) -> bool {
@@ -56,6 +66,10 @@ impl Display {
 
     pub fn is_online(self) -> bool {
         unsafe { CGDisplayIsOnline(self.0) != 0 }
+    }
+
+    pub fn is_retina(self) -> bool {
+        unsafe { BackingScaleFactor() == 2.0 }
     }
 
     pub fn bounds(self) -> CGRect {

--- a/libs/scrap/src/quartz/ffi.rs
+++ b/libs/scrap/src/quartz/ffi.rs
@@ -193,6 +193,7 @@ extern "C" {
     pub fn CGDisplayIsOnline(display: u32) -> i32;
 
     pub fn CGDisplayBounds(display: u32) -> CGRect;
+    pub fn BackingScaleFactor() -> f32;
 
     // IOSurface
 


### PR DESCRIPTION
Fixes: #5246 
Working: https://github.com/rustdesk/rustdesk/issues/5246#issuecomment-1907200031

`BackingScaleFactor` is 2.0 if it is a retina display. [Doc](https://developer.apple.com/documentation/appkit/nswindow/1419459-backingscalefactor)

# This merge has been reverted because causing more severe bug