### PR TITLE
fix: multi-window, fullscreen state

### DIFF
--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -63,6 +63,7 @@ const String kWindowEventActiveDisplaySession = "active_display_session";
 const String kWindowEventGetRemoteList = "get_remote_list";
 const String kWindowEventGetSessionIdList = "get_session_id_list";
 const String kWindowEventRemoteWindowCoords = "remote_window_coords";
+const String kWindowEventSetFullscreen = "set_fullscreen";
 
 const String kWindowEventMoveTabToNewWindow = "move_tab_to_new_window";
 const String kWindowEventGetCachedSessionData = "get_cached_session_data";


### PR DESCRIPTION
## Preview

### Windows

#### Before


https://github.com/rustdesk/rustdesk/assets/13586388/199dfb5e-f941-46d6-a3d3-16338fd3a554

#### After


https://github.com/rustdesk/rustdesk/assets/13586388/3e3699bb-ece4-4756-8cb9-520bc7e89354

### Linux

#### Before


https://github.com/rustdesk/rustdesk/assets/13586388/45b38796-e0d0-4f34-b965-f056fd7145fa

#### After


https://github.com/rustdesk/rustdesk/assets/13586388/099fe06c-d2e5-44fc-b314-cf920ae48785

#### MacOS


https://github.com/rustdesk/rustdesk/assets/13586388/1661ee00-5e1f-4900-9fc5-4fd9908ffe7a


## Fix desc

1. Set pre frame position and size if is fullscreen or maximized. The pre code only check if is maximized.
2. Always use `bind.mainGetPeerFlutterOptionSync()` to get peer flutter option. `bind.sessionGetFlutterOptionByPeerId()` may return empty if the session is not established yet.
3. Do not always use `stateGlobal.setFullscreen(true);` to set fullscreen. If current window id is not the window id of target peer connection, send an event to set fullscreen.
4. Use `setNewConnectWindowFrame()` to restore peer position when the connection is established.
5. Exit fullscreen state when the remote page is to close on Linux. If the window is left fullscreen and then reuse, the frame state will be incorrect when exit fullscreen the next time.   State `fullscreen -> hide -> show -> exit fullscreen`, then the window will be maximized and overlapped. No idea how the strange state comes, **just a workaround**.

<img width="596" alt="1716422154360" src="https://github.com/rustdesk/rustdesk/assets/13586388/6649a664-e060-4f98-b5c3-1ab8f38f6321">



https://github.com/rustdesk/rustdesk/assets/13586388/ff8de715-e8ad-48d0-ad3e-47d0f9fb9d82


