### PR TITLE
windows kill flutter main window when --server close

### DIFF
--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -565,7 +565,7 @@ fn core_main_invoke_new_connection(mut args: std::env::Args) -> Option<Vec<Strin
     {
         use winapi::um::winuser::WM_USER;
         let res = crate::platform::send_message_to_hnwd(
-            "FLUTTER_RUNNER_WIN32_WINDOW",
+            &crate::platform::FLUTTER_RUNNER_WIN32_WINDOW_CLASS,
             &crate::get_app_name(),
             (WM_USER + 2) as _, // referred from unilinks desktop pub
             uni_links.as_str(),

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -356,6 +356,8 @@ async fn handle(data: Data, stream: &mut Connection) {
                 crate::server::input_service::fix_key_down_timeout_at_exit();
                 if is_server() {
                     let _ = privacy_mode::turn_off_privacy(0, Some(PrivacyModeState::OffByPeer));
+                    #[cfg(all(windows, feature = "flutter"))]
+                    crate::platform::kill_flutter_main_window();
                 }
                 std::process::exit(0);
             }


### PR DESCRIPTION
`kill_flutter_main_window` can kill the hidden flutter window process in test.


https://github.com/rustdesk/rustdesk/assets/14891774/2357110f-7e91-4247-a957-a2fed7315ec1

