### PR TITLE
#7315 Fix lang detection for zh-TW

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -92,7 +92,7 @@ pub fn translate_locale(name: String, locale: &str) -> String {
     if lang.is_empty() {
         // zh_CN on Linux, zh-Hans-CN on mac, zh_CN_#Hans on Android
         if locale.starts_with("zh") {
-            lang = (if locale.contains("tw") {
+            lang = (if locale.contains("TW") {
                 "zh-tw"
             } else {
                 "zh-cn"


### PR DESCRIPTION
I use the sample code from [sys-locale](https://github.com/1Password/sys-locale).

````rust
use sys_locale::get_locale;

let locale = get_locale().unwrap_or_else(|| String::from("en-US"));

println!("The current locale is {}", locale);
````

It print this on my system:
```plaintext
The current locale is zh-TW
```