### PR TITLE
fix: ubuntu 18.04, service, Exec format error

### DIFF
--- a/res/DEBIAN/postinst
+++ b/res/DEBIAN/postinst
@@ -16,6 +16,12 @@ if [ "$1" = configure ]; then
 		parsedVersion=$(echo "${version//./}")
         mkdir -p /usr/lib/systemd/system/
 		cp /usr/share/rustdesk/files/systemd/rustdesk.service /usr/lib/systemd/system/rustdesk.service
+		# try fix error in Ubuntu 18.04
+		# Failed to reload rustdesk.service: Unit rustdesk.service is not loaded properly: Exec format error.
+		# /usr/lib/systemd/system/rustdesk.service:10: Executable path is not absolute: pkill -f "rustdesk --"
+		if [ -e /usr/bin/pkill ]; then
+			sed -i "s|pkill|/usr/bin/pkill|g" /usr/lib/systemd/system/rustdesk.service
+		fi
 		systemctl daemon-reload
 		systemctl enable rustdesk
 		systemctl start rustdesk


### PR DESCRIPTION
Try fix `rustdesk.service` on Ubuntu 18.04 or some other OSs.


https://github.com/rustdesk/rustdesk-server-pro/issues/298#issuecomment-2222910431