### PR TITLE
Refact. Win, file copy paste, default true

### DIFF
--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -441,10 +441,12 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
         child: Text(translate('Mute'))));
   }
   // file copy and paste
+  final peerHasFileClipboard = versionCmp(pi.version, '1.2.4') < 0 ||
+      pi.platformAdditions.containsKey(kPlatformAdditionsHasFileClipboard);
   if (ffiModel.keyboard &&
       perms['file'] != false &&
       bind.mainHasFileClipboard() &&
-      pi.platformAdditions.containsKey(kPlatformAdditionsHasFileClipboard)) {
+      peerHasFileClipboard) {
     final enabled = !ffiModel.viewOnly;
     final option = 'enable-file-transfer';
     final value =

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -441,12 +441,17 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
         child: Text(translate('Mute'))));
   }
   // file copy and paste
-  final peerHasFileClipboard = versionCmp(pi.version, '1.2.4') < 0 ||
+  // If the version is less than 1.2.4, file copy and paste is supported on Windows only.
+  final isSupportIfPeer_1_2_3 = versionCmp(pi.version, '1.2.4') < 0 &&
+      isWindows &&
+      pi.platform == kPeerPlatformWindows;
+  // If the version is 1.2.4 or later, file copy and paste is supported when kPlatformAdditionsHasFileClipboard is set.
+  final isSupportIfPeer_1_2_4 = versionCmp(pi.version, '1.2.4') >= 0 &&
+      bind.mainHasFileClipboard() &&
       pi.platformAdditions.containsKey(kPlatformAdditionsHasFileClipboard);
   if (ffiModel.keyboard &&
       perms['file'] != false &&
-      bind.mainHasFileClipboard() &&
-      peerHasFileClipboard) {
+      (isSupportIfPeer_1_2_3 || isSupportIfPeer_1_2_4)) {
     final enabled = !ffiModel.viewOnly;
     final option = 'enable-file-transfer';
     final value =

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1561,6 +1561,7 @@ impl UserDefaultConfig {
             }
             "custom_image_quality" => self.get_double_string(key, 50.0, 10.0, 0xFFF as f64),
             "custom-fps" => self.get_double_string(key, 30.0, 5.0, 120.0),
+            "enable_file_transfer" => self.get_string(key, "Y", vec![""]),
             _ => self
                 .get_after(key)
                 .map(|v| v.to_string())


### PR DESCRIPTION
1. Set "file copy and paste", option default "true".
2. Fix. File copy and maste, remote toolbar menu. Compatible with 1.2.3.