### PR TITLE
android request external stroage when start service for log

### DIFF
--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -367,6 +367,9 @@ class ServerModel with ChangeNotifier {
       }
     } else {
       await checkRequestNotificationPermission();
+      if (!await AndroidPermissionManager.check(kManageExternalStorage)) {
+        await AndroidPermissionManager.request(kManageExternalStorage);
+      }
       final res = await parent.target?.dialogManager
           .show<bool>((setState, close, context) {
         submit() => close(true);


### PR DESCRIPTION
This will not influence file transfer permission. Requesting external storage permissions does not turn on file transfer permissions, and turning off file transfer permissions does not turn off external storage permissions.