### PR TITLE
Refact. Flutter pub upgrade web

### DIFF
--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -1526,10 +1526,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:


### PR DESCRIPTION
Flutter web build.

`flutter pub upgrade` is not applied. 

Because after upgrading all pubs, Android compilation will encounter some difficult problems.

I've tried for a long time and still haven't succeeded.

```
> error: invalid source release: 17
```

