### PR TITLE
vcpkg: sort triplets and restore local opus port for 1.5.1

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -58,7 +58,7 @@ jobs:
         job:
           # - { target: i686-pc-windows-msvc        , os: windows-2022                  }
           # - { target: x86_64-pc-windows-gnu       , os: windows-2022                  }
-          - { target: x86_64-pc-windows-msvc, os: windows-2022, arch: x86_64 }
+          - { target: x86_64-pc-windows-msvc, os: windows-2022, arch: x86_64, vcpkg-triplet: x64-windows-static }
           # - { target: aarch64-pc-windows-msvc, os: windows-2022, arch: aarch64 }
     steps:
       - name: Export GitHub Actions cache environment variables
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install vcpkg dependencies
         run: |
-          $VCPKG_ROOT/vcpkg install --triplet x64-windows-static --x-install-root="$VCPKG_ROOT/installed"
+          $VCPKG_ROOT/vcpkg install --triplet ${{ matrix.job.vcpkg-triplet }} --x-install-root="$VCPKG_ROOT/installed"
         shell: bash
 
       - name: Build rustdesk
@@ -212,7 +212,7 @@ jobs:
         job:
           # - { target: i686-pc-windows-msvc        , os: windows-2022                  }
           # - { target: x86_64-pc-windows-gnu       , os: windows-2022                  }
-          - { target: i686-pc-windows-msvc, os: windows-2022, arch: x86 }
+          - { target: i686-pc-windows-msvc, os: windows-2022, arch: x86, vcpkg-triplet: x86-windows-static }
           # - { target: aarch64-pc-windows-msvc, os: windows-2022 }
     steps:
       - name: Export GitHub Actions cache environment variables
@@ -249,7 +249,7 @@ jobs:
 
       - name: Install vcpkg dependencies
         run: |
-          $VCPKG_ROOT/vcpkg install --triplet x86-windows-static --x-install-root="$VCPKG_ROOT/installed"
+          $VCPKG_ROOT/vcpkg install --triplet ${{ matrix.job.vcpkg-triplet }} --x-install-root="$VCPKG_ROOT/installed"
         shell: bash
 
       - name: Build rustdesk
@@ -408,6 +408,7 @@ jobs:
               arch: aarch64,
               target: aarch64-apple-ios,
               os: macos-13,
+              vcpkg-triplet: arm64-ios,
             }
     steps:
       - name: Export GitHub Actions cache environment variables
@@ -435,7 +436,7 @@ jobs:
 
       - name: Install vcpkg dependencies
         run: |
-          $VCPKG_ROOT/vcpkg install --triplet arm64-ios --x-install-root="$VCPKG_ROOT/installed"
+          $VCPKG_ROOT/vcpkg install --triplet ${{ matrix.job.vcpkg-triplet }} --x-install-root="$VCPKG_ROOT/installed"
         shell: bash
 
       - name: Install Rust toolchain
@@ -969,6 +970,7 @@ jobs:
               distro: ubuntu18.04,
               on: ubuntu-20.04,
               deb_arch: amd64,
+              vcpkg-triplet: x64-linux,
             }
           - {
               arch: aarch64,
@@ -976,6 +978,7 @@ jobs:
               distro: ubuntu18.04,
               on: [self-hosted, Linux, ARM64],
               deb_arch: arm64,
+              vcpkg-triplet: arm64-linux,
             }
     steps:
       - name: Export GitHub Actions cache environment variables
@@ -1043,14 +1046,7 @@ jobs:
       - name: Install vcpkg dependencies
         if: matrix.job.arch == 'x86_64' || env.UPLOAD_ARTIFACT == 'true'
         run: |
-          case ${{ matrix.job.target }} in
-            aarch64-unknown-linux-gnu)
-              $VCPKG_ROOT/vcpkg install --triplet arm64-linux --x-install-root="$VCPKG_ROOT/installed"
-            ;;
-            x86_64-unknown-linux-gnu)
-              $VCPKG_ROOT/vcpkg install --x-install-root="$VCPKG_ROOT/installed"
-            ;;
-          esac
+          $VCPKG_ROOT/vcpkg install --triplet ${{ matrix.job.vcpkg-triplet }} --x-install-root="$VCPKG_ROOT/installed"
         shell: bash
 
       - name: Restore bridge files
@@ -1281,6 +1277,7 @@ jobs:
               distro: ubuntu18.04,
               deb_arch: amd64,
               sciter_arch: x64,
+              vcpkg-triplet: x64-linux,
             }
           - {
               arch: armv7,
@@ -1289,6 +1286,7 @@ jobs:
               distro: ubuntu18.04-rustdesk,
               deb_arch: armhf,
               sciter_arch: arm32,
+              vcpkg-triplet: arm-linux,
             }
     steps:
       - name: Export GitHub Actions cache environment variables
@@ -1344,7 +1342,7 @@ jobs:
       - name: Install vcpkg dependencies
         run: |
           cp $PWD/res/vcpkg/linux.cmake $VCPKG_ROOT/scripts/toolchains/linux.cmake
-          $VCPKG_ROOT/vcpkg install --triplet arm-linux --x-install-root="$VCPKG_ROOT/installed"
+          $VCPKG_ROOT/vcpkg install --triplet ${{ matrix.job.vcpkg-triplet }} --x-install-root="$VCPKG_ROOT/installed"
         shell: bash
 
       - uses: rustdesk-org/run-on-arch-action@amd64-support

--- a/res/vcpkg/opus/fix-pkgconfig-version.patch
+++ b/res/vcpkg/opus/fix-pkgconfig-version.patch
@@ -1,0 +1,15 @@
+diff --git a/cmake/OpusPackageVersion.cmake b/cmake/OpusPackageVersion.cmake
+index 447ce3b..15ebd8e 100644
+--- a/cmake/OpusPackageVersion.cmake
++++ b/cmake/OpusPackageVersion.cmake
+@@ -4,7 +4,9 @@ endif()
+ set(__opus_version INCLUDED)
+ 
+ function(get_package_version PACKAGE_VERSION PROJECT_VERSION)
+-
++  set(PACKAGE_VERSION "0" CACHE STRING "opus package version")
++  set(PROJECT_VERSION "0" CACHE STRING "opus project version")
++  return()
+   find_package(Git)
+   if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git")
+     execute_process(COMMAND ${GIT_EXECUTABLE}

--- a/res/vcpkg/opus/portfile.cmake
+++ b/res/vcpkg/opus/portfile.cmake
@@ -1,0 +1,61 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO xiph/opus
+    REF "v${VERSION}"
+    SHA512 ba79ad035993e7bc4c09b7d77964ba913eb0b2be33305e8a04a8c49aaab21c4d96ac828e31ae45484896105851fdfc8c305c63c8400e4481dd76c62a1c12286b
+    HEAD_REF main
+    PATCHES fix-pkgconfig-version.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        avx2 AVX2_SUPPORTED
+)
+
+set(ADDITIONAL_OPUS_OPTIONS "")
+if(VCPKG_TARGET_IS_MINGW)
+    set(STACK_PROTECTOR OFF)
+    string(APPEND VCPKG_C_FLAGS "-D_FORTIFY_SOURCE=0")
+    string(APPEND VCPKG_CXX_FLAGS "-D_FORTIFY_SOURCE=0")
+    if(VCPKG_TARGET_ARCHITECTURE MATCHES "^(ARM|arm)64$")
+        list(APPEND ADDITIONAL_OPUS_OPTIONS "-DOPUS_USE_NEON=OFF") # for version 1.3.1 (remove for future Opus release)
+        list(APPEND ADDITIONAL_OPUS_OPTIONS "-DOPUS_DISABLE_INTRINSICS=ON") # for HEAD (and future Opus release)
+    endif()
+elseif(VCPKG_TARGET_IS_EMSCRIPTEN)
+    set(STACK_PROTECTOR OFF)
+else()
+    set(STACK_PROTECTOR ON)
+endif()
+
+if((VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm") OR
+   (VCPKG_TARGET_IS_ANDROID AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" AND VCPKG_CMAKE_CONFIGURE_OPTIONS MATCHES "ANDROID_ARM_NEON"))
+    message(STATUS "Disabling ARM NEON and intrinsics on ${TARGET_TRIPLET}")
+    list(APPEND ADDITIONAL_OPUS_OPTIONS "-DOPUS_DISABLE_INTRINSICS=ON -DCOMPILER_SUPPORTS_NEON=OFF") # for HEAD (and future Opus release)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
+        -DPACKAGE_VERSION=${VERSION}
+        -DOPUS_STACK_PROTECTOR=${STACK_PROTECTOR}
+        -DOPUS_INSTALL_PKG_CONFIG_MODULE=ON
+        -DOPUS_INSTALL_CMAKE_CONFIG_MODULE=ON
+        -DOPUS_BUILD_PROGRAMS=OFF
+        -DOPUS_BUILD_TESTING=OFF
+        ${ADDITIONAL_OPUS_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        OPUS_USE_NEON
+        OPUS_DISABLE_INTRINSICS
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/Opus)
+vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES m)
+
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
+                    "${CURRENT_PACKAGES_DIR}/lib/cmake"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/res/vcpkg/opus/vcpkg.json
+++ b/res/vcpkg/opus/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "opus",
+  "version": "1.5.1",
+  "description": "Totally open, royalty-free, highly versatile audio codec",
+  "homepage": "https://github.com/xiph/opus",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "avx2": {
+      "description": "Builds the library with avx2 instruction set"
+    }
+  }
+}


### PR DESCRIPTION
- **ci/flutter-build: Sort out triplets in job matrices**
- **Restore local port for opus 1.5.1**
