### PR TITLE
improve waiting for image when only one image received 

### DIFF
--- a/flutter/lib/mobile/pages/server_page.dart
+++ b/flutter/lib/mobile/pages/server_page.dart
@@ -42,25 +42,21 @@ class ServerPage extends StatefulWidget implements PageShape {
           return [
             PopupMenuItem(
               enabled: gFFI.serverModel.connectStatus > 0,
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
               value: "changeID",
               child: Text(translate("Change ID")),
             ),
             const PopupMenuDivider(),
             PopupMenuItem(
-              padding: const EdgeInsets.symmetric(horizontal: 0.0),
               value: 'AcceptSessionsViaPassword',
               child: listTile(
                   'Accept sessions via password', approveMode == 'password'),
             ),
             PopupMenuItem(
-              padding: const EdgeInsets.symmetric(horizontal: 0.0),
               value: 'AcceptSessionsViaClick',
               child:
                   listTile('Accept sessions via click', approveMode == 'click'),
             ),
             PopupMenuItem(
-              padding: const EdgeInsets.symmetric(horizontal: 0.0),
               value: "AcceptSessionsViaBoth",
               child: listTile("Accept sessions via both",
                   approveMode != 'password' && approveMode != 'click'),
@@ -69,35 +65,30 @@ class ServerPage extends StatefulWidget implements PageShape {
             if (showPasswordOption &&
                 verificationMethod != kUseTemporaryPassword)
               PopupMenuItem(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
                 value: "setPermanentPassword",
                 child: Text(translate("Set permanent password")),
               ),
             if (showPasswordOption &&
                 verificationMethod != kUsePermanentPassword)
               PopupMenuItem(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
                 value: "setTemporaryPasswordLength",
                 child: Text(translate("One-time password length")),
               ),
             if (showPasswordOption) const PopupMenuDivider(),
             if (showPasswordOption)
               PopupMenuItem(
-                padding: const EdgeInsets.symmetric(horizontal: 0.0),
                 value: kUseTemporaryPassword,
                 child: listTile('Use one-time password',
                     verificationMethod == kUseTemporaryPassword),
               ),
             if (showPasswordOption)
               PopupMenuItem(
-                padding: const EdgeInsets.symmetric(horizontal: 0.0),
                 value: kUsePermanentPassword,
                 child: listTile('Use permanent password',
                     verificationMethod == kUsePermanentPassword),
               ),
             if (showPasswordOption)
               PopupMenuItem(
-                padding: const EdgeInsets.symmetric(horizontal: 0.0),
                 value: kUseBothPasswords,
                 child: listTile(
                     'Use both passwords',

--- a/flutter/lib/models/desktop_render_texture.dart
+++ b/flutter/lib/models/desktop_render_texture.dart
@@ -8,6 +8,7 @@ import 'package:texture_rgba_renderer/texture_rgba_renderer.dart';
 import '../../common.dart';
 import './platform_model.dart';
 
+// Feature flutter_texture_render need to be enabled if feature gpucodec is enabled.
 final useTextureRender =
     bind.mainHasPixelbufferTextureRender() || bind.mainHasGpuTextureRender();
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -387,7 +387,8 @@ class FfiModel with ChangeNotifier {
 
   onUrlSchemeReceived(Map<String, dynamic> evt) {
     final url = evt['url'].toString().trim();
-    if (url.startsWith(bind.mainUriPrefixSync()) && handleUriLink(uriString: url)) {
+    if (url.startsWith(bind.mainUriPrefixSync()) &&
+        handleUriLink(uriString: url)) {
       return;
     }
     switch (url) {
@@ -2227,6 +2228,9 @@ class FFI {
       bind.sessionTryAddDisplay(
           sessionId: sessionId, displays: Int32List.fromList(displays));
       ffiModel.pi.currentDisplay = display;
+    }
+    if (connType == ConnType.defaultConn && useTextureRender) {
+      textureModel.updateCurrentDisplay(display ?? 0);
     }
     final stream = bind.sessionStart(sessionId: sessionId, id: id);
     final cb = ffiModel.startEventListener(sessionId, id);


### PR DESCRIPTION
1. fix padding of mobile server page PopupMenuItem
2. improve waiting for image when only one image received
* For flutter texture late creation: create texture between session add and session start, it works not in principle but in test.
* For late PeerInfo handling
	a. rgba texture render: allow zero size in on_rgba
	b. gpu texture render and rgba buffer render doesn't check size currently
* Fix wrong valid flag of first frame in rgba buffer render

Other issues:
- [ ] decodeImageFromPixels may fail on first image
- [ ] Correct width/height when resolution changes

Test: video service send only one frame

https://github.com/rustdesk/rustdesk/assets/14891774/42a37c07-3853-4ea3-8dab-4249b47f2524

![41a89e135b9cf6d9fce9d758c883ddf](https://github.com/rustdesk/rustdesk/assets/14891774/8ea3ce6d-9c5c-42f5-86ef-89ea94f5a291)



