### PR TITLE
fix: trackpad, reverse horizontal scroll

### DIFF
--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -973,12 +973,11 @@ pub fn handle_mouse_(evt: &MouseEvent, conn: i32) {
         },
         MOUSE_TYPE_WHEEL | MOUSE_TYPE_TRACKPAD => {
             #[allow(unused_mut)]
-            let mut x = evt.x;
+            let mut x = -evt.x;
             #[allow(unused_mut)]
             let mut y = evt.y;
             #[cfg(not(windows))]
             {
-                x = -x;
                 y = -y;
             }
 

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1018,7 +1018,7 @@ impl<T: InvokeUiSession> Session<T> {
             }
         }
 
-        let (x, y) = if mask == MOUSE_TYPE_WHEEL {
+        let (x, y) = if mask == MOUSE_TYPE_WHEEL || mask == MOUSE_TYPE_TRACKPAD {
             self.get_scroll_xy((x, y))
         } else {
             (x, y)


### PR DESCRIPTION
1. Reverse mouse wheel besides trackpad.
2. Reverse horizontal scroll. Use Windows as the controlled side is changed. Linux and MacOS works find as the controlled side.  
    Only trackpad is tested.  
    Mouse is not tested. But according to https://github.com/rustdesk/rustdesk/issues/1169 and https://github.com/rustdesk/rustdesk/pull/8806.  Mouse is also reversed.