### PR TITLE
fix: clipboard, support excel xml spreadsheet

### DIFF
--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -326,6 +326,7 @@ enum ClipboardFormat {
   ImageRgba = 21;
   ImagePng = 22;
   ImageSvg = 23;
+  Special = 31;
 }
 
 message Clipboard {
@@ -334,6 +335,8 @@ message Clipboard {
   int32 width = 3;
   int32 height = 4;
   ClipboardFormat format = 5;
+  // Special format name, only used when format is Special.
+  string special_name = 6;
 }
 
 message MultiClipboards { repeated Clipboard clipboards = 1; }


### PR DESCRIPTION
## Preview

### Bug

https://github.com/user-attachments/assets/1adfbc09-8c2e-4001-aaec-d84c901e5654


### Fixed



https://github.com/user-attachments/assets/c45b11e0-04f1-448f-bf04-53ecef2e1ec8




## Desc

Win -> Win, excel copy&paste, cells formats is broken since multi-formats is supported.

Because many clipboard formats are set to clipboard after copying.

When pasting, the formats: "XML Spreadsheet" > "HTML" > "plain text"

Though "plain text" has `\t` and `\r\n`, the content will not be used if "HTML" is also set.

## TODO

1. Cross platform.
2. Support other commonly used formats.
