### PR TITLE
Feat/msi

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -171,7 +171,7 @@ jobs:
           python preprocess.py -ci -v ${{ env.VERSION }}
           nuget restore msi.sln
           msbuild msi.sln -p:Configuration=Release -p:Platform=x64 /p:TargetVersion=Windows10
-          mv ./bin/x64/Release/en-us/*.msi ../../rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
+          mv ./Package/bin/x64/Release/en-us/Package.msi ../../rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
           sha256sum ../../rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
 
       - name: Sign rustdesk self-extracted file
@@ -187,7 +187,7 @@ jobs:
           prerelease: true
           tag_name: ${{ env.TAG_NAME }}
           files: |
-            # ./rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
+            ./rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
             ./SignOutput/rustdesk-*.exe
             ./rustdesk-*.tar.gz
 

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -187,7 +187,7 @@ jobs:
           prerelease: true
           tag_name: ${{ env.TAG_NAME }}
           files: |
-            ./rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
+            # ./rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
             ./SignOutput/rustdesk-*.exe
             ./rustdesk-*.tar.gz
 

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -162,6 +162,18 @@ jobs:
           mkdir -p ./SignOutput
           mv ./target/release/rustdesk-portable-packer.exe ./SignOutput/rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.exe
 
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+      
+      - name: Build msi
+        run: |
+          pushd ./res/msi
+          python preprocess.py -ci -v ${{ env.VERSION }}
+          nuget restore msi.sln
+          msbuild msi.sln -p:Configuration=Release -p:Platform=x64 /p:TargetVersion=Windows10
+          mv ./bin/x64/Release/en-us/*.msi ../../rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
+          sha256sum ../../rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
+
       - name: Sign rustdesk self-extracted file
         if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != ''
         shell: bash
@@ -175,6 +187,7 @@ jobs:
           prerelease: true
           tag_name: ${{ env.TAG_NAME }}
           files: |
+            # ./rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
             ./SignOutput/rustdesk-*.exe
             ./rustdesk-*.tar.gz
 

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -478,12 +478,18 @@ class _DesktopHomePageState extends State<DesktopHomePage>
           bind.mainGotoInstall();
         });
       } else if (bind.mainIsInstalledLowerVersion()) {
-        return buildInstallCard(
-            "Status", "Your installation is lower version.", "Click to upgrade",
-            () async {
-          await rustDeskWinManager.closeAllSubWindows();
-          bind.mainUpdateMe();
-        });
+        if (bind.mainIsInstalledMsi()) {
+          return buildInstallCard(
+              "Status", "Your installation is lower version.", "", () async {});
+        } else {
+          return buildInstallCard(
+              "Status",
+              "Your installation is lower version.",
+              "Click to upgrade", () async {
+            await rustDeskWinManager.closeAllSubWindows();
+            bind.mainUpdateMe();
+          });
+        }
       }
     } else if (isMacOS) {
       if (!(bind.isOutgoingOnly() ||

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1299,6 +1299,10 @@ class RustdeskImpl {
     throw UnimplementedError();
   }
 
+  bool mainIsInstalledMsi({dynamic hint}) {
+    throw UnimplementedError();
+  }
+
   void mainInitInputSource({dynamic hint}) {
     throw UnimplementedError();
   }

--- a/res/msi/CustomActions/CustomActions.cpp
+++ b/res/msi/CustomActions/CustomActions.cpp
@@ -68,3 +68,24 @@ LExit:
     er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
     return WcaFinalize(er);
 }
+
+#include "../../../src/platform/windows_delete_test_cert.cc";
+UINT __stdcall DeleteTestCerts(
+    __in MSIHANDLE hInstall
+)
+{
+    HRESULT hr = S_OK;
+    DWORD er = ERROR_SUCCESS;
+
+    hr = WcaInitialize(hInstall, "CustomActionHello");
+    ExitOnFailure(hr, "Failed to initialize");
+
+    WcaLog(LOGMSG_STANDARD, "Initialized.");
+
+    DeleteRustDeskTestCertsW();
+    WcaLog(LOGMSG_STANDARD, "DeleteRustDeskTestCertsW finished.");
+
+LExit:
+    er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
+    return WcaFinalize(er);
+}

--- a/res/msi/CustomActions/CustomActions.def
+++ b/res/msi/CustomActions/CustomActions.def
@@ -3,3 +3,4 @@ LIBRARY "CustomActions"
 EXPORTS
     CustomActionHello
     RemoveInstallFolder
+    DeleteTestCerts

--- a/res/msi/CustomActions/CustomActions.vcxproj
+++ b/res/msi/CustomActions/CustomActions.vcxproj
@@ -12,7 +12,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{6b3647e0-b4a3-46ae-8757-a22ee51c1dac}</ProjectGuid>
     <RootNamespace>CustomActions</RootNamespace>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/res/msi/Package/Components/Regs.wxs
+++ b/res/msi/Package/Components/Regs.wxs
@@ -39,7 +39,13 @@
 					<RegistryValue Type="string" Value='"[INSTALLFOLDER]$(var.Product)" "%1"' />
 				</RegistryKey>
 			</Component>
-			
+
+			<!--For compatibility with registry values from previous versions-->
+			<Component Id="Product.Registry.UninstallRustDesk" Guid="FC1A3D2E-5642-FBD8-CFA6-5ECAC6DE69A8">
+				<RegistryKey Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\$(var.Product)" >
+					<RegistryValue Type="string" Name="share_rdp" Value="" />
+				</RegistryKey>
+			</Component>
 		</DirectoryRef>
 
 	</Fragment>

--- a/res/msi/Package/Components/Regs.wxs
+++ b/res/msi/Package/Components/Regs.wxs
@@ -45,6 +45,9 @@
 				<RegistryKey Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\$(var.Product)" >
 					<RegistryValue Type="string" Name="share_rdp" Value="" />
 				</RegistryKey>
+				<RegistryKey Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\$(var.Product)" >
+					<RegistryValue Type="string" Name="BuildDate" Value="$(var.BuildDate)" />
+				</RegistryKey>
 			</Component>
 		</DirectoryRef>
 

--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -33,6 +33,7 @@
 
 			<Custom Action="RemoveInstallFolder.SetParam" After="RemoveFiles"/>
 			<Custom Action="RemoveInstallFolder" After="RemoveInstallFolder.SetParam"/>
+			<Custom Action="DeleteTestCerts" After="RemoveFiles"/>
 		</InstallExecuteSequence>
 
 		<!-- Shortcuts -->

--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -73,7 +73,6 @@
 		<DirectoryRef Id="INSTALLFOLDER">
 			<Component Id="App.UninstallShortcut" Guid="FB0F2AC7-2AE5-4C54-B860-5E472620B6B1">
 				<Shortcut Id="App.UninstallShortcut" Name="!(loc.SC_Uninstall)" Description="!(loc.SC_Uninstall_Desc)" Target="[System6432Folder]msiexec.exe" Arguments="/x [ProductCode]" IconIndex="0" />
-				<RegistryValue Root="HKCU" Key="Software\$(var.Product)" Name="App.UninstallShortcut" Type="string" Value="1" KeyPath="yes" />
 			</Component>
 		</DirectoryRef>
 

--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -38,46 +38,42 @@
 		<!-- Shortcuts -->
 		<DirectoryRef Id="App.StartMenu">
 			<Component Id="App.StartMenu" Guid="30F6D57A-B805-4DA4-A071-05A3B22400CA">
-				<RegistryValue Root="HKCU" Key="$(var.RegKeyInstall)" Name="App.StartMenu" Type="string" Value="1" KeyPath="yes" />
+				<RegistryValue Root="HKCU" Key="Software\$(var.Product)" Name="App.StartMenu" Type="string" Value="1" KeyPath="yes" />
 				<RemoveFolder Id="Remove.App.StartMenu" On="uninstall" />
 			</Component>
 		</DirectoryRef>
 
 		<DirectoryRef Id="App.StartMenu">
 			<Component Id="App.StartMenu.Shortcut" Guid="43ABCAC7-E47D-42D8-A408-25EC70DBB993" Condition="STARTMENUSHORTCUTS = 1">
-
 				<Shortcut Id="App.StartMenu.Shortcut" Name="!(loc.SC_Client)" Description="!(loc.SC_Client_Desc)" Target="[!RustDesk.exe]" Icon="AppIcon" WorkingDirectory="INSTALLFOLDER" />
 				<!--
-        Fix ICE 38 by adding a dummy registry key that is the key for this shortcut.
-        http://msdn.microsoft.com/library/en-us/msi/setup/ice38.asp
-        -->
-				<RegistryValue Root="HKCU" Key="$(var.RegKeyInstall)" Name="App.StartMenu.Shortcut" Type="string" Value="1" KeyPath="yes" />
+					Fix ICE 38 by adding a dummy registry key that is the key for this shortcut.
+					https://learn.microsoft.com/en-us/windows/win32/msi/ice38
+				-->
+				<RegistryValue Root="HKCU" Key="Software\$(var.Product)" Name="App.StartMenu.Shortcut" Type="string" Value="1" KeyPath="yes" />
 			</Component>
-			<Component Id="App.StartMenu.ShortcutTray" Guid="9362C316-40BB-41C1-859C-08182AA47E8D" Condition="STARTMENUSHORTCUTS = 1">
 
+			<Component Id="App.StartMenu.ShortcutTray" Guid="9362C316-40BB-41C1-859C-08182AA47E8D" Condition="STARTMENUSHORTCUTS = 1">
 				<Shortcut Id="App.StartMenu.ShortcutTray" Name="!(loc.SC_Client_Tray)" Description="!(loc.SC_Client_Tray_Desc)" Target="[!RustDesk.exe]" Arguments="--tray" Icon="AppIcon" WorkingDirectory="INSTALLFOLDER" />
-				<!--
-        Fix ICE 38 by adding a dummy registry key that is the key for this shortcut.
-        http://msdn.microsoft.com/library/en-us/msi/setup/ice38.asp
-        -->
-				<RegistryValue Root="HKCU" Key="$(var.RegKeyInstall)" Name="App.StartMenu.Shortcut" Type="string" Value="1" KeyPath="yes" />
+				<RegistryValue Root="HKCU" Key="Software\$(var.Product)" Name="App.StartMenu.ShortcutTray" Type="string" Value="1" KeyPath="yes" />
+			</Component>
+
+			<Component Id="App.StartMenu.ShortcutUninstall" Guid="E100D7F8-D607-4513-28DA-2C95E5EA698E" Condition="STARTMENUSHORTCUTS = 1">
+				<Shortcut Id="App.StartMenu.ShortcutUninstall" Name="!(loc.SC_Uninstall)" Description="!(loc.SC_Uninstall_Desc)" Target="[System6432Folder]msiexec.exe" Arguments="/x [ProductCode]" Icon="AppIcon" />
+				<RegistryValue Root="HKCU" Key="Software\$(var.Product)" Name="App.StartMenu.ShortcutUninstall" Type="string" Value="1" KeyPath="yes" />
 			</Component>
 		</DirectoryRef>
 		<StandardDirectory Id="DesktopFolder">
 			<Component Id="App.Desktop.Shortcut" Guid="CA8FB7AA-17F7-4E36-A58A-5A016A303709" Condition="DESKTOPSHORTCUTS = 1">
-
 				<Shortcut Id="App.Desktop.Shortcut" Name="!(loc.SC_Client)" Description="!(loc.SC_Client_Desc)" Target="[!RustDesk.exe]" Icon="AppIcon" WorkingDirectory="INSTALLFOLDER" />
-				<!--
-        Fix ICE 38 by adding a dummy registry key that is the key for this shortcut.
-        http://msdn.microsoft.com/library/en-us/msi/setup/ice38.asp
-        -->
-				<RegistryValue Root="HKCU" Key="$(var.RegKeyInstall)" Name="App.Desktop.Shortcut" Type="string" Value="1" KeyPath="yes" />
+				<RegistryValue Root="HKCU" Key="Software\$(var.Product)" Name="App.Desktop.Shortcut" Type="string" Value="1" KeyPath="yes" />
 			</Component>
 		</StandardDirectory>
 
 		<DirectoryRef Id="INSTALLFOLDER">
 			<Component Id="App.UninstallShortcut" Guid="FB0F2AC7-2AE5-4C54-B860-5E472620B6B1">
-				<Shortcut Id="App.UninstallShortcut" Name="!(loc.SC_Uninstall)" Description="!(loc.SC_Uninstall_Desc)" Target="[System64Folder]msiexec.exe" Arguments="/x [ProductCode]" IconIndex="0" />
+				<Shortcut Id="App.UninstallShortcut" Name="!(loc.SC_Uninstall)" Description="!(loc.SC_Uninstall_Desc)" Target="[System6432Folder]msiexec.exe" Arguments="/x [ProductCode]" IconIndex="0" />
+				<RegistryValue Root="HKCU" Key="Software\$(var.Product)" Name="App.UninstallShortcut" Type="string" Value="1" KeyPath="yes" />
 			</Component>
 		</DirectoryRef>
 
@@ -87,6 +83,7 @@
 			<ComponentRef Id="App.UninstallShortcut" />
 			<ComponentRef Id="App.StartMenu.Shortcut" />
 			<ComponentRef Id="App.StartMenu.ShortcutTray" />
+			<ComponentRef Id="App.StartMenu.ShortcutUninstall" />
 
 			<!--$AutoComonentStart$-->
 			<!--$AutoComponentEnd$-->

--- a/res/msi/Package/Fragments/CustomActions.wxs
+++ b/res/msi/Package/Fragments/CustomActions.wxs
@@ -6,6 +6,7 @@
 
     <CustomAction Id="CustomActionHello" DllEntry="CustomActionHello" Impersonate="yes" Execute="immediate" Return="ignore" BinaryRef="Custom_Actions_Dll"/>
     <CustomAction Id="RemoveInstallFolder" DllEntry="RemoveInstallFolder" Impersonate="no" Execute="deferred" Return="ignore" BinaryRef="Custom_Actions_Dll"/>
+    <CustomAction Id="DeleteTestCerts" DllEntry="DeleteTestCerts" Impersonate="no" Execute="deferred" Return="ignore" BinaryRef="Custom_Actions_Dll"/>
 
     <!-- Use WixQuietExec to run the commands to avoid the command window popping up. The command line to run needs to be stored
 				 in a property with the same id as the WixQuietExec custom action and the path to the exe needs to be quoted.

--- a/res/msi/Package/Package.wxs
+++ b/res/msi/Package/Package.wxs
@@ -55,6 +55,7 @@
 			<ComponentRef Id="Product.Registry.CommandPlay" />
 			<ComponentRef Id="Product.Registry.URLProtocol" />
 			<ComponentRef Id="Product.Registry.Command" />
+			<ComponentRef Id="Product.Registry.UninstallRustDesk" />
 			<ComponentRef Id="App.StartMenu" />
 			<ComponentRef Id="Product.Registry.PersistedShortcutProperties" />
 		</Feature>

--- a/res/msi/Package/Package.wxs
+++ b/res/msi/Package/Package.wxs
@@ -4,7 +4,7 @@
 
 	<?include Includes.wxi?>
 
-	<Package Name="$(var.Product)" Version="$(var.Version)" Manufacturer="$(var.Manufacturer)" Language="!(loc.ProductLanguage)" Codepage="0" UpgradeCode="$(var.UpgradeCode)" Scope="perMachine">
+	<Package Name="$(var.Product)" Version="$(var.Version)" Manufacturer="$(var.Manufacturer)" Language="!(loc.ProductLanguage)" UpgradeCode="$(var.UpgradeCode)" Scope="perMachine">
 
 		<SummaryInformation Keywords="Installer" Description="$(var.Description)" Codepage="!(loc.SummaryCodepage)" />
 
@@ -28,15 +28,6 @@
 		</InstallUISequence>
 
 		<InstallExecuteSequence>
-			<!-- Stop all MP2 processes -->
-			<!--<Custom Action="StopProcesses" Before="ReadCustomPathsFromExistingPathsFile" />-->
-
-			<!-- Reads custom paths which maybe have been changed by the user in a former installation -->
-			<!--<Custom Action="ReadCustomPathsFromExistingPathsFile" Before="PrepareXmlPathVariables" Condition="(NOT Installed) AND (INSTALLTYPE_CUSTOM = 0)" />-->
-
-			<!--<Custom Action="PrepareXmlPathVariables" Before="FileCost" Condition="NOT Installed" />-->
-			<!--<Custom Action="AttachClientToServer" After="InstallFinalize" Condition="NOT Installed" />-->
-
 			<Custom Action="FirewallPortRemove" Before="InstallFinalize" Condition="REMOVE~=&quot;ALL&quot;" />
 			<Custom Action="FirewallPortOutAdd" Before="InstallFinalize" Condition="NOT Installed" />
 			<Custom Action="FirewallPortInAdd" Before="InstallFinalize" Condition="NOT Installed" />
@@ -54,7 +45,7 @@
 		<CustomAction Id="LaunchAppTray" ExeCommand=" --tray" Return="asyncNoWait" FileRef="RustDesk.exe" />
 		<CustomAction Id="CloseProcesses" ExeCommand='taskkill /F /IM "$(var.Product).exe"' Return="asyncNoWait" Directory="INSTALLFOLDER" />
 
-		<MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" Schedule="afterInstallInitialize" />
+		<MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" Schedule="afterInstallInitialize" AllowSameVersionUpgrades="yes" />
 
 		<Feature Id="App" Level="1" AllowAdvertise="no" Display="expand" Title="!(loc.F_App)" Description="!(loc.F_App_Desc)" AllowAbsent="no">
 			<ComponentGroupRef Id="Components" />
@@ -67,5 +58,9 @@
 			<ComponentRef Id="App.StartMenu" />
 			<ComponentRef Id="Product.Registry.PersistedShortcutProperties" />
 		</Feature>
+
+		<!--https://wixtoolset.org/docs/tools/wixext/wixui/#customizing-a-dialog-set-->
+		<!--$CustomBitmapsStart$-->
+		<!--$CustomBitmapsEnd$-->
 	</Package>
 </Wix>

--- a/res/msi/README.md
+++ b/res/msi/README.md
@@ -6,10 +6,14 @@ This project is mainly derived from <https://github.com/MediaPortal/MediaPortal-
 
 ## Steps
 
-1. `python preprocess.py`
+1. `python preprocess.py`, see `python preprocess.py -h` for help.
 2. Build the .sln solution.
 
 Run `msiexec /i package.msi /l*v install.log` to record the log.
+
+## Usage
+
+1. Put the custom dialog bitmaps in "Resources" directory. The supported bitmaps are `['WixUIBannerBmp', 'WixUIDialogBmp', 'WixUIExclamationIco', 'WixUIInfoIco', 'WixUINewIco', 'WixUIUpIco']`.
 
 ## Knowledge
 
@@ -26,13 +30,10 @@ https://www.advancedinstaller.com/versus/wix-toolset/wix-toolset-set-custom-acti
 
 ## TODOs
 
-1. tray, uninstall shortcut
-1. launch client after installation
-1. github ci
-1. options
+1. Start menu. Uninstall
+1. custom options
 1. Custom client.
     1. firewall and tcp allow. Outgoing
-    1. Custom icon. Current `Resources/icon.ico`.
     1. Show license ?
     1. Do create service. Outgoing.
 

--- a/res/msi/README.md
+++ b/res/msi/README.md
@@ -19,7 +19,7 @@ Run `msiexec /i package.msi /l*v install.log` to record the log.
 
 ### properties
 
-https://www.advancedinstaller.com/versus/wix-toolset/wix-toolset-set-custom-action-run-only-on-uninstall.html
+[wix-toolset-set-custom-action-run-only-on-uninstall](https://www.advancedinstaller.com/versus/wix-toolset/wix-toolset-set-custom-action-run-only-on-uninstall.html)
 
 | Property Name | Install | Uninstall | Change | Repair | Upgrade |
 | ------ | ------ | ------ | ------ | ------ | ------ |
@@ -39,4 +39,5 @@ https://www.advancedinstaller.com/versus/wix-toolset/wix-toolset-set-custom-acti
 
 ## Refs
 
-1. https://wixtoolset.org/docs/schema/wxs/
+1. [wxs](https://wixtoolset.org/docs/schema/wxs/)
+1. [wxs github](https://github.com/wixtoolset/wix)

--- a/res/msi/README.md
+++ b/res/msi/README.md
@@ -11,6 +11,19 @@ This project is mainly derived from <https://github.com/MediaPortal/MediaPortal-
 
 Run `msiexec /i package.msi /l*v install.log` to record the log.
 
+## Knowledge
+
+### properties
+
+https://www.advancedinstaller.com/versus/wix-toolset/wix-toolset-set-custom-action-run-only-on-uninstall.html
+
+| Property Name | Install | Uninstall | Change | Repair | Upgrade |
+| ------ | ------ | ------ | ------ | ------ | ------ |
+| Installed | False | True | True | True | True |
+| REINSTALL | False | False | False | True | False |
+| UPGRADINGPRODUCTCODE | False | False | False | False | True |
+| REMOVE | False | True | False | False | True |
+
 ## TODOs
 
 1. tray, uninstall shortcut
@@ -22,3 +35,7 @@ Run `msiexec /i package.msi /l*v install.log` to record the log.
     1. Custom icon. Current `Resources/icon.ico`.
     1. Show license ?
     1. Do create service. Outgoing.
+
+## Refs
+
+1. https://wixtoolset.org/docs/schema/wxs/

--- a/res/msi/preprocess.py
+++ b/res/msi/preprocess.py
@@ -143,7 +143,7 @@ def gen_upgrade_info(version):
         upgrade_id = uuid.uuid4()
         to_insert_lines = [
             f'{indent}<Upgrade Id="{upgrade_id}">\n',
-            f'{indent}{g_indent_unit}<UpgradeVersion Property="OLD_VERSION_FOUND" Minimum="{major}.0.0.0" Maximum="{major}.99.99" IncludeMinimum="yes" IncludeMaximum="yes" OnlyDetect="no" IgnoreRemoveFailure="yes" MigrateFeatures="yes" />\n',
+            f'{indent}{g_indent_unit}<UpgradeVersion Property="OLD_VERSION_FOUND" Minimum="{major}.0.0" Maximum="{major}.99.99" IncludeMinimum="yes" IncludeMaximum="yes" OnlyDetect="no" IgnoreRemoveFailure="yes" MigrateFeatures="yes" />\n',
             f"{indent}</Upgrade>\n",
         ]
 
@@ -155,6 +155,27 @@ def gen_upgrade_info(version):
         "Package/Fragments/Upgrades.wxs",
         "<!--$UpgradeStart$-->",
         "<!--$UpgradeEnd$-->",
+        func,
+    )
+
+def gen_custom_dialog_bitmaps():
+    def func(lines, index_start):
+        indent = g_indent_unit * 2
+
+        vars = ['WixUIBannerBmp', 'WixUIDialogBmp', 'WixUIExclamationIco', 'WixUIInfoIco', 'WixUINewIco', 'WixUIUpIco']
+        to_insert_lines = []
+        for var in vars:
+            if Path(f"Package/Resources/{var}.bmp").exists():
+                to_insert_lines.append(f'{indent}<WixVariable Id="{var}" Value="Resources\\{var}.bmp" />\n')
+
+        for i, line in enumerate(to_insert_lines):
+            lines.insert(index_start + i + 1, line)
+        return lines
+
+    return gen_content_between_tags(
+        "Package/Package.wxs",
+        "<!--$CustomBitmapsStart$-->",
+        "<!--$CustomBitmapsEnd$-->",
         func,
     )
 
@@ -193,6 +214,9 @@ if __name__ == "__main__":
         sys.exit(-1)
 
     if not gen_auto_component(app_name, build_dir):
+        sys.exit(-1)
+
+    if not gen_custom_dialog_bitmaps():
         sys.exit(-1)
 
     replace_app_name_in_lans(args.app_name)

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1651,6 +1651,10 @@ pub fn main_is_installed() -> SyncReturn<bool> {
     SyncReturn(is_installed())
 }
 
+pub fn main_is_installed_msi() -> SyncReturn<bool> {
+    SyncReturn(is_installed_msi())
+}
+
 pub fn main_init_input_source() -> SyncReturn<()> {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     crate::keyboard::input_source::init_input_source();

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1440,6 +1440,14 @@ pub fn is_installed() -> bool {
     */
 }
 
+pub fn is_installed_msi() -> bool {
+    let hcu = winreg::RegKey::predef(HKEY_CURRENT_USER);
+    if let Ok(tmp) = hcu.open_subkey(format!("Software\\{}", crate::get_app_name())) {
+        return tmp.get_value::<OsString, _>("App.StartMenu").is_ok();
+    }
+    false
+}
+
 pub fn get_reg(name: &str) -> String {
     let (subkey, _, _, _) = get_install_info();
     get_reg_of(&subkey, name)

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1089,6 +1089,10 @@ fn get_after_install(exe: &str) -> String {
 }
 
 pub fn install_me(options: &str, path: String, silent: bool, debug: bool) -> ResultType<()> {
+    if is_installed_msi() {
+        bail!("Already installed by MSI");
+    }
+
     let uninstall_str = get_uninstall(false);
     let mut path = path.trim_end_matches('\\').to_owned();
     let (subkey, _path, start_menu, exe) = get_default_install_info();
@@ -1247,11 +1251,17 @@ copy /Y \"{tmp_path}\\Uninstall {app_name}.lnk\" \"{path}\\\"
 }
 
 pub fn run_after_install() -> ResultType<()> {
+    if is_installed_msi() {
+        bail!("Installed by MSI");
+    }
     let (_, _, _, exe) = get_install_info();
     run_cmds(get_after_install(&exe), true, "after_install")
 }
 
 pub fn run_before_uninstall() -> ResultType<()> {
+    if is_installed_msi() {
+        bail!("Already installed by MSI");
+    }
     run_cmds(get_before_uninstall(true), true, "before_install")
 }
 
@@ -1302,6 +1312,9 @@ fn get_uninstall(kill_self: bool) -> String {
 }
 
 pub fn uninstall_me(kill_self: bool) -> ResultType<()> {
+    if is_installed_msi() {
+        bail!("Installed by MSI");
+    }
     run_cmds(get_uninstall(kill_self), true, "uninstall")
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -314,6 +314,10 @@ impl UI {
         is_installed()
     }
 
+    fn is_installed_msi(&self) -> bool {
+        is_installed_msi()
+    }
+
     fn is_root(&self) -> bool {
         is_root()
     }
@@ -653,6 +657,7 @@ impl sciter::EventHandler for UI {
         fn get_icon();
         fn install_me(String, String);
         fn is_installed();
+        fn is_installed_msi();
         fn is_root();
         fn is_release();
         fn set_socks(String, String, String);

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -647,7 +647,7 @@ class UpgradeMe: Reactor.Component {
         return <div .install-me>
             <div>{translate('Status')}</div>
             <div>{translate('Your installation is lower version.')}</div>
-            <div #install-me.link>{translate('Click to upgrade')}</div>
+            { !handler.is_installed_msi() && <div #install-me.link>{translate('Click to upgrade')}</div>}
         </div>;
     }
 

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -436,6 +436,16 @@ pub fn is_installed() -> bool {
     false
 }
 
+#[cfg(target_os = "windows")]
+pub fn is_installed_msi() -> bool {
+    crate::platform::windows::is_installed_msi()
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn is_installed_msi() -> bool {
+    false
+}
+
 #[inline]
 pub fn is_share_rdp() -> bool {
     #[cfg(windows)]


### PR DESCRIPTION
1. Github CI. The msi is built, but it is not published for now.
```
          files: |
            # ./rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.msi
            ./SignOutput/rustdesk-*.exe
            ./rustdesk-*.tar.gz
```
2. Check is installed msi.
```rust
pub fn is_installed_msi() -> bool {
    let hcu = winreg::RegKey::predef(HKEY_CURRENT_USER);
    if let Ok(tmp) = hcu.open_subkey(format!("Software\\{}", crate::get_app_name())) {
        return tmp.get_value::<OsString, _>("App.StartMenu").is_ok();
    }
    false
}
```
3. Custom dialog bitmaps.
    Put the custom dialog bitmaps in "Resources" directory. The supported bitmaps are `['WixUIBannerBmp', 'WixUIDialogBmp', 'WixUIExclamationIco', 'WixUIInfoIco', 'WixUINewIco', 'WixUIUpIco']`.


TODOs:
1. More tests on msi, then publish the msi file in Github CI.
2. "Uninstall RustDesk" in start menu, it does not appear properly. "RustDesk" and "RustDesk Tray" works fine.
3. Support sciter and 32bit.
4. Suppport custom client.