### PR TITLE
update hwcodec, build linux ffmpeg lib on ubuntu 18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,8 +3038,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.7"
-source = "git+https://github.com/21pages/hwcodec#cc1e4412e0ea5e27a8a820a29051b1eeb42933e5"
+version = "0.4.8"
+source = "git+https://github.com/21pages/hwcodec#7cb16c64f4657385dd2adefcac7cff89088f4e6d"
 dependencies = [
  "bindgen 0.59.2",
  "cc",


### PR DESCRIPTION
* Build linux ffmpeg lib on ubuntu 18 container
* Fix ffmpeg ram nvnec not work if the display connected to nvidia gpu is not the primary display
* Fix windows mfx lib link error if vram feature is not enabled.