### PR TITLE
fix: keyboard, move tab to new window

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -245,8 +245,10 @@ class _RemotePageState extends State<RemotePage>
     super.dispose();
     debugPrint("REMOTE PAGE dispose session $sessionId ${widget.id}");
     _ffi.textureModel.onRemotePageDispose(closeSession);
-    // ensure we leave this session, this is a double check
-    _ffi.inputModel.enterOrLeave(false);
+    if (closeSession) {
+      // ensure we leave this session, this is a double check
+      _ffi.inputModel.enterOrLeave(false);
+    }
     DesktopMultiWindow.removeListener(this);
     _ffi.dialogManager.hideMobileActionsOverlay();
     _ffi.imageModel.disposeImage();


### PR DESCRIPTION
Do not disable keyboard when moving tab to new window on dispose.

![1726019513435](https://github.com/user-attachments/assets/22106188-567d-44c6-8684-36859474b9b3)

## Desc

`dispose()` of the remote page may be called after the new window is focused, and then the keyboard listener is disabled.

We can't enable it until we unfocus and focus the window again.

```console
flutter: session: aa37c85a-93ea-42fb-840f-6dd3c61cb343, enterOrLeave true
flutter: CustomTouchGestureRecognizer init

flutter: REMOTE PAGE dispose session aa37c85a-93ea-42fb-840f-6dd3c61cb343 1582680759
flutter: session: aa37c85a-93ea-42fb-840f-6dd3c61cb343, enterOrLeave false
flutter: deleting cursor with key 1582680759_65539_170666667_170666667

```

`closeSession` is used to skip some dispose steps when moving tab to new window.

