### PR TITLE
Fix/clipboard retry if is occupied

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 [[package]]
 name = "arboard"
 version = "3.4.0"
-source = "git+https://github.com/rustdesk-org/arboard#a04bdb1b368a99691822c33bf0f7ed497d6a7a35"
+source = "git+https://github.com/rustdesk-org/arboard#747ab2d9b40a5c9c5102051cf3b0bb38b4845e60"
 dependencies = [
  "clipboard-win",
  "core-graphics 0.23.2",
@@ -1677,7 +1677,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.4",
+ "libloading 0.7.4",
 ]
 
 [[package]]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,9 +1,10 @@
 use arboard::{ClipboardData, ClipboardFormat};
 use clipboard_master::{ClipboardHandler, Master, Shutdown};
-use hbb_common::{log, message_proto::*, ResultType};
+use hbb_common::{bail, log, message_proto::*, ResultType};
 use std::{
     sync::{mpsc::Sender, Arc, Mutex},
     thread::JoinHandle,
+    time::Duration,
 };
 
 pub const CLIPBOARD_NAME: &'static str = "clipboard";
@@ -25,6 +26,9 @@ lazy_static::lazy_static! {
     // Plain text is the only exception, it does not require the server to be present.
     static ref CLIPBOARD_CTX: Arc<Mutex<Option<ClipboardContext>>> = Arc::new(Mutex::new(None));
 }
+
+const CLIPBOARD_GET_MAX_RETRY: usize = 3;
+const CLIPBOARD_GET_RETRY_INTERVAL_DUR: Duration = Duration::from_millis(33);
 
 const SUPPORTED_FORMATS: &[ClipboardFormat] = &[
     ClipboardFormat::Text,
@@ -153,7 +157,10 @@ pub fn check_clipboard(
     let ctx2 = ctx.as_mut()?;
     let content = ctx2.get(side, force);
     if let Ok(content) = content {
-        if !content.is_empty() {
+        if content
+            .iter()
+            .any(|x| !(matches!(x, arboard::ClipboardData::None)))
+        {
             let mut msg = Message::new();
             let clipboards = proto::create_multi_clipboards(content);
             msg.set_multi_clipboards(clipboards.clone());
@@ -263,9 +270,28 @@ impl ClipboardContext {
         Ok(ClipboardContext { inner: board })
     }
 
+    fn get_formats(&mut self, formats: &[ClipboardFormat]) -> ResultType<Vec<ClipboardData>> {
+        for i in 0..CLIPBOARD_GET_MAX_RETRY {
+            match self.inner.get_formats(SUPPORTED_FORMATS) {
+                Ok(data) => return Ok(data),
+                Err(e) => match e {
+                    arboard::Error::ClipboardOccupied => {
+                        log::debug!("Clipboard is occupied, retrying... {}", i + 1);
+                        std::thread::sleep(CLIPBOARD_GET_RETRY_INTERVAL_DUR);
+                    }
+                    _ => {
+                        log::error!("Failed to get clipboard: {}", e);
+                        return Err(e.into());
+                    }
+                },
+            }
+        }
+        bail!("Clipboard is occupied, {CLIPBOARD_GET_MAX_RETRY} retries failed");
+    }
+
     pub fn get(&mut self, side: ClipboardSide, force: bool) -> ResultType<Vec<ClipboardData>> {
         let _lock = ARBOARD_MTX.lock().unwrap();
-        let data = self.inner.get_formats(SUPPORTED_FORMATS)?;
+        let data = self.get_formats(SUPPORTED_FORMATS)?;
         if data.is_empty() {
             return Ok(data);
         }

--- a/src/server/clipboard_service.rs
+++ b/src/server/clipboard_service.rs
@@ -150,7 +150,7 @@ impl Handler {
             is_sent = match rt.block_on(stream.send(&Data::ClipboardNonFile(None))) {
                 Ok(_) => true,
                 Err(e) => {
-                    log::debug!("failed to send to cm: {}", e);
+                    log::debug!("Failed to send to cm: {}", e);
                     false
                 }
             };
@@ -186,7 +186,7 @@ impl Handler {
                                     Err(e) => {
                                         // Reconnect to avoid the next raw data remaining in the buffer.
                                         self.stream = None;
-                                        log::debug!("failed to get raw clipboard data: {}", e);
+                                        log::debug!("Failed to get raw clipboard data: {}", e);
                                     }
                                 }
                             }

--- a/src/server/clipboard_service.rs
+++ b/src/server/clipboard_service.rs
@@ -11,6 +11,8 @@ use std::{
     sync::mpsc::{channel, RecvTimeoutError, Sender},
     time::Duration,
 };
+#[cfg(windows)]
+use tokio::runtime::Runtime;
 
 struct Handler {
     sp: EmptyExtraFieldService,
@@ -18,6 +20,8 @@ struct Handler {
     tx_cb_result: Sender<CallbackResult>,
     #[cfg(target_os = "windows")]
     stream: Option<ipc::ConnectionTmpl<parity_tokio_ipc::ConnectionClient>>,
+    #[cfg(target_os = "windows")]
+    rt: Option<Runtime>,
 }
 
 pub fn new() -> GenericService {
@@ -34,6 +38,8 @@ fn run(sp: EmptyExtraFieldService) -> ResultType<()> {
         tx_cb_result,
         #[cfg(target_os = "windows")]
         stream: None,
+        #[cfg(target_os = "windows")]
+        rt: None,
     };
 
     let (tx_start_res, rx_start_res) = channel();
@@ -129,29 +135,41 @@ impl Handler {
     // 1. the clipboard is not used frequently.
     // 2. the clipboard handle is sync and will not block the main thread.
     #[cfg(windows)]
-    #[tokio::main(flavor = "current_thread")]
-    async fn read_clipboard_from_cm_ipc(&mut self) -> ResultType<Vec<ClipboardNonFile>> {
+    fn read_clipboard_from_cm_ipc(&mut self) -> ResultType<Vec<ClipboardNonFile>> {
+        if self.rt.is_none() {
+            self.rt = Some(Runtime::new()?);
+        }
+        let Some(rt) = &self.rt else {
+            // unreachable!
+            bail!("failed to get tokio runtime");
+        };
         let mut is_sent = false;
         if let Some(stream) = &mut self.stream {
             // If previous stream is still alive, reuse it.
             // If the previous stream is dead, `is_sent` will trigger reconnect.
-            is_sent = stream.send(&Data::ClipboardNonFile(None)).await.is_ok();
+            is_sent = match rt.block_on(stream.send(&Data::ClipboardNonFile(None))) {
+                Ok(_) => true,
+                Err(e) => {
+                    log::debug!("failed to send to cm: {}", e);
+                    false
+                }
+            };
         }
         if !is_sent {
-            let mut stream = crate::ipc::connect(100, "_cm").await?;
-            stream.send(&Data::ClipboardNonFile(None)).await?;
+            let mut stream = rt.block_on(crate::ipc::connect(100, "_cm"))?;
+            rt.block_on(stream.send(&Data::ClipboardNonFile(None)))?;
             self.stream = Some(stream);
         }
 
         if let Some(stream) = &mut self.stream {
             loop {
-                match stream.next_timeout(800).await? {
+                match rt.block_on(stream.next_timeout(800))? {
                     Some(Data::ClipboardNonFile(Some((err, mut contents)))) => {
                         if !err.is_empty() {
                             bail!("{}", err);
                         } else {
                             if contents.iter().any(|c| c.next_raw) {
-                                match timeout(1000, stream.next_raw()).await {
+                                match rt.block_on(timeout(1000, stream.next_raw())) {
                                     Ok(Ok(mut data)) => {
                                         for c in &mut contents {
                                             if c.next_raw {

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -520,6 +520,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                                             }
                                         }
                                         Err(e) => {
+                                            log::debug!("Failed to get clipboard content. {}", e);
                                             allow_err!(self.stream.send(&Data::ClipboardNonFile(Some((format!("{}", e), vec![])))).await);
                                         }
                                     }


### PR DESCRIPTION
May fix 

https://github.com/rustdesk/rustdesk/issues/9263

https://github.com/rustdesk/rustdesk/issues/9222#issuecomment-2329233175

## Preview


https://github.com/user-attachments/assets/d06b61e4-a963-49a1-84aa-10d44d29e952

If there're multiple threads or processes trying to access the clipboard at the same time, the previous clipboard owner will fail to access the clipboard. This is a common case on Windows.

## Desc


1. Retry `3` times if clipboard is occupied.

![image](https://github.com/user-attachments/assets/2325942c-4a7c-483c-834b-911449e387c2)


2. Fix "async context" is destroyed after calling `read_clipboard_from_cm_ipc()`. Then the previous ipc connection (`stream`) is not reused at all. 