### PR TITLE
fix: android, touch mode, correct cursor input, on soft keyboard shows

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -721,8 +721,8 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
     if (renderObject is RenderBox) {
       final size = renderObject.size;
       Offset pos = renderObject.localToGlobal(Offset.zero);
-      gFFI.cursorModel.keyHelpToolsRect =
-          Rect.fromLTWH(pos.dx, pos.dy, size.width, size.height);
+      gFFI.cursorModel.keyHelpToolsVisibilityChanged(
+          Rect.fromLTWH(pos.dx, pos.dy, size.width, size.height));
     }
   }
 
@@ -734,7 +734,7 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
         inputModel.command;
 
     if (!_pin && !hasModifierOn && !widget.requestShow) {
-      gFFI.cursorModel.keyHelpToolsRect = null;
+      gFFI.cursorModel.keyHelpToolsVisibilityChanged(null);
       return Offstage();
     }
     final size = MediaQuery.of(context).size;


### PR DESCRIPTION
Only update adjust for keyboard on `onTapDown & onTapUp` events.

### Bug preview


https://github.com/rustdesk/rustdesk/assets/13586388/56fe5a4b-340a-49a5-a8c6-f84db7dba0f6

### Fixed preview


https://github.com/rustdesk/rustdesk/assets/13586388/4f791657-f02c-47d4-87d8-a324273f532e





## TODOs:

1. "Press & Drag" events are not will detected. 

The following two events will be triggered on "Press & Drag". But `onOneFingerPanStart()` may be triggerred a little late. Then the start position is wrong. User have to press a little longer to make sure the dragging start position is correct.

https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/common/widgets/remote_input.dart#L146

https://github.com/rustdesk/rustdesk/blob/master/flutter/lib/common/widgets/remote_input.dart#L224

2. There's an offset after holding and moving cursor in touch mode.


https://github.com/rustdesk/rustdesk/assets/13586388/bc54702e-3076-4ced-bec5-1017fc08d886



3. The soft keyboard Soft keyboard "show&hide" cannot be detected by UI sometimes.
