### PR TITLE
fix: mouse forward back

### DIFF
--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -154,8 +154,8 @@ impl MouseControllable for Enigo {
                 }
             },
             match button {
-                MouseButton::Back => XBUTTON1 as u32 * WHEEL_DELTA as u32,
-                MouseButton::Forward => XBUTTON2 as u32 * WHEEL_DELTA as u32,
+                MouseButton::Back => XBUTTON1 as u32,
+                MouseButton::Forward => XBUTTON2 as u32,
                 _ => 0,
             },
             0,


### PR DESCRIPTION
Fix forward and back buttons on Windows.

https://github.com/rustdesk/rustdesk/issues/1169


https://github.com/user-attachments/assets/256e2db0-ed60-49b1-8c40-8c97d7b7a22c




## TODOs

1. Add support on Wayland (uinput) . Need to add support in Crate `mouce` first.