### PR TITLE
fix: android prompt "Failed to stop voice call" on conn ended

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/AudioRecordHandle.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/AudioRecordHandle.kt
@@ -119,21 +119,17 @@ class AudioRecordHandle(private var context: Context, private var isVideoStart: 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             return false
         }
-        if (isVideoStart() || isAudioStart()) {
-            if (!switchToVoiceCall(mediaProjection)) {
-                return false
-            }
-        } else {
-            if (!switchToVoiceCall(mediaProjection)) {
-                return false
-            }
+        // No need to check if video or audio is started here.
+        if (!switchToVoiceCall(mediaProjection)) {
+            return false
         }
         return true
     }
 
     fun onVoiceCallClosed(mediaProjection: MediaProjection?): Boolean {
+        // Return true if `Build.VERSION.SDK_INT < Build.VERSION_CODES.R`, because is was not started.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            return false
+            return true
         }
         if (isVideoStart()) {
             switchOutVoiceCall(mediaProjection)

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -109,7 +109,6 @@ class _RemotePageState extends State<RemotePage> {
       // `on_voice_call_closed` should be called when the connection is ended.
       // The inner logic of `on_voice_call_closed` will check if the voice call is active.
       // Only one client is considered here for now.
-      // TODO: take into account the case where there are multiple clients
       gFFI.invokeMethod("on_voice_call_closed");
     }
   }

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -105,12 +105,10 @@ class _RemotePageState extends State<RemotePage> {
     }
     await keyboardSubscription.cancel();
     removeSharedStates(widget.id);
-    if (isAndroid) {
-      // `on_voice_call_closed` should be called when the connection is ended.
-      // The inner logic of `on_voice_call_closed` will check if the voice call is active.
-      // Only one client is considered here for now.
-      gFFI.invokeMethod("on_voice_call_closed");
-    }
+    // `on_voice_call_closed` should be called when the connection is ended.
+    // The inner logic of `on_voice_call_closed` will check if the voice call is active.
+    // Only one client is considered here for now.
+    gFFI.chatModel.onVoiceCallClosed("End connetion");
   }
 
   // to-do: It should be better to use transparent color instead of the bgColor.

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -106,6 +106,8 @@ class _RemotePageState extends State<RemotePage> {
     await keyboardSubscription.cancel();
     removeSharedStates(widget.id);
     if (isAndroid) {
+      // `on_voice_call_closed` should be called when the connection is ended.
+      // The inner logic of `on_voice_call_closed` will check if the voice call is active.
       // Only one client is considered here for now.
       // TODO: take into account the case where there are multiple clients
       gFFI.invokeMethod("on_voice_call_closed");

--- a/flutter/lib/models/chat_model.dart
+++ b/flutter/lib/models/chat_model.dart
@@ -533,11 +533,10 @@ class ChatModel with ChangeNotifier {
   }
 
   void onVoiceCallClosed(String reason) {
-    if (_voiceCallStatus.value == VoiceCallStatus.notStarted) {
-      return;
-    }
     _voiceCallStatus.value = VoiceCallStatus.notStarted;
     if (isAndroid) {
+      // We can always invoke "on_voice_call_closed"
+      // no matter if the `_voiceCallStatus` was `VoiceCallStatus.notStarted` or not.
       parent.target?.invokeMethod("on_voice_call_closed");
     }
   }

--- a/flutter/lib/models/chat_model.dart
+++ b/flutter/lib/models/chat_model.dart
@@ -533,9 +533,11 @@ class ChatModel with ChangeNotifier {
   }
 
   void onVoiceCallClosed(String reason) {
-    _voiceCallStatus.value = VoiceCallStatus.notStarted;
-    if (isAndroid) {
-      parent.target?.invokeMethod("on_voice_call_closed");
+    if (_voiceCallStatus.value != VoiceCallStatus.notStarted) {
+      _voiceCallStatus.value = VoiceCallStatus.notStarted;
+      if (isAndroid) {
+        parent.target?.invokeMethod("on_voice_call_closed");
+      }
     }
   }
 

--- a/flutter/lib/models/chat_model.dart
+++ b/flutter/lib/models/chat_model.dart
@@ -533,11 +533,12 @@ class ChatModel with ChangeNotifier {
   }
 
   void onVoiceCallClosed(String reason) {
-    if (_voiceCallStatus.value != VoiceCallStatus.notStarted) {
-      _voiceCallStatus.value = VoiceCallStatus.notStarted;
-      if (isAndroid) {
-        parent.target?.invokeMethod("on_voice_call_closed");
-      }
+    if (_voiceCallStatus.value == VoiceCallStatus.notStarted) {
+      return;
+    }
+    _voiceCallStatus.value = VoiceCallStatus.notStarted;
+    if (isAndroid) {
+      parent.target?.invokeMethod("on_voice_call_closed");
     }
   }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/8432 

### Bug desc

1. `onVoiceCallClosed()` returns `false` when `Build.VERSION.SDK_INT < Build.VERSION_CODES.R`.
It should return true, because the voice call was not started.
2. The flutter should reset the voice call status to `VoiceCallStatus.notStarted` on conn end.

We should always call `onVoiceCallClosed()` if using Android and end the connection.
The inner logic of voice call should check if it was started.
