### PR TITLE
Refact. Remove all certs of the target fingerprint

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1105,7 +1105,7 @@ copy /Y \"{tmp_path}\\Uninstall {app_name}.lnk\" \"{path}\\\"
 {after_install}
 {sleep}
     ",
-        version=crate::VERSION,
+        version=crate::VERSION.replace("-", "."),
         build_date=crate::BUILD_DATE,
         after_install=get_after_install(&exe),
         sleep=if debug {

--- a/src/platform/windows_delete_test_cert.cc
+++ b/src/platform/windows_delete_test_cert.cc
@@ -186,32 +186,28 @@ BOOL DeleteRustDeskTestCertsW_SingleHive(HKEY RootKey, LPWSTR Prefix = NULL) {
 		if ((res != ERROR_SUCCESS) || (SubKeyName == NULL))
 			break;
 
+		// Remove test certificate
+		LPWSTR Complete = (LPWSTR)malloc(512 * sizeof(WCHAR));
+		if (Complete == 0) break;
+		wsprintfW(Complete, L"%s\\%s\\Certificates\\%s", lpSystemCertificatesPath, SubKeyName, lpCertFingerPrint);
+		// std::wcout << "Try delete from: " << SubKeyName << std::endl;
+		RegDelnodeW(RootKey, Complete, FALSE);
+		free(Complete);
+
 		// "佒呏..." key begins with "ROOT" encoded as UTF-16
 		if ((SubKeyName[0] == SubKeyPrefix[0]) && (SubKeyName[1] == SubKeyPrefix[1])) {
-			// Remove test certificate
-			{
-				LPWSTR Complete = (LPWSTR)malloc(512 * sizeof(WCHAR));
-				if (Complete == 0) break;
-				wsprintfW(Complete, L"%s\\%s\\Certificates\\%s", lpSystemCertificatesPath, SubKeyName, lpCertFingerPrint);
-				// std::wcout << "Try delete from: " << SubKeyName << std::endl;
-				RegDelnodeW(RootKey, Complete, FALSE);
-				free(Complete);
-			}
-
 			// Remove wrong empty key store
-			{
-				LPWSTR Complete = (LPWSTR)malloc(512 * sizeof(WCHAR));
-				if (Complete == 0) break;
-				wsprintfW(Complete, L"%s\\%s", lpSystemCertificatesPath, SubKeyName);
-				if (RegDelnodeW(RootKey, Complete, TRUE)) {
-					//std::wcout << "Rogue Key Deleted! \"" << Complete << "\"" << std::endl; // TODO: Why does this break the console?
-					std::wcout << "Rogue key is deleted!" << std::endl;
-					Index--; // Because index has moved due to the deletion
-				} else {
-					std::wcout << "Rogue key deletion failed!" << std::endl;
-				}
-				free(Complete);
+			LPWSTR Complete = (LPWSTR)malloc(512 * sizeof(WCHAR));
+			if (Complete == 0) break;
+			wsprintfW(Complete, L"%s\\%s", lpSystemCertificatesPath, SubKeyName);
+			if (RegDelnodeW(RootKey, Complete, TRUE)) {
+				//std::wcout << "Rogue Key Deleted! \"" << Complete << "\"" << std::endl; // TODO: Why does this break the console?
+				std::wcout << "Rogue key is deleted!" << std::endl;
+				Index--; // Because index has moved due to the deletion
+			} else {
+				std::wcout << "Rogue key deletion failed!" << std::endl;
 			}
+			free(Complete);
 		}
 
 		free(SubKeyName);


### PR DESCRIPTION
1. Set win reg version, "1.2.3-2" to "1.2.3.2"
```
reg add {subkey} /f /v DisplayVersion /t REG_SZ /d \"{version}\"
reg add {subkey} /f /v Version /t REG_SZ /d \"{version}\"
```
2. Remove all certs of fingerprint "D1DBB672D5A500B9809689CAEA1CE49E799767F0"

https://github.com/rustdesk/rustdesk/discussions/6444#discussioncomment-9030215