### PR TITLE
refact: Wayland, do not show multi displays

### DIFF
--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -583,10 +583,11 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
         child: Text(translate('Lock after session end'))));
   }
 
-  if (bind.mainGetUseTextureRender() &&
+  if (!pi.isWayland &&
       pi.isSupportMultiDisplay &&
       PrivacyModeState.find(id).isEmpty &&
       pi.displaysCount.value > 1 &&
+      bind.mainGetUseTextureRender() &&
       bind.mainGetUserDefaultOption(key: kKeyShowMonitorsToolbar) == 'Y') {
     final value =
         bind.sessionGetDisplaysAsIndividualWindows(sessionId: ffi.sessionId) ==

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -467,7 +467,8 @@ class _RemoteToolbarState extends State<RemoteToolbar> {
 
     toolbarItems.add(Obx(() {
       if (PrivacyModeState.find(widget.id).isEmpty &&
-          pi.displaysCount.value > 1) {
+          pi.displaysCount.value > 1 &&
+          !pi.isWayland) {
         return _MonitorMenu(
             id: widget.id,
             ffi: widget.ffi,


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/assets/13586388/93d9f0a1-d4d9-4c86-99c5-f98c99c2b60c


TODOs:
1. The second connection (store the token -> disconnect -> connect) always connect to the same display.
    **IMPORTANT BUG**: If one person only choose the 2nd display to share, the first display should not be shared at all.


https://github.com/rustdesk/rustdesk/assets/13586388/8cef4bdc-a977-4607-9b48-112b836caa8f



2. Show the primary display if multiple displays are selected.
3. Support multiple displays.