### PR TITLE
update hwcodec, fix wrong gop, which causes FFmpeg nvenc vram encode delay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,8 +3037,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.13"
-source = "git+https://github.com/21pages/hwcodec#29f52366c274f55b74cca7e84fb33aa00f2b63a7"
+version = "0.4.15"
+source = "git+https://github.com/21pages/hwcodec#1d504ee590c15472813fecc22cee4b8149b2b8cd"
 dependencies = [
  "bindgen 0.59.2",
  "cc",


### PR DESCRIPTION
gop was set to u32::max (int -1) mistakely.

Test all the other desktop encoders, all latency free.