### PR TITLE
mobile view mode menu

### DIFF
--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -650,6 +650,18 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
     v.addAll(toolbarKeyboardToggles(ffi));
   }
 
+  // view mode (mobile only, desktop is in keyboard menu)
+  if (isMobile && versionCmp(pi.version, '1.2.0') >= 0) {
+    v.add(TToggleMenu(
+        value: ffiModel.viewOnly,
+        onChanged: (value) async {
+          if (value == null) return;
+          await bind.sessionToggleOption(
+              sessionId: ffi.sessionId, value: kOptionToggleViewOnly);
+          ffiModel.setViewOnly(id, value);
+        },
+        child: Text(translate('View Mode'))));
+  }
   return v;
 }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -192,7 +192,7 @@ class FfiModel with ChangeNotifier {
       _permissions[k] = v == 'true';
     });
     // Only inited at remote page
-    if (desktopType == DesktopType.remote) {
+    if (parent.target?.connType == ConnType.defaultConn) {
       KeyboardEnabledState.find(id).value = _permissions['keyboard'] != false;
     }
     debugPrint('updatePermission: $_permissions');
@@ -1726,7 +1726,7 @@ class PredefinedCursor {
     _image2 = img2.decodePng(base64Decode(png));
     if (_image2 != null) {
       // The png type of forbidden cursor image is `PngColorType.indexed`.
-      if (isWindows && id == kPreForbiddenCursorId) {
+      if (id == kPreForbiddenCursorId) {
         _image2 = _image2!.convert(format: img2.Format.uint8, numChannels: 4);
       }
 

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1614,5 +1614,13 @@ class RustdeskImpl {
     throw UnimplementedError();
   }
 
+  bool mainHasValidBotSync({dynamic hint}) {
+    throw UnimplementedError();
+  }
+
+  Future<String> mainVerifyBot({required String token, dynamic hint}) {
+    throw UnimplementedError();
+  }
+
   void dispose() {}
 }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/8689 

* Add view mode menu to mobile, disable the same menus as desktop
* Display forbidden cursor when not in view mode && no keyboard permission && not display remote cursor
* Hide keyboard/mouse bottom buttons when keyboard is disabled
* Fixe not listen keyboard permission change in some widgets
* Changing resolution and http proxy settings are missing for mobile devices, will be added if needed.

https://github.com/user-attachments/assets/2de11649-3b6e-487a-8e9d-fb79ff1b477c

