### PR TITLE
Update Dockerfile for missing pam dev lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt update -y && \
         libxcb-shape0-dev \
         libxcb-xfixes0-dev \
         libasound2-dev \
+        libpam0g-dev \
         libpulse-dev \
         make \
         cmake \


### PR DESCRIPTION
After failing to build with this due to the missing pam development library package I have added it to the DockerFile for the build image.

to be more specific i was getting the error: 
`Compilingpam-sys v1.0.0-alpha4
errorfailed to run custom build command for `pam-sys v1.0.0-alpha4`

Caused by:
  process didn't exit successfully: `/home/user/rustdesk/target/debug/build/pam-sys-8f2e6b1acacb4aab/build-script-build` (exit status: 101)
  --- stdout
  cargo:rustc-link-lib=pam
  cargo:rustc-link-lib=pam_misc
  cargo:rerun-if-changed=wrapper.h

  --- stderr
  wrapper.h:1:10: fatal error: 'security/pam_appl.h' file not found
  wrapper.h:1:10: fatal error: 'security/pam_appl.h' file not found, err: true
  thread 'main' panicked at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pam-sys-1.0.0-alpha4/build.rs:69:10:
  Unable to generate bindings: ()
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace`

After adding to the Dockerfile the install of 'libpam0g-dev' it now completes the build.