### PR TITLE
fix ab cache not work, set current ab name after load cache

### DIFF
--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -562,6 +562,10 @@ class AbModel {
       final data = jsonDecode(cache);
       if (data == null || data['access_token'] != access_token) return;
       _deserializeCache(data);
+      final name = bind.getLocalFlutterOption(k: 'current-ab-name');
+      if (addressbooks.containsKey(name)) {
+        _currentName.value = name;
+      }
     } catch (e) {
       debugPrint("load ab cache: $e");
     }


### PR DESCRIPTION
It's emtpy on startup because current name is not set after load cache, cause dummy address book's content is shown,  