### PR TITLE
fix android mediacodec encoding align

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,8 +3037,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.10"
-source = "git+https://github.com/21pages/hwcodec#9cb895fdaea198dd72bd75980109dbd05a059a60"
+version = "0.4.11"
+source = "git+https://github.com/21pages/hwcodec#a5864080e41836b94feb9f73732280c651162fec"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/libs/scrap/src/android/ffi.rs
+++ b/libs/scrap/src/android/ffi.rs
@@ -178,8 +178,8 @@ pub struct MediaCodecInfo {
 #[derive(Debug, Deserialize, Clone)]
 pub struct MediaCodecInfos {
     pub version: usize,
-    pub w: usize,
-    pub h: usize,
+    pub w: usize, // aligned
+    pub h: usize, // aligned
     pub codecs: Vec<MediaCodecInfo>,
 }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/8101

* update ffmpeg lib, mediacodec encoding align 64
* more d3d11 decode availablity check
* remove unused mediacodec info temporarily

![29183250f19469c2ca30afad16ce515](https://github.com/rustdesk/rustdesk/assets/14891774/c7e9b064-198d-46c5-b7c2-ede33a170e9b)
