### PR TITLE
avoid call refreshCurrentUser twice at startup

### DIFF
--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -34,6 +34,7 @@ class _OnlineStatusWidgetState extends State<OnlineStatusWidget> {
   final _svcStopped = Get.find<RxBool>(tag: 'stop-service');
   final _svcIsUsingPublicServer = true.obs;
   Timer? _updateTimer;
+  final DateTime _appStartTime = DateTime.now();
 
   double get em => 14.0;
   double? get height => bind.isIncomingOnly() ? null : em * 3;
@@ -176,7 +177,8 @@ class _OnlineStatusWidgetState extends State<OnlineStatusWidget> {
       stateGlobal.svcStatus.value = SvcStatus.notReady;
     } else if (statusNum == 1) {
       stateGlobal.svcStatus.value = SvcStatus.ready;
-      if (preStatus != SvcStatus.ready) {
+      if (preStatus != SvcStatus.ready &&
+          DateTime.now().difference(_appStartTime) > Duration(seconds: 5)) {
         gFFI.userModel.refreshCurrentUser();
       }
     } else {

--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -111,9 +111,9 @@ class AbModel {
   Future<void> _pullAb(
       {required ForcePullAb? force, required bool quiet}) async {
     if (bind.isDisableAb()) return;
-    debugPrint("pullAb, force: $force, quiet: $quiet");
     if (!gFFI.userModel.isLogin) return;
     if (force == null && listInitialized && current.initialized) return;
+    debugPrint("pullAb, force: $force, quiet: $quiet");
     if (!listInitialized || force == ForcePullAb.listAndCurrent) {
       try {
         // Read personal guid every time to avoid upgrading the server without closing the main window


### PR DESCRIPTION
refreshCurrentUser will be called at these 2 position:

1. runMainApp or runMobileApp in main.dart
2. when connect status is ready

Both of these two happens at startup, when connect status is ready and startup time < 5 seconds, not call refreshCurrentUser