### PR TITLE
linux install service, stop service before start

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1392,7 +1392,7 @@ pub fn install_service() -> bool {
     let cp = switch_service(false);
     let app_name = crate::get_app_name().to_lowercase();
     if !run_cmds_pkexec(&format!(
-        "{cp} systemctl enable {app_name}; systemctl start {app_name};"
+        "{cp} systemctl enable {app_name}; systemctl stop {app_name}; systemctl start {app_name};"
     )) {
         Config::set_option("stop-service".into(), "Y".into());
         return true;


### PR DESCRIPTION
If the stop-service option before installation is "Y", after installation --sever is also started up. When clicking to start service, restart --server to make it read the config file, otherwise the service can't be started util --server is restarted.

[before.webm](https://github.com/user-attachments/assets/30feefb9-20bf-4e7c-a81f-ae68dc2fe2e6)

[after.webm](https://github.com/user-attachments/assets/3dcf1c4b-5ab8-4d8b-9225-18ad43336943)

