### PR TITLE
fix: android, touch mode, move cursor

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -95,7 +95,7 @@ class _RawTouchGestureDetectorRegionState
     }
     if (handleTouch) {
       // Desktop or mobile "Touch mode"
-      if (ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy)) {
+      if (ffi.cursorModel.moveTapDown(d.localPosition.dx, d.localPosition.dy)) {
         inputModel.tapDown(MouseButtons.left);
       }
     }
@@ -106,7 +106,7 @@ class _RawTouchGestureDetectorRegionState
       return;
     }
     if (handleTouch) {
-      if (ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy)) {
+      if (ffi.cursorModel.moveTapUp(d.localPosition.dx, d.localPosition.dy)) {
         inputModel.tapUp(MouseButtons.left);
       }
     }

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -717,8 +717,8 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
     if (renderObject is RenderBox) {
       final size = renderObject.size;
       Offset pos = renderObject.localToGlobal(Offset.zero);
-      gFFI.cursorModel.keyHelpToolsRect =
-          Rect.fromLTWH(pos.dx, pos.dy, size.width, size.height);
+      gFFI.cursorModel.keyHelpToolsVisibilityChanged(
+          Rect.fromLTWH(pos.dx, pos.dy, size.width, size.height));
     }
   }
 
@@ -730,7 +730,7 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
         inputModel.command;
 
     if (!_pin && !hasModifierOn && !widget.requestShow) {
-      gFFI.cursorModel.keyHelpToolsRect = null;
+      gFFI.cursorModel.keyHelpToolsVisibilityChanged(null);
       return Offstage();
     }
     final size = MediaQuery.of(context).size;
@@ -867,7 +867,7 @@ class ImagePaint extends StatelessWidget {
   Widget build(BuildContext context) {
     final m = Provider.of<ImageModel>(context);
     final c = Provider.of<CanvasModel>(context);
-    final adjust = gFFI.cursorModel.adjustForKeyboard();
+    final adjust = gFFI.cursorModel.adjustForKeyboard;
     var s = c.scale;
     return CustomPaint(
       painter: ImagePainter(
@@ -881,7 +881,7 @@ class CursorPaint extends StatelessWidget {
   Widget build(BuildContext context) {
     final m = Provider.of<CursorModel>(context);
     final c = Provider.of<CanvasModel>(context);
-    final adjust = gFFI.cursorModel.adjustForKeyboard();
+    final adjust = gFFI.cursorModel.adjustForKeyboard;
     var s = c.scale;
     double hotx = m.hotx;
     double hoty = m.hoty;


### PR DESCRIPTION
Only update adjust for keyboard on `onTapDown & onTapUp` events.

### Bug preview


https://github.com/rustdesk/rustdesk/assets/13586388/56fe5a4b-340a-49a5-a8c6-f84db7dba0f6

### Fixed preview


https://github.com/rustdesk/rustdesk/assets/13586388/b983ed24-5f12-432f-9390-6c63630f27fd


## TODOs:

1. "Press & Drag" events are not will detected. 

The following two events will be triggered on "Press & Drag". But `onOneFingerPanStart()` may be triggerred a little late. Then the start position is wrong. User have to press a little longer to make sure the dragging start position is correct.

https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/common/widgets/remote_input.dart#L146

https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/common/widgets/remote_input.dart#L224

2. The soft keyboard Soft keyboard "show&hide" cannot be detected by UI sometimes.
