### PR TITLE
Fix. Text clipboard is not working correctly

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -702,12 +702,9 @@ impl Client {
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    fn try_stop_clipboard(_self_id: &str) {
+    fn try_stop_clipboard() {
         #[cfg(feature = "flutter")]
-        if crate::flutter::sessions::other_sessions_running(
-            _self_id.to_string(),
-            ConnType::DEFAULT_CONN,
-        ) {
+        if crate::flutter::sessions::has_sessions_running(ConnType::DEFAULT_CONN) {
             return;
         }
         TEXT_CLIPBOARD_STATE.lock().unwrap().running = false;

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -286,7 +286,7 @@ impl<T: InvokeUiSession> Remote<T> {
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         if _set_disconnected_ok {
-            Client::try_stop_clipboard(&self.handler.get_id());
+            Client::try_stop_clipboard();
         }
 
         #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1790,13 +1790,10 @@ pub mod sessions {
 
     #[inline]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    pub fn other_sessions_running(peer_id: String, conn_type: ConnType) -> bool {
-        SESSIONS
-            .read()
-            .unwrap()
-            .get(&(peer_id, conn_type))
-            .map(|s| s.session_handlers.read().unwrap().len() != 0)
-            .unwrap_or(false)
+    pub fn has_sessions_running(conn_type: ConnType) -> bool {
+        SESSIONS.read().unwrap().iter().any(|((_, r#type), s)| {
+            *r#type == conn_type && s.session_handlers.read().unwrap().len() != 0
+        })
     }
 }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/6859

### Bug

If there're multiple connections, and one connection is going to end.

We need to check if clipboard checking loop should be stoped.

The previous check is wrong. So the checking loop is early exited.

### Fixed

Change

```rust
    pub fn other_sessions_running(peer_id: String, conn_type: ConnType) -> bool {
        SESSIONS
            .read()
            .unwrap()
            .get(&(peer_id, conn_type))
            .map(|s| s.session_handlers.read().unwrap().len() != 0)
            .unwrap_or(false)
}
```

to

```rust
    pub fn has_sessions_running(conn_type: ConnType) -> bool {
        SESSIONS.read().unwrap().iter().any(|((_, r#type), s)| {
            *r#type == conn_type && s.session_handlers.read().unwrap().len() != 0
        })
    }
```

