### PR TITLE
vram avoid always fallback to gdi

### DIFF
--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -528,6 +528,7 @@ fn run(vs: VideoService) -> ResultType<()> {
         #[cfg(all(windows, feature = "vram"))]
         if c.is_gdi() && encoder.input_texture() {
             log::info!("changed to gdi when using vram");
+            VRamEncoder::set_fallback_gdi(display_idx, true);
             bail!("SWITCH");
         }
         check_privacy_mode_changed(&sp, c.privacy_mode_id)?;
@@ -568,6 +569,10 @@ fn run(vs: VideoService) -> ResultType<()> {
                 }
                 #[cfg(windows)]
                 {
+                    #[cfg(feature = "vram")]
+                    if try_gdi == 1 && !c.is_gdi() {
+                        VRamEncoder::set_fallback_gdi(display_idx, false);
+                    }
                     try_gdi = 0;
                 }
                 Ok(())


### PR DESCRIPTION
If fallback to gdi three times in a row, set vram encoding not available to avoid switch in a loop. Test with random fallback gdi manually.

Related log: https://github.com/rustdesk/rustdesk/issues/8193#issuecomment-2141045678

