### PR TITLE
fix the bottom of FFmpeg vram qsv encoding being cropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,8 +3037,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.12"
-source = "git+https://github.com/21pages/hwcodec#6fbafe7dd25adad5e897b3192b2b40b720a9b118"
+version = "0.4.13"
+source = "git+https://github.com/21pages/hwcodec#29f52366c274f55b74cca7e84fb33aa00f2b63a7"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1737,7 +1737,10 @@ class PredefinedCursor {
         _image?.dispose();
         _image = await img.decodeImageFromPixels(
             data, defaultImg.width, defaultImg.height, ui.PixelFormat.rgba8888);
-
+        if (_image == null) {
+          print("decodeImageFromPixels failed, pre-defined cursor $id");
+          return;
+        }
         double scale = 1.0;
         if (isWindows) {
           data = _image2!.getBytes(order: img2.ChannelOrder.bgra);
@@ -2104,7 +2107,7 @@ class CursorModel with ChangeNotifier {
     _x = -10000;
     _x = -10000;
     _image = null;
-    _images.clear();
+    disposeImages();
 
     _clearCache();
     _cache = null;


### PR DESCRIPTION
1. update hwcodec, fix the bottom of FFmpeg vram qsv encoding being cropped
2. return if decode pre-defined image failed 

before: 
![before](https://github.com/rustdesk/rustdesk/assets/14891774/b5136ac8-a916-400c-9879-7ba5c7925f2c)
after:
![after](https://github.com/rustdesk/rustdesk/assets/14891774/acdb5bf8-f7d2-4eed-9a26-0372d092a166)
