### PR TITLE
fix: build ios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5837,11 +5837,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-foundation-sys 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",


### PR DESCRIPTION
https://github.com/kornelski/rust-security-framework/pull/204

```
ld: Undefined symbols:
     _kSecMatchSubjectWholeString, referenced from:
         security_framework::item::ItemSearchOptions::search::he568de2b0004b0c0 in liblibrustdesk.a[872](security_framework-88ef6afe340eb2ab.security_framework.e4562ffe63567184-cgu.0.rcgu.o)
```

TODO:

There's also a warning after commit [2116fec20b5a2165df97e329c156baf308668efc](https://github.com/fufesou/rustdesk/commit/2116fec20b5a2165df97e329c156baf308668efc#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542). No idea how to fix it. But it does not stop building.
```
ld: warning: Could not find or use auto-linked framework 'CoreAudioTypes': framework 'CoreAudioTypes' not found
```