### PR TITLE
Fix. Potential dead lock

### DIFF
--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -1044,7 +1044,9 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
 
     loop {
         if let Ok(mut c) = ipc::connect(1000, "").await {
-            let mut timer = time::interval(time::Duration::from_secs(1));
+            const TIMER_OUT: time::Duration = time::Duration::from_secs(1);
+            let mut timer = time::interval(TIMER_OUT);
+            let mut last_timer = time::Instant::now() - TIMER_OUT * 2;
             loop {
                 tokio::select! {
                     res = c.next() => {
@@ -1112,6 +1114,12 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
                         allow_err!(c.send(&data).await);
                     }
                     _ = timer.tick() => {
+                        let now = time::Instant::now();
+                        if last_timer.elapsed() < TIMER_OUT {
+                            continue;
+                        }
+                        last_timer = now;
+
                         c.send(&ipc::Data::OnlineStatus(None)).await.ok();
                         c.send(&ipc::Data::Options(None)).await.ok();
                         c.send(&ipc::Data::Config(("id".to_owned(), None))).await.ok();


### PR DESCRIPTION

## Bug

Potential block forever.

Maybe the same to https://github.com/rustdesk/rustdesk/discussions/7115 .

### Example

Online status, Windows

![image](https://github.com/rustdesk/rustdesk/assets/13586388/f4a55b7b-bbfa-43a9-8762-34057b10081c)


1. Query https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ui_interface.rs#L1114
2. Response https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ipc.rs#L355
3. Handle Response https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ui_interface.rs#L1090

When exiting sleep, [`timer.tick()`](https://github.com/rustdesk/rustdesk/blob/d7dcb5feab270d06d24fea42c1bdb1e6b597df9b/src/ui_interface.rs#L1114) will be triggered multiple times, causing events to be sent multiple times.

[Handling Response](https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ui_interface.rs#L1090
)  and  [Querying](https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ui_interface.rs#L1114) are in the same `tokio::select!`, so the [Handling Response](https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ui_interface.rs#L1090
) branch is rarely reached in a short time when exiting sleep.

Since [Handling Response](https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ui_interface.rs#L1090
) is rarely called,
There is too much data in the named pipe and [Responsing](https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ipc.rs#L355) will  will be blocked.

Since [Responsing](https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ipc.rs#L355)  is blocked, [Querying](https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ui_interface.rs#L1114) is also blocked if there is too much data in the named pipe.

Since [Querying](https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ui_interface.rs#L1114) is blocked, [Handling Response](https://github.com/rustdesk/rustdesk/blob/39d41486d6774e825001adabd34ddad9e33cd76c/src/ui_interface.rs#L1090
)  will never execute.

Then the named pipe will block forever after there is a lot of data in it.

### How to reproduce

1. Start the Client
2. Disconnect from the server. Then the online status will be "Not ready. Please check your connection"
3. Sleep your PC
4. Exit sleep after about 20 minutes
5. The online status will be "Not ready. Please check your connection" forever even the network to the server is ok.

### Reason

https://docs.rs/tokio/latest/tokio/time/struct.Interval.html#method.tick

This method will execute multiple times immediately after blocking some time.

#### example

```rust
use tokio::{
    self,
    time::{interval, sleep, Duration},
};
use chrono::{Local,format::StrftimeItems};

#[tokio::main]
async fn main() {
    let mut timer = interval(Duration::from_secs(1));
    sleep(Duration::from_secs(5)).await;
    let mut c = 0;
    loop {
        tokio::select! {
            _ = timer.tick() => {
                let format = StrftimeItems::new("%Y-%m-%d %H:%M:%S");
                println!("{}: timer tick", Local::now().format_with_items(format));
                c += 1;
                if c == 8 {
                    break;
                }
            }
        }
    }
}
```

```output
2024-02-17 11:03:12: timer tick
2024-02-17 11:03:12: timer tick
2024-02-17 11:03:12: timer tick
2024-02-17 11:03:12: timer tick
2024-02-17 11:03:12: timer tick
2024-02-17 11:03:12: timer tick
2024-02-17 11:03:13: timer tick
2024-02-17 11:03:14: timer tick
```

## TODO
Check if there are some other places that have the same potential issue.