### PR TITLE
windows specific session, not show remote screen until correct session id is ensured

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1519,6 +1519,10 @@ impl LoginConfigHandler {
         let mut n = 0;
         let mut msg = OptionMessage::new();
         msg.user_session = self.selected_user_session_id.clone();
+        if msg.user_session.is_empty() {
+            // indicate support user session id
+            msg.user_session = "INVALID".to_owned();
+        }
         n += 1;
 
         if self.conn_type.eq(&ConnType::FILE_TRANSFER) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -2599,7 +2599,7 @@ pub async fn handle_hash(
     peer: &mut Stream,
 ) {
     lc.write().unwrap().hash = hash.clone();
-    let uuid = lc.read().unwrap().switch_uuid.clone();
+    let uuid = lc.write().unwrap().switch_uuid.take();
     if let Some(uuid) = uuid {
         if let Ok(uuid) = uuid::Uuid::from_str(&uuid) {
             send_switch_login_request(lc.clone(), peer, uuid).await;


### PR DESCRIPTION
#6825 
1.  The controlled side doesn't know the selected session id  util the control side choose it, in order to show black screen when switching session id:
* For Windows multi-active sessions, the subscription to the remote service will be delayed until the control side selects the session id, so I use a "INVALID" session id to show the control side can respond to the `RdpUserSessions` message
* For others, subscribe directly 
2. Fix switch sides not work for reconnect, which would cause using the old uuid to send `SwitchSidesResponse` rather than `LoginRequest` for reconnection, and makes switching side to multi-session Windows not work.

notice:
If connect to a minisized rdp session window, it'll always be "Connected, waiting for image" until the window is restored.

https://github.com/rustdesk/rustdesk/assets/14891774/f388d6a4-fa3b-417e-9b11-fd073013abed

