### PR TITLE
Not require both  max-width and max-height of mediacodec larger than  screen width and screen height

### DIFF
--- a/libs/scrap/src/android/ffi.rs
+++ b/libs/scrap/src/android/ffi.rs
@@ -178,6 +178,8 @@ pub struct MediaCodecInfo {
 #[derive(Debug, Deserialize, Clone)]
 pub struct MediaCodecInfos {
     pub version: usize,
+    pub w: usize,
+    pub h: usize,
     pub codecs: Vec<MediaCodecInfo>,
 }
 


### PR DESCRIPTION
* Only use hardware codec, when api < 29, judge with codec name prefix.