### PR TITLE
fix: win, multi-display settings changed

### DIFF
--- a/src/privacy_mode/win_virtual_display.rs
+++ b/src/privacy_mode/win_virtual_display.rs
@@ -154,6 +154,8 @@ impl PrivacyModeImpl {
         Self::restore_displays(&self.virtual_displays);
         allow_err!(Self::commit_change_display(0));
         self.restore_plug_out_monitor();
+        self.displays.clear();
+        self.virtual_displays.clear();
     }
 
     fn restore_plug_out_monitor(&mut self) {


### PR DESCRIPTION
https://www.reddit.com/r/rustdesk/comments/1dr07wx/rustdesk_changes_my_multimonitor_layout_upon/

## Bug


https://github.com/rustdesk/rustdesk/assets/13586388/48435e6d-9384-4362-b719-72f0615daa87



1. Windows, multi-display, as the controlled side.
2. Connect
3. Turn on privacy mode, with mode 2.
4. Turn off privacy mode.

Then the display settings are continues changed when connect & disconnect.


## Fixed

Clear the displays data after restoring, to avoid repeated settings.


https://github.com/rustdesk/rustdesk/assets/13586388/86b30413-6a70-4cc8-afd9-285bd8ff6489



## TODO

![image](https://github.com/rustdesk/rustdesk/assets/13586388/c3e661f0-80d2-4c94-883f-c80ba51ec8bb)

Display positions and sizes do not match the real ones.


