### PR TITLE
fix nextRgba not called when switching to texture render

### DIFF
--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -794,7 +794,7 @@ impl InvokeUiSession for FlutterHandler {
         for (_, session) in self.session_handlers.read().unwrap().iter() {
             if session.renderer.on_texture(display, texture) {
                 if let Some(stream) = &session.event_stream {
-                    stream.add(EventToUI::Texture(display));
+                    stream.add(EventToUI::Texture(display, true));
                 }
             }
         }
@@ -1087,7 +1087,7 @@ impl FlutterHandler {
             if use_texture_render || session.displays.len() > 1 {
                 if session.renderer.on_rgba(display, rgba) {
                     if let Some(stream) = &session.event_stream {
-                        stream.add(EventToUI::Rgba(display));
+                        stream.add(EventToUI::Texture(display, false));
                     }
                 }
             }

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -89,7 +89,7 @@ pub fn stop_global_event_stream(app_type: String) {
 pub enum EventToUI {
     Event(String),
     Rgba(usize),
-    Texture(usize),
+    Texture(usize, bool), // (display, gpu_texture)
 }
 
 pub fn host_stop_system_key_propagate(_stopped: bool) {


### PR DESCRIPTION
Because rgba buffer render doesn't support multi display, when switch to multi display, it is possible that `rgba.valid` has been set to valid but `nextRgab` is not called, when switching back to single display, `rgba.valid` is still true.


`nextRgba` not called when switching to texture render.
![0b909f43d1e2a2782e72af066600d6a](https://github.com/user-attachments/assets/23f081c1-a10d-48ae-89ee-94d665e091b0)



It happens at the end of the video.

https://github.com/user-attachments/assets/9a6c605f-6a30-45c9-94ac-66dff91fc133

