### PR TITLE
Fix typo on ja.rs

### DIFF
--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -430,7 +430,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("length>=8", "8文字以上"),
         ("Weak", "脆弱"),
         ("Medium", "普通"),
-        ("Strong", "協力"),
+        ("Strong", "強力"),
         ("Switch Sides", "接続方向の切り替え"),
         ("Please confirm if you want to share your desktop?", "デスクトップの共有を許可しますか？"),
         ("Display", "ディスプレイ"),


### PR DESCRIPTION
"Strong" is correctly translated as "強力" in Japanese.
"協力" means "Cooperation".