### PR TITLE
Use JNI MediaCodec-backed hardware codecs on Android (fix some waiting for image)

### DIFF
--- a/libs/scrap/src/android/ffi.rs
+++ b/libs/scrap/src/android/ffi.rs
@@ -349,6 +349,10 @@ fn init_ndk_context() -> JniResult<()> {
                 jvm.get_java_vm_pointer() as _,
                 ctx.as_obj().as_raw() as _,
             );
+            #[cfg(feature = "hwcodec")]
+            hwcodec::android::ffmpeg_set_java_vm(
+                jvm.get_java_vm_pointer() as _,
+            );
         }
         *lock = true;
         return Ok(());


### PR DESCRIPTION
This is a companion change utilizing https://github.com/rustdesk-org/hwcodec/pull/12
