### PR TITLE
Refact. Qs, do not check qs on startup(flutter).

### DIFF
--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -98,11 +98,9 @@ Future<void> main(List<String> args) async {
   }
 }
 
-Future<bool> initEnv(String appType) async {
+Future<void> initEnv(String appType) async {
   // global shared preference
-  if (!await platformFFI.init(appType)) {
-    return false;
-  }
+  await platformFFI.init(appType);
   // global FFI, use this **ONLY** for global configuration
   // for convenience, use global FFI on mobile platform
   // focus on multi-ffi on desktop first
@@ -111,14 +109,11 @@ Future<bool> initEnv(String appType) async {
   _registerEventHandler();
   // Update the system theme.
   updateSystemWindowTheme();
-  return true;
 }
 
 void runMainApp(bool startService) async {
   // register uni links
-  if (!await initEnv(kAppTypeMain)) {
-    return;
-  }
+  await initEnv(kAppTypeMain);
   // trigger connection status updater
   await bind.mainCheckConnectStatus();
   if (startService) {
@@ -152,9 +147,7 @@ void runMainApp(bool startService) async {
 }
 
 void runMobileApp() async {
-  if (!await initEnv(kAppTypeMain)) {
-    return;
-  }
+  await initEnv(kAppTypeMain);
   if (isAndroid) androidChannelInit();
   platformFFI.syncAndroidServiceAppDirConfigPath();
   await Future.wait([gFFI.abModel.loadCache(), gFFI.groupModel.loadCache()]);
@@ -167,9 +160,7 @@ void runMultiWindow(
   Map<String, dynamic> argument,
   String appType,
 ) async {
-  if (!await initEnv(appType)) {
-    return;
-  }
+  await initEnv(appType);
   final title = getWindowName();
   // set prevent close to true, we handle close event manually
   WindowController.fromWindowId(kWindowId!).setPreventClose(true);
@@ -232,9 +223,7 @@ void runMultiWindow(
 }
 
 void runConnectionManagerScreen() async {
-  if (!await initEnv(kAppTypeConnectionManager)) {
-    return;
-  }
+  await initEnv(kAppTypeConnectionManager);
   _runApp(
     '',
     const DesktopServerPage(),
@@ -337,9 +326,7 @@ void _runApp(
 
 void runInstallPage() async {
   await windowManager.ensureInitialized();
-  if (!await initEnv(kAppTypeMain)) {
-    return;
-  }
+  await initEnv(kAppTypeMain);
   _runApp('', const InstallPage(), MyTheme.currentThemeMode());
   WindowOptions windowOptions =
       getHiddenTitleBarWindowOptions(size: Size(800, 600), center: true);

--- a/flutter/lib/models/native_model.dart
+++ b/flutter/lib/models/native_model.dart
@@ -109,7 +109,7 @@ class PlatformFFI {
           sessionId: sessionId, display: display, ptr: ptr);
 
   /// Init the FFI class, loads the native Rust core library.
-  Future<bool> init(String appType) async {
+  Future<void> init(String appType) async {
     _appType = appType;
     final dylib = Platform.isAndroid
         ? DynamicLibrary.open('librustdesk.so')
@@ -130,9 +130,6 @@ class PlatformFFI {
         debugPrint('Failed to get documents directory: $e');
       }
       _ffiBind = RustdeskImpl(dylib);
-      if (_ffiBind.isQs() && (_appType != kAppTypeMain && _appType != kAppTypeConnectionManager)) {
-        return false;
-      }
 
       if (Platform.isLinux) {
         // Start a dbus service, no need to await
@@ -206,7 +203,6 @@ class PlatformFFI {
       debugPrintStack(label: 'initialize failed: $e');
     }
     version = await getVersion();
-    return true;
   }
 
   Future<bool> tryHandle(Map<String, dynamic> evt) async {


### PR DESCRIPTION
To avoid confusion.

Revert to `initEnv` check on flutter and do not check qs on flutter.

Process will not exit if early return on the flutter side.

core_main.rs has checked qs already.