### PR TITLE
fix: wayland, accept conn

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1228,6 +1228,10 @@ impl Connection {
         if self.file_transfer.is_some() {
             res.set_peer_info(pi);
         } else {
+            if let Some(msg_out) = super::display_service::is_inited_msg() {
+                self.send(msg_out).await;
+            }
+
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             {
                 #[cfg(not(windows))]
@@ -1249,9 +1253,6 @@ impl Connection {
             }
 
             try_activate_screen();
-            if let Some(msg_out) = super::video_service::is_inited_msg() {
-                self.send(msg_out).await;
-            }
 
             match super::display_service::update_get_sync_displays().await {
                 Err(err) => {

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -838,14 +838,6 @@ fn handle_one_frame(
     Ok(send_conn_ids)
 }
 
-pub fn is_inited_msg() -> Option<Message> {
-    #[cfg(target_os = "linux")]
-    if !is_x11() {
-        return super::wayland::is_inited();
-    }
-    None
-}
-
 #[inline]
 pub fn refresh() {
     #[cfg(target_os = "android")]


### PR DESCRIPTION
Show prompt window after the controlled side accepting the connection.


### Fix desc

Move the `is_inited_msg()` before `try_get_displays()`. Because `try_get_displays()` will try to get the display to share and block current thread.

<img width="764" alt="1715124767823" src="https://github.com/rustdesk/rustdesk/assets/13586388/eac291d8-6ed7-4ec0-a888-325bc809b990">


https://github.com/rustdesk/rustdesk/assets/13586388/ae241742-bade-4237-b92c-2fb3e5993738



#### Chore

Remove dup code `is_inited_msg()`.