### PR TITLE
fix: window backgroud color

### DIFF
--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -157,6 +157,7 @@ const String kKeyReverseMouseWheel = "reverse_mouse_wheel";
 const String kEnvPortableExecutable = "RUSTDESK_APPNAME";
 
 const Color kColorWarn = Color.fromARGB(255, 245, 133, 59);
+const Color kColorCanvas = Colors.black;
 
 const int kMobileDefaultDisplayWidth = 720;
 const int kMobileDefaultDisplayHeight = 1280;

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -277,7 +277,7 @@ class _RemotePageState extends State<RemotePage>
       return Stack(
         children: [
           Container(
-              color: Colors.black,
+              color: kColorCanvas,
               child: RawKeyFocusScope(
                   focusNode: _rawKeyFocusNode,
                   onFocusChange: (bool imageFocused) {

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -334,7 +334,7 @@ class DesktopTab extends StatelessWidget {
 
   List<Widget> _tabWidgets = [];
   Widget _buildPageView() {
-    return _buildBlock(
+    final child = _buildBlock(
         child: Obx(() => PageView(
             controller: state.value.pageController,
             physics: NeverScrollableScrollPhysics(),
@@ -358,6 +358,11 @@ class DesktopTab extends StatelessWidget {
                 return newList;
               }
             }())));
+    if (tabType == DesktopTabType.remoteScreen) {
+      return Container(color: kColorCanvas, child: child);
+    } else {
+      return child;
+    }
   }
 
   /// Check whether to show ListView

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -310,7 +310,7 @@ class _RemotePageState extends State<RemotePage> {
               initialEntries: [
                 OverlayEntry(builder: (context) {
                   return Container(
-                    color: Colors.black,
+                    color: kColorCanvas,
                     child: isWebDesktop
                         ? getBodyForDesktopWithListener(keyboard)
                         : SafeArea(


### PR DESCRIPTION
Set the background color to the canvas color.  Avoid black-white changes when closing the window.


https://github.com/rustdesk/rustdesk/assets/13586388/32472917-bde5-4ee3-8484-ed9c71034a87

