### PR TITLE
Refactoring of build.py and bugfixes to improve the support of Windows

### DIFF
--- a/build.py
+++ b/build.py
@@ -458,9 +458,11 @@ def build_flutter_windows(version, features, skip_portable_pack):
     
     #respect system ACLs and prevent 'except FileExistsError' handling
     if os.path.exists(f'./rustdesk-{version}-install.exe'):
-        os.replace('./rustdesk_portable.exe', f'./rustdesk-{version}-install.exe')
+        os.replace('./rustdesk_portable.exe',
+                   f'./rustdesk-{version}-install.exe')
     else:
-        os.rename('./rustdesk_portable.exe', f'./rustdesk-{version}-install.exe')
+        shutil.copy2('./rustdesk_portable.exe',
+                    f'./rustdesk-{version}-install.exe')
     print(
         f'output location: {os.path.abspath(os.curdir)}/rustdesk-{version}-install.exe')
 
@@ -504,7 +506,9 @@ def main():
             return
         system2('cargo build --release --features ' + features)
         # system2('upx.exe target/release/rustdesk.exe')
-        system2('mv target/release/rustdesk.exe target/release/RustDesk.exe')
+        # system2('mv target/release/rustdesk.exe target/release/RustDesk.exe') <- This won't work under Windows CMD shell
+        os.replace('target/release/rustdesk.exe',
+            'target/release/RustDesk.exe')
         pa = os.environ.get('P')
         if pa:
             # https://certera.com/kb/tutorial-guide-for-safenet-authentication-client-for-code-signing/
@@ -513,13 +517,16 @@ def main():
                 'target\\release\\rustdesk.exe')
         else:
             print('Not signed')
-        system2(
-            f'cp -rf target/release/RustDesk.exe {res_dir}')
+        # system2(
+        #    f'cp -rf target/release/RustDesk.exe {res_dir}') <- This wont work via Windows CMD shell
+        shutil.copy2('target/release/RustDesk.exe', f'{res_dir}/RustDesk.exe')
         os.chdir('libs/portable')
         system2('pip3 install -r requirements.txt')
         system2(
             f'python ./generate.py -f ../../{res_dir} -o . -e ../../{res_dir}/rustdesk-{version}-win7-install.exe')
-        system2('mv ../../{res_dir}/rustdesk-{version}-win7-install.exe ../..')
+        # system2('mv ../../{res_dir}/rustdesk-{version}-win7-install.exe ../..') <- This wont work via Windows CMD shell
+        os.replace(f'../../{res_dir}/rustdesk-{version}-win7-install.exe',
+            f'../../rustdesk-{version}-win7-install.exe')
     elif os.path.isfile('/usr/bin/pacman'):
         # pacman -S -needed base-devel
         system2("sed -i 's/pkgver=.*/pkgver=%s/g' res/PKGBUILD" % version)

--- a/build.py
+++ b/build.py
@@ -445,7 +445,7 @@ def build_flutter_windows(version, features, skip_portable_pack):
     os.chdir('libs/portable')
     system2('pip3 install -r requirements.txt')
     system2(
-        f'python3 ./generate.py -f ../../{flutter_build_dir_2} -o ./ -e ../../{flutter_build_dir_2}rustdesk.exe')
+        f'python ./generate.py -f ../../{flutter_build_dir_2} -o ./ -e ../../{flutter_build_dir_2}rustdesk.exe')
     os.chdir('../..')
     if os.path.exists('./rustdesk_portable.exe'):
         os.replace('./target/release/rustdesk-portable-packer.exe',
@@ -455,7 +455,12 @@ def build_flutter_windows(version, features, skip_portable_pack):
                   './rustdesk_portable.exe')
     print(
         f'output location: {os.path.abspath(os.curdir)}/rustdesk_portable.exe')
-    os.rename('./rustdesk_portable.exe', f'./rustdesk-{version}-install.exe')
+    
+    #respect system ACLs and prevent 'except FileExistsError' handling
+    if os.path.exists(f'./rustdesk-{version}-install.exe'):
+        os.replace('./rustdesk_portable.exe', f'./rustdesk-{version}-install.exe')
+    else:
+        os.rename('./rustdesk_portable.exe', f'./rustdesk-{version}-install.exe')
     print(
         f'output location: {os.path.abspath(os.curdir)}/rustdesk-{version}-install.exe')
 
@@ -473,7 +478,11 @@ def main():
     features = ','.join(get_features(args))
     flutter = args.flutter
     if not flutter:
-        system2('python3 res/inline-sciter.py')
+        #By default system uses python instead of python3 in windows, and *NIX is the opposite (unless python-is-python3 package is installed)
+        if not windows:
+            system2('python3 res/inline-sciter.py')
+        else:
+            system2('python res/inline-sciter.py')
     print(args.skip_cargo)
     if args.skip_cargo:
         skip_cargo = True
@@ -509,7 +518,7 @@ def main():
         os.chdir('libs/portable')
         system2('pip3 install -r requirements.txt')
         system2(
-            f'python3 ./generate.py -f ../../{res_dir} -o . -e ../../{res_dir}/rustdesk-{version}-win7-install.exe')
+            f'python ./generate.py -f ../../{res_dir} -o . -e ../../{res_dir}/rustdesk-{version}-win7-install.exe')
         system2('mv ../../{res_dir}/rustdesk-{version}-win7-install.exe ../..')
     elif os.path.isfile('/usr/bin/pacman'):
         # pacman -S -needed base-devel

--- a/build.py
+++ b/build.py
@@ -327,7 +327,7 @@ def build_flutter_deb(version, features):
     system2('mkdir -p tmpdeb/usr/share/polkit-1/actions')
     system2('rm tmpdeb/usr/bin/rustdesk || true')
     system2(
-        f'cp -r {flutter_build_dir}/* tmpdeb/usr/lib/rustdesk/')
+        f'cp -r {flutter_build_dir}* tmpdeb/usr/lib/rustdesk/')
     system2(
         'cp ../res/rustdesk.service tmpdeb/usr/share/rustdesk/files/systemd/')
     system2(
@@ -424,7 +424,7 @@ def build_flutter_arch_manjaro(version, features):
     ffi_bindgen_function_refactor()
     os.chdir('flutter')
     system2('flutter build linux --release')
-    system2(f'strip {flutter_build_dir}/lib/librustdesk.so')
+    system2(f'strip {flutter_build_dir}lib/librustdesk.so')
     os.chdir('../res')
     system2('HBB=`pwd`/.. FLUTTER=1 makepkg -f')
 
@@ -445,7 +445,7 @@ def build_flutter_windows(version, features, skip_portable_pack):
     os.chdir('libs/portable')
     system2('pip3 install -r requirements.txt')
     system2(
-        f'python3 ./generate.py -f ../../{flutter_build_dir_2} -o . -e ../../{flutter_build_dir_2}/rustdesk.exe')
+        f'python3 ./generate.py -f ../../{flutter_build_dir_2} -o ./ -e ../../{flutter_build_dir_2}rustdesk.exe')
     os.chdir('../..')
     if os.path.exists('./rustdesk_portable.exe'):
         os.replace('./target/release/rustdesk-portable-packer.exe',


### PR DESCRIPTION
I've made some changes to build.py:

- Removed consecutive slashes that would occur in some places due to path concatenation;
- Replaced cp/mv system calls on windows with shutil.copy2 and os.replace respectively. Now you can use system shells such as PowerShell or CMD to build;
- Fixed os.rename causing windows-specific error `except FileExistsError` if the `./rustdesk-{version}-install.exe` still existed after the previous build. This also improves ACLs handling;
- Replaced system calls for `python3`  **on Windows** to use `python` instead, as it's the default python3 binary, and the python2 is deprecated. This should allow to build on the new systems without symlinking python3 to python;

It might be better to use some kind of logic (like getting and parsing the output of `python -V ` and `python3 -V` respectively) to determine which binary to use, and then calling the binary directly, but I find it unnecessary complicated as Python 2 is deprecated anyway.


I've tested it with nightly workflow, as well as with `python ./build.py --hwcodec --flutter` and `.\build.py --portable --hwcodec --flutter --vram --skip-portable-pack` with both CMD ans PS shells, and it compiles and works.
However, the deprecated non-flutter build doesn't compile (it doesn't compile on the master branch either: `NotADirectoryError: [WinError 267] The directory name is invalid: '../../resources'`) due to a problem with passing `res_dir` to the `./generate.py`. 


I'm planning to make a CI (or at least scripts) for building the Windows version natively on Windows or Windows containers, if this pull request gets merged. The reason is that, when you only need a Windows binary (e.g. developing on Win), it would be faster to compile only Windows-version.