### PR TITLE
fix hide ab tag when custom client startup

### DIFF
--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -87,7 +87,7 @@ class _PeerTabPageState extends State<PeerTabPage>
               : PeerUiType.list;
     }
     hideAbTagsPanel.value =
-        bind.mainGetLocalOption(key: kOptionHideAbTagsPanel).isNotEmpty;
+        bind.mainGetLocalOption(key: kOptionHideAbTagsPanel) == 'Y';
     super.initState();
   }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/8794

not custom: 'Y', ''
custom: 'Y', 'N'
should not use isNotEmpty