### PR TITLE
flutter windows main.cpp get app name from rust

### DIFF
--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -154,6 +154,17 @@ pub unsafe extern "C" fn free_c_args(ptr: *mut *mut c_char, len: c_int) {
     // Afterwards the vector will be dropped and thus freed.
 }
 
+#[cfg(windows)]
+#[no_mangle]
+pub unsafe extern "C" fn get_rustdesk_app_name(buffer: *mut u16, length: i32) -> i32 {
+    let name = crate::platform::wide_string(&crate::get_app_name());
+    if length > name.len() as i32 {
+        std::ptr::copy_nonoverlapping(name.as_ptr(), buffer, name.len());
+        return 0;
+    }
+    -1
+}
+
 #[derive(Default)]
 struct SessionHandler {
     event_stream: Option<StreamSink<EventToUI>>,

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1748,7 +1748,7 @@ pub fn get_double_click_time() -> u32 {
     unsafe { GetDoubleClickTime() }
 }
 
-fn wide_string(s: &str) -> Vec<u16> {
+pub fn wide_string(s: &str) -> Vec<u16> {
     use std::os::windows::prelude::OsStrExt;
     std::ffi::OsStr::new(s)
         .encode_wide()


### PR DESCRIPTION
FindWindow is used for singleton and now core_main.rs doesn't handle url parameters, this pr only get the app name from rust.
If the app name is "RustDesk",  it works; not works yet if it's not "RustDesk".