### PR TITLE
fix, shared memory size uses the max resolution of all displays

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3150,6 +3150,7 @@ impl Connection {
             .map(|t| t.0 = Instant::now());
     }
 
+    #[cfg(feature = "hwcodec")]
     fn update_supported_encoding(&mut self) {
         let Some(last) = &self.last_supported_encoding else {
             return;

--- a/src/server/portable_service.rs
+++ b/src/server/portable_service.rs
@@ -549,9 +549,13 @@ pub mod client {
             let mut max_pixel = 0;
             let align = 64;
             for d in displays {
-                let pixel = utils::align(d.width(), align) * utils::align(d.height(), align);
-                if max_pixel < pixel {
-                    max_pixel = pixel;
+                let resolutions = crate::platform::resolutions(&d.name());
+                for r in resolutions {
+                    let pixel =
+                        utils::align(r.width as _, align) * utils::align(r.height as _, align);
+                    if max_pixel < pixel {
+                        max_pixel = pixel;
+                    }
                 }
             }
             let shmem_size = utils::align(ADDR_CAPTURE_FRAME + max_pixel * 4, align);


### PR DESCRIPTION
The case of setting a monitor inserted later as the primary monitor is not taken into account