### PR TITLE
If there is hardware ram encoder as fallback, not require all adapters support the codec format

### DIFF
--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -139,6 +139,7 @@ impl Encoder {
                 Err(e) => {
                     log::error!("new hw encoder failed: {e:?}, clear config");
                     hbb_common::config::HwCodecConfig::clear_ram();
+                    Self::update(EncodingUpdate::Check);
                     *ENCODE_CODEC_FORMAT.lock().unwrap() = CodecFormat::VP9;
                     Err(e)
                 }
@@ -151,6 +152,7 @@ impl Encoder {
                 Err(e) => {
                     log::error!("new vram encoder failed: {e:?}, clear config");
                     hbb_common::config::HwCodecConfig::clear_vram();
+                    Self::update(EncodingUpdate::Check);
                     *ENCODE_CODEC_FORMAT.lock().unwrap() = CodecFormat::VP9;
                     Err(e)
                 }

--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -96,10 +96,7 @@ impl EncoderApi for HwRamEncoder {
                         height: ctx.height as _,
                         bitrate,
                     }),
-                    Err(_) => {
-                        HwCodecConfig::clear_ram();
-                        Err(anyhow!(format!("Failed to create encoder")))
-                    }
+                    Err(_) => Err(anyhow!(format!("Failed to create encoder"))),
                 }
             }
             _ => Err(anyhow!("encoder type mismatch")),


### PR DESCRIPTION
Currently, all displays use the same codec format for encoding. If there is no fallback, and not all displays support the vram encoding, use vram encoding would result in the loop setting of the current encoding codec by different display. Therefore, in the absence of fallback, it is required that all displays support the codec format. With fallback, it is no longer necessary for all displays to support encoding in that codec format. If the hardware codec creation fails, RustDesk_hwcodec.toml will be cleared, avoiding the continuous setting of the current codec.