### PR TITLE
fix: try workaround, macos, subwindow, frozen

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hbb/main.dart';
 import 'package:get/get.dart';
 import 'package:provider/provider.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
@@ -417,7 +418,9 @@ class _RemotePageState extends State<RemotePage>
 
   void leaveView(PointerExitEvent evt) {
     if (isMacOS) {
-      DesktopMultiWindow.hideShow();
+      if (kWindowId != null) {
+        DesktopMultiWindow.hideShow(kWindowId!);
+      }
     }
 
     if (_ffi.ffiModel.keyboard) {

--- a/flutter/lib/utils/multi_window_manager.dart
+++ b/flutter/lib/utils/multi_window_manager.dart
@@ -141,7 +141,17 @@ class RustDeskMultiWindowManager {
       ));
     }
     if (isMacOS) {
-      Future.microtask(() => windowController.show());
+      Future.microtask(() {
+        windowController.show();
+        // Manually simulate the hide/show event to fix the issue 
+        // https://github.com/rustdesk/rustdesk/issues/8548
+        // https://github.com/flutter/flutter/issues/133533
+        // https://github.com/MixinNetwork/flutter-plugins/issues/289#issuecomment-1817665239
+        // https://github.com/rustdesk/rustdesk/pull/8712#issuecomment-2229912473
+        Future.delayed(const Duration(milliseconds: 300), () {
+          DesktopMultiWindow.hideShow(-1);
+        });
+      });
     }
     registerActiveWindow(windowId);
     windows.add(windowId);

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -335,7 +335,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "53fee59855c44f35381428c9fb7c7678f700d11d"
+      resolved-ref: "c9ac8e78f8e8f0a554062c2c13cdeb644af2c25b"
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"


### PR DESCRIPTION
Simulate `hide&show` events on creating new window with a delay. Not sure if `300ms` is a good choice.

### Maybe another workaround

Add ci for macos

```yaml
      - name: Workaround for flutter issue
        shell: bash
        run: |
          cd "$(dirname "$(which flutter)")"
          # https://github.com/flutter/flutter/issues/133533
          sed -i -e 's/_setFramesEnabledState(false);/\/\/_setFramesEnabledState(false);/g' ../packages/flutter/lib/src/scheduler/binding.dart
          grep -n '_setFramesEnabledState(false);' ../packages/flutter/lib/src/scheduler/binding.dart
```

It may consume a little more CPU when hide the window.
