### PR TITLE
fix: macos tab drag

### DIFF
--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -396,6 +396,16 @@ class DesktopTab extends StatelessWidget {
                       }
                     : null,
                 onPanStart: (_) => startDragging(isMainWindow),
+                onPanCancel: () {
+                  if (isMacOS) {
+                    setMovable(isMainWindow, false);
+                  }
+                },
+                onPanEnd: (_) {
+                  if (isMacOS) {
+                    setMovable(isMainWindow, false);
+                  }
+                },
                 child: Row(
                   children: [
                     Offstage(
@@ -783,6 +793,14 @@ void startDragging(bool isMainWindow) {
     windowManager.startDragging();
   } else {
     WindowController.fromWindowId(kWindowId!).startDragging();
+  }
+}
+
+void setMovable(bool isMainWindow, bool movable) {
+  if (isMainWindow) {
+    windowManager.setMovable(movable);
+  } else {
+    WindowController.fromWindowId(kWindowId!).setMovable(movable);
   }
 }
 

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -95,6 +95,7 @@ Future<void> main(List<String> args) async {
     desktopType = DesktopType.main;
     await windowManager.ensureInitialized();
     windowManager.setPreventClose(true);
+    windowManager.setMovable(false);
     runMainApp(true);
   }
 }
@@ -167,6 +168,7 @@ void runMultiWindow(
   final title = getWindowName();
   // set prevent close to true, we handle close event manually
   WindowController.fromWindowId(kWindowId!).setPreventClose(true);
+  WindowController.fromWindowId(kWindowId!).setMovable(false);
   late Widget widget;
   switch (appType) {
     case kAppTypeDesktopRemote:

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -335,7 +335,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: bfbed668445edaea0626fb7d6b8b2aab3a444b17
+      resolved-ref: 3535741662c5b7529e182227a277a8551aed3398
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"


### PR DESCRIPTION

https://github.com/rustdesk/rustdesk/assets/13586388/941ed7c7-e07f-4f31-992e-7e6bc040387d


Restoring window positions tests ok.
