### PR TITLE
fix: android, touch mode, one finger pan, start pos

### DIFF
--- a/flutter/lib/common/widgets/gestures.dart
+++ b/flutter/lib/common/widgets/gestures.dart
@@ -112,6 +112,8 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
     };
   }
 
+  // FIXME: This debounce logic is not working properly.
+  // If we move our finger very fast, we won't be able to detect the "oneFingerPan" event sometimes.
   void onOneFingerStartDebounce(ScaleUpdateDetails d) {
     start(ScaleUpdateDetails d) {
       _currentState = GestureState.oneFingerPan;

--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -69,6 +69,8 @@ class RawTouchGestureDetectorRegion extends StatefulWidget {
 class _RawTouchGestureDetectorRegionState
     extends State<RawTouchGestureDetectorRegion> {
   Offset _cacheLongPressPosition = Offset(0, 0);
+  // Timestamp of the last long press event.
+  int _cacheLongPressPositionTs = 0;
   double _mouseScrollIntegral = 0; // mouse scroll speed controller
   double _scale = 1;
 
@@ -151,6 +153,7 @@ class _RawTouchGestureDetectorRegionState
     if (handleTouch) {
       ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy);
       _cacheLongPressPosition = d.localPosition;
+      _cacheLongPressPositionTs = DateTime.now().millisecondsSinceEpoch;
     }
   }
 
@@ -232,6 +235,16 @@ class _RawTouchGestureDetectorRegionState
       }
       if (isDesktop) {
         ffi.cursorModel.trySetRemoteWindowCoords();
+      }
+      // Workaround for the issue that the first pan event is sent a long time after the start event.
+      // If the time interval between the start event and the first pan event is less than 500ms,
+      // we consider to use the long press position as the start position.
+      //
+      // TODO: We should find a better way to send the first pan event as soon as possible.
+      if (DateTime.now().millisecondsSinceEpoch - _cacheLongPressPositionTs <
+          500) {
+        ffi.cursorModel
+            .move(_cacheLongPressPosition.dx, _cacheLongPressPosition.dy);
       }
       inputModel.sendMouse('down', MouseButtons.left);
       ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy);


### PR DESCRIPTION
Simple workaround for the issue that the first pan event is sent a long time after the start event.
Then the dragging start position is wrong.

Use `_cacheLongPressPositionTs()` to check if `onOneFingerPanStart()` is just after `onLongPressDown()`.

TODOs:

1. The `onOneFingerPanStart()` cannot be triggered if press and moving very fast. But this may not affect the user experience too much
