### PR TITLE
update hwcodec, qsv support changing bitrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,8 +3038,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.8"
-source = "git+https://github.com/21pages/hwcodec#7cb16c64f4657385dd2adefcac7cff89088f4e6d"
+version = "0.4.9"
+source = "git+https://github.com/21pages/hwcodec#7a52282267cb6aadbcd74c132bd4ecd43ab6f505"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -183,7 +183,7 @@ impl EncoderApi for HwRamEncoder {
     }
 
     fn support_abr(&self) -> bool {
-        !self.name.contains("qsv")
+        ["qsv", "vaapi"].iter().all(|&x| !self.name.contains(x))
     }
 }
 

--- a/libs/scrap/src/common/vram.rs
+++ b/libs/scrap/src/common/vram.rs
@@ -16,7 +16,7 @@ use hbb_common::{
     ResultType,
 };
 use hwcodec::{
-    common::{DataFormat, Driver, MAX_GOP},
+    common::{AdapterVendor::*, DataFormat, Driver, MAX_GOP},
     vram::{
         decode::{self, DecodeFrame, Decoder},
         encode::{self, EncodeFrame, Encoder},
@@ -49,6 +49,7 @@ pub struct VRamEncoder {
     bitrate: u32,
     last_frame_len: usize,
     same_bad_len_counter: usize,
+    config: VRamEncoderConfig,
 }
 
 impl EncoderApi for VRamEncoder {
@@ -84,6 +85,7 @@ impl EncoderApi for VRamEncoder {
                         bitrate,
                         last_frame_len: 0,
                         same_bad_len_counter: 0,
+                        config,
                     }),
                     Err(_) => {
                         hbb_common::config::HwCodecConfig::clear_vram();
@@ -179,7 +181,7 @@ impl EncoderApi for VRamEncoder {
     }
 
     fn support_abr(&self) -> bool {
-        self.ctx.f.driver != Driver::MFX
+        self.config.device.vendor_id != ADAPTER_VENDOR_INTEL as u32
     }
 }
 


### PR DESCRIPTION
* FFmpeg 5.1 qsv doesn's support changing bitrate, patch related code from FFmpeg 7.0 and update windows FFmpeg lib. It's 
effective on h264 but not on h265.
* Intel bitrate change requires encoder reset, so mark it as abr unsupported. 