### PR TITLE
Connection dialoge should be centered

### DIFF
--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -258,7 +258,7 @@ showCmWindow({bool isStartup = false}) async {
     ]);
     // ensure initial window size to be changed
     await windowManager.setSizeAlignment(
-        kConnectionManagerWindowSizeClosedChat, Alignment.topRight);
+        kConnectionManagerWindowSizeClosedChat, Alignment.center);
     _isCmReadyToShow = true;
   } else if (_isCmReadyToShow) {
     if (await windowManager.getOpacity() != 1) {
@@ -266,7 +266,7 @@ showCmWindow({bool isStartup = false}) async {
       await windowManager.focus();
       await windowManager.minimize(); //needed
       await windowManager.setSizeAlignment(
-          kConnectionManagerWindowSizeClosedChat, Alignment.topRight);
+          kConnectionManagerWindowSizeClosedChat, Alignment.center);
       windowOnTop(null);
     }
   }


### PR DESCRIPTION
The connection approval dialoge should be center as in other Remote-Apps such as Anydesk. On bigger monitors it is purely annoying and sometimes you do not even look on your top right corner.