### PR TITLE
Fix. Cert, remove strange cert folders .

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -8,7 +8,7 @@ on:
         default: true
       upload-tag:
         type: string
-        default: "1.2.3-1"
+        default: "1.2.3-2"
 
 env:
   CARGO_NDK_VERSION: "3.1.2"
@@ -18,11 +18,11 @@ env:
   # for arm64 linux
   FLUTTER_ELINUX_VERSION: "3.10.6"
   FLUTTER_ELINUX_COMMIT_ID: "410b3ca42f2cd0c485edf517a1666652bab442d4"
-  TAG_NAME: "1.2.3-1"
+  TAG_NAME: "1.2.3-2"
   # vcpkg version: 2023.04.15
   # for multiarch gcc compatibility
   VCPKG_COMMIT_ID: "501db0f17ef6df184fcdbfbe0f87cde2313b6ab1"
-  VERSION: "1.2.3-1"
+  VERSION: "1.2.3-2"
   NDK_VERSION: "r25c"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: '${{ secrets.ANDROID_SIGNING_KEY }}'

--- a/.github/workflows/flutter-tag.yml
+++ b/.github/workflows/flutter-tag.yml
@@ -15,4 +15,4 @@ jobs:
     secrets: inherit
     with:
       upload-artifact: true
-      upload-tag: "1.2.3-1" 
+      upload-tag: "1.2.3-2" 

--- a/.github/workflows/history.yml
+++ b/.github/workflows/history.yml
@@ -10,7 +10,7 @@ env:
   # vcpkg version: 2022.05.10
   # for multiarch gcc compatibility
   VCPKG_COMMIT_ID: "501db0f17ef6df184fcdbfbe0f87cde2313b6ab1"
-  VERSION: "1.2.3-1"
+  VERSION: "1.2.3-2"
 
 jobs:
   build-for-history-windows:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5227,7 +5227,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk"
-version = "1.2.3-1"
+version = "1.2.3-2"
 dependencies = [
  "android_logger",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk"
-version = "1.2.3-1"
+version = "1.2.3-2"
 authors = ["rustdesk <info@rustdesk.com>"]
 edition = "2021"
 build= "build.rs"

--- a/appimage/AppImageBuilder-aarch64.yml
+++ b/appimage/AppImageBuilder-aarch64.yml
@@ -2,7 +2,7 @@
 version: 1
 script:
  - rm -rf ./AppDir || true
- - bsdtar -zxvf ../rustdesk-1.2.3-1.deb
+ - bsdtar -zxvf ../rustdesk-1.2.3-2.deb
  - tar -xvf ./data.tar.xz
  - mkdir ./AppDir
  - mv ./usr ./AppDir/usr
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.2.3-1
+    version: 1.2.3-2
     exec: usr/lib/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/appimage/AppImageBuilder-x86_64.yml
+++ b/appimage/AppImageBuilder-x86_64.yml
@@ -2,7 +2,7 @@
 version: 1
 script:
  - rm -rf ./AppDir || true
- - bsdtar -zxvf ../rustdesk-1.2.3-1.deb
+ - bsdtar -zxvf ../rustdesk-1.2.3-2.deb
  - tar -xvf ./data.tar.xz
  - mkdir ./AppDir
  - mv ./usr ./AppDir/usr
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.2.3-1
+    version: 1.2.3-2
     exec: usr/lib/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,11 @@
 #[cfg(windows)]
 fn build_windows() {
     let file = "src/platform/windows.cc";
-    cc::Build::new().file(file).compile("windows");
+    let file2  = "src/platform/windows_delete_test_cert.cc";
+    cc::Build::new().file(file).file(file2).compile("windows");
     println!("cargo:rustc-link-lib=WtsApi32");
     println!("cargo:rerun-if-changed={}", file);
+    println!("cargo:rerun-if-changed={}", file2);
 }
 
 #[cfg(target_os = "macos")]

--- a/flatpak/rustdesk.json
+++ b/flatpak/rustdesk.json
@@ -12,7 +12,7 @@
       "name": "rustdesk",
       "buildsystem": "simple",
       "build-commands": [
-        "bsdtar -zxvf rustdesk-1.2.3-1.deb",
+        "bsdtar -zxvf rustdesk-1.2.3-2.deb",
         "tar -xvf ./data.tar.xz",
         "cp -r ./usr/*  /app/",
         "mkdir -p /app/bin && ln -s /app/lib/rustdesk/rustdesk /app/bin/rustdesk",
@@ -26,7 +26,7 @@
       "sources": [
         {
           "type": "file",
-          "path": "../rustdesk-1.2.3-1.deb"
+          "path": "../rustdesk-1.2.3-2.deb"
         },
         {
           "type": "file",

--- a/res/PKGBUILD
+++ b/res/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=rustdesk
-pkgver=1.2.3-1
+pkgver=1.2.3-2
 pkgrel=0
 epoch=
 pkgdesc=""

--- a/res/rpm-flutter-suse.spec
+++ b/res/rpm-flutter-suse.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.2.3-1
+Version:    1.2.3-2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.2.3-1
+Version:    1.2.3-2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.2.3-1
+Version:    1.2.3-2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/src/platform/windows_delete_test_cert.cc
+++ b/src/platform/windows_delete_test_cert.cc
@@ -1,5 +1,4 @@
 // https://github.com/rustdesk/rustdesk/discussions/6444#discussioncomment-9010062
-// https://gist.github.com/danielmarschall/9bba7abde478e3c78f4f6163deea99de
 
 #include <iostream>
 #include <Windows.h>
@@ -17,6 +16,13 @@
 //
 //  Return:     TRUE if successful.
 //              FALSE if an error occurs.
+//
+//  Note:       If bOneLevel is TRUE, only current key and its first level subkeys are deleted.
+//              The first level subkeys are deleted only if they do not have subkeys.
+//
+//              If some subkeys have subkeys, but the previous empty subkeys are deleted.
+//              It's ok for the certificates, because the empty subkeys are not used
+//              and they can be created automatically.
 //
 //*************************************************************
 
@@ -193,10 +199,12 @@ BOOL DeleteRustDeskTestCertsW_SingleHive(HKEY RootKey, LPWSTR Prefix = NULL) {
 			LPWSTR Complete = (LPWSTR)malloc(512 * sizeof(WCHAR));
 			if (Complete == 0) break;
 			wsprintfW(Complete, L"%s\\%s", lpSystemCertificatesPath, SubKeyName);
-			//std::wcout << "Rogue Key Deleted! \"" << Complete << "\"" << std::endl; // TODO: Why does this break the console?
-			std::wcout << "Rogue Key Deleted!" << std::endl;
 			if (RegDelnodeW(RootKey, Complete, TRUE)) {
+				//std::wcout << "Rogue Key Deleted! \"" << Complete << "\"" << std::endl; // TODO: Why does this break the console?
+				std::wcout << "Rogue key is deleted!" << std::endl;
 				Index--; // Because index has moved due to the deletion
+			} else {
+				std::wcout << "Rogue key deletion failed!" << std::endl;
 			}
 			free(Complete);
 		}

--- a/src/platform/windows_delete_test_cert.cc
+++ b/src/platform/windows_delete_test_cert.cc
@@ -1,0 +1,253 @@
+// https://github.com/rustdesk/rustdesk/discussions/6444#discussioncomment-9010062
+// https://gist.github.com/danielmarschall/9bba7abde478e3c78f4f6163deea99de
+
+#include <iostream>
+#include <Windows.h>
+#include <strsafe.h>
+
+//*************************************************************
+//
+//  RegDelnodeRecurseW()
+//
+//  Purpose:    Deletes a registry key and all its subkeys / values.
+//
+//  Parameters: hKeyRoot    -   Root key
+//              lpSubKey    -   SubKey to delete
+//              bOneLevel   -   Delete lpSubKey and its first level subdirectory
+//
+//  Return:     TRUE if successful.
+//              FALSE if an error occurs.
+//
+//*************************************************************
+
+BOOL RegDelnodeRecurseW(HKEY hKeyRoot, LPWSTR lpSubKey, BOOL bOneLevel)
+{
+	LPWSTR lpEnd;
+	LONG lResult;
+	DWORD dwSize;
+	WCHAR szName[MAX_PATH];
+	HKEY hKey;
+	FILETIME ftWrite;
+
+	// First, see if we can delete the key without having
+	// to recurse.
+
+	lResult = RegDeleteKeyW(hKeyRoot, lpSubKey);
+
+	if (lResult == ERROR_SUCCESS)
+		return TRUE;
+
+	lResult = RegOpenKeyExW(hKeyRoot, lpSubKey, 0, KEY_READ, &hKey);
+
+	if (lResult != ERROR_SUCCESS)
+	{
+		if (lResult == ERROR_FILE_NOT_FOUND) {
+			//printf("Key not found.\n");
+			return TRUE;
+		}
+		else {
+			//printf("Error opening key.\n");
+			return FALSE;
+		}
+	}
+
+	// Check for an ending slash and add one if it is missing.
+
+	lpEnd = lpSubKey + lstrlenW(lpSubKey);
+
+	if (*(lpEnd - 1) != L'\\')
+	{
+		*lpEnd = L'\\';
+		lpEnd++;
+		*lpEnd = L'\0';
+	}
+
+	// Enumerate the keys
+
+	dwSize = MAX_PATH;
+	lResult = RegEnumKeyExW(hKey, 0, szName, &dwSize, NULL,
+		NULL, NULL, &ftWrite);
+
+	if (lResult == ERROR_SUCCESS)
+	{
+		do {
+
+			*lpEnd = L'\0';
+			StringCchCatW(lpSubKey, MAX_PATH * 2, szName);
+
+			if (bOneLevel) {
+				lResult = RegDeleteKeyW(hKeyRoot, lpSubKey);
+				if (lResult != ERROR_SUCCESS) {
+					return FALSE;
+				}
+			}
+			else {
+				if (!RegDelnodeRecurseW(hKeyRoot, lpSubKey, bOneLevel)) {
+					break;
+				}
+			}
+
+			dwSize = MAX_PATH;
+
+			lResult = RegEnumKeyExW(hKey, 0, szName, &dwSize, NULL,
+				NULL, NULL, &ftWrite);
+
+		} while (lResult == ERROR_SUCCESS);
+	}
+
+	lpEnd--;
+	*lpEnd = L'\0';
+
+	RegCloseKey(hKey);
+
+	// Try again to delete the key.
+
+	lResult = RegDeleteKeyW(hKeyRoot, lpSubKey);
+
+	if (lResult == ERROR_SUCCESS)
+		return TRUE;
+
+	return FALSE;
+}
+
+//*************************************************************
+//
+//  RegDelnodeW()
+//
+//  Purpose:    Deletes a registry key and all its subkeys / values.
+//
+//  Parameters: hKeyRoot    -   Root key
+//              lpSubKey    -   SubKey to delete
+//              bOneLevel   -   Delete lpSubKey and its first level subdirectory
+//
+//  Return:     TRUE if successful.
+//              FALSE if an error occurs.
+//
+//*************************************************************
+
+BOOL RegDelnodeW(HKEY hKeyRoot, LPCWSTR lpSubKey, BOOL bOneLevel)
+{
+	//return FALSE; // For Testing
+
+	WCHAR szDelKey[MAX_PATH * 2];
+
+	StringCchCopyW(szDelKey, MAX_PATH * 2, lpSubKey);
+	return RegDelnodeRecurseW(hKeyRoot, szDelKey, bOneLevel);
+
+}
+
+//*************************************************************
+//
+//  DeleteRustDeskTestCertsW_SingleHive()
+//
+//  Purpose:    Deletes RustDesk Test certificates and wrong key stores
+//
+//  Parameters: RootKey     -   Root key
+//              Prefix      -   SID if RootKey=HKEY_USERS
+//
+//  Return:     TRUE if successful.
+//              FALSE if an error occurs.
+//
+//*************************************************************
+
+BOOL DeleteRustDeskTestCertsW_SingleHive(HKEY RootKey, LPWSTR Prefix = NULL) {
+	// WDKTestCert to be removed from all stores
+	LPCWSTR lpCertFingerPrint = L"D1DBB672D5A500B9809689CAEA1CE49E799767F0";
+
+	// Wrong key stores to be removed completely
+	LPCSTR RootName = "ROOT";
+	LPWSTR SubKeyPrefix = (LPWSTR)RootName; // sic! Convert of ANSI to UTF-16
+
+	LPWSTR lpSystemCertificatesPath = (LPWSTR)malloc(512 * sizeof(WCHAR));
+	if (lpSystemCertificatesPath == 0) return FALSE;
+	if (Prefix == NULL) {
+		wsprintfW(lpSystemCertificatesPath, L"Software\\Microsoft\\SystemCertificates");
+	}
+	else {
+		wsprintfW(lpSystemCertificatesPath, L"%s\\Software\\Microsoft\\SystemCertificates", Prefix);
+	}
+
+	HKEY hRegSystemCertificates;
+	LONG res = RegOpenKeyExW(RootKey, lpSystemCertificatesPath, NULL, KEY_ALL_ACCESS, &hRegSystemCertificates);
+	if (res != ERROR_SUCCESS)
+		return FALSE;
+
+	for (DWORD Index = 0; ; Index++) {
+		LPWSTR SubKeyName = (LPWSTR)malloc(255 * sizeof(WCHAR));
+		if (SubKeyName == 0) break;
+		DWORD cName = 255;
+		LONG res = RegEnumKeyExW(hRegSystemCertificates, Index, SubKeyName, &cName, NULL, NULL, NULL, NULL);
+		if ((res != ERROR_SUCCESS) || (SubKeyName == NULL))
+			break;
+
+		// Remove test certificate
+		LPWSTR Complete = (LPWSTR)malloc(512 * sizeof(WCHAR));
+		if (Complete == 0) break;
+		wsprintfW(Complete, L"%s\\%s\\Certificates\\%s", lpSystemCertificatesPath, SubKeyName, lpCertFingerPrint);
+		std::wcout << "Try delete from: " << SubKeyName << std::endl;
+		RegDelnodeW(RootKey, Complete, FALSE);
+		free(Complete);
+
+		if ((SubKeyName[0] == SubKeyPrefix[0]) && (SubKeyName[1] == SubKeyPrefix[1])) {
+			// "Chinese Characters" key begins with "ROOT" encoded as UTF-16
+			LPWSTR Complete = (LPWSTR)malloc(512 * sizeof(WCHAR));
+			if (Complete == 0) break;
+			wsprintfW(Complete, L"%s\\%s", lpSystemCertificatesPath, SubKeyName);
+			//std::wcout << "Rogue Key Deleted! \"" << Complete << "\"" << std::endl; // TODO: Why does this break the console?
+			std::wcout << "Rogue Key Deleted!" << std::endl;
+			if (RegDelnodeW(RootKey, Complete, TRUE)) {
+				Index--; // Because index has moved due to the deletion
+			}
+			free(Complete);
+		}
+
+		free(SubKeyName);
+	}
+	RegCloseKey(hRegSystemCertificates);
+	return TRUE;
+}
+
+//*************************************************************
+//
+//  DeleteRustDeskTestCertsW()
+//
+//  Purpose:    Deletes RustDesk Test certificates and wrong key stores
+//
+//  Parameters: None
+//
+//  Return:     None
+//
+//*************************************************************
+
+extern "C" void DeleteRustDeskTestCertsW() {
+	// Current user
+	std::wcout << "*** Current User" << std::endl;
+	DeleteRustDeskTestCertsW_SingleHive(HKEY_CURRENT_USER);
+
+	// Local machine (requires admin rights)
+	std::wcout << "*** Local Machine" << std::endl;
+	DeleteRustDeskTestCertsW_SingleHive(HKEY_LOCAL_MACHINE);
+
+	// Iterate through all users (requires admin rights)
+	LPCWSTR lpRoot = L"";
+	HKEY hRegUsers;
+	LONG res = RegOpenKeyExW(HKEY_USERS, lpRoot, NULL, KEY_READ, &hRegUsers);
+	if (res != ERROR_SUCCESS) return;
+	for (DWORD Index = 0; ; Index++) {
+		LPWSTR SubKeyName = (LPWSTR)malloc(255 * sizeof(WCHAR));
+		if (SubKeyName == 0) break;
+		DWORD cName = 255;
+		LONG res = RegEnumKeyExW(hRegUsers, Index, SubKeyName, &cName, NULL, NULL, NULL, NULL);
+		if ((res != ERROR_SUCCESS) || (SubKeyName == NULL))
+			break;
+		std::wcout << "*** User: " << SubKeyName << std::endl;
+		DeleteRustDeskTestCertsW_SingleHive(HKEY_USERS, SubKeyName);
+	}
+	RegCloseKey(hRegUsers);
+}
+
+// int main()
+// {
+// 	DeleteRustDeskTestCertsW();
+// 	return 0;
+// }


### PR DESCRIPTION
RustDesk can remove test certs in the "Trusted Root Certification Authorities" on uninstall.

But 1.2.3-1 will still create unexpected cert folder, because the wrong parameter of `CertOpenSystemStoreW`

```rust
CertOpenSystemStoreW(0 as _, "ROOT\0".as_ptr() as _);
```

https://github.com/rustdesk/rustdesk/discussions/6444#discussioncomment-9017532

Thanks to @danielmarschall  for fingering out the cause and providing the code.

https://github.com/rustdesk/rustdesk/discussions/6444#discussioncomment-9010062
https://github.com/rustdesk/rustdesk/discussions/6444#discussioncomment-9014382