### PR TITLE
fix: keyboard input, mulit windows

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -784,6 +784,9 @@ class InputModel {
     if (!isInputSourceFlutter) {
       bind.sessionEnterOrLeave(sessionId: sessionId, enter: enter);
     }
+    if (enter) {
+      bind.setCurSessionId(sessionId: sessionId);
+    }
   }
 
   /// Send mouse movement event with distance in [x] and [y].


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/8791#discussioncomment-10460053

## Preview

https://github.com/user-attachments/assets/2f58d76a-d752-4d57-90a8-d8db75e6ceee


https://github.com/user-attachments/assets/81a951e1-5d70-4906-8b27-45c20d169481

## Desc

The keyboard events are sent to the controlled side of `CUR_SESSION_ID`.

https://github.com/rustdesk/rustdesk/blob/40239a1c414158a3248bc400d9dca049292848e4/src/flutter.rs#L47

But the only place to change `CUR_SESSION_ID` is clicking the session tab.

https://github.com/rustdesk/rustdesk/blob/40239a1c414158a3248bc400d9dca049292848e4/flutter/lib/desktop/pages/remote_tab_page.dart#L72

When creating multiple windows, users typically do not click on the session tab to select the current session. So we need a more common place to set current session `enterOrLeave()`.