### PR TITLE
update hwcodec, fix gpu/cpu stuck caused by nv codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,8 +3038,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.3.3"
-source = "git+https://github.com/21pages/hwcodec#eeebf980d4eb41daaf05090b097d5a59d688d3d8"
+version = "0.4.1"
+source = "git+https://github.com/21pages/hwcodec#17870c015a3f371339a91c5305d1e920bd8284e3"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/libs/scrap/src/common/vram.rs
+++ b/libs/scrap/src/common/vram.rs
@@ -17,7 +17,7 @@ use hbb_common::{
 };
 use hwcodec::{
     common::{DataFormat, Driver, MAX_GOP},
-    native::{
+    vram::{
         decode::{self, DecodeFrame, Decoder},
         encode::{self, EncodeFrame, Encoder},
         Available, DecodeContext, DynamicContext, EncodeContext, FeatureContext,
@@ -294,6 +294,10 @@ impl VRamDecoder {
     pub fn try_get(format: CodecFormat, luid: Option<i64>) -> Option<DecodeContext> {
         let v: Vec<_> = Self::available(format, luid);
         if v.len() > 0 {
+            // prefer ffmpeg
+            if let Some(ctx) = v.iter().find(|c| c.driver == Driver::FFMPEG) {
+                return Some(ctx.clone());
+            }
             Some(v[0].clone())
         } else {
             None


### PR DESCRIPTION
* Disable all nv codec encoding on windows except nv sdk encoding, because it doesn't use CUcontext
* Keep nv codec on linux, because I didn't reproduce the stuck on it
* Add ffmpeg d3d11 vram decoding

Others: 
* No checking win10, IsWindows10OrGreater require manifest
* No checking d3d11 decoding capabilities and let ffmpeg give the results
