### PR TITLE
Show current codec in menu when auto codec is chosen

### DIFF
--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -355,14 +355,18 @@ Future<List<TRadioMenu<String>>> toolbarCodec(
 
   TRadioMenu<String> radio(String label, String value, bool enabled) {
     return TRadioMenu<String>(
-        child: Text(translate(label)),
+        child: Text(label),
         value: value,
         groupValue: groupValue,
         onChanged: enabled ? onChanged : null);
   }
 
+  var autoLabel = translate('Auto');
+  if (groupValue == 'auto') {
+    autoLabel = '$autoLabel (${ffi.qualityMonitorModel.data.codecFormat})';
+  }
   return [
-    radio('Auto', 'auto', true),
+    radio(autoLabel, 'auto', true),
     if (codecs[0]) radio('VP8', 'vp8', codecs[0]),
     radio('VP9', 'vp9', true),
     if (codecs[1]) radio('AV1', 'av1', codecs[1]),

--- a/libs/scrap/src/common/vram.rs
+++ b/libs/scrap/src/common/vram.rs
@@ -186,8 +186,8 @@ impl EncoderApi for VRamEncoder {
 }
 
 impl VRamEncoder {
-    pub fn try_get(device: &AdapterDevice, name: CodecName) -> Option<FeatureContext> {
-        let v: Vec<_> = Self::available(name)
+    pub fn try_get(device: &AdapterDevice, format: CodecFormat) -> Option<FeatureContext> {
+        let v: Vec<_> = Self::available(format)
             .drain(..)
             .filter(|e| e.luid == device.luid)
             .collect();
@@ -202,15 +202,15 @@ impl VRamEncoder {
         }
     }
 
-    pub fn available(name: CodecName) -> Vec<FeatureContext> {
+    pub fn available(format: CodecFormat) -> Vec<FeatureContext> {
         let not_use = ENOCDE_NOT_USE.lock().unwrap().clone();
         if not_use.values().any(|not_use| *not_use) {
             log::info!("currently not use vram encoders: {not_use:?}");
             return vec![];
         }
-        let data_format = match name {
-            CodecName::H264VRAM => DataFormat::H264,
-            CodecName::H265VRAM => DataFormat::H265,
+        let data_format = match format {
+            CodecFormat::H264 => DataFormat::H264,
+            CodecFormat::H265 => DataFormat::H265,
             _ => return vec![],
         };
         let Ok(displays) = crate::Display::all() else {

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -422,8 +422,8 @@ fn run(vs: VideoService) -> ResultType<()> {
         last_portable_service_running,
     );
     Encoder::set_fallback(&encoder_cfg);
-    let codec_name = Encoder::negotiated_codec();
-    let recorder = get_recorder(c.width, c.height, &codec_name, record_incoming);
+    let codec_format = Encoder::negotiated_codec();
+    let recorder = get_recorder(c.width, c.height, &codec_format, record_incoming);
     let mut encoder;
     let use_i444 = Encoder::use_i444(&encoder_cfg);
     match Encoder::new(encoder_cfg.clone(), use_i444) {
@@ -480,7 +480,7 @@ fn run(vs: VideoService) -> ResultType<()> {
             let _ = try_broadcast_display_changed(&sp, display_idx, &c);
             bail!("SWITCH");
         }
-        if codec_name != Encoder::negotiated_codec() {
+        if codec_format != Encoder::negotiated_codec() {
             bail!("SWITCH");
         }
         #[cfg(windows)]
@@ -491,7 +491,7 @@ fn run(vs: VideoService) -> ResultType<()> {
             bail!("SWITCH");
         }
         #[cfg(all(windows, feature = "vram"))]
-        if c.is_gdi() && (codec_name == CodecName::H264VRAM || codec_name == CodecName::H265VRAM) {
+        if c.is_gdi() && encoder.input_texture() {
             log::info!("changed to gdi when using vram");
             bail!("SWITCH");
         }
@@ -647,111 +647,57 @@ fn get_encoder_config(
     // https://www.wowza.com/community/t/the-correct-keyframe-interval-in-obs-studio/95162
     let keyframe_interval = if record { Some(240) } else { None };
     let negotiated_codec = Encoder::negotiated_codec();
-    match negotiated_codec.clone() {
-        CodecName::H264VRAM | CodecName::H265VRAM => {
+    match negotiated_codec {
+        CodecFormat::H264 | CodecFormat::H265 => {
             #[cfg(feature = "vram")]
-            if let Some(feature) = VRamEncoder::try_get(&c.device(), negotiated_codec.clone()) {
-                EncoderCfg::VRAM(VRamEncoderConfig {
+            if let Some(feature) = VRamEncoder::try_get(&c.device(), negotiated_codec) {
+                return EncoderCfg::VRAM(VRamEncoderConfig {
                     device: c.device(),
                     width: c.width,
                     height: c.height,
                     quality,
                     feature,
                     keyframe_interval,
-                })
-            } else {
-                handle_hw_encoder(
-                    negotiated_codec.clone(),
-                    c.width,
-                    c.height,
-                    quality as _,
-                    keyframe_interval,
-                )
+                });
             }
-            #[cfg(not(feature = "vram"))]
-            handle_hw_encoder(
-                negotiated_codec.clone(),
-                c.width,
-                c.height,
-                quality as _,
+            #[cfg(feature = "hwcodec")]
+            if let Some(hw) = HwRamEncoder::try_get(negotiated_codec) {
+                return EncoderCfg::HWRAM(HwRamEncoderConfig {
+                    name: hw.name,
+                    width: c.width,
+                    height: c.height,
+                    quality,
+                    keyframe_interval,
+                });
+            }
+            EncoderCfg::VPX(VpxEncoderConfig {
+                width: c.width as _,
+                height: c.height as _,
+                quality,
+                codec: VpxVideoCodecId::VP9,
                 keyframe_interval,
-            )
+            })
         }
-        CodecName::H264RAM(_name) | CodecName::H265RAM(_name) => handle_hw_encoder(
-            negotiated_codec.clone(),
-            c.width,
-            c.height,
-            quality as _,
-            keyframe_interval,
-        ),
-        name @ (CodecName::VP8 | CodecName::VP9) => EncoderCfg::VPX(VpxEncoderConfig {
+        format @ (CodecFormat::VP8 | CodecFormat::VP9) => EncoderCfg::VPX(VpxEncoderConfig {
             width: c.width as _,
             height: c.height as _,
             quality,
-            codec: if name == CodecName::VP8 {
+            codec: if format == CodecFormat::VP8 {
                 VpxVideoCodecId::VP8
             } else {
                 VpxVideoCodecId::VP9
             },
             keyframe_interval,
         }),
-        CodecName::AV1 => EncoderCfg::AOM(AomEncoderConfig {
+        CodecFormat::AV1 => EncoderCfg::AOM(AomEncoderConfig {
             width: c.width as _,
             height: c.height as _,
             quality,
             keyframe_interval,
         }),
-    }
-}
-
-fn handle_hw_encoder(
-    _name: CodecName,
-    width: usize,
-    height: usize,
-    quality: Quality,
-    keyframe_interval: Option<usize>,
-) -> EncoderCfg {
-    let f = || {
-        #[cfg(feature = "hwcodec")]
-        match _name {
-            CodecName::H264VRAM | CodecName::H265VRAM => {
-                let format = if _name == CodecName::H265VRAM {
-                    CodecFormat::H265
-                } else {
-                    CodecFormat::H264
-                };
-                if let Some(hw) = HwRamEncoder::try_get(format) {
-                    return Ok(EncoderCfg::HWRAM(HwRamEncoderConfig {
-                        name: hw.name,
-                        width,
-                        height,
-                        quality,
-                        keyframe_interval,
-                    }));
-                }
-            }
-            CodecName::H264RAM(name) | CodecName::H265RAM(name) => {
-                return Ok(EncoderCfg::HWRAM(HwRamEncoderConfig {
-                    name,
-                    width,
-                    height,
-                    quality,
-                    keyframe_interval,
-                }));
-            }
-            _ => {
-                return Err(());
-            }
-        };
-
-        Err(())
-    };
-
-    match f() {
-        Ok(cfg) => cfg,
         _ => EncoderCfg::VPX(VpxEncoderConfig {
-            width: width as _,
-            height: height as _,
+            width: c.width as _,
+            height: c.height as _,
             quality,
             codec: VpxVideoCodecId::VP9,
             keyframe_interval,
@@ -762,7 +708,7 @@ fn handle_hw_encoder(
 fn get_recorder(
     width: usize,
     height: usize,
-    codec_name: &CodecName,
+    codec_format: &CodecFormat,
     record_incoming: bool,
 ) -> Arc<Mutex<Option<Recorder>>> {
     let recorder = if record_incoming {
@@ -782,7 +728,7 @@ fn get_recorder(
             filename: "".to_owned(),
             width,
             height,
-            format: codec_name.into(),
+            format: codec_format.clone(),
             tx,
         })
         .map_or(Default::default(), |r| Arc::new(Mutex::new(Some(r))))


### PR DESCRIPTION
1. Change negotiated codec name to negotiated codec format, which is more reasonable.
2. Fallback to vp9 directly if failed to create encoder, currently failed creation will clear hwcodec config.
3. Show current codec in menu when auto codec is chosen.


https://github.com/rustdesk/rustdesk/assets/14891774/57c48cbf-9e19-4d25-b607-f7d1c176ede8


