### PR TITLE
fix, windows try kill flutter main window process only when --server's ipc is occupied

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -356,8 +356,6 @@ async fn handle(data: Data, stream: &mut Connection) {
                 crate::server::input_service::fix_key_down_timeout_at_exit();
                 if is_server() {
                     let _ = privacy_mode::turn_off_privacy(0, Some(PrivacyModeState::OffByPeer));
-                    #[cfg(all(windows, feature = "flutter"))]
-                    crate::platform::kill_flutter_main_window();
                 }
                 std::process::exit(0);
             }
@@ -969,6 +967,12 @@ pub fn get_proxy_status() -> bool {
 pub async fn test_rendezvous_server() -> ResultType<()> {
     let mut c = connect(1000, "").await?;
     c.send(&Data::TestRendezvousServer).await?;
+    Ok(())
+}
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn test_ipc_connection() -> ResultType<()> {
+    connect(1000, "").await?;
     Ok(())
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -470,6 +470,11 @@ pub async fn start_server(is_server: bool) {
         std::thread::spawn(move || {
             if let Err(err) = crate::ipc::start("") {
                 log::error!("Failed to start ipc: {}", err);
+                #[cfg(all(windows, feature = "flutter"))]
+                if crate::is_server() && crate::ipc::test_ipc_connection().is_ok() {
+                    log::error!("ipc is occupied by another process, try kill it");
+                    crate::platform::try_kill_flutter_main_window_process();
+                }
                 std::process::exit(-1);
             }
         });


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/pull/8077

It can't be reproduced, so I make special exes to simulate it.

Test step:
1. Make a special exe that --server will delay start ipc so that main window process have enough time to occupy the ipc, and install the exe.
2. If main window occupy the ipc, it'll receive the close message from --service and call `std::process::exit`, If I change the multi window plugin and make it  always prevent close, `std::process::exit` still work, in order to reproduce the occupying, make a special exe that remove the line `std::process::exit`, so that the main window can't be killed by --service. So this pr fix the condition that `std::process::exit` not work.
https://github.com/rustdesk/rustdesk/blob/c2b7810c3375137666d6e744f47e2f1295de652f/src/ipc.rs#L362
3. Kill the --server process and start the special main window process right now.
4. If the installed exe is based on master, --server will be restarted in a loop; If the installed exe is based on pr, --server will kill the main window process when it finds that its ipc is occupied.

https://github.com/rustdesk/rustdesk/assets/14891774/7fda1bc6-71c1-4882-a4a9-aee29d9da3af


https://github.com/rustdesk/rustdesk/assets/14891774/b0e8743f-f0f3-4c09-a1b0-660015bcdce9

