### PR TITLE
fix: privacy mode, windows vd, init resolution

### DIFF
--- a/src/privacy_mode.rs
+++ b/src/privacy_mode.rs
@@ -187,6 +187,7 @@ fn get_supported_impl(impl_key: &str) -> String {
     if supported_impls.iter().any(|(k, _)| k == &impl_key) {
         return impl_key.to_owned();
     };
+    // TODO: Is it a good idea to use fallback here? Because user do not know the fallback.
     // fallback
     let mut cur_impl = get_option("privacy-mode-impl-key".to_owned());
     if !get_supported_privacy_mode_impl()
@@ -223,6 +224,8 @@ async fn turn_on_privacy_async(impl_key: String, conn_id: i32) -> Option<ResultT
         let res = turn_on_privacy_sync(&impl_key, conn_id);
         let _ = tx.send(res);
     });
+    // Wait at most 5 seconds for the result.
+    // Because it may take a long time to turn on the privacy mode with amyuni idd.
     match hbb_common::timeout(5000, rx).await {
         Ok(res) => match res {
             Ok(res) => res,

--- a/src/privacy_mode/win_topmost_window.rs
+++ b/src/privacy_mode/win_topmost_window.rs
@@ -75,7 +75,7 @@ impl PrivacyMode for PrivacyModeImpl {
     fn is_async_privacy_mode(&self) -> bool {
         false
     }
-    
+
     fn init(&self) -> ResultType<()> {
         Ok(())
     }

--- a/src/privacy_mode/win_virtual_display.rs
+++ b/src/privacy_mode/win_virtual_display.rs
@@ -213,6 +213,8 @@ impl PrivacyModeImpl {
                 dm.u1.s2_mut().dmPosition.x -= new_primary_dm.u1.s2().dmPosition.x;
                 dm.u1.s2_mut().dmPosition.y -= new_primary_dm.u1.s2().dmPosition.y;
                 dm.dmFields |= DM_POSITION;
+                dm.dmPelsWidth = 1920;
+                dm.dmPelsHeight = 1080;
                 let rc = ChangeDisplaySettingsExW(
                     dd.DeviceName.as_ptr(),
                     &mut dm,
@@ -220,7 +222,6 @@ impl PrivacyModeImpl {
                     flags,
                     NULL,
                 );
-
                 if rc != DISP_CHANGE_SUCCESSFUL {
                     log::error!(
                         "Failed ChangeDisplaySettingsEx, device name: {:?}, flags: {}, ret: {}",
@@ -230,6 +231,15 @@ impl PrivacyModeImpl {
                     );
                     bail!("Failed ChangeDisplaySettingsEx, ret: {}", rc);
                 }
+
+                // If we want to set dpi, the following references may be helpful.
+                // And setting dpi should be called after changing the display settings.
+                // https://stackoverflow.com/questions/35233182/how-can-i-change-windows-10-display-scaling-programmatically-using-c-sharp
+                // https://github.com/lihas/windows-DPI-scaling-sample/blob/master/DPIHelper/DpiHelper.cpp
+                //
+                // But the official API does not provide a way to get/set dpi.
+                // https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ne-wingdi-displayconfig_device_info_type
+                // https://github.com/lihas/windows-DPI-scaling-sample/blob/738ac18b7a7ce2d8fdc157eb825de9cb5eee0448/DPIHelper/DpiHelper.h#L37
             }
         }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/8946

Use resolution `1920x1080` for privacy mode 2.


![a](https://github.com/user-attachments/assets/aced9eea-16cf-4eb7-8d5d-bc84bd0f1935)


The resolution of control side is not used, since `DPI` also affects the display.

Maybe we can add the `DPI` setting in the future.
