### PR TITLE
Refact/android input changed notify clients

### DIFF
--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -177,6 +177,11 @@ class ServerModel with ChangeNotifier {
         await timerCallback();
       });
     }
+
+    // Initial keyboard status is off on mobile
+    if (isMobile) {
+      bind.mainSetOption(key: kOptionEnableKeyboard, value: 'N');
+    }
   }
 
   /// 1. check android permission

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -786,6 +786,13 @@ pub fn main_show_option(_key: String) -> SyncReturn<bool> {
 }
 
 pub fn main_set_option(key: String, value: String) {
+    #[cfg(target_os = "android")]
+    if key.eq(config::keys::OPTION_ENABLE_KEYBOARD) {
+        crate::ui_cm_interface::notify_input_control(config::option2bool(
+            config::keys::OPTION_ENABLE_KEYBOARD,
+            &value,
+        ));
+    }
     if key.eq("custom-rendezvous-server") {
         set_option(key, value.clone());
         #[cfg(target_os = "android")]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -189,6 +189,8 @@ pub enum Data {
     MouseMoveTime(i64),
     Authorize,
     Close,
+    #[cfg(target_os = "android")]
+    InputControl(bool),
     #[cfg(windows)]
     SAS,
     UserSid(Option<u32>),

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -457,6 +457,11 @@ impl Connection {
                             conn.on_close("connection manager", true).await;
                             break;
                         }
+                        #[cfg(target_os = "android")]
+                        ipc::Data::InputControl(v) => {
+                            conn.keyboard = v;
+                            conn.send_permission(Permission::Keyboard, v).await;
+                        }
                         ipc::Data::CmErr(e) => {
                             if e != "expected" {
                                 // cm closed before connection

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -400,6 +400,9 @@ impl Connection {
         }
         #[cfg(target_os = "android")]
         start_channel(rx_to_cm, tx_from_cm);
+        #[cfg(target_os = "android")]
+        conn.send_permission(Permission::Keyboard, conn.keyboard).await;
+        #[cfg(not(target_os = "android"))]
         if !conn.keyboard {
             conn.send_permission(Permission::Keyboard, false).await;
         }

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -280,6 +280,15 @@ pub fn close(id: i32) {
 }
 
 #[inline]
+#[cfg(target_os = "android")]
+pub fn notify_input_control(v: bool) {
+    for (_, mut client) in CLIENTS.write().unwrap().iter_mut() {
+        client.keyboard = v;
+        allow_err!(client.tx.send(Data::InputControl(v)));
+    }
+}
+
+#[inline]
 pub fn remove(id: i32) {
     CLIENTS.write().unwrap().remove(&id);
 }


### PR DESCRIPTION
Notify input permission on Android (controlled). No need to reconnect to get new permission.


https://github.com/rustdesk/rustdesk/assets/13586388/3b9ed753-4d7a-4765-a9e0-7b0e55082597

