### PR TITLE
Refact. SAS

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:uuid/uuid.dart';
 import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/foundation.dart';
@@ -1009,6 +1010,14 @@ class CustomAlertDialog extends StatelessWidget {
           buttonPadding: MyTheme.dialogButtonPadding),
     );
   }
+}
+
+void msgBoxMainWindow(String title, String type, String text, String link,
+    OverlayDialogManager dialogManager,
+    {bool? hasCancel}) {
+  msgBox(UuidValue('00000000-0000-0000-0000-000000000000'), 'custom-$type', title, text,
+      link, dialogManager,
+      hasCancel: hasCancel);
 }
 
 void msgBox(SessionID sessionId, String type, String title, String text,

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -10,6 +10,7 @@ import 'package:flutter_hbb/common/widgets/setting_widgets.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_home_page.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_tab_page.dart';
+import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:flutter_hbb/models/server_model.dart';
 import 'package:flutter_hbb/plugin/manager.dart';
@@ -830,6 +831,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
     bool enabled = !locked;
     return _Card(title: 'Security', children: [
       shareRdp(context, enabled),
+      sas(context, enabled),
       _OptionCheckBox(context, 'Deny LAN discovery', 'enable-lan-discovery',
           reverse: true, enabled: enabled),
       ...directIp(context),
@@ -866,6 +868,51 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
             ],
           ).marginOnly(left: _kCheckBoxLeftMargin),
           onTap: enabled ? () => onChanged(!value) : null),
+    );
+  }
+
+  sas(BuildContext context, bool enabled) {
+    return Consumer<SasModel>(
+      builder: (context, model, child) {
+        onChanged(bool b) async {
+          final res = bind.mainEnableSas(v: b);
+          if (res.isNotEmpty) {
+            msgBoxMainWindow(
+                'Permissions', 'error', res, '', gFFI.dialogManager,
+                hasCancel: false);
+          } else {
+            msgBoxMainWindow(
+              'Permissions',
+              'custom-info-nocancel',
+              b ? 'sas-enabled-tip' : 'sas-disabled-tip',
+              '',
+              gFFI.dialogManager,
+              hasCancel: false,
+            );
+            model.notify();
+          }
+        }
+
+        bool value = bind.mainIsSasEnabled();
+        return Offstage(
+          offstage: !(isWindows && bind.mainIsInstalled()),
+          child: GestureDetector(
+              child: Row(
+                children: [
+                  Checkbox(
+                          value: value,
+                          onChanged: enabled ? (_) => onChanged(!value) : null)
+                      .marginOnly(right: 5),
+                  Expanded(
+                    child: Text(translate('config-sas-tip'),
+                        style: TextStyle(
+                            color: disabledTextColor(context, enabled))),
+                  )
+                ],
+              ).marginOnly(left: _kCheckBoxLeftMargin),
+              onTap: enabled ? () => onChanged(!value) : null),
+        );
+      },
     );
   }
 

--- a/flutter/lib/desktop/pages/desktop_tab_page.dart
+++ b/flutter/lib/desktop/pages/desktop_tab_page.dart
@@ -4,15 +4,18 @@ import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_home_page.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_setting_page.dart';
 import 'package:flutter_hbb/desktop/widgets/tabbar_widget.dart';
+import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
 import 'package:get/get.dart';
+import 'package:provider/provider.dart';
 import 'package:window_manager/window_manager.dart';
 
 import '../../common/shared_state.dart';
 
 class DesktopTabPage extends StatefulWidget {
   const DesktopTabPage({Key? key}) : super(key: key);
+  static SasModel sasModel = SasModel();
 
   @override
   State<DesktopTabPage> createState() => _DesktopTabPageState();
@@ -25,9 +28,12 @@ class DesktopTabPage extends StatefulWidget {
           label: kTabLabelSettingPage,
           selectedIcon: Icons.build_sharp,
           unselectedIcon: Icons.build_outlined,
-          page: DesktopSettingPage(
-            key: const ValueKey(kTabLabelSettingPage),
-            initialPage: initialPage,
+          page: ChangeNotifierProvider.value(
+            value: DesktopTabPage.sasModel,
+            child: DesktopSettingPage(
+              key: const ValueKey(kTabLabelSettingPage),
+              initialPage: initialPage,
+            ),
           )));
     } catch (e) {
       debugPrintStack(label: '$e');
@@ -49,8 +55,11 @@ class _DesktopTabPageState extends State<DesktopTabPage> {
         selectedIcon: Icons.home_sharp,
         unselectedIcon: Icons.home_outlined,
         closable: false,
-        page: DesktopHomePage(
-          key: const ValueKey(kTabLabelHomePage),
+        page: ChangeNotifierProvider.value(
+          value: DesktopTabPage.sasModel,
+          child: DesktopHomePage(
+            key: const ValueKey(kTabLabelHomePage),
+          ),
         )));
     if (bind.isIncomingOnly()) {
       tabController.onSelected = (key) {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2116,6 +2116,10 @@ class ElevationModel with ChangeNotifier {
   onPortableServiceRunning(bool running) => _running = running;
 }
 
+class SasModel with ChangeNotifier {
+  notify() => notifyListeners();
+}
+
 enum ConnType { defaultConn, fileTransfer, portForward, rdp }
 
 /// Flutter state manager and data communication with the Rust core.

--- a/flutter/lib/models/web_model.dart
+++ b/flutter/lib/models/web_model.dart
@@ -157,4 +157,12 @@ class PlatformFFI {
 
   // just for compilation
   void syncAndroidServiceAppDirConfigPath() {}
+
+  bool mainIsSasEnabled({dynamic hint}) {
+    throw UnimplementedError();
+  }
+
+  String mainEnableSas({required bool v, dynamic hint}) {
+    throw UnimplementedError();
+  }
 }

--- a/flutter/lib/models/web_model.dart
+++ b/flutter/lib/models/web_model.dart
@@ -157,12 +157,4 @@ class PlatformFFI {
 
   // just for compilation
   void syncAndroidServiceAppDirConfigPath() {}
-
-  bool mainIsSasEnabled({dynamic hint}) {
-    throw UnimplementedError();
-  }
-
-  String mainEnableSas({required bool v, dynamic hint}) {
-    throw UnimplementedError();
-  }
 }

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1573,5 +1573,13 @@ class RustdeskImpl {
     throw UnimplementedError();
   }
 
+  bool mainIsSasEnabled({dynamic hint}) {
+    throw UnimplementedError();
+  }
+
+  String mainEnableSas({required bool v, dynamic hint}) {
+    throw UnimplementedError();
+  }
+
   void dispose() {}
 }

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -84,6 +84,7 @@ lazy_static::lazy_static! {
     pub static ref APP_HOME_DIR: RwLock<String> = Default::default();
 }
 
+pub const LINK_DOCS_PREFIX: &str = "https://rustdesk.com/docs";
 pub const LINK_DOCS_HOME: &str = "https://rustdesk.com/docs/en/";
 pub const LINK_DOCS_X11_REQUIRED: &str = "https://rustdesk.com/docs/en/manual/linux/#x11-required";
 pub const LINK_HEADLESS_LINUX_SUPPORT: &str =

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1529,7 +1529,7 @@ impl<T: InvokeUiSession> Remote<T> {
                     let mut link = msgbox.link;
                     if let Some(v) = hbb_common::config::HELPER_URL.get(&link as &str) {
                         link = v.to_string();
-                    } else {
+                    } else if !link.starts_with(hbb_common::config::LINK_DOCS_PREFIX) {
                         log::warn!("Message box ignore link {} for security", &link);
                         link = "".to_string();
                     }

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2096,6 +2096,14 @@ pub fn main_get_hard_option(key: String) -> SyncReturn<String> {
     SyncReturn(get_hard_option(key))
 }
 
+pub fn main_is_sas_enabled() -> SyncReturn<bool> {
+    SyncReturn(is_sas_enabled())
+}
+
+pub fn main_enable_sas(v: bool) -> SyncReturn<String> {
+    SyncReturn(enable_sas(v))
+}
+
 #[cfg(target_os = "android")]
 pub mod server_side {
     use hbb_common::{config, log};

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "所有人"),
         ("ab_web_console_tip", "打开 Web 控制台以执行更多操作"),
         ("allow-only-conn-window-open-tip", "仅当 RustDesk 窗口打开时允许连接"),
+        ("config-sas-tip", "允许 SAS ，以接收 Ctrl+Alt+Del"),
+        ("sas-enabled-tip", "SAS 已启用，可以接收 Ctrl+Alt+Del"),
+        ("sas-disabled-tip", "SAS 已禁用，不再接收 Ctrl+Alt+Del"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Každý"),
         ("ab_web_console_tip", "Více na webové konzoli"),
         ("allow-only-conn-window-open-tip", "Povolit připojení pouze v případě, že je otevřené okno RustDesk"),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Jeder"),
         ("ab_web_console_tip", "Mehr über Webkonsole"),
         ("allow-only-conn-window-open-tip", "Verbindung nur zulassen, wenn das RustDesk-Fenster geöffnet ist"),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -219,5 +219,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("share_warning_tip", "The fields above are shared and visible to others."),
         ("ab_web_console_tip", "More on web console"),
         ("allow-only-conn-window-open-tip", "Only allow connection if RustDesk window is open"),
+        ("config-sas-tip", "Enable SAS to accept Ctrl+Alt+Del."),
+        ("sas-enabled-tip", "SAS is enabled, Ctrl+Alt+Del can be accepted."),
+        ("sas-disabled-tip", "SAS is disabled, Ctrl+Alt+Del cannot be accepted."),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Todos"),
         ("ab_web_console_tip", "Más en consola web"),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "هر کس"),
         ("ab_web_console_tip", "اطلاعات بیشتر در کنسول وب"),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Svatko"),
         ("ab_web_console_tip", "Više na web konzoli"),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Everyone"),
         ("ab_web_console_tip", "Altre info sulla console web"),
         ("allow-only-conn-window-open-tip", "Consenti la connessione solo se la finestra RustDesk è aperta"),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Visi"),
         ("ab_web_console_tip", "Vairāk par tīmekļa konsoli"),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Iedereen"),
         ("ab_web_console_tip", "Meer over de webconsole"),
         ("allow-only-conn-window-open-tip", "Alleen verbindingen toestaan als het RustDesk-venster geopend is"),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Todos"),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Все"),
         ("ab_web_console_tip", "Больше в веб-консоли"),
         ("allow-only-conn-window-open-tip", "Разрешать подключение только при открытом окне RustDesk"),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Každý"),
         ("ab_web_console_tip", "Viac na webovej konzole"),
         ("allow-only-conn-window-open-tip", "Povoliť pripojenie iba vtedy, ak je otvorené okno aplikácie RustDesk"),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "所有人"),
         ("ab_web_console_tip", "打開 Web 控制台以進行更多操作"),
         ("allow-only-conn-window-open-tip", "只在 RustDesk 視窗開啟時允許連接"),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", "Всі"),
         ("ab_web_console_tip", "Детальніше про веб-консоль"),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -601,5 +601,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Everyone", ""),
         ("ab_web_console_tip", ""),
         ("allow-only-conn-window-open-tip", ""),
+        ("config-sas-tip", ""),
+        ("sas-enabled-tip", ""),
+        ("sas-disabled-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -764,6 +764,10 @@ impl Connection {
                         handle_mouse(&msg, id);
                     }
                     MessageInput::Key((mut msg, press)) => {
+                        if try_handle_ctrl_alt_del(&msg, &tx) {
+                            continue;
+                        }
+
                         // todo: press and down have similar meanings.
                         if press && msg.mode.enum_value() == Ok(KeyboardMode::Legacy) {
                             msg.down = true;

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1330,16 +1330,15 @@ pub fn try_handle_ctrl_alt_del(evt: &KeyEvent, tx: &Sender) -> bool {
     if let Some(key_event::Union::ControlKey(ck)) = evt.union {
         if ck.value() == ControlKey::CtrlAltDel.value() {
             #[cfg(target_os = "windows")]
-            let res = send_sas();
-            #[cfg(not(target_os = "windows"))]
-            let res = Ok(());
-            if let Err(e) = res {
+            if let Err(e) = send_sas() {
                 let mut msg_out = Message::new();
                 msg_out.set_message_box(MessageBox {
                     msgtype: "custom-error-nocancel".to_owned(),
                     title: "Permissions".to_owned(),
                     text: e.to_string(),
-                    link: "https://rustdesk.com/docs/en/client/windows/#sas-secure-attention-sequence".to_owned(),
+                    link:
+                        "https://rustdesk.com/docs/en/client/windows/#sas-secure-attention-sequence"
+                            .to_owned(),
                     ..Default::default()
                 });
                 tx.send((Instant::now().into(), Arc::new(msg_out))).ok();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -314,6 +314,14 @@ impl UI {
         is_installed()
     }
 
+    fn is_sas_enabled(&self) -> bool {
+        is_sas_enabled()
+    }
+
+    fn enable_sas(&self, v: bool) -> String {
+        enable_sas(v)
+    }
+
     fn is_root(&self) -> bool {
         is_root()
     }
@@ -653,6 +661,8 @@ impl sciter::EventHandler for UI {
         fn get_icon();
         fn install_me(String, String);
         fn is_installed();
+        fn is_sas_enabled();
+        fn enable_sas(bool);
         fn is_root();
         fn is_release();
         fn set_socks(String, String, String);

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -86,6 +86,25 @@ class ShareRdp: Reactor.Component {
     }
 }
 
+class Sas: Reactor.Component {
+    function render() {
+        var sas_string = translate("config-sas-tip");
+        var cls = handler.is_sas_enabled()  ? "selected" : "line-through";
+        return <li class={cls}><span>{svg_checkmark}</span>{sas_string}</li>;
+    }
+    
+    function onClick() {
+        var v = !handler.is_sas_enabled();
+        var res = handler.enable_sas(v);
+        if (res == '') {
+            msgbox('custom-info-nocancel', translate('Info'), translate(v ? 'sas-enabled-tip' : 'sas-disabled-tip'));
+            app.update();
+        } else {
+            msgbox('custom-error', translate('Error'), res);
+        }
+    }
+}
+
 var direct_server;
 class DirectServer: Reactor.Component {
     function this() {
@@ -319,6 +338,7 @@ class MyIdMenu: Reactor.Component {
                 <div .separator />
                 <li #stop-service class={service_stopped ? "line-through" : "selected"}><span>{svg_checkmark}</span>{translate("Enable service")}</li>
                 {is_win && handler.is_installed() ? <ShareRdp /> : ""}
+                {is_win && handler.is_installed() ? <Sas /> : ""}
                 <DirectServer />
                 {false && handler.using_public_server() && <li #allow-always-relay><span>{svg_checkmark}</span>{translate('Always connect via relay')}</li>}
                 {handler.is_ok_change_id() ? <div .separator /> : ""}
@@ -567,6 +587,7 @@ class App: Reactor.Component
                     {!is_win || handler.is_installed() ? "": <InstallMe />}
                     {software_update_url ? <UpdateMe /> : ""}
                     {is_win && handler.is_installed() && !software_update_url && handler.is_installed_lower_version() ? <UpgradeMe /> : ""}
+                    {is_win && handler.is_installed() && !handler.is_sas_enabled() ? <SasCard /> : ""}
                     {is_can_screen_recording ? "": <CanScreenRecording />}
                     {is_can_screen_recording && !handler.is_process_trusted(false) ? <TrustMe /> : ""}
                     {!service_stopped && is_can_screen_recording && handler.is_process_trusted(false) && handler.is_installed() && !handler.is_installed_daemon(false) ? <InstallDaemon /> : ""}
@@ -694,6 +715,26 @@ class UpdateMe: Reactor.Component {
             url,
             self.url(path),
             onsuccess, onerror, onprogress);
+    }
+}
+
+class SasCard: Reactor.Component {
+    function render() {
+        return <div .install-me>
+            <div>{translate('Permissions')}</div>
+            <div>{translate('config-sas-tip')}</div>
+            <div #install-me.link>{translate('Enable')}</div>
+        </div>;
+    }
+
+    event click $(#install-me) {
+        var res = handler.enable_sas(true);
+        if (res == '') {
+            msgbox('custom-info-nocancel', translate('Info'), translate('sas-enabled-tip'));
+            app.update();
+        } else {
+            msgbox('custom-error', translate('Error'), res);
+        }
     }
 }
 

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -436,6 +436,26 @@ pub fn is_installed() -> bool {
     false
 }
 
+#[cfg(target_os = "windows")]
+pub fn is_sas_enabled() -> bool {
+    crate::platform::windows::is_sas_enabled()
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn is_sas_enabled() -> bool {
+    false
+}
+
+#[cfg(target_os = "windows")]
+pub fn enable_sas(v: bool) -> String {
+    ipc::enable_sas(v, 1000).unwrap_or_else(|e| e.to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn enable_sas() -> String {
+    "".to_owned()
+}
+
 #[inline]
 pub fn is_share_rdp() -> bool {
     #[cfg(windows)]

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -452,7 +452,7 @@ pub fn enable_sas(v: bool) -> String {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn enable_sas() -> String {
+pub fn enable_sas(_v: bool) -> String {
     "".to_owned()
 }
 


### PR DESCRIPTION
1. Remove registry setting `SoftwareSASGeneration` when install.
2. Switch [`SAS`](https://learn.microsoft.com/en-us/windows/win32/secgloss/s-gly#:~:text=clients%20and%20servers.-,secure%20attention%20sequence,-(SAS)%20A%20key) manually.


https://github.com/rustdesk/rustdesk/assets/13586388/60047bc4-85d2-4012-a11c-ba58f65f1ddb



https://github.com/rustdesk/rustdesk/assets/13586388/0dbd0716-0eb4-44e2-a217-a5f03de6297d


**Note**: A new docs link is introduced. The related docs will be updated later.
