### PR TITLE
fix: macos, fullscreen, remove mimimize button

### DIFF
--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -588,7 +588,7 @@ class _MobileActionMenu extends StatelessWidget {
           assetName: 'assets/actions_mobile.svg',
           tooltip: 'Mobile Actions',
           onPressed: () =>
-          ffi.dialogManager.mobileActionsOverlayVisible.toggle(),
+              ffi.dialogManager.mobileActionsOverlayVisible.toggle(),
           color: ffi.dialogManager.mobileActionsOverlayVisible.isTrue
               ? _ToolbarTheme.blueColor
               : _ToolbarTheme.inactiveColor,
@@ -2465,7 +2465,7 @@ class _DraggableShowHideState extends State<_DraggableShowHide> {
                 ),
               ),
             )),
-        Obx(() => Offstage(
+        if (!isMacOS) Obx(() => Offstage(
               offstage: isFullscreen.isFalse,
               child: TextButton(
                 onPressed: () => widget.setMinimize(),


### PR DESCRIPTION
MacOS is unable to [`miniaturize()`](https://developer.apple.com/documentation/appkit/nswindow/1419426-miniaturize) in fullscreen state.

<img width="198" alt="1717248054322" src="https://github.com/rustdesk/rustdesk/assets/13586388/d1fda1e8-b7dd-4399-97c2-87888ac06588">
