### PR TITLE
fix cursor menu divider and specific auto codec shows null

### DIFF
--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -362,7 +362,8 @@ Future<List<TRadioMenu<String>>> toolbarCodec(
   }
 
   var autoLabel = translate('Auto');
-  if (groupValue == 'auto') {
+  if (groupValue == 'auto' &&
+      ffi.qualityMonitorModel.data.codecFormat != null) {
     autoLabel = '$autoLabel (${ffi.qualityMonitorModel.data.codecFormat})';
   }
   return [
@@ -380,7 +381,6 @@ Future<List<TToggleMenu>> toolbarCursor(
   List<TToggleMenu> v = [];
   final ffiModel = ffi.ffiModel;
   final pi = ffiModel.pi;
-  final perms = ffiModel.permissions;
   final sessionId = ffi.sessionId;
 
   // show remote cursor

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1067,7 +1067,6 @@ class _DisplayMenuState extends State<_DisplayMenu> {
             id: widget.id,
             ffi: widget.ffi,
           ),
-        Divider(),
         cursorToggles(),
         Divider(),
         toggles(),
@@ -1219,14 +1218,16 @@ class _DisplayMenuState extends State<_DisplayMenu> {
         hasData: (data) {
           final v = data as List<TToggleMenu>;
           if (v.isEmpty) return Offstage();
-          return Column(
-              children: v
-                  .map((e) => CkbMenuButton(
-                      value: e.value,
-                      onChanged: e.onChanged,
-                      child: e.child,
-                      ffi: ffi))
-                  .toList());
+          return Column(children: [
+            Divider(),
+            ...v
+                .map((e) => CkbMenuButton(
+                    value: e.value,
+                    onChanged: e.onChanged,
+                    child: e.child,
+                    ffi: ffi))
+                .toList(),
+          ]);
         });
   }
 


### PR DESCRIPTION
The specific auto codec will be same with the quality montitor when `Codec` menu is expanded.
I add ChangeNotifierProvider but still not real time, so I will solve other issues first.

https://github.com/rustdesk/rustdesk/assets/14891774/0c878a47-ec4f-4eb5-85ec-e37ed6e8134c

![rustdesk_YGFxwEDn1v](https://github.com/rustdesk/rustdesk/assets/14891774/12eb5f36-d6bd-44e0-b83d-c6331ee07155)

![rustdesk_vCY3wFX30A](https://github.com/rustdesk/rustdesk/assets/14891774/b03af0da-9182-43d8-b39c-2351780daed7)


