### PR TITLE
fix: keyboard, sciter

### DIFF
--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::file_trait::FileManager,
-    common::{is_keyboard_mode_supported, make_fd_to_json},
+    common::make_fd_to_json,
     flutter::{
         self, session_add, session_add_existed, session_start_, sessions, try_sync_peer_option,
     },
@@ -19,13 +19,11 @@ use hbb_common::allow_err;
 use hbb_common::{
     config::{self, LocalConfig, PeerConfig, PeerInfoSerde},
     fs, lazy_static, log,
-    message_proto::KeyboardMode,
     rendezvous_proto::ConnType,
     ResultType,
 };
 use std::{
     collections::HashMap,
-    str::FromStr,
     sync::{
         atomic::{AtomicI32, Ordering},
         Arc,
@@ -447,15 +445,7 @@ pub fn session_get_custom_image_quality(session_id: SessionID) -> Option<Vec<i32
 
 pub fn session_is_keyboard_mode_supported(session_id: SessionID, mode: String) -> SyncReturn<bool> {
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
-        if let Ok(mode) = KeyboardMode::from_str(&mode[..]) {
-            SyncReturn(is_keyboard_mode_supported(
-                &mode,
-                session.get_peer_version(),
-                &session.peer_platform(),
-            ))
-        } else {
-            SyncReturn(false)
-        }
+        SyncReturn(session.is_keyboard_mode_supported(mode))
     } else {
         SyncReturn(false)
     }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -34,6 +34,7 @@ const OS_LOWER_ANDROID: &str = "android";
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 static KEYBOARD_HOOKED: AtomicBool = AtomicBool::new(false);
 
+#[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 static IS_RDEV_ENABLED: AtomicBool = AtomicBool::new(false);
 
@@ -71,6 +72,7 @@ pub mod client {
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn change_grab_status(state: GrabState, keyboard_mode: &str) {
+        #[cfg(feature = "flutter")]
         if !IS_RDEV_ENABLED.load(Ordering::SeqCst) {
             return;
         }

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -152,10 +152,13 @@ class Header: Reactor.Component {
     }
 
     function renderKeyboardPop(){
+        const is_map_mode_supported = handler.is_keyboard_mode_supported("map");
+        const is_translate_mode_supported = handler.is_keyboard_mode_supported("translate");
         return <popup>
             <menu.context #keyboard-options>
-                <li #legacy><span>{svg_checkmark}</span>{translate('Legacy mode')}</li> 
-                <li #map><span>{svg_checkmark}</span>{translate('Map mode')}</li> 
+                <li #legacy><span>{svg_checkmark}</span>{translate('Legacy mode')}</li>
+                { is_map_mode_supported && <li #map><span>{svg_checkmark}</span>{translate('Map mode')}</li> }
+                { is_translate_mode_supported && <li #translate><span>{svg_checkmark}</span>{translate('Translate mode')}</li> }
             </menu>
         </popup>;
     }

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -487,6 +487,7 @@ impl sciter::EventHandler for SciterSession {
         fn peer_platform();
         fn set_write_override(i32, i32, bool, bool, bool);
         fn get_keyboard_mode();
+        fn is_keyboard_mode_supported(String);
         fn save_keyboard_mode(String);
         fn alternative_codecs();
         fn change_prefer_codec();

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -252,6 +252,18 @@ impl<T: InvokeUiSession> Session<T> {
         self.fallback_keyboard_mode()
     }
 
+    pub fn is_keyboard_mode_supported(&self, mode: String) -> bool {
+        if let Ok(mode) = KeyboardMode::from_str(&mode[..]) {
+            crate::common::is_keyboard_mode_supported(
+                &mode,
+                self.get_peer_version(),
+                &self.peer_platform(),
+            )
+        } else {
+            false
+        }
+    }
+
     pub fn save_keyboard_mode(&self, value: String) {
         self.lc.write().unwrap().save_keyboard_mode(value);
     }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/9143

## Preview


en -> fr

https://github.com/user-attachments/assets/d3fd20d7-9ba5-4692-b6f0-be53834199c4


## Desc

1. Sciter keyboard does not work because `IS_RDEV_ENABLED` is always `false`. `change_grab_status()` will never enable the keyboard callback. Sicter keyboard input is broken since https://github.com/rustdesk/rustdesk/pull/6561
2. Add "Translate mode" for sciter version.



