### PR TITLE
fix: multi-displays, displays changed, switch idx

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1003,14 +1003,15 @@ class FfiModel with ChangeNotifier {
             // Notify to switch display
             msgBox(sessionId, 'custom-nook-nocancel-hasclose-info', 'Prompt',
                 'display_is_plugged_out_msg', '', parent.target!.dialogManager);
-            final newDisplay = pi.primaryDisplay == kInvalidDisplayIndex
-                ? 0
-                : pi.primaryDisplay;
-            final displays = newDisplay;
+            final isPeerPrimaryDisplayValid =
+                pi.primaryDisplay == kInvalidDisplayIndex ||
+                    pi.primaryDisplay >= pi.displays.length;
+            final newDisplay =
+                isPeerPrimaryDisplayValid ? 0 : pi.primaryDisplay;
             bind.sessionSwitchDisplay(
               isDesktop: isDesktop,
               sessionId: sessionId,
-              value: Int32List.fromList([displays]),
+              value: Int32List.fromList([newDisplay]),
             );
 
             if (_pi.isSupportMultiUiSession) {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/8994

Use init display index as the primary index.

But when displays are changed, the primary display may also change.

No need to change the old primary index.
But we need to make sure that the old primary index does not exceed the display number. New conditions is added `pi.primaryDisplay >= pi.displays.length`.

### Reproduce steps

Windows/Linux/MacOS -> Win10/Win11

1. Controlled side, multiple displays, set main display to number other than `1`. Eg: `2`.
2. Control side, connect. Set primay display index to the second display.
3. Control side, turn on "Privacy mode 2".
4. Controlled side, plug in virtual display, turn off all physical displays.
5. The control end receives new screen display information, but only receives one screen display. However, the main screen display index is still the second one, which makes the current screen display index invalid.