### PR TITLE
Fix new cm tab not replace the old persisted tab

### DIFF
--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -552,6 +552,13 @@ class _DesktopTabState extends State<DesktopTab>
             controller: state.value.pageController,
             physics: NeverScrollableScrollPhysics(),
             children: () {
+              if (DesktopTabType.cm == tabType) {
+                // Fix when adding a new tab still showing closed tabs with the same peer id, which would happen after the DesktopTab was stateful.
+                return state.value.tabs.map((tab) {
+                  return tab.page;
+                }).toList();
+              }
+
               /// to-do refactor, separate connection state and UI state for remote session.
               /// [workaround] PageView children need an immutable list, after it has been passed into PageView
               final tabLen = state.value.tabs.length;

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -826,7 +826,7 @@ class Client {
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};
     data['id'] = id;
-    data['is_start'] = authorized;
+    data['authorized'] = authorized;
     data['is_file_transfer'] = isFileTransfer;
     data['port_forward'] = portForward;
     data['name'] = name;
@@ -840,6 +840,8 @@ class Client {
     data['block_input'] = blockInput;
     data['disconnected'] = disconnected;
     data['from_switch'] = fromSwitch;
+    data['in_voice_call'] = inVoiceCall;
+    data['incoming_voice_call'] = incomingVoiceCall;
     return data;
   }
 


### PR DESCRIPTION
* This happens when after changing DesktopTab to StatefulWidget, 1.2.7 and 1.3.0 have this problem.
* When `addConnection` in server_model.dart is called, the old closed client is removed, the client parameter of `buildConnectionCard` is new, but client id inside Consumer is old.
* The only state in cm page is timer, its value is kept in test.
* Fix by always rebuild all cm tabs, there may be a better way to solve the ui update.


[bug.webm](https://github.com/user-attachments/assets/ac05750c-92c8-43ab-893b-f9727c5c95ee)

[fixed.webm](https://github.com/user-attachments/assets/80616ac6-1cf9-425a-8f25-6d6882412b74)

[time_state_kept.webm](https://github.com/user-attachments/assets/a16c900f-177e-4314-9d02-ee48c402ad33)
