### PR TITLE
fix mediacodec bad encoding quality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,8 +3037,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.11"
-source = "git+https://github.com/21pages/hwcodec#a5864080e41836b94feb9f73732280c651162fec"
+version = "0.4.12"
+source = "git+https://github.com/21pages/hwcodec#6fbafe7dd25adad5e897b3192b2b40b720a9b118"
 dependencies = [
  "bindgen 0.59.2",
  "cc",


### PR DESCRIPTION
update hwcodec, add pts for ffmpeg encoding, which will  effect rate control.Before this commit, the traffic will drop to tens of kb per second after a few seconds, and now the traffic will remain dynamic stable.

traffic difference between different image quality

https://github.com/rustdesk/rustdesk/assets/14891774/61b85032-fba8-40e3-902b-072b4add370a


https://github.com/rustdesk/rustdesk/assets/14891774/ccc8aa09-cba9-4d13-9e59-ffebc0e84c65


https://github.com/rustdesk/rustdesk/assets/14891774/0ef5fdb9-d7fa-4d0e-9595-5f332fb32d6c














