### PR TITLE
Fix. Custom client, ui bugs

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3123,7 +3123,7 @@ Widget loadIcon(double size) {
 var imcomingOnlyHomeSize = Size(280, 300);
 Size getIncomingOnlyHomeSize() {
   final magicWidth = Platform.isWindows ? 11.0 : 2.0;
-  final magicHeight = 12.0;
+  final magicHeight = 10.0;
   return imcomingOnlyHomeSize +
       Offset(magicWidth, kDesktopRemoteTabBarHeight + magicHeight);
 }

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3122,8 +3122,8 @@ Widget loadIcon(double size) {
 
 var imcomingOnlyHomeSize = Size(280, 300);
 Size getIncomingOnlyHomeSize() {
-  final magicWidth = Platform.isWindows ? 11.0 : 0.0;
-  final magicHeight = 8.0;
+  final magicWidth = Platform.isWindows ? 11.0 : 2.0;
+  final magicHeight = 12.0;
   return imcomingOnlyHomeSize +
       Offset(magicWidth, kDesktopRemoteTabBarHeight + magicHeight);
 }

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -538,6 +538,10 @@ class _DesktopHomePageState extends State<DesktopHomePage>
         child: OutlinedButton(
           onPressed: () {
             SystemNavigator.pop(); // Close the application
+            // https://github.com/flutter/flutter/issues/66631
+            if (Platform.isWindows) {
+              exit(0);
+            }
           },
           child: Text(translate('Quit')),
         ),

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -375,7 +375,7 @@ class DesktopTab extends StatelessWidget {
         Expanded(
             child: GestureDetector(
                 // custom double tap handler
-                onTap: showMaximize
+                onTap: !bind.isIncomingOnly() && showMaximize
                     ? () {
                         final current = DateTime.now().millisecondsSinceEpoch;
                         final elapsed = current - _lastClickTime;


### PR DESCRIPTION
1. Workaround `SystemNavigator.pop();` on Windows.
2. Disable "double tap" if is incoming only.
3. Add some pixels for incoming only home page.