### PR TITLE
fix: audio rechannel len

### DIFF
--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -310,7 +310,7 @@ mod cpal_impl {
         let mut encoder = Encoder::new(sample_rate, encode_channel, LowDelay)?;
         // https://www.opus-codec.org/docs/html_api/group__opusencoder.html#gace941e4ef26ed844879fde342ffbe546
         // https://chromium.googlesource.com/chromium/deps/opus/+/1.1.1/include/opus.h
-        let frame_size = sample_rate as usize / 100; // 10 ms
+        let frame_size = sample_rate_0 as usize / 100; // 10 ms
         let encode_len = frame_size * encode_channel as usize;
         let rechannel_len = encode_len * device_channel as usize / encode_channel as usize;
         INPUT_BUFFER.lock().unwrap().clear();

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -310,6 +310,8 @@ mod cpal_impl {
         let mut encoder = Encoder::new(sample_rate, encode_channel, LowDelay)?;
         // https://www.opus-codec.org/docs/html_api/group__opusencoder.html#gace941e4ef26ed844879fde342ffbe546
         // https://chromium.googlesource.com/chromium/deps/opus/+/1.1.1/include/opus.h
+        // Do not set `frame_size = sample_rate as usize / 100;`
+        // Because we find `sample_rate as usize / 100` will cause encoder error in `encoder.encode_vec_float()`.
         let frame_size = sample_rate_0 as usize / 100; // 10 ms
         let encode_len = frame_size * encode_channel as usize;
         let rechannel_len = encode_len * device_channel as usize / encode_channel as usize;


### PR DESCRIPTION
Fix `rechannel_len` for opus encoder.

`frame_size` should be `sample_rate_0 as usize / 100; // 10 ms`. So after `crate::common::audio_resample()`, the data len is `sample_rate as usize / 100`.

eg:

```
SupportedStreamConfig { channels: 2, sample_rate: SampleRate(44100), buffer_size: Range { min: 64, max: 2048 }, sample_format: I32 }
```

then

```
sample_rate_0: 44100
sample_rate: 24000
device_channel: 2
encode_channel: 2
```

`rechannel_len` must be 882. After `crate::common::audio_resample()`, the data is 480, the same to `24000 / 100 * 2`.

If we use `let frame_size = sample_rate as usize / 100; // 10 ms`, the data will be 240, which is too short for opus encoder, and will always reutrn `OPUS_BAD_ARG`.   https://github.com/xiph/opus/blob/2554a89e02c7fc30a980b4f7e635ceae1ecba5d6/src/opus_encoder.c#L725