### PR TITLE
fix: wayland delete restore token

### DIFF
--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1605,5 +1605,10 @@ class RustdeskImpl {
     throw UnimplementedError();
   }
 
+  Future<String> mainHandleWaylandScreencastRestoreToken(
+      {required String key, required String value, dynamic hint}) {
+    throw UnimplementedError();
+  }
+
   void dispose() {}
 }

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -35,6 +35,11 @@ pub fn close_session() {
     let _ = RDP_RESPONSE.lock().unwrap().take();
 }
 
+#[inline]
+pub fn is_rdp_session_hold() -> bool {
+    RDP_RESPONSE.lock().unwrap().is_some()
+}
+
 pub fn try_close_session() {
     let mut rdp_res = RDP_RESPONSE.lock().unwrap();
     let mut close = false;

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -30,11 +30,26 @@ lazy_static! {
     pub static ref RDP_RESPONSE: Mutex<Option<RdpResponse>> = Mutex::new(None);
 }
 
+pub fn try_close_session() {
+    let mut rdp_res = RDP_RESPONSE.lock().unwrap();
+    let mut close = false;
+    if let Some(rdp_res) = &*rdp_res {
+        // If is server running and restore token is supported, there's no need to keep the session.
+        if is_server_running() && rdp_res.is_support_restore_token {
+            close = true;
+        }
+    }
+    if close {
+        *rdp_res = None;
+    }
+}
+
 pub struct RdpResponse {
     pub conn: Arc<SyncConnection>,
     pub streams: Vec<PwStreamInfo>,
     pub fd: OwnedFd,
     pub session: dbus::Path<'static>,
+    pub is_support_restore_token: bool,
 }
 #[derive(Debug, Clone, Copy)]
 pub struct PwStreamInfo {
@@ -476,6 +491,7 @@ pub fn request_remote_desktop() -> Result<
         OwnedFd,
         Vec<PwStreamInfo>,
         dbus::Path<'static>,
+        bool,
     ),
     Box<dyn Error>,
 > {
@@ -504,6 +520,14 @@ pub fn request_remote_desktop() -> Result<
         "handle_token".to_string(),
         Variant(Box::new("u1".to_string())),
     );
+
+    let mut is_support_restore_token = false;
+    if let Ok(version) = screencast_portal::version(&portal) {
+        if version >= 4 {
+            is_support_restore_token = true;
+        }
+    }
+
     // The following code may be improved.
     // https://flatpak.github.io/xdg-desktop-portal/#:~:text=To%20avoid%20a%20race%20condition
     // To avoid a race condition
@@ -524,6 +548,7 @@ pub fn request_remote_desktop() -> Result<
             streams.clone(),
             session.clone(),
             failure.clone(),
+            is_support_restore_token,
         ),
         failure_res.clone(),
     )?;
@@ -547,7 +572,13 @@ pub fn request_remote_desktop() -> Result<
     if let Some(fd_res) = fd_res.clone() {
         if let Some(session) = session_res.clone() {
             if !streams_res.is_empty() {
-                return Ok((conn, fd_res, streams_res.clone(), session));
+                return Ok((
+                    conn,
+                    fd_res,
+                    streams_res.clone(),
+                    session,
+                    is_support_restore_token,
+                ));
             }
         }
     }
@@ -561,6 +592,7 @@ fn on_create_session_response(
     streams: Arc<Mutex<Vec<PwStreamInfo>>>,
     session: Arc<Mutex<Option<dbus::Path<'static>>>>,
     failure: Arc<AtomicBool>,
+    is_support_restore_token: bool,
 ) -> impl Fn(
     OrgFreedesktopPortalRequestResponse,
     &SyncConnection,
@@ -591,15 +623,13 @@ fn on_create_session_response(
         let mut args: PropMap = HashMap::new();
         // See `is_server_running()` to understand the following code.
         if is_server_running() {
-            if let Ok(version) = screencast_portal::version(&portal) {
-                if version >= 4 {
-                    let restore_token = config::LocalConfig::get_option(RESTORE_TOKEN_CONF_KEY);
-                    if !restore_token.is_empty() {
-                        args.insert(RESTORE_TOKEN.to_string(), Variant(Box::new(restore_token)));
-                    }
-                    // persist_mode may be configured by the user.
-                    args.insert("persist_mode".to_string(), Variant(Box::new(2u32)));
+            if is_support_restore_token {
+                let restore_token = config::LocalConfig::get_option(RESTORE_TOKEN_CONF_KEY);
+                if !restore_token.is_empty() {
+                    args.insert(RESTORE_TOKEN.to_string(), Variant(Box::new(restore_token)));
                 }
+                // persist_mode may be configured by the user.
+                args.insert("persist_mode".to_string(), Variant(Box::new(2u32)));
             }
             args.insert(
                 "handle_token".to_string(),
@@ -613,7 +643,13 @@ fn on_create_session_response(
             handle_response(
                 c,
                 path,
-                on_select_sources_response(fd.clone(), streams.clone(), failure.clone(), ses),
+                on_select_sources_response(
+                    fd.clone(),
+                    streams.clone(),
+                    failure.clone(),
+                    ses,
+                    is_support_restore_token,
+                ),
                 failure.clone(),
             )?;
         } else {
@@ -627,7 +663,13 @@ fn on_create_session_response(
             handle_response(
                 c,
                 path,
-                on_select_devices_response(fd.clone(), streams.clone(), failure.clone(), ses),
+                on_select_devices_response(
+                    fd.clone(),
+                    streams.clone(),
+                    failure.clone(),
+                    ses,
+                    is_support_restore_token,
+                ),
                 failure.clone(),
             )?;
         }
@@ -641,6 +683,7 @@ fn on_select_devices_response(
     streams: Arc<Mutex<Vec<PwStreamInfo>>>,
     failure: Arc<AtomicBool>,
     session: dbus::Path<'static>,
+    is_support_restore_token: bool,
 ) -> impl Fn(
     OrgFreedesktopPortalRequestResponse,
     &SyncConnection,
@@ -662,7 +705,13 @@ fn on_select_devices_response(
         handle_response(
             c,
             path,
-            on_select_sources_response(fd.clone(), streams.clone(), failure.clone(), session),
+            on_select_sources_response(
+                fd.clone(),
+                streams.clone(),
+                failure.clone(),
+                session,
+                is_support_restore_token,
+            ),
             failure.clone(),
         )?;
 
@@ -675,6 +724,7 @@ fn on_select_sources_response(
     streams: Arc<Mutex<Vec<PwStreamInfo>>>,
     failure: Arc<AtomicBool>,
     session: dbus::Path<'static>,
+    is_support_restore_token: bool,
 ) -> impl Fn(
     OrgFreedesktopPortalRequestResponse,
     &SyncConnection,
@@ -696,7 +746,12 @@ fn on_select_sources_response(
         handle_response(
             c,
             path,
-            on_start_response(fd.clone(), streams.clone(), session.clone()),
+            on_start_response(
+                fd.clone(),
+                streams.clone(),
+                session.clone(),
+                is_support_restore_token,
+            ),
             failure.clone(),
         )?;
 
@@ -708,6 +763,7 @@ fn on_start_response(
     fd: Arc<Mutex<Option<OwnedFd>>>,
     streams: Arc<Mutex<Vec<PwStreamInfo>>>,
     session: dbus::Path<'static>,
+    is_support_restore_token: bool,
 ) -> impl Fn(
     OrgFreedesktopPortalRequestResponse,
     &SyncConnection,
@@ -717,15 +773,13 @@ fn on_start_response(
         let portal = get_portal(c);
         // See `is_server_running()` to understand the following code.
         if is_server_running() {
-            if let Ok(version) = screencast_portal::version(&portal) {
-                if version >= 4 {
-                    if let Some(restore_token) = r.results.get(RESTORE_TOKEN) {
-                        if let Some(restore_token) = restore_token.as_str() {
-                            config::LocalConfig::set_option(
-                                RESTORE_TOKEN_CONF_KEY.to_owned(),
-                                restore_token.to_owned(),
-                            );
-                        }
+            if is_support_restore_token {
+                if let Some(restore_token) = r.results.get(RESTORE_TOKEN) {
+                    if let Some(restore_token) = restore_token.as_str() {
+                        config::LocalConfig::set_option(
+                            RESTORE_TOKEN_CONF_KEY.to_owned(),
+                            restore_token.to_owned(),
+                        );
                     }
                 }
             }
@@ -752,7 +806,7 @@ pub fn get_capturables() -> Result<Vec<PipeWireCapturable>, Box<dyn Error>> {
     };
 
     if rdp_connection.is_none() {
-        let (conn, fd, streams, session) = request_remote_desktop()?;
+        let (conn, fd, streams, session, is_support_restore_token) = request_remote_desktop()?;
         let conn = Arc::new(conn);
 
         let rdp_res = RdpResponse {
@@ -760,6 +814,7 @@ pub fn get_capturables() -> Result<Vec<PipeWireCapturable>, Box<dyn Error>> {
             streams,
             fd,
             session,
+            is_support_restore_token,
         };
         *rdp_connection = Some(rdp_res);
     }

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -32,7 +32,7 @@ lazy_static! {
 
 #[inline]
 pub fn close_session() {
-    let _ RDP_RESPONSE.lock().unwrap().take();
+    let _ = RDP_RESPONSE.lock().unwrap().take();
 }
 
 pub fn try_close_session() {

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -30,6 +30,11 @@ lazy_static! {
     pub static ref RDP_RESPONSE: Mutex<Option<RdpResponse>> = Mutex::new(None);
 }
 
+#[inline]
+pub fn close_session() {
+    let _ RDP_RESPONSE.lock().unwrap().take();
+}
+
 pub fn try_close_session() {
     let mut rdp_res = RDP_RESPONSE.lock().unwrap();
     let mut close = false;

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -909,6 +909,33 @@ pub fn main_set_local_option(key: String, value: String) {
     set_local_option(key, value)
 }
 
+// We do use use `main_get_local_option` and `main_set_local_option`.
+//
+// 1. For get, the value is stored in the server process.
+// 2. For clear, we need to need to return the error mmsg from the server process to flutter.
+pub fn main_handle_wayland_screencast_restore_token(key: String, value: String) -> String {
+    if value == "get" {
+        match crate::ipc::get_wayland_screencast_restore_token(key) {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("Failed to get wayland screencast restore token, {}", e);
+                "".to_owned()
+            }
+        }
+    } else if value == "clear" {
+        match crate::ipc::clear_wayland_screencast_restore_token(key.clone()) {
+            Ok(true) => {
+                set_local_option(key, "".to_owned());
+                "".to_owned()
+            }
+            Ok(false) => "Failed to clear, please try again.".to_owned(),
+            Err(e) => format!("Failed to clear, {}", e),
+        }
+    } else {
+        "".to_owned()
+    }
+}
+
 pub fn main_get_input_source() -> SyncReturn<String> {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     let input_source = get_cur_session_input_source();

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -913,6 +913,7 @@ pub fn main_set_local_option(key: String, value: String) {
 //
 // 1. For get, the value is stored in the server process.
 // 2. For clear, we need to need to return the error mmsg from the server process to flutter.
+#[cfg(target_os = "linux")]
 pub fn main_handle_wayland_screencast_restore_token(key: String, value: String) -> String {
     if value == "get" {
         match crate::ipc::get_wayland_screencast_restore_token(key) {
@@ -934,6 +935,11 @@ pub fn main_handle_wayland_screencast_restore_token(key: String, value: String) 
     } else {
         "".to_owned()
     }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn main_handle_wayland_screencast_restore_token(_key: String, _value: String) -> String {
+    "".to_owned()
 }
 
 pub fn main_get_input_source() -> SyncReturn<String> {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -536,6 +536,8 @@ async fn handle(data: Data, stream: &mut Connection) {
                 Some(get_local_option(key.clone()))
             } else if value == "clear" {
                 set_local_option(key.clone(), "".to_owned());
+                #[cfg(target_os = "linux")]
+                scrap::wayland::pipewire::close_session();
                 Some("".to_owned())
             } else {
                 None

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -5,7 +5,10 @@ use std::{
 #[cfg(not(windows))]
 use std::{fs::File, io::prelude::*};
 
-use crate::privacy_mode::PrivacyModeState;
+use crate::{
+    privacy_mode::PrivacyModeState,
+    ui_interface::{get_local_option, set_local_option},
+};
 use bytes::Bytes;
 use parity_tokio_ipc::{
     Connection as Conn, ConnectionClient as ConnClient, Endpoint, Incoming, SecurityAttributes,
@@ -234,6 +237,8 @@ pub enum Data {
     CmErr(String),
     CheckHwcodec,
     VideoConnCount(Option<usize>),
+    // Although the key is not neccessary, it is used to avoid hardcoding the key.
+    WaylandScreencastRestoreToken((String, String)),
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -524,6 +529,23 @@ async fn handle(data: Data, stream: &mut Connection) {
             #[cfg(any(target_os = "windows", target_os = "linux"))]
             if crate::platform::is_root() {
                 scrap::hwcodec::start_check_process(true);
+            }
+        }
+        Data::WaylandScreencastRestoreToken((key, value)) => {
+            let v = if value == "get" {
+                Some(get_local_option(key.clone()))
+            } else if value == "clear" {
+                set_local_option(key.clone(), "".to_owned());
+                Some("".to_owned())
+            } else {
+                None
+            };
+            if let Some(v) = v {
+                allow_err!(
+                    stream
+                        .send(&Data::WaylandScreencastRestoreToken((key, v)))
+                        .await
+                );
             }
         }
         _ => {}
@@ -957,6 +979,35 @@ pub async fn connect_to_user_session(usid: Option<u32>) -> ResultType<()> {
 pub async fn notify_server_to_check_hwcodec() -> ResultType<()> {
     connect(1_000, "").await?.send(&&Data::CheckHwcodec).await?;
     Ok(())
+}
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn get_wayland_screencast_restore_token(key: String) -> ResultType<String> {
+    let v = handle_wayland_screencast_restore_token(key, "get".to_owned()).await?;
+    Ok(v.unwrap_or_default())
+}
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn clear_wayland_screencast_restore_token(key: String) -> ResultType<bool> {
+    if let Some(v) = handle_wayland_screencast_restore_token(key, "clear".to_owned()).await? {
+        return Ok(v.is_empty());
+    }
+    return Ok(false);
+}
+
+async fn handle_wayland_screencast_restore_token(
+    key: String,
+    value: String,
+) -> ResultType<Option<String>> {
+    let ms_timeout = 1_000;
+    let mut c = connect(ms_timeout, "").await?;
+    c.send(&Data::WaylandScreencastRestoreToken((key, value)))
+        .await?;
+    if let Some(Data::WaylandScreencastRestoreToken((_key, v))) = c.next_timeout(ms_timeout).await?
+    {
+        return Ok(Some(v));
+    }
+    return Ok(None);
 }
 
 #[cfg(test)]

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "未找到音频输入设备"),
         ("Incoming", "被控"),
         ("Outgoing", "主控"),
-        ("Clear wayland screen selection", "清除 Wayland 的屏幕选择"),
-        ("clear_wayland_screen_selection_tip", "清除 Wayland 的屏幕选择后，您可以重新选择分享的屏幕。"),
-        ("confirm_clear_wayland_screen_selection_tip", "是否确认清除 Wayland 的分享屏幕选择？"),
+        ("Clear Wayland screen selection", "清除 Wayland 的屏幕选择"),
+        ("clear_Wayland_screen_selection_tip", "清除 Wayland 的屏幕选择后，您可以重新选择分享的屏幕。"),
+        ("confirm_clear_Wayland_screen_selection_tip", "是否确认清除 Wayland 的分享屏幕选择？"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "未找到音频输入设备"),
         ("Incoming", "被控"),
         ("Outgoing", "主控"),
+        ("Clear wayland screen selection", "清除 Wayland 的屏幕选择"),
+        ("clear_wayland_screen_selection_tip", "清除 Wayland 的屏幕选择后，您可以重新选择分享的屏幕。"),
+        ("confirm_clear_wayland_screen_selection_tip", "是否确认清除 Wayland 的分享屏幕选择？"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "Nebylo nalezeno žádné vstupní zvukové zařízení."),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "Nebylo nalezeno žádné vstupní zvukové zařízení."),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "Kein Audio-Eingabegerät gefunden."),
         ("Incoming", "Eingehend"),
         ("Outgoing", "Ausgehend"),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "Kein Audio-Eingabegerät gefunden."),
         ("Incoming", "Eingehend"),
         ("Outgoing", "Ausgehend"),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -225,5 +225,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Follow remote window focus", ""),
         ("default_proxy_tip", "Default protocol and port are Socks5 and 1080"),
         ("no_audio_input_device_tip", "No audio input device found."),
+        ("clear_wayland_screen_selection_tip", "After clearing the screen selection, you can reselect the screen to share."),
+        ("confirm_clear_wayland_screen_selection_tip", "Are you sure to clear the Wayland screen selection?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -225,7 +225,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Follow remote window focus", ""),
         ("default_proxy_tip", "Default protocol and port are Socks5 and 1080"),
         ("no_audio_input_device_tip", "No audio input device found."),
-        ("clear_wayland_screen_selection_tip", "After clearing the screen selection, you can reselect the screen to share."),
-        ("confirm_clear_wayland_screen_selection_tip", "Are you sure to clear the Wayland screen selection?"),
+        ("clear_Wayland_screen_selection_tip", "After clearing the screen selection, you can reselect the screen to share."),
+        ("confirm_clear_Wayland_screen_selection_tip", "Are you sure to clear the Wayland screen selection?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "Nessun dispositivo input audio trovato."),
         ("Incoming", "In entrata"),
         ("Outgoing", "In uscita"),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "Nessun dispositivo input audio trovato."),
         ("Incoming", "In entrata"),
         ("Outgoing", "In uscita"),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "Nav atrasta neviena audio ievades ierīce."),
         ("Incoming", "Ienākošie"),
         ("Outgoing", "Izejošie"),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "Nav atrasta neviena audio ievades ierīce."),
         ("Incoming", "Ienākošie"),
         ("Outgoing", "Izejošie"),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "Nenašlo sa žiadne vstupné zvukové zariadenie."),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", "Nenašlo sa žiadne vstupné zvukové zariadenie."),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -607,13 +607,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Follow remote window focus", ""),
         ("default_proxy_tip", ""),
         ("no_audio_input_device_tip", ""),
-<<<<<<< HEAD
-        ("Incoming", ""),
-        ("Outgoing", ""),
-=======
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
->>>>>>> 65138937a (fix: wayland delete restore token)
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -607,6 +607,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Follow remote window focus", ""),
         ("default_proxy_tip", ""),
         ("no_audio_input_device_tip", ""),
+        ("Incoming", ""),
+        ("Outgoing", ""),
         ("Clear Wayland screen selection", ""),
         ("clear_Wayland_screen_selection_tip", ""),
         ("confirm_clear_Wayland_screen_selection_tip", ""),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -607,7 +607,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Follow remote window focus", ""),
         ("default_proxy_tip", ""),
         ("no_audio_input_device_tip", ""),
+<<<<<<< HEAD
         ("Incoming", ""),
         ("Outgoing", ""),
+=======
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
+>>>>>>> 65138937a (fix: wayland delete restore token)
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -609,8 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
-        ("Clear wayland screen selection", ""),
-        ("clear_wayland_screen_selection_tip", ""),
-        ("confirm_clear_wayland_screen_selection_tip", ""),
+        ("Clear Wayland screen selection", ""),
+        ("clear_Wayland_screen_selection_tip", ""),
+        ("confirm_clear_Wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -609,5 +609,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no_audio_input_device_tip", ""),
         ("Incoming", ""),
         ("Outgoing", ""),
+        ("Clear wayland screen selection", ""),
+        ("clear_wayland_screen_selection_tip", ""),
+        ("confirm_clear_wayland_screen_selection_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3736,6 +3736,8 @@ mod raii {
                 display_service::reset_resolutions();
                 #[cfg(windows)]
                 let _ = virtual_display_manager::reset_all();
+                #[cfg(target_os = "linux")]
+                scrap::wayland::pipewire::try_close_session();
             }
             Self::check_wake_lock();
         }


### PR DESCRIPTION
1. Add a button to clear wayland restore token.
2. If restore token is supported, do not hold the dbus session.
3. Support close session if restore is not supported. Then the user can select another screen without restarting the server process.


https://github.com/rustdesk/rustdesk/assets/13586388/bfbf7870-5521-4607-9de3-c2ab492623ae


