### PR TITLE
fix: restore window, on connection

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1567,8 +1567,7 @@ Future<void> saveWindowPosition(WindowType type, {int? windowId}) async {
   late Offset position;
   late Size sz;
   late bool isMaximized;
-  bool isFullscreen = stateGlobal.fullscreen.isTrue ||
-      (isMacOS && stateGlobal.closeOnFullscreen == true);
+  bool isFullscreen = stateGlobal.fullscreen.isTrue;
   setPreFrame() {
     final pos = bind.getLocalFlutterOption(k: windowFramePrefix + type.name);
     var lpos = LastWindowPosition.loadFromString(pos);
@@ -1890,7 +1889,6 @@ Future<bool> restoreWindowPosition(WindowType type,
       }
       if (lpos.isFullscreen == true) {
         if (!isMacOS) {
-          stateGlobal.setFullscreen(false);
           await restoreFrame();
         }
         // An duration is needed to avoid the window being restored after fullscreen.
@@ -2906,10 +2904,10 @@ openMonitorInNewTabOrWindow(int i, String peerId, PeerInfo pi,
 
 setNewConnectWindowFrame(int windowId, String peerId, Rect? screenRect) async {
   if (screenRect == null) {
-    restoreWindowPosition(WindowType.RemoteDesktop,
+    await restoreWindowPosition(WindowType.RemoteDesktop,
         windowId: windowId, peerId: peerId);
   } else {
-    tryMoveToScreenAndSetFullscreen(screenRect);
+    await tryMoveToScreenAndSetFullscreen(screenRect);
   }
 }
 

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -641,14 +641,12 @@ class WindowActionPanelState extends State<WindowActionPanel>
       }
       // macOS specific workaround, the window is not hiding when in fullscreen.
       if (isMacOS && await windowManager.isFullScreen()) {
-        stateGlobal.closeOnFullscreen ??= true;
         await windowManager.setFullScreen(false);
         await macOSWindowClose(
           () async => await windowManager.isFullScreen(),
           mainWindowClose,
         );
       } else {
-        stateGlobal.closeOnFullscreen ??= false;
         await mainWindowClose();
       }
     } else {
@@ -660,7 +658,6 @@ class WindowActionPanelState extends State<WindowActionPanel>
 
         if (await widget.onClose?.call() ?? true) {
           if (await controller.isFullScreen()) {
-            stateGlobal.closeOnFullscreen ??= true;
             await controller.setFullscreen(false);
             stateGlobal.setFullscreen(false, procWnd: false);
             await macOSWindowClose(
@@ -668,7 +665,6 @@ class WindowActionPanelState extends State<WindowActionPanel>
               () async => await notMainWindowClose(controller),
             );
           } else {
-            stateGlobal.closeOnFullscreen ??= false;
             await notMainWindowClose(controller);
           }
         }

--- a/flutter/lib/models/state_model.dart
+++ b/flutter/lib/models/state_model.dart
@@ -18,8 +18,6 @@ class StateGlobal {
   final RxDouble _windowBorderWidth = RxDouble(kWindowBorderWidth);
   final RxBool showRemoteToolBar = false.obs;
   final svcStatus = SvcStatus.notReady.obs;
-  // Only used for macOS
-  bool? closeOnFullscreen;
   final RxBool isFocused = false.obs;
 
   String _inputSource = '';

--- a/flutter/lib/utils/multi_window_manager.dart
+++ b/flutter/lib/utils/multi_window_manager.dart
@@ -174,7 +174,9 @@ class RustDeskMultiWindowManager {
                   windowId: windowId, peerId: remoteId);
             }
             await DesktopMultiWindow.invokeMethod(windowId, methodName, msg);
-            WindowController.fromWindowId(windowId).show();
+            if (methodName != kWindowEventNewRemoteDesktop) {
+              WindowController.fromWindowId(windowId).show();
+            }
             registerActiveWindow(windowId);
             return MultiWindowCallResult(windowId, null);
           }

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -203,12 +203,6 @@ class RustdeskImpl {
         ]));
   }
 
-  Future<String?> sessionGetFlutterOptionByPeerId(
-      {required String id, required String k, dynamic hint}) {
-    return Future(
-        () => js.context.callMethod('getByName', ['option:flutter:peer', k]));
-  }
-
   int getNextTextureKey({dynamic hint}) {
     return 0;
   }

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -335,7 +335,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: ef03db52a20a7899da135d694c071fa3866c8fb1
+      resolved-ref: 965b6ceba095b120c37c368abc2e4dbc8a71e09c
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -278,15 +278,6 @@ pub fn session_set_flutter_option(session_id: SessionID, k: String, v: String) {
     }
 }
 
-// This function is only used for the default connection session.
-pub fn session_get_flutter_option_by_peer_id(id: String, k: String) -> Option<String> {
-    if let Some(session) = sessions::get_session_by_peer_id(id, ConnType::DEFAULT_CONN) {
-        Some(session.get_flutter_option(k))
-    } else {
-        None
-    }
-}
-
 pub fn get_next_texture_key() -> SyncReturn<i32> {
     let k = TEXTURE_RENDER_KEY.fetch_add(1, Ordering::SeqCst) + 1;
     SyncReturn(k)


### PR DESCRIPTION
### fullscreen

1.  https://github.com/rustdesk-org/rustdesk_desktop_multi_window/pull/10
2. Do not call `await WindowController.fromWindowId(windowId()).setFullscreen(false);` in `onRemoveId()`, closing window is faster.
3. Remove `closeOnFullscreen`. The fullscreen state is maintained in `restoreWindowPosition()` and `restoreWindowPosition()` is called when establishing a new session.

### restore frame

1. Set frame and then `windowOnTop()` for a new remote session.
![image](https://github.com/rustdesk/rustdesk/assets/13586388/d2c54189-6805-4455-82e1-f4f5ecefe77f)

2. Do not call `WindowController.fromWindowId(windowId).show();` when the connection is `kWindowEventNewRemoteDesktop`.  Because `windowOnTop()` will also call `show()`.

### other

1. Remove unused ffi function `session_get_flutter_option_by_peer_id()`.



https://github.com/rustdesk/rustdesk/assets/13586388/85162a3c-90ab-48c8-b89e-7e45449d0a72


