### PR TITLE
if fps is adjusted below 30, not set fps to 30 when changing image quality

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1203,6 +1203,7 @@ pub struct LoginConfigHandler {
     pub save_ab_password_to_recent: bool, // true: connected with ab password
     pub other_server: Option<(String, String, String)>,
     pub custom_fps: Arc<Mutex<Option<usize>>>,
+    pub last_auto_fps: Option<usize>,
     pub adapter_luid: Option<i64>,
     pub mark_unsupported: Vec<CodecFormat>,
     pub selected_windows_session_id: Option<u32>,

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -410,9 +410,12 @@ impl<T: InvokeUiSession> Session<T> {
             self.send(Data::Message(msg));
         }
         if value != "custom" {
-            // non custom quality use 30 fps
-            let msg = self.lc.write().unwrap().set_custom_fps(30, false);
-            self.send(Data::Message(msg));
+            let last_auto_fps = self.lc.read().unwrap().last_auto_fps;
+            if last_auto_fps.unwrap_or(usize::MAX) >= 30 {
+                // non custom quality use 30 fps
+                let msg = self.lc.write().unwrap().set_custom_fps(30, false);
+                self.send(Data::Message(msg));
+            }
         }
     }
 


### PR DESCRIPTION
before: set fps to 30 when changing to non-custom quality

https://github.com/rustdesk/rustdesk/assets/14891774/fcaf6287-4e98-46f6-b7f9-a7a1ac6fae6f

after: not changing fps if adjusted fps is below 30 

https://github.com/rustdesk/rustdesk/assets/14891774/9760734f-a95b-44d0-b278-4ec0cd9eddf3

https://github.com/rustdesk/rustdesk/assets/14891774/d9834530-1c3a-47fc-99b0-bed5e71fafa0

