### PR TITLE
fix: win portable, clear dir

### DIFF
--- a/libs/portable/generate.py
+++ b/libs/portable/generate.py
@@ -4,6 +4,7 @@ import os
 import optparse
 from hashlib import md5
 import brotli
+import datetime
 
 # 4GB maximum
 length_count = 4
@@ -43,8 +44,8 @@ def write_metadata(md5_table: dict, output_folder: str, exe: str):
         exe_encoded = exe.encode(encoding='utf-8')
         f.write((len(exe_encoded)).to_bytes(length=length_count, byteorder='big'))
         f.write(exe_encoded)
-        (_, md5_code) = md5_table[exe]
-        f.write(md5_code)
+        ts = int(datetime.datetime.now().timestamp() * 1000)
+        f.write(ts.to_bytes(length=8, byteorder='big'))
         # others
         for path in md5_table.keys():
             (compressed_data, md5_code) = md5_table[path]

--- a/libs/portable/generate.py
+++ b/libs/portable/generate.py
@@ -37,7 +37,15 @@ def generate_md5_table(folder: str, level) -> dict:
 def write_metadata(md5_table: dict, output_folder: str, exe: str):
     output_path = os.path.join(output_folder, "data.bin")
     with open(output_path, "wb") as f:
+        # begin
         f.write("rustdesk".encode(encoding=encoding))
+        # executable
+        exe_encoded = exe.encode(encoding='utf-8')
+        f.write((len(exe_encoded)).to_bytes(length=length_count, byteorder='big'))
+        f.write(exe_encoded)
+        (_, md5_code) = md5_table[exe]
+        f.write(md5_code)
+        # others
         for path in md5_table.keys():
             (compressed_data, md5_code) = md5_table[path]
             data_length = len(compressed_data)
@@ -53,8 +61,6 @@ def write_metadata(md5_table: dict, output_folder: str, exe: str):
             f.write(md5_code)
         # end
         f.write("rustdesk".encode(encoding=encoding))
-        # executable
-        f.write(exe.encode(encoding='utf-8'))
     print(f"metadata had written to {output_path}")
 
 

--- a/libs/portable/src/bin_reader.rs
+++ b/libs/portable/src/bin_reader.rs
@@ -69,14 +69,23 @@ impl BinaryData {
 
 impl BinaryReader {
     #[inline]
-    pub fn get_exe_md5() -> (String, String) {
+    pub fn get_exe_timestamp() -> (String, u64) {
         let mut base: usize = META_BEGIN.len();
         let len = Self::get_len(base);
         base += LENGTH;
         let exe = String::from_utf8_lossy(&BIN_DATA[base..base + len]).to_string();
         base += len;
-        let md5 = String::from_utf8_lossy(&BIN_DATA[base..base + MD5_LENGTH]).to_string();
-        (exe, md5)
+        let ts = u64::from_be_bytes([
+            BIN_DATA[base],
+            BIN_DATA[base + 1],
+            BIN_DATA[base + 2],
+            BIN_DATA[base + 3],
+            BIN_DATA[base + 4],
+            BIN_DATA[base + 5],
+            BIN_DATA[base + 6],
+            BIN_DATA[base + 7],
+        ]);
+        (exe, ts)
     }
 
     #[inline]
@@ -98,7 +107,7 @@ impl BinaryReader {
             panic!("bin file is not valid!");
         }
         base += META_BEGIN.len();
-        base += LENGTH + Self::get_len(base) + MD5_LENGTH;
+        base += LENGTH + Self::get_len(base) + 8;
         loop {
             iden = String::from_utf8_lossy(&BIN_DATA[base..base + META_END.len()]);
             if iden == META_END {


### PR DESCRIPTION
1. Move (executable, timestamp) to the front of the bin data.
It is not necessary to read all the data before determining that the files need to be overwritten.
2. If the timestamps are not equal or the exe does not exist, delete the old files and copy the new files.