### PR TITLE
refact: macos, hide&show on leaving view

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -416,6 +416,10 @@ class _RemotePageState extends State<RemotePage>
   }
 
   void leaveView(PointerExitEvent evt) {
+    if (isMacOS) {
+      DesktopMultiWindow.hideShow();
+    }
+
     if (_ffi.ffiModel.keyboard) {
       _ffi.inputModel.tryMoveEdgeOnExit(evt.position);
     }

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -335,7 +335,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "60773827434eefe6d01eefa814dca9a032b970b3"
+      resolved-ref: "53fee59855c44f35381428c9fb7c7678f700d11d"
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"


### PR DESCRIPTION

Try workaround https://github.com/rustdesk/rustdesk/issues/8548

No side effects are found.

https://github.com/user-attachments/assets/ae2fb31b-c220-4000-89a6-a56e2ceb58d3

