### PR TITLE
fix: revert key events to raw key events on Linux

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -27,6 +27,10 @@ class RawKeyFocusScope extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // https://github.com/flutter/flutter/issues/154053
+    final useRawKeyEvents = isLinux && !isWeb;
+    // FIXME: On Windows, `AltGr` will generate `Alt` and `Control` key events,
+    // while `Alt` and `Control` are seperated key events for en-US input method.
     return FocusScope(
         autofocus: true,
         child: Focus(
@@ -34,7 +38,14 @@ class RawKeyFocusScope extends StatelessWidget {
             canRequestFocus: true,
             focusNode: focusNode,
             onFocusChange: onFocusChange,
-            onKeyEvent: (node, event) => inputModel.handleKeyEvent(event),
+            onKey: useRawKeyEvents
+                ? (FocusNode data, RawKeyEvent event) =>
+                    inputModel.handleRawKeyEvent(event)
+                : null,
+            onKeyEvent: useRawKeyEvents
+                ? null
+                : (FocusNode node, KeyEvent event) =>
+                    inputModel.handleKeyEvent(event),
             child: child));
   }
 }

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -508,6 +508,27 @@ pub fn session_handle_flutter_key_event(
     }
 }
 
+pub fn session_handle_flutter_raw_key_event(
+    session_id: SessionID,
+    name: String,
+    platform_code: i32,
+    position_code: i32,
+    lock_modes: i32,
+    down_or_up: bool,
+) {
+    if let Some(session) = sessions::get_session_by_session_id(&session_id) {
+        let keyboard_mode = session.get_keyboard_mode();
+        session.handle_flutter_raw_key_event(
+            &keyboard_mode,
+            &name,
+            platform_code,
+            position_code,
+            lock_modes,
+            down_or_up,
+        );
+    }
+}
+
 // SyncReturn<()> is used to make sure enter() and leave() are executed in the sequence this function is called.
 //
 // If the cursor jumps between remote page of two connections, leave view and enter view will be called.

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -788,12 +788,84 @@ impl<T: InvokeUiSession> Session<T> {
     }
 
     #[cfg(any(target_os = "ios"))]
-    pub fn handle_flutter_key_event(
+    pub fn handle_flutter_raw_key_event(
         &self,
         _keyboard_mode: &str,
         _name: &str,
         _platform_code: i32,
         _position_code: i32,
+        _lock_modes: i32,
+        _down_or_up: bool,
+    ) {
+    }
+
+    #[cfg(not(any(target_os = "ios")))]
+    pub fn handle_flutter_raw_key_event(
+        &self,
+        keyboard_mode: &str,
+        name: &str,
+        platform_code: i32,
+        position_code: i32,
+        lock_modes: i32,
+        down_or_up: bool,
+    ) {
+        if name == "flutter_key" {
+            self._handle_key_flutter_simulation(keyboard_mode, platform_code, down_or_up);
+        } else {
+            self._handle_raw_key_non_flutter_simulation(
+                keyboard_mode,
+                platform_code,
+                position_code,
+                lock_modes,
+                down_or_up,
+            );
+        }
+    }
+
+    #[cfg(not(any(target_os = "ios")))]
+    fn _handle_raw_key_non_flutter_simulation(
+        &self,
+        keyboard_mode: &str,
+        platform_code: i32,
+        position_code: i32,
+        lock_modes: i32,
+        down_or_up: bool,
+    ) {
+        if position_code < 0 || platform_code < 0 {
+            return;
+        }
+        let platform_code: u32 = platform_code as _;
+        let position_code: KeyCode = position_code as _;
+
+        #[cfg(not(target_os = "windows"))]
+        let key = rdev::key_from_code(position_code) as rdev::Key;
+        // Windows requires special handling
+        #[cfg(target_os = "windows")]
+        let key = rdev::get_win_key(platform_code, position_code);
+
+        let event_type = if down_or_up {
+            KeyPress(key)
+        } else {
+            KeyRelease(key)
+        };
+        let event = Event {
+            time: SystemTime::now(),
+            unicode: None,
+            platform_code,
+            position_code: position_code as _,
+            event_type,
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
+            extra_data: 0,
+        };
+        keyboard::client::process_event(keyboard_mode, &event, Some(lock_modes));
+    }
+
+    #[cfg(any(target_os = "ios"))]
+    pub fn handle_flutter_key_event(
+        &self,
+        _keyboard_mode: &str,
+        _character: &str,
+        _usb_hid: i32,
         _lock_modes: i32,
         _down_or_up: bool,
     ) {
@@ -870,7 +942,7 @@ impl<T: InvokeUiSession> Session<T> {
         // We need to set the platform code (keysym) if is AltGr.
         // https://github.com/rustdesk/rustdesk/blob/07cf1b4db5ef2f925efd3b16b87c33ce03c94809/src/keyboard.rs#L1029
         // https://github.com/flutter/flutter/issues/153811
-        #[cfg(target_os = "linux")] 
+        #[cfg(target_os = "linux")]
         let platform_code: u32 = position_code as _;
 
         let event_type = if down_or_up {


### PR DESCRIPTION
Revert key events to raw key events on Linux desktop because of https://github.com/flutter/flutter/issues/154053 .

### Compare to the old logic

https://github.com/rustdesk/rustdesk/compare/9d9741f18efd3ef1361c5b0e0d8e562c5f93acdd...fufesou:rustdesk:fix/keyboard_linux_raw_key_event?expand=1


### Tests

- [ ] Linux ->
  - [ ] Windows
    - [x] Character keys
        - [x] en-US -> en-US
        - [x] en-US -> fr-FR
          - [x] Normal keys
          - [x] AltGr keys
          - [x] Dead keys
        - [x] fr-FR -> en-US
        - [x] fr-FR -> fr-FR
    - [x] Shortcuts
    - [ ] System keys
    - [x] Navigation keys
    - [x] Function keys
    - [x] Numeric keypad
    - [x] Lock keys
  - [ ] Linux
    - [x] Character keys
        - [x] en-US -> en-US
        - [x] en-US -> fr-FR
          - [x] Normal keys
          - [x] AltGr keys
          - [x] Dead keys
        - [x] fr-FR -> en-US
        - [x] fr-FR -> fr-FR
    - [x] Shortcuts
    - [ ] System keys
    - [x] Navigation keys
    - [x] Function keys
    - [x] Numeric keypad
    - [x] Lock keys
  - [ ] MacOS
    - [x] Character keys
        - [x] en-US -> en-US
        - [x] en-US -> fr-FR
          - [x] Normal keys
          - [x] AltGr keys
          - [x] Dead keys
        - [x] fr-FR -> en-US
        - [x] fr-FR -> fr-FR
    - [x] Shortcuts
    - [ ] System keys
    - [x] Navigation keys
    - [x] Function keys
    - [x] Numeric keypad
    - [x] Lock keys