### PR TITLE
fix: mobile, conn page, jump on exiting remote

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -647,8 +647,12 @@ String formatDurationToTime(Duration duration) {
 
 closeConnection({String? id}) {
   if (isAndroid || isIOS) {
-    gFFI.chatModel.hideChatOverlay();
-    Navigator.popUntil(globalKey.currentContext!, ModalRoute.withName("/"));
+    () async {
+      await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
+          overlays: SystemUiOverlay.values);
+      gFFI.chatModel.hideChatOverlay();
+      Navigator.popUntil(globalKey.currentContext!, ModalRoute.withName("/"));
+    }();
   } else {
     if (isWeb) {
       Navigator.popUntil(globalKey.currentContext!, ModalRoute.withName("/"));


### PR DESCRIPTION
The connection page jumps after exiting the remote page.

Because it also exit fullscreen at that time.


