### PR TITLE
refact: update crate tfc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6593,11 +6593,11 @@ dependencies = [
 
 [[package]]
 name = "tfc"
-version = "0.6.1"
-source = "git+https://github.com/rustdesk-org/The-Fat-Controller#9dd86151525fd010dc93f6bc9b6aedd1a75cc342"
+version = "0.7.0"
+source = "git+https://github.com/rustdesk-org/The-Fat-Controller?branch=history/rebase_upstream_20240722#de9c8ba480f166a9fc90aaa47bb0e84b443ea9c6"
 dependencies = [
  "anyhow",
- "core-graphics 0.22.3",
+ "core-graphics 0.23.2",
  "unicode-segmentation",
  "winapi 0.3.9",
  "x11 2.19.0",

--- a/libs/enigo/Cargo.toml
+++ b/libs/enigo/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 log = "0.4"
 rdev = { git = "https://github.com/rustdesk-org/rdev" }
-tfc = { git = "https://github.com/rustdesk-org/The-Fat-Controller" }
+tfc = { git = "https://github.com/rustdesk-org/The-Fat-Controller", branch = "history/rebase_upstream_20240722" }
 hbb_common = { path = "../hbb_common" }
 
 [features]


### PR DESCRIPTION
Win (fr-FR) -> Win,Linux,MacOS (en-US), map mode and translate mode are tested.
Normal keys, `Shift` + Others, Dead keys (`AltGr` + Others), Accet (`AltGr` + `7` + `e`) are tested.


### NOTE

The latest commit of https://github.com/rustdesk-org/The-Fat-Controller/commits/history/rebase_upstream_20240722 is not used
, because `is_aligned()` is not stable for rust `1.75`.

![image](https://github.com/user-attachments/assets/0ab28268-b6e0-451a-9ef9-fa15a5808785)


