### PR TITLE
fix: macos, load multi dylib instances

### DIFF
--- a/flutter/lib/models/native_model.dart
+++ b/flutter/lib/models/native_model.dart
@@ -117,9 +117,13 @@ class PlatformFFI {
             ? DynamicLibrary.open('librustdesk.so')
             : isWindows
                 ? DynamicLibrary.open('librustdesk.dll')
-                : isMacOS
-                    ? DynamicLibrary.open("liblibrustdesk.dylib")
-                    : DynamicLibrary.process();
+                :
+                // Use executable itself as the dynamic library for MacOS.
+                // Multiple dylib instances will cause some global instances to be invalid.
+                // eg. `lazy_static` objects in rust side, will be created more than once, which is not expected.
+                //
+                // isMacOS? DynamicLibrary.open("liblibrustdesk.dylib") :
+                DynamicLibrary.process();
     debugPrint('initializing FFI $_appType');
     try {
       _session_get_rgba = dylib.lookupFunction<F3Dart, F3>("session_get_rgba");


### PR DESCRIPTION
Multiple dylib instances will cause some global instances to be invalid.

eg. lazy_static objects in rust side, will be created more than once.



https://github.com/user-attachments/assets/800258ea-de61-42f4-ace8-b16b5fad68b7

