### PR TITLE
refactor windows specific session

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2990,3 +2990,83 @@ ColorFilter? svgColor(Color? color) {
     return ColorFilter.mode(color, BlendMode.srcIn);
   }
 }
+
+// ignore: must_be_immutable
+class ComboBox extends StatelessWidget {
+  late final List<String> keys;
+  late final List<String> values;
+  late final String initialKey;
+  late final Function(String key) onChanged;
+  late final bool enabled;
+  late String current;
+
+  ComboBox({
+    Key? key,
+    required this.keys,
+    required this.values,
+    required this.initialKey,
+    required this.onChanged,
+    this.enabled = true,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    var index = keys.indexOf(initialKey);
+    if (index < 0) {
+      index = 0;
+    }
+    var ref = values[index].obs;
+    current = keys[index];
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: enabled
+              ? MyTheme.color(context).border2 ?? MyTheme.border
+              : MyTheme.border,
+        ),
+        borderRadius:
+            BorderRadius.circular(8), //border raiuds of dropdown button
+      ),
+      height: 42, // should be the height of a TextField
+      child: Obx(() => DropdownButton<String>(
+            isExpanded: true,
+            value: ref.value,
+            elevation: 16,
+            underline: Container(),
+            style: TextStyle(
+                color: enabled
+                    ? Theme.of(context).textTheme.titleMedium?.color
+                    : disabledTextColor(context, enabled)),
+            icon: const Icon(
+              Icons.expand_more_sharp,
+              size: 20,
+            ).marginOnly(right: 15),
+            onChanged: enabled
+                ? (String? newValue) {
+                    if (newValue != null && newValue != ref.value) {
+                      ref.value = newValue;
+                      current = newValue;
+                      onChanged(keys[values.indexOf(newValue)]);
+                    }
+                  }
+                : null,
+            items: values.map<DropdownMenuItem<String>>((String value) {
+              return DropdownMenuItem<String>(
+                value: value,
+                child: Text(
+                  value,
+                  style: const TextStyle(fontSize: 15),
+                  overflow: TextOverflow.ellipsis,
+                ).marginOnly(left: 15),
+              );
+            }).toList(),
+          )),
+    ).marginOnly(bottom: 5);
+  }
+}
+
+Color? disabledTextColor(BuildContext context, bool enabled) {
+  return enabled
+      ? null
+      : Theme.of(context).textTheme.titleLarge?.color?.withOpacity(0.6);
+}

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -514,7 +514,7 @@ class _GeneralState extends State<_General> {
       if (!keys.contains(currentKey)) {
         currentKey = '';
       }
-      return _ComboBox(
+      return ComboBox(
         keys: keys,
         values: values,
         initialKey: currentKey,
@@ -600,7 +600,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
                       child: Text(
                     translate('enable-2fa-title'),
                     style:
-                        TextStyle(color: _disabledTextColor(context, enabled)),
+                        TextStyle(color: disabledTextColor(context, enabled)),
                   ))
                 ],
               )),
@@ -654,7 +654,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
       }
 
       return _Card(title: 'Permissions', children: [
-        _ComboBox(
+        ComboBox(
             keys: [
               '',
               'full',
@@ -761,7 +761,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
                         Text(
                           value,
                           style: TextStyle(
-                              color: _disabledTextColor(
+                              color: disabledTextColor(
                                   context, onChanged != null)),
                         ),
                       ],
@@ -781,7 +781,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
           final usePassword = model.approveMode != 'click';
 
           return _Card(title: 'Password', children: [
-            _ComboBox(
+            ComboBox(
               enabled: !locked,
               keys: modeKeys,
               values: modeValues,
@@ -841,7 +841,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
               Expanded(
                 child: Text(translate('Enable RDP session sharing'),
                     style:
-                        TextStyle(color: _disabledTextColor(context, enabled))),
+                        TextStyle(color: disabledTextColor(context, enabled))),
               )
             ],
           ).marginOnly(left: _kCheckBoxLeftMargin),
@@ -944,7 +944,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
                       child: Text(
                     translate('Use IP Whitelisting'),
                     style:
-                        TextStyle(color: _disabledTextColor(context, enabled)),
+                        TextStyle(color: disabledTextColor(context, enabled)),
                   ))
                 ],
               )),
@@ -988,7 +988,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
                       child: Text(
                         translate('Hide connection management window'),
                         style: TextStyle(
-                            color: _disabledTextColor(
+                            color: disabledTextColor(
                                 context, enabled && enableHideCm)),
                       ),
                     ),
@@ -1686,12 +1686,6 @@ Widget _Card(
   );
 }
 
-Color? _disabledTextColor(BuildContext context, bool enabled) {
-  return enabled
-      ? null
-      : Theme.of(context).textTheme.titleLarge?.color?.withOpacity(0.6);
-}
-
 // ignore: non_constant_identifier_names
 Widget _OptionCheckBox(BuildContext context, String label, String key,
     {Function()? update,
@@ -1740,7 +1734,7 @@ Widget _OptionCheckBox(BuildContext context, String label, String key,
           Expanded(
               child: Text(
             translate(label),
-            style: TextStyle(color: _disabledTextColor(context, enabled)),
+            style: TextStyle(color: disabledTextColor(context, enabled)),
           ))
         ],
       ),
@@ -1777,7 +1771,7 @@ Widget _Radio<T>(BuildContext context,
                   overflow: autoNewLine ? null : TextOverflow.ellipsis,
                   style: TextStyle(
                       fontSize: _kContentFontSize,
-                      color: _disabledTextColor(context, enabled)))
+                      color: disabledTextColor(context, enabled)))
               .marginOnly(left: 5),
         ),
       ],
@@ -1827,7 +1821,7 @@ Widget _SubLabeledWidget(BuildContext context, String label, Widget child,
     children: [
       Text(
         '${translate(label)}: ',
-        style: TextStyle(color: _disabledTextColor(context, enabled)),
+        style: TextStyle(color: disabledTextColor(context, enabled)),
       ),
       SizedBox(
         width: 10,
@@ -1891,7 +1885,7 @@ _LabeledTextField(
             '${translate(label)}:',
             textAlign: TextAlign.right,
             style: TextStyle(
-                fontSize: 16, color: _disabledTextColor(context, enabled)),
+                fontSize: 16, color: disabledTextColor(context, enabled)),
           ).marginOnly(right: 10)),
       Expanded(
         child: TextField(
@@ -1901,85 +1895,11 @@ _LabeledTextField(
             decoration: InputDecoration(
                 errorText: errorText.isNotEmpty ? errorText : null),
             style: TextStyle(
-              color: _disabledTextColor(context, enabled),
+              color: disabledTextColor(context, enabled),
             )),
       ),
     ],
   ).marginOnly(bottom: 8);
-}
-
-// ignore: must_be_immutable
-class _ComboBox extends StatelessWidget {
-  late final List<String> keys;
-  late final List<String> values;
-  late final String initialKey;
-  late final Function(String key) onChanged;
-  late final bool enabled;
-  late String current;
-
-  _ComboBox({
-    Key? key,
-    required this.keys,
-    required this.values,
-    required this.initialKey,
-    required this.onChanged,
-    this.enabled = true,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    var index = keys.indexOf(initialKey);
-    if (index < 0) {
-      index = 0;
-    }
-    var ref = values[index].obs;
-    current = keys[index];
-    return Container(
-      decoration: BoxDecoration(
-        border: Border.all(
-          color: enabled
-              ? MyTheme.color(context).border2 ?? MyTheme.border
-              : MyTheme.border,
-        ),
-        borderRadius:
-            BorderRadius.circular(8), //border raiuds of dropdown button
-      ),
-      height: 42, // should be the height of a TextField
-      child: Obx(() => DropdownButton<String>(
-            isExpanded: true,
-            value: ref.value,
-            elevation: 16,
-            underline: Container(),
-            style: TextStyle(
-                color: enabled
-                    ? Theme.of(context).textTheme.titleMedium?.color
-                    : _disabledTextColor(context, enabled)),
-            icon: const Icon(
-              Icons.expand_more_sharp,
-              size: 20,
-            ).marginOnly(right: 15),
-            onChanged: enabled
-                ? (String? newValue) {
-                    if (newValue != null && newValue != ref.value) {
-                      ref.value = newValue;
-                      current = newValue;
-                      onChanged(keys[values.indexOf(newValue)]);
-                    }
-                  }
-                : null,
-            items: values.map<DropdownMenuItem<String>>((String value) {
-              return DropdownMenuItem<String>(
-                value: value,
-                child: Text(
-                  value,
-                  style: const TextStyle(fontSize: _kContentFontSize),
-                  overflow: TextOverflow.ellipsis,
-                ).marginOnly(left: 15),
-              );
-            }).toList(),
-          )),
-    ).marginOnly(bottom: 5);
-  }
 }
 
 class _CountDownButton extends StatefulWidget {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -245,8 +245,8 @@ class FfiModel with ChangeNotifier {
       var name = evt['name'];
       if (name == 'msgbox') {
         handleMsgBox(evt, sessionId, peerId);
-      } else if (name == 'set_multiple_user_session') {
-        handleMultipleUserSession(evt, sessionId, peerId);
+      } else if (name == 'set_multiple_windows_session') {
+        handleMultipleWindowsSession(evt, sessionId, peerId);
       } else if (name == 'peer_info') {
         handlePeerInfo(evt, peerId, false);
       } else if (name == 'sync_peer_info') {
@@ -490,7 +490,7 @@ class FfiModel with ChangeNotifier {
     dialogManager.dismissByTag(tag);
   }
 
-  handleMultipleUserSession(
+  handleMultipleWindowsSession(
       Map<String, dynamic> evt, SessionID sessionId, String peerId) {
     if (parent.target == null) return;
     final dialogManager = parent.target!.dialogManager;
@@ -564,8 +564,7 @@ class FfiModel with ChangeNotifier {
 
   void reconnect(OverlayDialogManager dialogManager, SessionID sessionId,
       bool forceRelay) {
-    bind.sessionReconnect(
-        sessionId: sessionId, forceRelay: forceRelay, userSessionId: "");
+    bind.sessionReconnect(sessionId: sessionId, forceRelay: forceRelay);
     clearPermissions();
     dialogManager.dismissAll();
     dialogManager.showLoading(translate('Connecting...'),

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -122,11 +122,12 @@ message PeerInfo {
   // Use JSON's key-value format which is friendly for peer to handle.
   // NOTE: Only support one-level dictionaries (for peer to update), and the key is of type string.
   string platform_additions = 12;
+  WindowsSessions windows_sessions = 13;
 }
 
-message RdpUserSession {  
-  string user_session_id = 1;  
-  string user_name = 2;  
+message WindowsSession {  
+  uint32 sid = 1;  
+  string name = 2;  
 }  
 
 message LoginResponse {
@@ -594,7 +595,7 @@ message OptionMessage {
   BoolOption disable_keyboard = 12;
 // Position 13 is used for Resolution. Remove later.
 // Resolution custom_resolution = 13;
-  string user_session = 14;
+  BoolOption support_windows_specific_session = 14;
 }
 
 message TestDelay {
@@ -709,8 +710,9 @@ message PluginFailure {
   string msg = 3;
 }
 
-message RdpUserSessions {
-  repeated RdpUserSession rdp_user_sessions = 1;
+message WindowsSessions {
+  repeated WindowsSession sessions = 1;
+  uint32 current_sid = 2;
 }
 
 message Misc {
@@ -744,7 +746,7 @@ message Misc {
     ToggleVirtualDisplay toggle_virtual_display = 32;
     TogglePrivacyMode toggle_privacy_mode = 33;
     SupportedEncoding supported_encoding = 34;
-    RdpUserSessions rdp_user_sessions = 35;
+    uint32 selected_sid = 35;
   }
 }
 

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1314,13 +1314,6 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                 }
                 Some(message::Union::Misc(misc)) => match misc.union {
-                    Some(misc::Union::RdpUserSessions(sessions)) => {
-                        if !sessions.rdp_user_sessions.is_empty() {
-                            self.handler
-                                .set_multiple_user_session(sessions.rdp_user_sessions);
-                            return false;
-                        }
-                    }
                     Some(misc::Union::AudioFormat(f)) => {
                         self.audio_sender.send(MediaData::AudioFormat(f)).ok();
                     }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -826,15 +826,21 @@ impl InvokeUiSession for FlutterHandler {
         )
     }
 
-    fn set_multiple_user_session(&self, sessions: Vec<hbb_common::message_proto::RdpUserSession>) {
-        let formatted_sessions: Vec<String> = sessions
-            .iter()
-            .map(|session| format!("{}-{}", session.user_session_id, session.user_name))
-            .collect();
-        let sessions = formatted_sessions.join(",");
+    fn set_multiple_windows_session(&self, sessions: Vec<WindowsSession>) {
+        let mut msg_vec = Vec::new();
+        let mut sessions = sessions;
+        for d in sessions.drain(..) {
+            let mut h: HashMap<&str, String> = Default::default();
+            h.insert("sid", d.sid.to_string());
+            h.insert("name", d.name);
+            msg_vec.push(h);
+        }
         self.push_event(
-            "set_multiple_user_session",
-            vec![("user_sessions", &sessions)],
+            "set_multiple_windows_session",
+            vec![(
+                "user_sessions",
+                &serde_json::ser::to_string(&msg_vec).unwrap_or("".to_owned()),
+            )],
         );
     }
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -217,9 +217,9 @@ pub fn session_record_status(session_id: SessionID, status: bool) {
     }
 }
 
-pub fn session_reconnect(session_id: SessionID, force_relay: bool, user_session_id: String) {
+pub fn session_reconnect(session_id: SessionID, force_relay: bool) {
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
-        session.reconnect(force_relay, user_session_id);
+        session.reconnect(force_relay);
     }
     session_on_waiting_for_image_dialog_show(session_id);
 }
@@ -699,6 +699,12 @@ pub fn session_change_resolution(session_id: SessionID, display: i32, width: i32
 pub fn session_set_size(_session_id: SessionID, _display: usize, _width: usize, _height: usize) {
     #[cfg(feature = "flutter_texture_render")]
     super::flutter::session_set_size(_session_id, _display, _width, _height)
+}
+
+pub fn session_send_selected_session_id(session_id: SessionID, sid: String) {
+    if let Some(session) = sessions::get_session_by_session_id(&session_id) {
+        session.send_selected_session_id(sid);
+    }
 }
 
 pub fn main_get_sound_inputs() -> Vec<String> {

--- a/src/platform/windows.cc
+++ b/src/platform/windows.cc
@@ -434,17 +434,6 @@ extern "C"
         return nout;
     }
 
-    uint32_t get_current_process_session_id()
-    {
-        DWORD sessionId = 0;
-        HANDLE hProcess = GetCurrentProcess();
-        if (hProcess) {
-            ProcessIdToSessionId(GetCurrentProcessId(), &sessionId);
-            CloseHandle(hProcess);
-        }
-        return sessionId;
-    }
-
     uint32_t get_session_user_info(PWSTR bufin, uint32_t nin, BOOL rdp, uint32_t id)
     {
         uint32_t nout = 0;

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -50,7 +50,7 @@ use scrap::hwcodec::{HwEncoder, HwEncoderConfig};
 use scrap::Capturer;
 use scrap::{
     aom::AomEncoderConfig,
-    codec::{Encoder, EncoderCfg, EncodingUpdate, Quality},
+    codec::{Encoder, EncoderCfg, Quality},
     record::{Recorder, RecorderContext},
     vpxcodec::{VpxEncoderConfig, VpxVideoCodecId},
     CodecName, Display, Frame, TraitCapturer,
@@ -643,7 +643,7 @@ fn get_encoder_config(
         GpuEncoder::set_not_use(_display_idx, true);
     }
     #[cfg(feature = "gpucodec")]
-    Encoder::update(EncodingUpdate::Check);
+    Encoder::update(scrap::codec::EncodingUpdate::Check);
     // https://www.wowza.com/community/t/the-correct-keyframe-interval-in-obs-studio/95162
     let keyframe_interval = if record { Some(240) } else { None };
     let negotiated_codec = Encoder::negotiated_codec();

--- a/src/ui/common.tis
+++ b/src/ui/common.tis
@@ -304,21 +304,7 @@ function msgbox(type, title, content, link="", callback=null, height=180, width=
                 return;
             }
         };
-    } else if (type === "multiple-sessions") {
-        var parts = content.split("-");
-        var ids = parts[0].split(",");
-        var names = parts[1].split(",");
-        var sessionData = [];
-        for (var i = 0; i < ids.length; i++) {
-            sessionData.push({ id: ids[i], name: names[i] });
-        }
-        content = <MultipleSessionComponent sessions={sessionData} />;
-        callback = function () {
-            retryConnect();
-            return;
-        };
-        height += 50;
-    } 
+    }
     last_msgbox_tag = type + "-" + title + "-" + content + "-" + link;
     $(#msgbox).content(<MsgboxComponent width={width} height={height} autoLogin={autoLogin} type={type} title={title} content={content} link={link} remember={remember} callback={callback} contentStyle={contentStyle} hasRetry={hasRetry} />);
 }
@@ -353,7 +339,7 @@ handler.msgbox_retry = function(type, title, text, link, hasRetry) {
 function retryConnect(cancelTimer=false) {
     if (cancelTimer) self.timer(0, retryConnect);
     if (!is_port_forward) connecting();
-    handler.reconnect(false, "");
+    handler.reconnect(false);
 }
 /******************** end of msgbox ****************************************/
 
@@ -474,19 +460,12 @@ function awake() {
 
 class MultipleSessionComponent extends Reactor.Component {
     this var sessions = [];
-    this var selectedSessionId = null;
-    this var sessionlength = 0;
     this var messageText = translate("Please select the user you want to connect to");
 
     function this(params) {
         if (params && params.sessions) {
             this.sessions = params.sessions;
-            this.selectedSessionId = params.sessions[0].id;
-            this.sessions.map(session => {
-                this.sessionlength += session.name.length;
-            });
         }
-        handler.set_selected_user_session_id(this.selectedSessionId);
     }
 
     function render() {
@@ -494,15 +473,9 @@ class MultipleSessionComponent extends Reactor.Component {
             <div .title>{this.messageText}</div>
             <select>
                 {this.sessions.map(session =>
-                    <option value={session.id}>{session.name}</option>
+                    <option value={session.sid}>{session.name}</option>
                 )}
             </select>
         </div>;
-    }
-
-    event change {
-        var selectedSessionName = this.value.substr(this.messageText.length + this.sessionlength);
-        this.selectedSessionId = this.sessions.find(session => session.name == selectedSessionName).id;
-        handler.set_selected_user_session_id(this.selectedSessionId);
     }
 }

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -527,8 +527,15 @@ handler.updateDisplays = function(v) {
     }
 }
 
-handler.setMultipleUserSession = function(usid,uname) {
-    msgbox("multiple-sessions", translate("Multiple active user sessions found"), usid+"-"+uname, "", function(res) {});
+handler.setMultipleWindowsSession = function(sessions) {
+    // It will be covered by other message box if the timer is not used, 
+    self.timer(1000ms, function() {
+        msgbox("multiple-sessions-nocancel", translate("Multiple active user sessions found"), <MultipleSessionComponent sessions={sessions} />, "", function(res) {
+            if (res && res.sid) {
+                handler.set_selected_windows_session_id("" + res.sid);
+            }
+        }, 230);
+    });
 }
 
 function updatePrivacyMode() {

--- a/src/ui/msgbox.tis
+++ b/src/ui/msgbox.tis
@@ -312,6 +312,9 @@ class MsgboxComponent: Reactor.Component {
                 return;
             }
         }
+        if (this.type == "multiple-sessions-nocancel") {
+            values.sid = (this.$$(select))[0].value;
+        }
         return values;
     }
     

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1003,7 +1003,7 @@ impl<T: InvokeUiSession> Session<T> {
         }
     }
 
-    pub fn reconnect(&self, force_relay: bool, user_session_id: String) {
+    pub fn reconnect(&self, force_relay: bool) {
         // 1. If current session is connecting, do not reconnect.
         // 2. If the connection is established, send `Data::Close`.
         // 3. If the connection is disconnected, do nothing.
@@ -1022,9 +1022,6 @@ impl<T: InvokeUiSession> Session<T> {
         // override only if true
         if true == force_relay {
             self.lc.write().unwrap().force_relay = true;
-        }
-        if !user_session_id.is_empty() {
-            self.lc.write().unwrap().selected_user_session_id = user_session_id;
         }
         let mut lock = self.thread.lock().unwrap();
         // No need to join the previous thread, because it will exit automatically.
@@ -1254,6 +1251,19 @@ impl<T: InvokeUiSession> Session<T> {
     pub fn close_voice_call(&self) {
         self.send(Data::CloseVoiceCall);
     }
+
+    pub fn send_selected_session_id(&self, sid: String) {
+        if let Ok(sid) = sid.parse::<u32>() {
+            self.lc.write().unwrap().selected_windows_session_id = Some(sid);
+            let mut misc = Misc::new();
+            misc.set_selected_sid(sid);
+            let mut msg = Message::new();
+            msg.set_misc(misc);
+            self.send(Data::Message(msg));
+        } else {
+            log::error!("selected invalid sid: {}", sid);
+        }
+    }
 }
 
 pub trait InvokeUiSession: Send + Sync + Clone + 'static + Sized + Default {
@@ -1313,7 +1323,7 @@ pub trait InvokeUiSession: Send + Sync + Clone + 'static + Sized + Default {
     fn next_rgba(&self, display: usize);
     #[cfg(all(feature = "gpucodec", feature = "flutter"))]
     fn on_texture(&self, display: usize, texture: *mut c_void);
-    fn set_multiple_user_session(&self, sessions: Vec<hbb_common::message_proto::RdpUserSession>);
+    fn set_multiple_windows_session(&self, sessions: Vec<WindowsSession>);
 }
 
 impl<T: InvokeUiSession> Deref for Session<T> {
@@ -1355,8 +1365,8 @@ impl<T: InvokeUiSession> Interface for Session<T> {
         handle_login_error(self.lc.clone(), err, self)
     }
 
-    fn set_multiple_user_sessions(&self, sessions: Vec<hbb_common::message_proto::RdpUserSession>) {
-        self.ui_handler.set_multiple_user_session(sessions);
+    fn set_multiple_windows_session(&self, sessions: Vec<WindowsSession>) {
+        self.ui_handler.set_multiple_windows_session(sessions);
     }
 
     fn handle_peer_info(&self, mut pi: PeerInfo) {
@@ -1417,6 +1427,19 @@ impl<T: InvokeUiSession> Interface for Session<T> {
             std::fs::File::create(&path).ok();
             if let Some(path) = path.to_str() {
                 crate::platform::windows::add_recent_document(&path);
+            }
+        }
+        if !pi.windows_sessions.sessions.is_empty() {
+            let selected = self
+                .lc
+                .read()
+                .unwrap()
+                .selected_windows_session_id
+                .to_owned();
+            if selected == Some(pi.windows_sessions.current_sid) {
+                self.send_selected_session_id(pi.windows_sessions.current_sid.to_string());
+            } else {
+                self.set_multiple_windows_session(pi.windows_sessions.sessions.clone());
             }
         }
     }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/pull/6825
1. Modify the process to have the control side lead the session switching: After the control side sends a `LoginRequest`, the controlled side will add all session information and the current session ID in the `LoginResponse`. Upon receiving the `LoginResponse`, the control side will check if the current session ID matches the ID in the `LoginConfigHandler`. If they match, the control side will send the current session ID. If they don't match, a session selection dialog will pop up, the selected session id will be sent. Upon receiving this message, the controlled side will restart if different or sub service if same .
2. Always show physical console session on the top
3. Show running session and distinguish sessions with the same name
4. Not sub remote services or call `read_dir` until correct session id is ensured
5. Fix switch sides not work for multisession pc
6. Remove all session string join/split except get_available_sessions in windows.rs, account name can use '-'
7. Fix prelogin, when share rdp is enabled and there is a rdp session, the console is in login screen, get_active_username will be the rdp's username and prelogin will be false, cm can't be created and that causes disconnection in a loop
8. Rename all user session variable to windows session
9. Session select dropdown uses the same widget as in setting page.
10. Fix file transfer, caused by `pi.username = self.lc.read().unwrap().get_username(&pi);` overide empty username and `get_active_username` doesn't return current session username
* Fix home directory not change when session changed, or wrong home directory
* Fix show empty remote directory rather than error messagbox when current session is in login screen,  

Known issue:
1. Use current process session id for `run_as_user`, sahil says it can be wrong but I didn't reproduce.
2. Have not change tray process to current session

![90dd5859c32ad5c3f61156c20aa6ea1](https://github.com/rustdesk/rustdesk/assets/14891774/dc36acde-6af9-4e05-9403-bcd317380e6c)


Flutter version connect to windows server 2019 with 2 rdp session and console session logged out

https://github.com/rustdesk/rustdesk/assets/14891774/0261d759-eff6-4436-89e8-e5b610a0a2b4

Sciter version connect to windows 10 with 1 rdp session and console session logged out

https://github.com/rustdesk/rustdesk/assets/14891774/6daef9b6-1b97-45d4-b439-5db3122ab825

