### PR TITLE
opt pull ab

### DIFF
--- a/flutter/lib/common/widgets/address_book.dart
+++ b/flutter/lib/common/widgets/address_book.dart
@@ -46,12 +46,6 @@ class _AddressBookState extends State<AddressBook> {
               child: ElevatedButton(
                   onPressed: loginDialog, child: Text(translate("Login"))));
         } else {
-          if (gFFI.abModel.currentAbLoading.value &&
-              gFFI.abModel.currentAbEmtpy) {
-            return const Center(
-              child: CircularProgressIndicator(),
-            );
-          }
           return Column(
             children: [
               buildErrorBanner(context,

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hbb/common/widgets/dialog.dart';
 import 'package:flutter_hbb/consts.dart';
+import 'package:flutter_hbb/models/ab_model.dart';
 import 'package:flutter_hbb/models/peer_tab_model.dart';
 import 'package:get/get.dart';
 import 'package:provider/provider.dart';
@@ -1059,9 +1060,11 @@ class AddressBookPeerCard extends BasePeerCard {
     return menuItems;
   }
 
+  // address book does not need to update
   @protected
   @override
-  void _update() => gFFI.abModel.pullAb(quiet: true);
+  void _update() =>
+      {}; //gFFI.abModel.pullAb(force: ForcePullAb.current, quiet: true);
 
   @protected
   MenuEntryBase<String> _editTagAction(String id) {

--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -62,7 +62,9 @@ class _PeerTabPageState extends State<PeerTabPage>
         AddressBook(
           menuPadding: _menuPadding(),
         ),
-        ({dynamic hint}) => gFFI.abModel.pullAb(force: hint == null)),
+        ({dynamic hint}) => gFFI.abModel.pullAb(
+            force: hint == null ? ForcePullAb.listAndCurrent : null,
+            quiet: false)),
     _TabEntry(
       MyGroup(
         menuPadding: _menuPadding(),

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:bot_toast/bot_toast.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hbb/common/hbbs/hbbs.dart';
+import 'package:flutter_hbb/models/ab_model.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
 
@@ -102,7 +103,10 @@ class UserModel {
 
   // update ab and group status
   static Future<void> updateOtherModels() async {
-    await Future.wait([gFFI.abModel.pullAb(), gFFI.groupModel.pull()]);
+    await Future.wait([
+      gFFI.abModel.pullAb(force: ForcePullAb.listAndCurrent, quiet: false),
+      gFFI.groupModel.pull()
+    ]);
   }
 
   Future<void> logOut({String? apiServer}) async {


### PR DESCRIPTION
1. Test legacy/new mode only upon logging out.
2. Avoid pulling all data unnecessarily:
* On startup: Retrieve list, current, and personal ab.
* On refresh: Retrieve list and current ab.
* On changing ab/switching tabs: Attempt to pull current ab if not initialized.
3. Cache only personal and current ab.
4. Only synchronize current ab from recent.
5. Remove ab loading CircularProgressIndicator.