### PR TITLE
replace appindicator to ayatana-appindicator

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -884,7 +884,7 @@ jobs:
                git \
                g++ \
                g++-multilib \
-               libappindicator3-dev \
+               libayatana-appindicator3-dev \
                libasound2-dev \
                libc6-dev \
                libclang-10-dev \
@@ -1144,7 +1144,7 @@ jobs:
                git \
                g++ \
                g++-multilib \
-               libappindicator3-dev \
+               libayatana-appindicator3-dev \
                libasound2-dev \
                libc6-dev \
                libclang-10-dev \
@@ -1418,7 +1418,7 @@ jobs:
                gcc \
                git \
                g++ \
-               libappindicator3-dev \
+               libayatana-appindicator3-dev \
                libasound2-dev \
                libclang-10-dev \
                libgstreamer1.0-dev \
@@ -1675,7 +1675,7 @@ jobs:
                gcc \
                git \
                g++ \
-               libappindicator3-dev \
+               libayatana-appindicator3-dev \
                libasound2-dev \
                libclang-dev \
                libdbus-1-dev \

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -262,7 +262,7 @@ jobs:
                git \
                g++ \
                g++-multilib \
-               libappindicator3-dev \
+               libayatana-appindicator3-dev\
                libasound2-dev \
                libc6-dev \
                libclang-10-dev \

--- a/build.py
+++ b/build.py
@@ -287,7 +287,7 @@ Version: %s
 Architecture: %s
 Maintainer: rustdesk <info@rustdesk.com>
 Homepage: https://rustdesk.com
-Depends: libgtk-3-0, libxcb-randr0, libxdo3, libxfixes3, libxcb-shape0, libxcb-xfixes0, libasound2, libsystemd0, curl, libva-drm2, libva-x11-2, libvdpau1, libgstreamer-plugins-base1.0-0, libpam0g, libappindicator3-1, gstreamer1.0-pipewire%s
+Depends: libgtk-3-0, libxcb-randr0, libxdo3, libxfixes3, libxcb-shape0, libxcb-xfixes0, libasound2, libsystemd0, curl, libva-drm2, libva-x11-2, libvdpau1, libgstreamer-plugins-base1.0-0, libpam0g, libayatana-appindicator3-1, gstreamer1.0-pipewire%s
 Description: A remote control software.
 
 """ % (version, get_deb_arch(), get_deb_extra_depends())

--- a/res/rpm-flutter-suse.spec
+++ b/res/rpm-flutter-suse.spec
@@ -3,7 +3,7 @@ Version:    1.3.0
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0
-Requires:   gtk3 libxcb1 xdotool libXfixes3 alsa-utils libXtst6 libappindicator-gtk3 libvdpau1 libva2 pam gstreamer-plugins-base gstreamer-plugin-pipewire
+Requires:   gtk3 libxcb1 xdotool libXfixes3 alsa-utils libXtst6 libayatana-appindicator3-1 libvdpau1 libva2 pam gstreamer-plugins-base gstreamer-plugin-pipewire
 Provides:   libdesktop_drop_plugin.so()(64bit), libdesktop_multi_window_plugin.so()(64bit), libfile_selector_linux_plugin.so()(64bit), libflutter_custom_cursor_plugin.so()(64bit), libflutter_linux_gtk.so()(64bit), libscreen_retriever_plugin.so()(64bit), libtray_manager_plugin.so()(64bit), liburl_launcher_linux_plugin.so()(64bit), libwindow_manager_plugin.so()(64bit), libwindow_size_plugin.so()(64bit), libtexture_rgba_renderer_plugin.so()(64bit)
 
 %description

--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -3,7 +3,7 @@ Version:    1.3.0
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0
-Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libappindicator-gtk3 libvdpau libva pam gstreamer1-plugins-base
+Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libayatana-appindicator3-1 libvdpau libva pam gstreamer1-plugins-base
 Provides:   libdesktop_drop_plugin.so()(64bit), libdesktop_multi_window_plugin.so()(64bit), libfile_selector_linux_plugin.so()(64bit), libflutter_custom_cursor_plugin.so()(64bit), libflutter_linux_gtk.so()(64bit), libscreen_retriever_plugin.so()(64bit), libtray_manager_plugin.so()(64bit), liburl_launcher_linux_plugin.so()(64bit), libwindow_manager_plugin.so()(64bit), libwindow_size_plugin.so()(64bit), libtexture_rgba_renderer_plugin.so()(64bit)
 
 %description

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -3,7 +3,7 @@ Version:    1.3.0
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0
-Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libappindicator libvdpau1 libva2 pam gstreamer1-plugins-base
+Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libayatana-appindicator3-1 libvdpau1 libva2 pam gstreamer1-plugins-base
 
 %description
 The best open-source remote desktop client software, written in Rust.


### PR DESCRIPTION
1. Replace  appindicator to ayatana-appindicator
* debian: tested on ubuntu 22.04
* debian flatpak: still use old appindicator, the control file of deb doesn't effect flatpak because it's not used, the tray doesn't show with nightly build.
* fedora: tested on fedora 38, the tray doesn't show with nightly build.
* suse: only test install because failed to install desktop
* arch: still use old one becase failed to build with `libayatana-appindicator`, althrough the package can be found on latest arch. https://github.com/21pages/rustdesk/actions/runs/10489496699/job/29054390628
2. Add to recommands, not implemented.
* debian: libayatana-appindicator3-1 is not added to `Recommands`, because libayatana-appindicator3-1 is not installed when it's in `Recommands` on ubuntu 22.04
* Rpm not well supported, https://unix.stackexchange.com/questions/73690/rpmbuild-is-there-a-way-to-specify-recommended-packages
3. Searched package, althrough not same as package in control file.
Arch:
![9b20c850ae64af9a52cda45ff37b7b6](https://github.com/user-attachments/assets/cd688aee-298a-4966-be5c-ed981ceb328b)
Suse:
![3717f4935508eea79916f76cf6641c5](https://github.com/user-attachments/assets/b07c0385-e36d-443e-962b-271b6184b54b)
Fedora:
![99989cc75bc6d9bc9833adcd2e954db](https://github.com/user-attachments/assets/8cff2f38-1789-44e3-9aa5-20ab3ddce984)

