### PR TITLE
fix: deactive widget ancester

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -455,9 +455,8 @@ class _RemotePageState extends State<RemotePage>
       }, onExit: (evt) {
         if (!isWeb) bind.hostStopSystemKeyPropagate(stopped: true);
       }, child: LayoutBuilder(builder: (context, constraints) {
-        Future.delayed(Duration.zero, () {
-          Provider.of<CanvasModel>(context, listen: false).updateViewStyle();
-        });
+        final c = Provider.of<CanvasModel>(context, listen: false);
+        Future.delayed(Duration.zero, () => c.updateViewStyle());
         final peerDisplay = CurrentDisplayState.find(widget.id);
         return Obx(
           () => _ffi.ffiModel.pi.isSet.isFalse


### PR DESCRIPTION
This issue is easy to reproduce on my Mac (by increasing the delay to 1 second), but not on Windows and Linux.

```dart
        Future.delayed(Duration(seconds: 1), () {
          Provider.of<CanvasModel>(context, listen: false).updateViewStyle();
        });
```


<img width="561" alt="c186029774c7d60cb923b42b4cfcb82" src="https://github.com/rustdesk/rustdesk/assets/13586388/7644dd02-16d2-441a-aac6-78da3d08d8bd">
