### PR TITLE
fix: desktop, remote toolbar autohide

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -85,6 +85,9 @@ class _RemotePageState extends State<RemotePage>
 
   final FocusNode _rawKeyFocusNode = FocusNode(debugLabel: "rawkeyFocusNode");
 
+  // We need `_instanceIdOnEnterOrLeaveImage4Toolbar` together with `_onEnterOrLeaveImage4Toolbar`
+  // to identify the toolbar instance and its callback function.
+  int? _instanceIdOnEnterOrLeaveImage4Toolbar;
   Function(bool)? _onEnterOrLeaveImage4Toolbar;
 
   late FFI _ffi;
@@ -268,9 +271,18 @@ class _RemotePageState extends State<RemotePage>
           id: widget.id,
           ffi: _ffi,
           state: widget.toolbarState,
-          onEnterOrLeaveImageSetter: (func) =>
-              _onEnterOrLeaveImage4Toolbar = func,
-          onEnterOrLeaveImageCleaner: () => _onEnterOrLeaveImage4Toolbar = null,
+          onEnterOrLeaveImageSetter: (id, func) {
+            _instanceIdOnEnterOrLeaveImage4Toolbar = id;
+            _onEnterOrLeaveImage4Toolbar = func;
+          },
+          onEnterOrLeaveImageCleaner: (id) {
+            // If _instanceIdOnEnterOrLeaveImage4Toolbar != id
+            // it means `_onEnterOrLeaveImage4Toolbar` is not set or it has been changed to another toolbar.
+            if (_instanceIdOnEnterOrLeaveImage4Toolbar == id) {
+              _instanceIdOnEnterOrLeaveImage4Toolbar = null;
+              _onEnterOrLeaveImage4Toolbar = null;
+            }
+          },
           setRemoteState: setState,
         );
 

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -332,8 +332,8 @@ class RemoteToolbar extends StatefulWidget {
   final String id;
   final FFI ffi;
   final ToolbarState state;
-  final Function(Function(bool)) onEnterOrLeaveImageSetter;
-  final VoidCallback onEnterOrLeaveImageCleaner;
+  final Function(int, Function(bool)) onEnterOrLeaveImageSetter;
+  final Function(int) onEnterOrLeaveImageCleaner;
   final Function(VoidCallback) setRemoteState;
 
   RemoteToolbar({
@@ -393,7 +393,7 @@ class _RemoteToolbarState extends State<RemoteToolbar> {
       initialValue: 0,
     );
 
-    widget.onEnterOrLeaveImageSetter((enter) {
+    widget.onEnterOrLeaveImageSetter(identityHashCode(this), (enter) {
       if (enter) {
         triggerAutoHide();
         _isCursorOverImage = true;
@@ -413,12 +413,11 @@ class _RemoteToolbarState extends State<RemoteToolbar> {
   dispose() {
     super.dispose();
 
-    widget.onEnterOrLeaveImageCleaner();
+    widget.onEnterOrLeaveImageCleaner(identityHashCode(this));
   }
 
   @override
   Widget build(BuildContext context) {
-    // No need to use future builder here.
     return Align(
       alignment: Alignment.topCenter,
       child: Obx(() => show.value


### PR DESCRIPTION
Fix remote toolbar, autohide.

### Fixed preview

https://github.com/rustdesk/rustdesk/assets/13586388/e8a03357-1ba5-418e-b9e5-b4b33342e802


### Bug desc

Remote toolbar is created and destory more than one time. 
The destory(dispose) function will cause the autohide not working.

When refreshing the toolbar widget, the new widget is created and then the old widget is disposed.

After adding some print in `_RemoteToolbarState`

```
debugPrint('REMOVE ME ======================== _RemoteToolbarState [${identityHashCode(this)}] initState');
debugPrint('REMOVE ME ========================  _RemoteToolbarState [${identityHashCode(this)}] dispose');
debugPrint('REMOVE ME ====================== _RemoteToolbarState [${identityHashCode(this)}] build');
```

I can see

```
flutter: REMOVE ME ======================== _RemoteToolbarState [965824738] initState
flutter: REMOVE ME ====================== _RemoteToolbarState [965824738] build
flutter: REMOVE ME ======================== _RemoteToolbarState [52152775] initState
flutter: REMOVE ME ====================== _RemoteToolbarState [52152775] build
flutter: REMOVE ME ========================  _RemoteToolbarState [965824738] dispose
flutter: REMOVE ME ======================== _RemoteToolbarState [325133259] initState
flutter: REMOVE ME ====================== _RemoteToolbarState [325133259] build
flutter: CustomTouchGestureRecognizer init
flutter: REMOVE ME ========================  _RemoteToolbarState [52152775] dispose
flutter: CustomTouchGestureRecognizer init
flutter: REMOVE ME ======================== _RemoteToolbarState [887362112] initState
flutter: REMOVE ME ====================== _RemoteToolbarState [887362112] build
flutter: CustomTouchGestureRecognizer init
flutter: REMOVE ME ========================  _RemoteToolbarState [325133259] dispose
```

