### PR TITLE
fix lan peers batch deletion

### DIFF
--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -399,9 +399,9 @@ class _PeerTabPageState extends State<PeerTabPage>
             final peers = model.selectedPeers;
             switch (model.currentTab) {
               case 0:
-                peers.map((p) async {
+                for (var p in peers) {
                   await bind.mainRemovePeer(id: p.id);
-                }).toList();
+                }
                 await bind.mainLoadRecentPeers();
                 break;
               case 1:
@@ -413,9 +413,9 @@ class _PeerTabPageState extends State<PeerTabPage>
                 await bind.mainLoadFavPeers();
                 break;
               case 2:
-                peers.map((p) async {
+                for (var p in peers) {
                   await bind.mainRemoveDiscovered(id: p.id);
-                }).toList();
+                }
                 await bind.mainLoadLanPeers();
                 break;
               case 3:


### PR DESCRIPTION
This only happens in lan peers. `peers.map((p) async {})` is not sync and peers are loaded before deletion.

```
let mut peers = config::LanPeers::load().peers;
peers.retain(|x| x.id != id);
```

https://github.com/user-attachments/assets/ec4d84fd-57e8-4555-b26e-540816e2159b


https://github.com/user-attachments/assets/8af5255c-3a16-405f-9304-be4691d8d63b

