### PR TITLE
not use av1 as auto codec on x86 sciter

### DIFF
--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -239,7 +239,8 @@ impl Encoder {
 
         #[allow(unused_mut)]
         let mut auto_codec = CodecName::VP9;
-        if av1_useable {
+        // aom is very slow for x86 sciter version on windows x64
+        if av1_useable && !(cfg!(windows) && std::env::consts::ARCH == "x86") {
             auto_codec = CodecName::AV1;
         }
         let mut system = System::new();


### PR DESCRIPTION
aom is slow for x86 sciter, but I didn't notice much difference after simple test with 32-bit and 64-bit [aomenc ](https://aomedia.googlesource.com/aom/+/refs/heads/main/apps/aomenc.c).
