### PR TITLE
file transfer status text overflow at start

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
 
 env:
-  FLUTTER_VERSION: "3.16.9"
+  FLUTTER_VERSION: "3.19.6"
   FLUTTER_RUST_BRIDGE_VERSION: "1.80.1"
   RUST_VERSION: "1.75" # https://github.com/rustdesk/rustdesk/discussions/7503
 

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -976,8 +976,11 @@ jobs:
       - name: fix android for flutter 3.13
         if: $${{ env.ANDROID_FLUTTER_VERSION == '3.13.9' }}
         run: |
-          sed -i 's/uni_links_desktop/#uni_links_desktop/g' flutter/pubspec.yaml
-          cd flutter/lib
+          cd flutter
+          sed -i 's/uni_links_desktop/#uni_links_desktop/g' pubspec.yaml
+          sed -i 's/extended_text: .*/extended_text: 11.1.0/' pubspec.yaml
+          flutter pub get
+          cd lib
           find . | grep dart | xargs sed -i 's/textScaler: TextScaler.linear(\(.*\)),/textScaleFactor: \1,/g'
 
       - name: Build rustdesk lib
@@ -1210,8 +1213,11 @@ jobs:
       - name: fix android for flutter 3.13
         if: $${{ env.ANDROID_FLUTTER_VERSION == '3.13.9' }}
         run: |
-          sed -i 's/uni_links_desktop/#uni_links_desktop/g' flutter/pubspec.yaml
-          cd flutter/lib
+          cd flutter
+          sed -i 's/uni_links_desktop/#uni_links_desktop/g' pubspec.yaml
+          sed -i 's/extended_text: .*/extended_text: 11.1.0/' pubspec.yaml
+          flutter pub get
+          cd lib
           find . | grep dart | xargs sed -i 's/textScaler: TextScaler.linear(\(.*\)),/textScaleFactor: \1,/g'
 
       - name: Build rustdesk

--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:extended_text/extended_text.dart';
 import 'package:flutter_hbb/desktop/widgets/dragable_divider.dart';
 import 'package:percent_indicator/percent_indicator.dart';
 import 'package:desktop_drop/desktop_drop.dart';
@@ -211,10 +212,13 @@ class _FileManagerPageState extends State<FileManagerPage>
                               Tooltip(
                                 waitDuration: Duration(milliseconds: 500),
                                 message: item.jobName,
-                                child: Text(
+                                child: ExtendedText(
                                   item.jobName,
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
+                                  overflowWidget: TextOverflowWidget(
+                                      child: Text("..."),
+                                      position: TextOverflowPosition.start),
                                 ),
                               ),
                               Tooltip(

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -380,6 +380,22 @@ packages:
       url: "https://github.com/rustdesk-org/dynamic_layouts.git"
     source: git
     version: "0.0.1+1"
+  extended_text:
+    dependency: "direct main"
+    description:
+      name: extended_text
+      sha256: "7f382de3af12992e34bd72ddd36becf90c4720900af126cb9859f0189af71ffe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
+  extended_text_library:
+    dependency: transitive
+    description:
+      name: extended_text_library
+      sha256: "55d09098ec56fab0d9a8a68950ca0bbf2efa1327937f7cec6af6dfa066234829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.0"
   external_path:
     dependency: "direct main"
     description:
@@ -1613,5 +1629,5 @@ packages:
     source: hosted
     version: "0.2.1"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -104,6 +104,7 @@ dependencies:
   pull_down_button: ^0.9.3
   device_info_plus: ^9.1.0
   qr_flutter: ^4.1.0
+  extended_text: 13.0.0
 
 dev_dependencies:
   icons_launcher: ^2.0.4


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/9096#issuecomment-2296452332

1. Change the flutter version to 3.19.6 in bridge.yml
2. Change extended_text pub version to flutter 3.13 when building android

workflow: https://github.com/21pages/rustdesk/actions/runs/10546687575, failure on macos is due to other reasons.

![image](https://github.com/user-attachments/assets/66e502f5-24a5-4bae-aa3e-7a48328ae5cc)
