### PR TITLE
fix: mobile, query onlines, on active

### DIFF
--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -875,11 +875,13 @@ class _PeerSortDropdownState extends State<PeerSortDropdown> {
   @override
   void initState() {
     if (!PeerSortType.values.contains(peerSort.value)) {
-      peerSort.value = PeerSortType.remoteId;
-      bind.setLocalFlutterOption(
-        k: kOptionPeerSorting,
-        v: peerSort.value,
-      );
+      Future.delayed(Duration.zero, () {
+        peerSort.value = PeerSortType.remoteId;
+        bind.setLocalFlutterOption(
+          k: kOptionPeerSorting,
+          v: peerSort.value,
+        );
+      });
     }
     super.initState();
   }

--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -876,6 +876,7 @@ class _PeerSortDropdownState extends State<PeerSortDropdown> {
   void initState() {
     if (!PeerSortType.values.contains(peerSort.value)) {
       Future.delayed(Duration.zero, () {
+        // do not change obx directly in initState, so do in future.
         peerSort.value = PeerSortType.remoteId;
         bind.setLocalFlutterOption(
           k: kOptionPeerSorting,

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -384,7 +384,7 @@ class FfiModel with ChangeNotifier {
       } else if (name == 'use_texture_render') {
         _handleUseTextureRender(evt, sessionId, peerId);
       } else {
-        debugPrint('Unknown event name: $name');
+        debugPrint('Event is not handled in the fixed branch: $name');
       }
     };
   }


### PR DESCRIPTION
1. Add `WidgetsBindingObserver` to detect if RustDesk is active, for querying online.
2. Always set last query peers in `_queryOnlines()` to avoid wrong check of `setEquals(_curPeers, _lastQueryPeers)` (`true`).
![image](https://github.com/user-attachments/assets/76e49d52-526b-4ed5-bba7-096fc3241b34)
3. Avoid error 
![image](https://github.com/user-attachments/assets/d8505f02-ebee-4ce6-acfb-63dfa001af5b)

```
the framework builds parent widgets before children, which means a dirty descendant will always be
built. Otherwise, the framework might not visit this widget during this build phase.
The widget on which setState() or markNeedsBuild() was called was:
  ObxValue<RxList<dynamic>>
The widget which was currently being built when the offending call was made was:
  Container

The relevant error-causing widget was:
  Container
  Container:file:///home/ubuntu/workspace/rust/rustdesk/flutter/lib/common/widgets/peer_tab_page.dart:117:18

When the exception was thrown, this was the stack:
#0      Element.markNeedsBuild.<anonymous closure> (package:flutter/src/widgets/framework.dart:5042:9)
#1      Element.markNeedsBuild (package:flutter/src/widgets/framework.dart:5054:6)
#2      State.setState (package:flutter/src/widgets/framework.dart:1223:15)
#3      ObxState._updateTree (package:get/get_state_manager/src/rx_flutter/rx_obx_widget.dart:43:7)
#4      GetStream._notifyData (package:get/get_rx/src/rx_stream/get_stream.dart:47:21)
#5      GetStream.add (package:get/get_rx/src/rx_stream/get_stream.dart:97:5)
#6      NotifyManager.addListener.<anonymous closure> (package:get/get_rx/src/rx_types/rx_core/rx_impl.dart:158:40)
#7      GetStream._notifyData (package:get/get_rx/src/rx_stream/get_stream.dart:47:21)
#8      GetStream.add (package:get/get_rx/src/rx_stream/get_stream.dart:97:5)
#9      RxObjectMixin.value= (package:get/get_rx/src/rx_types/rx_core/rx_impl.dart:105:13)
#10     _PeerSortDropdownState.initState (package:flutter_hbb/common/widgets/peer_tab_page.dart:877:22)
```