### PR TITLE
fix: keyboard input method, for flutter input

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -327,23 +327,15 @@ class InputModel {
 
   InputModel(this.parent) {
     sessionId = parent.target!.sessionId;
-
-    // It is ok to call updateKeyboardMode() directly.
-    // Because `bind` is initialized in `PlatformFFI.init()` which is called very early.
-    // But we still wrap it in a Future.delayed() to make it more clear.
-    Future.delayed(Duration(milliseconds: 100), () {
-      updateKeyboardMode();
-    });
   }
 
+  // This function must be called after the peer info is received.
+  // Because `sessionGetKeyboardMode` relies on the peer version.
   updateKeyboardMode() async {
     // * Currently mobile does not enable map mode
     if (isDesktop || isWebDesktop) {
-      if (keyboardMode.isEmpty) {
-        keyboardMode =
-            await bind.sessionGetKeyboardMode(sessionId: sessionId) ??
-                kKeyLegacyMode;
-      }
+      keyboardMode = await bind.sessionGetKeyboardMode(sessionId: sessionId) ??
+          kKeyLegacyMode;
     }
   }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -725,6 +725,9 @@ class FfiModel with ChangeNotifier {
 
   /// Handle the peer info event based on [evt].
   handlePeerInfo(Map<String, dynamic> evt, String peerId, bool isCache) async {
+    // This call is to ensuer the keyboard mode is updated depending on the peer version.
+    parent.target?.inputModel.updateKeyboardMode();
+
     // Map clone is required here, otherwise "evt" may be changed by other threads through the reference.
     // Because this function is asynchronous, there's an "await" in this function.
     cachedPeerData.peerInfo = {...evt};

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -233,12 +233,12 @@ impl<T: InvokeUiSession> Session<T> {
         }
     }
 
-    // Note: This function must be called after peer info is received.
+    // Caution: This function must be called after peer info is received.
     pub fn get_keyboard_mode(&self) -> String {
         let mode = self.lc.read().unwrap().keyboard_mode.clone();
         let keyboard_mode = KeyboardMode::from_str(&mode);
 
-        // Caution: peer_version is 0 before peer info is received.
+        // Note: peer_version is 0 before peer info is received.
         let peer_version = self.get_peer_version();
         let platform = self.peer_platform();
 

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -233,10 +233,12 @@ impl<T: InvokeUiSession> Session<T> {
         }
     }
 
+    // Note: This function must be called after peer info is received.
     pub fn get_keyboard_mode(&self) -> String {
         let mode = self.lc.read().unwrap().keyboard_mode.clone();
         let keyboard_mode = KeyboardMode::from_str(&mode);
 
+        // Caution: peer_version is 0 before peer info is received.
         let peer_version = self.get_peer_version();
         let platform = self.peer_platform();
 


### PR DESCRIPTION
### Bug desc

The flutter input source always use the legacy keyboard mode.

Because the keyboard mod relies on the peer version, and the keyboard mode is set before the peer info is received.

### Fix desc

Call `updateKeyboardMode()` after the peer info is received.

Because `get_keyboard_mode()` relies on peer's version.

Remove the call `updateKeyboardMode()` in `InputModel`'s constructor, because it will be called after the peer info is received.