### PR TITLE
fix: windows, remote window, resizing

### DIFF
--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -335,7 +335,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: cd323a66d0771aeea4bc243a203eacfb6f89e3e4
+      resolved-ref: "80b063b9d4e015f62e17f42a5aa0b3d20a365926"
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/9061


https://github.com/user-attachments/assets/ac7ff458-b823-445d-ab35-ef604766762b


# Tests

https://github.com/rustdesk/rustdesk/discussions/9063#discussioncomment-10338875

## Single monitor

- [x] "Minimize, Restore/Maximize, Close" buttons.
  - [x] Main window
  - [x] Remote window
- [x] Window edges, normal, maximized, fullscreen.  Whether the edges can be shown.
  - [x] Main window
  - [x] Remote window

- [x] Resizing
  - [x] Main window
  - [x] Remote window
  - [x] Corner resize
  - [x] Edge resize

- [x] Show all contents, without crops. Remote window, normal, maximized, fullscreen.


## Multiple monitors

- [x] Different arrangements.

- [x] Different main display.
  - [x] Display 1 as main display
  - [x] Display 2 as main display
  - [x] Display 3 as main display

- [x] Different scale on some monitors.
  - [x] Display 1 (100), Display 2 (150), Display 3(200)
  - [x] Display 1 (150), Display 2 (120), Display 3(100)

## Note

1. **The experience of resizing through the top edge is not good**.  History issue.


https://github.com/user-attachments/assets/b5e84e57-5067-4ecc-a1d3-ab1ab21f7e84


