### PR TITLE
Fix cursor lost after locking screen

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -906,9 +906,7 @@ class InputModel {
     }
 
     if (!cursorModel.gotMouseControl) {
-      bool selfGetControl =
-          (x - lastMousePos.dx).abs() > kMouseControlDistance ||
-              (y - lastMousePos.dy).abs() > kMouseControlDistance;
+      bool selfGetControl = x != lastMousePos.dx || y != lastMousePos.dy;
       if (selfGetControl) {
         cursorModel.gotMouseControl = true;
       } else {


### PR DESCRIPTION
#824 
Fix cursor lost after locking screen。
I find updateCursorPosition will emit after locking screen.IsConnIn2Secs func will return false.CursorModel.gotMouseControl is false.
Simaple way is update _checkPeerControlProtected func.
Better way is not emit updateCursorPosition.