### PR TITLE
Fedora build fixes

### DIFF
--- a/flutter/linux/CMakeLists.txt
+++ b/flutter/linux/CMakeLists.txt
@@ -15,6 +15,7 @@ cmake_policy(SET CMP0063 NEW)
 
 # Load bundled libraries from the lib/ directory relative to the binary.
 set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 
 # Root filesystem for cross-building.
 if(FLUTTER_TARGET_PLATFORM_SYSROOT)

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -3,7 +3,7 @@ Version:    1.2.4
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0
-Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libappindicator libvdpau1 libva2 pam gstreamer1-plugins-base
+Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libappindicator libvdpau libva pam gstreamer1-plugins-base
 
 %description
 The best open-source remote desktop client software, written in Rust.
@@ -38,7 +38,6 @@ install $HBB/res/rustdesk-link.desktop %{buildroot}/usr/share/rustdesk/files/
 /usr/share/icons/hicolor/scalable/apps/rustdesk.svg
 /usr/share/rustdesk/files/rustdesk.desktop
 /usr/share/rustdesk/files/rustdesk-link.desktop
-/usr/share/rustdesk/files/__pycache__/*
 
 %changelog
 # let's skip this for now


### PR DESCRIPTION
I recently built RustDesk on Fedora 39, and came across a couple of issues. These changes "fixes" the issues, but I'm not sure if the fixes are the best/correct fixes, so you should evaluate them before merging.

### `rpm.spec`
- Dependencies `libvdpau1` and `libva2` doesn't exist in Fedora 39 - but `libvdpau` and `libva` do, and everything seems to be working when using them instead. It's strange that they are there if they never existed though, so maybe there are differences between different distros or distro generations? All I know if that they no longer exist in Fedora 39.
- The reference to `__pycache__` failed simply because there were no files there. I don't know if there used to be files there or if I did something wrong, but the RPM package installs and works just fine without this folder.

### `rpath`s
There are some new restrictions in recent versions of `rpmbuild`, among them that all `rpath`s are checked. This prevents building the package, but actually revealed a problem that is true also for others distros. I don't really understand much about CMake, but the "problem" is introduced with the plugin include `include(flutter/generated_plugins.cmake)`.

The way this works is that `rpath`s are set to their current absolute locations at first, and then corrected to their "final" values when the components are "installed". `set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")` is effectuated only during "installation". But, the included "plugins" are never "installed", so their `rpath`s are never corrected. This means that their `rpath`s remain that of their absolute locations when they were build. This path is obviously invalid once they are installed on another computer.

My workaround is to use the "installed" `rpath`s from the start. It will break the ability to run this before the files are packaged, but I'm not sure if that's an issue or not. The correct "fix" would be to call `install` on these "plugins" in some kind of loop in the script, but I don't know how to do that.

