### PR TITLE
install ffmpeg lib with vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ env:
 #   MIN_SUPPORTED_RUST_VERSION: "1.46.0"
 #   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-  # vcpkg version: 2023.10.19
+  # vcpkg version: 2024.06.15
   # for multiarch gcc compatibility
-  VCPKG_COMMIT_ID: "8eb57355a4ffb410a2e94c07b4dca2dffbee8e50"
+  VCPKG_COMMIT_ID: "f7423ee180c4b7f40d43402c2feb3859161ef625"
 
 on:
   workflow_dispatch:
@@ -112,6 +112,8 @@ jobs:
                libgstreamer-plugins-base1.0-dev \
                libgtk-3-dev \
                libpulse-dev \
+               libva-dev \
+               libvdpau-dev \
                libxcb-randr0-dev \
                libxcb-shape0-dev \
                libxcb-xfixes0-dev \

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -115,6 +115,8 @@ jobs:
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
 
       - name: Install vcpkg dependencies
+        env:
+          VCPKG_DEFAULT_HOST_TRIPLET: ${{ matrix.job.vcpkg-triplet }}
         run: |
           $VCPKG_ROOT/vcpkg install --triplet ${{ matrix.job.vcpkg-triplet }} --x-install-root="$VCPKG_ROOT/installed"
         shell: bash
@@ -255,6 +257,8 @@ jobs:
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
 
       - name: Install vcpkg dependencies
+        env:
+          VCPKG_DEFAULT_HOST_TRIPLET: ${{ matrix.job.vcpkg-triplet }}
         run: |
           $VCPKG_ROOT/vcpkg install --triplet ${{ matrix.job.vcpkg-triplet }} --x-install-root="$VCPKG_ROOT/installed"
         shell: bash
@@ -427,7 +431,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install nasm
+          brew install nasm yasm
       - name: Checkout source code
         uses: actions/checkout@v3
       - name: Install flutter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,8 +3087,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.4.19"
-source = "git+https://github.com/21pages/hwcodec#852de98224605db7a2495cf276776dabaf8aa139"
+version = "0.5.0"
+source = "git+https://github.com/21pages/hwcodec#470d18826dc334b964c51acf0c6ac3bcf56f56ad"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -188,6 +188,50 @@ fn gen_vcpkg_package(package: &str, ffi_header: &str, generated: &str, regex: &s
     generate_bindings(&ffi_header, &includes, &ffi_rs, &exact_file, regex);
 }
 
+// If you have problems installing ffmpeg, you can disable hwcodec feature and disable this function.
+fn ffmpeg() {
+    // ffmpeg
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let static_libs = vec!["avcodec", "avutil", "avformat"];
+    static_libs.iter().for_each(|lib| {
+        find_package(lib);
+    });
+    if target_os == "windows" {
+        println!("cargo:rustc-link-lib=static=libmfx");
+    }
+
+    // os
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let dyn_libs: Vec<&str> = if target_os == "windows" {
+        ["User32", "bcrypt", "ole32", "advapi32"].to_vec()
+    } else if target_os == "linux" {
+        let mut v = ["va", "va-drm", "va-x11", "vdpau", "X11", "stdc++"].to_vec();
+        if target_arch == "x86_64" {
+            v.push("z");
+        }
+        v
+    } else if target_os == "macos" || target_os == "ios" {
+        ["c++", "m"].to_vec()
+    } else if target_os == "android" {
+        ["z", "m", "android", "atomic"].to_vec()
+    } else {
+        panic!("unsupported os");
+    };
+    dyn_libs
+        .iter()
+        .map(|lib| println!("cargo:rustc-link-lib={}", lib))
+        .count();
+
+    if target_os == "macos" || target_os == "ios" {
+        println!("cargo:rustc-link-lib=framework=CoreFoundation");
+        println!("cargo:rustc-link-lib=framework=CoreVideo");
+        println!("cargo:rustc-link-lib=framework=CoreMedia");
+        println!("cargo:rustc-link-lib=framework=VideoToolbox");
+        println!("cargo:rustc-link-lib=framework=AVFoundation");
+    }
+}
+
 fn main() {
     // note: all link symbol names in x86 (32-bit) are prefixed wth "_".
     // run "rustup show" to show current default toolchain, if it is stable-x86-pc-windows-msvc,
@@ -204,6 +248,7 @@ fn main() {
     gen_vcpkg_package("libvpx", "vpx_ffi.h", "vpx_ffi.rs", "^[vV].*");
     gen_vcpkg_package("aom", "aom_ffi.h", "aom_ffi.rs", "^(aom|AOM|OBU|AV1).*");
     gen_vcpkg_package("libyuv", "yuv_ffi.h", "yuv_ffi.rs", ".*");
+    ffmpeg();
 
     // there is problem with cfg(target_os) in build.rs, so use our workaround
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/res/vcpkg/ffmpeg/0002-fix-msvc-link.patch
+++ b/res/vcpkg/ffmpeg/0002-fix-msvc-link.patch
@@ -1,0 +1,11 @@
+diff --git a/configure b/configure
+--- a/configure
++++ b/configure
+@@ -6162,6 +6162,7 @@ EOF
+         test -n "$extern_prefix"  && append X86ASMFLAGS "-DPREFIX"
+         case "$objformat" in
+             elf*) enabled debug && append X86ASMFLAGS $x86asm_debug ;;
++            win*) enabled debug && append X86ASMFLAGS "-g" ;;
+         esac
+ 
+         enabled avx512    && check_x86asm avx512_external    "vmovdqa32 [eax]{k1}{z}, zmm0"

--- a/res/vcpkg/ffmpeg/0003-fix-windowsinclude.patch
+++ b/res/vcpkg/ffmpeg/0003-fix-windowsinclude.patch
@@ -1,0 +1,13 @@
+diff --git a/fftools/cmdutils.c b/fftools/cmdutils.c
+--- a/fftools/cmdutils.c
++++ b/fftools/cmdutils.c
+@@ -51,6 +51,8 @@
+ #include "fopen_utf8.h"
+ #include "opt_common.h"
+ #ifdef _WIN32
++#define _WIN32_WINNT 0x0502
++#define WIN32_LEAN_AND_MEAN
+ #include <windows.h>
+ #include "compat/w32dlfcn.h"
+ #endif
+ 

--- a/res/vcpkg/ffmpeg/0005-fix-nasm.patch
+++ b/res/vcpkg/ffmpeg/0005-fix-nasm.patch
@@ -1,0 +1,55 @@
+diff --git a/libavcodec/x86/Makefile b/libavcodec/x86/Makefile
+--- a/libavcodec/x86/Makefile
++++ b/libavcodec/x86/Makefile
+@@ -158,6 +158,8 @@ X86ASM-OBJS-$(CONFIG_ALAC_DECODER)     += x86/alacdsp.o
+ X86ASM-OBJS-$(CONFIG_APNG_DECODER)     += x86/pngdsp.o
+ X86ASM-OBJS-$(CONFIG_CAVS_DECODER)     += x86/cavsidct.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_CFHD_ENCODER)     += x86/cfhdencdsp.o
++endif
+ X86ASM-OBJS-$(CONFIG_CFHD_DECODER)     += x86/cfhddsp.o
+ X86ASM-OBJS-$(CONFIG_DCA_DECODER)      += x86/dcadsp.o x86/synth_filter.o
+ X86ASM-OBJS-$(CONFIG_DIRAC_DECODER)    += x86/diracdsp.o                \
+@@ -175,15 +177,21 @@                                           x86/hevc_sao_10bit.o
+ X86ASM-OBJS-$(CONFIG_JPEG2000_DECODER) += x86/jpeg2000dsp.o
+ X86ASM-OBJS-$(CONFIG_LSCR_DECODER)     += x86/pngdsp.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_MLP_DECODER)      += x86/mlpdsp.o
++endif
+ X86ASM-OBJS-$(CONFIG_MPEG4_DECODER)    += x86/xvididct.o
+ X86ASM-OBJS-$(CONFIG_PNG_DECODER)      += x86/pngdsp.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_PRORES_DECODER)   += x86/proresdsp.o
+ X86ASM-OBJS-$(CONFIG_PRORES_LGPL_DECODER) += x86/proresdsp.o
++endif
+ X86ASM-OBJS-$(CONFIG_RV40_DECODER)     += x86/rv40dsp.o
+ X86ASM-OBJS-$(CONFIG_SBC_ENCODER)      += x86/sbcdsp.o
+ X86ASM-OBJS-$(CONFIG_SVQ1_ENCODER)     += x86/svq1enc.o
+ X86ASM-OBJS-$(CONFIG_TAK_DECODER)      += x86/takdsp.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_TRUEHD_DECODER)   += x86/mlpdsp.o
++endif
+ X86ASM-OBJS-$(CONFIG_TTA_DECODER)      += x86/ttadsp.o
+ X86ASM-OBJS-$(CONFIG_TTA_ENCODER)      += x86/ttaencdsp.o
+ X86ASM-OBJS-$(CONFIG_UTVIDEO_DECODER)  += x86/utvideodsp.o
+diff --git a/libavfilter/x86/Makefile b/libavfilter/x86/Makefile
+--- a/libavfilter/x86/Makefile
++++ b/libavfilter/x86/Makefile
+@@ -44,6 +44,8 @@ 
+ X86ASM-OBJS-$(CONFIG_AFIR_FILTER)            += x86/af_afir.o
+ X86ASM-OBJS-$(CONFIG_ANLMDN_FILTER)          += x86/af_anlmdn.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_ATADENOISE_FILTER)      += x86/vf_atadenoise.o
++endif
+ X86ASM-OBJS-$(CONFIG_BLEND_FILTER)           += x86/vf_blend.o
+ X86ASM-OBJS-$(CONFIG_BWDIF_FILTER)           += x86/vf_bwdif.o
+ X86ASM-OBJS-$(CONFIG_COLORSPACE_FILTER)      += x86/colorspacedsp.o
+@@ -62,6 +62,8 @@ X86ASM-OBJS-$(CONFIG_LUT3D_FILTER)           += x86/vf_lut3d.o
+ X86ASM-OBJS-$(CONFIG_MASKEDCLAMP_FILTER)     += x86/vf_maskedclamp.o
+ X86ASM-OBJS-$(CONFIG_MASKEDMERGE_FILTER)     += x86/vf_maskedmerge.o
++ifdef ARCH_X86_64
+ X86ASM-OBJS-$(CONFIG_NLMEANS_FILTER)         += x86/vf_nlmeans.o
++endif
+ X86ASM-OBJS-$(CONFIG_OVERLAY_FILTER)         += x86/vf_overlay.o
+ X86ASM-OBJS-$(CONFIG_PP7_FILTER)             += x86/vf_pp7.o
+ X86ASM-OBJS-$(CONFIG_PSNR_FILTER)            += x86/vf_psnr.o

--- a/res/vcpkg/ffmpeg/0012-Fix-ssl-110-detection.patch
+++ b/res/vcpkg/ffmpeg/0012-Fix-ssl-110-detection.patch
@@ -1,0 +1,14 @@
+diff --git a/configure b/configure
+index 2be953f7e7..e075949ffc 100755
+--- a/configure
++++ b/configure
+@@ -6497,6 +6497,7 @@ enabled openssl           && { { check_pkg_config openssl "openssl >= 3.0.0
+                                  { enabled gplv3 || ! enabled gpl || enabled nonfree || die "ERROR: OpenSSL >=3.0.0 requires --enable-version3"; }; } ||
+                                { enabled gpl && ! enabled nonfree && die "ERROR: OpenSSL <3.0.0 is incompatible with the gpl"; } ||
+                                check_pkg_config openssl openssl openssl/ssl.h OPENSSL_init_ssl ||
+                                check_pkg_config openssl openssl openssl/ssl.h SSL_library_init ||
++                               check_lib openssl openssl/ssl.h OPENSSL_init_ssl -lssl -lcrypto $pthreads_extralibs -ldl ||
+                                check_lib openssl openssl/ssl.h OPENSSL_init_ssl -lssl -lcrypto ||
+                                check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto ||
+                                check_lib openssl openssl/ssl.h SSL_library_init -lssl32 -leay32 ||
+

--- a/res/vcpkg/ffmpeg/0013-define-WINVER.patch
+++ b/res/vcpkg/ffmpeg/0013-define-WINVER.patch
@@ -1,0 +1,15 @@
+diff --color -Naur src_old/libavcodec/mf_utils.c src/libavcodec/mf_utils.c
+--- src_old/libavcodec/mf_utils.c	2020-07-11 05:26:17.000000000 +0700
++++ src/libavcodec/mf_utils.c	2020-11-13 12:55:57.226976400 +0700
+@@ -22,6 +22,11 @@
+ #define _WIN32_WINNT 0x0602
+ #endif
+ 
++#if !defined(WINVER) || WINVER < 0x0602
++#undef WINVER
++#define WINVER 0x0602
++#endif
++
+ #include "mf_utils.h"
+ #include "libavutil/pixdesc.h"
+ 

--- a/res/vcpkg/ffmpeg/5.1/0001-avcodec-amfenc-add-query_timeout-option-for-h264-hev.patch
+++ b/res/vcpkg/ffmpeg/5.1/0001-avcodec-amfenc-add-query_timeout-option-for-h264-hev.patch
@@ -1,0 +1,71 @@
+From f0b694749b38b2cfd94df4eed10e667342c234e5 Mon Sep 17 00:00:00 2001
+From: 21pages <pages21@163.com>
+Date: Sat, 24 Feb 2024 15:33:24 +0800
+Subject: [PATCH 1/2] avcodec/amfenc: add query_timeout option for h264/hevc
+
+Signed-off-by: 21pages <pages21@163.com>
+---
+ libavcodec/amfenc.h      | 1 +
+ libavcodec/amfenc_h264.c | 4 ++++
+ libavcodec/amfenc_hevc.c | 4 ++++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/libavcodec/amfenc.h b/libavcodec/amfenc.h
+index 1ab98d2f78..e92120ea39 100644
+--- a/libavcodec/amfenc.h
++++ b/libavcodec/amfenc.h
+@@ -87,6 +87,7 @@ typedef struct AmfContext {
+     int                 quality;
+     int                 b_frame_delta_qp;
+     int                 ref_b_frame_delta_qp;
++    int64_t             query_timeout;
+ 
+     // Dynamic options, can be set after Init() call
+ 
+diff --git a/libavcodec/amfenc_h264.c b/libavcodec/amfenc_h264.c
+index efb04589f6..f55dbc80f0 100644
+--- a/libavcodec/amfenc_h264.c
++++ b/libavcodec/amfenc_h264.c
+@@ -121,6 +121,7 @@ static const AVOption options[] = {
+     { "aud",            "Inserts AU Delimiter NAL unit",        OFFSET(aud)          ,AV_OPT_TYPE_BOOL,  { .i64 = 0 }, 0, 1, VE },
+ 
+     { "log_to_dbg",     "Enable AMF logging to debug output",   OFFSET(log_to_dbg)    , AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
++    { "query_timeout", "Timeout for QueryOutput call in ms", OFFSET(query_timeout), AV_OPT_TYPE_INT64, { .i64 = -1 }, -1, 1000, VE },
+ 
+     { NULL }
+ };
+@@ -155,6 +156,9 @@ static av_cold int amf_encode_init_h264(AVCodecContext *avctx)
+ 
+     AMF_ASSIGN_PROPERTY_RATE(res, ctx->encoder, AMF_VIDEO_ENCODER_FRAMERATE, framerate);
+ 
++    if (ctx->query_timeout >= 0)
++        AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_QUERY_TIMEOUT, ctx->query_timeout);
++
+     switch (avctx->profile) {
+     case FF_PROFILE_H264_BASELINE:
+         profile = AMF_VIDEO_ENCODER_PROFILE_BASELINE;
+diff --git a/libavcodec/amfenc_hevc.c b/libavcodec/amfenc_hevc.c
+index 8ab9330730..7a40bcad31 100644
+--- a/libavcodec/amfenc_hevc.c
++++ b/libavcodec/amfenc_hevc.c
+@@ -89,6 +89,7 @@ static const AVOption options[] = {
+     { "aud",            "Inserts AU Delimiter NAL unit",            OFFSET(aud)           ,AV_OPT_TYPE_BOOL,{ .i64 = 0 }, 0, 1, VE },
+ 
+     { "log_to_dbg",     "Enable AMF logging to debug output",   OFFSET(log_to_dbg), AV_OPT_TYPE_BOOL,{ .i64 = 0 }, 0, 1, VE },
++    { "query_timeout", "Timeout for QueryOutput call in ms", OFFSET(query_timeout), AV_OPT_TYPE_INT64, { .i64 = -1 }, -1, 1000, VE },
+     { NULL }
+ };
+ 
+@@ -122,6 +123,9 @@ static av_cold int amf_encode_init_hevc(AVCodecContext *avctx)
+ 
+     AMF_ASSIGN_PROPERTY_RATE(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_FRAMERATE, framerate);
+ 
++    if (ctx->query_timeout >= 0)
++        AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_QUERY_TIMEOUT, ctx->query_timeout);
++
+     switch (avctx->profile) {
+     case FF_PROFILE_HEVC_MAIN:
+         profile = AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN;
+-- 
+2.43.0.windows.1
+

--- a/res/vcpkg/ffmpeg/5.1/0002-libavcodec-amfenc-reconfig-when-bitrate-change.patch
+++ b/res/vcpkg/ffmpeg/5.1/0002-libavcodec-amfenc-reconfig-when-bitrate-change.patch
@@ -1,0 +1,71 @@
+From 4d0d20d96ad458cfec0444b9be0182ca6085ee0c Mon Sep 17 00:00:00 2001
+From: 21pages <pages21@163.com>
+Date: Sat, 24 Feb 2024 16:02:44 +0800
+Subject: [PATCH 2/2] libavcodec/amfenc: reconfig when bitrate change
+
+Signed-off-by: 21pages <pages21@163.com>
+---
+ libavcodec/amfenc.c | 20 ++++++++++++++++++++
+ libavcodec/amfenc.h |  1 +
+ 2 files changed, 21 insertions(+)
+
+diff --git a/libavcodec/amfenc.c b/libavcodec/amfenc.c
+index a033e1220e..3eab01a903 100644
+--- a/libavcodec/amfenc.c
++++ b/libavcodec/amfenc.c
+@@ -222,6 +222,7 @@ static int amf_init_context(AVCodecContext *avctx)
+ 
+     ctx->hwsurfaces_in_queue = 0;
+     ctx->hwsurfaces_in_queue_max = 16;
++    ctx->av_bitrate = avctx->bit_rate;
+ 
+     // configure AMF logger
+     // the return of these functions indicates old state and do not affect behaviour
+@@ -575,6 +576,23 @@ static void amf_release_buffer_with_frame_ref(AMFBuffer *frame_ref_storage_buffe
+     frame_ref_storage_buffer->pVtbl->Release(frame_ref_storage_buffer);
+ }
+ 
++static int reconfig_encoder(AVCodecContext *avctx)
++{
++    AmfContext *ctx = avctx->priv_data;
++    AMF_RESULT  res = AMF_OK;
++
++    if (ctx->av_bitrate != avctx->bit_rate) {
++        av_log(ctx, AV_LOG_INFO, "change bitrate from %d to %d\n", ctx->av_bitrate, avctx->bit_rate);
++        ctx->av_bitrate = avctx->bit_rate;
++        if (avctx->codec->id == AV_CODEC_ID_H264) {
++            AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_TARGET_BITRATE, avctx->bit_rate);
++        } else if (avctx->codec->id == AV_CODEC_ID_HEVC) {
++            AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_TARGET_BITRATE, avctx->bit_rate);
++        }
++    }
++    return 0;
++}
++
+ int ff_amf_receive_packet(AVCodecContext *avctx, AVPacket *avpkt)
+ {
+     AmfContext *ctx = avctx->priv_data;
+@@ -586,6 +604,8 @@ int ff_amf_receive_packet(AVCodecContext *avctx, AVPacket *avpkt)
+     AVFrame    *frame = ctx->delayed_frame;
+     int         block_and_wait;
+ 
++    reconfig_encoder(avctx);
++
+     if (!ctx->encoder)
+         return AVERROR(EINVAL);
+ 
+diff --git a/libavcodec/amfenc.h b/libavcodec/amfenc.h
+index e92120ea39..31172645f2 100644
+--- a/libavcodec/amfenc.h
++++ b/libavcodec/amfenc.h
+@@ -107,6 +107,7 @@ typedef struct AmfContext {
+     int                 me_half_pel;
+     int                 me_quarter_pel;
+     int                 aud;
++    int64_t             av_bitrate;
+ 
+     // HEVC - specific options
+ 
+-- 
+2.43.0.windows.1
+

--- a/res/vcpkg/ffmpeg/5.1/0003-use-release-7.0-s-qsvenc-update_bitrate.patch
+++ b/res/vcpkg/ffmpeg/5.1/0003-use-release-7.0-s-qsvenc-update_bitrate.patch
@@ -1,0 +1,95 @@
+From afe89a70f6bc7ebd0a6a0a31101801b88cbd60ee Mon Sep 17 00:00:00 2001
+From: 21pages <pages21@163.com>
+Date: Sun, 5 May 2024 12:45:23 +0800
+Subject: [PATCH] use release/7.0's update_bitrate
+
+Signed-off-by: 21pages <pages21@163.com>
+---
+ libavcodec/qsvenc.c | 39 +++++++++++++++++++++++++++++++++++++++
+ libavcodec/qsvenc.h |  6 ++++++
+ 2 files changed, 45 insertions(+)
+
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index 2382c2f5f7..9b34f37eb3 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -714,6 +714,11 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+     brc_param_multiplier       = (FFMAX(FFMAX3(target_bitrate_kbps, max_bitrate_kbps, buffer_size_in_kilobytes),
+                                   initial_delay_in_kilobytes) + 0x10000) / 0x10000;
+ 
++    q->old_rc_buffer_size = avctx->rc_buffer_size;
++    q->old_rc_initial_buffer_occupancy = avctx->rc_initial_buffer_occupancy;
++    q->old_bit_rate = avctx->bit_rate;
++    q->old_rc_max_rate = avctx->rc_max_rate;
++
+     switch (q->param.mfx.RateControlMethod) {
+     case MFX_RATECONTROL_CBR:
+     case MFX_RATECONTROL_VBR:
+@@ -1657,6 +1662,39 @@ static int update_qp(AVCodecContext *avctx, QSVEncContext *q,
+     return updated;
+ }
+ 
++static int update_bitrate(AVCodecContext *avctx, QSVEncContext *q)
++{
++    int updated = 0;
++    int target_bitrate_kbps, max_bitrate_kbps, brc_param_multiplier;
++    int buffer_size_in_kilobytes, initial_delay_in_kilobytes;
++
++    UPDATE_PARAM(q->old_rc_buffer_size, avctx->rc_buffer_size);
++    UPDATE_PARAM(q->old_rc_initial_buffer_occupancy, avctx->rc_initial_buffer_occupancy);
++    UPDATE_PARAM(q->old_bit_rate, avctx->bit_rate);
++    UPDATE_PARAM(q->old_rc_max_rate, avctx->rc_max_rate);
++    if (!updated)
++        return 0;
++
++    buffer_size_in_kilobytes   = avctx->rc_buffer_size / 8000;
++    initial_delay_in_kilobytes = avctx->rc_initial_buffer_occupancy / 8000;
++    target_bitrate_kbps        = avctx->bit_rate / 1000;
++    max_bitrate_kbps           = avctx->rc_max_rate / 1000;
++    brc_param_multiplier       = (FFMAX(FFMAX3(target_bitrate_kbps, max_bitrate_kbps, buffer_size_in_kilobytes),
++                                    initial_delay_in_kilobytes) + 0x10000) / 0x10000;
++
++    q->param.mfx.BufferSizeInKB = buffer_size_in_kilobytes / brc_param_multiplier;
++    q->param.mfx.InitialDelayInKB = initial_delay_in_kilobytes / brc_param_multiplier;
++    q->param.mfx.TargetKbps = target_bitrate_kbps / brc_param_multiplier;
++    q->param.mfx.MaxKbps = max_bitrate_kbps / brc_param_multiplier;
++    q->param.mfx.BRCParamMultiplier = brc_param_multiplier;
++    av_log(avctx, AV_LOG_VERBOSE,
++            "Reset BufferSizeInKB: %d; InitialDelayInKB: %d; "
++            "TargetKbps: %d; MaxKbps: %d; BRCParamMultiplier: %d\n",
++            q->param.mfx.BufferSizeInKB, q->param.mfx.InitialDelayInKB,
++            q->param.mfx.TargetKbps, q->param.mfx.MaxKbps, q->param.mfx.BRCParamMultiplier);
++    return updated;
++}
++
+ static int update_parameters(AVCodecContext *avctx, QSVEncContext *q,
+                              const AVFrame *frame)
+ {
+@@ -1666,6 +1704,7 @@ static int update_parameters(AVCodecContext *avctx, QSVEncContext *q,
+         return 0;
+ 
+     needReset = update_qp(avctx, q, frame);
++    needReset |= update_bitrate(avctx, q);
+     if (!needReset)
+         return 0;
+ 
+diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
+index b754ac4b56..5745533165 100644
+--- a/libavcodec/qsvenc.h
++++ b/libavcodec/qsvenc.h
+@@ -224,6 +224,12 @@ typedef struct QSVEncContext {
+     int min_qp_p;
+     int max_qp_b;
+     int min_qp_b;
++
++    // These are used for bitrate control reset
++    int old_bit_rate;
++    int old_rc_buffer_size;
++    int old_rc_initial_buffer_occupancy;
++    int old_rc_max_rate;
+ } QSVEncContext;
+ 
+ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q);
+-- 
+2.43.0.windows.1
+

--- a/res/vcpkg/ffmpeg/5.1/0004-amf-colorspace.patch
+++ b/res/vcpkg/ffmpeg/5.1/0004-amf-colorspace.patch
@@ -1,0 +1,172 @@
+From 7c29a6936e7b7a3a3a0bcc88894f2b739bdae9cf Mon Sep 17 00:00:00 2001
+From: 21pages <sunboeasy@gmail.com>
+Date: Thu, 11 Jul 2024 16:24:27 +0800
+Subject: [PATCH] amf colorspace
+
+Signed-off-by: 21pages <sunboeasy@gmail.com>
+---
+ libavcodec/amfenc.h      |  1 +
+ libavcodec/amfenc_h264.c | 45 ++++++++++++++++++++++++++++++++++
+ libavcodec/amfenc_hevc.c | 52 ++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 98 insertions(+)
+
+diff --git a/libavcodec/amfenc.h b/libavcodec/amfenc.h
+index 31172645f2..493e01603d 100644
+--- a/libavcodec/amfenc.h
++++ b/libavcodec/amfenc.h
+@@ -23,6 +23,7 @@
+ 
+ #include <AMF/components/VideoEncoderVCE.h>
+ #include <AMF/components/VideoEncoderHEVC.h>
++#include <AMF/components/ColorSpace.h>
+ 
+ #include "libavutil/fifo.h"
+ 
+diff --git a/libavcodec/amfenc_h264.c b/libavcodec/amfenc_h264.c
+index f55dbc80f0..a916b35f9c 100644
+--- a/libavcodec/amfenc_h264.c
++++ b/libavcodec/amfenc_h264.c
+@@ -139,6 +139,9 @@ static av_cold int amf_encode_init_h264(AVCodecContext *avctx)
+     AMFRate                          framerate;
+     AMFSize                          framesize = AMFConstructSize(avctx->width, avctx->height);
+     int                              deblocking_filter = (avctx->flags & AV_CODEC_FLAG_LOOP_FILTER) ? 1 : 0;
++    amf_int64                        color_depth;
++    amf_int64                        color_profile;
++    enum                             AVPixelFormat pix_fmt;
+ 
+     if (avctx->framerate.num > 0 && avctx->framerate.den > 0) {
+         framerate = AMFConstructRate(avctx->framerate.num, avctx->framerate.den);
+@@ -199,11 +202,53 @@ static av_cold int amf_encode_init_h264(AVCodecContext *avctx)
+         AMF_ASSIGN_PROPERTY_RATIO(res, ctx->encoder, AMF_VIDEO_ENCODER_ASPECT_RATIO, ratio);
+     }
+ 
++    color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_UNKNOWN;
+     /// Color Range (Partial/TV/MPEG or Full/PC/JPEG)
+     if (avctx->color_range == AVCOL_RANGE_JPEG) {
+         AMF_ASSIGN_PROPERTY_BOOL(res, ctx->encoder, AMF_VIDEO_ENCODER_FULL_RANGE_COLOR, 1);
++        /// Color Space for Full (JPEG) Range
++        switch (avctx->colorspace) {
++        case AVCOL_SPC_SMPTE170M:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_FULL_601;
++            break;
++        case AVCOL_SPC_BT709:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_FULL_709;
++            break;
++        case AVCOL_SPC_BT2020_NCL:
++        case AVCOL_SPC_BT2020_CL:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_FULL_2020;
++            break;
++        }
++    } else {
++        AMF_ASSIGN_PROPERTY_BOOL(res, ctx->encoder, AMF_VIDEO_ENCODER_FULL_RANGE_COLOR, 0);
++        /// Color Space for Limited (MPEG) range
++        switch (avctx->colorspace) {
++        case AVCOL_SPC_SMPTE170M:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_601;
++            break;
++        case AVCOL_SPC_BT709:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_709;
++            break;
++        case AVCOL_SPC_BT2020_NCL:
++        case AVCOL_SPC_BT2020_CL:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_2020;
++            break;
++        }
++    }
++    /// Color Depth
++    pix_fmt = avctx->hw_frames_ctx ? ((AVHWFramesContext*)avctx->hw_frames_ctx->data)->sw_format
++                                : avctx->pix_fmt;
++    color_depth = AMF_COLOR_BIT_DEPTH_8;
++    if (pix_fmt == AV_PIX_FMT_P010) {
++        color_depth = AMF_COLOR_BIT_DEPTH_10;
+     }
+ 
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_COLOR_BIT_DEPTH, color_depth);
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_OUTPUT_COLOR_PROFILE, color_profile);
++    /// Color Transfer Characteristics (AMF matches ISO/IEC)
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_OUTPUT_TRANSFER_CHARACTERISTIC, (amf_int64)avctx->color_trc);
++    /// Color Primaries (AMF matches ISO/IEC)
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_OUTPUT_COLOR_PRIMARIES, (amf_int64)avctx->color_primaries);
+     // autodetect rate control method
+     if (ctx->rate_control_mode == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_UNKNOWN) {
+         if (ctx->qp_i != -1 || ctx->qp_p != -1 || ctx->qp_b != -1) {
+diff --git a/libavcodec/amfenc_hevc.c b/libavcodec/amfenc_hevc.c
+index 7a40bcad31..e7979d9aeb 100644
+--- a/libavcodec/amfenc_hevc.c
++++ b/libavcodec/amfenc_hevc.c
+@@ -106,6 +106,9 @@ static av_cold int amf_encode_init_hevc(AVCodecContext *avctx)
+     AMFRate             framerate;
+     AMFSize             framesize = AMFConstructSize(avctx->width, avctx->height);
+     int                 deblocking_filter = (avctx->flags & AV_CODEC_FLAG_LOOP_FILTER) ? 1 : 0;
++    amf_int64           color_depth;
++    amf_int64           color_profile;
++    enum                AVPixelFormat pix_fmt;
+ 
+     if (avctx->framerate.num > 0 && avctx->framerate.den > 0) {
+         framerate = AMFConstructRate(avctx->framerate.num, avctx->framerate.den);
+@@ -130,6 +133,9 @@ static av_cold int amf_encode_init_hevc(AVCodecContext *avctx)
+     case FF_PROFILE_HEVC_MAIN:
+         profile = AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN;
+         break;
++    case FF_PROFILE_HEVC_MAIN_10:
++        profile = AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN_10;
++        break;
+     default:
+         break;
+     }
+@@ -158,6 +164,52 @@ static av_cold int amf_encode_init_hevc(AVCodecContext *avctx)
+         AMF_ASSIGN_PROPERTY_RATIO(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_ASPECT_RATIO, ratio);
+     }
+ 
++    // Color Metadata
++    color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_UNKNOWN;
++    if (avctx->color_range == AVCOL_RANGE_JPEG) {
++        AMF_ASSIGN_PROPERTY_BOOL(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_NOMINAL_RANGE, 1);
++        switch (avctx->colorspace) {
++        case AVCOL_SPC_SMPTE170M:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_FULL_601;
++            break;
++        case AVCOL_SPC_BT709:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_FULL_709;
++            break;
++        case AVCOL_SPC_BT2020_NCL:
++        case AVCOL_SPC_BT2020_CL:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_FULL_2020;
++            break;
++        }
++    } else {
++        AMF_ASSIGN_PROPERTY_BOOL(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_NOMINAL_RANGE, 0);
++        switch (avctx->colorspace) {
++        case AVCOL_SPC_SMPTE170M:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_601;
++            break;
++        case AVCOL_SPC_BT709:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_709;
++            break;
++        case AVCOL_SPC_BT2020_NCL:
++        case AVCOL_SPC_BT2020_CL:
++            color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_2020;
++            break;
++        }
++    }
++    /// Color Depth
++    pix_fmt = avctx->hw_frames_ctx ? ((AVHWFramesContext*)avctx->hw_frames_ctx->data)->sw_format
++                                    : avctx->pix_fmt;
++    color_depth = AMF_COLOR_BIT_DEPTH_8;
++    if (pix_fmt == AV_PIX_FMT_P010) {
++        color_depth = AMF_COLOR_BIT_DEPTH_10;
++    }
++
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_COLOR_BIT_DEPTH, color_depth);
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_OUTPUT_COLOR_PROFILE, color_profile);
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_OUTPUT_TRANSFER_CHARACTERISTIC, (amf_int64)avctx->color_trc);
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_OUTPUT_COLOR_PRIMARIES, (amf_int64)avctx->color_primaries);
++
++
++
+     // Picture control properties
+     AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, ctx->gops_per_idr);
+     AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_GOP_SIZE, avctx->gop_size);
+-- 
+2.39.3 (Apple Git-145)
+

--- a/res/vcpkg/ffmpeg/7.0/0001-android-mediacodec-encode-align-64.patch
+++ b/res/vcpkg/ffmpeg/7.0/0001-android-mediacodec-encode-align-64.patch
@@ -1,0 +1,40 @@
+From be3d9d8092720bbe4239212648d2e9c4ffd7f40c Mon Sep 17 00:00:00 2001
+From: 21pages <pages21@163.com>
+Date: Wed, 22 May 2024 17:09:28 +0800
+Subject: [PATCH] android mediacodec encode align 64
+
+Signed-off-by: 21pages <pages21@163.com>
+---
+ libavcodec/mediacodecenc.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/libavcodec/mediacodecenc.c b/libavcodec/mediacodecenc.c
+index 984014f1b1..8dcd3dcd64 100644
+--- a/libavcodec/mediacodecenc.c
++++ b/libavcodec/mediacodecenc.c
+@@ -200,16 +200,17 @@ static av_cold int mediacodec_init(AVCodecContext *avctx)
+     ff_AMediaFormat_setString(format, "mime", codec_mime);
+     // Workaround the alignment requirement of mediacodec. We can't do it
+     // silently for AV_PIX_FMT_MEDIACODEC.
++    const int align = 64;
+     if (avctx->pix_fmt != AV_PIX_FMT_MEDIACODEC) {
+-        s->width = FFALIGN(avctx->width, 16);
+-        s->height = FFALIGN(avctx->height, 16);
++        s->width = FFALIGN(avctx->width, align);
++        s->height = FFALIGN(avctx->height, align);
+     } else {
+         s->width = avctx->width;
+         s->height = avctx->height;
+-        if (s->width % 16 || s->height % 16)
++        if (s->width % align || s->height % align)
+             av_log(avctx, AV_LOG_WARNING,
+-                    "Video size %dx%d isn't align to 16, it may have device compatibility issue\n",
+-                    s->width, s->height);
++                    "Video size %dx%d isn't align to %d, it may have device compatibility issue\n",
++                    s->width, s->height, align);
+     }
+     ff_AMediaFormat_setInt32(format, "width", s->width);
+     ff_AMediaFormat_setInt32(format, "height", s->height);
+-- 
+2.34.1
+

--- a/res/vcpkg/ffmpeg/FindFFMPEG.cmake.in
+++ b/res/vcpkg/ffmpeg/FindFFMPEG.cmake.in
@@ -1,0 +1,161 @@
+# Distributed under the OSI-approved BSD 3-Clause License.
+#
+#.rst:
+# FindFFMPEG
+# --------
+#
+# Find the FFPMEG libraries
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# The following variables will be defined:
+#
+#  ``FFMPEG_FOUND``
+#    True if FFMPEG found on the local system
+#
+#  ``FFMPEG_INCLUDE_DIRS``
+#    Location of FFMPEG header files
+#
+#  ``FFMPEG_LIBRARY_DIRS``
+#    Location of FFMPEG libraries
+#
+#  ``FFMPEG_LIBRARIES``
+#    List of the FFMPEG libraries found
+#
+#
+
+include(FindPackageHandleStandardArgs)
+include(SelectLibraryConfigurations)
+include(CMakeFindDependencyMacro)
+
+if(NOT FFMPEG_FOUND)
+
+# Compute the installation path relative to this file.
+get_filename_component(SEARCH_PATH "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(SEARCH_PATH "${SEARCH_PATH}" PATH)
+get_filename_component(SEARCH_PATH "${SEARCH_PATH}" PATH)
+if(SEARCH_PATH STREQUAL "/")
+  set(SEARCH_PATH "")
+endif()
+
+set(FFMPEG_VERSION "@FFMPEG_VERSION@")
+
+function(append_dependencies out)
+    cmake_parse_arguments(PARSE_ARGV 1 "arg" "DEBUG" "NAMES" "")
+    if(${arg_DEBUG})
+        set(config DEBUG)
+        set(path "${CURRENT_INSTALLED_DIR}/debug/lib/")
+    else()
+        set(config RELEASE)
+        set(path "${CURRENT_INSTALLED_DIR}/lib/")
+    endif()
+    foreach(lib_name ${arg_NAMES})
+        if("${lib_name}" STREQUAL "-pthread")
+            list(APPEND ${out} "-pthread")
+        elseif("${lib_name}" STREQUAL "-pthreads")
+            list(APPEND ${out} "-pthreads")
+        elseif("${lib_name}" STREQUAL "gcc")
+            list(APPEND ${out} "-lgcc")
+        elseif("${lib_name}" STREQUAL "gcc_s")
+            list(APPEND ${out} "-lgcc_s")
+        elseif("${lib_name}" STREQUAL "stdc++")
+            list(APPEND ${out} "-lstdc++")
+        elseif("${lib_name}" STREQUAL "atomic")
+            list(APPEND ${out} "-latomic")
+        else()
+            # first look in ${path} specifically to ensure we find the right release/debug variant
+            find_library(FFMPEG_DEPENDENCY_${lib_name}_${config} NAMES "${lib_name}" PATHS "${path}" NO_DEFAULT_PATH)
+            # if not found there, must be a system dependency, so look elsewhere
+            find_library(FFMPEG_DEPENDENCY_${lib_name}_${config} NAMES "${lib_name}" REQUIRED)
+            list(APPEND ${out} "${FFMPEG_DEPENDENCY_${lib_name}_${config}}")
+        endif()
+    endforeach()
+    set("${out}" "${${out}}" PARENT_SCOPE)
+endfunction()
+
+macro(FFMPEG_FIND varname shortname headername)
+  if(NOT FFMPEG_${varname}_INCLUDE_DIRS)
+    find_path(FFMPEG_${varname}_INCLUDE_DIRS NAMES lib${shortname}/${headername} ${headername} PATHS ${SEARCH_PATH}/include NO_DEFAULT_PATH)
+  endif()
+  if(NOT FFMPEG_${varname}_LIBRARY)
+    find_library(FFMPEG_${varname}_LIBRARY_RELEASE NAMES ${shortname} PATHS ${SEARCH_PATH}/lib/ NO_DEFAULT_PATH)
+    find_library(FFMPEG_${varname}_LIBRARY_DEBUG NAMES ${shortname}d ${shortname} PATHS ${SEARCH_PATH}/debug/lib/ NO_DEFAULT_PATH)
+    get_filename_component(FFMPEG_${varname}_LIBRARY_RELEASE_DIR ${FFMPEG_${varname}_LIBRARY_RELEASE} DIRECTORY)
+    get_filename_component(FFMPEG_${varname}_LIBRARY_DEBUG_DIR ${FFMPEG_${varname}_LIBRARY_DEBUG} DIRECTORY)
+    select_library_configurations(FFMPEG_${varname})
+    set(FFMPEG_${varname}_LIBRARY ${FFMPEG_${varname}_LIBRARY} CACHE STRING "")
+  endif()
+  if (FFMPEG_${varname}_LIBRARY AND FFMPEG_${varname}_INCLUDE_DIRS)
+    set(FFMPEG_${varname}_FOUND TRUE BOOL)
+    list(APPEND FFMPEG_INCLUDE_DIRS ${FFMPEG_${varname}_INCLUDE_DIRS})
+    list(APPEND FFMPEG_LIBRARIES ${FFMPEG_${varname}_LIBRARY})
+    list(APPEND FFMPEG_LIBRARY_DIRS ${FFMPEG_${varname}_LIBRARY_RELEASE_DIR} ${FFMPEG_${varname}_LIBRARY_DEBUG_DIR})
+  endif()
+endmacro(FFMPEG_FIND)
+
+if(@ENABLE_AVDEVICE@)
+  FFMPEG_FIND(libavdevice   avdevice   avdevice.h)
+endif()
+if(@ENABLE_AVFILTER@)
+  FFMPEG_FIND(libavfilter   avfilter   avfilter.h)
+endif()
+if(@ENABLE_AVFORMAT@)
+  FFMPEG_FIND(libavformat   avformat   avformat.h)
+endif()
+if(@ENABLE_AVCODEC@)
+  FFMPEG_FIND(libavcodec    avcodec    avcodec.h)
+endif()
+if(@ENABLE_POSTPROC@)
+  FFMPEG_FIND(libpostproc   postproc   postprocess.h)
+endif()
+if(@ENABLE_SWRESAMPLE@)
+  FFMPEG_FIND(libswresample swresample swresample.h)
+endif()
+if(@ENABLE_SWSCALE@)
+  FFMPEG_FIND(libswscale    swscale    swscale.h)
+endif()
+FFMPEG_FIND(libavutil       avutil     avutil.h)
+
+if (FFMPEG_libavutil_FOUND)
+  list(REMOVE_DUPLICATES FFMPEG_INCLUDE_DIRS)
+  list(REMOVE_DUPLICATES FFMPEG_LIBRARY_DIRS)
+  set(FFMPEG_libavutil_VERSION "@LIBAVUTIL_VERSION@" CACHE STRING "")
+
+  if(FFMPEG_libavcodec_FOUND)
+    set(FFMPEG_libavcodec_VERSION "@LIBAVCODEC_VERSION@" CACHE STRING "")
+  endif()
+  if(FFMPEG_libavdevice_FOUND)
+    set(FFMPEG_libavdevice_VERSION "@LIBAVDEVICE_VERSION@" CACHE STRING "")
+  endif()
+  if(FFMPEG_libavfilter_FOUND)
+    set(FFMPEG_libavfilter_VERSION "@LIBAVFILTER_VERSION@" CACHE STRING "")
+  endif()
+  if(FFMPEG_libavformat_FOUND)
+    set(FFMPEG_libavformat_VERSION "@LIBAVFORMAT_VERSION@" CACHE STRING "")
+  endif()
+  if(FFMPEG_libswresample_FOUND)
+    set(FFMPEG_libswresample_VERSION "@LIBSWRESAMPLE_VERSION@" CACHE STRING "")
+  endif()
+  if(FFMPEG_libswscale_FOUND)
+    set(FFMPEG_libswscale_VERSION "@LIBSWSCALE_VERSION@" CACHE STRING "")
+  endif()
+
+  append_dependencies(FFMPEG_DEPS_LIBRARY_RELEASE NAMES "@FFMPEG_DEPENDENCIES_RELEASE@")
+  append_dependencies(FFMPEG_DEPS_LIBRARY_DEBUG   NAMES "@FFMPEG_DEPENDENCIES_DEBUG@" DEBUG)
+  if(FFMPEG_DEPS_LIBRARY_RELEASE OR FFMPEG_DEPS_LIBRARY_DEBUG)
+    select_library_configurations(FFMPEG_DEPS)
+    list(APPEND FFMPEG_LIBRARIES ${FFMPEG_DEPS_LIBRARY})
+  endif()
+
+  set(FFMPEG_LIBRARY ${FFMPEG_LIBRARIES})
+
+  set(FFMPEG_FOUND TRUE CACHE BOOL "")
+  set(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} CACHE STRING "")
+  set(FFMPEG_INCLUDE_DIRS ${FFMPEG_INCLUDE_DIRS} CACHE STRING "")
+  set(FFMPEG_LIBRARY_DIRS ${FFMPEG_LIBRARY_DIRS} CACHE STRING "")
+endif()
+
+find_package_handle_standard_args(FFMPEG REQUIRED_VARS FFMPEG_LIBRARIES FFMPEG_LIBRARY_DIRS FFMPEG_INCLUDE_DIRS)
+
+endif()

--- a/res/vcpkg/ffmpeg/build.sh.in
+++ b/res/vcpkg/ffmpeg/build.sh.in
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+set -e
+
+export PATH="$PATH:/usr/bin"
+
+command -v cygpath >/dev/null && have_cygpath=1
+
+cygpath() {
+    if [ -n "$have_cygpath" ]; then
+        command cygpath "$@"
+    else
+        eval _p='$'$#
+        printf '%s\n' "$_p"
+    fi
+}
+
+move_binary() {
+    SOURCE=$1
+    TARGET=$2
+    BINARY=$3
+
+    # run lipo over the command to check whether it really
+    # is a binary that we need to merge architectures
+    lipo $SOURCE/$BINARY -info &> /dev/null || return 0
+
+    # get the directory name the file is in
+    DIRNAME=$(dirname $BINARY)
+
+    # ensure the directory to move the binary to exists
+    mkdir -p $TARGET/$DIRNAME
+
+    # now finally move the binary
+    mv $SOURCE/$BINARY $TARGET/$BINARY
+}
+
+move_binaries() {
+    SOURCE=$1
+    TARGET=$2
+
+    [ ! -d $SOURCE ] && return 0
+    pushd $SOURCE
+
+    for BINARY in $(find . -type f); do
+        move_binary $SOURCE $TARGET $BINARY
+    done
+
+    popd
+}
+
+merge_binaries() {
+    TARGET=$1
+    SOURCE=$2
+
+    shift
+    shift
+
+    pushd $SOURCE/$1
+    BINARIES=$(find . -type f)
+    popd
+
+    for BINARY in $BINARIES; do
+        COMMAND="lipo -create -output $TARGET/$BINARY"
+
+        for ARCH in $@; do
+            COMMAND="$COMMAND -arch $ARCH $SOURCE/$ARCH/$BINARY"
+        done
+
+        $($COMMAND)
+    done
+}
+
+export PKG_CONFIG_PATH="$(cygpath -p "${PKG_CONFIG_PATH}")"
+
+# Export HTTP(S)_PROXY as http(s)_proxy:
+[ -n "$HTTP_PROXY"  ] && export http_proxy="$HTTP_PROXY"
+[ -n "$HTTPS_PROXY" ] && export https_proxy="$HTTPS_PROXY"
+
+PATH_TO_BUILD_DIR=$(  cygpath "@BUILD_DIR@")
+PATH_TO_SRC_DIR=$(    cygpath "@SOURCE_PATH@")
+PATH_TO_PACKAGE_DIR=$(cygpath "@INST_PREFIX@")
+
+JOBS=@VCPKG_CONCURRENCY@
+
+OSX_ARCHS="@OSX_ARCHS@"
+OSX_ARCH_COUNT=0@OSX_ARCH_COUNT@
+
+# Default to hardware concurrency if unset.
+: ${JOBS:=$(nproc)}
+
+# Disable asm and x86asm on all android targets because they trigger build failures:
+# arm64 Android build fails with 'relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol ff_cos_32; recompile with -fPIC'
+# x86 Android build fails with 'error: inline assembly requires more registers than available'.
+# x64 Android build fails with 'relocation R_X86_64_PC32 cannot be used against symbol ff_h264_cabac_tables; recompile with -fPIC'
+if [ "@VCPKG_CMAKE_SYSTEM_NAME@" = "Android" ]; then
+    OPTIONS_arm=" --disable-asm --disable-x86asm"
+    OPTIONS_arm64=" --disable-asm --disable-x86asm"
+    OPTIONS_x86=" --disable-asm --disable-x86asm"
+    OPTIONS_x86_64="${OPTIONS_x86}"
+else
+    OPTIONS_arm=" --disable-asm --disable-x86asm"
+    OPTIONS_arm64=" --enable-asm --disable-x86asm"
+    OPTIONS_x86=" --enable-asm --enable-x86asm"
+    OPTIONS_x86_64="${OPTIONS_x86}"
+fi
+
+build_ffmpeg() {
+    # extract build architecture
+    BUILD_ARCH=$1
+    shift
+
+    echo "BUILD_ARCH=${BUILD_ARCH}"
+
+    # get architecture-specific options
+    OPTION_VARIABLE="OPTIONS_${BUILD_ARCH}"
+    echo "OPTION_VARIABLE=${OPTION_VARIABLE}"
+
+    echo "=== CONFIGURING ==="
+
+    sh "$PATH_TO_SRC_DIR/configure" "--prefix=$PATH_TO_PACKAGE_DIR" @CONFIGURE_OPTIONS@ --arch=${BUILD_ARCH} ${!OPTION_VARIABLE} $@
+
+    echo "=== BUILDING ==="
+
+    make -j${JOBS} V=1
+
+    echo "=== INSTALLING ==="
+
+    make install
+}
+
+cd "$PATH_TO_BUILD_DIR"
+
+if [ $OSX_ARCH_COUNT -gt 0 ]; then
+    for ARCH in $OSX_ARCHS; do
+        echo "=== CLEANING FOR $ARCH ==="
+
+        make clean && make distclean
+
+        build_ffmpeg $ARCH --extra-cflags=-arch --extra-cflags=$ARCH --extra-ldflags=-arch --extra-ldflags=$ARCH
+
+        echo "=== COLLECTING BINARIES FOR $ARCH ==="
+
+        move_binaries $PATH_TO_PACKAGE_DIR/lib $PATH_TO_BUILD_DIR/stage/$ARCH/lib
+        move_binaries $PATH_TO_PACKAGE_DIR/bin $PATH_TO_BUILD_DIR/stage/$ARCH/bin
+    done
+
+    echo "=== MERGING ARCHITECTURES ==="
+
+    merge_binaries $PATH_TO_PACKAGE_DIR $PATH_TO_BUILD_DIR/stage $OSX_ARCHS
+else
+    build_ffmpeg @BUILD_ARCH@
+fi

--- a/res/vcpkg/ffmpeg/portfile.cmake
+++ b/res/vcpkg/ffmpeg/portfile.cmake
@@ -1,0 +1,682 @@
+if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_LINUX)
+    set(FF_VERSION "n5.1.5")
+    set(FF_SHA512 "a933f18e53207ccc277b42c9a68db00f31cefec555e6d5d7c57db3409023b2c38fd93ebe2ccfcd17ba2397adb912e93f2388241ca970b7d8bd005ccfe86d5679")
+else()
+    set(FF_VERSION "n7.0.1")
+    set(FF_SHA512 "1212ebcb78fdaa103b0304373d374e41bf1fe680e1fa4ce0f60624857491c26b4dda004c490c3ef32d4a0e10f42ae6b54546f9f318e2dcfbaa116117f687bc88")
+endif()
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ffmpeg/ffmpeg
+    REF "${FF_VERSION}"
+    SHA512 "${FF_SHA512}"
+    HEAD_REF master
+    PATCHES
+    0002-fix-msvc-link.patch # upstreamed in future version
+    0003-fix-windowsinclude.patch
+    0005-fix-nasm.patch # upstreamed in future version
+    0012-Fix-ssl-110-detection.patch
+    0013-define-WINVER.patch
+)
+
+if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_LINUX)
+    vcpkg_apply_patches(
+        SOURCE_PATH ${SOURCE_PATH}
+        PATCHES
+            ${CMAKE_CURRENT_LIST_DIR}/5.1/0001-avcodec-amfenc-add-query_timeout-option-for-h264-hev.patch
+            ${CMAKE_CURRENT_LIST_DIR}/5.1/0002-libavcodec-amfenc-reconfig-when-bitrate-change.patch
+            ${CMAKE_CURRENT_LIST_DIR}/5.1/0003-use-release-7.0-s-qsvenc-update_bitrate.patch
+            ${CMAKE_CURRENT_LIST_DIR}/5.1/0004-amf-colorspace.patch
+    )
+elseif(VCPKG_TARGET_IS_ANDROID)
+    vcpkg_apply_patches(
+        SOURCE_PATH ${SOURCE_PATH}
+        PATCHES
+            ${CMAKE_CURRENT_LIST_DIR}/7.0/0001-android-mediacodec-encode-align-64.patch
+    )
+endif()
+
+if(SOURCE_PATH MATCHES " ")
+    message(FATAL_ERROR "Error: ffmpeg will not build with spaces in the path. Please use a directory with no spaces")
+endif()
+
+if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "wasm32")
+    vcpkg_find_acquire_program(NASM)
+    get_filename_component(NASM_EXE_PATH "${NASM}" DIRECTORY)
+    vcpkg_add_to_path("${NASM_EXE_PATH}")
+endif()
+
+set(OPTIONS "\
+--disable-shared \
+--enable-static \
+--enable-pic \
+--disable-everything \
+--disable-programs \
+--disable-doc \
+--disable-htmlpages \
+--disable-manpages \
+--disable-podpages \
+--disable-txtpages \
+--disable-network \
+--disable-appkit \
+--disable-coreimage \
+--disable-metal \
+--disable-sdl2 \
+--disable-securetransport \
+--disable-vulkan \
+--disable-audiotoolbox \
+--disable-v4l2-m2m \
+--disable-debug \
+--disable-valgrind-backtrace \
+--disable-large-tests \
+--disable-avdevice \
+--enable-avcodec \
+--enable-avformat \
+--disable-avfilter \
+--disable-swresample \
+--disable-swscale \
+--disable-postproc \
+--enable-decoder=h264 \
+--enable-decoder=hevc \
+--enable-parser=h264 \
+--enable-parser=hevc \
+--enable-bsf=h264_mp4toannexb \
+--enable-bsf=hevc_mp4toannexb  \
+--enable-bsf=h264_metadata \
+--enable-bsf=hevc_metadata \
+--enable-muxer=mp4 \
+--enable-protocol=file \
+")
+
+if(VCPKG_HOST_IS_WINDOWS)
+    vcpkg_acquire_msys(MSYS_ROOT PACKAGES automake1.16)
+    set(SHELL "${MSYS_ROOT}/usr/bin/bash.exe")
+    vcpkg_add_to_path("${MSYS_ROOT}/usr/share/automake-1.16")
+    string(APPEND OPTIONS " --pkg-config=${CURRENT_HOST_INSTALLED_DIR}/tools/pkgconf/pkgconf${VCPKG_HOST_EXECUTABLE_SUFFIX}")
+else()
+    find_program(SHELL bash)
+endif()
+
+if(VCPKG_TARGET_IS_LINUX)
+    string(APPEND OPTIONS  "\
+--target-os=linux \
+--enable-pthreads \
+--enable-cuda \
+--enable-cuda_llvm \
+--enable-ffnvcodec \
+--enable-encoder=h264_nvenc \
+--enable-encoder=hevc_nvenc \
+--enable-hwaccel=h264_nvdec \
+--enable-hwaccel=hevc_nvdec \
+--enable-amf  \
+--enable-encoder=h264_amf \
+--enable-encoder=hevc_amf \
+--enable-hwaccel=h264_vaapi \
+--enable-hwaccel=hevc_vaapi \
+--enable-encoder=h264_vaapi \
+--enable-encoder=hevc_vaapi \
+")
+elseif(VCPKG_TARGET_IS_WINDOWS)
+    string(APPEND OPTIONS "\
+--target-os=win32 \
+--toolchain=msvc \
+--enable-gpl \
+--enable-d3d11va \
+--enable-cuda \
+--enable-ffnvcodec \
+--enable-hwaccel=h264_nvdec \
+--enable-hwaccel=hevc_nvdec \
+--enable-hwaccel=h264_d3d11va \
+--enable-hwaccel=hevc_d3d11va \
+--enable-hwaccel=h264_d3d11va2 \
+--enable-hwaccel=hevc_d3d11va2 \
+--enable-amf \
+--enable-encoder=h264_amf \
+--enable-encoder=hevc_amf \
+--enable-encoder=h264_nvenc \
+--enable-encoder=hevc_nvenc \
+--enable-libmfx \
+--enable-encoder=h264_qsv \
+--enable-encoder=hevc_qsv \
+")    
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+        set(LIB_MACHINE_ARG /machine:x86)
+        string(APPEND OPTIONS " --arch=i686 --enable-cross-compile")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        set(LIB_MACHINE_ARG /machine:x64)
+        string(APPEND OPTIONS " --arch=x86_64")
+    else()
+        message(FATAL_ERROR "Unsupported target architecture")
+    endif()
+elseif(VCPKG_TARGET_IS_OSX)
+    string(APPEND OPTIONS "\
+--disable-autodetect \
+--enable-videotoolbox \
+--enable-encoder=h264_videotoolbox,hevc_videotoolbox \
+--enable-hwaccel=h264_videotoolbox,hevc_videotoolbox \
+")
+elseif(VCPKG_TARGET_IS_IOS)
+    string(APPEND OPTIONS "\
+--arch=arm64 \
+--disable-autodetect \
+--disable-hwaccels \
+--disable-encoders \
+--disable-videotoolbox \
+--extra-cflags=\"-arch arm64 -mios-version-min=8.0 -fembed-bitcode\" \
+--extra-ldflags=\"-arch arm64 -mios-version-min=8.0 -fembed-bitcode\" \
+")
+elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Android")
+    string(APPEND OPTIONS "\
+--target-os=android \
+--disable-asm \
+--enable-jni \
+--enable-mediacodec \
+--disable-hwaccels \
+--enable-encoder=h264_mediacodec \
+--enable-encoder=hevc_mediacodec \
+--enable-decoder=h264_mediacodec \
+--enable-decoder=hevc_mediacodec \
+")
+endif()
+
+if(VCPKG_TARGET_IS_OSX)
+    list(JOIN VCPKG_OSX_ARCHITECTURES " " OSX_ARCHS)
+    list(LENGTH VCPKG_OSX_ARCHITECTURES OSX_ARCH_COUNT)
+endif()
+
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+if(VCPKG_DETECTED_MSVC)
+    string(APPEND OPTIONS " --disable-inline-asm") # clang-cl has inline assembly but this leads to undefined symbols.
+    set(OPTIONS "--toolchain=msvc ${OPTIONS}")
+
+    # This is required because ffmpeg depends upon optimizations to link correctly
+    string(APPEND VCPKG_COMBINED_C_FLAGS_DEBUG " -O2")
+    string(REGEX REPLACE "(^| )-RTC1( |$)" " " VCPKG_COMBINED_C_FLAGS_DEBUG "${VCPKG_COMBINED_C_FLAGS_DEBUG}")
+    string(REGEX REPLACE "(^| )-Od( |$)" " " VCPKG_COMBINED_C_FLAGS_DEBUG "${VCPKG_COMBINED_C_FLAGS_DEBUG}")
+    string(REGEX REPLACE "(^| )-Ob0( |$)" " " VCPKG_COMBINED_C_FLAGS_DEBUG "${VCPKG_COMBINED_C_FLAGS_DEBUG}")
+endif()
+
+string(APPEND VCPKG_COMBINED_C_FLAGS_DEBUG " -I \"${CURRENT_INSTALLED_DIR}/include\"")
+string(APPEND VCPKG_COMBINED_C_FLAGS_RELEASE " -I \"${CURRENT_INSTALLED_DIR}/include\"")
+
+# # Setup vcpkg toolchain
+set(prog_env "")
+
+if(VCPKG_DETECTED_CMAKE_C_COMPILER)
+    get_filename_component(CC_path "${VCPKG_DETECTED_CMAKE_C_COMPILER}" DIRECTORY)
+    get_filename_component(CC_filename "${VCPKG_DETECTED_CMAKE_C_COMPILER}" NAME)
+    set(ENV{CC} "${CC_filename}")
+    string(APPEND OPTIONS " --cc=${CC_filename}")
+
+    # string(APPEND OPTIONS " --host_cc=${CC_filename}") ffmpeg not yet setup for cross builds?
+    list(APPEND prog_env "${CC_path}")
+endif()
+
+if(VCPKG_DETECTED_CMAKE_CXX_COMPILER)
+    get_filename_component(CXX_path "${VCPKG_DETECTED_CMAKE_CXX_COMPILER}" DIRECTORY)
+    get_filename_component(CXX_filename "${VCPKG_DETECTED_CMAKE_CXX_COMPILER}" NAME)
+    set(ENV{CXX} "${CXX_filename}")
+    string(APPEND OPTIONS " --cxx=${CXX_filename}")
+
+    # string(APPEND OPTIONS " --host_cxx=${CC_filename}")
+    list(APPEND prog_env "${CXX_path}")
+endif()
+
+if(VCPKG_DETECTED_CMAKE_RC_COMPILER)
+    get_filename_component(RC_path "${VCPKG_DETECTED_CMAKE_RC_COMPILER}" DIRECTORY)
+    get_filename_component(RC_filename "${VCPKG_DETECTED_CMAKE_RC_COMPILER}" NAME)
+    set(ENV{WINDRES} "${RC_filename}")
+    string(APPEND OPTIONS " --windres=${RC_filename}")
+    list(APPEND prog_env "${RC_path}")
+endif()
+
+if(VCPKG_DETECTED_CMAKE_LINKER AND VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    get_filename_component(LD_path "${VCPKG_DETECTED_CMAKE_LINKER}" DIRECTORY)
+    get_filename_component(LD_filename "${VCPKG_DETECTED_CMAKE_LINKER}" NAME)
+    set(ENV{LD} "${LD_filename}")
+    string(APPEND OPTIONS " --ld=${LD_filename}")
+
+    # string(APPEND OPTIONS " --host_ld=${LD_filename}")
+    list(APPEND prog_env "${LD_path}")
+endif()
+
+if(VCPKG_DETECTED_CMAKE_NM)
+    get_filename_component(NM_path "${VCPKG_DETECTED_CMAKE_NM}" DIRECTORY)
+    get_filename_component(NM_filename "${VCPKG_DETECTED_CMAKE_NM}" NAME)
+    set(ENV{NM} "${NM_filename}")
+    string(APPEND OPTIONS " --nm=${NM_filename}")
+    list(APPEND prog_env "${NM_path}")
+endif()
+
+if(VCPKG_DETECTED_CMAKE_AR)
+    get_filename_component(AR_path "${VCPKG_DETECTED_CMAKE_AR}" DIRECTORY)
+    get_filename_component(AR_filename "${VCPKG_DETECTED_CMAKE_AR}" NAME)
+
+    if(AR_filename MATCHES [[^(llvm-)?lib\.exe$]])
+        set(ENV{AR} "ar-lib ${AR_filename}")
+        string(APPEND OPTIONS " --ar='ar-lib ${AR_filename}'")
+    else()
+        set(ENV{AR} "${AR_filename}")
+        string(APPEND OPTIONS " --ar='${AR_filename}'")
+    endif()
+
+    list(APPEND prog_env "${AR_path}")
+endif()
+
+if(VCPKG_DETECTED_CMAKE_RANLIB)
+    get_filename_component(RANLIB_path "${VCPKG_DETECTED_CMAKE_RANLIB}" DIRECTORY)
+    get_filename_component(RANLIB_filename "${VCPKG_DETECTED_CMAKE_RANLIB}" NAME)
+    set(ENV{RANLIB} "${RANLIB_filename}")
+    string(APPEND OPTIONS " --ranlib=${RANLIB_filename}")
+    list(APPEND prog_env "${RANLIB_path}")
+endif()
+
+if(VCPKG_DETECTED_CMAKE_STRIP)
+    get_filename_component(STRIP_path "${VCPKG_DETECTED_CMAKE_STRIP}" DIRECTORY)
+    get_filename_component(STRIP_filename "${VCPKG_DETECTED_CMAKE_STRIP}" NAME)
+    set(ENV{STRIP} "${STRIP_filename}")
+    string(APPEND OPTIONS " --strip=${STRIP_filename}")
+    list(APPEND prog_env "${STRIP_path}")
+endif()
+
+list(REMOVE_DUPLICATES prog_env)
+vcpkg_add_to_path(PREPEND ${prog_env})
+
+# More? OBJCC BIN2C
+file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg" "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
+
+set(FFMPEG_PKGCONFIG_MODULES libavutil)
+
+set(OPTIONS_CROSS "--enable-cross-compile")
+
+# ffmpeg needs --cross-prefix option to use appropriate tools for cross-compiling.
+if(VCPKG_DETECTED_CMAKE_C_COMPILER MATCHES "([^\/]*-)gcc$")
+    string(APPEND OPTIONS_CROSS " --cross-prefix=${CMAKE_MATCH_1}")
+endif()
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    set(BUILD_ARCH "x86_64")
+else()
+    set(BUILD_ARCH ${VCPKG_TARGET_ARCHITECTURE})
+endif()
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    if(VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_find_acquire_program(GASPREPROCESSOR)
+
+        foreach(GAS_PATH ${GASPREPROCESSOR})
+            get_filename_component(GAS_ITEM_PATH ${GAS_PATH} DIRECTORY)
+            vcpkg_add_to_path("${GAS_ITEM_PATH}")
+        endforeach(GAS_PATH)
+    endif()
+endif()
+
+set(OPTIONS_DEBUG "--disable-optimizations")
+set(OPTIONS_RELEASE "--enable-optimizations")
+
+set(OPTIONS "${OPTIONS} ${OPTIONS_CROSS}")
+
+if(VCPKG_TARGET_IS_MINGW)
+    set(OPTIONS "${OPTIONS} --extra_cflags=-D_WIN32_WINNT=0x0601")
+elseif(VCPKG_TARGET_IS_WINDOWS)
+    set(OPTIONS "${OPTIONS} --extra-cflags=-DHAVE_UNISTD_H=0")
+endif()
+
+vcpkg_find_acquire_program(PKGCONFIG)
+set(OPTIONS "${OPTIONS} --pkg-config=${PKGCONFIG}")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    set(OPTIONS "${OPTIONS} --pkg-config-flags=--static")
+endif()
+
+message(STATUS "Building Options: ${OPTIONS}")
+
+# Release build
+if(NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+    if(VCPKG_DETECTED_MSVC)
+        set(OPTIONS_RELEASE "${OPTIONS_RELEASE} --extra-ldflags=-libpath:\"${CURRENT_INSTALLED_DIR}/lib\"")
+    else()
+        set(OPTIONS_RELEASE "${OPTIONS_RELEASE} --extra-ldflags=-L\"${CURRENT_INSTALLED_DIR}/lib\"")
+    endif()
+
+    message(STATUS "Building Release Options: ${OPTIONS_RELEASE}")
+    set(ENV{PKG_CONFIG_PATH} "${CURRENT_INSTALLED_DIR}/lib/pkgconfig")
+    message(STATUS "Building ${PORT} for Release")
+    file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
+
+    # We use response files here as the only known way to handle spaces in paths
+    set(crsp "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/cflags.rsp")
+    string(REGEX REPLACE "-arch [A-Za-z0-9_]+" "" VCPKG_COMBINED_C_FLAGS_RELEASE_SANITIZED "${VCPKG_COMBINED_C_FLAGS_RELEASE}")
+    file(WRITE "${crsp}" "${VCPKG_COMBINED_C_FLAGS_RELEASE_SANITIZED}")
+    set(ldrsp "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/ldflags.rsp")
+    string(REGEX REPLACE "-arch [A-Za-z0-9_]+" "" VCPKG_COMBINED_SHARED_LINKER_FLAGS_RELEASE_SANITIZED "${VCPKG_COMBINED_SHARED_LINKER_FLAGS_RELEASE}")
+    file(WRITE "${ldrsp}" "${VCPKG_COMBINED_SHARED_LINKER_FLAGS_RELEASE_SANITIZED}")
+    set(ENV{CFLAGS} "@${crsp}")
+
+    # All tools except the msvc arm{,64} assembler accept @... as response file syntax.
+    # For that assembler, there is no known way to pass in flags. We must hope that not passing flags will work acceptably.
+    if(NOT VCPKG_DETECTED_MSVC OR NOT VCPKG_TARGET_ARCHITECTURE MATCHES "^arm")
+        set(ENV{ASFLAGS} "@${crsp}")
+    endif()
+
+    set(ENV{LDFLAGS} "@${ldrsp}")
+    set(ENV{ARFLAGS} "${VCPKG_COMBINED_STATIC_LINKER_FLAGS_RELEASE}")
+
+    set(BUILD_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel")
+    set(CONFIGURE_OPTIONS "${OPTIONS} ${OPTIONS_RELEASE}")
+    set(INST_PREFIX "${CURRENT_PACKAGES_DIR}")
+
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/build.sh.in" "${BUILD_DIR}/build.sh" @ONLY)
+
+    z_vcpkg_setup_pkgconfig_path(CONFIG RELEASE)
+
+    vcpkg_execute_required_process(
+        COMMAND "${SHELL}" ./build.sh
+        WORKING_DIRECTORY "${BUILD_DIR}"
+        LOGNAME "build-${TARGET_TRIPLET}-rel"
+        SAVE_LOG_FILES ffbuild/config.log
+    )
+
+    z_vcpkg_restore_pkgconfig_path()
+endif()
+
+# Debug build
+if(NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    if(VCPKG_DETECTED_MSVC)
+        set(OPTIONS_DEBUG "${OPTIONS_DEBUG} --extra-ldflags=-libpath:\"${CURRENT_INSTALLED_DIR}/debug/lib\"")
+    else()
+        set(OPTIONS_DEBUG "${OPTIONS_DEBUG} --extra-ldflags=-L\"${CURRENT_INSTALLED_DIR}/debug/lib\"")
+    endif()
+
+    message(STATUS "Building Debug Options: ${OPTIONS_DEBUG}")
+    set(ENV{LDFLAGS} "${VCPKG_COMBINED_SHARED_LINKER_FLAGS_DEBUG}")
+    set(ENV{PKG_CONFIG_PATH} "${CURRENT_INSTALLED_DIR}/debug/lib/pkgconfig")
+    message(STATUS "Building ${PORT} for Debug")
+    file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
+    set(crsp "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/cflags.rsp")
+    string(REGEX REPLACE "-arch [A-Za-z0-9_]+" "" VCPKG_COMBINED_C_FLAGS_DEBUG_SANITIZED "${VCPKG_COMBINED_C_FLAGS_DEBUG}")
+    file(WRITE "${crsp}" "${VCPKG_COMBINED_C_FLAGS_DEBUG_SANITIZED}")
+    set(ldrsp "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/ldflags.rsp")
+    string(REGEX REPLACE "-arch [A-Za-z0-9_]+" "" VCPKG_COMBINED_SHARED_LINKER_FLAGS_DEBUG_SANITIZED "${VCPKG_COMBINED_SHARED_LINKER_FLAGS_DEBUG}")
+    file(WRITE "${ldrsp}" "${VCPKG_COMBINED_SHARED_LINKER_FLAGS_DEBUG_SANITIZED}")
+    set(ENV{CFLAGS} "@${crsp}")
+
+    if(NOT VCPKG_DETECTED_MSVC OR NOT VCPKG_TARGET_ARCHITECTURE MATCHES "^arm")
+        set(ENV{ASFLAGS} "@${crsp}")
+    endif()
+
+    set(ENV{LDFLAGS} "@${ldrsp}")
+    set(ENV{ARFLAGS} "${VCPKG_COMBINED_STATIC_LINKER_FLAGS_DEBUG}")
+
+    set(BUILD_DIR "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg")
+    set(CONFIGURE_OPTIONS "${OPTIONS} ${OPTIONS_DEBUG}")
+    set(INST_PREFIX "${CURRENT_PACKAGES_DIR}/debug")
+
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/build.sh.in" "${BUILD_DIR}/build.sh" @ONLY)
+
+    z_vcpkg_setup_pkgconfig_path(CONFIG DEBUG)
+
+    vcpkg_execute_required_process(
+        COMMAND "${SHELL}" ./build.sh
+        WORKING_DIRECTORY "${BUILD_DIR}"
+        LOGNAME "build-${TARGET_TRIPLET}-dbg"
+        SAVE_LOG_FILES ffbuild/config.log
+    )
+
+    z_vcpkg_restore_pkgconfig_path()
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(GLOB DEF_FILES "${CURRENT_PACKAGES_DIR}/lib/*.def" "${CURRENT_PACKAGES_DIR}/debug/lib/*.def")
+
+    if(NOT VCPKG_TARGET_IS_MINGW)
+        if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+            set(LIB_MACHINE_ARG /machine:ARM)
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+            set(LIB_MACHINE_ARG /machine:ARM64)
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+            set(LIB_MACHINE_ARG /machine:x86)
+        elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+            set(LIB_MACHINE_ARG /machine:x64)
+        else()
+            message(FATAL_ERROR "Unsupported target architecture")
+        endif()
+
+        foreach(DEF_FILE ${DEF_FILES})
+            get_filename_component(DEF_FILE_DIR "${DEF_FILE}" DIRECTORY)
+            get_filename_component(DEF_FILE_NAME "${DEF_FILE}" NAME)
+            string(REGEX REPLACE "-[0-9]*\\.def" "${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}" OUT_FILE_NAME "${DEF_FILE_NAME}")
+            file(TO_NATIVE_PATH "${DEF_FILE}" DEF_FILE_NATIVE)
+            file(TO_NATIVE_PATH "${DEF_FILE_DIR}/${OUT_FILE_NAME}" OUT_FILE_NATIVE)
+            message(STATUS "Generating ${OUT_FILE_NATIVE}")
+            vcpkg_execute_required_process(
+                COMMAND lib.exe "/def:${DEF_FILE_NATIVE}" "/out:${OUT_FILE_NATIVE}" ${LIB_MACHINE_ARG}
+                WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}"
+                LOGNAME "libconvert-${TARGET_TRIPLET}"
+            )
+        endforeach()
+    endif()
+
+    file(GLOB EXP_FILES "${CURRENT_PACKAGES_DIR}/lib/*.exp" "${CURRENT_PACKAGES_DIR}/debug/lib/*.exp")
+    file(GLOB LIB_FILES "${CURRENT_PACKAGES_DIR}/bin/*${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}" "${CURRENT_PACKAGES_DIR}/debug/bin/*${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
+
+    if(VCPKG_TARGET_IS_MINGW)
+        file(GLOB LIB_FILES_2 "${CURRENT_PACKAGES_DIR}/bin/*.lib" "${CURRENT_PACKAGES_DIR}/debug/bin/*.lib")
+    endif()
+
+    set(files_to_remove ${EXP_FILES} ${LIB_FILES} ${LIB_FILES_2} ${DEF_FILES})
+
+    if(files_to_remove)
+        file(REMOVE ${files_to_remove})
+    endif()
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include" "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_copy_pdbs()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(_dirs "/")
+
+    if(NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        list(APPEND _dirs "/debug/")
+    endif()
+
+    foreach(_debug IN LISTS _dirs)
+        foreach(PKGCONFIG_MODULE IN LISTS FFMPEG_PKGCONFIG_MODULES)
+            set(PKGCONFIG_FILE "${CURRENT_PACKAGES_DIR}${_debug}lib/pkgconfig/${PKGCONFIG_MODULE}.pc")
+
+            # remove redundant cygwin style -libpath entries
+            execute_process(
+                COMMAND "${MSYS_ROOT}/usr/bin/cygpath.exe" -u "${CURRENT_INSTALLED_DIR}"
+                OUTPUT_VARIABLE CYG_INSTALLED_DIR
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+            vcpkg_replace_string("${PKGCONFIG_FILE}" "-libpath:${CYG_INSTALLED_DIR}${_debug}lib/pkgconfig/../../lib " "")
+
+            # transform libdir, includedir, and prefix paths from cygwin style to windows style
+            file(READ "${PKGCONFIG_FILE}" PKGCONFIG_CONTENT)
+
+            foreach(PATH_NAME prefix libdir includedir)
+                string(REGEX MATCH "${PATH_NAME}=[^\n]*" PATH_VALUE "${PKGCONFIG_CONTENT}")
+                string(REPLACE "${PATH_NAME}=" "" PATH_VALUE "${PATH_VALUE}")
+
+                if(NOT PATH_VALUE)
+                    message(FATAL_ERROR "failed to find pkgconfig variable ${PATH_NAME}")
+                endif()
+
+                execute_process(
+                    COMMAND "${MSYS_ROOT}/usr/bin/cygpath.exe" -w "${PATH_VALUE}"
+                    OUTPUT_VARIABLE FIXED_PATH
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                )
+                file(TO_CMAKE_PATH "${FIXED_PATH}" FIXED_PATH)
+                vcpkg_replace_string("${PKGCONFIG_FILE}" "${PATH_NAME}=${PATH_VALUE}" "${PATH_NAME}=${FIXED_PATH}")
+            endforeach()
+
+            # list libraries with -l flag (so pkgconf knows they are libraries and not just linker flags)
+            foreach(LIBS_ENTRY Libs Libs.private)
+                string(REGEX MATCH "${LIBS_ENTRY}: [^\n]*" LIBS_VALUE "${PKGCONFIG_CONTENT}")
+
+                if(NOT LIBS_VALUE)
+                    message(FATAL_ERROR "failed to find pkgconfig entry ${LIBS_ENTRY}")
+                endif()
+
+                string(REPLACE "${LIBS_ENTRY}: " "" LIBS_VALUE "${LIBS_VALUE}")
+
+                if(LIBS_VALUE)
+                    set(LIBS_VALUE_OLD "${LIBS_VALUE}")
+                    string(REGEX REPLACE "([^ ]+)[.]lib" "-l\\1" LIBS_VALUE "${LIBS_VALUE}")
+                    set(LIBS_VALUE_NEW "${LIBS_VALUE}")
+                    vcpkg_replace_string("${PKGCONFIG_FILE}" "${LIBS_ENTRY}: ${LIBS_VALUE_OLD}" "${LIBS_ENTRY}: ${LIBS_VALUE_NEW}")
+                endif()
+            endforeach()
+        endforeach()
+    endforeach()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+# Handle dependencies
+x_vcpkg_pkgconfig_get_modules(PREFIX FFMPEG_PKGCONFIG MODULES ${FFMPEG_PKGCONFIG_MODULES} LIBS)
+
+function(append_dependencies_from_libs out)
+    cmake_parse_arguments(PARSE_ARGV 1 "arg" "" "LIBS" "")
+    string(REGEX REPLACE "[ ]+" ";" contents "${arg_LIBS}")
+    list(FILTER contents EXCLUDE REGEX "^-F.+")
+    list(FILTER contents EXCLUDE REGEX "^-framework$")
+    list(FILTER contents EXCLUDE REGEX "^-L.+")
+    list(FILTER contents EXCLUDE REGEX "^-libpath:.+")
+    list(TRANSFORM contents REPLACE "^-Wl,-framework," "-l")
+    list(FILTER contents EXCLUDE REGEX "^-Wl,.+")
+    list(TRANSFORM contents REPLACE "^-l" "")
+    list(FILTER contents EXCLUDE REGEX "^avutil$")
+    list(FILTER contents EXCLUDE REGEX "^avcodec$")
+    list(FILTER contents EXCLUDE REGEX "^avdevice$")
+    list(FILTER contents EXCLUDE REGEX "^avfilter$")
+    list(FILTER contents EXCLUDE REGEX "^avformat$")
+    list(FILTER contents EXCLUDE REGEX "^postproc$")
+    list(FILTER contents EXCLUDE REGEX "^swresample$")
+    list(FILTER contents EXCLUDE REGEX "^swscale$")
+
+    if(VCPKG_TARGET_IS_WINDOWS)
+        list(TRANSFORM contents TOLOWER)
+    endif()
+
+    if(contents)
+        list(APPEND "${out}" "${contents}")
+        set("${out}" "${${out}}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+append_dependencies_from_libs(FFMPEG_DEPENDENCIES_RELEASE LIBS "${FFMPEG_PKGCONFIG_LIBS_RELEASE}")
+append_dependencies_from_libs(FFMPEG_DEPENDENCIES_DEBUG LIBS "${FFMPEG_PKGCONFIG_LIBS_DEBUG}")
+
+# must remove duplicates from the front to respect link order so reverse first
+list(REVERSE FFMPEG_DEPENDENCIES_RELEASE)
+list(REVERSE FFMPEG_DEPENDENCIES_DEBUG)
+list(REMOVE_DUPLICATES FFMPEG_DEPENDENCIES_RELEASE)
+list(REMOVE_DUPLICATES FFMPEG_DEPENDENCIES_DEBUG)
+list(REVERSE FFMPEG_DEPENDENCIES_RELEASE)
+list(REVERSE FFMPEG_DEPENDENCIES_DEBUG)
+
+message(STATUS "Dependencies (release): ${FFMPEG_DEPENDENCIES_RELEASE}")
+message(STATUS "Dependencies (debug):   ${FFMPEG_DEPENDENCIES_DEBUG}")
+
+# Handle version strings
+function(extract_regex_from_file out)
+    cmake_parse_arguments(PARSE_ARGV 1 "arg" "MAJOR" "FILE_WITHOUT_EXTENSION;REGEX" "")
+    file(READ "${arg_FILE_WITHOUT_EXTENSION}.h" contents)
+
+    if(contents MATCHES "${arg_REGEX}")
+        if(NOT CMAKE_MATCH_COUNT EQUAL 1)
+            message(FATAL_ERROR "Could not identify match group in regular expression \"${arg_REGEX}\"")
+        endif()
+    else()
+        if(arg_MAJOR)
+            file(READ "${arg_FILE_WITHOUT_EXTENSION}_major.h" contents)
+
+            if(contents MATCHES "${arg_REGEX}")
+                if(NOT CMAKE_MATCH_COUNT EQUAL 1)
+                    message(FATAL_ERROR "Could not identify match group in regular expression \"${arg_REGEX}\"")
+                endif()
+            else()
+                message(WARNING "Could not find line matching \"${arg_REGEX}\" in file \"${arg_FILE_WITHOUT_EXTENSION}_major.h\"")
+            endif()
+        else()
+            message(WARNING "Could not find line matching \"${arg_REGEX}\" in file \"${arg_FILE_WITHOUT_EXTENSION}.h\"")
+        endif()
+    endif()
+
+    set("${out}" "${CMAKE_MATCH_1}" PARENT_SCOPE)
+endfunction()
+
+function(extract_version_from_component out)
+    cmake_parse_arguments(PARSE_ARGV 1 "arg" "" "COMPONENT" "")
+    string(TOLOWER "${arg_COMPONENT}" component_lower)
+    string(TOUPPER "${arg_COMPONENT}" component_upper)
+    extract_regex_from_file(major_version
+        FILE_WITHOUT_EXTENSION "${SOURCE_PATH}/${component_lower}/version"
+        MAJOR
+        REGEX "#define ${component_upper}_VERSION_MAJOR[ ]+([0-9]+)"
+    )
+    extract_regex_from_file(minor_version
+        FILE_WITHOUT_EXTENSION "${SOURCE_PATH}/${component_lower}/version"
+        REGEX "#define ${component_upper}_VERSION_MINOR[ ]+([0-9]+)"
+    )
+    extract_regex_from_file(micro_version
+        FILE_WITHOUT_EXTENSION "${SOURCE_PATH}/${component_lower}/version"
+        REGEX "#define ${component_upper}_VERSION_MICRO[ ]+([0-9]+)"
+    )
+    set("${out}" "${major_version}.${minor_version}.${micro_version}" PARENT_SCOPE)
+endfunction()
+
+extract_regex_from_file(FFMPEG_VERSION
+    FILE_WITHOUT_EXTENSION "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/libavutil/ffversion"
+    REGEX "#define FFMPEG_VERSION[ ]+\"(.+)\""
+)
+
+extract_version_from_component(LIBAVUTIL_VERSION
+    COMPONENT libavutil)
+extract_version_from_component(LIBAVCODEC_VERSION
+    COMPONENT libavcodec)
+extract_version_from_component(LIBAVDEVICE_VERSION
+    COMPONENT libavdevice)
+extract_version_from_component(LIBAVFILTER_VERSION
+    COMPONENT libavfilter)
+extract_version_from_component(LIBAVFORMAT_VERSION
+    COMPONENT libavformat)
+extract_version_from_component(LIBSWRESAMPLE_VERSION
+    COMPONENT libswresample)
+extract_version_from_component(LIBSWSCALE_VERSION
+    COMPONENT libswscale)
+
+# Handle copyright
+file(STRINGS "${CURRENT_BUILDTREES_DIR}/build-${TARGET_TRIPLET}-rel-out.log" LICENSE_STRING REGEX "License: .*" LIMIT_COUNT 1)
+
+if(LICENSE_STRING STREQUAL "License: LGPL version 2.1 or later")
+    set(LICENSE_FILE "COPYING.LGPLv2.1")
+elseif(LICENSE_STRING STREQUAL "License: LGPL version 3 or later")
+    set(LICENSE_FILE "COPYING.LGPLv3")
+elseif(LICENSE_STRING STREQUAL "License: GPL version 2 or later")
+    set(LICENSE_FILE "COPYING.GPLv2")
+elseif(LICENSE_STRING STREQUAL "License: GPL version 3 or later")
+    set(LICENSE_FILE "COPYING.GPLv3")
+elseif(LICENSE_STRING STREQUAL "License: nonfree and unredistributable")
+    set(LICENSE_FILE "COPYING.NONFREE")
+    file(WRITE "${SOURCE_PATH}/${LICENSE_FILE}" "${LICENSE_STRING}")
+else()
+    message(FATAL_ERROR "Failed to identify license (${LICENSE_STRING})")
+endif()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/FindFFMPEG.cmake.in" "${CURRENT_PACKAGES_DIR}/share/${PORT}/FindFFMPEG.cmake" @ONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/${LICENSE_FILE}")

--- a/res/vcpkg/ffmpeg/usage
+++ b/res/vcpkg/ffmpeg/usage
@@ -1,0 +1,6 @@
+To use ffmpeg add the following to your CMake project:
+
+    find_package(FFMPEG REQUIRED)
+    target_include_directories(main PRIVATE ${FFMPEG_INCLUDE_DIRS})
+    target_link_directories(main PRIVATE ${FFMPEG_LIBRARY_DIRS})
+    target_link_libraries(main PRIVATE ${FFMPEG_LIBRARIES})

--- a/res/vcpkg/ffmpeg/vcpkg-cmake-wrapper.cmake
+++ b/res/vcpkg/ffmpeg/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,47 @@
+set(FFMPEG_PREV_MODULE_PATH ${CMAKE_MODULE_PATH})
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+include(SelectLibraryConfigurations)
+
+cmake_policy(SET CMP0012 NEW)
+
+set(vcpkg_no_avcodec_target ON)
+set(vcpkg_no_avformat_target ON)
+set(vcpkg_no_avutil_target ON)
+if(TARGET FFmpeg::avcodec)
+  set(vcpkg_no_avcodec_target OFF)
+endif()
+if(TARGET FFmpeg::avformat)
+  set(vcpkg_no_avformat_target OFF)
+endif()
+if(TARGET FFmpeg::avutil)
+  set(vcpkg_no_avutil_target OFF)
+endif()
+
+_find_package(${ARGS})
+
+if(WIN32)
+  set(PKG_CONFIG_EXECUTABLE "${CMAKE_CURRENT_LIST_DIR}/../../../@_HOST_TRIPLET@/tools/pkgconf/pkgconf.exe" CACHE STRING "" FORCE)
+endif()
+
+set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH ON) # Required for CMAKE_MINIMUM_REQUIRED_VERSION VERSION_LESS 3.1 which otherwise ignores CMAKE_PREFIX_PATH
+
+if(@WITH_MFX@)
+  find_package(PkgConfig )
+  pkg_check_modules(libmfx  IMPORTED_TARGET libmfx)
+  list(APPEND FFMPEG_LIBRARIES PkgConfig::libmfx)
+  if(vcpkg_no_avcodec_target AND TARGET FFmpeg::avcodec)
+    target_link_libraries(FFmpeg::avcodec INTERFACE PkgConfig::libmfx)
+  endif()
+  if(vcpkg_no_avutil_target AND TARGET FFmpeg::avutil)
+    target_link_libraries(FFmpeg::avutil INTERFACE PkgConfig::libmfx)
+  endif()
+endif()
+
+set(FFMPEG_LIBRARY ${FFMPEG_LIBRARIES})
+
+set(CMAKE_MODULE_PATH ${FFMPEG_PREV_MODULE_PATH})
+
+unset(vcpkg_no_avformat_target)
+unset(vcpkg_no_avcodec_target)
+unset(vcpkg_no_avutil_target)

--- a/res/vcpkg/ffmpeg/vcpkg.json
+++ b/res/vcpkg/ffmpeg/vcpkg.json
@@ -1,0 +1,47 @@
+{
+  "name": "ffmpeg",
+  "version": "7.0.1",
+  "port-version": 0,
+  "description": [
+    "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
+    "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."
+  ],
+  "homepage": "https://ffmpeg.org",
+  "license": null,
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
+    {
+      "name": "vcpkg-pkgconfig-get-modules",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "avcodec",
+    "avdevice",
+    "avformat"
+  ],
+  "features": {
+    "amf": {
+      "description": "AMD AMF codec support",
+      "dependencies": [
+        "amd-amf"
+      ]
+    },
+    "nvcodec": {
+      "description": "Nvidia video decoding/encoding acceleration",
+      "supports": "linux | (!osx & !uwp & !(arm64 & windows))",
+      "dependencies": [
+        "ffnvcodec"
+      ]
+    },
+    "qsv": {
+      "description": "Intel QSV Codec",
+      "dependencies": [
+        "mfx-dispatch"
+      ]
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -51,13 +51,44 @@
     {
       "name": "libyuv",
       "host": false
+    },
+    {
+      "name": "ffmpeg",
+      "host": true,
+      "features": [
+        {
+          "name": "amf",
+          "platform": "((windows | linux) & static)"
+        },
+        {
+          "name": "nvcodec",
+          "platform": "((windows | linux) & static)"
+        },
+        {
+          "name": "qsv",
+          "platform": "(windows & static)"
+        }
+      ],
+      "platform": "((windows | linux | osx) & static)"
+    },
+    {
+      "name": "ffmpeg",
+      "host": false,
+      "platform": "((android | ios) & static)"
     }
   ],
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": ""
+      "baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625"
     },
-    "overlay-ports": [ "./res/vcpkg" ]
-  }
+    "overlay-ports": [
+      "./res/vcpkg"
+    ]
+  },
+  "overrides": [
+    { "name": "ffnvcodec", "version": "11.1.5.2" },
+    { "name": "amd-amf", "version": "1.4.29" },
+    { "name": "mfx-dispatch", "version": "1.35.1" }
+  ]
 }


### PR DESCRIPTION
* Use vcpkg to install ffmpeg and build sdk from source, so no prebuild lib in hwcodec.
* Link ffmpeg in rustdesk directly, ffmpeg can be used as basic library.
* For windows developers, `VCPKG_DEFAULT_HOST_TRIPLET` env need to be set to `x64-windows-static` during installation.
* Most code in `res/vcpkg/ffmpeg` is from https://github.com/microsoft/vcpkg/tree/2024.06.15/ports/ffmpeg
* Tested windows/mac/linux/android, still work