### PR TITLE
impore fps control, quicker send refresh and clear video queue

### DIFF
--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -319,13 +319,8 @@ impl<T: InvokeUiSession> Remote<T> {
                     let is_stopping_allowed = clip.is_stopping_allowed();
                     let server_file_transfer_enabled =
                         *self.handler.server_file_transfer_enabled.read().unwrap();
-                    let file_transfer_enabled = self
-                        .handler
-                        .lc
-                        .read()
-                        .unwrap()
-                        .enable_file_copy_paste
-                        .v;
+                    let file_transfer_enabled =
+                        self.handler.lc.read().unwrap().enable_file_copy_paste.v;
                     let view_only = self.handler.lc.read().unwrap().view_only.v;
                     let stop = is_stopping_allowed
                         && (view_only
@@ -1032,13 +1027,15 @@ impl<T: InvokeUiSession> Remote<T> {
                 ctl.last_auto_fps = Some(auto_fps);
             }
             // send refresh
+            let tolerable = std::cmp::min(decode_fps, video_queue.capacity() / 2);
             if ctl.refresh_times < 10 // enough
-                && (len > video_queue.capacity() / 2
-                        && (ctl.refresh_times == 0 || ctl.last_refresh_instant.elapsed().as_secs() > 30))
+                && (len > tolerable
+                        && (ctl.refresh_times == 0 || ctl.last_refresh_instant.elapsed().as_secs() > 10))
             {
                 // Refresh causes client set_display, left frames cause flickering.
                 while let Some(_) = video_queue.pop() {}
                 self.handler.refresh_video(*display as _);
+                log::info!("Refresh display {} to reduce delay", display);
                 ctl.refresh_times += 1;
                 ctl.last_refresh_instant = Instant::now();
             }
@@ -1765,13 +1762,7 @@ impl<T: InvokeUiSession> Remote<T> {
         ))]
         {
             let enabled = *self.handler.server_file_transfer_enabled.read().unwrap()
-                && self
-                    .handler
-                    .lc
-                    .read()
-                    .unwrap()
-                    .enable_file_copy_paste
-                    .v;
+                && self.handler.lc.read().unwrap().enable_file_copy_paste.v;
             ContextSend::enable(enabled);
         }
     }
@@ -1794,13 +1785,7 @@ impl<T: InvokeUiSession> Remote<T> {
         };
 
         let is_stopping_allowed = clip.is_stopping_allowed_from_peer();
-        let file_transfer_enabled = self
-            .handler
-            .lc
-            .read()
-            .unwrap()
-            .enable_file_copy_paste
-            .v;
+        let file_transfer_enabled = self.handler.lc.read().unwrap().enable_file_copy_paste.v;
         let stop = is_stopping_allowed && !file_transfer_enabled;
         log::debug!(
                 "Process clipboard message from server peer, stop: {}, is_stopping_allowed: {}, file_transfer_enabled: {}",


### PR DESCRIPTION
change refresh threshold from `video_queue.capacity() / 2` to `std::cmp::min(decode_fps, video_queue.capacity() / 2)`

Please not close https://github.com/rustdesk/rustdesk/issues/8136,  becase there are other issues to be resolved.

### Test

use sleep 100ms to simulate slow decoding

**Before**: takes about 30s to be reactable



https://github.com/rustdesk/rustdesk/assets/14891774/c98ac071-79a7-42c3-a752-4d35ebc7b808


**After**: takes about 2s to be reactable


https://github.com/rustdesk/rustdesk/assets/14891774/24738935-6d00-4fb3-bed2-00fd8bc2a3cb

