### PR TITLE
fix: keep window pos after new conn

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2981,11 +2981,15 @@ openMonitorInNewTabOrWindow(int i, String peerId, PeerInfo pi,
       kMainWindowId, kWindowEventOpenMonitorSession, jsonEncode(args));
 }
 
-setNewConnectWindowFrame(
-    int windowId, String peerId, int? display, Rect? screenRect) async {
+setNewConnectWindowFrame(int windowId, String peerId, int preSessionCount,
+    int? display, Rect? screenRect) async {
   if (screenRect == null) {
-    await restoreWindowPosition(WindowType.RemoteDesktop,
-        windowId: windowId, display: display, peerId: peerId);
+    // Do not restore window position to new connection if there's a pre-session.
+    // https://github.com/rustdesk/rustdesk/discussions/8825
+    if (preSessionCount == 0) {
+      await restoreWindowPosition(WindowType.RemoteDesktop,
+          windowId: windowId, display: display, peerId: peerId);
+    }
   } else {
     await tryMoveToScreenAndSetFullscreen(screenRect);
   }

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -45,7 +45,9 @@ class RemotePage extends StatefulWidget {
     this.switchUuid,
     this.forceRelay,
     this.isSharedPassword,
-  }) : super(key: key);
+  }) : super(key: key) {
+    initSharedStates(id);
+  }
 
   final String id;
   final SessionID? sessionId;
@@ -99,7 +101,6 @@ class _RemotePageState extends State<RemotePage>
   }
 
   void _initStates(String id) {
-    initSharedStates(id);
     _zoomCursor = PeerBoolOption.find(id, kOptionZoomCursor);
     _showRemoteCursor = ShowRemoteCursorState.find(id);
     _keyboardEnabled = KeyboardEnabledState.find(id);

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -407,12 +407,14 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
       final display = args['display'];
       final displays = args['displays'];
       final screenRect = parseParamScreenRect(args);
+      final prePeerCount = tabController.length;
       Future.delayed(Duration.zero, () async {
         if (stateGlobal.fullscreen.isTrue) {
           await WindowController.fromWindowId(windowId()).setFullscreen(false);
           stateGlobal.setFullscreen(false, procWnd: false);
         }
-        await setNewConnectWindowFrame(windowId(), id!, display, screenRect);
+        await setNewConnectWindowFrame(
+            windowId(), id!, prePeerCount, display, screenRect);
         Future.delayed(Duration(milliseconds: isWindows ? 100 : 0), () async {
           await windowOnTop(windowId());
         });


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/8825

1. Keep window pos.  Check current session count before restore window postion.

<img width="595" alt="1721915528830" src="https://github.com/user-attachments/assets/7ecaa088-2efb-455d-bde0-7ffb918a1f36">


2. Do some init in StatefulWidget constructor. If try init in its `State` class, it may be too late. Because I see the init function is called after building the widget tree sometimes.


https://github.com/user-attachments/assets/c6e411a0-aea0-44b3-b814-2e43c2af5689



```
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following message was thrown building Obx(has builder, dirty, state: ObxState#1fda9):
"RxString" not found. You need to call "Get.put(RxString())" or "Get.lazyPut(()=>RxString())"

The relevant error-causing widget was:
  Obx Obx:file:///D:/Projects/rust/rustdesk/flutter/lib/desktop/pages/remote_tab_page.dart:133:54

When the exception was thrown, this was the stack:
#0      GetInstance.find (package:get/get_instance/src/get_instance.dart:306:7)
#1      Inst.find (package:get/get_instance/src/extension_instance.dart:69:45)
#2      FingerprintState.find (package:flutter_hbb/common/shared_state.dart:145:42)
#3      _ConnectionTabPageState.build.<anonymous closure>.<anonymous closure>
(package:flutter_hbb/desktop/pages/remote_tab_page.dart:159:48)
```

### Bug


https://github.com/user-attachments/assets/0e5f474b-71b4-4c4e-b50b-b0575a1445c8



### Fixed



https://github.com/user-attachments/assets/b1d80ede-3612-41c3-92e9-fc5f21f50132

