### PR TITLE
refact: seperate audio device for voice call

### DIFF
--- a/flutter/lib/common/widgets/audio_input.dart
+++ b/flutter/lib/common/widgets/audio_input.dart
@@ -2,22 +2,39 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hbb/common.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 
+const _kWindowsSystemSound = 'System Sound';
+
 typedef AudioINputSetDevice = void Function(String device);
 typedef AudioInputBuilder = Widget Function(
     List<String> devices, String currentDevice, AudioINputSetDevice setDevice);
 
 class AudioInput extends StatelessWidget {
   final AudioInputBuilder builder;
+  final bool isCm;
+  final bool isVoiceCall;
 
-  const AudioInput({Key? key, required this.builder}) : super(key: key);
+  const AudioInput(
+      {Key? key,
+      required this.builder,
+      required this.isCm,
+      required this.isVoiceCall})
+      : super(key: key);
 
   static String getDefault() {
     if (isWindows) return translate('System Sound');
     return '';
   }
 
-  static Future<String> getValue() async {
-    String device = await bind.mainGetOption(key: 'audio-input');
+  static Future<String> getAudioInput(bool isCm, bool isVoiceCall) {
+    if (isVoiceCall) {
+      return bind.getVoiceCallInputDevice(isCm: isCm);
+    } else {
+      return bind.mainGetOption(key: 'audio-input');
+    }
+  }
+
+  static Future<String> getValue(bool isCm, bool isVoiceCall) async {
+    String device = await getAudioInput(isCm, isVoiceCall);
     if (device.isNotEmpty) {
       return device;
     } else {
@@ -25,31 +42,39 @@ class AudioInput extends StatelessWidget {
     }
   }
 
-  static Future<void> setDevice(String device) async {
+  static Future<void> setDevice(
+      String device, bool isCm, bool isVoiceCall) async {
     if (device == getDefault()) device = '';
-    await bind.mainSetOption(key: 'audio-input', value: device);
+    if (isVoiceCall) {
+      await bind.setVoiceCallInputDevice(isCm: isCm, device: device);
+    } else {
+      await bind.mainSetOption(key: 'audio-input', value: device);
+    }
   }
 
-  static Future<Map<String, Object>> getDevicesInfo() async {
+  static Future<Map<String, Object>> getDevicesInfo(
+      bool isCm, bool isVoiceCall) async {
     List<String> devices = (await bind.mainGetSoundInputs()).toList();
     if (isWindows) {
-      devices.insert(0, translate('System Sound'));
+      devices.insert(0, translate(_kWindowsSystemSound));
     }
-    String current = await getValue();
+    String current = await getValue(isCm, isVoiceCall);
     return {'devices': devices, 'current': current};
   }
 
   @override
   Widget build(BuildContext context) {
     return futureBuilder(
-      future: getDevicesInfo(),
+      future: getDevicesInfo(isCm, isVoiceCall),
       hasData: (data) {
         String currentDevice = data['current'];
         List<String> devices = data['devices'] as List<String>;
         if (devices.isEmpty) {
           return const Offstage();
         }
-        return builder(devices, currentDevice, setDevice);
+        return builder(devices, currentDevice, (devices) {
+          setDevice(devices, isCm, isVoiceCall);
+        });
       },
     );
   }

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -500,7 +500,7 @@ class _GeneralState extends State<_General> {
       return const Offstage();
     }
 
-    return AudioInput(builder: (devices, currentDevice, setDevice) {
+    builder(devices, currentDevice, setDevice) {
       return _Card(title: 'Audio Input Device', children: [
         ...devices.map((device) => _Radio<String>(context,
                 value: device,
@@ -511,7 +511,9 @@ class _GeneralState extends State<_General> {
               setState(() {});
             }))
       ]);
-    });
+    }
+
+    return AudioInput(builder: builder, isCm: false, isVoiceCall: false);
   }
 
   Widget record(BuildContext context) {

--- a/flutter/lib/desktop/pages/server_page.dart
+++ b/flutter/lib/desktop/pages/server_page.dart
@@ -732,7 +732,7 @@ class _CmControlPanel extends StatelessWidget {
                 child: buildButton(context,
                     color: MyTheme.accent,
                     onClick: null, onTapDown: (details) async {
-                  final devicesInfo = await AudioInput.getDevicesInfo();
+                  final devicesInfo = await AudioInput.getDevicesInfo(true, true);
                   List<String> devices = devicesInfo['devices'] as List<String>;
                   if (devices.isEmpty) {
                     msgBox(
@@ -758,13 +758,13 @@ class _CmControlPanel extends StatelessWidget {
                               value: d,
                               height: 18,
                               padding: EdgeInsets.zero,
-                              onTap: () => AudioInput.setDevice(d),
+                              onTap: () => AudioInput.setDevice(d, true, true),
                               child: IgnorePointer(
                                   child: RadioMenuButton(
                                 value: d,
                                 groupValue: currentDevice,
                                 onChanged: (v) {
-                                  if (v != null) AudioInput.setDevice(v);
+                                  if (v != null) AudioInput.setDevice(v, true, true);
                                 },
                                 child: Container(
                                   child: Text(

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1984,28 +1984,31 @@ class _VoiceCallMenu extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     menuChildrenGetter() {
-      final audioInput =
-          AudioInput(builder: (devices, currentDevice, setDevice) {
-        return Column(
-          children: devices
-              .map((d) => RdoMenuButton<String>(
-                    child: Container(
-                      child: Text(
-                        d,
-                        overflow: TextOverflow.ellipsis,
+      final audioInput = AudioInput(
+        builder: (devices, currentDevice, setDevice) {
+          return Column(
+            children: devices
+                .map((d) => RdoMenuButton<String>(
+                      child: Container(
+                        child: Text(
+                          d,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        constraints: BoxConstraints(maxWidth: 250),
                       ),
-                      constraints: BoxConstraints(maxWidth: 250),
-                    ),
-                    value: d,
-                    groupValue: currentDevice,
-                    onChanged: (v) {
-                      if (v != null) setDevice(v);
-                    },
-                    ffi: ffi,
-                  ))
-              .toList(),
-        );
-      });
+                      value: d,
+                      groupValue: currentDevice,
+                      onChanged: (v) {
+                        if (v != null) setDevice(v);
+                      },
+                      ffi: ffi,
+                    ))
+                .toList(),
+          );
+        },
+        isCm: false,
+        isVoiceCall: true,
+      );
       return [
         audioInput,
         Divider(),

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1319,6 +1319,25 @@ pub fn cm_close_voice_call(id: i32) {
     crate::ui_cm_interface::close_voice_call(id);
 }
 
+pub fn set_voice_call_input_device(is_cm: bool, device: String) {
+    if is_cm {
+        let _ = crate::ipc::set_config("voice-call-input", device);
+    } else {
+        crate::audio_service::set_voice_call_input_device(Some(device), true);
+    }
+}
+
+pub fn get_voice_call_input_device(is_cm: bool) -> String {
+    if is_cm {
+        match crate::ipc::get_config("voice-call-input") {
+            Ok(Some(device)) => device,
+            _ => "".to_owned(),
+        }
+    } else {
+        crate::audio_service::get_voice_call_input_device().unwrap_or_default()
+    }
+}
+
 pub fn main_get_last_remote_id() -> String {
     LocalConfig::get_remote_id()
 }


### PR DESCRIPTION
Do not use "audio-input" for voice call.

## Desc

Add new audio input variable in audio service.
This variable takes effect only during voice call, it has higher priority of the "audio-input" option.

This variable is not an option, because it may be better to always use the default input as the voice call initial input.

```rust
lazy_static::lazy_static! {
    static ref VOICE_CALL_INPUT_DEVICE: Arc::<Mutex::<Option<String>>> = Default::default();
}
```

### Set

This variable is set when starting a voice call or set the input device on voice call menu.

```rust
fn set_voice_call_input_device()
```

### Get

This variable is got to show curren input device when showing the voice call selecting menu.

```rust
pub fn get_voice_call_input_device(is_cm: bool) -> String {
    if is_cm {
        match crate::ipc::get_config("voice-call-input") {
            Ok(Some(device)) => device,
            _ => "".to_owned(),
        }
    } else {
        crate::audio_service::get_voice_call_input_device().unwrap_or_default()
    }
}
```

### Reset

This variable is reset when ending voice call or connection.

```rust
crate::audio_service::set_voice_call_input_device(None, true);
```

## Preview

No much preview, because it's audio.

https://github.com/user-attachments/assets/9727d90d-7c64-4af8-b2e0-0d1730e7051f

