### PR TITLE
add enable directx option, android software encoding half resolution option

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -103,6 +103,9 @@ class MainService : Service() {
                     put("scale",SCREEN_INFO.scale)
                 }.toString()
             }
+            "is_start" -> {
+                isStart.toString()
+            }
             else -> ""
         }
     }
@@ -172,10 +175,10 @@ class MainService : Service() {
                 Log.d(logTag, "from rust:stop_capture")
                 stopCapture()
             }
-            "is_hardware_codec" -> {
-                val isHwCodec = arg1.toBoolean()
-                if (isHardwareCodec != isHwCodec) {
-                    isHardwareCodec = isHwCodec
+            "half_scale" -> {
+                val halfScale = arg1.toBoolean()
+                if (isHalfScale != halfScale) {
+                    isHalfScale = halfScale
                     updateScreenInfo(resources.configuration.orientation)
                 }
                 
@@ -251,7 +254,7 @@ class MainService : Service() {
         super.onDestroy()
     }
 
-    private var isHardwareCodec: Boolean? = null;
+    private var isHalfScale: Boolean? = null;
     private fun updateScreenInfo(orientation: Int) {
         var w: Int
         var h: Int
@@ -284,7 +287,7 @@ class MainService : Service() {
         Log.d(logTag,"updateScreenInfo:w:$w,h:$h")
         var scale = 1
         if (w != 0 && h != 0) {
-            if (isHardwareCodec == false && (w > MAX_SCREEN_SIZE || h > MAX_SCREEN_SIZE)) {
+            if (isHalfScale == true && (w > MAX_SCREEN_SIZE || h > MAX_SCREEN_SIZE)) {
                 scale = 2
                 w /= scale
                 h /= scale

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -134,6 +134,7 @@ const String kOptionEnableCheckUpdate = "enable-check-update";
 const String kOptionAllowLinuxHeadless = "allow-linux-headless";
 const String kOptionAllowRemoveWallpaper = "allow-remove-wallpaper";
 const String kOptionStopService = "stop-service";
+const String kOptionDirectxCapture = "enable-directx-capture";
 
 const String kOptionToggleViewOnly = "view-only";
 

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -315,11 +315,11 @@ class _GeneralState extends State<_General> {
           children: [
             service(),
             theme(),
+            _Card(title: 'Language', children: [language()]),
             hwcodec(),
             audio(context),
             record(context),
             WaylandCard(),
-            _Card(title: 'Language', children: [language()]),
             other()
           ],
         ).marginOnly(bottom: _kListViewBottomMargin));
@@ -413,6 +413,12 @@ class _GeneralState extends State<_General> {
             'Check for software update on startup',
             kOptionEnableCheckUpdate,
             isServer: false,
+          ),
+        if (isWindows && !bind.isOutgoingOnly())
+          _OptionCheckBox(
+            context,
+            'Capture screen using DirectX',
+            kOptionDirectxCapture,
           )
       ],
     ];

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -2084,6 +2084,7 @@ pub mod keys {
     pub const OPTION_KEY: &str = "key";
     pub const OPTION_PRESET_ADDRESS_BOOK_NAME: &str = "preset-address-book-name";
     pub const OPTION_PRESET_ADDRESS_BOOK_TAG: &str = "preset-address-book-tag";
+    pub const OPTION_ENABLE_DIRECTX_CAPTURE: &str = "enable-directx-capture";
 
     // flutter local options
     pub const OPTION_FLUTTER_REMOTE_MENUBAR_STATE: &str = "remoteMenubarState";
@@ -2206,6 +2207,7 @@ pub mod keys {
         OPTION_KEY,
         OPTION_PRESET_ADDRESS_BOOK_NAME,
         OPTION_PRESET_ADDRESS_BOOK_TAG,
+        OPTION_ENABLE_DIRECTX_CAPTURE,
     ];
 }
 

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -2085,6 +2085,8 @@ pub mod keys {
     pub const OPTION_PRESET_ADDRESS_BOOK_NAME: &str = "preset-address-book-name";
     pub const OPTION_PRESET_ADDRESS_BOOK_TAG: &str = "preset-address-book-tag";
     pub const OPTION_ENABLE_DIRECTX_CAPTURE: &str = "enable-directx-capture";
+    pub const OPTION_ENABLE_ANDRIOD_SOFTWARE_ENCODING_HALF_SCALE: &str =
+        "enable-andriod-software-encoding-half-scale";
 
     // flutter local options
     pub const OPTION_FLUTTER_REMOTE_MENUBAR_STATE: &str = "remoteMenubarState";
@@ -2208,6 +2210,7 @@ pub mod keys {
         OPTION_PRESET_ADDRESS_BOOK_NAME,
         OPTION_PRESET_ADDRESS_BOOK_TAG,
         OPTION_ENABLE_DIRECTX_CAPTURE,
+        OPTION_ENABLE_ANDRIOD_SOFTWARE_ENCODING_HALF_SCALE,
     ];
 }
 

--- a/libs/scrap/src/common/android.rs
+++ b/libs/scrap/src/common/android.rs
@@ -182,3 +182,8 @@ fn get_size() -> Option<(u16, u16, u16)> {
     }
     None
 }
+
+pub fn is_start() -> Option<bool> {
+    let res = call_main_service_get_by_name("is_start").ok()?;
+    Some(res == "true")
+}

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -21,10 +21,7 @@ use crate::{
 use hbb_common::{
     anyhow::anyhow,
     bail,
-    config::{
-        keys::{OPTION_ENABLE_DIRECTX_CAPTURE, OPTION_ENABLE_HWCODEC},
-        Config, PeerConfig,
-    },
+    config::{keys::OPTION_ENABLE_HWCODEC, option2bool, Config, PeerConfig},
     lazy_static, log,
     message_proto::{
         supported_decoding::PreferCodec, video_frame, Chroma, CodecAbility, EncodedVideoFrames,
@@ -840,14 +837,20 @@ impl Decoder {
 #[cfg(any(feature = "hwcodec", feature = "mediacodec"))]
 pub fn enable_hwcodec_option() -> bool {
     if cfg!(windows) || cfg!(target_os = "linux") || cfg!(target_os = "android") {
-        return Config::get_option(OPTION_ENABLE_HWCODEC) != "N";
+        return option2bool(
+            OPTION_ENABLE_HWCODEC,
+            &Config::get_option(OPTION_ENABLE_HWCODEC),
+        );
     }
     false
 }
 #[cfg(feature = "vram")]
 pub fn enable_vram_option(encode: bool) -> bool {
     if cfg!(windows) {
-        let enable = Config::get_option(OPTION_ENABLE_HWCODEC) != "N";
+        let enable = option2bool(
+            OPTION_ENABLE_HWCODEC,
+            &Config::get_option(OPTION_ENABLE_HWCODEC),
+        );
         if encode {
             enable && enable_directx_capture()
         } else {
@@ -860,7 +863,11 @@ pub fn enable_vram_option(encode: bool) -> bool {
 
 #[cfg(windows)]
 pub fn enable_directx_capture() -> bool {
-    Config::get_option(OPTION_ENABLE_DIRECTX_CAPTURE) != "N"
+    use hbb_common::config::keys::OPTION_ENABLE_DIRECTX_CAPTURE as OPTION;
+    option2bool(
+        OPTION,
+        &Config::get_option(hbb_common::config::keys::OPTION_ENABLE_DIRECTX_CAPTURE),
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -491,3 +491,8 @@ pub trait GoogleImage {
 pub fn screen_size() -> (u16, u16, u16) {
     SCREEN_SIZE.lock().unwrap().clone()
 }
+
+#[cfg(target_os = "android")]
+pub fn is_start() -> Option<bool> {
+    android::is_start()
+}

--- a/libs/scrap/src/common/vram.rs
+++ b/libs/scrap/src/common/vram.rs
@@ -354,7 +354,7 @@ impl VRamDecoder {
     }
 
     pub fn possible_available_without_check() -> (bool, bool) {
-        if !enable_vram_option() {
+        if !enable_vram_option(false) {
             return (false, false);
         }
         let v = crate::hwcodec::HwCodecConfig::get().vram_decode;

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", "从不"),
         ("During controlled", "被控期间"),
         ("During service is on", "服务开启期间"),
+        ("Capture screen using DirectX", "使用 DirectX 捕获屏幕"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", "Nikdy"),
         ("During controlled", "Během řízeného"),
         ("During service is on", "Během služby je v provozu"),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", "Niemals"),
         ("During controlled", "Wenn kontrolliert"),
         ("During service is on", "Wenn der Dienst läuft"),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", "Nunca"),
         ("During controlled", "Mientras está siendo controlado"),
         ("During service is on", "Mientras el servicio está activo"),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", "Mai"),
         ("During controlled", "Durante il controllo"),
         ("During service is on", "Quando il servizio è attivo"),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", "Nekad"),
         ("During controlled", "Lietošanas laikā"),
         ("During service is on", "Kamēr pakalpojums ir ieslēgts"),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -125,7 +125,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Good image quality", "Лучшее качество изображения"),
         ("Balanced", "Баланс между качеством и откликом"),
         ("Optimize reaction time", "Лучшее время отклика"),
-        ("Custom", "Заданное пользователем"), 
+        ("Custom", "Заданное пользователем"),
         ("Show remote cursor", "Показывать удалённый курсор"),
         ("Show quality monitor", "Показывать монитор качества"),
         ("Disable clipboard", "Отключить буфер обмена"),
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", "Нет"),
         ("During controlled", "При управлении"),
         ("During service is on", "При запущенной службе"),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", "Nikdy"),
         ("During controlled", "Počas kontrolovaného"),
         ("During service is on", "Počas služby je v prevádzke"),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", "從不"),
         ("During controlled", "被控期間"),
         ("During service is on", "服務開啟期間"),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ua.rs
+++ b/src/lang/ua.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -621,5 +621,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Never", ""),
         ("During controlled", ""),
         ("During service is on", ""),
+        ("Capture screen using DirectX", ""),
     ].iter().cloned().collect();
 }

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -409,6 +409,7 @@ fn run(vs: VideoService) -> ResultType<()> {
     let mut c = get_capturer(display_idx, last_portable_service_running)?;
     #[cfg(windows)]
     if !scrap::codec::enable_directx_capture() && !c.is_gdi() {
+        log::info!("disable dxgi with option, fall back to gdi");
         c.set_gdi();
     }
     let mut video_qos = VIDEO_QOS.lock().unwrap();
@@ -840,16 +841,33 @@ fn get_recorder(
 
 #[cfg(target_os = "android")]
 fn check_change_scale(hardware: bool) -> ResultType<()> {
+    use hbb_common::config::keys::OPTION_ENABLE_ANDRIOD_SOFTWARE_ENCODING_HALF_SCALE as SCALE_SOFT;
+
+    // isStart flag is set at the end of startCapture() in Android, wait it to be set.
+    for i in 0..6 {
+        if scrap::is_start() == Some(true) {
+            log::info!("start flag is set");
+            break;
+        }
+        log::info!("wait for start, {i}");
+        std::thread::sleep(Duration::from_millis(50));
+        if i == 5 {
+            log::error!("wait for start timeout");
+        }
+    }
     let screen_size = scrap::screen_size();
-    log::info!("hardware: {hardware}, screen_size: {screen_size:?}",);
+    let scale_soft = hbb_common::config::option2bool(SCALE_SOFT, &Config::get_option(SCALE_SOFT));
+    let half_scale = !hardware && scale_soft;
+    log::info!("hardware: {hardware}, scale_soft: {scale_soft}, screen_size: {screen_size:?}",);
     scrap::android::call_main_service_set_by_name(
-        "is_hardware_codec",
-        Some(hardware.to_string().as_str()),
+        "half_scale",
+        Some(half_scale.to_string().as_str()),
         None,
     )
     .ok();
     let old_scale = screen_size.2;
     let new_scale = scrap::screen_size().2;
+    log::info!("old_scale: {old_scale}, new_scale: {new_scale}");
     if old_scale != new_scale {
         log::info!("switch due to scale changed, {old_scale} -> {new_scale}");
         // switch is not a must, but it is better to do so.

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -407,7 +407,10 @@ fn run(vs: VideoService) -> ResultType<()> {
     let display_idx = vs.idx;
     let sp = vs.sp;
     let mut c = get_capturer(display_idx, last_portable_service_running)?;
-
+    #[cfg(windows)]
+    if !scrap::codec::enable_directx_capture() && !c.is_gdi() {
+        c.set_gdi();
+    }
     let mut video_qos = VIDEO_QOS.lock().unwrap();
     video_qos.refresh(None);
     let mut spf;


### PR DESCRIPTION
1. add option enable directx capture screen, default true

![be25615004be7a33315219960e30571](https://github.com/rustdesk/rustdesk/assets/14891774/46e4cf00-fced-4c1e-9781-f06011b51d47)

![1718965133095](https://github.com/rustdesk/rustdesk/assets/14891774/02ac1b26-248b-4f8d-a6e0-e812a95628ea)


2. add option android software encoding half scale, and wait for isStart flag to be true befoe check scale. video service run and startCapture is called at the same time, isStart can be false when check scale, and isStart is checked when call stopCapture and startCapture.
 
default

https://github.com/rustdesk/rustdesk/assets/14891774/f0e80a0d-dd13-47df-b583-e4a4b9351638

disable half scale resolution

https://github.com/rustdesk/rustdesk/assets/14891774/71a6aa1e-b3bc-4822-8f5d-061786e48ead

when isStart is late to be set (fixed by wait)

https://github.com/rustdesk/rustdesk/assets/14891774/a2d4b73a-fe18-4ce1-90a0-d6b1ee21646a

![wait-isStart](https://github.com/rustdesk/rustdesk/assets/14891774/4a8a7aea-7cc5-4e69-8cec-077225bb560e)

