### PR TITLE
fix: video service, do not skip refresh message

### DIFF
--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1914,6 +1914,12 @@ pub mod sessions {
                     // Try capture all displays.
                     s.capture_displays(vec![], vec![], value);
                 }
+                // When switching display, we also need to send "Refresh display" message.
+                // On the controlled side:
+                // 1. If this display is not currently captured -> Refresh -> Message "Refresh display" is not required.
+                // One more key frame (first frame) will be sent because the refresh message.
+                // 2. If this display is currently captured -> Not refresh -> Message "Refresh display" is required.
+                // Without the message, the control side cannot see the latest display image.
                 #[cfg(not(any(target_os = "android", target_os = "ios")))]
                 {
                     let is_support_multi_ui_session = crate::common::is_support_multi_ui_session(

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -68,8 +68,6 @@ use std::{
 pub const NAME: &'static str = "video";
 pub const OPTION_REFRESH: &'static str = "refresh";
 
-const REFRESH_MIN_INTERVAL_MILLIS: u128 = 300;
-
 lazy_static::lazy_static! {
     static ref FRAME_FETCHED_NOTIFIER: (UnboundedSender<(i32, Option<Instant>)>, Arc<TokioMutex<UnboundedReceiver<(i32, Option<Instant>)>>>) = {
         let (tx, rx) = unbounded_channel();
@@ -78,8 +76,6 @@ lazy_static::lazy_static! {
     pub static ref VIDEO_QOS: Arc<Mutex<VideoQoS>> = Default::default();
     pub static ref IS_UAC_RUNNING: Arc<Mutex<bool>> = Default::default();
     pub static ref IS_FOREGROUND_WINDOW_ELEVATED: Arc<Mutex<bool>> = Default::default();
-    // Avoid refreshing too frequently
-    static ref LAST_REFRESH_TIME: Arc<Mutex<HashMap<usize, Instant>>> = Default::default();
 }
 
 #[inline]
@@ -517,23 +513,9 @@ fn run(vs: VideoService) -> ResultType<()> {
         drop(video_qos);
 
         if sp.is_option_true(OPTION_REFRESH) {
-            if LAST_REFRESH_TIME
-                .lock()
-                .unwrap()
-                .get(&vs.idx)
-                .map(|x| x.elapsed().as_millis() > REFRESH_MIN_INTERVAL_MILLIS)
-                .unwrap_or(true)
-            {
-                let _ = try_broadcast_display_changed(&sp, display_idx, &c, true);
-                LAST_REFRESH_TIME
-                    .lock()
-                    .unwrap()
-                    .insert(vs.idx, Instant::now());
-                log::info!("switch to refresh");
-                bail!("SWITCH");
-            } else {
-                sp.set_option_bool(OPTION_REFRESH, false);
-            }
+            let _ = try_broadcast_display_changed(&sp, display_idx, &c, true);
+            log::info!("switch to refresh");
+            bail!("SWITCH");
         }
         if codec_format != Encoder::negotiated_codec() {
             log::info!(


### PR DESCRIPTION
Revert `video_service`, remove `LAST_REFRESH_TIME`. Do not skip refresh message.

The code is not the same as commit `c04f460bbdd3a4d9deb2200d82ac1bcbc3d4c101`

https://github.com/dignow/rustdesk/blob/c04f460bbdd3a4d9deb2200d82ac1bcbc3d4c101/src/server/video_service.rs

