### PR TITLE
build.py: update system2 function

### DIFF
--- a/build.py
+++ b/build.py
@@ -33,9 +33,9 @@ def get_arch() -> str:
 
 
 def system2(cmd):
-    err = os.system(cmd)
-    if err != 0:
-        print(f"Error occurred when executing: {cmd}. Exiting.")
+    exit_code = os.system(cmd)
+    if exit_code != 0:
+        sys.stderr.write(f"Error occurred when executing: `{cmd}`. Exiting.\n")
         sys.exit(-1)
 
 


### PR DESCRIPTION
`os.system` returns exit code, not an error. IMO it also makes more sense writing it into stderr instead of stdout.