### PR TITLE
fix black screen issue when controlling the second screen on versions that lack multiple display support while using vram decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,7 +3039,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "hwcodec"
 version = "0.4.1"
-source = "git+https://github.com/21pages/hwcodec#17870c015a3f371339a91c5305d1e920bd8284e3"
+source = "git+https://github.com/21pages/hwcodec#b6b23d920feb0c343d8fb8dad9a2a95dca47a088"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,8 +3038,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.1"
-source = "git+https://github.com/21pages/hwcodec#b6b23d920feb0c343d8fb8dad9a2a95dca47a088"
+version = "0.4.2"
+source = "git+https://github.com/21pages/hwcodec#b8ed1e869b3456af6a5f77b7617f861d9a99dcdd"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -221,7 +221,6 @@ impl Encoder {
         let h265_useable =
             _all_support_h265_decoding && (h265vram_encoding || h265hw_encoding.is_some());
         let mut name = ENCODE_CODEC_NAME.lock().unwrap();
-        let mut preference = PreferCodec::Auto;
         let preferences: Vec<_> = decodings
             .iter()
             .filter(|(_, s)| {
@@ -233,9 +232,20 @@ impl Encoder {
             })
             .map(|(_, s)| s.prefer)
             .collect();
-        if preferences.len() > 0 && preferences.iter().all(|&p| p == preferences[0]) {
-            preference = preferences[0].enum_value_or(PreferCodec::Auto);
+        // find the most frequent preference
+        let mut counts = Vec::new();
+        for pref in &preferences {
+            match counts.iter_mut().find(|(p, _)| p == pref) {
+                Some((_, count)) => *count += 1,
+                None => counts.push((pref.clone(), 1)),
+            }
         }
+        let max_count = counts.iter().map(|(_, count)| *count).max().unwrap_or(0);
+        let (most_frequent, _) = counts
+            .into_iter()
+            .find(|(_, count)| *count == max_count)
+            .unwrap_or((PreferCodec::Auto.into(), 0));
+        let preference = most_frequent.enum_value_or(PreferCodec::Auto);
 
         #[allow(unused_mut)]
         let mut auto_codec = CodecName::VP9;

--- a/libs/scrap/src/common/vram.rs
+++ b/libs/scrap/src/common/vram.rs
@@ -24,8 +24,6 @@ use hwcodec::{
     },
 };
 
-const OUTPUT_SHARED_HANDLE: bool = false;
-
 // https://www.reddit.com/r/buildapc/comments/d2m4ny/two_graphics_cards_two_monitors/
 // https://www.reddit.com/r/techsupport/comments/t2v9u6/dual_monitor_setup_with_dual_gpu/
 // https://cybersided.com/two-monitors-two-gpus/
@@ -331,8 +329,8 @@ impl VRamDecoder {
     }
 
     pub fn new(format: CodecFormat, luid: Option<i64>) -> ResultType<Self> {
-        log::info!("try create {format:?} vram decoder, luid: {luid:?}");
         let ctx = Self::try_get(format, luid).ok_or(anyhow!("Failed to get decode context"))?;
+        log::info!("try create vram decoder: {ctx:?}");
         match Decoder::new(ctx) {
             Ok(decoder) => Ok(Self { decoder }),
             Err(_) => {
@@ -376,7 +374,7 @@ pub(crate) fn check_available_vram() -> String {
         gop: MAX_GOP as _,
     };
     let encoders = encode::available(d);
-    let decoders = decode::available(OUTPUT_SHARED_HANDLE);
+    let decoders = decode::available();
     let available = Available {
         e: encoders,
         d: decoders,


### PR DESCRIPTION
1. Prevent the creation of unnecessary video decoders. When the primary display index is not zero, more than one decoder will be created.
2. Controlled side uses the most frequent selected codec. Before this pr, if there are multiple choices, auto codec will be used.
3. Fix black screen issue when controlling the second screen on versions that lack multiple display support while using vram decoding The `display` field in `VideoFrame` proto is always 0 for old version, so it will always set display 0's texture type rather than current display's. Other decoding is not affected because RgbaTexture is default.


https://github.com/rustdesk/rustdesk/assets/14891774/c681b63b-e704-4d9f-85f7-2661bbb427ce


https://github.com/rustdesk/rustdesk/assets/14891774/50bb7cb6-3a52-4371-ad39-1bf386e3bc73

