### PR TITLE
quit cm process if ipc connection to ipc server closed

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -84,6 +84,7 @@ lazy_static::lazy_static! {
     // Is server logic running. The server code can invoked to run by the main process if --server is not running.
     static ref SERVER_RUNNING: Arc<RwLock<bool>> = Default::default();
     static ref IS_MAIN: bool = std::env::args().nth(1).map_or(true, |arg| !arg.starts_with("--"));
+    static ref IS_CM: bool = std::env::args().nth(1) == Some("--cm".to_owned()) || std::env::args().nth(1) == Some("--cm-no-ui".to_owned());
 }
 
 pub struct SimpleCallOnReturn {
@@ -135,6 +136,11 @@ pub fn is_server() -> bool {
 #[inline]
 pub fn is_main() -> bool {
     *IS_MAIN
+}
+
+#[inline]
+pub fn is_cm() -> bool {
+    *IS_CM
 }
 
 // Is server logic running.

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -477,7 +477,10 @@ pub fn core_main() -> Option<Vec<String>> {
         } else if args[0] == "--cm-no-ui" {
             #[cfg(feature = "flutter")]
             #[cfg(not(any(target_os = "android", target_os = "ios", target_os = "windows")))]
-            crate::flutter::connection_manager::start_cm_no_ui();
+            {
+                crate::ui_interface::start_option_status_sync();
+                crate::flutter::connection_manager::start_cm_no_ui();
+            }
             return None;
         } else {
             #[cfg(all(feature = "flutter", feature = "plugin_framework"))]

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -625,7 +625,6 @@ pub async fn start_ipc<T: InvokeUiCM>(cm: ConnectionManager<T>) {
         OPTION_ENABLE_FILE_TRANSFER,
         &Config::get_option(OPTION_ENABLE_FILE_TRANSFER),
     ));
-
     match ipc::new_listener("_cm").await {
         Ok(mut incoming) => {
             while let Some(result) = incoming.next().await {
@@ -647,7 +646,7 @@ pub async fn start_ipc<T: InvokeUiCM>(cm: ConnectionManager<T>) {
             log::error!("Failed to start cm ipc server: {}", err);
         }
     }
-    crate::platform::quit_gui();
+    quit_cm();
 }
 
 #[cfg(target_os = "android")]
@@ -1041,4 +1040,12 @@ pub fn close_voice_call(id: i32) {
         #[cfg(not(any(target_os = "ios")))]
         allow_err!(client.tx.send(Data::CloseVoiceCall("".to_owned())));
     };
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn quit_cm() {
+    // in case of std::process::exit not work
+    log::info!("quit cm");
+    CLIENTS.write().unwrap().clear();
+    crate::platform::quit_gui();
 }

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -1138,6 +1138,7 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
         )
     ))]
     let mut enable_file_transfer = "".to_owned();
+    let is_cm = crate::common::is_cm();
 
     loop {
         if let Ok(mut c) = ipc::connect(1000, "").await {
@@ -1148,6 +1149,9 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
                         match res {
                             Err(err) => {
                                 log::error!("ipc connection closed: {}", err);
+                                if is_cm {
+                                    crate::ui_cm_interface::quit_cm();
+                                }
                                 break;
                             }
                             #[cfg(not(any(target_os = "android", target_os = "ios")))]


### PR DESCRIPTION
* Quit cm process if ipc connection to ipc server is closed.

**test ipc connection closed**: close portble main window process, cm has a closed client.

https://github.com/user-attachments/assets/07792aad-b6cd-4158-bec7-2274532f45eb


https://github.com/user-attachments/assets/c897f3c7-29ce-4d0b-a221-da90113ea51c

**test wrong sid**: cm has a closed client, change to another windows session.

https://github.com/user-attachments/assets/c6362352-e2d6-460b-820a-1801299d5ca3


https://github.com/user-attachments/assets/8b3ee437-18d0-4e75-8300-9bab74055f45


Also tested 2 rdp session, windows/linux/mac login screen.
