### PR TITLE
Fix. Mis, do not InstallValidate when uninstall

### DIFF
--- a/res/msi/Package/Package.wxs
+++ b/res/msi/Package/Package.wxs
@@ -32,6 +32,10 @@
 
 			<InstallExecute After="RemoveExistingProducts" />
 
+			<!--Only do InstallValidate if is not Uninstall-->
+			<!--Do InstallValidate if is Install, Change, Repair, Upgrade-->
+			<InstallValidate Condition="NOT (Installed AND REMOVE AND NOT UPGRADINGPRODUCTCODE )" />
+
 			<Custom Action="TerminateProcesses" Before="RemoveFiles"/>
 			<Custom Action="TerminateProcesses.SetParam" Before="TerminateProcesses"/>
 


### PR DESCRIPTION
Skip "InstallValidate" when uninstall.

<img width="363" alt="1712848014993" src="https://github.com/rustdesk/rustdesk/assets/13586388/afe50bfd-302f-4364-af98-3573bbf760a0">

We can guarantee that the service will be shut down and no related processes will be running.



Then sequence `InstallValidate` --> `InstallInitialize` --> `StopServices` can not be changed.
So the only way is to disable `InstallValidate` when uninstall.

https://github.com/wixtoolset/wix/blob/41e11442b2ca93e444b60213b5ae99dcbab787d8/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerStandard.cs#L318
