### PR TITLE
opt supported encoding update, consider multi connections

### DIFF
--- a/libs/scrap/src/common/record.rs
+++ b/libs/scrap/src/common/record.rs
@@ -2,9 +2,7 @@ use crate::CodecFormat;
 #[cfg(feature = "hwcodec")]
 use hbb_common::anyhow::anyhow;
 use hbb_common::{
-    bail, chrono,
-    config::Config,
-    log,
+    bail, chrono, log,
     message_proto::{message, video_frame, EncodedVideoFrame, Message},
     ResultType,
 };

--- a/libs/scrap/src/common/vram.rs
+++ b/libs/scrap/src/common/vram.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     codec::{base_bitrate, enable_vram_option, EncoderApi, EncoderCfg, Quality},
-    AdapterDevice, CodecFormat, CodecName, EncodeInput, EncodeYuvFormat, Pixfmt,
+    AdapterDevice, CodecFormat, EncodeInput, EncodeYuvFormat, Pixfmt,
 };
 use hbb_common::{
     anyhow::{anyhow, bail, Context},
@@ -283,10 +283,6 @@ impl VRamEncoder {
     pub fn set_not_use(display: usize, not_use: bool) {
         log::info!("set display#{display} not use vram encode to {not_use}");
         ENOCDE_NOT_USE.lock().unwrap().insert(display, not_use);
-    }
-
-    pub fn not_use() -> bool {
-        ENOCDE_NOT_USE.lock().unwrap().iter().any(|v| *v.1)
     }
 }
 

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -638,6 +638,8 @@ impl Drop for Raii {
     fn drop(&mut self) {
         #[cfg(feature = "vram")]
         VRamEncoder::set_not_use(self.0, false);
+        #[cfg(feature = "vram")]
+        Encoder::update(scrap::codec::EncodingUpdate::Check);
         VIDEO_QOS.lock().unwrap().set_support_abr(self.0, true);
     }
 }


### PR DESCRIPTION
Previously, the supported encodings were sent without considering the presence of multiple connections.
Currently, eg: when mac client and x86 sciter client connect to the same device, mac client won't show av1 codec choice.