### PR TITLE
fix android possible waiting for image issue

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -338,9 +338,7 @@ class MainService : Service() {
                 ).apply {
                     setOnImageAvailableListener({ imageReader: ImageReader ->
                         try {
-                            if (!isStart) {
-                                return@setOnImageAvailableListener
-                            }
+                            // If not call acquireLatestImage, listener will not be called again
                             imageReader.acquireLatestImage().use { image ->
                                 if (image == null || !isStart) return@setOnImageAvailableListener
                                 val planes = image.planes


### PR DESCRIPTION
`isStart` can be false when `onImageAvailable` is called, If not call `acquireLatestImage`, listener will not be called again

![acquireLatestImage](https://github.com/rustdesk/rustdesk/assets/14891774/d4ef035a-ecdb-46ce-ba48-2ecf36932123)
