### PR TITLE
fix: win, virtual display

### DIFF
--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1780,6 +1780,54 @@ pub fn try_sync_peer_option(
     }
 }
 
+pub(super) fn session_update_virtual_display(session: &FlutterSession, index: i32, on: bool) {
+    let virtual_display_key = "virtual-display";
+    let displays = session.get_option(virtual_display_key.to_owned());
+    if !on {
+        if index == -1 {
+            if !displays.is_empty() {
+                session.set_option(virtual_display_key.to_owned(), "".to_owned());
+            }
+        } else {
+            let mut vdisplays = displays.split(',').collect::<Vec<_>>();
+            let len = vdisplays.len();
+            if index == 0 {
+                // 0 means we cann't toggle the virtual display by index.
+                vdisplays.remove(vdisplays.len() - 1);
+            } else {
+                if let Some(i) = vdisplays.iter().position(|&x| x == index.to_string()) {
+                    vdisplays.remove(i);
+                }
+            }
+            if vdisplays.len() != len {
+                session.set_option(
+                    virtual_display_key.to_owned(),
+                    vdisplays.join(",").to_owned(),
+                );
+            }
+        }
+    } else {
+        let mut vdisplays = displays
+            .split(',')
+            .map(|x| x.to_string())
+            .collect::<Vec<_>>();
+        let len = vdisplays.len();
+        if index == 0 {
+            vdisplays.push(index.to_string());
+        } else {
+            if !vdisplays.iter().any(|x| *x == index.to_string()) {
+                vdisplays.push(index.to_string());
+            }
+        }
+        if vdisplays.len() != len {
+            session.set_option(
+                virtual_display_key.to_owned(),
+                vdisplays.join(",").to_owned(),
+            );
+        }
+    }
+}
+
 // sessions mod is used to avoid the big lock of sessions' map.
 pub mod sessions {
     use std::collections::HashSet;

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1568,6 +1568,7 @@ pub fn session_on_waiting_for_image_dialog_show(session_id: SessionID) {
 pub fn session_toggle_virtual_display(session_id: SessionID, index: i32, on: bool) {
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
         session.toggle_virtual_display(index, on);
+        flutter::session_update_virtual_display(&session, index, on);
     }
 }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2595,3 +2595,107 @@ pub fn try_set_window_foreground(window: HWND) {
         }
     }
 }
+
+pub mod reg_display_settings {
+    use hbb_common::ResultType;
+    use serde_derive::{Deserialize, Serialize};
+    use std::collections::HashMap;
+    use winreg::{enums::*, RegValue};
+    const REG_GRAPHICS_DRIVERS_PATH: &str = "SYSTEM\\CurrentControlSet\\Control\\GraphicsDrivers";
+    const REG_CONNECTIVITY_PATH: &str = "Connectivity";
+
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct RegRecovery {
+        path: String,
+        key: String,
+        old: (Vec<u8>, isize),
+        new: (Vec<u8>, isize),
+    }
+
+    pub fn read_reg_connectivity() -> ResultType<HashMap<String, HashMap<String, RegValue>>>
+    {
+        let hklm = winreg::RegKey::predef(HKEY_LOCAL_MACHINE);
+        let reg_connectivity = hklm.open_subkey_with_flags(
+            format!("{}\\{}", REG_GRAPHICS_DRIVERS_PATH, REG_CONNECTIVITY_PATH),
+            KEY_READ,
+        )?;
+
+        let mut map_connectivity = HashMap::new();
+        for key in reg_connectivity.enum_keys() {
+            let key = key?;
+            let mut map_item = HashMap::new();
+            let reg_item = reg_connectivity.open_subkey_with_flags(&key, KEY_READ)?;
+            for value in reg_item.enum_values() {
+                let (name, value) = value?;
+                map_item.insert(name, value);
+            }
+            map_connectivity.insert(key, map_item);
+        }
+        Ok(map_connectivity)
+    }
+
+    pub fn diff_recent_connectivity(
+        map1: HashMap<String, HashMap<String, RegValue>>,
+        map2: HashMap<String, HashMap<String, RegValue>>,
+    ) -> Option<RegRecovery> {
+        for (subkey, map_item2) in map2 {
+            if let Some(map_item1) = map1.get(&subkey) {
+                let key = "Recent";
+                if let Some(value1) = map_item1.get(key) {
+                    if let Some(value2) = map_item2.get(key) {
+                        if value1 != value2 {
+                            return Some(RegRecovery {
+                                path: format!(
+                                    "{}\\{}\\{}",
+                                    REG_GRAPHICS_DRIVERS_PATH, REG_CONNECTIVITY_PATH, subkey
+                                ),
+                                key: key.to_owned(),
+                                old: (value1.bytes.clone(), value1.vtype.clone() as isize),
+                                new: (value2.bytes.clone(), value2.vtype.clone() as isize),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    pub fn restore_reg_connectivity(reg_recovery: RegRecovery) -> ResultType<()> {
+        let hklm = winreg::RegKey::predef(HKEY_LOCAL_MACHINE);
+        let reg_item = hklm.open_subkey_with_flags(&reg_recovery.path, KEY_READ | KEY_WRITE)?;
+        let cur_reg_value = reg_item.get_raw_value(&reg_recovery.key)?;
+        let new_reg_value = RegValue {
+            bytes: reg_recovery.new.0,
+            vtype: isize_to_reg_type(reg_recovery.new.1),
+        };
+        if cur_reg_value != new_reg_value {
+            return Ok(());
+        }
+        let reg_value = RegValue {
+            bytes: reg_recovery.old.0,
+            vtype: isize_to_reg_type(reg_recovery.old.1),
+        };
+        reg_item.set_raw_value(&reg_recovery.key, &reg_value)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn isize_to_reg_type(i: isize) -> RegType {
+        match i {
+            0 => RegType::REG_NONE,
+            1 => RegType::REG_SZ,
+            2 => RegType::REG_EXPAND_SZ,
+            3 => RegType::REG_BINARY,
+            4 => RegType::REG_DWORD,
+            5 => RegType::REG_DWORD_BIG_ENDIAN,
+            6 => RegType::REG_LINK,
+            7 => RegType::REG_MULTI_SZ,
+            8 => RegType::REG_RESOURCE_LIST,
+            9 => RegType::REG_FULL_RESOURCE_DESCRIPTOR,
+            10 => RegType::REG_RESOURCE_REQUIREMENTS_LIST,
+            11 => RegType::REG_QWORD,
+            _ => RegType::REG_NONE,
+        }
+    }
+}

--- a/src/privacy_mode/win_virtual_display.rs
+++ b/src/privacy_mode/win_virtual_display.rs
@@ -1,5 +1,5 @@
 use super::{PrivacyMode, PrivacyModeState, INVALID_PRIVACY_MODE_CONN_ID, NO_PHYSICAL_DISPLAYS};
-use crate::virtual_display_manager;
+use crate::{platform::windows::reg_display_settings, virtual_display_manager};
 use hbb_common::{allow_err, bail, config::Config, log, ResultType};
 use std::{
     io::Error,
@@ -150,7 +150,8 @@ impl PrivacyModeImpl {
     }
 
     fn restore_plug_out_monitor(&mut self) {
-        let _ = virtual_display_manager::plug_out_monitor_indices(&self.virtual_displays_added);
+        let _ =
+            virtual_display_manager::plug_out_monitor_indices(&self.virtual_displays_added, true);
         self.virtual_displays_added.clear();
     }
 
@@ -296,7 +297,7 @@ impl PrivacyModeImpl {
 
             // No physical displays, no need to use the privacy mode.
             if self.displays.is_empty() {
-                virtual_display_manager::plug_out_monitor_indices(&displays)?;
+                virtual_display_manager::plug_out_monitor_indices(&displays, false)?;
                 bail!(NO_PHYSICAL_DISPLAYS);
             }
 
@@ -414,8 +415,14 @@ impl PrivacyMode for PrivacyModeImpl {
     ) -> ResultType<()> {
         self.check_off_conn_id(conn_id)?;
         super::win_input::unhook()?;
-        self.restore_plug_out_monitor();
+        let virtual_display_added = self.virtual_displays_added.len() > 0;
+        if virtual_display_added {
+            self.restore_plug_out_monitor();
+        }
         restore_reg_connectivity(false);
+        if !virtual_display_added {
+            Self::commit_change_display(CDS_RESET)?;
+        }
 
         if self.conn_id != INVALID_PRIVACY_MODE_CONN_ID {
             if let Some(state) = state {
@@ -462,7 +469,7 @@ pub fn restore_reg_connectivity(plug_out_monitors: bool) {
         return;
     }
     if plug_out_monitors {
-        let _ = virtual_display_manager::plug_out_monitor(-1);
+        let _ = virtual_display_manager::plug_out_monitor(-1, true);
     }
     if let Ok(reg_recovery) =
         serde_json::from_str::<reg_display_settings::RegRecovery>(&config_recovery_value)
@@ -472,108 +479,4 @@ pub fn restore_reg_connectivity(plug_out_monitors: bool) {
         }
     }
     reset_config_reg_connectivity();
-}
-
-mod reg_display_settings {
-    use hbb_common::ResultType;
-    use serde_derive::{Deserialize, Serialize};
-    use std::collections::HashMap;
-    use winreg::{enums::*, RegValue};
-    const REG_GRAPHICS_DRIVERS_PATH: &str = "SYSTEM\\CurrentControlSet\\Control\\GraphicsDrivers";
-    const REG_CONNECTIVITY_PATH: &str = "Connectivity";
-
-    #[derive(Serialize, Deserialize, Debug)]
-    pub(super) struct RegRecovery {
-        path: String,
-        key: String,
-        old: (Vec<u8>, isize),
-        new: (Vec<u8>, isize),
-    }
-
-    pub(super) fn read_reg_connectivity() -> ResultType<HashMap<String, HashMap<String, RegValue>>>
-    {
-        let hklm = winreg::RegKey::predef(HKEY_LOCAL_MACHINE);
-        let reg_connectivity = hklm.open_subkey_with_flags(
-            format!("{}\\{}", REG_GRAPHICS_DRIVERS_PATH, REG_CONNECTIVITY_PATH),
-            KEY_READ,
-        )?;
-
-        let mut map_connectivity = HashMap::new();
-        for key in reg_connectivity.enum_keys() {
-            let key = key?;
-            let mut map_item = HashMap::new();
-            let reg_item = reg_connectivity.open_subkey_with_flags(&key, KEY_READ)?;
-            for value in reg_item.enum_values() {
-                let (name, value) = value?;
-                map_item.insert(name, value);
-            }
-            map_connectivity.insert(key, map_item);
-        }
-        Ok(map_connectivity)
-    }
-
-    pub(super) fn diff_recent_connectivity(
-        map1: HashMap<String, HashMap<String, RegValue>>,
-        map2: HashMap<String, HashMap<String, RegValue>>,
-    ) -> Option<RegRecovery> {
-        for (subkey, map_item2) in map2 {
-            if let Some(map_item1) = map1.get(&subkey) {
-                let key = "Recent";
-                if let Some(value1) = map_item1.get(key) {
-                    if let Some(value2) = map_item2.get(key) {
-                        if value1 != value2 {
-                            return Some(RegRecovery {
-                                path: format!(
-                                    "{}\\{}\\{}",
-                                    REG_GRAPHICS_DRIVERS_PATH, REG_CONNECTIVITY_PATH, subkey
-                                ),
-                                key: key.to_owned(),
-                                old: (value1.bytes.clone(), value1.vtype.clone() as isize),
-                                new: (value2.bytes.clone(), value2.vtype.clone() as isize),
-                            });
-                        }
-                    }
-                }
-            }
-        }
-        None
-    }
-
-    pub(super) fn restore_reg_connectivity(reg_recovery: RegRecovery) -> ResultType<()> {
-        let hklm = winreg::RegKey::predef(HKEY_LOCAL_MACHINE);
-        let reg_item = hklm.open_subkey_with_flags(&reg_recovery.path, KEY_READ | KEY_WRITE)?;
-        let cur_reg_value = reg_item.get_raw_value(&reg_recovery.key)?;
-        let new_reg_value = RegValue {
-            bytes: reg_recovery.new.0,
-            vtype: isize_to_reg_type(reg_recovery.new.1),
-        };
-        if cur_reg_value != new_reg_value {
-            return Ok(());
-        }
-        let reg_value = RegValue {
-            bytes: reg_recovery.old.0,
-            vtype: isize_to_reg_type(reg_recovery.old.1),
-        };
-        reg_item.set_raw_value(&reg_recovery.key, &reg_value)?;
-        Ok(())
-    }
-
-    #[inline]
-    fn isize_to_reg_type(i: isize) -> RegType {
-        match i {
-            0 => RegType::REG_NONE,
-            1 => RegType::REG_SZ,
-            2 => RegType::REG_EXPAND_SZ,
-            3 => RegType::REG_BINARY,
-            4 => RegType::REG_DWORD,
-            5 => RegType::REG_DWORD_BIG_ENDIAN,
-            6 => RegType::REG_LINK,
-            7 => RegType::REG_MULTI_SZ,
-            8 => RegType::REG_RESOURCE_LIST,
-            9 => RegType::REG_FULL_RESOURCE_DESCRIPTOR,
-            10 => RegType::REG_RESOURCE_REQUIREMENTS_LIST,
-            11 => RegType::REG_QWORD,
-            _ => RegType::REG_NONE,
-        }
-    }
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2670,7 +2670,7 @@ impl Connection {
                 }
             }
         } else {
-            if let Err(e) = virtual_display_manager::plug_out_monitor(t.display) {
+            if let Err(e) = virtual_display_manager::plug_out_monitor(t.display, false) {
                 log::error!("Failed to plug out virtual display {}: {}", t.display, e);
                 self.send(make_msg(format!(
                     "Failed to plug out virtual displays: {}",

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -433,7 +433,6 @@ pub fn try_get_displays_(add_amyuni_headless: bool) -> ResultType<Vec<Display>> 
     // }
 
     let no_displays_v = no_displays(&displays);
-    virtual_display_manager::set_can_plug_out_all(!no_displays_v);
     if no_displays_v {
         log::debug!("no displays, create virtual display");
         if let Err(e) = virtual_display_manager::plug_in_headless() {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/8044

## Preview

### Fix "No physical displays, no need to use the privacy mode."

May fix https://github.com/rustdesk/rustdesk/discussions/8994#discussioncomment-10300985

#### Bug


https://github.com/user-attachments/assets/9d55eae0-2a6e-4973-873b-79070f49b6f7


#### Fixed


https://github.com/user-attachments/assets/72310e89-f12c-438b-9319-4fdec05cf2f7


### Default resolution 1920x1080

https://github.com/user-attachments/assets/42c39a49-2439-41d1-a739-0d6014de3586

### Restore on conn & disconn

https://github.com/user-attachments/assets/8f9c033d-0cc3-405d-a55d-f6b280c04d3c

The options is stored in the peer's configuration.


```toml
[options]
virtual-display = ''
```

or

```toml
[options]
virtual-display = ',0,0'
```

## Desc

### Fix "No physical displays, no need to use the privacy mode."

The registry value is restored, but the settings in display settings is not refreshed if no virtual displays are plugged in/out.

We can manually trigger the refresh by the following call if no vitual displays are pluged in/out. 

![image](https://github.com/user-attachments/assets/7593bf55-b25d-445d-b5e5-2d64976b1d69)


### Default resolution 1920x1080

1. Move `mod reg_display_settings` from `src/privacy_mode/win_virtual_display.rs` to `src/platform/windows.rs`.
2. Spawn a new thread to check if the virtual display is plugged in for the first time.

![image](https://github.com/user-attachments/assets/ef4b7487-5a5a-4925-8d08-eae16ff81882)

![image](https://github.com/user-attachments/assets/a1bb6601-3457-48e2-b028-321798a8c041)

### Restore on conn & disconn

1. Save option.

![image](https://github.com/user-attachments/assets/f11a8753-9632-45d5-8104-ac7df23ecb2c)

2. Remove virtual displays on disconnection.

![image](https://github.com/user-attachments/assets/79b3a0dd-5328-42c9-933a-168d6b2df1a8)

3. Restore virtual displays.

![image](https://github.com/user-attachments/assets/317243c3-c016-4fd2-9fe4-2721384e1bf6)

**Note**:
1. Virtual displays are removed when the last connection is closed on the controlled side.  
If `A`,`B` -> `C`, `A` has one virtual display. Then `A` disconnect and connect, there will be two virtual displays on `C`.
Because `B` did not disconnect, `C` will not remove virtual displays. `A` will plug in one virtual display on conn.

We cannot control the display index to plug in with amyuni idd.

2. After all connections are closed, all virtual displays of amyuni idd will be deleted.



