### PR TITLE
fix: not plug virtual dislay, non win, installed

### DIFF
--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -73,6 +73,22 @@ pub struct Remote<T: InvokeUiSession> {
     fps_control: FpsControl,
     decode_fps: Arc<RwLock<Option<usize>>>,
     chroma: Arc<RwLock<Option<Chroma>>>,
+    peer_info: ParsedPeerInfo,
+}
+
+#[derive(Default)]
+struct ParsedPeerInfo {
+    platform: String,
+    is_installed: bool,
+    idd_impl: String,
+}
+
+impl ParsedPeerInfo {
+    fn is_support_virtual_display(&self) -> bool {
+        self.is_installed
+            && self.platform == "Windows"
+            && (self.idd_impl == "rustdesk_idd" || self.idd_impl == "amyuni_idd")
+    }
 }
 
 impl<T: InvokeUiSession> Remote<T> {
@@ -112,6 +128,7 @@ impl<T: InvokeUiSession> Remote<T> {
             fps_control: Default::default(),
             decode_fps,
             chroma,
+            peer_info: Default::default(),
         }
     }
 
@@ -938,6 +955,9 @@ impl<T: InvokeUiSession> Remote<T> {
     }
 
     async fn send_toggle_virtual_display_msg(&self, peer: &mut Stream) {
+        if !self.peer_info.is_support_virtual_display() {
+            return;
+        }
         let lc = self.handler.lc.read().unwrap();
         let displays = lc.get_option("virtual-display");
         for d in displays.split(',') {
@@ -961,6 +981,11 @@ impl<T: InvokeUiSession> Remote<T> {
             && lc.get_toggle_option("privacy-mode")
         {
             let impl_key = lc.get_option("privacy-mode-impl-key");
+            if impl_key == crate::privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY
+                && !self.peer_info.is_support_virtual_display()
+            {
+                return;
+            }
             let mut misc = Misc::new();
             misc.set_toggle_privacy_mode(TogglePrivacyMode {
                 impl_key,
@@ -1142,6 +1167,7 @@ impl<T: InvokeUiSession> Remote<T> {
                     Some(login_response::Union::PeerInfo(pi)) => {
                         let peer_version = pi.version.clone();
                         let peer_platform = pi.platform.clone();
+                        self.set_peer_info(&pi);
                         self.handler.handle_peer_info(pi);
                         self.check_clipboard_file_context();
                         if !(self.handler.is_file_transfer() || self.handler.is_port_forward()) {
@@ -1630,6 +1656,25 @@ impl<T: InvokeUiSession> Remote<T> {
             }
         }
         true
+    }
+
+    fn set_peer_info(&mut self, pi: &PeerInfo) {
+        self.peer_info.platform = pi.platform.clone();
+        if let Ok(platform_additions) =
+            serde_json::from_str::<HashMap<String, serde_json::Value>>(&pi.platform_additions)
+        {
+            self.peer_info.is_installed = platform_additions
+                .get("is_installed")
+                .map(|v| v.as_bool())
+                .flatten()
+                .unwrap_or(false);
+            self.peer_info.idd_impl = platform_additions
+                .get("idd_impl")
+                .map(|v| v.as_str())
+                .flatten()
+                .unwrap_or_default()
+                .to_string();
+        }
     }
 
     async fn handle_back_notification(&mut self, notification: BackNotification) -> bool {


### PR DESCRIPTION
Do not send message "plug in virtual display" if peer is not windows and installed.

The peer info is parsed in UI side, flutter and sicter (additional info ignored).

We can move  `send_toggle_virtual_display_msg()` to the flutter side.

But it may be better to do in rust side.


https://github.com/user-attachments/assets/a9d46363-e2de-43a3-855c-d65bfe887cf5

