### PR TITLE
Refact/multi window soft rendering

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2924,10 +2924,10 @@ openMonitorInNewTabOrWindow(int i, String peerId, PeerInfo pi,
       kMainWindowId, kWindowEventOpenMonitorSession, jsonEncode(args));
 }
 
-setNewConnectWindowFrame(int windowId, String peerId, Rect? screenRect) async {
+setNewConnectWindowFrame(int windowId, String peerId, int? display, Rect? screenRect) async {
   if (screenRect == null) {
     await restoreWindowPosition(WindowType.RemoteDesktop,
-        windowId: windowId, peerId: peerId);
+        windowId: windowId, display: display, peerId: peerId);
   } else {
     await tryMoveToScreenAndSetFullscreen(screenRect);
   }

--- a/flutter/lib/common/widgets/setting_widgets.dart
+++ b/flutter/lib/common/widgets/setting_widgets.dart
@@ -234,12 +234,12 @@ List<(String, String)> otherDefaultSettings() {
     ('True color (4:4:4)', kOptionI444),
     ('Reverse mouse wheel', kKeyReverseMouseWheel),
     ('swap-left-right-mouse', kOptionSwapLeftRightMouse),
-    if (isDesktop && bind.mainGetUseTextureRender())
+    if (isDesktop)
       (
         'Show displays as individual windows',
         kKeyShowDisplaysAsIndividualWindows
       ),
-    if (isDesktop && bind.mainGetUseTextureRender())
+    if (isDesktop)
       (
         'Use all my displays for the remote session',
         kKeyUseAllMyDisplaysForTheRemoteSession

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -586,7 +586,6 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
   if (pi.isSupportMultiDisplay &&
       PrivacyModeState.find(id).isEmpty &&
       pi.displaysCount.value > 1 &&
-      bind.mainGetUseTextureRender() &&
       bind.mainGetUserDefaultOption(key: kKeyShowMonitorsToolbar) == 'Y') {
     final value =
         bind.sessionGetDisplaysAsIndividualWindows(sessionId: ffi.sessionId) ==
@@ -602,9 +601,7 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
   }
 
   final isMultiScreens = !isWeb && (await getScreenRectList()).length > 1;
-  if (bind.mainGetUseTextureRender() &&
-      pi.isSupportMultiDisplay &&
-      isMultiScreens) {
+  if (pi.isSupportMultiDisplay && isMultiScreens) {
     final value = bind.sessionGetUseAllMyDisplaysForTheRemoteSession(
             sessionId: ffi.sessionId) ==
         'Y';

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -648,7 +648,7 @@ class _ImagePaintState extends State<ImagePaint> {
                 ),
                 c.size,
                 isViewOriginal())
-            : _buildScrollAuthNonTextureRender(m, c, s);
+            : _buildScrollAutoNonTextureRender(m, c, s);
         return mouseRegion(child: _buildListener(paintWidget));
       } else {
         return Container();
@@ -664,7 +664,7 @@ class _ImagePaintState extends State<ImagePaint> {
     );
   }
 
-  Widget _buildScrollAuthNonTextureRender(
+  Widget _buildScrollAutoNonTextureRender(
       ImageModel m, CanvasModel c, double s) {
     return CustomPaint(
       size: Size(c.size.width, c.size.height),

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -617,11 +617,11 @@ class _ImagePaintState extends State<ImagePaint> {
       final paintWidth = c.getDisplayWidth() * s;
       final paintHeight = c.getDisplayHeight() * s;
       final paintSize = Size(paintWidth, paintHeight);
-      final paintWidget = m.useTextureRender ||
-              widget.ffi.ffiModel.pi.currentDisplay == kAllDisplayValue
-          ? _BuildPaintTextureRender(
-              c, s, Offset.zero, paintSize, isViewOriginal())
-          : _buildScrollbarNonTextureRender(m, paintSize, s);
+      final paintWidget =
+          m.useTextureRender || widget.ffi.ffiModel.pi.forceTextureRender
+              ? _BuildPaintTextureRender(
+                  c, s, Offset.zero, paintSize, isViewOriginal())
+              : _buildScrollbarNonTextureRender(m, paintSize, s);
       return NotificationListener<ScrollNotification>(
           onNotification: (notification) {
             c.updateScrollPercent();
@@ -639,18 +639,18 @@ class _ImagePaintState extends State<ImagePaint> {
           ));
     } else {
       if (c.size.width > 0 && c.size.height > 0) {
-        final paintWidget = m.useTextureRender ||
-                widget.ffi.ffiModel.pi.currentDisplay == kAllDisplayValue
-            ? _BuildPaintTextureRender(
-                c,
-                s,
-                Offset(
-                  isLinux ? c.x.toInt().toDouble() : c.x,
-                  isLinux ? c.y.toInt().toDouble() : c.y,
-                ),
-                c.size,
-                isViewOriginal())
-            : _buildScrollAutoNonTextureRender(m, c, s);
+        final paintWidget =
+            m.useTextureRender || widget.ffi.ffiModel.pi.forceTextureRender
+                ? _BuildPaintTextureRender(
+                    c,
+                    s,
+                    Offset(
+                      isLinux ? c.x.toInt().toDouble() : c.x,
+                      isLinux ? c.y.toInt().toDouble() : c.y,
+                    ),
+                    c.size,
+                    isViewOriginal())
+                : _buildScrollAutoNonTextureRender(m, c, s);
         return mouseRegion(child: _buildListener(paintWidget));
       } else {
         return Container();

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -617,7 +617,8 @@ class _ImagePaintState extends State<ImagePaint> {
       final paintWidth = c.getDisplayWidth() * s;
       final paintHeight = c.getDisplayHeight() * s;
       final paintSize = Size(paintWidth, paintHeight);
-      final paintWidget = m.useTextureRender
+      final paintWidget = m.useTextureRender ||
+              widget.ffi.ffiModel.pi.currentDisplay == kAllDisplayValue
           ? _BuildPaintTextureRender(
               c, s, Offset.zero, paintSize, isViewOriginal())
           : _buildScrollbarNonTextureRender(m, paintSize, s);
@@ -638,7 +639,8 @@ class _ImagePaintState extends State<ImagePaint> {
           ));
     } else {
       if (c.size.width > 0 && c.size.height > 0) {
-        final paintWidget = m.useTextureRender
+        final paintWidget = m.useTextureRender ||
+                widget.ffi.ffiModel.pi.currentDisplay == kAllDisplayValue
             ? _BuildPaintTextureRender(
                 c,
                 s,

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -420,7 +420,7 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
           await WindowController.fromWindowId(windowId()).setFullscreen(false);
           stateGlobal.setFullscreen(false, procWnd: false);
         }
-        await setNewConnectWindowFrame(windowId(), id!, screenRect);
+        await setNewConnectWindowFrame(windowId(), id!, display, screenRect);
         Future.delayed(Duration(milliseconds: isWindows ? 100 : 0), () async {
           await windowOnTop(windowId());
         });

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -643,15 +643,12 @@ class _MonitorMenu extends StatelessWidget {
   }
 
   Widget buildMonitorSubmenuWidget(BuildContext context) {
-    final m = Provider.of<ImageModel>(context);
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         Row(children: buildMonitorList(context, false)),
-        supportIndividualWindows && m.useTextureRender ? Divider() : Offstage(),
-        supportIndividualWindows && m.useTextureRender
-            ? chooseDisplayBehavior()
-            : Offstage(),
+        supportIndividualWindows ? Divider() : Offstage(),
+        supportIndividualWindows ? chooseDisplayBehavior() : Offstage(),
       ],
     );
   }
@@ -824,7 +821,6 @@ class _MonitorMenu extends StatelessWidget {
     RxInt display = CurrentDisplayState.find(id);
     if (display.value != i) {
       final isChooseDisplayToOpenInNewWindow = pi.isSupportMultiDisplay &&
-          bind.mainGetUseTextureRender() &&
           bind.sessionGetDisplaysAsIndividualWindows(
                   sessionId: ffi.sessionId) ==
               'Y';

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -734,10 +734,7 @@ class _MonitorMenu extends StatelessWidget {
     for (int i = 0; i < pi.displays.length; i++) {
       monitorList.add(buildMonitorButton(i));
     }
-    final m = Provider.of<ImageModel>(context);
-    if (supportIndividualWindows &&
-        m.useTextureRender &&
-        pi.displays.length > 1) {
+    if (supportIndividualWindows && pi.displays.length > 1) {
       monitorList.add(buildMonitorButton(kAllDisplayValue));
     }
     return monitorList;

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui' as ui;

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1185,10 +1185,11 @@ class ImageModel with ChangeNotifier {
 
   onRgba(int display, Uint8List rgba) {
     final pid = parent.target?.id;
+    final rect = parent.target?.ffiModel.pi.getDisplayRect(display);
     img.decodeImageFromPixels(
         rgba,
-        parent.target?.ffiModel.rect?.width.toInt() ?? 0,
-        parent.target?.ffiModel.rect?.height.toInt() ?? 0,
+        rect?.width.toInt() ?? 0,
+        rect?.height.toInt() ?? 0,
         isWeb ? ui.PixelFormat.rgba8888 : ui.PixelFormat.bgra8888,
         onPixelsCopied: () {
       // Unlock the rgba memory from rust codes.
@@ -2693,30 +2694,32 @@ class PeerInfo with ChangeNotifier {
   bool get isAmyuniIdd =>
       platformAdditions[kPlatformAdditionsIddImpl] == 'amyuni_idd';
 
-  Display? tryGetDisplay() {
+  Display? tryGetDisplay({int? display}) {
     if (displays.isEmpty) {
       return null;
     }
-    if (currentDisplay == kAllDisplayValue) {
+    display ??= currentDisplay;
+    if (display == kAllDisplayValue) {
       return displays[0];
     } else {
-      if (currentDisplay > 0 && currentDisplay < displays.length) {
-        return displays[currentDisplay];
+      if (display > 0 && display < displays.length) {
+        return displays[display];
       } else {
         return displays[0];
       }
     }
   }
 
-  Display? tryGetDisplayIfNotAllDisplay() {
+  Display? tryGetDisplayIfNotAllDisplay({int? display}) {
     if (displays.isEmpty) {
       return null;
     }
-    if (currentDisplay == kAllDisplayValue) {
+    display ??= currentDisplay;
+    if (display == kAllDisplayValue) {
       return null;
     }
-    if (currentDisplay >= 0 && currentDisplay < displays.length) {
-      return displays[currentDisplay];
+    if (display >= 0 && display < displays.length) {
+      return displays[display];
     } else {
       return null;
     }
@@ -2739,6 +2742,12 @@ class PeerInfo with ChangeNotifier {
       return displays[display].scale;
     }
     return 1.0;
+  }
+
+  Rect? getDisplayRect(int display) {
+    final d = tryGetDisplayIfNotAllDisplay(display: display);
+    if (d == null) return null;
+    return Rect.fromLTWH(d.x, d.y, d.width.toDouble(), d.height.toDouble());
   }
 }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -2497,6 +2498,9 @@ class FFI {
           }
         } else if (message is EventToUI_Rgba) {
           final display = message.field0;
+          if (display == 1) {
+            debugPrint('REMOVE ME ========================= handle display 1');
+          }
           if (imageModel.useTextureRender) {
             debugPrint("EventToUI_Rgba display:$display");
             textureModel.setTextureType(display: display, gpuTexture: false);
@@ -2505,6 +2509,7 @@ class FFI {
             // Fetch the image buffer from rust codes.
             final sz = platformFFI.getRgbaSize(sessionId, display);
             if (sz == 0) {
+                       debugPrint('REMOVE ME ========================= session, rgba size is 0');
               return;
             }
             final rgba = platformFFI.getRgba(sessionId, display, sz);

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2497,8 +2497,9 @@ class FFI {
           }
         } else if (message is EventToUI_Rgba) {
           final display = message.field0;
-          if (imageModel.useTextureRender) {
-            debugPrint("EventToUI_Rgba display:$display");
+          if (imageModel.useTextureRender ||
+              ffiModel.pi.currentDisplay == kAllDisplayValue) {
+            //debugPrint("EventToUI_Rgba display:$display");
             textureModel.setTextureType(display: display, gpuTexture: false);
             onEvent2UIRgba();
           } else {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2497,9 +2497,6 @@ class FFI {
           }
         } else if (message is EventToUI_Rgba) {
           final display = message.field0;
-          if (display == 1) {
-            debugPrint('REMOVE ME ========================= handle display 1');
-          }
           if (imageModel.useTextureRender) {
             debugPrint("EventToUI_Rgba display:$display");
             textureModel.setTextureType(display: display, gpuTexture: false);
@@ -2508,7 +2505,6 @@ class FFI {
             // Fetch the image buffer from rust codes.
             final sz = platformFFI.getRgbaSize(sessionId, display);
             if (sz == 0) {
-                       debugPrint('REMOVE ME ========================= session, rgba size is 0');
               return;
             }
             final rgba = platformFFI.getRgba(sessionId, display, sz);

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -63,11 +63,6 @@ class RustdeskImpl {
     return '';
   }
 
-  void sessionTryAddDisplay(
-      {required UuidValue sessionId,
-      required Int32List displays,
-      dynamic hint}) {}
-
   String sessionAddSync(
       {required UuidValue sessionId,
       required String id,

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -89,6 +89,14 @@ class RustdeskImpl {
     return Stream.empty();
   }
 
+  Stream<EventToUI> sessionStartWithDisplays(
+      {required UuidValue sessionId,
+      required String id,
+      required Int32List displays,
+      dynamic hint}) {
+    throw UnimplementedError();
+  }
+
   Future<bool?> sessionGetRemember(
       {required UuidValue sessionId, dynamic hint}) {
     return Future(

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1041,6 +1041,7 @@ impl FlutterHandler {
         } else {
             let mut rgba_data = RgbaData::default();
             std::mem::swap::<Vec<u8>>(&mut rgba.raw, &mut rgba_data.data);
+            rgba_data.size_got = false;
             rgba_write_lock.insert(display, rgba_data);
         }
         drop(rgba_write_lock);

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -408,6 +408,25 @@ impl VideoRenderer {
         }
     }
 
+    fn add_displays(&self, displays: &[i32]) {
+        let mut sessions_lock = self.map_display_sessions.write().unwrap();
+        for display in displays {
+            let d = *display as usize;
+            if !sessions_lock.contains_key(&d) {
+                sessions_lock.insert(
+                    d,
+                    DisplaySessionInfo {
+                        texture_rgba_ptr: 0,
+                        size: (0, 0),
+                        #[cfg(feature = "vram")]
+                        gpu_output_ptr: usize::default(),
+                        notify_render_type: None,
+                    },
+                );
+            }
+        }
+    }
+
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn on_rgba(&self, display: usize, rgba: &scrap::ImageRgb) -> bool {
         let mut write_lock = self.map_display_sessions.write().unwrap();
@@ -1046,10 +1065,16 @@ impl FlutterHandler {
             if map_display_sessions.len() > 1 {
                 continue;
             }
-            make sure map_display_sessions is set first.
-            if map_display_sessions.contains_key(&display) {
-                if let Some(stream) = &h.event_stream {
-                    stream.add(EventToUI::Rgba(display));
+            if h.renderer
+                .map_display_sessions
+                .read()
+                .unwrap()
+                .contains_key(&display)
+            {
+                if map_display_sessions.contains_key(&display) {
+                    if let Some(stream) = &h.event_stream {
+                        stream.add(EventToUI::Rgba(display));
+                    }
                 }
             }
         }
@@ -1532,6 +1557,21 @@ pub fn session_register_gpu_texture(_session_id: SessionID, _display: usize, _ou
             .get(&_session_id)
         {
             h.renderer.register_gpu_output(_display, _output_ptr);
+            break;
+        }
+    }
+}
+
+pub fn session_add_displays(session_id: &SessionID, displays: &[i32]) {
+    for s in sessions::get_sessions() {
+        if let Some(h) = s
+            .ui_handler
+            .session_handlers
+            .read()
+            .unwrap()
+            .get(session_id)
+        {
+            h.renderer.add_displays(displays);
             break;
         }
     }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -209,6 +209,8 @@ struct RgbaData {
     // SAFETY: [rgba] is guarded by [rgba_valid], and it's safe to reach [rgba] with `rgba_valid == true`.
     // We must check the `rgba_valid` before reading [rgba].
     data: Vec<u8>,
+    // data should not update if size_got is true.
+    // Because flutter side will get the size first, then get the data.
     size_got: bool,
 }
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -111,10 +111,6 @@ pub fn session_add_existed_sync(id: String, session_id: SessionID) -> SyncReturn
 }
 
 pub fn session_try_add_display(session_id: SessionID, displays: Vec<i32>) -> SyncReturn<()> {
-    // `session_add_displays` is used for software rendering, multi-ui sessions.
-    // We need to add displays to the session first, then capture the displays.
-    // Otherwise, the session may not send video frames to the flutter side.
-    super::flutter::session_add_displays(&session_id, &displays);
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
         session.capture_displays(displays, vec![], vec![]);
     }

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -110,17 +110,6 @@ pub fn session_add_existed_sync(id: String, session_id: SessionID) -> SyncReturn
     }
 }
 
-pub fn session_try_add_display(session_id: SessionID, displays: Vec<i32>) -> SyncReturn<()> {
-    // `session_add_displays` is used for software rendering, multi-ui sessions.
-    // We need to add displays to the session first, then capture the displays.
-    // Otherwise, the session may not send video frames to the flutter side.
-    super::flutter::session_add_displays(&session_id, &displays);
-    if let Some(session) = sessions::get_session_by_session_id(&session_id) {
-        session.capture_displays(displays, vec![], vec![]);
-    }
-    SyncReturn(())
-}
-
 pub fn session_add_sync(
     session_id: SessionID,
     id: String,
@@ -155,6 +144,27 @@ pub fn session_start(
     id: String,
 ) -> ResultType<()> {
     session_start_(&session_id, &id, events2ui)
+}
+
+pub fn session_start_with_displays(
+    events2ui: StreamSink<EventToUI>,
+    session_id: SessionID,
+    id: String,
+    displays: Vec<i32>,
+) -> ResultType<()> {
+    session_start_(&session_id, &id, events2ui)?;
+
+    // `session_add_displays` is used for software rendering, multi-ui sessions.
+    // We need to add displays to the session first, then capture the displays.
+    // Otherwise, the session may not send video frames to the flutter side.
+    super::flutter::session_add_displays(&session_id, &displays);
+    if let Some(session) = sessions::get_session_by_session_id(&session_id) {
+        session.capture_displays(displays.clone(), vec![], vec![]);
+        for display in displays {
+            session.refresh_video(display as _);
+        }
+    }
+    Ok(())
 }
 
 pub fn session_get_remember(session_id: SessionID) -> Option<bool> {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -111,6 +111,10 @@ pub fn session_add_existed_sync(id: String, session_id: SessionID) -> SyncReturn
 }
 
 pub fn session_try_add_display(session_id: SessionID, displays: Vec<i32>) -> SyncReturn<()> {
+    // `session_add_displays` is used for software rendering, multi-ui sessions.
+    // We need to add displays to the session first, then capture the displays.
+    // Otherwise, the session may not send video frames to the flutter side.
+    super::flutter::session_add_displays(&session_id, &displays);
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
         session.capture_displays(displays, vec![], vec![]);
     }


### PR DESCRIPTION
1. Flutter image pant, support multi ui sessions.  for images merging, force texture render.

https://github.com/rustdesk/rustdesk/discussions/8304

https://github.com/rustdesk/rustdesk/assets/13586388/f4076f63-ef41-46b4-ae89-6a07eac08e49



https://github.com/rustdesk/rustdesk/assets/13586388/fc45ca04-c5d0-4f3f-a2cc-e2d8e3976bb6


2. Always add an offset to the new connection window. Otherwise the second window may cover the frist one if they are connected to the same peer.

![image](https://github.com/rustdesk/rustdesk/assets/13586388/fb10e290-c581-4864-8b58-02ddb8e9756e)

3. Add new ffi method `sessionStartWithDisplays()` and remove `sessionTryAddDisplay()`.  
Because `sessionStart()` immediately return a stream, but the `session_start()` on rust side is called async (later). So we need to pass `displays` in `session_start()` instead of call `sessionTryAddDisplay()`. To make sure the stream on rust side is ready before the first image arrives.  

![image](https://github.com/rustdesk/rustdesk/assets/13586388/2b42b025-5f40-4bc7-ac44-e6185a3b35f8)


I've tested the flutter stream will not loose events.
  a. The base test example https://github.com/fzyzcjy/flutter_rust_bridge/tree/v1.80.1/frb_example/pure_dart . 
  b. Remove all test codes other than https://github.com/fzyzcjy/flutter_rust_bridge/blob/v1.80.1/frb_example/pure_dart/dart/lib/main.dart#L249
  c. Add `await Future.delayed(Duration(seconds: 3));` here https://github.com/fzyzcjy/flutter_rust_bridge/blob/9904bc6ce4a9433c035141d931f7bc69c83655ab/frb_dart/lib/src/basic.dart#L109

Then rust will push events first. Flutter will try receive events after 3 seconds. All events can be received.



