### PR TITLE
fix: scroll percent is auto reset after detecting displays change

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1017,6 +1017,8 @@ class FfiModel with ChangeNotifier {
         }
       }
     }
+    parent.target!.canvasModel
+        .tryUpdateScrollStyle(Duration(milliseconds: 300), null);
     notifyListeners();
   }
 
@@ -1412,10 +1414,20 @@ class CanvasModel with ChangeNotifier {
     if (refreshMousePos) {
       parent.target?.inputModel.refreshMousePos();
     }
-    if (style == kRemoteViewStyleOriginal &&
-        _scrollStyle == ScrollStyle.scrollbar) {
-      updateScrollPercent();
+    tryUpdateScrollStyle(Duration.zero, style);
+  }
+
+  tryUpdateScrollStyle(Duration duration, String? style) async {
+    if (_scrollStyle != ScrollStyle.scrollbar) return;
+    style ??= await bind.sessionGetViewStyle(sessionId: sessionId);
+    if (style != kRemoteViewStyleOriginal) {
+      return;
     }
+
+    _resetScroll();
+    Future.delayed(duration, () async {
+      updateScrollPercent();
+    });
   }
 
   updateScrollStyle() async {


### PR DESCRIPTION


### Bug preview

Scroll value is auto reset after detecting displays change. Then the cursor's position mismatch.

https://github.com/rustdesk/rustdesk/assets/13586388/c5266222-d8c9-42e8-910b-df122abf588b

### Fixed preview

Try `updateScrollPercent()` in `handleSyncPeerInfo`

https://github.com/rustdesk/rustdesk/assets/13586388/a6fbc8b7-416c-485e-ac9d-ca3c647f0f7a

