### PR TITLE
not show paste menu when mobile control mobile

### DIFF
--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -115,7 +115,10 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
     );
   }
   // paste
-  if (isMobile && perms['keyboard'] != false && perms['clipboard'] != false) {
+  if (isMobile &&
+      pi.platform != kPeerPlatformAndroid &&
+      perms['keyboard'] != false &&
+      perms['clipboard'] != false) {
     v.add(TTextMenu(
         child: Text(translate('Paste')),
         onPressed: () async {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/8203

**control mobile**
![29748b1ace5ca9ad5f6b4e897d27d92](https://github.com/rustdesk/rustdesk/assets/14891774/93a103e6-1e37-48f3-a49b-ba659dd68d7e)

**control desktop**
![e11cff81359745c5ff40f84a6c2dbd8](https://github.com/rustdesk/rustdesk/assets/14891774/2ae5bc7b-da2c-48ef-be28-991faf5b18c4)
