### PR TITLE
Use fallback codec if first frame fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,7 +3045,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "hwcodec"
 version = "0.7.0"
-source = "git+https://github.com/rustdesk-org/hwcodec#6abd1898f3a03481ed0c038507b5218d6ea94267"
+source = "git+https://github.com/rustdesk-org/hwcodec#b78a69c81631dd9ccfed9df68709808193082242"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1670,9 +1670,11 @@ impl Connection {
                 .await
                 {
                     log::error!("ipc to connection manager exit: {}", err);
+                    // https://github.com/rustdesk/rustdesk-server-pro/discussions/382#discussioncomment-10525725, cm may start failed
                     #[cfg(windows)]
                     if !crate::platform::is_prelogin()
                         && !err.to_string().contains(crate::platform::EXPLORER_EXE)
+                        && !crate::hbbs_http::sync::is_pro()
                     {
                         allow_err!(tx_from_cm_clone.send(Data::CmErr(err.to_string())));
                     }


### PR DESCRIPTION
* Both encoding and decoding use fallback if first frame fails
* More aggresive max fail counter
* Update hwcodec, add judgement when length of the encoded data is zero, https://github.com/rustdesk/rustdesk-server-pro/discussions/382#discussioncomment-10525997
* Fix serde hwcodec config toml fails when the non-first vec![] is empty, https://github.com/toml-rs/toml-rs/issues/384, the config file is used for cache, when check process is not finished, the cache is used. `confy` use toml 0.5, which has the problem, toml 0.7 doesn't have this problem.
* Allow cm not start for pro user, https://github.com/rustdesk/rustdesk-server-pro/discussions/382#discussioncomment-10525725

https://github.com/user-attachments/assets/d515be52-075b-4cf5-b842-a568501fcbd6



https://github.com/user-attachments/assets/b4cedf4e-8256-4c12-a278-3fc43dd43b7d


https://github.com/user-attachments/assets/768c5bde-48f8-4a8e-b9e0-f8527471fda0

```
#[derive(Serialize, Deserialize)]
struct StringTest {
    a: Vec<String>,
    b: Vec<String>,
}
```
![69abc5e6055bb1bd3083afaa422ca5d](https://github.com/user-attachments/assets/7dc43a6b-e7fe-4c6f-8fcc-7bb3c4a51259)
