### PR TITLE
fix: clipboard, windows, controlled side, formats

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -108,6 +108,7 @@ pub enum FS {
 pub struct ClipboardNonFile {
     pub compress: bool,
     pub content: bytes::Bytes,
+    pub content_len: usize,
     pub next_raw: bool,
     pub width: i32,
     pub height: i32,

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -108,6 +108,7 @@ pub enum FS {
 pub struct ClipboardNonFile {
     pub compress: bool,
     pub content: bytes::Bytes,
+    pub next_raw: bool,
     pub width: i32,
     pub height: i32,
     // message.proto: ClipboardFormat

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,10 +1,3 @@
-use std::{
-    collections::HashMap,
-    sync::atomic::{AtomicBool, Ordering},
-};
-#[cfg(not(windows))]
-use std::{fs::File, io::prelude::*};
-
 use crate::{
     privacy_mode::PrivacyModeState,
     ui_interface::{get_local_option, set_local_option},
@@ -14,6 +7,12 @@ use parity_tokio_ipc::{
     Connection as Conn, ConnectionClient as ConnClient, Endpoint, Incoming, SecurityAttributes,
 };
 use serde_derive::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicBool, Ordering},
+};
+#[cfg(not(windows))]
+use std::{fs::File, io::prelude::*};
 
 #[cfg(all(feature = "flutter", feature = "plugin_framework"))]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -26,8 +25,11 @@ use hbb_common::{
     config::{self, Config, Config2},
     futures::StreamExt as _,
     futures_util::sink::SinkExt,
-    log, password_security as password, timeout, tokio,
-    tokio::io::{AsyncRead, AsyncWrite},
+    log, password_security as password, timeout,
+    tokio::{
+        self,
+        io::{AsyncRead, AsyncWrite},
+    },
     tokio_util::codec::Framed,
     ResultType,
 };
@@ -98,6 +100,18 @@ pub enum FS {
         last_modified: u64,
         is_upload: bool,
     },
+}
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "t")]
+pub struct ClipboardNonFile {
+    pub compress: bool,
+    pub content: bytes::Bytes,
+    pub width: i32,
+    pub height: i32,
+    // message.proto: ClipboardFormat
+    pub format: i32,
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -207,6 +221,8 @@ pub enum Data {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     ClipboardFile(ClipboardFile),
     ClipboardFileEnabled(bool),
+    #[cfg(target_os = "windows")]
+    ClipboardNonFile(Option<(String, Vec<ClipboardNonFile>)>),
     PrivacyModeState((i32, PrivacyModeState, String)),
     TestRendezvousServer,
     #[cfg(not(any(target_os = "android", target_os = "ios")))]


### PR DESCRIPTION
Get clipboard contents from cm though ipc on Windows "--server", fallback directly get clipboard formats.

![image](https://github.com/user-attachments/assets/02d62a1f-89ec-4fed-9cea-8e74e0bf7d68)

#### Note

`1024*3` is used as the threshold to send raw in ipc for now. Maybe there's a better value.

![image](https://github.com/user-attachments/assets/80926021-5780-4386-8226-65dafd7eb9d8)


### Preview


https://github.com/user-attachments/assets/6b624251-0071-4f38-997d-fb6331bed1e8


https://github.com/user-attachments/assets/249cba58-4088-4e37-9eb3-aaacc32131e2


https://github.com/user-attachments/assets/339b418a-aa41-4d9f-a145-c2adc8a85be3

https://github.com/user-attachments/assets/13464dbc-bbdb-45dd-93af-b0792e04da89




