### PR TITLE
fix: linux, custom client, incoming only, resizable

### DIFF
--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -154,6 +154,7 @@ const kDefaultScrollDuration = Duration(milliseconds: 50);
 const kDefaultMouseWheelThrottleDuration = Duration(milliseconds: 50);
 const kFullScreenEdgeSize = 0.0;
 const kMaximizeEdgeSize = 0.0;
+// Do not use kWindowEdgeSize directly. Use `windowEdgeSize` in `common.dart` instead.
 final kWindowEdgeSize = isWindows ? 1.0 : 5.0;
 final kWindowBorderWidth = isLinux ? 1.0 : 0.0;
 const kDesktopMenuPadding = EdgeInsets.only(left: 12.0, right: 3.0);

--- a/flutter/lib/desktop/pages/desktop_tab_page.dart
+++ b/flutter/lib/desktop/pages/desktop_tab_page.dart
@@ -57,10 +57,10 @@ class _DesktopTabPageState extends State<DesktopTabPage> {
       tabController.onSelected = (key) {
         if (key == kTabLabelHomePage) {
           windowManager.setSize(getIncomingOnlyHomeSize());
-          windowManager.setResizable(false);
+          setResizable(false);
         } else {
           windowManager.setSize(getIncomingOnlySettingsSize());
-          windowManager.setResizable(true);
+          setResizable(true);
         }
       };
     }

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -144,12 +144,8 @@ void runMainApp(bool startService) async {
     }
     windowManager.setOpacity(1);
     windowManager.setTitle(getWindowName());
-    // `windowManager.setResizable(false)` will reset the window size to the default size on Linux.
-    // https://stackoverflow.com/questions/8193613/gtk-window-resize-disable-without-going-back-to-default
-    if (!isLinux) {
-      windowManager.setResizable(!bind.isIncomingOnly());
-    }
-    // For Linux, we set the edge size to 0 to disable resize. See `get windowEdgeSize` in common.dart.
+    // Do not use `windowManager.setResizable()` here.
+    setResizable(!bind.isIncomingOnly());
   });
 }
 
@@ -243,7 +239,7 @@ void runConnectionManagerScreen() async {
   } else {
     await showCmWindow(isStartup: true);
   }
-  windowManager.setResizable(false);
+  setResizable(false);
   // Start the uni links handler and redirect links to Native, not for Flutter.
   listenUniLinks(handleByFlutter: false);
 }

--- a/flutter/lib/models/state_model.dart
+++ b/flutter/lib/models/state_model.dart
@@ -56,8 +56,7 @@ class StateGlobal {
     if (!_fullscreen.isTrue) {
       if (isMaximized.value != v) {
         isMaximized.value = v;
-        _resizeEdgeSize.value =
-            isMaximized.isTrue ? kMaximizeEdgeSize : windowEdgeSize;
+        refreshResizeEdgeSize();
       }
       if (!isMacOS) {
         _windowBorderWidth.value = v ? 0 : kWindowBorderWidth;
@@ -71,11 +70,7 @@ class StateGlobal {
     if (_fullscreen.value != v) {
       _fullscreen.value = v;
       _showTabBar.value = !_fullscreen.value;
-      _resizeEdgeSize.value = fullscreen.isTrue
-          ? kFullScreenEdgeSize
-          : isMaximized.isTrue
-              ? kMaximizeEdgeSize
-              : windowEdgeSize;
+      refreshResizeEdgeSize();
       print(
           "fullscreen: $fullscreen, resizeEdgeSize: ${_resizeEdgeSize.value}");
       _windowBorderWidth.value = fullscreen.isTrue ? 0 : kWindowBorderWidth;
@@ -95,6 +90,12 @@ class StateGlobal {
       }
     }
   }
+
+  refreshResizeEdgeSize() => _resizeEdgeSize.value = fullscreen.isTrue
+      ? kFullScreenEdgeSize
+      : isMaximized.isTrue
+          ? kMaximizeEdgeSize
+          : windowEdgeSize;
 
   String getInputSource({bool force = false}) {
     if (force || _inputSource.isEmpty) {


### PR DESCRIPTION
Remove `windowManager.setResizable()`, use `setResizable()` in `common.dart` instead.

https://github.com/rustdesk/rustdesk/assets/13586388/e010bfc2-994b-423c-9750-60f0bae5569d

