### PR TITLE
add ffmpeg mediacodec h264/h265 encode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,8 +3038,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.9"
-source = "git+https://github.com/21pages/hwcodec#7a52282267cb6aadbcd74c132bd4ecd43ab6f505"
+version = "0.4.10"
+source = "git+https://github.com/21pages/hwcodec#9cb895fdaea198dd72bd75980109dbd05a059a60"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/flutter/android/app/src/main/kotlin/ffi.kt
+++ b/flutter/android/app/src/main/kotlin/ffi.kt
@@ -18,4 +18,5 @@ object FFI {
     external fun translateLocale(localeName: String, input: String): String
     external fun refreshScreen()
     external fun setFrameRawEnable(name: String, value: Boolean)
+    external fun setCodecInfo(info: String)
 }

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -44,6 +44,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
   var _onlyWhiteList = false;
   var _enableDirectIPAccess = false;
   var _enableRecordSession = false;
+  var _enableHardwareCodec = false;
   var _autoRecordIncomingSession = false;
   var _allowAutoDisconnect = false;
   var _localIP = "";
@@ -118,6 +119,13 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
       if (enableRecordSession != _enableRecordSession) {
         update = true;
         _enableRecordSession = enableRecordSession;
+      }
+
+      final enableHardwareCodec = option2bool(
+          'enable-hwcodec', await bind.mainGetOption(key: 'enable-hwcodec'));
+      if (_enableHardwareCodec != enableHardwareCodec) {
+        update = true;
+        _enableHardwareCodec = enableHardwareCodec;
       }
 
       final autoRecordIncomingSession = option2bool(
@@ -513,6 +521,22 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
             },
           )
         ]),
+        if (isAndroid)
+          SettingsSection(title: Text(translate('Hardware Codec')), tiles: [
+            SettingsTile.switchTile(
+              title: Text(translate('Enable hardware codec')),
+              initialValue: _enableHardwareCodec,
+              onToggle: (v) async {
+                await bind.mainSetOption(
+                    key: "enable-hwcodec", value: v ? "" : "N");
+                final newValue =
+                    await bind.mainGetOption(key: "enable-hwcodec") != "N";
+                setState(() {
+                  _enableHardwareCodec = newValue;
+                });
+              },
+            ),
+          ]),
         if (isAndroid && !outgoingOnly)
           SettingsSection(
             title: Text(translate("Recording")),

--- a/libs/scrap/examples/benchmark.rs
+++ b/libs/scrap/examples/benchmark.rs
@@ -272,6 +272,7 @@ mod hw {
         let mut encoder = HwRamEncoder::new(
             EncoderCfg::HWRAM(HwRamEncoderConfig {
                 name: info.name.clone(),
+                mc_name: None,
                 width,
                 height,
                 quality,

--- a/libs/scrap/src/common/aom.rs
+++ b/libs/scrap/src/common/aom.rs
@@ -296,6 +296,14 @@ impl EncoderApi for AomEncoder {
     fn support_abr(&self) -> bool {
         true
     }
+
+    fn support_changing_quality(&self) -> bool {
+        true
+    }
+
+    fn latency_free(&self) -> bool {
+        true
+    }
 }
 
 impl AomEncoder {

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -70,6 +70,10 @@ pub trait EncoderApi {
     fn bitrate(&self) -> u32;
 
     fn support_abr(&self) -> bool;
+
+    fn support_changing_quality(&self) -> bool;
+
+    fn latency_free(&self) -> bool;
 }
 
 pub struct Encoder {
@@ -138,6 +142,9 @@ impl Encoder {
                 }),
                 Err(e) => {
                     log::error!("new hw encoder failed: {e:?}, clear config");
+                    #[cfg(target_os = "android")]
+                    crate::android::ffi::clear_codec_info();
+                    #[cfg(not(target_os = "android"))]
                     hbb_common::config::HwCodecConfig::clear_ram();
                     Self::update(EncodingUpdate::Check);
                     *ENCODE_CODEC_FORMAT.lock().unwrap() = CodecFormat::VP9;
@@ -346,7 +353,14 @@ impl Encoder {
             EncoderCfg::AOM(_) => CodecFormat::AV1,
             #[cfg(feature = "hwcodec")]
             EncoderCfg::HWRAM(hw) => {
-                if hw.name.to_lowercase().contains("h264") {
+                let name = hw.name.to_lowercase();
+                if name.contains("vp8") {
+                    CodecFormat::VP8
+                } else if name.contains("vp9") {
+                    CodecFormat::VP9
+                } else if name.contains("av1") {
+                    CodecFormat::AV1
+                } else if name.contains("h264") {
                     CodecFormat::H264
                 } else {
                     CodecFormat::H265
@@ -817,7 +831,7 @@ impl Decoder {
 
 #[cfg(any(feature = "hwcodec", feature = "mediacodec"))]
 pub fn enable_hwcodec_option() -> bool {
-    if cfg!(windows) || cfg!(target_os = "linux") || cfg!(feature = "mediacodec") {
+    if cfg!(windows) || cfg!(target_os = "linux") || cfg!(target_os = "android") {
         if let Some(v) = Config2::get().options.get("enable-hwcodec") {
             return v != "N";
         }
@@ -844,6 +858,15 @@ pub enum Quality {
 impl Default for Quality {
     fn default() -> Self {
         Self::Balanced
+    }
+}
+
+impl Quality {
+    pub fn is_custom(&self) -> bool {
+        match self {
+            Quality::Custom(_) => true,
+            _ => false,
+        }
     }
 }
 

--- a/libs/scrap/src/common/vpxcodec.rs
+++ b/libs/scrap/src/common/vpxcodec.rs
@@ -235,6 +235,13 @@ impl EncoderApi for VpxEncoder {
     fn support_abr(&self) -> bool {
         true
     }
+    fn support_changing_quality(&self) -> bool {
+        true
+    }
+
+    fn latency_free(&self) -> bool {
+        true
+    }
 }
 
 impl VpxEncoder {

--- a/libs/scrap/src/common/vram.rs
+++ b/libs/scrap/src/common/vram.rs
@@ -180,6 +180,14 @@ impl EncoderApi for VRamEncoder {
     fn support_abr(&self) -> bool {
         self.config.device.vendor_id != ADAPTER_VENDOR_INTEL as u32
     }
+
+    fn support_changing_quality(&self) -> bool {
+        true
+    }
+
+    fn latency_free(&self) -> bool {
+        true
+    }
 }
 
 impl VRamEncoder {

--- a/src/server/video_qos.rs
+++ b/src/server/video_qos.rs
@@ -124,6 +124,10 @@ impl VideoQoS {
         self.support_abr.insert(display_idx, support);
     }
 
+    pub fn in_vbr_state(&self) -> bool {
+        Config::get_option("enable-abr") != "N" && self.support_abr.iter().all(|e| *e.1)
+    }
+
     pub fn refresh(&mut self, typ: Option<RefreshType>) {
         // fps
         let user_fps = |u: &UserData| {
@@ -178,8 +182,7 @@ impl VideoQoS {
         let mut quality = latest_quality;
 
         // network delay
-        let abr_enabled =
-            Config::get_option("enable-abr") != "N" && self.support_abr.iter().all(|e| *e.1);
+        let abr_enabled = self.in_vbr_state();
         if abr_enabled && typ != Some(RefreshType::SetImageQuality) {
             // max delay
             let delay = self


### PR DESCRIPTION
* Check available when app start from kotlin via get codec info
* For latency free, repeat encode 10 frame at most when capture return WouldBlock
* For changing quality, kotlin support but jni doesn't support, rerun video service when quality is manualy changed
* 3 or 6 times bitrate for mediacodec because its quality is poor


https://github.com/rustdesk/rustdesk/assets/14891774/fbfebe4d-c6f7-4b12-8a64-89b8d21e5c79

https://github.com/rustdesk/rustdesk/assets/14891774/67a6dba0-3ef3-45b4-8a74-303896a058e0

https://github.com/rustdesk/rustdesk/assets/14891774/fea562c5-d564-49cc-9ac9-921f5c86ce5c

