### PR TITLE
not close connection if failed to start cm due to no explorer.exe

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1595,7 +1595,9 @@ impl Connection {
                 {
                     log::error!("ipc to connection manager exit: {}", err);
                     #[cfg(windows)]
-                    if !crate::platform::is_prelogin() {
+                    if !crate::platform::is_prelogin()
+                        && !err.to_string().contains(crate::platform::EXPLORER_EXE)
+                    {
                         allow_err!(tx_from_cm_clone.send(Data::CmErr(err.to_string())));
                     }
                 }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/8193

https://github.com/rustdesk/rustdesk/assets/14891774/c7a17043-8763-4480-9487-cf97455e8720


If we use other processes, as least user id need to be checked.
