### PR TITLE
CI: Remove unused apt package

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -38,10 +38,8 @@ jobs:
             git \
             g++ \
             libclang-10-dev \
-            libclang-dev \
             libgtk-3-dev \
             llvm-10-dev \
-            llvm-dev \
             nasm \
             ninja-build \
             pkg-config \

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -783,7 +783,6 @@ jobs:
                libasound2-dev \
                libc6-dev \
                libclang-10-dev \
-               libclang-dev \
                libgstreamer1.0-dev \
                libgstreamer-plugins-base1.0-dev \
                libgtk-3-dev \
@@ -797,7 +796,6 @@ jobs:
                libxdo-dev \
                libxfixes-dev \
                llvm-10-dev \
-               llvm-dev \
                nasm \
                ninja-build \
                openjdk-11-jdk-headless \
@@ -1073,7 +1071,6 @@ jobs:
                libappindicator3-dev \
                libasound2-dev \
                libclang-10-dev \
-               libclang-dev \
                libgstreamer1.0-dev \
                libgstreamer-plugins-base1.0-dev \
                libgtk-3-dev \
@@ -1087,7 +1084,6 @@ jobs:
                libxdo-dev \
                libxfixes-dev \
                llvm-10-dev \
-               llvm-dev \
                nasm \
                ninja-build \
                pkg-config \


### PR DESCRIPTION
Currently there are two overlaping apt metapackages being installed in CI workflows: llvm-dev and llvm-10-dev. Installing both of them increases time for the workflow.
In ubuntu:18.04 (the one is being used in the workflow) llvm-dev is resolved to llvm-6-dev. The difference between installing llvm-dev and llvm-10-dev are these packages: 

- libjsoncpp1(installed only with llvm-dev and I can't seem to find the usage of this package in the code),
- libllvm10 and libllvm6.0,
- llvm-10 and llvm-6.0,
- llvm-10-dev and llvm-6.0-dev,
- llvm-10-runtime and llvm-6.0-runtime.

You can see that by trying to installing them separately:
```
root@9b7cdaa9581a:/# apt install llvm-dev
The following additional packages will be installed:
  binfmt-support libedit2 libffi-dev libjsoncpp1 libllvm6.0 libpipeline1 libtinfo-dev llvm llvm-6.0 llvm-6.0-dev
  llvm-6.0-runtime llvm-runtime
Suggested packages:
  llvm-6.0-doc
The following NEW packages will be installed:
  binfmt-support libedit2 libffi-dev libjsoncpp1 libllvm6.0 libpipeline1 libtinfo-dev llvm llvm-6.0 llvm-6.0-dev
  llvm-6.0-runtime llvm-dev llvm-runtime
0 upgraded, 13 newly installed, 0 to remove and 1 not upgraded.
```

```
root@9b7cdaa9581a:/# apt install llvm-dev llvm-10-dev
The following additional packages will be installed:
  binfmt-support file libclang-cpp10 libedit2 libexpat1 libffi-dev libgomp1 libjsoncpp1 libllvm10 libllvm6.0
  libmagic-mgc libmagic1 libmpdec2 libpfm4 libpipeline1 libpython3-stdlib libpython3.6-minimal libpython3.6-stdlib
  libreadline7 libsqlite3-0 libssl1.1 libtinfo-dev libyaml-0-2 libz3-4 libz3-dev llvm llvm-10 llvm-10-runtime
  llvm-10-tools llvm-6.0 llvm-6.0-dev llvm-6.0-runtime llvm-runtime mime-support python3 python3-minimal
  python3-pkg-resources python3-pygments python3-yaml python3.6 python3.6-minimal readline-common xz-utils
Suggested packages:
  llvm-10-doc llvm-6.0-doc python3-doc python3-tk python3-venv python3-setuptools ttf-bitstream-vera python3.6-venv
  python3.6-doc binutils readline-doc
The following NEW packages will be installed:
  binfmt-support file libclang-cpp10 libedit2 libexpat1 libffi-dev libgomp1 libjsoncpp1 libllvm10 libllvm6.0
  libmagic-mgc libmagic1 libmpdec2 libpfm4 libpipeline1 libpython3-stdlib libpython3.6-minimal libpython3.6-stdlib
  libreadline7 libsqlite3-0 libssl1.1 libtinfo-dev libyaml-0-2 libz3-4 libz3-dev llvm llvm-10 llvm-10-dev
  llvm-10-runtime llvm-10-tools llvm-6.0 llvm-6.0-dev llvm-6.0-runtime llvm-dev llvm-runtime mime-support python3
  python3-minimal python3-pkg-resources python3-pygments python3-yaml python3.6 python3.6-minimal readline-common
  xz-utils
0 upgraded, 45 newly installed, 0 to remove and 1 not upgraded.
```

```
root@9b7cdaa9581a:/# apt install llvm-10-dev
The following additional packages will be installed:
  binfmt-support file libclang-cpp10 libedit2 libexpat1 libffi-dev libgomp1 libllvm10 libmagic-mgc libmagic1 libmpdec2
  libpfm4 libpipeline1 libpython3-stdlib libpython3.6-minimal libpython3.6-stdlib libreadline7 libsqlite3-0 libssl1.1
  libtinfo-dev libyaml-0-2 libz3-4 libz3-dev llvm-10 llvm-10-runtime llvm-10-tools mime-support python3
  python3-minimal python3-pkg-resources python3-pygments python3-yaml python3.6 python3.6-minimal readline-common
  xz-utils
Suggested packages:
  llvm-10-doc python3-doc python3-tk python3-venv python3-setuptools ttf-bitstream-vera python3.6-venv python3.6-doc
  binutils readline-doc
The following NEW packages will be installed:
  binfmt-support file libclang-cpp10 libedit2 libexpat1 libffi-dev libgomp1 libllvm10 libmagic-mgc libmagic1 libmpdec2
  libpfm4 libpipeline1 libpython3-stdlib libpython3.6-minimal libpython3.6-stdlib libreadline7 libsqlite3-0 libssl1.1
  libtinfo-dev libyaml-0-2 libz3-4 libz3-dev llvm-10 llvm-10-dev llvm-10-runtime llvm-10-tools mime-support python3
  python3-minimal python3-pkg-resources python3-pygments python3-yaml python3.6 python3.6-minimal readline-common
  xz-utils
0 upgraded, 37 newly installed, 0 to remove and 1 not upgraded.
```

I'd suggest using both more up-to-date and specific version of the package (llvm-10-dev).
I've run workflow on these changes and it compiles without errors. Although I'm unable to test IOS and aarch64 builds as these require self-hosted runner.