### PR TITLE
fix: mobile cursor, check null

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -938,9 +938,13 @@ class CursorPaint extends StatelessWidget {
     }
 
     final image = m.image ?? preDefaultCursor.image;
+    if (image == null) {
+      return Offstage();
+    }
+
     final minSize = 24.0;
     double mins =
-        minSize / (image!.width > image.height ? image.width : image.height);
+        minSize / (image.width > image.height ? image.width : image.height);
     double factor = 1.0;
     if (s < mins) {
       factor = s / mins;


### PR DESCRIPTION
`preDefaultCursor.image` may be ready after sometime (decoding pre-default image data).