### PR TITLE
fix: mstsc switch, plug in virtual displays

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1231,8 +1231,12 @@ impl Connection {
         } else {
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             {
+                #[cfg(not(all(windows, feature = "virtual_display_driver")))]
+                let displays = display_service::try_get_displays();
+                #[cfg(all(windows, feature = "virtual_display_driver"))]
+                let displays = display_service::try_get_displays_add_amyuni_headless();
                 pi.resolutions = Some(SupportedResolutions {
-                    resolutions: display_service::try_get_displays()
+                    resolutions: displays
                         .map(|displays| {
                             displays
                                 .get(self.display_idx)

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -382,11 +382,13 @@ pub fn try_get_displays() -> ResultType<Vec<Display>> {
 // If we add a virtual display, we cannot remove it automatically.
 // So when using amyuni idd, we only add a virtual display for headless if it is required.
 // eg. when the client is connecting.
+#[inline]
 #[cfg(all(windows, feature = "virtual_display_driver"))]
 pub fn try_get_displays_add_amyuni_headless() -> ResultType<Vec<Display>> {
     try_get_displays_(true)
 }
 
+#[inline]
 #[cfg(all(windows, feature = "virtual_display_driver"))]
 pub fn try_get_displays_(add_amyuni_headless: bool) -> ResultType<Vec<Display>> {
     let mut displays = Display::all()?;

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -372,15 +372,45 @@ pub fn try_get_displays() -> ResultType<Vec<Display>> {
     Ok(Display::all()?)
 }
 
+#[inline]
 #[cfg(all(windows, feature = "virtual_display_driver"))]
 pub fn try_get_displays() -> ResultType<Vec<Display>> {
+    try_get_displays_(false)
+}
+
+// We can't get full control of the virtual display if we use amyuni idd.
+// If we add a virtual display, we cannot remove it automatically.
+// So when using amyuni idd, we only add a virtual display for headless if it is required.
+// eg. when the client is connecting.
+#[cfg(all(windows, feature = "virtual_display_driver"))]
+pub fn try_get_displays_add_amyuni_headless() -> ResultType<Vec<Display>> {
+    try_get_displays_(true)
+}
+
+#[cfg(all(windows, feature = "virtual_display_driver"))]
+pub fn try_get_displays_(add_amyuni_headless: bool) -> ResultType<Vec<Display>> {
     let mut displays = Display::all()?;
+
+    // Do not add virtual display if the platform is not installed or the virtual display is not supported.
+    if !crate::platform::is_installed() || !virtual_display_manager::is_virtual_display_supported() {
+        return Ok(displays);
+    }
+
+    // Enable headless virtual display when
+    // 1. `amyuni` idd is not used.
+    // 2. `amyuni` idd is used and `add_amyuni_headless` is true.
+    if virtual_display_manager::is_amyuni_idd() && !add_amyuni_headless {
+        return Ok(displays);
+    }
+
+    // If is switching session, no displays may be detected. But it is not a real case.
+    if displays.is_empty() && crate::platform::desktop_changed() {
+        return Ok(displays);
+    }
+
     let no_displays_v = no_displays(&displays);
     virtual_display_manager::set_can_plug_out_all(!no_displays_v);
-    if crate::platform::is_installed()
-        && no_displays_v
-        && virtual_display_manager::is_virtual_display_supported()
-    {
+    if no_displays_v {
         log::debug!("no displays, create virtual display");
         if let Err(e) = virtual_display_manager::plug_in_headless() {
             log::error!("plug in headless failed {}", e);


### PR DESCRIPTION
## Bug description

When RustDesk is connecting, using mstsc to connect and disconnect may trigger RustDesk to insert a virtual display.

When switching desktop session (mstsc connecting and disconnecting), RustDesk may detect 0 displays, then it will try to plug in a virtual display for headless.

## Fix description

### Check if desktop change.

```rust
    // If is desktop changed, we may detect no displays.
    if displays.is_empty() && crate::platform::desktop_changed() {
        return Ok(displays);
    }
```

### Only plug in virtual display for headless when the client is connecting (`amyuni` idd)

Sometimes we cannot detect `desktop_changed()` when the desktop session is switching.

For `amyuni` idd, we enable headless virtual display only when the client is connecting (get displays).

```rust
    // Enable headless virtual display when
    // 1. `amyuni` idd is not used.
    // 2. `amyuni` idd is used and `add_amyuni_headless` is true.
    if virtual_display_manager::is_amyuni_idd() && !add_amyuni_headless {
        return Ok(displays);
    }
```


This is not a 100% guarantee that a virtual display will not be inserted incorrectly.
But it’s very hard to reproduce this issue with these checks.
