### PR TITLE
refact: android ios, lan discovery

### DIFF
--- a/src/lan.rs
+++ b/src/lan.rs
@@ -190,9 +190,20 @@ fn send_query() -> ResultType<Vec<UdpSocket>> {
     }
 
     let mut msg_out = Message::new();
+    // We may not be able to get the mac address on mobile platforms.
+    // So we need to use the id to avoid discovering ourselves.
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    let id = crate::ui_interface::get_id();
+    // `crate::ui_interface::get_id()` will cause error:
+    // `get_id()` uses async code with `current_thread`, which is not allowed in this context.
+    //
+    // No need to get id for desktop platforms.
+    // We can use the mac address to identify the device.
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    let id = "".to_owned();
     let peer = PeerDiscovery {
         cmd: "ping".to_owned(),
-        id: crate::ui_interface::get_id(),
+        id,
         ..Default::default()
     };
     msg_out.set_peer_discovery(peer);

--- a/src/lan.rs
+++ b/src/lan.rs
@@ -1,4 +1,3 @@
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use hbb_common::config::Config;
 use hbb_common::{
     allow_err,
@@ -22,7 +21,7 @@ use std::{
 
 type Message = RendezvousMessage;
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
+#[cfg(not(target_os = "ios"))]
 pub(super) fn start_listening() -> ResultType<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], get_broadcast_port()));
     let socket = std::net::UdpSocket::bind(addr)?;
@@ -40,13 +39,22 @@ pub(super) fn start_listening() -> ResultType<()> {
                                 &Config::get_option("enable-lan-discovery"),
                             )
                         {
+                            let id = Config::get_id();
+                            if p.id == id {
+                                continue;
+                            }
                             if let Some(self_addr) = get_ipaddr_by_peer(&addr) {
                                 let mut msg_out = Message::new();
+                                let mut hostname = whoami::hostname();
+                                // The default hostname is "localhost" which is a bit confusing
+                                if hostname == "localhost" {
+                                    hostname = "unknown".to_owned();
+                                }
                                 let peer = PeerDiscovery {
                                     cmd: "pong".to_owned(),
                                     mac: get_mac(&self_addr),
-                                    id: Config::get_id(),
-                                    hostname: whoami::hostname(),
+                                    id,
+                                    hostname,
                                     username: crate::platform::get_active_username(),
                                     platform: whoami::platform().to_string(),
                                     ..Default::default()
@@ -100,17 +108,17 @@ fn get_broadcast_port() -> u16 {
 }
 
 fn get_mac(_ip: &IpAddr) -> String {
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    #[cfg(not(target_os = "ios"))]
     if let Ok(mac) = get_mac_by_ip(_ip) {
         mac.to_string()
     } else {
         "".to_owned()
     }
-    #[cfg(any(target_os = "android", target_os = "ios"))]
+    #[cfg(target_os = "ios")]
     "".to_owned()
 }
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
+#[cfg(not(target_os = "ios"))]
 fn get_mac_by_ip(ip: &IpAddr) -> ResultType<String> {
     for interface in default_net::get_interfaces() {
         match ip {
@@ -153,6 +161,10 @@ fn get_ipaddr_by_peer<A: ToSocketAddrs>(peer: A) -> Option<IpAddr> {
 
 fn create_broadcast_sockets() -> Vec<UdpSocket> {
     let mut ipv4s = Vec::new();
+    // TODO: maybe we should use a better way to get ipv4 addresses.
+    // But currently, it's ok to use `[Ipv4Addr::UNSPECIFIED]` for discovery.
+    // `default_net::get_interfaces()` causes undefined symbols error when `flutter build` on iOS simulator x86_64
+    #[cfg(not(any(target_os = "ios")))]
     for interface in default_net::get_interfaces() {
         for ipv4 in &interface.ipv4 {
             ipv4s.push(ipv4.addr.clone());
@@ -180,6 +192,7 @@ fn send_query() -> ResultType<Vec<UdpSocket>> {
     let mut msg_out = Message::new();
     let peer = PeerDiscovery {
         cmd: "ping".to_owned(),
+        id: crate::ui_interface::get_id(),
         ..Default::default()
     };
     msg_out.set_peer_discovery(peer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 mod keyboard;
-#[cfg(not(any(target_os = "ios")))]
 /// cbindgen:ignore
 pub mod platform;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -12,7 +11,6 @@ mod server;
 #[cfg(not(any(target_os = "ios")))]
 pub use self::server::*;
 mod client;
-#[cfg(not(any(target_os = "ios")))]
 mod lan;
 #[cfg(not(any(target_os = "ios")))]
 mod rendezvous_mediator;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -100,6 +100,7 @@ impl WakeLock {
     }
 }
 
+#[cfg(not(target_os = "ios"))]
 pub fn get_wakelock(_display: bool) -> WakeLock {
     hbb_common::log::info!("new wakelock, require display on: {_display}");
     #[cfg(target_os = "android")]

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -76,8 +76,11 @@ impl RendezvousMediator {
         tokio::spawn(async move {
             direct_server(server_cloned).await;
         });
+        #[cfg(target_os = "android")]
+        let start_lan_listening = true;
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        if crate::platform::is_installed() {
+        let start_lan_listening = crate::platform::is_installed();
+        if start_lan_listening {
             std::thread::spawn(move || {
                 allow_err!(super::lan::start_listening());
             });

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -692,7 +692,6 @@ pub fn create_shortcut(_id: String) {
 #[cfg(any(target_os = "android", target_os = "ios", feature = "flutter"))]
 #[inline]
 pub fn discover() {
-    #[cfg(not(any(target_os = "ios")))]
     std::thread::spawn(move || {
         allow_err!(crate::lan::discover());
     });


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/5345#discussioncomment-9853063

## Preview

<img width="207" alt="6ee16718a703b844000f487cf1c250e" src="https://github.com/user-attachments/assets/74ad42fa-6b60-4d68-b701-8e9e0dd70e35">

## Desc

1. Enable `lan::start_listening()` on Android.
2. Enable lan discovery on iOS.
3.When querying the lan, send "self-id". The server will use the id to determine whether the request is from itself. Because the mac address is relatively unstable, it may not be possible to obtain the mac address on Android.