### PR TITLE
windows replace uni with cmd to start up main window after installation

### DIFF
--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -338,7 +338,6 @@ void runInstallPage() async {
     windowManager.focus();
     windowManager.setOpacity(1);
     windowManager.setAlignment(Alignment.center); // ensure
-    windowManager.setTitle(getWindowName());
   });
 }
 

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -116,15 +116,27 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   if (!command_line_arguments.empty() && command_line_arguments.front().compare(0, cmParam.size(), cmParam.c_str()) == 0) {
     is_cm_page = true;
   }
+  bool is_install_page = false;
+  auto installParam = std::string("--install");
+  if (!command_line_arguments.empty() && command_line_arguments.front().compare(0, installParam.size(), installParam.c_str()) == 0) {
+    is_install_page = true;
+  }
+
   command_line_arguments.insert(command_line_arguments.end(), rust_args.begin(), rust_args.end());
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(800, 600);
-  if (!window.CreateAndShow(
-          is_cm_page ? app_name + L" - Connection Manager" : app_name, origin,
-          size, !is_cm_page)) {
+  std::wstring window_title;
+  if (is_cm_page) {
+    window_title = app_name + L" - Connection Manager";
+  } else if (is_install_page) {
+    window_title = app_name + L" - Install";
+  } else {
+    window_title = app_name;
+  }
+  if (!window.CreateAndShow(window_title, origin, size, !is_cm_page)) {
       return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2185,12 +2185,10 @@ sc start {app_name}
 
 fn run_after_run_cmds(silent: bool) {
     let (_, _, _, exe) = get_install_info();
-    let app = crate::get_app_name().to_lowercase();
     if !silent {
         log::debug!("Spawn new window");
         allow_err!(std::process::Command::new("cmd")
-            .arg("/c")
-            .arg(format!("timeout /t 2 & start {app}://"))
+            .args(&["/c", "timeout", "/t", "2", "&", &format!("{exe}")])
             .creation_flags(winapi::um::winbase::CREATE_NO_WINDOW)
             .spawn());
     }


### PR DESCRIPTION
This is to avoid uni link not working

**Test**
The main window can pop up after installation, when stopping the service, or when starting the service.
The install directory is `C:\Program Files\RustDesk` so it works with empty spaces in the `exe`.

https://github.com/rustdesk/rustdesk/assets/14891774/f6145008-81d9-48ef-8a49-f9e71f1ef955


https://github.com/rustdesk/rustdesk/assets/14891774/bfa09e32-3570-47ff-b162-e5fe56d742a0


https://github.com/rustdesk/rustdesk/assets/14891774/473ca72d-7b6f-498f-8287-521374e8d72b

**Other change**
The install window's title  is changed to "appname - Install" to distinguish it from the main application window.
