### PR TITLE
fix: do not call WakeLock on Web (mobile)

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -68,7 +68,7 @@ class _RemotePageState extends State<RemotePage> {
       gFFI.dialogManager
           .showLoading(translate('Connecting...'), onCancel: closeConnection);
     });
-    if (isMobile) { // == !isWeb
+    if (!isWeb) {
       WakelockPlus.enable();
     }
     _physicalFocusNode.requestFocus();
@@ -97,7 +97,7 @@ class _RemotePageState extends State<RemotePage> {
     gFFI.dialogManager.dismissAll();
     await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
         overlays: SystemUiOverlay.values);
-    if (isMobile) { // == !isWeb
+    if (!isWeb) {
       await WakelockPlus.disable();
     }
     await keyboardSubscription.cancel();

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -68,7 +68,9 @@ class _RemotePageState extends State<RemotePage> {
       gFFI.dialogManager
           .showLoading(translate('Connecting...'), onCancel: closeConnection);
     });
-    WakelockPlus.enable();
+    if (isMobile) { // == !isWeb
+      WakelockPlus.enable();
+    }
     _physicalFocusNode.requestFocus();
     gFFI.inputModel.listenToMouse(true);
     gFFI.qualityMonitorModel.checkShowQualityMonitor(sessionId);
@@ -95,7 +97,9 @@ class _RemotePageState extends State<RemotePage> {
     gFFI.dialogManager.dismissAll();
     await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
         overlays: SystemUiOverlay.values);
-    await WakelockPlus.disable();
+    if (isMobile) { // == !isWeb
+      await WakelockPlus.disable();
+    }
     await keyboardSubscription.cancel();
     removeSharedStates(widget.id);
   }


### PR DESCRIPTION
While doing tests and researchs for #7667 I stumbled upon a small issue

```js
Uncaught ReferenceError: "Wakelock is not defined"
```

I've done the same thing as in `flutter/lib/desktop/pages/remote_page.dart`, making `Wakelock` usage exclusive to non-web apps https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/desktop/pages/remote_page.dart#L128