### PR TITLE
refact: win idd, x86 on x64

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -264,7 +264,10 @@ jobs:
           echo "output_folder=./Release" >> $GITHUB_OUTPUT
           curl -LJ -o ./usbmmidd_v2.zip https://github.com/rustdesk-org/rdev/releases/download/usbmmidd_v2/usbmmidd_v2.zip
           unzip usbmmidd_v2.zip
-          rm -rf ./usbmmidd_v2/x64 ./usbmmidd_v2/deviceinstaller.exe ./usbmmidd_v2/deviceinstaller64.exe ./usbmmidd_v2/usbmmidd.bat 
+          # Do not remove x64 files, because the user may run the 32bit version on a 64bit system.
+          # Do nto remove ./usbmmidd_v2/deviceinstaller64.exe, as x86 exe cannot install and uninstall drivers when running on x64,
+          # we need the x64 exe to install and uninstall the driver.
+          rm -rf ./usbmmidd_v2/deviceinstaller.exe ./usbmmidd_v2/usbmmidd.bat 
           mv ./usbmmidd_v2 ./Release || true
 
       - name: find Runner.res

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -265,7 +265,7 @@ jobs:
           curl -LJ -o ./usbmmidd_v2.zip https://github.com/rustdesk-org/rdev/releases/download/usbmmidd_v2/usbmmidd_v2.zip
           unzip usbmmidd_v2.zip
           # Do not remove x64 files, because the user may run the 32bit version on a 64bit system.
-          # Do nto remove ./usbmmidd_v2/deviceinstaller64.exe, as x86 exe cannot install and uninstall drivers when running on x64,
+          # Do not remove ./usbmmidd_v2/deviceinstaller64.exe, as x86 exe cannot install and uninstall drivers when running on x64,
           # we need the x64 exe to install and uninstall the driver.
           rm -rf ./usbmmidd_v2/deviceinstaller.exe ./usbmmidd_v2/usbmmidd.bat 
           mv ./usbmmidd_v2 ./Release || true

--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -29,6 +29,7 @@
 		<CustomAction Id="SetPropertyServiceStop.SetParam.ConfigKey" Return="check" Property="ConfigKey" Value="stop-service" />
 		<CustomAction Id="SetPropertyServiceStop.SetParam.PropertyName" Return="check" Property="PropertyName" Value="STOP_SERVICE" />
 		<CustomAction Id="TryDeleteStartupShortcut.SetParam" Return="check" Property="ShortcutName" Value="$(var.Product) Tray" />
+		<CustomAction Id="RemoveAmyuniIdd.SetParam" Return="check" Property="RemoveAmyuniIdd" Value="[INSTALLFOLDER]" />
 		<InstallExecuteSequence>
 
 			<Custom Action="SetPropertyIsServiceRunning" After="InstallInitialize" Condition="Installed" />
@@ -73,6 +74,7 @@
 			<Custom Action="TerminateBrokers" Before="RemoveInstallFolder"/>
 			<Custom Action="TerminateBrokers.SetParam" Before="TerminateBrokers"/>
 			<Custom Action="RemoveAmyuniIdd" Before="RemoveInstallFolder"/>
+			<Custom Action="RemoveAmyuniIdd.SetParam" Before="RemoveAmyuniIdd"/>
 		</InstallExecuteSequence>
 
 		<!-- Shortcuts -->

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -29,6 +29,7 @@ use std::{
     time::{Duration, Instant},
 };
 use wallpaper;
+use winapi::um::sysinfoapi::{GetNativeSystemInfo, SYSTEM_INFO};
 use winapi::{
     ctypes::c_void,
     shared::{minwindef::*, ntdef::NULL, windef::*, winerror::*},
@@ -1302,7 +1303,7 @@ fn get_uninstall(kill_self: bool) -> String {
     if exist \"%PROGRAMDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\{app_name} Tray.lnk\" del /f /q \"%PROGRAMDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\{app_name} Tray.lnk\"
     ",
         before_uninstall=get_before_uninstall(kill_self),
-        uninstall_amyuni_idd=get_uninstall_amyuni_idd(&path),
+        uninstall_amyuni_idd=get_uninstall_amyuni_idd(),
         app_name = crate::get_app_name(),
     )
 }
@@ -2369,7 +2370,7 @@ impl Drop for WallPaperRemover {
     }
 }
 
-fn get_uninstall_amyuni_idd(path: &str) -> String {
+fn get_uninstall_amyuni_idd() -> String {
     match std::env::current_exe() {
         Ok(path) => format!("\"{}\" --uninstall-amyuni-idd", path.to_str().unwrap_or("")),
         Err(e) => {
@@ -2389,4 +2390,14 @@ pub fn is_service_running(service_name: &str) -> bool {
         let service_name = wide_string(service_name);
         is_service_running_w(service_name.as_ptr() as _)
     }
+}
+
+pub fn is_x64() -> bool {
+    const PROCESSOR_ARCHITECTURE_AMD64: u16 = 9;
+
+    let mut sys_info = SYSTEM_INFO::default();
+    unsafe {
+        GetNativeSystemInfo(&mut sys_info as _);
+    }
+    unsafe { sys_info.u.s().wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64 }
 }

--- a/src/privacy_mode/win_topmost_window.rs
+++ b/src/privacy_mode/win_topmost_window.rs
@@ -72,6 +72,10 @@ pub struct PrivacyModeImpl {
 }
 
 impl PrivacyMode for PrivacyModeImpl {
+    fn is_async_privacy_mode(&self) -> bool {
+        false
+    }
+    
     fn init(&self) -> ResultType<()> {
         Ok(())
     }

--- a/src/privacy_mode/win_virtual_display.rs
+++ b/src/privacy_mode/win_virtual_display.rs
@@ -360,6 +360,10 @@ impl PrivacyModeImpl {
 }
 
 impl PrivacyMode for PrivacyModeImpl {
+    fn is_async_privacy_mode(&self) -> bool {
+        virtual_display_manager::is_amyuni_idd()
+    }
+
     fn init(&self) -> ResultType<()> {
         Ok(())
     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2883,7 +2883,7 @@ impl Connection {
                 }
             }
 
-            let turn_on_res = privacy_mode::turn_on_privacy(&impl_key, self.inner.id);
+            let turn_on_res = privacy_mode::turn_on_privacy(&impl_key, self.inner.id).await;
             match turn_on_res {
                 Some(Ok(res)) => {
                     if res {

--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -536,6 +536,8 @@ pub mod amyuni_idd {
         Ok(())
     }
 
+    // `std::thread::sleep()` with a timeout is acceptable here.
+    // Because user can wait for a while to plug in a monitor.
     fn plug_in_monitor_(add: bool, is_driver_async_installed: bool) -> ResultType<()> {
         let timeout = Duration::from_secs(3);
         let now = Instant::now();

--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -454,11 +454,13 @@ pub mod amyuni_idd {
     pub fn uninstall_driver() -> ResultType<()> {
         if let Ok(Some(work_dir)) = get_deviceinstaller64_work_dir() {
             if crate::platform::windows::is_x64() {
+                log::info!("Uninstalling driver by deviceinstaller64.exe");
                 install_if_x86_on_x64(&work_dir, "remove usbmmidd")?;
                 return Ok(());
             }
         }
 
+        log::info!("Uninstalling driver by SetupAPI");
         let mut reboot_required = false;
         let _ = unsafe { win_device::uninstall_driver(HARDWARE_ID, &mut reboot_required)? };
         Ok(())
@@ -504,6 +506,7 @@ pub mod amyuni_idd {
 
         if let Ok(Some(work_dir)) = get_deviceinstaller64_work_dir() {
             if crate::platform::windows::is_x64() {
+                log::info!("Installing driver by deviceinstaller64.exe");
                 install_if_x86_on_x64(&work_dir, "install usbmmidd.inf usbmmidd")?;
                 *is_async = true;
                 return Ok(());
@@ -520,6 +523,7 @@ pub mod amyuni_idd {
         }
         let inf_path = inf_path.to_string_lossy().to_string();
 
+        log::info!("Installing driver by SetupAPI");
         let mut reboot_required = false;
         let _ =
             unsafe { win_device::install_driver(&inf_path, HARDWARE_ID, &mut reboot_required)? };

--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -403,9 +403,16 @@ pub mod rustdesk_idd {
 pub mod amyuni_idd {
     use super::windows;
     use crate::platform::win_device;
-    use hbb_common::{bail, lazy_static, log, ResultType};
-    use std::sync::{Arc, Mutex};
-    use winapi::shared::guiddef::GUID;
+    use hbb_common::{bail, lazy_static, log, tokio::time::Instant, ResultType};
+    use std::{
+        ptr::null_mut,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+    use winapi::{
+        shared::{guiddef::GUID, winerror::ERROR_NO_MORE_ITEMS},
+        um::shellapi::ShellExecuteA,
+    };
 
     const INF_PATH: &str = r#"usbmmidd_v2\usbmmIdd.inf"#;
     const INTERFACE_GUID: GUID = GUID {
@@ -423,19 +430,79 @@ pub mod amyuni_idd {
 
     pub fn uninstall_driver() -> ResultType<()> {
         let mut reboot_required = false;
-        unsafe {
-            win_device::uninstall_driver(HARDWARE_ID, &mut reboot_required)?;
+        let res = unsafe { win_device::uninstall_driver(HARDWARE_ID, &mut reboot_required) };
+        retry_install_if_x86_on_x64(res, "remove usbmmidd", true)?;
+        Ok(())
+    }
+
+    // SetupDiCallClassInstaller() will always fail if current_exe() is built as x86 and running on x64.
+    // So we need to call another x64 version exe to install and uninstall the driver.
+    // We need to force try when uninstalling the driver. Because `win_device::uninstall_driver()` always return Ok(()).
+    fn retry_install_if_x86_on_x64(
+        res: Result<(), win_device::DeviceError>,
+        args: &str,
+        uninstall: bool,
+    ) -> ResultType<()> {
+        if res.is_ok() && !uninstall {
+            return Ok(());
+        }
+        if !crate::platform::windows::is_x64() {
+            let _ = res?;
+            return Ok(());
+        }
+
+        let cur_exe = std::env::current_exe()?;
+        let Some(cur_dir) = cur_exe.parent() else {
+            bail!("Cannot get parent of current exe file.");
+        };
+        let work_dir = cur_dir.join("usbmmidd_v2");
+        if !work_dir.exists() {
+            bail!("usbmmidd_v2 does not exist.",);
+        }
+        let exefile = "deviceinstaller64.exe";
+        let exe_path = work_dir.join(exefile);
+        if !exe_path.exists() {
+            let _ = res?;
+            return Ok(());
+        }
+        let Some(work_dir) = work_dir.to_str() else {
+            bail!("Cannot convert work_dir to string.");
+        };
+        let mut work_dir2 = work_dir.as_bytes().to_vec();
+        work_dir2.push(0);
+
+        const SW_HIDE: i32 = 0;
+        let mut args = args.bytes().collect::<Vec<_>>();
+        args.push(0);
+        let mut exe_file = exefile.bytes().collect::<Vec<_>>();
+        exe_file.push(0);
+        let hi = unsafe {
+            ShellExecuteA(
+                null_mut(),
+                "open\0".as_ptr() as _,
+                exe_file.as_ptr() as _,
+                args.as_ptr() as _,
+                work_dir2.as_ptr() as _,
+                SW_HIDE,
+            ) as i32
+        };
+        if hi <= 32 {
+            log::error!("Failed to run deviceinstaller: {}", hi);
+            bail!("Failed to run deviceinstaller.")
         }
         Ok(())
     }
 
-    fn check_install_driver() -> ResultType<()> {
+    // If the driver is installed by "deviceinstaller64.exe", the driver will be installed asynchronously.
+    // The caller must wait some time before using the driver.
+    fn check_install_driver(is_async: &mut bool) -> ResultType<()> {
         let _l = LOCK.lock().unwrap();
         let drivers = windows::get_display_drivers();
         if drivers
             .iter()
             .any(|(s, c)| s == super::AMYUNI_IDD_DEVICE_STRING && *c == 0)
         {
+            *is_async = false;
             return Ok(());
         }
 
@@ -451,18 +518,46 @@ pub mod amyuni_idd {
         let inf_path = inf_path.to_string_lossy().to_string();
 
         let mut reboot_required = false;
-        unsafe {
-            win_device::install_driver(&inf_path, HARDWARE_ID, &mut reboot_required)?;
-        }
+        let install_res =
+            unsafe { win_device::install_driver(&inf_path, HARDWARE_ID, &mut reboot_required) };
+        *is_async = !install_res.is_ok();
+        retry_install_if_x86_on_x64(install_res, "install usbmmidd.inf usbmmidd", false)?;
+        *is_async = true;
         Ok(())
     }
 
     #[inline]
-    fn plug_in_monitor_(add: bool) -> ResultType<()> {
+    fn plug_monitor_(add: bool) -> Result<(), win_device::DeviceError> {
         let cmd = if add { 0x10 } else { 0x00 };
         let cmd = [cmd, 0x00, 0x00, 0x00];
         unsafe {
             win_device::device_io_control(&INTERFACE_GUID, PLUG_MONITOR_IO_CONTROL_CDOE, &cmd, 0)?;
+        }
+        Ok(())
+    }
+
+    fn plug_in_monitor_(add: bool, is_driver_async_installed: bool) -> ResultType<()> {
+        let timeout = Duration::from_secs(3);
+        let now = Instant::now();
+        loop {
+            match plug_monitor_(add) {
+                Ok(_) => {
+                    break;
+                }
+                Err(e) => {
+                    if is_driver_async_installed {
+                        if let win_device::DeviceError::WinApiLastErr(_, e2) = &e {
+                            if e2.raw_os_error() == Some(ERROR_NO_MORE_ITEMS as _) {
+                                if now.elapsed() < timeout {
+                                    std::thread::sleep(Duration::from_millis(100));
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+                    return Err(e.into());
+                }
+            }
         }
         Ok(())
     }
@@ -472,16 +567,18 @@ pub mod amyuni_idd {
             return Ok(());
         }
 
-        if let Err(e) = check_install_driver() {
+        let mut is_async = false;
+        if let Err(e) = check_install_driver(&mut is_async) {
             log::error!("Failed to install driver: {}", e);
             bail!("Failed to install driver.");
         }
 
-        plug_in_monitor_(true)
+        plug_in_monitor_(true, is_async)
     }
 
     pub fn plug_in_monitor() -> ResultType<()> {
-        if let Err(e) = check_install_driver() {
+        let mut is_async = false;
+        if let Err(e) = check_install_driver(&mut is_async) {
             log::error!("Failed to install driver: {}", e);
             bail!("Failed to install driver.");
         }
@@ -490,7 +587,7 @@ pub mod amyuni_idd {
             bail!("There are already 4 monitors plugged in.");
         }
 
-        plug_in_monitor_(true)
+        plug_in_monitor_(true, is_async)
     }
 
     pub fn plug_out_monitor(index: i32) -> ResultType<()> {
@@ -525,7 +622,7 @@ pub mod amyuni_idd {
             to_plug_out_count = 1;
         }
         for _i in 0..to_plug_out_count {
-            let _ = plug_in_monitor_(false);
+            let _ = plug_monitor_(false);
         }
         Ok(())
     }

--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -502,29 +502,28 @@ pub mod amyuni_idd {
             return Ok(());
         }
 
+        if let Ok(Some(work_dir)) = get_deviceinstaller64_work_dir() {
+            if crate::platform::windows::is_x64() {
+                install_if_x86_on_x64(&work_dir, "install usbmmidd.inf usbmmidd")?;
+                *is_async = true;
+                return Ok(());
+            }
+        }
+
         let exe_file = std::env::current_exe()?;
         let Some(cur_dir) = exe_file.parent() else {
             bail!("Cannot get parent of current exe file");
         };
-
         let inf_path = cur_dir.join(INF_PATH);
         if !inf_path.exists() {
             bail!("Driver inf file not found.");
         }
         let inf_path = inf_path.to_string_lossy().to_string();
 
-        if let Ok(Some(work_dir)) = get_deviceinstaller64_work_dir() {
-            if crate::platform::windows::is_x64() {
-                *is_async = true;
-                install_if_x86_on_x64(&work_dir, "install usbmmidd.inf usbmmidd")?;
-                return Ok(());
-            }
-        }
-
-        *is_async = false;
         let mut reboot_required = false;
         let _ =
             unsafe { win_device::install_driver(&inf_path, HARDWARE_ID, &mut reboot_required)? };
+        *is_async = false;
         Ok(())
     }
 


### PR DESCRIPTION
Keep `deviceinstaller64.exe` in x86 build, as x86 build cannot install and uninstall the indirect display driver.

Use `deviceinstaller64.exe` as a fallback when installing x86 on x64 fails.

