### PR TITLE
Fix mouse mismatch in gnome-wayland with scale.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -37,6 +37,8 @@ mod clipboard_service;
 #[cfg(target_os = "linux")]
 pub(crate) mod wayland;
 #[cfg(target_os = "linux")]
+pub mod gnome;
+#[cfg(target_os = "linux")]
 pub mod uinput;
 #[cfg(target_os = "linux")]
 pub mod rdp_input;

--- a/src/server/gnome.rs
+++ b/src/server/gnome.rs
@@ -1,0 +1,49 @@
+use dbus::blocking::Connection;
+use dbus::arg;
+use hbb_common::log;
+use std::env::var;
+use std::time::Duration;
+
+const XDG_CURRENT_DESKTOP: &'static str = "XDG_CURRENT_DESKTOP";
+const XDG_SESSION_TYPE: &'static str = "XDG_SESSION_TYPE";
+
+fn is_gnome_wayland() -> bool {
+    let e1 = var(XDG_CURRENT_DESKTOP).map(|e| e == "GNOME").unwrap_or(false);
+    let e2 = var(XDG_SESSION_TYPE).map(|e| e == "wayland").unwrap_or(false);
+    return e1 && e2;
+}
+
+type Res = (u32,
+            Vec<(u32, i32, i32, i32, i32, i32, u32, Vec<u32>, arg::PropMap)>,
+            Vec<(u32, i32, i32, Vec<u32>, String, Vec<u32>, Vec<u32>, arg::PropMap)>,
+            Vec<(u32, i32, u32, u32, f64, u32)>,
+            i32,
+            i32);
+
+// return (width, height) 
+// Reference https://wiki.gnome.org/Initiatives/Wayland/Gaps/DisplayConfig
+pub fn gnome_wayland_get_resolution() -> Option<(i32, i32)> {
+    if !is_gnome_wayland() {
+        log::info!("DEBUG POINT: is not gnome wayland.");
+        return None;
+    }
+    let conn = Connection::new_session();
+    if conn.is_err() {
+        return None;
+    }
+    let conn = conn.unwrap();
+
+    // Open a proxy to the Mutter DisplayConfig
+    let proxy = conn.with_proxy(
+        "org.gnome.Mutter.DisplayConfig",
+        "/org/gnome/Mutter/DisplayConfig",
+        Duration::from_millis(5000),
+    );
+
+    let res = proxy.method_call("org.gnome.Mutter.DisplayConfig", "GetResources", ("max_screen_width", "max_screen_height"));
+    if res.is_err() {
+        return None
+    }
+    let res: Res = res.unwrap();
+    Some((res.4, res.5))
+}

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -1,4 +1,5 @@
 use super::*;
+use gnome::gnome_wayland_get_resolution;
 use hbb_common::{allow_err, platform::linux::DISTRO};
 use scrap::{is_cursor_embedded, set_map_err, Capturer, Display, Frame, TraitCapturer};
 use std::io;
@@ -113,7 +114,12 @@ pub(super) fn is_inited() -> Option<Message> {
     }
 }
 
-fn get_max_desktop_resolution() -> Option<String> {
+fn get_max_desktop_resolution() -> Option<(i32, i32)> {
+    // Special for gnome-wayland #6502
+    if let Some(res) = gnome_wayland_get_resolution() {
+        return Some(res);
+    }
+
     // works with Xwayland
     let output: Output = Command::new("sh")
         .arg("-c")
@@ -123,7 +129,16 @@ fn get_max_desktop_resolution() -> Option<String> {
 
     if output.status.success() {
         let result = String::from_utf8_lossy(&output.stdout);
-        Some(result.trim().to_string())
+        let s = result.trim().to_string();
+        let resolution: Vec<&str> = s.split(" ").collect();
+        let w = resolution[0].parse();
+        let h = resolution[2]
+            .trim_end_matches(",")
+            .parse();
+        match (w, h) {
+            (Ok(w_), Ok(h_)) => Some((w_, h_)),
+            _=> None,
+        }
     } else {
         None
     }
@@ -168,13 +183,7 @@ pub(super) async fn check_init() -> ResultType<()> {
                 );
 
                 let (max_width, max_height) = match get_max_desktop_resolution() {
-                    Some(result) if !result.is_empty() => {
-                        let resolution: Vec<&str> = result.split(" ").collect();
-                        let w: i32 = resolution[0].parse().unwrap_or(origin.0 + width as i32);
-                        let h: i32 = resolution[2]
-                            .trim_end_matches(",")
-                            .parse()
-                            .unwrap_or(origin.1 + height as i32);
+                    Some((w, h)) => {
                         if w < origin.0 + width as i32 || h < origin.1 + height as i32 {
                             (origin.0 + width as i32, origin.1 + height as i32)
                         }


### PR DESCRIPTION
Fix #8524