### PR TITLE
Fix. Text Copy&Paste on Linux is unstable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,12 +271,11 @@ dependencies = [
 
 [[package]]
 name = "arboard"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafb29b107435aa276664c1db8954ac27a6e105cdad3c88287a199eb0e313c08"
+version = "3.3.1"
+source = "git+https://github.com/fufesou/arboard?branch=feat/x11_set_conn_timeout#956b5f8693b4fc7fddd7b8cafbe1111a892b34b1"
 dependencies = [
  "clipboard-win",
- "core-graphics 0.22.3",
+ "core-graphics 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "image",
  "log",
  "objc",
@@ -284,9 +283,9 @@ dependencies = [
  "objc_id",
  "parking_lot",
  "thiserror",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
  "wl-clipboard-rs",
- "x11rb",
+ "x11rb 0.13.0",
 ]
 
 [[package]]
@@ -997,18 +996,16 @@ dependencies = [
  "thiserror",
  "utf16string",
  "x11-clipboard",
- "x11rb",
+ "x11rb 0.12.0",
 ]
 
 [[package]]
 name = "clipboard-win"
-version = "4.5.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+checksum = "3ec832972fefb8cf9313b45a0d1945e29c9c251f1d4c6eafc5fe2124c02d2e81"
 dependencies = [
  "error-code",
- "str-buf",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1731,7 +1728,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.1",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -1980,13 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
-]
+checksum = "281e452d3bad4005426416cdba5ccfd4f5c1280e10099e21db27f7c1c28347fc"
 
 [[package]]
 name = "evdev"
@@ -2465,6 +2458,16 @@ checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5501,7 +5504,7 @@ dependencies = [
  "winres",
  "wol-rs",
  "x11-clipboard",
- "x11rb",
+ "x11rb 0.12.0",
  "zip",
 ]
 
@@ -5998,12 +6001,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strength_reduce"
@@ -7785,7 +7782,7 @@ name = "x11-clipboard"
 version = "0.8.1"
 source = "git+https://github.com/clslaid/x11-clipboard?branch=feat/store-batch#5fc2e73bc01ada3681159b34cf3ea8f0d14cd904"
 dependencies = [
- "x11rb",
+ "x11rb 0.12.0",
 ]
 
 [[package]]
@@ -7805,11 +7802,22 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
 dependencies = [
- "gethostname",
+ "gethostname 0.3.0",
  "nix 0.26.4",
  "winapi 0.3.9",
  "winapi-wsapoll",
- "x11rb-protocol",
+ "x11rb-protocol 0.12.0",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
+dependencies = [
+ "gethostname 0.4.3",
+ "rustix 0.38.21",
+ "x11rb-protocol 0.13.0",
 ]
 
 [[package]]
@@ -7820,6 +7828,12 @@ checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
 dependencies = [
  "nix 0.26.4",
 ]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
 
 [[package]]
 name = "xdg-home"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ sys-locale = "0.3"
 enigo = { path = "libs/enigo", features = [ "with_serde" ] }
 clipboard = { path = "libs/clipboard" }
 ctrlc = "3.2"
-arboard = { version = "3.2", features = ["wayland-data-control"] }
+arboard = { git = "https://github.com/fufesou/arboard", branch = "feat/x11_set_conn_timeout", features = ["wayland-data-control"] }
 system_shutdown = "4.0"
 qrcode-generator = "4.1"
 

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -17,16 +17,15 @@ use hbb_common::tokio::sync::mpsc::error::TryRecvError;
 use hbb_common::{
     allow_err,
     config::{PeerConfig, TransferSerde},
-    fs,
     fs::{
-        can_enable_overwrite_detection, get_job, get_string, new_send_confirm, DigestCheckResult,
-        RemoveJobMeta,
+        self, can_enable_overwrite_detection, get_job, get_string, new_send_confirm,
+        DigestCheckResult, RemoveJobMeta,
     },
     get_time, log,
-    message_proto::permission_info::Permission,
-    message_proto::*,
+    message_proto::{permission_info::Permission, *},
     protobuf::Message as _,
     rendezvous_proto::ConnType,
+    timeout,
     tokio::{
         self,
         sync::mpsc,
@@ -170,7 +169,8 @@ impl<T: InvokeUiSession> Remote<T> {
                 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
                 let mut rx_clip_client = rx_clip_client_lock.lock().await;
 
-                let mut status_timer = crate::rustdesk_interval(time::interval(Duration::new(1, 0)));
+                let mut status_timer =
+                    crate::rustdesk_interval(time::interval(Duration::new(1, 0)));
                 let mut fps_instant = Instant::now();
 
                 loop {
@@ -1099,15 +1099,19 @@ impl<T: InvokeUiSession> Remote<T> {
                         if !(self.handler.is_file_transfer() || self.handler.is_port_forward()) {
                             #[cfg(feature = "flutter")]
                             #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                            Client::try_start_clipboard(None);
+                            let rx = Client::try_start_clipboard(None);
                             #[cfg(not(feature = "flutter"))]
                             #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                            Client::try_start_clipboard(Some(
+                            let rx = Client::try_start_clipboard(Some(
                                 crate::client::ClientClipboardContext {
                                     cfg: self.handler.get_permission_config(),
                                     tx: self.sender.clone(),
                                 },
                             ));
+                            // To make sure current text clipboard data is updated.
+                            if let Some(mut rx) = rx {
+                                timeout(common::CLIPBOARD_INTERVAL, rx.recv()).await.ok();
+                            }
 
                             #[cfg(not(any(target_os = "android", target_os = "ios")))]
                             if let Some(msg_out) = Client::get_current_text_clipboard_msg() {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1387,6 +1387,11 @@ pub fn rustdesk_interval(i: Interval) -> ThrottledInterval {
 )))]
 pub struct ClipboardContext(arboard::Clipboard);
 
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "ios",
+    all(target_os = "linux", feature = "unix-file-copy-paste")
+)))]
 impl ClipboardContext {
     #[inline]
     #[cfg(any(target_os = "windows", target_os = "macos"))]
@@ -1513,6 +1518,11 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "ios",
+        all(target_os = "linux", feature = "unix-file-copy-paste")
+    )))]
     async fn test_clipboard_context() {
         #[cfg(target_os = "linux")]
         let dur = {

--- a/src/server/clipboard_service.rs
+++ b/src/server/clipboard_service.rs
@@ -34,18 +34,16 @@ pub fn new() -> GenericService {
 }
 
 fn run(sp: EmptyExtraFieldService, state: &mut State) -> ResultType<()> {
-    if let Some(ctx) = state.ctx.as_mut() {
-        if let Some(msg) = check_clipboard(ctx, None) {
-            sp.send(msg);
-        }
-        sp.snapshot(|sps| {
-            let txt = crate::CONTENT.lock().unwrap().clone();
-            if !txt.is_empty() {
-                let msg_out = crate::create_clipboard_msg(txt);
-                sps.send_shared(Arc::new(msg_out));
-            }
-            Ok(())
-        })?;
+    if let Some(msg) = check_clipboard(&mut state.ctx, None) {
+        sp.send(msg);
     }
+    sp.snapshot(|sps| {
+        let txt = crate::CONTENT.lock().unwrap().clone();
+        if !txt.is_empty() {
+            let msg_out = crate::create_clipboard_msg(txt);
+            sps.send_shared(Arc::new(msg_out));
+        }
+        Ok(())
+    })?;
     Ok(())
 }


### PR DESCRIPTION
This PR may fix https://github.com/rustdesk/rustdesk/issues/6859 on Linux platform.

### Issue

`arboard` uses a fixed duration(10ms) as the timeout for x11 connection. 


https://github.com/1Password/arboard/blob/77e0e078eb460ac2fa0eda96124163c11ef6b2d1/src/platform/linux/x11.rs#L142


But for RustDesk, sometimes it needs about 20ms or more to connect x11.

So the text clipboard is not stable.

And if the following line fails, the "copy & paste" from client to host will not work anymore in that connection.

https://github.com/rustdesk/rustdesk/blob/7b317619acdf26853e05c5e398f5bdc19fee776c/src/client.rs#L726 


### Fixed 

In this PR, retry and increasing timeout are added for `new()` and `get_text()`.

```rust
        for i in 1..4 {
            arboard::Clipboard::set_x11_server_conn_timeout(dur * i);
            match arboard::Clipboard::new() {
                Ok(c) => return Ok(ClipboardContext(c)),
                Err(arboard::Error::X11ServerConnTimeout) => continue,
                Err(err) => return Err(err.into()),
            }
        }
        bail!("Failed to create clipboard context, timeout");
```

PR for `arboard` is also submitted.
