### PR TITLE
fix mouse wheel scroll up not work when controlling mac hidpi

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3615,6 +3615,11 @@ impl Retina {
 
     #[inline]
     fn on_mouse_event(&mut self, e: &mut MouseEvent, current: usize) {
+        let evt_type = e.mask & 0x7;
+        if evt_type == crate::input::MOUSE_TYPE_WHEEL {
+            // x and y are always 0, +1 or -1
+            return;
+        }
         let Some(d) = self.displays.get(current) else {
             return;
         };


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/7419#issuecomment-2080408360

https://github.com/rustdesk/rustdesk/blob/ade458b8202978f45979f86a6f1f925eaaa4734b/flutter/lib/models/input_model.dart#L806

[mac_hidpi_wheel.webm](https://github.com/rustdesk/rustdesk/assets/14891774/42939a3c-71b2-43fc-80bf-247170c0d705)
