### PR TITLE
windows specific session, fix sciter empty file directory or wrong home

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1309,6 +1309,7 @@ impl Connection {
                 && crate::platform::is_share_rdp()
                 && raii::AuthedConnID::remote_and_file_conn_count() == 1
                 && sessions.len() > 1
+                && sessions.iter().any(|e| e.sid == current_sid)
                 && (get_version_number(&self.lr.version) > get_version_number("1.2.4")
                     || self.lr.option.support_windows_specific_session == BoolOption::Yes.into())
             {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1269,6 +1269,14 @@ impl<T: InvokeUiSession> Session<T> {
                             self.on_error(
                                 "No active console user logged on, please connect and logon first.",
                             );
+                        } else {
+                            #[cfg(not(feature = "flutter"))]
+                            {
+                                let remote_dir = self.get_option("remote_dir".to_string());
+                                let show_hidden =
+                                    !self.get_option("remote_show_hidden".to_string()).is_empty();
+                                self.read_remote_dir(remote_dir, show_hidden);
+                            }
                         }
                     } else {
                         self.msgbox(


### PR DESCRIPTION
#7184

Login request use the remote dir of last user name
https://github.com/rustdesk/rustdesk/blob/58ddac63d267d747ff7f3c591dea6934f9d78799/src/client.rs#L1900

flutter version will read remote directory after receiving peer info, sciter won't.
https://github.com/rustdesk/rustdesk/blob/58ddac63d267d747ff7f3c591dea6934f9d78799/flutter/lib/models/model.dart#L705

When no-admin session request admin directory, it's empty

https://github.com/rustdesk/rustdesk/assets/14891774/d9044096-c1df-4d58-9de6-b326acb8cf7b

When admin session request non-admin directory, it's wrong home:

https://github.com/rustdesk/rustdesk/assets/14891774/3a32432a-42fd-46cc-86d5-d0c88742392a

Fixed:

https://github.com/rustdesk/rustdesk/assets/14891774/f0946287-fe98-4c33-97fd-c5bb60b28833

