### PR TITLE
Add `/r` tip at `id_input_tip`

### DIFF
--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -565,7 +565,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Plug out all", "拔出所有"),
         ("True color (4:4:4)", "真彩模式（4:4:4）"),
         ("Enable blocking user input", "允许阻止用户输入"),
-        ("id_input_tip", "可以输入 ID、直连 IP，或域名和端口号（<域名>:<端口号>）。\n要访问另一台服务器上的设备，请附加服务器地址（<ID>@<服务器地址>?key=<密钥>）。比如，\n9123456234@192.168.16.1:21117?key=5Qbwsde3unUcJBtrx9ZkvUmwFNoExHzpryHuPUdqlWM=。\n要访问公共服务器上的设备，请输入 \"<ID>@public\", 无需密钥。"),
+        ("id_input_tip", "可以输入 ID、直连 IP，或域名和端口号（<域名>:<端口号>）。\n要访问另一台服务器上的设备，请附加服务器地址（<ID>@<服务器地址>?key=<密钥>）。比如，\n9123456234@192.168.16.1:21117?key=5Qbwsde3unUcJBtrx9ZkvUmwFNoExHzpryHuPUdqlWM=。\n要访问公共服务器上的设备，请输入 \"<ID>@public\", 无需密钥。\n\n如果您想要在首次连接时，强制走中继连接，请在 ID 的后面添加 \"/r\"，例如，\"9123456234/r\"。"),
         ("privacy_mode_impl_mag_tip", "模式 1"),
         ("privacy_mode_impl_virtual_display_tip", "模式 2"),
         ("Enter privacy mode", "进入隐私模式"),

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -201,7 +201,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("display_is_plugged_out_msg", "The display is plugged out, switch to the first display."),
         ("elevated_switch_display_msg", "Switch to the primary display because multiple displays are not supported in elevated user mode."),
         ("selinux_tip", "SELinux is enabled on your device, which may prevent RustDesk from running properly as controlled side."),
-        ("id_input_tip", "You can input an ID, a direct IP, or a domain with a port (<domain>:<port>).\nIf you want to access a device on another server, please append the server address (<id>@<server_address>?key=<key_value>), for example,\n9123456234@192.168.16.1:21117?key=5Qbwsde3unUcJBtrx9ZkvUmwFNoExHzpryHuPUdqlWM=.\nIf you want to access a device on a public server, please input \"<id>@public\", the key is not needed for public server"),
+        ("id_input_tip", "You can input an ID, a direct IP, or a domain with a port (<domain>:<port>).\nIf you want to access a device on another server, please append the server address (<id>@<server_address>?key=<key_value>), for example,\n9123456234@192.168.16.1:21117?key=5Qbwsde3unUcJBtrx9ZkvUmwFNoExHzpryHuPUdqlWM=.\nIf you want to access a device on a public server, please input \"<id>@public\", the key is not needed for public server.\n\nIf you want to force the use of a relay connection on the first connection, add \"/r\" at the end of the ID, for example, \"9123456234/r\"."),
         ("privacy_mode_impl_mag_tip", "Mode 1"),
         ("privacy_mode_impl_virtual_display_tip", "Mode 2"),
         ("idd_not_support_under_win10_2004_tip", "Indirect display driver is not supported. Windows 10, version 2004 or newer is required."),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -564,7 +564,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Plug out all", "拔出所有"),
         ("True color (4:4:4)", "全彩模式（4:4:4）"),
         ("Enable blocking user input", "允許封鎖使用者輸入"),
-        ("id_input_tip", "您可以輸入 ID、IP、或網域名稱+端口號（<網域名稱>:<端口號>）。\n如果您要存取位於其他伺服器上的設備，請在ID之後添加伺服器地址（<ID>@<伺服器地址>?key=<金鑰>）\n例如：9123456234@192.168.16.1:21117?key=5Qbwsde3unUcJBtrx9ZkvUmwFNoExHzpryHuPUdqlWM=\n要存取公共伺服器上的設備，請輸入\"<id>@public\"，不需輸入金鑰。"),
+        ("id_input_tip", "您可以輸入 ID、IP、或網域名稱+端口號（<網域名稱>:<端口號>）。\n如果您要存取位於其他伺服器上的設備，請在ID之後添加伺服器地址（<ID>@<伺服器地址>?key=<金鑰>）\n例如：9123456234@192.168.16.1:21117?key=5Qbwsde3unUcJBtrx9ZkvUmwFNoExHzpryHuPUdqlWM=\n要存取公共伺服器上的設備，請輸入\"<id>@public\"，不需輸入金鑰。\n\n如果您想要在第一次連線時，強制使用中繼連接，請在 ID 的末尾添加 \"/r\"，例如，\"9123456234/r\"。"),
         ("privacy_mode_impl_mag_tip", "模式 1"),
         ("privacy_mode_impl_virtual_display_tip", "模式 2"),
         ("Enter privacy mode", "進入隱私模式"),


### PR DESCRIPTION
RustDesk will try direct connection for initial connections, if failed, there will cause 3 behaviors,

1. Just fallback to relay connection. (Most of times
 
2. Show `relay_hint_tip` and ask user to try again or use relay connection instead. (Sometimes
https://github.com/rustdesk/rustdesk/blob/b5935eb4c59adff660dc756a03156188df4ab81a/src/lang/en.rs#L146

3. Failed (rarely
And nothing user can do, because `Always connect via relay` button isn't available if it haven't connected this device before, so add `/r` at the initial connections is required.

<hr>

Yeah, we have `/r` for a long time, but seems lots of people still don't know this functionality, so add  `/r` tip at `id_input_tip` may help end user to overcome the problem. And hope the connection behavior may fix at the future.