### PR TITLE
fix: revert window border width back to 1.0, on Win and Mac

### DIFF
--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -216,7 +216,7 @@ const kFullScreenEdgeSize = 0.0;
 const kMaximizeEdgeSize = 0.0;
 // Do not use kWindowEdgeSize directly. Use `windowEdgeSize` in `common.dart` instead.
 final kWindowEdgeSize = isWindows ? 1.0 : 5.0;
-final kWindowBorderWidth = isLinux ? 1.0 : 0.0;
+final kWindowBorderWidth = 1.0;
 const kDesktopMenuPadding = EdgeInsets.only(left: 12.0, right: 3.0);
 const kFrameBorderRadius = 12.0;
 const kFrameClipRRectBorderRadius = 12.0;


### PR DESCRIPTION

https://github.com/rustdesk/rustdesk/assets/13586388/337213ed-fb4d-4d27-a740-4323b89b4630


https://github.com/rustdesk/rustdesk/assets/13586388/229cadc7-bb18-451e-b244-7960ed27d5e1

