### PR TITLE
fix: wrong use of Instant sub, just after booting

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1443,7 +1443,7 @@ impl ThrottledInterval {
         let period = i.period();
         ThrottledInterval {
             interval: i,
-            next_tick: Instant::now() + period,
+            next_tick: Instant::now(),
             min_interval: Duration::from_secs_f64(period.as_secs_f64() * 0.9),
         }
     }
@@ -1456,8 +1456,9 @@ impl ThrottledInterval {
     pub fn poll_tick(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Instant> {
         match self.interval.poll_tick(cx) {
             Poll::Ready(instant) => {
-                if self.next_tick <= Instant::now() {
-                    self.next_tick = Instant::now() + self.min_interval;
+                let now = Instant::now();
+                if self.next_tick <= now {
+                    self.next_tick = now + self.min_interval;
                     Poll::Ready(instant)
                 } else {
                     // This call is required since tokio 1.27

--- a/src/common.rs
+++ b/src/common.rs
@@ -1434,7 +1434,7 @@ pub fn using_public_server() -> bool {
 
 pub struct ThrottledInterval {
     interval: Interval,
-    last_tick: Instant,
+    next_tick: Instant,
     min_interval: Duration,
 }
 
@@ -1443,7 +1443,7 @@ impl ThrottledInterval {
         let period = i.period();
         ThrottledInterval {
             interval: i,
-            last_tick: Instant::now() - period * 2,
+            next_tick: Instant::now() + period,
             min_interval: Duration::from_secs_f64(period.as_secs_f64() * 0.9),
         }
     }
@@ -1456,8 +1456,8 @@ impl ThrottledInterval {
     pub fn poll_tick(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Instant> {
         match self.interval.poll_tick(cx) {
             Poll::Ready(instant) => {
-                if self.last_tick.elapsed() >= self.min_interval {
-                    self.last_tick = Instant::now();
+                if self.next_tick <= Instant::now() {
+                    self.next_tick = Instant::now() + self.min_interval;
                     Poll::Ready(instant)
                 } else {
                     // This call is required since tokio 1.27


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/8462

`Instant::now() - period * 2` will cause crash or dead lock on windows if the os is just booted.

https://doc.rust-lang.org/std/time/struct.Instant.html#:~:text=QueryPerformanceCounter

The following pictures show that the process is locked when `Instant(27.65) - Duration(60)`

<img width="950" alt="84004a6e9a4f51b173b43770c1b5702" src="https://github.com/rustdesk/rustdesk/assets/13586388/3b3fb5c7-c373-4092-bebc-c07ee2351935">

<img width="776" alt="83ce0ca6d0dcbc4b769b67d70b072af" src="https://github.com/rustdesk/rustdesk/assets/13586388/31d25d53-de1d-440d-8bfa-c77ee8741904">
