### PR TITLE
fix: android, touch mode, soft keyboard, no pointer events

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -95,8 +95,9 @@ class _RawTouchGestureDetectorRegionState
     }
     if (handleTouch) {
       // Desktop or mobile "Touch mode"
-      ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy);
-      inputModel.tapDown(MouseButtons.left);
+      if (ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy)) {
+        inputModel.tapDown(MouseButtons.left);
+      }
     }
   }
 
@@ -105,8 +106,9 @@ class _RawTouchGestureDetectorRegionState
       return;
     }
     if (handleTouch) {
-      ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy);
-      inputModel.tapUp(MouseButtons.left);
+      if (ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy)) {
+        inputModel.tapUp(MouseButtons.left);
+      }
     }
   }
 
@@ -132,6 +134,9 @@ class _RawTouchGestureDetectorRegionState
 
   onDoubleTap() {
     if (lastDeviceKind != PointerDeviceKind.touch) {
+      return;
+    }
+    if (ffiModel.touchMode && ffi.cursorModel.lastIsBlocked) {
       return;
     }
     inputModel.tap(MouseButtons.left);
@@ -222,6 +227,9 @@ class _RawTouchGestureDetectorRegionState
       return;
     }
     if (handleTouch) {
+      if (ffi.cursorModel.shouldBlock(d.localPosition.dx, d.localPosition.dy)) {
+        return;
+      }
       if (isDesktop) {
         ffi.cursorModel.trySetRemoteWindowCoords();
       }
@@ -242,6 +250,9 @@ class _RawTouchGestureDetectorRegionState
 
   onOneFingerPanUpdate(DragUpdateDetails d) {
     if (lastDeviceKind != PointerDeviceKind.touch) {
+      return;
+    }
+    if (ffi.cursorModel.shouldBlock(d.localPosition.dx, d.localPosition.dy)) {
       return;
     }
     ffi.cursorModel.updatePan(d.delta, d.localPosition, handleTouch);

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -679,6 +679,7 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
   var _fn = false;
   var _pin = false;
   final _keyboardVisibilityController = KeyboardVisibilityController();
+  final _key = GlobalKey();
 
   InputModel get inputModel => gFFI.inputModel;
 
@@ -704,6 +705,24 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
   }
 
   @override
+  void initState() {
+    super.initState();
+  }
+
+  _updateRect() {
+    RenderObject? renderObject = _key.currentContext?.findRenderObject();
+    if (renderObject == null) {
+      return;
+    }
+    if (renderObject is RenderBox) {
+      final size = renderObject.size;
+      Offset pos = renderObject.localToGlobal(Offset.zero);
+      gFFI.cursorModel.keyHelpToolsRect =
+          Rect.fromLTWH(pos.dx, pos.dy, size.width, size.height);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final hasModifierOn = inputModel.ctrl ||
         inputModel.alt ||
@@ -711,6 +730,7 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
         inputModel.command;
 
     if (!_pin && !hasModifierOn && !widget.requestShow) {
+      gFFI.cursorModel.keyHelpToolsRect = null;
       return Offstage();
     }
     final size = MediaQuery.of(context).size;
@@ -821,7 +841,12 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
       }),
     ];
     final space = size.width > 320 ? 4.0 : 2.0;
+    // 500 ms is long enough for this widget to be built!
+    Future.delayed(Duration(milliseconds: 500), () {
+      _updateRect();
+    });
     return Container(
+        key: _key,
         color: Color(0xAA000000),
         padding: EdgeInsets.only(
             top: _keyboardVisibilityController.isVisible ? 24 : 4, bottom: 8),

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1800,6 +1800,18 @@ class CursorModel with ChangeNotifier {
   String peerId = '';
   WeakReference<FFI> parent;
 
+  // Only for mobile, touch mode
+  // To block touch event above the KeyHelpTools
+  //
+  // A better way is to not listen events from the KeyHelpTools.
+  // But we're now using a Container(child: Stack(...)) to wrap the KeyHelpTools,
+  // and the listener is on the Container.
+  Rect? _keyHelpToolsRect;
+  bool _lastIsBlocked = false;
+
+  set keyHelpToolsRect(Rect? r) => _keyHelpToolsRect = r;
+  get lastIsBlocked => _lastIsBlocked;
+
   ui.Image? get image => _image;
   CursorData? get cache => _cache;
 
@@ -1844,9 +1856,10 @@ class CursorModel with ChangeNotifier {
     return Rect.fromLTWH(x0, y0, size.width / scale, size.height / scale);
   }
 
+  get keyboardHeight => MediaQueryData.fromWindow(ui.window).viewInsets.bottom;
+
   double adjustForKeyboard() {
     final m = MediaQueryData.fromWindow(ui.window);
-    var keyboardHeight = m.viewInsets.bottom;
     final size = m.size;
     if (keyboardHeight < 100) return 0;
     final s = parent.target?.canvasModel.scale ?? 1.0;
@@ -1855,9 +1868,29 @@ class CursorModel with ChangeNotifier {
     return h - thresh;
   }
 
+  // mobile Soft keyboard, block touch event from the KeyHelpTools
+  shouldBlock(double x, double y) {
+    if (!(parent.target?.ffiModel.touchMode ?? false)) {
+      return false;
+    }
+    if (_keyHelpToolsRect == null) {
+      return false;
+    }
+    if (isPointInRect(Offset(x, y), _keyHelpToolsRect!)) {
+      return true;
+    }
+    return false;
+  }
+
   move(double x, double y) {
+    if (shouldBlock(x, y)) {
+      _lastIsBlocked = true;
+      return false;
+    }
+    _lastIsBlocked = false;
     moveLocal(x, y);
     parent.target?.inputModel.moveMouse(_x, _y);
+    return true;
   }
 
   moveLocal(double x, double y) {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -182,6 +182,7 @@ class FfiModel with ChangeNotifier {
   toggleTouchMode() {
     if (!isPeerAndroid) {
       _touchMode = !_touchMode;
+      parent.target?.cursorModel.lastIsBlocked = false;
       notifyListeners();
     }
   }
@@ -1807,10 +1808,9 @@ class CursorModel with ChangeNotifier {
   // But we're now using a Container(child: Stack(...)) to wrap the KeyHelpTools,
   // and the listener is on the Container.
   Rect? _keyHelpToolsRect;
-  bool _lastIsBlocked = false;
+  bool lastIsBlocked = false;
 
   set keyHelpToolsRect(Rect? r) => _keyHelpToolsRect = r;
-  get lastIsBlocked => _lastIsBlocked;
 
   ui.Image? get image => _image;
   CursorData? get cache => _cache;
@@ -1884,10 +1884,10 @@ class CursorModel with ChangeNotifier {
 
   move(double x, double y) {
     if (shouldBlock(x, y)) {
-      _lastIsBlocked = true;
+      lastIsBlocked = true;
       return false;
     }
-    _lastIsBlocked = false;
+    lastIsBlocked = false;
     moveLocal(x, y);
     parent.target?.inputModel.moveMouse(_x, _y);
     return true;


### PR DESCRIPTION
Block touch events on `KeyHelpTools`.

### Bug preview


https://github.com/rustdesk/rustdesk/assets/13586388/24d9d45c-b808-4772-923a-bfac77333446

### Fixed preview


https://github.com/rustdesk/rustdesk/assets/13586388/caa9b51d-9cd0-4a5b-a5db-bf68620079f9



TODOs:

1. Mobile touch mode, compute the correct position for touch mode.

![image](https://github.com/rustdesk/rustdesk/assets/13586388/6d342fdb-d7e0-4120-ba08-0909398e988d)

We want to move cursor to `A`, but we send the position of `A'`, while the cursor is moved to `B`.

a. There's an offset of cursor and image when soft keyboard is shown up.
b. We use local position, but user wants to move the cursor according remote coordination.


2. Soft keyboard "show&hide" cannot be detected by UI sometimes.
