### PR TITLE
wayland not call check_get_displays_changed_msg

### DIFF
--- a/libs/scrap/src/common/linux.rs
+++ b/libs/scrap/src/common/linux.rs
@@ -59,6 +59,7 @@ impl Display {
         })
     }
 
+    // Call this function carefully for wayland, it may cause blocking
     pub fn all() -> io::Result<Vec<Display>> {
         Ok(if super::is_x11() {
             x11::Display::all()?

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -187,6 +187,7 @@ pub fn check_displays_changed() -> ResultType<()> {
     #[cfg(target_os = "linux")]
     {
         // For wayland, call Display::all() in video service will cause block, reproduced by refresh, I don't know the reason.
+        // block, or even crash here, https://github.com/rustdesk/rustdesk/blob/0bb4d43e9ea9d9dfb9c46c8d27d1a97cd0ad6bea/libs/scrap/src/wayland/pipewire.rs#L235
         if !is_x11() {
             return Ok(());
         }

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -184,6 +184,13 @@ fn check_get_displays_changed_msg() -> Option<Message> {
 }
 
 pub fn check_displays_changed() -> ResultType<()> {
+    #[cfg(target_os = "linux")]
+    {
+        // For wayland, call Display::all() in video service will cause block, reproduced by refresh, I don't know the reason.
+        if !is_x11() {
+            return Ok(());
+        }
+    }
     check_update_displays(&try_get_displays()?);
     Ok(())
 }
@@ -394,7 +401,8 @@ pub fn try_get_displays_(add_amyuni_headless: bool) -> ResultType<Vec<Display>> 
     let mut displays = Display::all()?;
 
     // Do not add virtual display if the platform is not installed or the virtual display is not supported.
-    if !crate::platform::is_installed() || !virtual_display_manager::is_virtual_display_supported() {
+    if !crate::platform::is_installed() || !virtual_display_manager::is_virtual_display_supported()
+    {
         return Ok(displays);
     }
 


### PR DESCRIPTION
For wayland, call Display::all() in video service will cause block.

block, even crash here, https://github.com/rustdesk/rustdesk/blob/0bb4d43e9ea9d9dfb9c46c8d27d1a97cd0ad6bea/libs/scrap/src/wayland/pipewire.rs#L235

[wayland.webm](https://github.com/rustdesk/rustdesk/assets/14891774/6b2257f7-3c46-4249-bb3f-d2d5200ddeb1)
