### PR TITLE
fix: resize top edge

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3492,7 +3492,8 @@ Widget buildVirtualWindowFrame(BuildContext context, Widget child) {
   );
 }
 
-get windowEdgeSize => isLinux && !_linuxWindowResizable ? 0.0 : kWindowEdgeSize;
+get windowResizeEdgeSize =>
+    isLinux && !_linuxWindowResizable ? 0.0 : kWindowResizeEdgeSize;
 
 // `windowManager.setResizable(false)` will reset the window size to the default size on Linux and then set unresizable.
 // See _linuxWindowResizable for more details.
@@ -3570,3 +3571,19 @@ Widget netWorkErrorWidget() {
     ],
   ));
 }
+
+List<ResizeEdge>? get windowManagerEnableResizeEdges => isWindows
+    ? [
+        ResizeEdge.topLeft,
+        ResizeEdge.top,
+        ResizeEdge.topRight,
+      ]
+    : null;
+
+List<SubWindowResizeEdge>? get subWindowManagerEnableResizeEdges => isWindows
+    ? [
+        SubWindowResizeEdge.topLeft,
+        SubWindowResizeEdge.top,
+        SubWindowResizeEdge.topRight,
+      ]
+    : null;

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -241,9 +241,9 @@ const kDefaultScrollDuration = Duration(milliseconds: 50);
 const kDefaultMouseWheelThrottleDuration = Duration(milliseconds: 50);
 const kFullScreenEdgeSize = 0.0;
 const kMaximizeEdgeSize = 0.0;
-// Do not use kWindowEdgeSize directly. Use `windowEdgeSize` in `common.dart` instead.
-final kWindowEdgeSize = isWindows ? 1.0 : 5.0;
-final kWindowBorderWidth = 1.0;
+// Do not use kWindowResizeEdgeSize directly. Use `windowResizeEdgeSize` in `common.dart` instead.
+const kWindowResizeEdgeSize = 5.0;
+const kWindowBorderWidth = 1.0;
 const kDesktopMenuPadding = EdgeInsets.only(left: 12.0, right: 3.0);
 const kFrameBorderRadius = 12.0;
 const kFrameClipRRectBorderRadius = 12.0;

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -257,8 +257,9 @@ class _ConnectionPageState extends State<ConnectionPage>
   @override
   void onWindowLeaveFullScreen() {
     // Restore edge border to default edge size.
-    stateGlobal.resizeEdgeSize.value =
-        stateGlobal.isMaximized.isTrue ? kMaximizeEdgeSize : windowEdgeSize;
+    stateGlobal.resizeEdgeSize.value = stateGlobal.isMaximized.isTrue
+        ? kMaximizeEdgeSize
+        : windowResizeEdgeSize;
   }
 
   @override

--- a/flutter/lib/desktop/pages/desktop_tab_page.dart
+++ b/flutter/lib/desktop/pages/desktop_tab_page.dart
@@ -126,6 +126,7 @@ class _DesktopTabPageState extends State<DesktopTabPage>
         : Obx(
             () => DragToResizeArea(
               resizeEdgeSize: stateGlobal.resizeEdgeSize.value,
+              enableResizeEdges: windowManagerEnableResizeEdges,
               child: tabWidget,
             ),
           );

--- a/flutter/lib/desktop/pages/file_manager_tab_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_tab_page.dart
@@ -111,6 +111,7 @@ class _FileManagerTabPageState extends State<FileManagerTabPage> {
         : SubWindowDragToResizeArea(
             child: tabWidget,
             resizeEdgeSize: stateGlobal.resizeEdgeSize.value,
+            enableResizeEdges: subWindowManagerEnableResizeEdges,
             windowId: stateGlobal.windowId,
           );
   }

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -43,6 +43,7 @@ class _InstallPageState extends State<InstallPage> {
   Widget build(BuildContext context) {
     return DragToResizeArea(
       resizeEdgeSize: stateGlobal.resizeEdgeSize.value,
+      enableResizeEdges: windowManagerEnableResizeEdges,
       child: Container(
         child: Scaffold(
             backgroundColor: Theme.of(context).colorScheme.background,

--- a/flutter/lib/desktop/pages/port_forward_tab_page.dart
+++ b/flutter/lib/desktop/pages/port_forward_tab_page.dart
@@ -127,6 +127,7 @@ class _PortForwardTabPageState extends State<PortForwardTabPage> {
             () => SubWindowDragToResizeArea(
               child: tabWidget,
               resizeEdgeSize: stateGlobal.resizeEdgeSize.value,
+              enableResizeEdges: subWindowManagerEnableResizeEdges,
               windowId: stateGlobal.windowId,
             ),
           );

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -228,6 +228,7 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
               // Specially configured for a better resize area and remote control.
               childPadding: kDragToResizeAreaPadding,
               resizeEdgeSize: stateGlobal.resizeEdgeSize.value,
+              enableResizeEdges: subWindowManagerEnableResizeEdges,
               windowId: stateGlobal.windowId,
             ));
   }

--- a/flutter/lib/models/state_model.dart
+++ b/flutter/lib/models/state_model.dart
@@ -14,7 +14,7 @@ class StateGlobal {
   bool _isMinimized = false;
   final RxBool isMaximized = false.obs;
   final RxBool _showTabBar = true.obs;
-  final RxDouble _resizeEdgeSize = RxDouble(windowEdgeSize);
+  final RxDouble _resizeEdgeSize = RxDouble(windowResizeEdgeSize);
   final RxDouble _windowBorderWidth = RxDouble(kWindowBorderWidth);
   final RxBool showRemoteToolBar = false.obs;
   final svcStatus = SvcStatus.notReady.obs;
@@ -93,7 +93,7 @@ class StateGlobal {
       ? kFullScreenEdgeSize
       : isMaximized.isTrue
           ? kMaximizeEdgeSize
-          : windowEdgeSize;
+          : windowResizeEdgeSize;
 
   String getInputSource({bool force = false}) {
     if (force || _inputSource.isEmpty) {


### PR DESCRIPTION
## Preview

### Bug

https://github.com/user-attachments/assets/b5e84e57-5067-4ecc-a1d3-ab1ab21f7e84

### Fixed


https://github.com/user-attachments/assets/e92910b5-41fc-41d2-832e-dd52b70e96e6


#### System window


https://github.com/user-attachments/assets/4a293180-7319-425f-956b-4e014a8e7818



## Desc

On Windows, only the top and corner resize edges are set.

### More

The sizing border of a window (in black) are the red rectangles.

![image](https://github.com/user-attachments/assets/f9c095fb-09a9-4a8b-99f6-cfad6eef243f)

### window manager

Run window manager's default example, change the following three lines. Monitor scale is 150%.

https://github.com/rustdesk-org/window_manager/blob/f19acdb008645366339444a359a45c3257c8b32e/windows/window_manager_plugin.cpp#L154

```c++
      sz->rgrc[0].right -= 8;
      sz->rgrc[0].bottom -= 8;
      sz->rgrc[0].left -= -8;
```

1. Change the values to 0.

<img width="155" alt="1723734509761" src="https://github.com/user-attachments/assets/d22c7d19-e77c-40da-b6e6-b1d4b2c0213a">

2. Change the values to 11. (11 -> scale 150%, 8 -> scale 100%)

<img width="200" alt="1723734665214" src="https://github.com/user-attachments/assets/7262907c-04d6-4421-a57c-be107468a1d4">


3. Change the values to 200.

<img width="219" alt="1723734599214" src="https://github.com/user-attachments/assets/a9731ee7-380a-419c-9c08-cdd05e5b02ff">


We can see that the window has an 11-pixel transparent area for resizing.

#### TODO

We need to query and set a better value based on the current monitor scale.

1. Window manager and multi desktop window.
2. `kWindowResizeEdgeSize` for top edge in RustDesk.

## Tests

- [x] Compare to the system window
- [x] Do no affect the cursor in remote window
- [x] Fullscreen
- [x] Move cursor in/out window, trigger resizing


## Refs and useful links

1. https://learn.microsoft.com/en-us/windows/win32/winmsg/window-styles
3. https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsystemmetrics
6. https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/nf-dwmapi-dwmgetwindowattribute
