### PR TITLE
--no-server arg to avoid server ipc occupied by ui

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -401,10 +401,10 @@ async fn handle(data: Data, stream: &mut Connection) {
                     std::fs::remove_file(&Config::ipc_path("")).ok();
                     #[cfg(target_os = "linux")]
                     {
-                        // https://github.com/rustdesk/rustdesk/discussions/9254, slow on some machines
-                        hbb_common::sleep((crate::platform::SERVICE_INTERVAL * 2) as f32 / 1000.0 + 1.2)
+                        hbb_common::sleep((crate::platform::SERVICE_INTERVAL * 2) as f32 / 1000.0)
                             .await;
-                        crate::run_me::<&str>(vec![]).ok();
+                        // https://github.com/rustdesk/rustdesk/discussions/9254
+                        crate::run_me::<&str>(vec!["--no-server"]).ok();
                     }
                     #[cfg(target_os = "macos")]
                     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
         cli::connect_test(p, key, token);
     } else if let Some(p) = matches.value_of("server") {
         log::info!("id={}", hbb_common::config::Config::get_id());
-        crate::start_server(true);
+        crate::start_server(true, false);
     }
     common::global_clean();
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1378,6 +1378,7 @@ pub fn uninstall_service(show_new_window: bool, _: bool) -> bool {
         Config::set_option("stop-service".into(), "".into());
         return true;
     }
+    // systemctl stop will kill child processes, below may not be executed.
     if show_new_window {
         run_me_with(2);
     }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/9254

* When the server ipc receives a `Close` message, it will start a process to wait for 0.6 seconds and then starting the main window. then exit immediately. However, the main window might start before the --server option is activated. To address this, add the --no-server argument when launching the main window; this will make the main window process repeatedly attempt to connect to the IPC server in a loop.
* If the main window is a child process of --service and systemctl stop is executed, the main window process will be terminated and will not reopen.

start stop service test

[no-server.webm](https://github.com/user-attachments/assets/35c37c2e-ed7f-430d-8463-2d993d4b2367)
