### PR TITLE
fix: linux, login wayland, server

### DIFF
--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -142,9 +142,17 @@ pub fn get_values_of_seat0_with_gdm_wayland(indices: &[usize]) -> Vec<String> {
     _get_values_of_seat0(indices, false)
 }
 
+// Ignore "3 sessions listed."
+fn ignore_loginctl_line(line: &str) -> bool {
+    line.contains("sessions") || line.split(" ").count() < 4
+}
+
 fn _get_values_of_seat0(indices: &[usize], ignore_gdm_wayland: bool) -> Vec<String> {
     if let Ok(output) = run_loginctl(None) {
         for line in String::from_utf8_lossy(&output.stdout).lines() {
+            if ignore_loginctl_line(line) {
+                continue;
+            }
             if line.contains("seat0") {
                 if let Some(sid) = line.split_whitespace().next() {
                     if is_active(sid) {
@@ -163,6 +171,9 @@ fn _get_values_of_seat0(indices: &[usize], ignore_gdm_wayland: bool) -> Vec<Stri
 
         // some case, there is no seat0 https://github.com/rustdesk/rustdesk/issues/73
         for line in String::from_utf8_lossy(&output.stdout).lines() {
+            if ignore_loginctl_line(line) {
+                continue;
+            }
             if let Some(sid) = line.split_whitespace().next() {
                 if is_active(sid) {
                     let d = get_display_server_of_session(sid);

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1241,7 +1241,7 @@ mod desktop {
                 return;
             }
 
-            let seat0_values = get_values_of_seat0(&[0, 1, 2]);
+            let seat0_values = get_values_of_seat0_with_gdm_wayland(&[0, 1, 2]);
             if seat0_values[0].is_empty() {
                 *self = Self::default();
                 self.is_rustdesk_subprocess = false;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1168,18 +1168,21 @@ impl Connection {
         }
         #[cfg(target_os = "linux")]
         if !self.file_transfer.is_some() && !self.port_forward_socket.is_some() {
-            let dtype = crate::platform::linux::get_display_server();
-            if dtype != crate::platform::linux::DISPLAY_SERVER_X11
-                && dtype != crate::platform::linux::DISPLAY_SERVER_WAYLAND
-            {
-                let msg = if crate::platform::linux::is_login_screen_wayland() {
-                    crate::client::LOGIN_SCREEN_WAYLAND.to_owned()
-                } else {
-                    format!(
+            let mut msg = "".to_string();
+            if crate::platform::linux::is_login_screen_wayland() {
+                msg = crate::client::LOGIN_SCREEN_WAYLAND.to_owned()
+            } else {
+                let dtype = crate::platform::linux::get_display_server();
+                if dtype != crate::platform::linux::DISPLAY_SERVER_X11
+                    && dtype != crate::platform::linux::DISPLAY_SERVER_WAYLAND
+                {
+                    msg = format!(
                         "Unsupported display server type \"{}\", x11 or wayland expected",
                         dtype
-                    )
-                };
+                    );
+                }
+            }
+            if !msg.is_empty() {
                 res.set_error(msg);
                 let mut msg_out = Message::new();
                 msg_out.set_login_response(res);


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/8106

1. Ignore "3 sessions listed." when parsing output of `loginctl`.
2. Refresing desktop env, includes gdm wayland value.
3. Refactor check logic of current display.


https://github.com/rustdesk/rustdesk/assets/13586388/49ba0a94-5fe8-4c9b-93a3-bc898309d090




https://github.com/rustdesk/rustdesk/assets/13586388/c18032a3-dbfc-4ba8-a6d4-6913bef02260


