### PR TITLE
upgrade uni link desktop

### DIFF
--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -418,6 +418,9 @@ class _ConnectionPageState extends State<ConnectionPage>
                           onChanged: (v) {
                             _idController.id = v;
                           },
+                          onSubmitted: (_) {
+                            onConnect();
+                          },
                         ));
                   },
                   onSelected: (option) {

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -1317,12 +1317,11 @@ packages:
   uni_links_desktop:
     dependency: "direct main"
     description:
-      path: "."
-      ref: HEAD
-      resolved-ref: e1d25263ae7c214ff52a66a9cf28aea8f408742e
-      url: "https://github.com/rustdesk-org/uni_links_desktop"
-    source: git
-    version: "0.1.6"
+      name: uni_links_desktop
+      sha256: "692de81efc32ef72df56d428902afb5216d5f9e43d71c7b315d360acd7a1e115"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.7"
   uni_links_platform_interface:
     dependency: transitive
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -79,9 +79,7 @@ dependencies:
     git:
       url: https://github.com/rustdesk-org/flutter_improved_scrolling
   uni_links: ^0.5.1
-  uni_links_desktop:
-    git:
-      url: https://github.com/rustdesk-org/uni_links_desktop
+  uni_links_desktop: ^0.1.7
   path: ^1.8.1
   auto_size_text: ^3.0.0
   bot_toast: ^4.0.3


### PR DESCRIPTION
1.  https://github.com/leanflutter/uni_links_desktop/issues/15 

Version 0.1.7 doesn't have multi-window problems, tested with: 
https://github.com/21pages/rustdesk/releases/download/1.2.3-1/rustdesk-1.2.3-1-x86_64-uri_link_desktop-0.1.6.dmg
https://github.com/21pages/rustdesk/releases/download/nightly/rustdesk-1.2.4-x86_64-uni_links_desktop-0.1.7.dmg

2. ID input TextField supports "Enter" key connection, and the text content of the TextFiled will be used as ID, the drop-down items will not be used.