### PR TITLE
fix extracted process window not foreground

### DIFF
--- a/libs/portable/src/main.rs
+++ b/libs/portable/src/main.rs
@@ -19,6 +19,8 @@ const APP_METADATA_CONFIG: &str = "meta.toml";
 const META_LINE_PREFIX_TIMESTAMP: &str = "timestamp = ";
 const APP_PREFIX: &str = "rustdesk";
 const APPNAME_RUNTIME_ENV_KEY: &str = "RUSTDESK_APPNAME";
+#[cfg(windows)]
+const SET_FOREGROUND_WINDOW_ENV_KEY: &str = "SET_FOREGROUND_WINDOW";
 
 fn is_timestamp_matches(dir: &PathBuf, ts: &mut u64) -> bool {
     let Ok(app_metadata) = std::str::from_utf8(APP_METADATA) else {
@@ -57,7 +59,13 @@ fn write_meta(dir: &PathBuf, ts: u64) {
     }
 }
 
-fn setup(reader: BinaryReader, dir: Option<PathBuf>, clear: bool) -> Option<PathBuf> {
+fn setup(
+    reader: BinaryReader,
+    dir: Option<PathBuf>,
+    clear: bool,
+    _args: &Vec<String>,
+    _ui: &mut bool,
+) -> Option<PathBuf> {
     let dir = if let Some(dir) = dir {
         dir
     } else {
@@ -72,6 +80,11 @@ fn setup(reader: BinaryReader, dir: Option<PathBuf>, clear: bool) -> Option<Path
 
     let mut ts = 0;
     if clear || !is_timestamp_matches(&dir, &mut ts) {
+        #[cfg(windows)]
+        if _args.is_empty() {
+            *_ui = true;
+            ui::setup();
+        }
         std::fs::remove_dir_all(&dir).ok();
     }
     for file in reader.files.iter() {
@@ -85,7 +98,7 @@ fn setup(reader: BinaryReader, dir: Option<PathBuf>, clear: bool) -> Option<Path
     Some(dir.join(&reader.exe))
 }
 
-fn execute(path: PathBuf, args: Vec<String>) {
+fn execute(path: PathBuf, args: Vec<String>, _ui: bool) {
     println!("executing {}", path.display());
     // setup env
     let exe = std::env::current_exe().unwrap_or_default();
@@ -97,13 +110,28 @@ fn execute(path: PathBuf, args: Vec<String>) {
     {
         use std::os::windows::process::CommandExt;
         cmd.creation_flags(winapi::um::winbase::CREATE_NO_WINDOW);
+        if _ui {
+            cmd.env(SET_FOREGROUND_WINDOW_ENV_KEY, "1");
+        }
     }
-    cmd.env(APPNAME_RUNTIME_ENV_KEY, exe_name)
+    let _child = cmd
+        .env(APPNAME_RUNTIME_ENV_KEY, exe_name)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
-        .spawn()
-        .ok();
+        .spawn();
+
+    #[cfg(windows)]
+    if _ui {
+        match _child {
+            Ok(child) => unsafe {
+                winapi::um::winuser::AllowSetForegroundWindow(child.id() as u32);
+            },
+            Err(e) => {
+                eprintln!("{:?}", e);
+            }
+        }
+    }
 }
 
 fn main() {
@@ -121,23 +149,21 @@ fn main() {
     let click_setup = args.is_empty() && arg_exe.to_lowercase().ends_with("install.exe");
     let quick_support = args.is_empty() && arg_exe.to_lowercase().ends_with("qs.exe");
 
-    #[cfg(windows)]
-    if args.is_empty() {
-        ui::setup();
-    }
-
+    let mut ui = false;
     let reader = BinaryReader::default();
     if let Some(exe) = setup(
         reader,
         None,
         click_setup || args.contains(&"--silent-install".to_owned()),
+        &args,
+        &mut ui,
     ) {
         if click_setup {
             args = vec!["--install".to_owned()];
         } else if quick_support {
             args = vec!["--quick_support".to_owned()];
         }
-        execute(exe, args);
+        execute(exe, args, ui);
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -87,6 +87,8 @@ pub fn start(args: &mut [String]) {
     frame.set_title(&crate::get_app_name());
     #[cfg(target_os = "macos")]
     crate::platform::delegate::make_menubar(frame.get_host(), args.is_empty());
+    #[cfg(windows)]
+    crate::platform::try_set_window_foreground(frame.get_hwnd() as _);
     let page;
     if args.len() > 1 && args[0] == "--play" {
         args[0] = "--connect".to_owned();


### PR DESCRIPTION
1. The parent process sets the child process through `AllowSetForegroundWindow`. If the child process has the environment `SET_FOREGROUND_WINDOW`, call `SetForegroundWindow`.
2. Sometimes `install` and `run without install` can't create foreground processes and force them to be the foreground. (In fact hard to reproduce with latest flutter version.)
3. Show loading only when override extracted files.

https://github.com/rustdesk/rustdesk/assets/14891774/7898bf15-5c03-4bef-a92b-88ab55ea56a3

https://github.com/rustdesk/rustdesk/assets/14891774/ee932225-f17f-4ddc-9c46-916416b3b755

https://github.com/rustdesk/rustdesk/assets/14891774/17fd1669-7047-402e-b25d-ef7ecd3886d6

https://github.com/rustdesk/rustdesk/assets/14891774/ba2bb28e-b491-4c19-b2a0-229bf6f8583d

https://github.com/rustdesk/rustdesk/assets/14891774/08a796ab-2825-4c20-b5aa-855c069c167e


