### PR TITLE
fix: clipboard, read as much as possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 [[package]]
 name = "arboard"
 version = "3.4.0"
-source = "git+https://github.com/rustdesk-org/arboard#75166f255bf2fd6c662269029f5130b11d024f46"
+source = "git+https://github.com/rustdesk-org/arboard#a04bdb1b368a99691822c33bf0f7ed497d6a7a35"
 dependencies = [
  "clipboard-win",
  "core-graphics 0.23.2",
@@ -234,6 +234,8 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "parking_lot",
+ "serde 1.0.203",
+ "serde_derive",
  "windows-sys 0.48.0",
  "wl-clipboard-rs",
  "x11rb 0.13.1",
@@ -1675,7 +1677,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.4",
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/rustdesk-org/arboard/pull/9

Read clibpard formats, ignore errors, to read as much formats as possible.

Because sometimes reading plain text is ok, but not the other formats. (on Windows). Maybe it depend on the system settings.

