### PR TITLE
Peers. Multiselect. Provide actions only if peers selected

### DIFF
--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -336,15 +336,26 @@ class _PeerTabPageState extends State<PeerTabPage>
   Widget createMultiSelectionBar() {
     final model = Provider.of<PeerTabModel>(context);
     return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        deleteSelection(),
-        addSelectionToFav(),
-        addSelectionToAb(),
-        editSelectionTags(),
-        Expanded(child: Container()),
-        selectionCount(model.selectedPeers.length),
-        selectAll(),
-        closeSelection(),
+        Offstage(
+          offstage: model.selectedPeers.isEmpty,
+          child: Row(
+            children: [
+              deleteSelection(),
+              addSelectionToFav(),
+              addSelectionToAb(),
+              editSelectionTags(),
+            ],
+          ),
+        ),
+        Row(
+          children: [
+            selectionCount(model.selectedPeers.length),
+            selectAll(),
+            closeSelection(),
+          ],
+        )
       ],
     );
   }


### PR DESCRIPTION
See comment https://github.com/rustdesk/rustdesk/issues/7116#issuecomment-1941563315

No selection, no action
![multiselect-action-1](https://github.com/rustdesk/rustdesk/assets/67791701/b3c57684-f86c-4f09-bddc-4685805187a5)

Selection, action available
![multiselect-action-2](https://github.com/rustdesk/rustdesk/assets/67791701/6ea2a2fc-4812-439a-abf6-6de7cddd44f5)

I can currently not build the apk, so i am not 100% aware of possible side effects for mobile. Please take a look to verify that there are none.
