### PR TITLE
fix: macos, terminate, close main then remote windows

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2384,6 +2384,10 @@ Future<void> onActiveWindowChanged() async {
       await windowManager.setPreventClose(false);
       await windowManager.close();
       if (isMacOS) {
+        // If we call without delay, `flutter/macos/Runner/MainFlutterWindow.swift` can handle the "terminate" event.
+        // But the app will not close.
+        //
+        // No idea why we need to delay here, `terminate()` itself is also an async function.
         Future.delayed(Duration.zero, () {
           RdPlatformChannel.instance.terminate();
         });

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -893,7 +893,7 @@ class OverlayDialogManager {
 makeMobileActionsOverlayEntry(VoidCallback? onHide, {FFI? ffi}) {
   final position = SimpleWrapper(Offset(0, 0));
   makeMobileActions(BuildContext context, double s) {
-    final scale =  s < 0.85 ? 0.85 : s;
+    final scale = s < 0.85 ? 0.85 : s;
     final session = ffi ?? gFFI;
     // compute overlay position
     final screenW = MediaQuery.of(context).size.width;
@@ -2384,7 +2384,9 @@ Future<void> onActiveWindowChanged() async {
       await windowManager.setPreventClose(false);
       await windowManager.close();
       if (isMacOS) {
-        RdPlatformChannel.instance.terminate();
+        Future.delayed(Duration.zero, () {
+          RdPlatformChannel.instance.terminate();
+        });
       }
     }
   }


### PR DESCRIPTION

Cannot exit application if close main window first.

https://github.com/rustdesk/rustdesk/assets/13586388/a4e67df5-4d5a-4234-94f9-b25987141972


No idea why `Future.delayed` is needed, but it works.