### PR TITLE
Refact. ci, third party, upload artifact

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -38,6 +38,7 @@ jobs:
   build-RustDeskTempTopMostWindow:
     uses: ./.github/workflows/third-party-RustDeskTempTopMostWindow.yml
     with:
+      upload-artifact: ${{ inputs.upload-artifact }}
       target: windows-2019
       configuration: Release
       platform: x64
@@ -138,6 +139,7 @@ jobs:
 
       - name: Download RustDeskTempTopMostWindow artifacts
         uses: actions/download-artifact@master
+        if: ${{ inputs.upload-artifact }}
         with:
           name: topmostwindow-artifacts
           path: './flutter/build/windows/x64/runner/Release/'

--- a/.github/workflows/third-party-RustDeskTempTopMostWindow.yml
+++ b/.github/workflows/third-party-RustDeskTempTopMostWindow.yml
@@ -3,6 +3,9 @@ name: build RustDeskTempTopMostWindow
 on:
   workflow_call:
     inputs:
+        upload-artifact:
+          type: boolean
+          default: true
         target:
             description: 'Target'
             required: true
@@ -50,6 +53,7 @@ jobs:
 
       - name: Archive build artifacts
         uses: actions/upload-artifact@master
+        if: ${{ inputs.upload-artifact }}
         with:
             name: topmostwindow-artifacts
             path: |


### PR DESCRIPTION
No need to upload and download artifacts of third party if do not publish. 