### PR TITLE
fix: crash, drop tokio RunTime in async context (Wayland)

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -481,7 +481,7 @@ pub async fn start_server(is_server: bool) {
         });
         input_service::fix_key_down_timeout_loop();
         #[cfg(target_os = "linux")]
-        if crate::platform::current_is_wayland() {
+        if input_service::wayland_use_uinput() {
             allow_err!(input_service::setup_uinput(0, 1920, 0, 1080).await);
         }
         #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1320,7 +1320,7 @@ impl Connection {
                     #[cfg(target_os = "linux")]
                     {
                         // use rdp_input when uinput is not available in wayland. Ex: flatpak
-                        if !is_x11() && !crate::is_server() {
+                        if input_service::wayland_use_rdp_input() {
                             let _ = setup_rdp_input().await;
                         }
                     }

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1636,6 +1636,18 @@ async fn send_sas() -> ResultType<()> {
     Ok(())
 }
 
+#[inline]
+#[cfg(target_os = "linux")]
+pub fn wayland_use_uinput() -> bool {
+    !crate::platform::is_x11() && crate::is_server()
+}
+
+#[inline]
+#[cfg(target_os = "linux")]
+pub fn wayland_use_rdp_input() -> bool {
+    !crate::platform::is_x11() && !crate::is_server()
+}
+
 lazy_static::lazy_static! {
     static ref MODIFIER_MAP: HashMap<i32, Key> = [
         (ControlKey::Alt, Key::Alt),

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -134,7 +134,7 @@ pub(super) async fn check_init() -> ResultType<()> {
         let mut minx = 0;
         let mut maxx = 0;
         let mut miny = 0;
-        let mut maxy: i32 = 0;
+        let mut maxy = 0;
         let use_uinput = crate::input_service::wayland_use_uinput();
 
         if *CAP_DISPLAY_INFO.read().unwrap() == 0 {

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -134,7 +134,8 @@ pub(super) async fn check_init() -> ResultType<()> {
         let mut minx = 0;
         let mut maxx = 0;
         let mut miny = 0;
-        let mut maxy = 0;
+        let mut maxy: i32 = 0;
+        let use_uinput = crate::input_service::wayland_use_uinput();
 
         if *CAP_DISPLAY_INFO.read().unwrap() == 0 {
             let mut lock = CAP_DISPLAY_INFO.write().unwrap();
@@ -167,28 +168,29 @@ pub(super) async fn check_init() -> ResultType<()> {
                     num_cpus::get(),
                 );
 
-                let (max_width, max_height) = match get_max_desktop_resolution() {
-                    Some(result) if !result.is_empty() => {
-                        let resolution: Vec<&str> = result.split(" ").collect();
-                        let w: i32 = resolution[0].parse().unwrap_or(origin.0 + width as i32);
-                        let h: i32 = resolution[2]
-                            .trim_end_matches(",")
-                            .parse()
-                            .unwrap_or(origin.1 + height as i32);
-                        if w < origin.0 + width as i32 || h < origin.1 + height as i32 {
-                            (origin.0 + width as i32, origin.1 + height as i32)
+                if use_uinput {
+                    let (max_width, max_height) = match get_max_desktop_resolution() {
+                        Some(result) if !result.is_empty() => {
+                            let resolution: Vec<&str> = result.split(" ").collect();
+                            let w: i32 = resolution[0].parse().unwrap_or(origin.0 + width as i32);
+                            let h: i32 = resolution[2]
+                                .trim_end_matches(",")
+                                .parse()
+                                .unwrap_or(origin.1 + height as i32);
+                            if w < origin.0 + width as i32 || h < origin.1 + height as i32 {
+                                (origin.0 + width as i32, origin.1 + height as i32)
+                            } else {
+                                (w, h)
+                            }
                         }
-                        else{
-                            (w, h)
-                        }
-                    }
-                    _ => (origin.0 + width as i32, origin.1 + height as i32),
-                };
+                        _ => (origin.0 + width as i32, origin.1 + height as i32),
+                    };
 
-                minx = 0;
-                maxx = max_width;
-                miny = 0;
-                maxy = max_height;
+                    minx = 0;
+                    maxx = max_width;
+                    miny = 0;
+                    maxy = max_height;
+                }
 
                 let capturer = Box::into_raw(Box::new(
                     Capturer::new(display).with_context(|| "Failed to create capturer")?,
@@ -206,15 +208,17 @@ pub(super) async fn check_init() -> ResultType<()> {
             }
         }
 
-        if minx != maxx && miny != maxy {
-            log::info!(
-                "update mouse resolution: ({}, {}), ({}, {})",
-                minx,
-                maxx,
-                miny,
-                maxy
-            );
-            allow_err!(input_service::update_mouse_resolution(minx, maxx, miny, maxy).await);
+        if use_uinput {
+            if minx != maxx && miny != maxy {
+                log::info!(
+                    "update mouse resolution: ({}, {}), ({}, {})",
+                    minx,
+                    maxx,
+                    miny,
+                    maxy
+                );
+                allow_err!(input_service::update_mouse_resolution(minx, maxx, miny, maxy).await);
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/9051

## Reproduce steps

1. Enable selinux.
2. Do not config RustDesk selinux policies.
3. Start rustdesk service. The `--server` process will not be started.
4. Start rustdesk client.

## Desc

> This happens when a runtime is dropped from within an asynchronous context.


1. `setup_uinput()` is called. `UInputKeyboard` and `UInputMouse` contains `Runtime`.
https://github.com/rustdesk/rustdesk/blob/ed18e3c7860edca81d07794773bd86ea51e14e18/src/server/input_service.rs#L519

https://github.com/rustdesk/rustdesk/blob/ed18e3c7860edca81d07794773bd86ea51e14e18/src/server/uinput.rs#L30

2. `setup_rdp_input()` is called. The previous added `UInputKeyboard` and `UInputMouse` instances are dropped.
https://github.com/rustdesk/rustdesk/blob/ed18e3c7860edca81d07794773bd86ea51e14e18/src/server/input_service.rs#L500

So we need to avoid dropping the `Runtime` within an asynchronous context.

## Tests

- [x]  Pure client
- [x] Enable selinux, start service and client.
- [x]  Disable selinux (or add selinux policies), start service.
