### PR TITLE
Fix CPU performance montor on non-English Windows

### DIFF
--- a/libs/hbb_common/src/platform/windows.rs
+++ b/libs/hbb_common/src/platform/windows.rs
@@ -9,7 +9,7 @@ use winapi::{
     um::{
         handleapi::CloseHandle,
         pdh::{
-            PdhAddCounterA, PdhCloseQuery, PdhCollectQueryData, PdhCollectQueryDataEx,
+            PdhAddEnglishCounterA, PdhCloseQuery, PdhCollectQueryData, PdhCollectQueryDataEx,
             PdhGetFormattedCounterValue, PdhOpenQueryA, PDH_FMT_COUNTERVALUE, PDH_FMT_DOUBLE,
             PDH_HCOUNTER, PDH_HQUERY,
         },
@@ -71,9 +71,9 @@ pub fn start_cpu_performance_monitor() {
         }
         let _query = RAIIPDHQuery(query);
         let mut counter: PDH_HCOUNTER = std::mem::zeroed();
-        ret = PdhAddCounterA(query, COUNTER_PATH.as_ptr() as _, 0, &mut counter);
+        ret = PdhAddEnglishCounterA(query, COUNTER_PATH.as_ptr() as _, 0, &mut counter);
         if ret != 0 {
-            log::error!("PdhAddCounterA failed: 0x{:X}", ret);
+            log::error!("PdhAddEnglishCounterA failed: 0x{:X}", ret);
             return;
         }
         ret = PdhCollectQueryData(query);


### PR DESCRIPTION
Performance counters are localized, which leads to 

```
ERROR [libs\hbb_common\src\platform\windows.rs:71] PdhAddCounterA failed: 0xC0000BB8
```

being logged when you start ruskdesk on non-English windows versions. I assume that it also means that CPU monitoring fails.

As long as Windows XP support isn't a concern, this should fix it (`PdhAddEnglishCounterA` was introduced with Vista).

Disclaimer: I have no previous experience with Rust and really have no idea what I'm doing, but this was such a simple change that I took the chance. I have compiled and run it (flutter was a <cencored>) and the error is no longer logged.