### PR TITLE
fix: resize top edge

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3492,7 +3492,8 @@ Widget buildVirtualWindowFrame(BuildContext context, Widget child) {
   );
 }
 
-get windowEdgeSize => isLinux && !_linuxWindowResizable ? 0.0 : kWindowEdgeSize;
+get windowResizeEdgeSize =>
+    isLinux && !_linuxWindowResizable ? 0.0 : kWindowResizeEdgeSize;
 
 // `windowManager.setResizable(false)` will reset the window size to the default size on Linux and then set unresizable.
 // See _linuxWindowResizable for more details.

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -241,9 +241,9 @@ const kDefaultScrollDuration = Duration(milliseconds: 50);
 const kDefaultMouseWheelThrottleDuration = Duration(milliseconds: 50);
 const kFullScreenEdgeSize = 0.0;
 const kMaximizeEdgeSize = 0.0;
-// Do not use kWindowEdgeSize directly. Use `windowEdgeSize` in `common.dart` instead.
-final kWindowEdgeSize = isWindows ? 1.0 : 5.0;
-final kWindowBorderWidth = 1.0;
+// Do not use kWindowResizeEdgeSize directly. Use `windowResizeEdgeSize` in `common.dart` instead.
+const kWindowResizeEdgeSize = 5.0;
+const kWindowBorderWidth = 1.0;
 const kDesktopMenuPadding = EdgeInsets.only(left: 12.0, right: 3.0);
 const kFrameBorderRadius = 12.0;
 const kFrameClipRRectBorderRadius = 12.0;

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -257,8 +257,9 @@ class _ConnectionPageState extends State<ConnectionPage>
   @override
   void onWindowLeaveFullScreen() {
     // Restore edge border to default edge size.
-    stateGlobal.resizeEdgeSize.value =
-        stateGlobal.isMaximized.isTrue ? kMaximizeEdgeSize : windowEdgeSize;
+    stateGlobal.resizeEdgeSize.value = stateGlobal.isMaximized.isTrue
+        ? kMaximizeEdgeSize
+        : windowResizeEdgeSize;
   }
 
   @override

--- a/flutter/lib/models/state_model.dart
+++ b/flutter/lib/models/state_model.dart
@@ -14,7 +14,7 @@ class StateGlobal {
   bool _isMinimized = false;
   final RxBool isMaximized = false.obs;
   final RxBool _showTabBar = true.obs;
-  final RxDouble _resizeEdgeSize = RxDouble(windowEdgeSize);
+  final RxDouble _resizeEdgeSize = RxDouble(windowResizeEdgeSize);
   final RxDouble _windowBorderWidth = RxDouble(kWindowBorderWidth);
   final RxBool showRemoteToolBar = false.obs;
   final svcStatus = SvcStatus.notReady.obs;
@@ -93,7 +93,7 @@ class StateGlobal {
       ? kFullScreenEdgeSize
       : isMaximized.isTrue
           ? kMaximizeEdgeSize
-          : windowEdgeSize;
+          : windowResizeEdgeSize;
 
   String getInputSource({bool force = false}) {
     if (force || _inputSource.isEmpty) {


### PR DESCRIPTION
## Preview

### Bug

https://github.com/user-attachments/assets/b5e84e57-5067-4ecc-a1d3-ab1ab21f7e84

### Fixed

https://github.com/user-attachments/assets/d9c270ec-ebda-4940-8da5-9d89fce160a4

## Desc

We have historically changed `kWindowEdgeSize`, `4.0` -> `1.0` -> `5.0` -> `1.0` for Windows.
But I can confirm we it should be greater than `1.0`, as it is only used for resizing.

Only top edige has the issue because the others edge has an extra 8 pixels for dragging.

https://github.com/rustdesk-org/window_manager/blob/f19acdb008645366339444a359a45c3257c8b32e/windows/window_manager_plugin.cpp#L154

1. It may be better to remove the fixed 8 pixels. And set the dragging edge side only in `DragToResizeArea` https://github.com/rustdesk-org/window_manager/blob/f19acdb008645366339444a359a45c3257c8b32e/lib/src/widgets/drag_to_resize_area.dart#L27
2. It's better to apply dpi, not a fixed drag edge size. eg. `8 * 150%`

## Tests

- [ ] Compare to the system window
- [ ] Do no affect the cursor in remote window
- [ ] Fullscreen
- [ ] Move cursor in/out window, trigger resizing
