### PR TITLE
enable ffmpeg native h264/h265 software decoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,8 +3024,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.3.0"
-source = "git+https://github.com/21pages/hwcodec#6ce1cbab2ff270a81784303192e8906ef597ee02"
+version = "0.3.1"
+source = "git+https://github.com/21pages/hwcodec#c5d647d1f7506b437e983fe45ed5dc8e4f326e1f"
 dependencies = [
  "bindgen 0.59.2",
  "cc",


### PR DESCRIPTION
It's available on windows, linux x86




https://github.com/rustdesk/rustdesk/assets/14891774/16584833-b8ee-4f7b-8c9d-dd1a2ad14912

