### PR TITLE
fix: mobile more actions, check version 1.2.7

### DIFF
--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1882,7 +1882,7 @@ class _KeyboardMenu extends StatelessWidget {
 
   mobileActions() {
     if (pi.platform != kPeerPlatformAndroid) return [];
-    final enabled = versionCmp(pi.version, '1.2.6') >= 0;
+    final enabled = versionCmp(pi.version, '1.2.7') >= 0;
     if (!enabled) return [];
     return [
       Divider(),

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -558,6 +558,8 @@ class _RemotePageState extends State<RemotePage> {
         !gFFI.ffiModel.keyboard) {
       return [];
     }
+    final enabled = versionCmp(gFFI.ffiModel.pi.version, '1.2.7') >= 0;
+    if (!enabled) return [];
     return [
       TTextMenu(
         child: Text(translate('Back')),


### PR DESCRIPTION
The peer version must be greater than `1.2.7` to support more mobile actions.