### PR TITLE
 fix: Msi custom app, different component guids

### DIFF
--- a/res/msi/README.md
+++ b/res/msi/README.md
@@ -1,6 +1,6 @@
 # RustDesk msi project
 
-Use Visual Studio 2022 to compile this project.
+Use Visual Studio 2019 to compile this project.
 
 This project is mainly derived from <https://github.com/MediaPortal/MediaPortal-2.git> .
 


### PR DESCRIPTION
1. Remove fixed guid for each file component. Because no need to set the fixed guids.
```python
            guid = uuid.uuid5(
                uuid.NAMESPACE_OID, app_name + "/" + str(relative_file_path)
            )
```
2. Set random guid for components of custom client. No need to use the fixed guids.
```python
def replace_component_guids_in_wxs():
    ...
```
3. The other changes are just formatting.