### PR TITLE
update hwcodec, remove AVCodecParserContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,8 +3037,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.16"
-source = "git+https://github.com/21pages/hwcodec#0973290faddc4e22936859dd10f05610eb8d1619"
+version = "0.4.17"
+source = "git+https://github.com/21pages/hwcodec#38eb9bfc4730986ebeb519ab39027d654356ce1a"
 dependencies = [
  "bindgen 0.59.2",
  "cc",


### PR DESCRIPTION
It was used to decode different resolution with same decoder, but may cause crash.