### PR TITLE
fix linux ffmpeg link, still link ffmpeg in hwcodec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,8 +3087,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwcodec"
-version = "0.5.0"
-source = "git+https://github.com/21pages/hwcodec#470d18826dc334b964c51acf0c6ac3bcf56f56ad"
+version = "0.5.1"
+source = "git+https://github.com/21pages/hwcodec#74e8288f776a9d43861f16aa62e86b57c7209868"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -189,6 +189,8 @@ fn gen_vcpkg_package(package: &str, ffi_header: &str, generated: &str, regex: &s
 }
 
 // If you have problems installing ffmpeg, you can download $VCPKG_ROOT/installed from ci
+// Linux require link in hwcodec
+/*
 fn ffmpeg() {
     // ffmpeg
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
@@ -230,6 +232,7 @@ fn ffmpeg() {
         println!("cargo:rustc-link-lib=framework=AVFoundation");
     }
 }
+*/
 
 fn main() {
     // note: all link symbol names in x86 (32-bit) are prefixed wth "_".
@@ -247,7 +250,7 @@ fn main() {
     gen_vcpkg_package("libvpx", "vpx_ffi.h", "vpx_ffi.rs", "^[vV].*");
     gen_vcpkg_package("aom", "aom_ffi.h", "aom_ffi.rs", "^(aom|AOM|OBU|AV1).*");
     gen_vcpkg_package("libyuv", "yuv_ffi.h", "yuv_ffi.rs", ".*");
-    ffmpeg();
+    // ffmpeg();
 
     // there is problem with cfg(target_os) in build.rs, so use our workaround
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();


### PR DESCRIPTION
Current nightly `rustdesk-1.2.7-x86_64.deb` is only 18.5M, ffmpeg is not linked.