### PR TITLE
fix: win, file clipboard

### DIFF
--- a/libs/clipboard/src/platform/windows.rs
+++ b/libs/clipboard/src/platform/windows.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     allow_err, send_data, ClipboardFile, CliprdrError, CliprdrServiceContext, ResultType,
-    ERR_CODE_INVALID_PARAMETER, ERR_CODE_SERVER_FUNCTION_NONE, VEC_MSG_CHANNEL,
+    ERR_CODE_INVALID_PARAMETER, ERR_CODE_SEND_MSG, ERR_CODE_SERVER_FUNCTION_NONE, VEC_MSG_CHANNEL,
 };
 use hbb_common::log;
 use std::{
@@ -998,7 +998,7 @@ extern "C" fn notify_callback(conn_id: UINT32, msg: *const NOTIFICATION_MESSAGE)
         }
     };
     // no need to handle result here
-    send_data(conn_id as _, data);
+    allow_err!(send_data(conn_id as _, data));
 
     0
 }
@@ -1045,7 +1045,13 @@ extern "C" fn client_format_list(
             .iter()
             .for_each(|msg_channel| allow_err!(msg_channel.sender.send(data.clone())));
     } else {
-        send_data(conn_id, data);
+        match send_data(conn_id, data) {
+            Ok(_) => {}
+            Err(e) => {
+                log::error!("failed to send format list: {:?}", e);
+                return ERR_CODE_SEND_MSG;
+            }
+        }
     }
 
     0
@@ -1067,9 +1073,13 @@ extern "C" fn client_format_list_response(
         msg_flags
     );
     let data = ClipboardFile::FormatListResponse { msg_flags };
-    send_data(conn_id, data);
-
-    0
+    match send_data(conn_id, data) {
+        Ok(_) => 0,
+        Err(e) => {
+            log::error!("failed to send format list response: {:?}", e);
+            ERR_CODE_SEND_MSG
+        }
+    }
 }
 
 extern "C" fn client_format_data_request(
@@ -1090,10 +1100,13 @@ extern "C" fn client_format_data_request(
         conn_id,
         requested_format_id
     );
-    // no need to handle result here
-    send_data(conn_id, data);
-
-    0
+    match send_data(conn_id, data) {
+        Ok(_) => 0,
+        Err(e) => {
+            log::error!("failed to send format data request: {:?}", e);
+            ERR_CODE_SEND_MSG
+        }
+    }
 }
 
 extern "C" fn client_format_data_response(
@@ -1125,9 +1138,13 @@ extern "C" fn client_format_data_response(
         msg_flags,
         format_data,
     };
-    send_data(conn_id, data);
-
-    0
+    match send_data(conn_id, data) {
+        Ok(_) => 0,
+        Err(e) => {
+            log::error!("failed to send format data response: {:?}", e);
+            ERR_CODE_SEND_MSG
+        }
+    }
 }
 
 extern "C" fn client_file_contents_request(
@@ -1175,9 +1192,13 @@ extern "C" fn client_file_contents_request(
         clip_data_id,
     };
     log::debug!("client_file_contents_request called, data: {:?}", &data);
-    send_data(conn_id, data);
-
-    0
+    match send_data(conn_id, data) {
+        Ok(_) => 0,
+        Err(e) => {
+            log::error!("failed to send file contents request: {:?}", e);
+            ERR_CODE_SEND_MSG
+        }
+    }
 }
 
 extern "C" fn client_file_contents_response(
@@ -1213,7 +1234,11 @@ extern "C" fn client_file_contents_response(
         msg_flags,
         stream_id
     );
-    send_data(conn_id, data);
-
-    0
+    match send_data(conn_id, data) {
+        Ok(_) => 0,
+        Err(e) => {
+            log::error!("failed to send file contents response: {:?}", e);
+            ERR_CODE_SEND_MSG
+        }
+    }
 }

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -353,6 +353,7 @@ impl<T: InvokeUiSession> Remote<T> {
                     } else {
                         if let Err(e) = ContextSend::make_sure_enabled() {
                             log::error!("failed to restart clipboard context: {}", e);
+                            // to-do: Show msgbox with "Don't show again" option
                         };
                         log::debug!("Send system clipboard message to remote");
                         let msg = crate::clipboard_file::clip_2_msg(clip);


### PR DESCRIPTION
Related issue https://github.com/rustdesk/rustdesk/issues/9222
But this commit probably didn't fix it.

1. Return the result of `wait_response_event()` in `cliprdr_send_format_list()`

```C
static UINT cliprdr_send_data_request(UINT32 connID, wfClipboard *clipboard, UINT32 formatId)
```

The last line does not return any value, which causes **undefined behavior**.

![image](https://github.com/user-attachments/assets/0adcf84e-a6f1-47b0-b925-f9ab5c50f697)


2. Add recv flags to avoid waiting a long time if failed to `SetEvent()`.

![image](https://github.com/user-attachments/assets/d8393eef-c85f-4c52-9d8b-12092cf7dd81)

![image](https://github.com/user-attachments/assets/3ff33919-dbd0-44d3-afe5-8306af35f680)

3. Return `ERR_CODE_SEND_MSG` if failed to send clipboard message. Then the thread will not wait the response message.

## The possible reasons for https://github.com/rustdesk/rustdesk/issues/9222

1. Failed to send clipboard message. (Local side)
2. Failed to receive clipboard message. (Remote side)
3. Failed to send response. (Remote side)
4. Failed to receive response. (Local side)
5. Failed to notify the waiting thread of the received response.
6. Dead lock.

I did not find dead lock.

This commit improves the logic of steps 1 and 5.

## Tests

Copy&Paste files is tested.

