### PR TITLE
fix: add support for headless in docker

### DIFF
--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -49,6 +49,16 @@ pub fn is_x11_or_headless() -> bool {
 const INVALID_SESSION: &str = "4294967295";
 
 pub fn get_display_server() -> String {
+    // Check for forced display server environment variable first
+    if let Ok(forced_display) = std::env::var("RUSTDESK_FORCED_DISPLAY_SERVER") {
+        return forced_display;
+    }
+
+    // Check if `loginctl` can be called successfully
+    if run_loginctl(None).is_err() {
+        return DISPLAY_SERVER_X11.to_owned();
+    }
+
     let mut session = get_values_of_seat0(&[0])[0].clone();
     if session.is_empty() {
         // loginctl has not given the expected output.  try something else.


### PR DESCRIPTION
# Try to make rustdesk work in the docker environment for testing, and even for Google Colab,  and computer datacenter, at least technically, two minor fix:

1. allow user to forced set desktop system by envirement variable like **RUSTDESK_FORCED_DISPLAY_SERVER**
2. back to default if loginctl can't be used(failed)

# Why need this fix:
When the system has no systemd context like run in docker, loginctl can't be used even 4 queries, you will get:

**System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down**

and **echo $?** get **1**

# Review our old code:

from the old code we can expect, that in docker, it should be x11 which is the default if nothing fit, but it's not, maybe because we can not use loginctl in docker?

```rust
//libs/hbb_common/src/platform/linux.rs
pub fn get_display_server() -> String {
    let mut session = get_values_of_seat0(&[0])[0].clone();
    if session.is_empty() {
        // loginctl has not given the expected output.  try something else.
        if let Ok(sid) = std::env::var("XDG_SESSION_ID") {
            // could also execute "cat /proc/self/sessionid"
            session = sid;
        }
        if session.is_empty() {
            session = run_cmds("cat /proc/self/sessionid").unwrap_or_default();
            if session == INVALID_SESSION {
                session = "".to_owned();
            }
        }
    }
    if session.is_empty() {
        "".to_owned()
    } else {
        get_display_server_of_session(&session)
    }
}

pub fn get_display_server_of_session(session: &str) -> String {
    let mut display_server = if let Ok(output) =
        run_loginctl(Some(vec!["show-session", "-p", "Type", session]))
    // Check session type of the session
    {
        let display_server = String::from_utf8_lossy(&output.stdout)
            .replace("Type=", "")
            .trim_end()
            .into();
        if display_server == "tty" {
            // If the type is tty...
            if let Ok(output) = run_loginctl(Some(vec!["show-session", "-p", "TTY", session]))
            // Get the tty number
            {
                let tty: String = String::from_utf8_lossy(&output.stdout)
                    .replace("TTY=", "")
                    .trim_end()
                    .into();
                if let Ok(xorg_results) = run_cmds(&format!("ps -e | grep \"{tty}.\\\\+Xorg\""))
                // And check if Xorg is running on that tty
                {
                    if xorg_results.trim_end() != "" {
                        // If it is, manually return "x11", otherwise return tty
                        return "x11".to_owned();
                    }
                }
            }
        }
        display_server
    } else {
        "".to_owned()
    };
    if display_server.is_empty() || display_server == "tty" {
        // loginctl has not given the expected output.  try something else.
        if let Ok(sestype) = std::env::var("XDG_SESSION_TYPE") {
            display_server = sestype;
        }
    }
    if display_server == "" {
        display_server = "x11".to_owned();
    }
    display_server.to_lowercase()
}
fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
    let mut cmd = std::process::Command::new("loginctl");
    if let Some(a) = args {
        return cmd.args(a).output();
    }
    cmd.output()
}
```
refs:
https://github.com/rustdesk/rustdesk/pull/3902
https://github.com/rustdesk/rustdesk/wiki/Headless-Linux-Support
https://github.com/rustdesk/rustdesk/issues/634
https://github.com/rustdesk/rustdesk/issues/192
https://github.com/rustdesk/rustdesk/issues/1131
https://github.com/rustdesk/rustdesk/issues/5976

@fufesou please have a review, I have very little rust and background of C++, hope I can do something