### PR TITLE
fix: switch texture, do not input os password

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -112,6 +112,7 @@ class FfiModel with ChangeNotifier {
   RxBool waitForImageDialogShow = true.obs;
   Timer? waitForImageTimer;
   RxBool waitForFirstImage = true.obs;
+  bool isRefreshing = false;
 
   Rect? get rect => _rect;
   bool get isOriginalResolutionSet =>
@@ -392,6 +393,7 @@ class FfiModel with ChangeNotifier {
       Map<String, dynamic> evt, SessionID sessionId, String peerId) {
     parent.target?.imageModel.setUseTextureRender(evt['v'] == 'Y');
     waitForFirstImage.value = true;
+    isRefreshing = true;
     showConnectedWaitingForImage(parent.target!.dialogManager, sessionId,
         'success', 'Successful', kMsgboxTextWaitingForImage);
   }
@@ -677,7 +679,7 @@ class FfiModel with ChangeNotifier {
     );
     waitForImageDialogShow.value = true;
     waitForImageTimer = Timer(Duration(milliseconds: 1500), () {
-      if (waitForFirstImage.isTrue) {
+      if (waitForFirstImage.isTrue && !isRefreshing) {
         bind.sessionInputOsPassword(sessionId: sessionId, value: '');
       }
     });
@@ -795,6 +797,7 @@ class FfiModel with ChangeNotifier {
       if (displays.isNotEmpty) {
         _reconnects = 1;
         waitForFirstImage.value = true;
+        isRefreshing = false;
       }
       Map<String, dynamic> features = json.decode(evt['features']);
       _pi.features.privacyMode = features['privacy_mode'] == 1;
@@ -2348,6 +2351,7 @@ class FFI {
   /// Mobile reuse FFI
   void mobileReset() {
     ffiModel.waitForFirstImage.value = true;
+    ffiModel.isRefreshing = false;
     ffiModel.waitForImageDialogShow.value = true;
     ffiModel.waitForImageTimer?.cancel();
     ffiModel.waitForImageTimer = null;

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -473,6 +473,7 @@ impl<T: InvokeUiSession> Session<T> {
     pub fn use_texture_render_changed(&self) {
         self.send(Data::ResetDecoder(None));
         self.change_prefer_codec();
+        self.send(Data::Message(LoginConfigHandler::refresh()));
     }
 
     pub fn restart_remote_device(&self) {


### PR DESCRIPTION
Do not call `bind.sessionInputOsPassword(sessionId: sessionId, value: '');` if switching texture render option.

## Bug

https://github.com/rustdesk/rustdesk/assets/13586388/044221b8-12c9-4f3f-baf6-41542640ba75


## Fixed



https://github.com/rustdesk/rustdesk/assets/13586388/d9fbeaab-00fd-4622-ad6a-e7c9f258194b

