### PR TITLE
Fix. Multi-display connection, resolutions

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -715,6 +715,8 @@ class FfiModel with ChangeNotifier {
     // Map clone is required here, otherwise "evt" may be changed by other threads through the reference.
     // Because this function is asynchronous, there's an "await" in this function.
     cachedPeerData.peerInfo = {...evt};
+    // Do not cache resolutions, because a new display connection have different resolutions.
+    cachedPeerData.peerInfo.remove('resolutions');
 
     // Recent peer is updated by handle_peer_info(ui_session_interface.rs) --> handle_peer_info(client.rs) --> save_config(client.rs)
     bind.mainLoadRecentPeers();
@@ -770,7 +772,9 @@ class FfiModel with ChangeNotifier {
       }
       Map<String, dynamic> features = json.decode(evt['features']);
       _pi.features.privacyMode = features['privacy_mode'] == 1;
-      handleResolutions(peerId, evt["resolutions"]);
+      if (!isCache) {
+        handleResolutions(peerId, evt["resolutions"]);
+      }
       parent.target?.elevationModel.onPeerInfo(_pi);
     }
     if (connType == ConnType.defaultConn) {
@@ -2317,6 +2321,8 @@ class FFI {
           }
           await ffiModel.handleCachedPeerData(data, id);
           await sessionRefreshVideo(sessionId, ffiModel.pi);
+          await bind.sessionRequestInitMsgs(
+              sessionId: sessionId, display: ffiModel.pi.currentDisplay);
         });
         isToNewWindowNotified.value = true;
       }

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2321,7 +2321,7 @@ class FFI {
           }
           await ffiModel.handleCachedPeerData(data, id);
           await sessionRefreshVideo(sessionId, ffiModel.pi);
-          await bind.sessionRequestInitMsgs(
+          await bind.sessionRequestNewDisplayInitMsgs(
               sessionId: sessionId, display: ffiModel.pi.currentDisplay);
         });
         isToNewWindowNotified.value = true;

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1577,7 +1577,7 @@ class RustdeskImpl {
     throw UnimplementedError();
   }
 
-  Future<void> sessionRequestInitMsgs(
+  Future<void> sessionRequestNewDisplayInitMsgs(
       {required UuidValue sessionId, required int display, dynamic hint}) {
     throw UnimplementedError();
   }

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1577,5 +1577,10 @@ class RustdeskImpl {
     throw UnimplementedError();
   }
 
+  Future<void> sessionRequestInitMsgs(
+      {required UuidValue sessionId, required int display, dynamic hint}) {
+    throw UnimplementedError();
+  }
+
   void dispose() {}
 }

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -504,6 +504,11 @@ message Resolution {
   int32 height = 2;
 }
 
+message DisplayResolution {
+  int32 display = 1;
+  Resolution resolution = 2;
+}
+
 message SupportedResolutions { repeated Resolution resolutions = 1; }
 
 message SwitchDisplay {
@@ -736,6 +741,8 @@ message Misc {
     bool portable_service_running = 20;
     SwitchSidesRequest switch_sides_request = 21;
     SwitchBack switch_back = 22;
+    // Deprecated since 1.2.4.
+    // Use change_display_resolution instead
     Resolution change_resolution = 24;
     PluginRequest plugin_request = 25;
     PluginFailure plugin_failure = 26;
@@ -748,6 +755,7 @@ message Misc {
     TogglePrivacyMode toggle_privacy_mode = 33;
     SupportedEncoding supported_encoding = 34;
     uint32 selected_sid = 35;
+    DisplayResolution change_display_resolution = 36;
   }
 }
 

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -721,6 +721,13 @@ message WindowsSessions {
   uint32 current_sid = 2;
 }
 
+// Query a message from peer.
+message MessageQuery {
+  // The SwitchDisplay message of the target display.
+  // If the target display is not found, the message will be ignored.
+  int32 switch_display = 1;
+}
+
 message Misc {
   oneof union {
     ChatMessage chat_message = 4;
@@ -741,8 +748,8 @@ message Misc {
     bool portable_service_running = 20;
     SwitchSidesRequest switch_sides_request = 21;
     SwitchBack switch_back = 22;
-    // Deprecated since 1.2.4.
-    // Use change_display_resolution instead
+    // Deprecated since 1.2.4, use `change_display_resolution` (36) instead.
+    // But we must keep it for compatibility when peer version < 1.2.4.
     Resolution change_resolution = 24;
     PluginRequest plugin_request = 25;
     PluginFailure plugin_failure = 26;
@@ -756,6 +763,7 @@ message Misc {
     SupportedEncoding supported_encoding = 34;
     uint32 selected_sid = 35;
     DisplayResolution change_display_resolution = 36;
+    MessageQuery message_query = 37;
   }
 }
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2104,6 +2104,12 @@ pub fn main_check_hwcodec() {
     check_hwcodec()
 }
 
+pub fn session_request_init_msgs(session_id: SessionID, display: usize) {
+    if let Some(session) = sessions::get_session_by_session_id(&session_id) {
+        session.request_init_msgs(display);
+    }
+}
+
 #[cfg(target_os = "android")]
 pub mod server_side {
     use hbb_common::{config, log};

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2104,7 +2104,7 @@ pub fn main_check_hwcodec() {
     check_hwcodec()
 }
 
-pub fn session_request_init_msgs(session_id: SessionID, display: usize) {
+pub fn session_request_new_display_init_msgs(session_id: SessionID, display: usize) {
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
         session.request_init_msgs(display);
     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2347,6 +2347,13 @@ impl Connection {
                             }
                         }
                     }
+                    Some(misc::Union::MessageQuery(mq)) => {
+                        if let Some(msg_out) =
+                            video_service::make_display_changed_msg(mq.switch_display as _, None)
+                        {
+                            self.send(msg_out).await;
+                        }
+                    }
                     _ => {}
                 },
                 Some(message::Union::AudioFrame(frame)) => {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2655,7 +2655,7 @@ impl Connection {
                     }
                     let mut record_changed = true;
                     #[cfg(all(windows, feature = "virtual_display_driver"))]
-                    if virtual_display_manager::amyuni_idd::is_self_display(&name) {
+                    if virtual_display_manager::amyuni_idd::is_my_display(&name) {
                         record_changed = false;
                     }
                     if record_changed {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2300,7 +2300,11 @@ impl Connection {
                         }
                     }
                     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                    Some(misc::Union::ChangeResolution(r)) => self.change_resolution(&r),
+                    Some(misc::Union::ChangeResolution(r)) => self.change_resolution(None, &r),
+                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                    Some(misc::Union::ChangeDisplayResolution(dr)) => {
+                        self.change_resolution(Some(dr.display as _), &dr.resolution)
+                    }
                     #[cfg(all(feature = "flutter", feature = "plugin_framework"))]
                     #[cfg(not(any(target_os = "android", target_os = "ios")))]
                     Some(misc::Union::PluginRequest(p)) => {
@@ -2472,11 +2476,14 @@ impl Connection {
 
                 #[cfg(not(any(target_os = "android", target_os = "ios")))]
                 if s.width != 0 && s.height != 0 {
-                    self.change_resolution(&Resolution {
-                        width: s.width,
-                        height: s.height,
-                        ..Default::default()
-                    });
+                    self.change_resolution(
+                        None,
+                        &Resolution {
+                            width: s.width,
+                            height: s.height,
+                            ..Default::default()
+                        },
+                    );
                 }
             }
 
@@ -2623,10 +2630,11 @@ impl Connection {
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    fn change_resolution(&mut self, r: &Resolution) {
+    fn change_resolution(&mut self, d: Option<usize>, r: &Resolution) {
         if self.keyboard {
             if let Ok(displays) = display_service::try_get_displays() {
-                if let Some(display) = displays.get(self.display_idx) {
+                let display_idx = d.unwrap_or(self.display_idx);
+                if let Some(display) = displays.get(display_idx) {
                     let name = display.name();
                     #[cfg(all(windows, feature = "virtual_display_driver"))]
                     if let Some(_ok) =
@@ -2638,11 +2646,18 @@ impl Connection {
                     {
                         return;
                     }
-                    display_service::set_last_changed_resolution(
-                        &name,
-                        (display.width() as _, display.height() as _),
-                        (r.width, r.height),
-                    );
+                    let mut record_changed = true;
+                    #[cfg(all(windows, feature = "virtual_display_driver"))]
+                    if virtual_display_manager::amyuni_idd::is_self_display(&name) {
+                        record_changed = false;
+                    }
+                    if record_changed {
+                        display_service::set_last_changed_resolution(
+                            &name,
+                            (display.width() as _, display.height() as _),
+                            (r.width, r.height),
+                        );
+                    }
                     if let Err(e) =
                         crate::platform::change_resolution(&name, r.width as _, r.height as _)
                     {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1239,14 +1239,14 @@ impl<T: InvokeUiSession> Session<T> {
             height,
             ..Default::default()
         };
-        if self.get_peer_version() < get_version_number("1.2.4") {
-            misc.set_change_resolution(resolution);
-        } else {
+        if crate::common::is_support_multi_ui_session_num(self.lc.read().unwrap().version) {
             misc.set_change_display_resolution(DisplayResolution {
                 display,
                 resolution: Some(resolution).into(),
                 ..Default::default()
             });
+        } else {
+            misc.set_change_resolution(resolution);
         }
         let mut msg = Message::new();
         msg.set_misc(misc);
@@ -1301,6 +1301,22 @@ impl<T: InvokeUiSession> Session<T> {
         } else {
             log::error!("selected invalid sid: {}", sid);
         }
+    }
+
+    #[inline]
+    pub fn request_init_msgs(&self, display: usize) {
+        self.send_message_query(display);
+    }
+
+    fn send_message_query(&self, display: usize) {
+        let mut misc = Misc::new();
+        misc.set_message_query(MessageQuery {
+            switch_display: display as _,
+            ..Default::default()
+        });
+        let mut msg = Message::new();
+        msg.set_misc(misc);
+        self.send(Data::Message(msg));
     }
 }
 

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1222,7 +1222,7 @@ impl<T: InvokeUiSession> Session<T> {
     pub fn change_resolution(&self, display: i32, width: i32, height: i32) {
         *self.last_change_display.lock().unwrap() =
             ChangeDisplayRecord::new(display, width, height);
-        self.do_change_resolution(width, height);
+        self.do_change_resolution(display, width, height);
     }
 
     #[inline]
@@ -1232,13 +1232,22 @@ impl<T: InvokeUiSession> Session<T> {
         }
     }
 
-    fn do_change_resolution(&self, width: i32, height: i32) {
+    fn do_change_resolution(&self, display: i32, width: i32, height: i32) {
         let mut misc = Misc::new();
-        misc.set_change_resolution(Resolution {
+        let resolution = Resolution {
             width,
             height,
             ..Default::default()
-        });
+        };
+        if self.get_peer_version() < get_version_number("1.2.4") {
+            misc.set_change_resolution(resolution);
+        } else {
+            misc.set_change_display_resolution(DisplayResolution {
+                display,
+                resolution: Some(resolution).into(),
+                ..Default::default()
+            });
+        }
         let mut msg = Message::new();
         msg.set_misc(misc);
         self.send(Data::Message(msg));

--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -538,7 +538,7 @@ pub mod amyuni_idd {
     }
 
     #[inline]
-    pub fn is_self_display(name: &str) -> bool {
+    pub fn is_my_display(name: &str) -> bool {
         windows::get_device_names(Some(super::AMYUNI_IDD_DEVICE_STRING))
             .iter()
             .any(|s| windows::is_device_name(s, name))

--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -536,6 +536,13 @@ pub mod amyuni_idd {
     pub fn get_monitor_count() -> usize {
         windows::get_device_names(Some(super::AMYUNI_IDD_DEVICE_STRING)).len()
     }
+
+    #[inline]
+    pub fn is_self_display(name: &str) -> bool {
+        windows::get_device_names(Some(super::AMYUNI_IDD_DEVICE_STRING))
+            .iter()
+            .any(|s| windows::is_device_name(s, name))
+    }
 }
 
 mod windows {


### PR DESCRIPTION
## Bug

### Preview


https://github.com/rustdesk/rustdesk/assets/13586388/e0cc5bed-b71b-4fcb-8ca2-461f7faad0d1



### Fixed

https://github.com/rustdesk/rustdesk/assets/13586388/cadc170c-614c-4608-a89a-6f97bfd6e8a4


## Description

### The resolutions list when opening a second display connection of the same peer

1. Check if `isCache` (new display connection). Do not use the resolutions if reading the cache data from another display.
```dart
      if (!isCache) {
        handleResolutions(peerId, evt["resolutions"]);
      }
```

2. `sessionRequestInitMsgs()` to get current display's informations.

```dart
          await bind.sessionRequestInitMsgs(
              sessionId: sessionId, display: ffiModel.pi.currentDisplay);
```

3. By sending a new message type.
```protobuf
message MessageQuery {
  // The SwitchDisplay message of the target display.
  // If the target display is not found, the message will be ignored.
  int32 switch_display = 1;
}
```

4. To get the `SwitchDisplay` message.
```rust
                    Some(misc::Union::MessageQuery(mq)) => {
                        if let Some(msg_out) =
                            video_service::make_display_changed_msg(mq.switch_display as _, None)
                        {
                            self.send(msg_out).await;
                        }
                    }
```

### Changing resolution when there're mulitple displays' connection
    
Introduce a new message `change_display_resolution`, because `change_resolution` does not contain a display index.
   
```
    // Deprecated since 1.2.4, use `change_display_resolution` (36) instead.
    // But we must keep it for compatibility when peer version < 1.2.4.
    Resolution change_resolution = 24;
...
    DisplayResolution change_display_resolution = 36;
```

Changing resolution of "1.2.4 -> 1.2.3" is tested.



