### PR TITLE
Fix. Input, macos, workaround fn

### DIFF
--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -424,7 +424,7 @@ struct VirtualInputState {
 #[cfg(target_os = "macos")]
 impl VirtualInputState {
     fn new() -> Option<Self> {
-        VirtualInput::new(CGEventSourceStateID::Private, CGEventTapLocation::Session)
+        VirtualInput::new(CGEventSourceStateID::CombinedSessionState, CGEventTapLocation::Session)
             .map(|virtual_input| Self {
                 virtual_input,
                 capslock_down: false,


### PR DESCRIPTION
Workaround sticky fn.

https://github.com/rustdesk/rustdesk/issues/5707

https://github.com/rustdesk/rustdesk/issues/7308

https://github.com/rustdesk/rustdesk/issues/6060

We already have a workaround here https://github.com/fufesou/rdev/blob/b3434caee84c92412b45a2f655a15ac5dad33488/src/macos/simulate.rs#L32

But this issue appears when RustDesk is installed, so we need to change the `CGEventSourceStateID`. https://developer.apple.com/documentation/coregraphics/cgeventsourcestateid

Related : https://stackoverflow.com/questions/74938870/sticky-fn-after-home-is-simulated-programmatically-macos/77002057
