### PR TITLE
fix: ios, chat window position, wrong member value

### DIFF
--- a/flutter/lib/common/widgets/overlay.dart
+++ b/flutter/lib/common/widgets/overlay.dart
@@ -486,7 +486,7 @@ class IOSDraggableState extends State<IOSDraggable> {
     _height = widget.height;
   }
 
-  get position => widget.position;
+  DraggableKeyPosition get position => widget.position;
 
   checkKeyboard() {
     final bottomHeight = MediaQuery.of(context).viewInsets.bottom;
@@ -494,13 +494,13 @@ class IOSDraggableState extends State<IOSDraggable> {
 
     // save
     if (!_keyboardVisible && currentVisible) {
-      _saveHeight = position.value.dy;
+      _saveHeight = position.pos.dy;
     }
 
     // reset
     if (_lastBottomHeight > 0 && bottomHeight == 0) {
       setState(() {
-        position.value = Offset(position.value.dx, _saveHeight);
+        position.update(Offset(position.pos.dx, _saveHeight));
       });
     }
 
@@ -508,10 +508,10 @@ class IOSDraggableState extends State<IOSDraggable> {
     if (_keyboardVisible && currentVisible) {
       final sumHeight = bottomHeight + _height;
       final contextHeight = MediaQuery.of(context).size.height;
-      if (sumHeight + position.value.dy > contextHeight) {
+      if (sumHeight + position.pos.dy > contextHeight) {
         final y = contextHeight - sumHeight;
         setState(() {
-          position.value = Offset(position.value.dx, y);
+          position.update(Offset(position.pos.dx, y));
         });
       }
     }
@@ -526,14 +526,14 @@ class IOSDraggableState extends State<IOSDraggable> {
     return Stack(
       children: [
         Positioned(
-          left: position.value.dx,
-          top: position.value.dy,
+          left: position.pos.dx,
+          top: position.pos.dy,
           child: GestureDetector(
             onPanUpdate: (details) {
               setState(() {
-                position.value += details.delta;
+                position.update(position.pos + details.delta);
               });
-              _chatModel?.setChatWindowPosition(position.value);
+              _chatModel?.setChatWindowPosition(position.pos);
             },
             child: Material(
               child: Container(


### PR DESCRIPTION

https://github.com/rustdesk/rustdesk/assets/13586388/5ca9ab7e-4d8a-485a-a6df-ea2d9e61539e

We may need to add types to the `get` function. Otherwise Flutter may not be able to infer errors for the type.