### PR TITLE
set personal ab password

### DIFF
--- a/flutter/lib/common/widgets/address_book.dart
+++ b/flutter/lib/common/widgets/address_book.dart
@@ -418,6 +418,7 @@ class _AddressBookState extends State<AddressBook> {
       return;
     }
     var isInProgress = false;
+    var passwordVisible = false;
     IDTextEditingController idController = IDTextEditingController(text: '');
     TextEditingController aliasController = TextEditingController(text: '');
     TextEditingController passwordController = TextEditingController(text: '');
@@ -512,7 +513,21 @@ class _AddressBookState extends State<AddressBook> {
                 if (!isLegacy)
                   TextField(
                     controller: passwordController,
-                    obscureText: true,
+                    obscureText: !passwordVisible,
+                    decoration: InputDecoration(
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                            passwordVisible
+                                ? Icons.visibility
+                                : Icons.visibility_off,
+                            color: MyTheme.lightTheme.primaryColor),
+                        onPressed: () {
+                          setState(() {
+                            passwordVisible = !passwordVisible;
+                          });
+                        },
+                      ),
+                    ),
                   ),
                 Align(
                   alignment: Alignment.centerLeft,

--- a/flutter/lib/common/widgets/address_book.dart
+++ b/flutter/lib/common/widgets/address_book.dart
@@ -87,7 +87,10 @@ class _AddressBookState extends State<AddressBook> {
                 child: Column(
                   children: [
                     _buildAbDropdown(),
-                    _buildTagHeader().marginOnly(left: 8.0, right: 0),
+                    _buildTagHeader().marginOnly(
+                        left: 8.0,
+                        right: gFFI.abModel.legacyMode.value ? 8.0 : 0,
+                        top: gFFI.abModel.legacyMode.value ? 8.0 : 0),
                     Expanded(
                       child: Container(
                         width: double.infinity,
@@ -422,7 +425,7 @@ class _AddressBookState extends State<AddressBook> {
     var selectedTag = List<dynamic>.empty(growable: true).obs;
     final style = TextStyle(fontSize: 14.0);
     String? errorMsg;
-    final isCurrentAbShared = !gFFI.abModel.current.isPersonal();
+    final isLegacy = gFFI.abModel.current.isLegacy();
 
     gFFI.dialogManager.show((setState, close, context) {
       submit() async {
@@ -442,7 +445,7 @@ class _AddressBookState extends State<AddressBook> {
             return;
           }
           var password = '';
-          if (isCurrentAbShared) {
+          if (!isLegacy) {
             password = passwordController.text;
           }
           String? errMsg2 = await gFFI.abModel.addIdToCurrent(
@@ -498,7 +501,7 @@ class _AddressBookState extends State<AddressBook> {
                 TextField(
                   controller: aliasController,
                 ),
-                if (isCurrentAbShared)
+                if (!isLegacy)
                   Align(
                     alignment: Alignment.centerLeft,
                     child: Text(
@@ -506,7 +509,7 @@ class _AddressBookState extends State<AddressBook> {
                       style: style,
                     ),
                   ).marginOnly(top: 8, bottom: marginBottom),
-                if (isCurrentAbShared)
+                if (!isLegacy)
                   TextField(
                     controller: passwordController,
                     obscureText: true,

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -1113,9 +1113,7 @@ class AddressBookPeerCard extends BasePeerCard {
   MenuEntryBase<String> _changeAbPassword() {
     return MenuEntryButton<String>(
       childBuilder: (TextStyle? style) => Text(
-        translate(gFFI.abModel.current.isPersonal()
-            ? 'Set Password'
-            : 'Set shared password'),
+        translate(peer.password.isEmpty ? 'Set Password' : 'Change Password'),
         style: style,
       ),
       proc: () {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -352,13 +352,22 @@ class FfiModel with ChangeNotifier {
         handleReloading(evt);
       } else if (name == 'plugin_option') {
         handleOption(evt);
-      } else if (name == "sync_peer_password_to_ab") {
+      } else if (name == "sync_peer_hash_password_to_personal_ab") {
+        if (desktopType == DesktopType.main) {
+          final id = evt['id'];
+          final hash = evt['hash'];
+          if (id != null && hash != null) {
+            gFFI.abModel
+                .changePersonalHashPassword(id.toString(), hash.toString());
+          }
+        }
+      } else if (name == "sync_peer_password_to_personal_ab") {
         if (desktopType == DesktopType.main) {
           final id = evt['id'];
           final password = evt['password'];
           if (id != null && password != null) {
             gFFI.abModel
-                .changePersonalHashPassword(id.toString(), password.toString());
+                .changePersonalPassword(id.toString(), password.toString());
           }
         }
       } else if (name == "cm_file_transfer_log") {

--- a/flutter/lib/models/peer_model.dart
+++ b/flutter/lib/models/peer_model.dart
@@ -61,7 +61,8 @@ class Peer {
     };
   }
 
-  Map<String, dynamic> toPersonalAbUploadJson(bool includingHash) {
+  Map<String, dynamic> toCustomJson(
+      {required bool includingHash, required bool includingPassword}) {
     var res = <String, dynamic>{
       "id": id,
       "username": username,
@@ -73,33 +74,10 @@ class Peer {
     if (includingHash) {
       res['hash'] = hash;
     }
-    return res;
-  }
-
-  Map<String, dynamic> toSharedAbUploadJson(bool includingPassword) {
-    var res = <String, dynamic>{
-      "id": id,
-      "username": username,
-      "hostname": hostname,
-      "platform": platform,
-      "alias": alias,
-      "tags": tags,
-    };
     if (includingPassword) {
       res['password'] = password;
     }
     return res;
-  }
-
-  Map<String, dynamic> toSharedAbCacheJson() {
-    return <String, dynamic>{
-      "id": id,
-      "username": username,
-      "hostname": hostname,
-      "platform": platform,
-      "alias": alias,
-      "tags": tags,
-    };
   }
 
   Map<String, dynamic> toGroupCacheJson() {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1648,6 +1648,12 @@ pub struct AbPeer {
         deserialize_with = "deserialize_string",
         skip_serializing_if = "String::is_empty"
     )]
+    pub password: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
     pub username: String,
     #[serde(
         default,

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1050,8 +1050,17 @@ pub fn session_add(
 
     LocalConfig::set_remote_id(&id);
 
+    let mut preset_password = password.clone();
+    let shared_password = if is_shared_password {
+        // To achieve a flexible password application order, we dont' treat shared password as a preset password.
+        preset_password = Default::default();
+        Some(password)
+    } else {
+        None
+    };
+
     let session: Session<FlutterHandler> = Session {
-        password: password.clone(),
+        password: preset_password,
         server_keyboard_enabled: Arc::new(RwLock::new(true)),
         server_file_transfer_enabled: Arc::new(RwLock::new(true)),
         server_clipboard_enabled: Arc::new(RwLock::new(true)),
@@ -1069,11 +1078,6 @@ pub fn session_add(
     #[cfg(not(feature = "gpucodec"))]
     let adapter_luid = None;
 
-    let shared_password = if is_shared_password {
-        Some(password)
-    } else {
-        None
-    };
     session.lc.write().unwrap().initialize(
         id.to_owned(),
         conn_type,

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", "我的地址簿"),
         ("Personal", "个人的"),
         ("Owner", "所有者"),
-        ("Set shared password", "设置共享密码"),
         ("Exist in", "存在于"),
         ("Read-only", "只读"),
         ("Read/Write", "读写"),

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", "Můj adresář"),
         ("Personal", "Osobní"),
         ("Owner", "Majitel"),
-        ("Set shared password", "Nastavit sdílené heslo"),
         ("Exist in", "Existuje v"),
         ("Read-only", "Pouze ke čtení"),
         ("Read/Write", "Režim čtení/zápisu"),

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", "Mein Adressbuch"),
         ("Personal", "Persönlich"),
         ("Owner", "Eigentümer"),
-        ("Set shared password", "Geteiltes Passwort setzen"),
         ("Exist in", "Existiert in …?"),
         ("Read-only", "Nur lesen"),
         ("Read/Write", "Lesen/Schreiben"),

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", "Mi directorio"),
         ("Personal", "Personal"),
         ("Owner", "Propietario"),
-        ("Set shared password", "Establecer contraseña compartida"),
         ("Exist in", "Existe en"),
         ("Read-only", "Solo-lectura"),
         ("Read/Write", "Lectura/Escritura"),

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", "Rubrica"),
         ("Personal", "Personale"),
         ("Owner", "Proprietario"),
-        ("Set shared password", "Imposta password condivisa"),
         ("Exist in", "Esiste in"),
         ("Read-only", "Sola lettura"),
         ("Read/Write", "Lettura/scrittura"),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", "Mana adrešu grāmata"),
         ("Personal", "Personīga"),
         ("Owner", "Īpašnieks"),
-        ("Set shared password", "Iestatīt koplietojamo paroli"),
         ("Exist in", "Pastāv iekš"),
         ("Read-only", "Tikai lasīt"),
         ("Read/Write", "Lasīt/Rakstīt"),

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", "Mijn adresboek"),
         ("Personal", "Persoonijk"),
         ("Owner", "Eigenaar"),
-        ("Set shared password", "Gedeeld wachtwoord instellen"),
         ("Exist in", "Bestaat in"),
         ("Read-only", "Alleen-lezen"),
         ("Read/Write", "Lezen/Schrijven"),

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", "Моя адресная книга"),
         ("Personal", "Личная"),
         ("Owner", "Владелец"),
-        ("Set shared password", "Установить общий пароль"),
         ("Exist in", "Существует в"),
         ("Read-only", "Только чтение"),
         ("Read/Write", "Чтение и запись"),

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", "Môj adresár"),
         ("Personal", "Osobné"),
         ("Owner", "Vlastník"),
-        ("Set shared password", "Nastaviť zdieľané heslo"),
         ("Exist in", "Existovať v"),
         ("Read-only", "len na čítanie"),
         ("Read/Write", "Režim čítania/zápisu"),

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", "我的通訊錄"),
         ("Personal", "個人的"),
         ("Owner", "擁有者"),
-        ("Set shared password", "設定共享密碼"),
         ("Exist in", "存在於"),
         ("Read-only", "唯讀"),
         ("Read/Write", "讀寫"),

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -592,7 +592,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("My address book", ""),
         ("Personal", ""),
         ("Owner", ""),
-        ("Set shared password", ""),
         ("Exist in", ""),
         ("Read-only", ""),
         ("Read/Write", ""),


### PR DESCRIPTION
1. Enable set personal ab password:
* The personal password is stored in cache and are used like the previously remembered hash password. Another way is pass to rust like shared password and used only when clicking personal ab peer card. 
* The UI login password will automatically synchronize to the personal ab.
* The password icon on the peer card will only appear when a password is set, ignore remembered password.
2. Multiple passwords problems:
* Password application priority: shared ab password (if  click the shared peer card) > personal ab password > personal ab remembered hash password > PeerConfig password.
* Forget password menu:
 Visibility: For recent tab , when a recent password exists;  For ab tab,  when a remembered password or a set password exists.
 Clicking on "Foget Password" will remove all local and  personal ab passwords.
3. add toggle password TextField visibility

    * Show empty TextField for changing password
    * Add "Remove" button to remove password

https://github.com/rustdesk/rustdesk/assets/14891774/92da3c0d-d37a-49c7-94b3-81079e83cdfa


https://github.com/rustdesk/rustdesk/assets/14891774/8eca353b-ebf0-4e42-89de-30a19ba0bd19

