### PR TITLE
fix: web v2, keyboard mode

### DIFF
--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1612,7 +1612,9 @@ class _KeyboardMenu extends StatelessWidget {
       // If use flutter to grab keys, we can only use one mode.
       // Map mode and Legacy mode, at least one of them is supported.
       String? modeOnly;
-      if (isInputSourceFlutter) {
+      // Keep both map and legacy mode on web at the moment.
+      // TODO: Remove legacy mode after web supports translate mode on web.
+      if (isInputSourceFlutter && isDesktop) {
         if (bind.sessionIsKeyboardModeSupported(
             sessionId: ffi.sessionId, mode: kKeyMapMode)) {
           modeOnly = kKeyMapMode;

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -508,7 +508,7 @@ class InputModel {
     }
 
     // * Currently mobile does not enable map mode
-    if ((isDesktop || isWebDesktop) && keyboardMode == 'map') {
+    if ((isDesktop || isWebDesktop) && keyboardMode == kKeyMapMode) {
       mapKeyboardModeRaw(e);
     } else {
       legacyKeyboardModeRaw(e);
@@ -537,7 +537,7 @@ class InputModel {
     }
 
     // * Currently mobile does not enable map mode
-    if ((isDesktop || isWebDesktop)) {
+    if ((isDesktop || isWebDesktop) && keyboardMode == kKeyMapMode) {
       // FIXME: e.character is wrong for dead keys, eg: ^ in de
       newKeyboardMode(
           e.character ?? '',

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -351,7 +351,7 @@ class RustdeskImpl {
 
   bool sessionIsKeyboardModeSupported(
       {required UuidValue sessionId, required String mode, dynamic hint}) {
-    return mode == kKeyLegacyMode;
+    return [kKeyLegacyMode, kKeyMapMode].contains(mode);
   }
 
   bool sessionIsMultiUiSession({required UuidValue sessionId, dynamic hint}) {


### PR DESCRIPTION
Add "Map mode" for web.
"Legacy mode" is temporarily kept.


en -> fr

https://github.com/user-attachments/assets/fa8f4331-1093-40b4-8222-50ff776e8cdb

