### PR TITLE
Fix. Msi, reg add SoftwareSASGeneration

### DIFF
--- a/res/msi/CustomActions/CustomActions.def
+++ b/res/msi/CustomActions/CustomActions.def
@@ -10,3 +10,4 @@ EXPORTS
     CreateStartService
     TryDeleteStartupShortcut
     SetPropertyFromConfig
+    AddRegSoftwareSASGeneration

--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -58,6 +58,8 @@
 			<Custom Action="AddFirewallRules" Before="InstallFinalize"/>
 			<Custom Action="AddFirewallRules.SetParam" Before="AddFirewallRules" Condition="NOT Installed"/>
 
+			<Custom Action="AddRegSoftwareSASGeneration" Before="InstallFinalize" />
+
 			<Custom Action="RemoveInstallFolder" Before="RemoveFiles" Condition="Installed AND NOT UPGRADINGPRODUCTCODE AND REMOVE"/>
 			<Custom Action="RemoveInstallFolder.SetParam" Before="RemoveInstallFolder" Condition="Installed AND NOT UPGRADINGPRODUCTCODE AND REMOVE"/>
 			<Custom Action="TryStopDeleteService" Before="RemoveInstallFolder.SetParam" />

--- a/res/msi/Package/Fragments/CustomActions.wxs
+++ b/res/msi/Package/Fragments/CustomActions.wxs
@@ -15,5 +15,6 @@
 		<CustomAction Id="TryStopDeleteService" DllEntry="TryStopDeleteService" Impersonate="no" Execute="deferred" Return="ignore" BinaryRef="Custom_Actions_Dll"/>
 		<CustomAction Id="TryDeleteStartupShortcut" DllEntry="TryDeleteStartupShortcut" Impersonate="yes" Execute="immediate" Return="ignore" BinaryRef="Custom_Actions_Dll"/>
 		<CustomAction Id="SetPropertyServiceStop" DllEntry="SetPropertyFromConfig" Impersonate="yes" Execute="immediate" Return="ignore" BinaryRef="Custom_Actions_Dll"/>
+		<CustomAction Id="AddRegSoftwareSASGeneration" DllEntry="AddRegSoftwareSASGeneration" Impersonate="no" Execute="deferred" Return="ignore" BinaryRef="Custom_Actions_Dll"/>
 	</Fragment>
 </Wix>


### PR DESCRIPTION
`reg add HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System /f /v SoftwareSASGeneration /t REG_DWORD /d 1`

The registry keys created(updated) by wix v4 will be deleted when uninstalling, rather than restored.
The self-installation method will not change this registray value when uninstalling.
So custom action is used to create the registry value.

There's a strange point is Win API `RegSetValueExW()` always return 998. https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--500-999-#:~:text=ERROR_NOACCESS-,998%20(0x3E6),-Invalid%20access%20to

Then both Win API and `ShellExecuteW()` are used.