### PR TITLE
Fix. Custom resolution removed after 2rd conn

### DIFF
--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1228,7 +1228,7 @@ impl<T: InvokeUiSession> Session<T> {
     #[inline]
     fn try_change_init_resolution(&self, display: i32) {
         if let Some((w, h)) = self.lc.read().unwrap().get_custom_resolution(display) {
-            self.do_change_resolution(w, h);
+            self.change_resolution(display, w, h);
         }
     }
 


### PR DESCRIPTION
Call `change_resolution()` to set `last_change_display`.

Then `handle_peer_switch_display()` --> `set_custom_resolution()` can syn last changed resolution.


## Issue

https://github.com/rustdesk/rustdesk/assets/13586388/c7026985-2ec3-4739-9b09-1438081b3e0a

