### PR TITLE
fix android crash caused by outdated video frame ptr

### DIFF
--- a/libs/scrap/src/android/ffi.rs
+++ b/libs/scrap/src/android/ffi.rs
@@ -48,6 +48,8 @@ impl FrameRaw {
 
     fn set_enable(&mut self, value: bool) {
         self.enable = value;
+        self.ptr.store(std::ptr::null_mut(), SeqCst);
+        self.len = 0;
     }
 
     fn update(&mut self, data: *mut u8, len: usize) {
@@ -141,11 +143,7 @@ pub extern "system" fn Java_ffi_FFI_setFrameRawEnable(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_ffi_FFI_init(
-    env: JNIEnv,
-    _class: JClass,
-    ctx: JObject,
-) {
+pub extern "system" fn Java_ffi_FFI_init(env: JNIEnv, _class: JClass, ctx: JObject) {
     log::debug!("MainService init from java");
     if let Ok(jvm) = env.get_java_vm() {
         *JVM.write().unwrap() = Some(jvm);


### PR DESCRIPTION
reproduce: landscape and portrait switching

crash reason
```
scrap::android::ffi: update ptr:529676931072 len:2764800
scrap::android::ffi: Java_ffi_FFI_setFrameRawEnable value:0
scrap::android::ffi: Java_ffi_FFI_setFrameRawEnable value:1
scrap::android::ffi: take ptr: 529676931072 len:2764800
scrap::android::ffi: update ptr:529682608128 len:2626560
```

full crash log
```
2024-05-09 21:38:40.690 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529676931072 len:2764800
2024-05-09 21:38:40.697 11598-11598 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: Java_ffi_FFI_setFrameRawEnable value:0
2024-05-09 21:38:40.697 11598-11598 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: Java_ffi_FFI_setFrameRawEnable value:0
2024-05-09 21:38:40.703 11598-12349 rustdesk                com.carriez.flutter_hbb              I  librustdesk::server::video_service: after encode_to_message
2024-05-09 21:38:40.704 11598-12349 rustdesk                com.carriez.flutter_hbb              I  librustdesk::server::video_service: before frame
2024-05-09 21:38:40.704 11598-12349 rustdesk                com.carriez.flutter_hbb              I  scrap::common::android: before get_video_raw
2024-05-09 21:38:40.720 11598-12349 rustdesk                com.carriez.flutter_hbb              I  librustdesk::server::video_service: before frame
2024-05-09 21:38:40.720 11598-12349 rustdesk                com.carriez.flutter_hbb              I  scrap::common::android: before get_video_raw
2024-05-09 21:38:40.739 11598-12349 rustdesk                com.carriez.flutter_hbb              I  librustdesk::server::video_service: before frame
2024-05-09 21:38:40.739 11598-12349 rustdesk                com.carriez.flutter_hbb              I  scrap::common::android: before get_video_raw
2024-05-09 21:38:40.746 11598-11598 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: Java_ffi_FFI_setFrameRawEnable value:1
2024-05-09 21:38:40.746 11598-11598 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: Java_ffi_FFI_setFrameRawEnable value:1
2024-05-09 21:38:40.755 11598-12349 rustdesk                com.carriez.flutter_hbb              I  librustdesk::server::video_service: before frame
2024-05-09 21:38:40.755 11598-12349 rustdesk                com.carriez.flutter_hbb              I  scrap::common::android: before get_video_raw
2024-05-09 21:38:40.755 11598-12349 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: take ptr: 529676931072 len:2764800
2024-05-09 21:38:40.781 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:40.841 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:40.855 11598-12028 rustdesk                com.carriez.flutter_hbb              I  librustdesk::server::display_service: Displays changed
2024-05-09 21:38:40.856 11598-12016 rustdesk                com.carriez.flutter_hbb              D  jni::wrapper::java_vm::vm: Attached daemon thread tokio-runtime-worker (ThreadId(13)). 4 threads attached
---------------------------- PROCESS STARTED (12387) for package com.carriez.flutter_hbb ----------------------------
2024-05-09 21:38:40.856 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:40.944 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:40.957 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:40.973 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:40.995 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.043 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.141 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.162 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.174 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.190 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.198 11598-12020 rustdesk                com.carriez.flutter_hbb              I  librustdesk::server::connection: Option update: OptionMessage { image_quality: NotSet, lock_after_session_end: NotSet, show_remote_cursor: NotSet, privacy_mode: NotSet, block_input: NotSet, custom_image_quality: 0, disable_audio: NotSet, disable_clipboard: NotSet, enable_file_transfer: NotSet, supported_decoding: MessageField(None), custom_fps: 60, disable_keyboard: NotSet, follow_remote_cursor: NotSet, follow_remote_window: NotSet, special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }
2024-05-09 21:38:41.208 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.226 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.241 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.257 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.274 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.291 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.308 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
2024-05-09 21:38:41.319 12384-12384 DEBUG                   crash_dump64                         A        #01 pc 000000000099f418  /data/app/~~tUN2kaWKt9QSvg8cKHjKxw==/com.carriez.flutter_hbb-X6amefXcZGpFa_l5daSKWA==/lib/arm64/librustdesk.so (_$LT$scrap..common..android..Capturer$u20$as$u20$scrap..common..TraitCapturer$GT$::frame::hc8ebe9a3894218f6+172)
2024-05-09 21:38:41.319 12384-12384 DEBUG                   crash_dump64                         A        #02 pc 00000000007683f4  /data/app/~~tUN2kaWKt9QSvg8cKHjKxw==/com.carriez.flutter_hbb-X6amefXcZGpFa_l5daSKWA==/lib/arm64/librustdesk.so (librustdesk::server::video_service::run::hff0043b92d01c838+4008)
2024-05-09 21:38:41.319 12384-12384 DEBUG                   crash_dump64                         A        #03 pc 00000000006bc948  /data/app/~~tUN2kaWKt9QSvg8cKHjKxw==/com.carriez.flutter_hbb-X6amefXcZGpFa_l5daSKWA==/lib/arm64/librustdesk.so (std::sys_common::backtrace::__rust_begin_short_backtrace::h18593485b4f32afb+660)
2024-05-09 21:38:41.319 12384-12384 DEBUG                   crash_dump64                         A        #04 pc 00000000006e098c  /data/app/~~tUN2kaWKt9QSvg8cKHjKxw==/com.carriez.flutter_hbb-X6amefXcZGpFa_l5daSKWA==/lib/arm64/librustdesk.so (core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h7af8f69a676ad651+108)
2024-05-09 21:38:41.319 12384-12384 DEBUG                   crash_dump64                         A        #05 pc 0000000001595e48  /data/app/~~tUN2kaWKt9QSvg8cKHjKxw==/com.carriez.flutter_hbb-X6amefXcZGpFa_l5daSKWA==/lib/arm64/librustdesk.so (std::sys::pal::unix::thread::Thread::new::thread_start::h9d781aa31d337b91+24)
2024-05-09 21:38:41.325 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
---------------------------- PROCESS ENDED (11598) for package com.carriez.flutter_hbb ----------------------------
2024-05-09 21:38:41.342 11598-12014 rustdesk                com.carriez.flutter_hbb              I  scrap::android::ffi: update ptr:529682608128 len:2626560
```