### PR TITLE
password max length prompt

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -381,6 +381,7 @@ class DialogTextField extends StatelessWidget {
   final FocusNode? focusNode;
   final TextInputType? keyboardType;
   final List<TextInputFormatter>? inputFormatters;
+  final int? maxLength;
 
   static const kUsernameTitle = 'Username';
   static const kUsernameIcon = Icon(Icons.account_circle_outlined);
@@ -398,6 +399,7 @@ class DialogTextField extends StatelessWidget {
       this.hintText,
       this.keyboardType,
       this.inputFormatters,
+      this.maxLength,
       required this.title,
       required this.controller})
       : super(key: key);
@@ -424,6 +426,7 @@ class DialogTextField extends StatelessWidget {
             obscureText: obscureText,
             keyboardType: keyboardType,
             inputFormatters: inputFormatters,
+            maxLength: maxLength,
           ),
         ),
       ],
@@ -681,6 +684,7 @@ class PasswordWidget extends StatefulWidget {
     this.hintText,
     this.errorText,
     this.title,
+    this.maxLength,
   }) : super(key: key);
 
   final TextEditingController controller;
@@ -689,6 +693,7 @@ class PasswordWidget extends StatefulWidget {
   final String? hintText;
   final String? errorText;
   final String? title;
+  final int? maxLength;
 
   @override
   State<PasswordWidget> createState() => _PasswordWidgetState();
@@ -751,6 +756,7 @@ class _PasswordWidgetState extends State<PasswordWidget> {
       obscureText: !_passwordVisible,
       errorText: widget.errorText,
       focusNode: _focusNode,
+      maxLength: widget.maxLength,
     );
   }
 }
@@ -2245,6 +2251,7 @@ void changeUnlockPinDialog(String oldPin, Function() callback) {
   final confirmController = TextEditingController(text: oldPin);
   String? pinErrorText;
   String? confirmationErrorText;
+  final maxLength = bind.mainMaxEncryptLen();
   gFFI.dialogManager.show((setState, close, context) {
     submit() async {
       pinErrorText = null;
@@ -2278,12 +2285,14 @@ void changeUnlockPinDialog(String oldPin, Function() callback) {
             controller: pinController,
             obscureText: true,
             errorText: pinErrorText,
+            maxLength: maxLength,
           ),
           DialogTextField(
             title: translate('Confirmation'),
             controller: confirmController,
             obscureText: true,
             errorText: confirmationErrorText,
+            maxLength: maxLength,
           )
         ],
       ).marginOnly(bottom: 12),

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -1200,6 +1200,7 @@ class MyGroupPeerCard extends BasePeerCard {
 }
 
 void _rdpDialog(String id) async {
+  final maxLength = bind.mainMaxEncryptLen();
   final port = await bind.mainGetPeerOption(id: id, key: 'rdp_port');
   final username = await bind.mainGetPeerOption(id: id, key: 'rdp_username');
   final portController = TextEditingController(text: port);
@@ -1288,6 +1289,7 @@ void _rdpDialog(String id) async {
                 Expanded(
                   child: Obx(() => TextField(
                         obscureText: secure.value,
+                        maxLength: maxLength,
                         decoration: InputDecoration(
                             labelText: isDesktop
                                 ? null

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -857,6 +857,7 @@ void setPasswordDialog({VoidCallback? notEmptyCallback}) async {
     // SpecialCharacterValidationRule(),
     MinCharactersValidationRule(8),
   ];
+  final maxLength = bind.mainMaxEncryptLen();
 
   gFFI.dialogManager.show((setState, close, context) {
     submit() {
@@ -915,6 +916,7 @@ void setPasswordDialog({VoidCallback? notEmptyCallback}) async {
                         errMsg0 = '';
                       });
                     },
+                    maxLength: maxLength,
                   ),
                 ),
               ],
@@ -941,6 +943,7 @@ void setPasswordDialog({VoidCallback? notEmptyCallback}) async {
                         errMsg1 = '';
                       });
                     },
+                    maxLength: maxLength,
                   ),
                 ),
               ],

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -2512,6 +2512,7 @@ void changeSocks5Proxy() async {
                                     : Icons.visibility))),
                         controller: pwdController,
                         enabled: !isOptFixed,
+                        maxLength: bind.mainMaxEncryptLen(),
                       )),
                 ),
               ],

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -39,7 +39,7 @@ pub const REG_INTERVAL: i64 = 15_000;
 pub const COMPRESS_LEVEL: i32 = 3;
 const SERIAL: i32 = 3;
 const PASSWORD_ENC_VERSION: &str = "00";
-const ENCRYPT_MAX_LEN: usize = 128;
+pub const ENCRYPT_MAX_LEN: usize = 128; // used for password, pin, etc, not for all
 
 #[cfg(target_os = "macos")]
 lazy_static::lazy_static! {

--- a/libs/hbb_common/src/password_security.rs
+++ b/libs/hbb_common/src/password_security.rs
@@ -89,11 +89,11 @@ pub fn encrypt_str_or_original(s: &str, version: &str, max_len: usize) -> String
         log::error!("Duplicate encryption!");
         return s.to_owned();
     }
-    if s.bytes().len() > max_len {
+    if s.chars().count() > max_len {
         return String::default();
     }
     if version == "00" {
-        if let Ok(s) = encrypt(s.as_bytes(), max_len) {
+        if let Ok(s) = encrypt(s.as_bytes()) {
             return version.to_owned() + &s;
         }
     }
@@ -130,7 +130,7 @@ pub fn encrypt_vec_or_original(v: &[u8], version: &str, max_len: usize) -> Vec<u
         return vec![];
     }
     if version == "00" {
-        if let Ok(s) = encrypt(v, max_len) {
+        if let Ok(s) = encrypt(v) {
             let mut version = version.to_owned().into_bytes();
             version.append(&mut s.into_bytes());
             return version;
@@ -155,8 +155,8 @@ pub fn decrypt_vec_or_original(v: &[u8], current_version: &str) -> (Vec<u8>, boo
     (v.to_owned(), false, !v.is_empty())
 }
 
-fn encrypt(v: &[u8], max_len: usize) -> Result<String, ()> {
-    if !v.is_empty() && v.len() <= max_len {
+fn encrypt(v: &[u8]) -> Result<String, ()> {
+    if !v.is_empty() {
         symmetric_crypt(v, true).map(|v| base64::encode(v, base64::Variant::Original))
     } else {
         Err(())

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2282,6 +2282,10 @@ pub fn main_clear_trusted_devices() {
     clear_trusted_devices()
 }
 
+pub fn main_max_encrypt_len() -> SyncReturn<usize> {
+    SyncReturn(max_encrypt_len())
+}
+
 pub fn session_request_new_display_init_msgs(session_id: SessionID, display: usize) {
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
         session.request_init_msgs(display);

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -928,16 +928,23 @@ pub fn set_permanent_password(v: String) -> ResultType<()> {
 pub fn set_unlock_pin(v: String, translate: bool) -> ResultType<()> {
     let v = v.trim().to_owned();
     let min_len = 4;
-    if !v.is_empty() && v.len() < min_len {
-        let err = if translate {
-            crate::lang::translate(
-                "Requires at least {".to_string() + &format!("{min_len}") + "} characters",
-            )
-        } else {
-            // Sometimes, translated can't show normally in command line
-            format!("Requires at least {} characters", min_len)
-        };
-        bail!(err);
+    let max_len = crate::ui_interface::max_encrypt_len();
+    let len = v.chars().count();
+    if !v.is_empty() {
+        if len < min_len {
+            let err = if translate {
+                crate::lang::translate(
+                    "Requires at least {".to_string() + &format!("{min_len}") + "} characters",
+                )
+            } else {
+                // Sometimes, translated can't show normally in command line
+                format!("Requires at least {} characters", min_len)
+            };
+            bail!(err);
+        }
+        if len > max_len {
+            bail!("No more than {max_len} characters");
+        }
     }
     Config::set_unlock_pin(&v);
     set_config("unlock-pin", v)

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -1495,3 +1495,8 @@ pub fn clear_trusted_devices() {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     ipc::clear_trusted_devices();
 }
+
+#[cfg(feature = "flutter")]
+pub fn max_encrypt_len() -> usize {
+    hbb_common::config::ENCRYPT_MAX_LEN
+}


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/9232

* Check chars count instead of checking bytes len when encrypt string
* Set maxLength in TextEdit for `pernament password`, `unlock pin`, `rdp password`, `proxy password`
* Other string: `os-username`, `os-password` not add input limit.
* Vec: `peer password`, `2fa token/secret` won't exceed the limit


https://github.com/user-attachments/assets/bd0eb201-1d38-444f-b0d6-99bae16ad113

![unlock_pin_cmdpng](https://github.com/user-attachments/assets/94b89902-f73a-4658-b778-2ecb7c4e72e3)
![unlock_pin_gui](https://github.com/user-attachments/assets/a11bd085-84d9-42b1-ae21-19068adb191b)
![rdp](https://github.com/user-attachments/assets/81056dc8-6157-4498-b660-8121973bcfa0)
![socks5](https://github.com/user-attachments/assets/ce33e54e-19ff-4a00-847d-080c5032be91)
