### PR TITLE
Refact/ci remove third party topmost window

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -35,8 +35,19 @@ env:
   UPLOAD_ARTIFACT: "${{ inputs.upload-artifact }}"
 
 jobs:
+  build-RustDeskTempTopMostWindow:
+    uses: ./.github/workflows/third-party/RustDeskTempTopMostWindow.yml
+    with:
+      target: windows-2019
+      configuration: Release
+      platform: x64
+      target_version: Windows10
+    strategy:
+        fail-fast: false
+
   build-for-windows-flutter:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
+    needs: [build-RustDeskTempTopMostWindow]
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false
@@ -124,6 +135,12 @@ jobs:
             echo "list ./libs/portable/Runner.res";
             ls -l ./libs/portable/Runner.res;
           fi
+
+      - name: Download RustDeskTempTopMostWindow artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: topmostwindow-artifacts
+          path: './flutter/build/windows/x64/runner/Release/'
 
       - name: Sign rustdesk files
         uses: GermanBluefox/code-sign-action@v7

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   build-RustDeskTempTopMostWindow:
-    uses: ./.github/workflows/third-party/RustDeskTempTopMostWindow.yml
+    uses: ./.github/workflows/third-party-RustDeskTempTopMostWindow.yml
     with:
       target: windows-2019
       configuration: Release
@@ -137,7 +137,7 @@ jobs:
           fi
 
       - name: Download RustDeskTempTopMostWindow artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@master
         with:
           name: topmostwindow-artifacts
           path: './flutter/build/windows/x64/runner/Release/'

--- a/.github/workflows/third-party-RustDeskTempTopMostWindow.yml
+++ b/.github/workflows/third-party-RustDeskTempTopMostWindow.yml
@@ -28,31 +28,28 @@ env:
   project_path: WindowInjection/WindowInjection.vcxproj
 
 jobs:
-  build:
+  build-RustDeskTempTopMostWindow:
     runs-on: ${{ inputs.target }}
     strategy:
         fail-fast: false
     env:
-      build_output_dir: WindowInjection/${{ inputs.platform }}/${{ inputs.configuration }}
+      build_output_dir: RustDeskTempTopMostWindow/WindowInjection/${{ inputs.platform }}/${{ inputs.configuration }}
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
 
       - name: Download the source code
         run: |
           git clone https://github.com/fufesou/RustDeskTempTopMostWindow RustDeskTempTopMostWindow
-          git checkout v0.3
 
-      - name: Build the solution
+        # Build. commit 53b548a5398624f7149a382000397993542ad796 is tag v0.3
+      - name: Build the project
         run: |
-          cd RustDeskTempTopMostWindow
+          cd RustDeskTempTopMostWindow && git checkout 53b548a5398624f7149a382000397993542ad796
           msbuild ${{ env.project_path }} -p:Configuration=${{ inputs.configuration }} -p:Platform=${{ inputs.platform }} /p:TargetVersion=${{ inputs.target_version }}
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@master
         with:
             name: topmostwindow-artifacts
             path: |

--- a/.github/workflows/third-party-RustDeskTempTopMostWindow.yml
+++ b/.github/workflows/third-party-RustDeskTempTopMostWindow.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Download the source code
         run: |
-          git clone https://github.com/fufesou/RustDeskTempTopMostWindow RustDeskTempTopMostWindow
+          git clone https://github.com/rustdesk-org/RustDeskTempTopMostWindow RustDeskTempTopMostWindow
 
         # Build. commit 53b548a5398624f7149a382000397993542ad796 is tag v0.3
       - name: Build the project

--- a/.github/workflows/third-party/RustDeskTempTopMostWindow.yml
+++ b/.github/workflows/third-party/RustDeskTempTopMostWindow.yml
@@ -1,0 +1,59 @@
+name: build RustDeskTempTopMostWindow
+
+on:
+  workflow_call:
+    inputs:
+        target:
+            description: 'Target'
+            required: true
+            type: string
+            default: 'windows-2019'
+        configuration:
+            description: 'Configuration'
+            required: true
+            type: string
+            default: 'Release'
+        platform:
+            description: 'Platform'
+            required: true
+            type: string
+            default: 'x64'
+        target_version:
+            description: 'TargetVersion'
+            required: true
+            type: string
+            default: 'Windows10'
+
+env:
+  project_path: WindowInjection/WindowInjection.vcxproj
+
+jobs:
+  build:
+    runs-on: ${{ inputs.target }}
+    strategy:
+        fail-fast: false
+    env:
+      build_output_dir: WindowInjection/${{ inputs.platform }}/${{ inputs.configuration }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Download the source code
+        run: |
+          git clone https://github.com/fufesou/RustDeskTempTopMostWindow RustDeskTempTopMostWindow
+          git checkout v0.3
+
+      - name: Build the solution
+        run: |
+          cd RustDeskTempTopMostWindow
+          msbuild ${{ env.project_path }} -p:Configuration=${{ inputs.configuration }} -p:Platform=${{ inputs.platform }} /p:TargetVersion=${{ inputs.target_version }}
+
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+            name: topmostwindow-artifacts
+            path: |
+              ./${{ env.build_output_dir }}/WindowInjection.dll

--- a/build.py
+++ b/build.py
@@ -80,8 +80,10 @@ def parse_rc_features(feature):
         return get_all_features()
     elif isinstance(feature, list):
         if windows:
+            # download third party is deprecated, we use github ci instead.
             # force add PrivacyMode
-            feature.append('PrivacyMode')
+            # feature.append('PrivacyMode')
+            pass
         for feat in feature:
             if isinstance(feat, str) and feat.upper() == 'ALL':
                 return get_all_features()
@@ -188,6 +190,9 @@ def generate_build_script_for_docker():
     system2("bash /tmp/build.sh")
 
 
+# Downloading third party resources is deprecated.
+# We can use this function in an offline build environment.
+# Even in an online environment, we recommend building third-party resources yourself.
 def download_extract_features(features, res_dir):
     import re
 


### PR DESCRIPTION
Remove the deps of the third-party prebuilt file (topmost window).

Build by github ci instead.
