### PR TITLE
refact: refresh on capture displays

### DIFF
--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1889,8 +1889,6 @@ pub mod sessions {
             let mut write_lock = s.ui_handler.session_handlers.write().unwrap();
             if let Some(h) = write_lock.get_mut(&session_id) {
                 h.displays = value.iter().map(|x| *x as usize).collect::<_>();
-                #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                let displays_refresh = value.clone();
                 if value.len() == 1 {
                     // Switch display.
                     // This operation will also cause the peer to send a switch display message.
@@ -1901,29 +1899,16 @@ pub mod sessions {
                         s.capture_displays(vec![], vec![], value);
                     } else {
                         // Check if other displays are needed.
-                        if value.len() == 1 {
-                            check_remove_unused_displays(
-                                Some(value[0] as _),
-                                &session_id,
-                                &s,
-                                &write_lock,
-                            );
-                        }
+                        check_remove_unused_displays(
+                            Some(value[0] as _),
+                            &session_id,
+                            &s,
+                            &write_lock,
+                        );
                     }
                 } else {
                     // Try capture all displays.
                     s.capture_displays(vec![], vec![], value);
-                }
-                #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                {
-                    let is_support_multi_ui_session = crate::common::is_support_multi_ui_session(
-                        &s.ui_handler.peer_info.read().unwrap().version,
-                    );
-                    if is_support_multi_ui_session {
-                        for display in displays_refresh.iter() {
-                            s.refresh_video(*display);
-                        }
-                    }
                 }
                 break;
             }

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -160,9 +160,6 @@ pub fn session_start_with_displays(
 
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
         session.capture_displays(displays.clone(), vec![], vec![]);
-        for display in displays {
-            session.refresh_video(display as _);
-        }
     }
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -386,6 +386,10 @@ impl Server {
             if Self::is_video_service_name(&name) {
                 if displays.contains(&name) {
                     if include {
+                        // Try unsubscribe first
+                        // 1. No effect if is not previously subscribed.
+                        // 2. Cause refresh if unsbuscribe and then subscribe. ( from all displays to one display )
+                        self.subscribe(&name, conn.clone(), false);
                         self.subscribe(&name, conn.clone(), true);
                     }
                 } else {


### PR DESCRIPTION
1. Refresh on capture changes on the control side. Message `CaptureDisplay`. And remove unnecessary refresh messages.
![image](https://github.com/user-attachments/assets/81a755bc-aeb7-4524-adce-ccae05274109)
2. Remove bad design of checking and skipping refresh event in a short time. `LAST_REFRESH_TIME`


### Note

![image](https://github.com/user-attachments/assets/35590f4a-9740-4f41-8a09-a7017db7369c)

The code is moved to the beginning of the loop, and the bail condition is removed.

![image](https://github.com/user-attachments/assets/ff347a69-226a-4d6a-be8f-7e07e8a9d68e)


### Preview

https://github.com/user-attachments/assets/9b1ee543-0ecd-4b5b-b081-970594e8252e


https://github.com/user-attachments/assets/3789bd90-6980-4571-8ab0-ebf2d995354a


https://github.com/user-attachments/assets/ae0d21db-a22b-4d56-8b74-4ee21a44b7f3

