### PR TITLE
fix: clipboard, cmd ipc

### DIFF
--- a/src/server/clipboard_service.rs
+++ b/src/server/clipboard_service.rs
@@ -95,25 +95,30 @@ impl Handler {
                     log::error!("Failed to read clipboard from cm: {}", e);
                 }
                 Ok(data) => {
-                    let mut msg = Message::new();
-                    let multi_clipboards = MultiClipboards {
-                        clipboards: data
-                            .into_iter()
-                            .map(|c| Clipboard {
-                                compress: c.compress,
-                                content: c.content,
-                                width: c.width,
-                                height: c.height,
-                                format: ClipboardFormat::from_i32(c.format)
-                                    .unwrap_or(ClipboardFormat::Text)
-                                    .into(),
-                                ..Default::default()
-                            })
-                            .collect(),
-                        ..Default::default()
-                    };
-                    msg.set_multi_clipboards(multi_clipboards);
-                    return Some(msg);
+                    // Skip sending empty clipboard data.
+                    // Maybe there's something wrong reading the clipboard data in cm, but no error msg is returned.
+                    // The clipboard data should not be empty, the last line will try again to get the clipboard data.
+                    if !data.is_empty() {
+                        let mut msg = Message::new();
+                        let multi_clipboards = MultiClipboards {
+                            clipboards: data
+                                .into_iter()
+                                .map(|c| Clipboard {
+                                    compress: c.compress,
+                                    content: c.content,
+                                    width: c.width,
+                                    height: c.height,
+                                    format: ClipboardFormat::from_i32(c.format)
+                                        .unwrap_or(ClipboardFormat::Text)
+                                        .into(),
+                                    ..Default::default()
+                                })
+                                .collect(),
+                            ..Default::default()
+                        };
+                        msg.set_multi_clipboards(multi_clipboards);
+                        return Some(msg);
+                    }
                 }
             }
         }

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -498,10 +498,10 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                                                 let (content, next_raw) = {
                                                     // TODO: find out a better threshold
                                                     if content_len > 1024 * 3 {
-                                                        (c.content, false)
-                                                    } else {
                                                         raw_contents.extend(c.content);
                                                         (bytes::Bytes::new(), true)
+                                                    } else {
+                                                        (c.content, false)
                                                     }
                                                 };
                                                 main_data.push(ClipboardNonFile {
@@ -515,7 +515,9 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                                                 });
                                             }
                                             allow_err!(self.stream.send(&Data::ClipboardNonFile(Some(("".to_owned(), main_data)))).await);
-                                            allow_err!(self.stream.send_raw(raw_contents.into()).await);
+                                            if !raw_contents.is_empty() {
+                                                allow_err!(self.stream.send_raw(raw_contents.into()).await);
+                                            }
                                         }
                                         Err(e) => {
                                             allow_err!(self.stream.send(&Data::ClipboardNonFile(Some((format!("{}", e), vec![])))).await);


### PR DESCRIPTION
1. Try read clipboard again if no data from cm. This maybe a workaround of https://github.com/rustdesk/rustdesk/issues/9263. We still need to find the reason.
2. Send raw contents if `content_len` > 1024*3. The previous code does not affect the correctness of copy&paste. It just cannot store the data into `raw_contents` correctly.
3. Skip sending raw contents if it is empty.
