### PR TITLE
Fix. Remote toolbar, menu refresh

### DIFF
--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -636,7 +636,7 @@ class _MonitorMenu extends StatelessWidget {
         menuStyle: MenuStyle(
             padding:
                 MaterialStatePropertyAll(EdgeInsets.symmetric(horizontal: 6))),
-        menuChildren: [buildMonitorSubmenuWidget()]);
+        menuChildrenGetter: () => [buildMonitorSubmenuWidget()]);
   }
 
   Widget buildMultiMonitorMenu() {
@@ -843,17 +843,17 @@ class _ControlMenu extends StatelessWidget {
         color: _ToolbarTheme.blueColor,
         hoverColor: _ToolbarTheme.hoverBlueColor,
         ffi: ffi,
-        menuChildren: toolbarControls(context, id, ffi).map((e) {
-          if (e.divider) {
-            return Divider();
-          } else {
-            return MenuButton(
-                child: e.child,
-                onPressed: e.onPressed,
-                ffi: ffi,
-                trailingIcon: e.trailingIcon);
-          }
-        }).toList());
+        menuChildrenGetter: () => toolbarControls(context, id, ffi).map((e) {
+              if (e.divider) {
+                return Divider();
+              } else {
+                return MenuButton(
+                    child: e.child,
+                    onPressed: e.onPressed,
+                    ffi: ffi,
+                    trailingIcon: e.trailingIcon);
+              }
+            }).toList());
   }
 }
 
@@ -1046,53 +1046,56 @@ class _DisplayMenuState extends State<_DisplayMenu> {
   Widget build(BuildContext context) {
     _screenAdjustor.updateScreen();
 
-    final menuChildren = <Widget>[
-      _screenAdjustor.adjustWindow(context),
-      viewStyle(),
-      scrollStyle(),
-      imageQuality(),
-      codec(),
-      _ResolutionsMenu(
-        id: widget.id,
-        ffi: widget.ffi,
-        screenAdjustor: _screenAdjustor,
-      ),
-      // We may add this feature if it is needed and we have an EV certificate.
-      // _VirtualDisplayMenu(
-      //   id: widget.id,
-      //   ffi: widget.ffi,
-      // ),
-      Divider(),
-      toggles(),
-    ];
-    // privacy mode
-    if (ffiModel.keyboard && pi.features.privacyMode) {
-      final privacyModeState = PrivacyModeState.find(id);
-      final privacyModeList =
-          toolbarPrivacyMode(privacyModeState, context, id, ffi);
-      if (privacyModeList.length == 1) {
-        menuChildren.add(CkbMenuButton(
-            value: privacyModeList[0].value,
-            onChanged: privacyModeList[0].onChanged,
-            child: privacyModeList[0].child,
-            ffi: ffi));
-      } else if (privacyModeList.length > 1) {
-        menuChildren.addAll([
-          Divider(),
-          _SubmenuButton(
-              ffi: widget.ffi,
-              child: Text(translate('Privacy mode')),
-              menuChildren: privacyModeList
-                  .map((e) => CkbMenuButton(
-                      value: e.value,
-                      onChanged: e.onChanged,
-                      child: e.child,
-                      ffi: ffi))
-                  .toList()),
-        ]);
+    menuChildrenGetter() {
+      final menuChildren = <Widget>[
+        _screenAdjustor.adjustWindow(context),
+        viewStyle(),
+        scrollStyle(),
+        imageQuality(),
+        codec(),
+        _ResolutionsMenu(
+          id: widget.id,
+          ffi: widget.ffi,
+          screenAdjustor: _screenAdjustor,
+        ),
+        // We may add this feature if it is needed and we have an EV certificate.
+        // _VirtualDisplayMenu(
+        //   id: widget.id,
+        //   ffi: widget.ffi,
+        // ),
+        Divider(),
+        toggles(),
+      ];
+      // privacy mode
+      if (ffiModel.keyboard && pi.features.privacyMode) {
+        final privacyModeState = PrivacyModeState.find(id);
+        final privacyModeList =
+            toolbarPrivacyMode(privacyModeState, context, id, ffi);
+        if (privacyModeList.length == 1) {
+          menuChildren.add(CkbMenuButton(
+              value: privacyModeList[0].value,
+              onChanged: privacyModeList[0].onChanged,
+              child: privacyModeList[0].child,
+              ffi: ffi));
+        } else if (privacyModeList.length > 1) {
+          menuChildren.addAll([
+            Divider(),
+            _SubmenuButton(
+                ffi: widget.ffi,
+                child: Text(translate('Privacy mode')),
+                menuChildren: privacyModeList
+                    .map((e) => CkbMenuButton(
+                        value: e.value,
+                        onChanged: e.onChanged,
+                        child: e.child,
+                        ffi: ffi))
+                    .toList()),
+          ]);
+        }
       }
+      menuChildren.add(widget.pluginItem);
+      return menuChildren;
     }
-    menuChildren.add(widget.pluginItem);
 
     return _IconSubmenuButton(
       tooltip: 'Display Settings',
@@ -1100,7 +1103,7 @@ class _DisplayMenuState extends State<_DisplayMenu> {
       ffi: widget.ffi,
       color: _ToolbarTheme.blueColor,
       hoverColor: _ToolbarTheme.hoverBlueColor,
-      menuChildren: menuChildren,
+      menuChildrenGetter: menuChildrenGetter,
     );
   }
 
@@ -1645,15 +1648,15 @@ class _KeyboardMenu extends StatelessWidget {
         ffi: ffi,
         color: _ToolbarTheme.blueColor,
         hoverColor: _ToolbarTheme.hoverBlueColor,
-        menuChildren: [
-          keyboardMode(modeOnly),
-          localKeyboardType(),
-          inputSource(),
-          Divider(),
-          viewMode(),
-          Divider(),
-          ...toolbarToggles,
-        ]);
+        menuChildrenGetter: () => [
+              keyboardMode(modeOnly),
+              localKeyboardType(),
+              inputSource(),
+              Divider(),
+              viewMode(),
+              Divider(),
+              ...toolbarToggles,
+            ]);
   }
 
   keyboardMode(String? modeOnly) {
@@ -1804,7 +1807,7 @@ class _ChatMenuState extends State<_ChatMenu> {
         ffi: widget.ffi,
         color: _ToolbarTheme.blueColor,
         hoverColor: _ToolbarTheme.hoverBlueColor,
-        menuChildren: [textChat(), voiceCall()]);
+        menuChildrenGetter: () => [textChat(), voiceCall()]);
   }
 
   textChat() {
@@ -2008,7 +2011,7 @@ class _IconSubmenuButton extends StatefulWidget {
   final Widget? icon;
   final Color color;
   final Color hoverColor;
-  final List<Widget> menuChildren;
+  final List<Widget> Function() menuChildrenGetter;
   final MenuStyle? menuStyle;
   final FFI ffi;
   final double? width;
@@ -2020,7 +2023,7 @@ class _IconSubmenuButton extends StatefulWidget {
     required this.tooltip,
     required this.color,
     required this.hoverColor,
-    required this.menuChildren,
+    required this.menuChildrenGetter,
     required this.ffi,
     this.menuStyle,
     this.width,
@@ -2064,7 +2067,8 @@ class _IconSubmenuButtonState extends State<_IconSubmenuButton> {
                           color: hover ? widget.hoverColor : widget.color,
                         ),
                         child: icon))),
-            menuChildren: widget.menuChildren
+            menuChildren: widget
+                .menuChildrenGetter()
                 .map((e) => _buildPointerTrackWidget(e, widget.ffi))
                 .toList()));
     return MenuBar(children: [


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/7602


https://github.com/rustdesk/rustdesk/assets/13586388/980195c0-ae24-43a3-9a4a-5e45726b89eb


## Reason

Flutter 3.16 triggers toolbar rebuild every time it shows the dropdown menu.

https://github.com/rustdesk/rustdesk/assets/13586388/6be75b31-5160-4bf5-9f09-459f89d0c8dc


But Flutter 3.19.5 will not cause the whole rebuild. It's better. 
The button widgets are rebuilt every time.

But the underlying data do not reload.





