### PR TITLE
hwcodec, only process that start ipc server start check process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,8 +3037,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.15"
-source = "git+https://github.com/21pages/hwcodec#1d504ee590c15472813fecc22cee4b8149b2b8cd"
+version = "0.4.16"
+source = "git+https://github.com/21pages/hwcodec#0973290faddc4e22936859dd10f05610eb8d1619"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1554,40 +1554,6 @@ impl LanPeers {
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
-pub struct HwCodecConfig {
-    #[serde(default, deserialize_with = "deserialize_string")]
-    pub ram: String,
-    #[serde(default, deserialize_with = "deserialize_string")]
-    pub vram: String,
-}
-
-impl HwCodecConfig {
-    pub fn load() -> HwCodecConfig {
-        Config::load_::<HwCodecConfig>("_hwcodec")
-    }
-
-    pub fn store(&self) {
-        Config::store_(self, "_hwcodec");
-    }
-
-    pub fn clear() {
-        HwCodecConfig::default().store();
-    }
-
-    pub fn clear_ram() {
-        let mut c = Self::load();
-        c.ram = Default::default();
-        c.store();
-    }
-
-    pub fn clear_vram() {
-        let mut c = Self::load();
-        c.vram = Default::default();
-        c.store();
-    }
-}
-
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct UserDefaultConfig {
     #[serde(default, deserialize_with = "deserialize_hashmap_string_string")]
     options: HashMap<String, String>,
@@ -2209,6 +2175,18 @@ pub mod keys {
         OPTION_PROXY_USERNAME,
         OPTION_PROXY_PASSWORD,
     ];
+}
+
+pub fn common_load<
+    T: serde::Serialize + serde::de::DeserializeOwned + Default + std::fmt::Debug,
+>(
+    suffix: &str,
+) -> T {
+    Config::load_::<T>(suffix)
+}
+
+pub fn common_store<T: serde::Serialize>(config: &T, suffix: &str) {
+    Config::store_(config, suffix);
 }
 
 #[cfg(test)]

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -144,10 +144,7 @@ impl Encoder {
                 }),
                 Err(e) => {
                     log::error!("new hw encoder failed: {e:?}, clear config");
-                    #[cfg(target_os = "android")]
-                    crate::android::ffi::clear_codec_info();
-                    #[cfg(not(target_os = "android"))]
-                    hbb_common::config::HwCodecConfig::clear_ram();
+                    HwCodecConfig::clear(false, true);
                     Self::update(EncodingUpdate::Check);
                     *ENCODE_CODEC_FORMAT.lock().unwrap() = CodecFormat::VP9;
                     Err(e)
@@ -160,7 +157,7 @@ impl Encoder {
                 }),
                 Err(e) => {
                     log::error!("new vram encoder failed: {e:?}, clear config");
-                    hbb_common::config::HwCodecConfig::clear_vram();
+                    HwCodecConfig::clear(true, true);
                     Self::update(EncodingUpdate::Check);
                     *ENCODE_CODEC_FORMAT.lock().unwrap() = CodecFormat::VP9;
                     Err(e)

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -416,7 +416,7 @@ pub fn core_main() -> Option<Vec<String>> {
             return None;
         } else if args[0] == "--check-hwcodec-config" {
             #[cfg(feature = "hwcodec")]
-            scrap::hwcodec::check_available_hwcodec();
+            crate::ipc::hwcodec_process();
             return None;
         } else if args[0] == "--cm" {
             // call connection manager to establish connections

--- a/src/server.rs
+++ b/src/server.rs
@@ -459,9 +459,6 @@ pub async fn start_server(is_server: bool) {
         log::info!("DISPLAY={:?}", std::env::var("DISPLAY"));
         log::info!("XAUTHORITY={:?}", std::env::var("XAUTHORITY"));
     }
-    #[cfg(feature = "hwcodec")]
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
-    scrap::hwcodec::start_check_process(false);
     #[cfg(windows)]
     hbb_common::platform::windows::start_cpu_performance_monitor();
 
@@ -489,6 +486,9 @@ pub async fn start_server(is_server: bool) {
         tokio::spawn(async { sync_and_watch_config_dir().await });
         #[cfg(target_os = "windows")]
         crate::platform::try_kill_broker();
+        #[cfg(feature = "hwcodec")]
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        scrap::hwcodec::start_check_process();
         crate::RendezvousMediator::start_all().await;
     } else {
         match crate::ipc::connect(1000, "").await {
@@ -509,6 +509,9 @@ pub async fn start_server(is_server: bool) {
                         }
                     }
                 }
+                #[cfg(feature = "hwcodec")]
+                #[cfg(any(target_os = "windows", target_os = "linux"))]
+                crate::ipc::client_get_hwcodec_config_thread(0);
             }
             Err(err) => {
                 log::info!("server not started (will try to start): {}", err);


### PR DESCRIPTION
* Check process send config to ipc server, other process get config from ipc server. Process will save config to toml, and the toml will be used if the config is none on windows.

* When start check process: ipc server process start or option changed from disable to enable

* When get config: main window start or option changed from disable to enable, start_video_audio_threads.

* Only windows implements signature, which is used to mark whether the gpu software and hardware information changes. 
  - After reboot, the signature doesn't change. 
  -  https://asawicki.info/news_1773_how_to_programmatically_check_graphics_driver_version, use dxgi way to get software version, it's not consistent with the visible driver version. 
  - After updating intel driver with small version change, the signature doesn't change, 
  - After updating nvidia driver with big version change, the signature changes.
  -  Linux doens't use toml file.