### PR TITLE
Fix. Msi, error 5 on uninstall

### DIFF
--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -34,7 +34,7 @@
 			<Custom Action="AddFirewallRules.SetParam" Before="InstallFinalize" Condition="NOT Installed"/>
 			<Custom Action="AddFirewallRules" After="AddFirewallRules.SetParam"/>
 
-			<Custom Action="RemoveInstallFolder.SetParam" After="RemoveFiles"/>
+			<Custom Action="RemoveInstallFolder.SetParam" After="RemoveFiles" Condition="Installed AND UPGRADINGPRODUCTCODE" />
 			<Custom Action="RemoveInstallFolder" After="RemoveInstallFolder.SetParam"/>
 			<Custom Action="RemoveFirewallRules.SetParam" Before="RemoveFiles"/>
 			<Custom Action="RemoveFirewallRules" After="RemoveFirewallRules.SetParam"/>
@@ -75,16 +75,16 @@
 			</Component>
 		</StandardDirectory>
 
-		<DirectoryRef Id="INSTALLFOLDER">
+		<!--<DirectoryRef Id="INSTALLFOLDER">
 			<Component Id="App.UninstallShortcut" Guid="FB0F2AC7-2AE5-4C54-B860-5E472620B6B1">
-				<Shortcut Id="App.UninstallShortcut" Name="!(loc.SC_Uninstall)" Description="!(loc.SC_Uninstall_Desc)" Target="[System6432Folder]msiexec.exe" Arguments="/x [ProductCode]" IconIndex="0" />
+				<Shortcut Id="App.UninstallShortcut" Name="!(loc.SC_Uninstall)" Description="!(loc.SC_Uninstall_Desc)" Target="[System6432Folder]msiexec.exe" Arguments="/x [ProductCode]" Icon="AppIcon" />
 			</Component>
-		</DirectoryRef>
+		</DirectoryRef>-->
 
 		<ComponentGroup Id="Components" Directory="INSTALLFOLDER">
 			<ComponentRef Id="RustDesk.exe" />
 			<ComponentRef Id="App.Desktop.Shortcut" />
-			<ComponentRef Id="App.UninstallShortcut" />
+			<!--<ComponentRef Id="App.UninstallShortcut" />-->
 			<ComponentRef Id="App.StartMenu.Shortcut" />
 			<ComponentRef Id="App.StartMenu.ShortcutTray" />
 			<ComponentRef Id="App.StartMenu.ShortcutUninstall" />


### PR DESCRIPTION
Strange access error on uninstall if the install directory is not the default one.

Fix it by commenting "app.Uninstall Shortcut".

![image](https://github.com/rustdesk/rustdesk/assets/13586388/5bd141b0-2b2f-4085-acea-d03bcf95d950)



https://github.com/rustdesk/rustdesk/assets/13586388/a4f50cea-7ce3-416e-a714-a355e1f82523

