### PR TITLE
fix: clipboard, set formats and enable option

### DIFF
--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1367,17 +1367,17 @@ impl<T: InvokeUiSession> Remote<T> {
                         // https://github.com/rustdesk/rustdesk/issues/3703#issuecomment-1474734754
                         match p.permission.enum_value() {
                             Ok(Permission::Keyboard) => {
+                                *self.handler.server_keyboard_enabled.write().unwrap() = p.enabled;
                                 #[cfg(feature = "flutter")]
                                 #[cfg(not(any(target_os = "android", target_os = "ios")))]
                                 crate::flutter::update_text_clipboard_required();
-                                *self.handler.server_keyboard_enabled.write().unwrap() = p.enabled;
                                 self.handler.set_permission("keyboard", p.enabled);
                             }
                             Ok(Permission::Clipboard) => {
+                                *self.handler.server_clipboard_enabled.write().unwrap() = p.enabled;
                                 #[cfg(feature = "flutter")]
                                 #[cfg(not(any(target_os = "android", target_os = "ios")))]
                                 crate::flutter::update_text_clipboard_required();
-                                *self.handler.server_clipboard_enabled.write().unwrap() = p.enabled;
                                 self.handler.set_permission("clipboard", p.enabled);
                             }
                             Ok(Permission::Audio) => {


### PR DESCRIPTION
1. Fix `update_text_clipboard_required()`, because it depends on `server_keyboard_enabled`

![image](https://github.com/user-attachments/assets/7f7aaed5-c215-467d-ace1-7dc21768cf35)

2. Fix set formats on Linux. Use a global variable to hold current clipboard content. Although it is currently possible to set the pasteboard under Linux, it is not correct.

![image](https://github.com/user-attachments/assets/9107d5c2-7be1-425e-81da-cbbfb268756a)
