### PR TITLE
fix: reduce rebuild for online state

### DIFF
--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -117,10 +117,17 @@ class _PeersViewState extends State<_PeersView>
   @override
   void onWindowFocus() {
     _queryCount = 0;
+    _isActive = true;
+  }
+
+  @override
+  void onWindowBlur() {
+    _isActive = false;
   }
 
   @override
   void onWindowRestore() {
+    _queryCount = 0;
     _isActive = true;
   }
 

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -120,8 +120,14 @@ class _PeersViewState extends State<_PeersView>
   }
 
   @override
+  void onWindowRestore() {
+    _isActive = true;
+  }
+
+  @override
   void onWindowMinimize() {
     _queryCount = _maxQueryCount;
+    _isActive = false;
   }
 
   // This function is required for mobile.

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -124,9 +124,11 @@ class _PeersViewState extends State<_PeersView>
   @override
   void onWindowBlur() {
     // We need this comparison because window restore (on Windows) also triggers `onWindowBlur()`.
+    // Maybe it's a bug of the window manager, but the source code seems to be correct.
+    //
     // Although `onWindowRestore()` is called after `onWindowBlur()` in my test,
     // we need the following comparison to ensure that `_isActive` is true in the end.
-    if (DateTime.now().difference(_lastWindowRestoreTime) <
+    if (isWindows && DateTime.now().difference(_lastWindowRestoreTime) <
         const Duration(milliseconds: 300)) {
       return;
     }
@@ -138,7 +140,6 @@ class _PeersViewState extends State<_PeersView>
   void onWindowRestore() {
     // Window restore (on MacOS and Linux) also triggers `onWindowFocus()`.
     if (!isWindows) return;
-
     _queryCount = 0;
     _isActive = true;
     _lastWindowRestoreTime = DateTime.now();

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -139,6 +139,7 @@ class _PeersViewState extends State<_PeersView>
   @override
   void onWindowRestore() {
     // Window restore (on MacOS and Linux) also triggers `onWindowFocus()`.
+    // But on Windows, it triggers `onWindowBlur()`, mybe it's a bug of the window manager.
     if (!isWindows) return;
     _queryCount = 0;
     _isActive = true;
@@ -147,10 +148,7 @@ class _PeersViewState extends State<_PeersView>
 
   @override
   void onWindowMinimize() {
-    // Window minimize (on MacOS and Linux) also triggers `onWindowBlur()`.
-    if (!isWindows) return;
-    _queryCount = _maxQueryCount;
-    _isActive = false;
+    // Window minimize also triggers `onWindowBlur()`.
   }
 
   // This function is required for mobile.

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -123,18 +123,22 @@ class _PeersViewState extends State<_PeersView>
 
   @override
   void onWindowBlur() {
-    // We need this comparison because window restore also triggers `onWindowBlur()`.
+    // We need this comparison because window restore (on Windows) also triggers `onWindowBlur()`.
     // Although `onWindowRestore()` is called after `onWindowBlur()` in my test,
     // we need the following comparison to ensure that `_isActive` is true in the end.
     if (DateTime.now().difference(_lastWindowRestoreTime) <
         const Duration(milliseconds: 300)) {
       return;
     }
+    _queryCount = _maxQueryCount;
     _isActive = false;
   }
 
   @override
   void onWindowRestore() {
+    // Window restore (on MacOS and Linux) also triggers `onWindowFocus()`.
+    if (!isWindows) return;
+
     _queryCount = 0;
     _isActive = true;
     _lastWindowRestoreTime = DateTime.now();
@@ -142,6 +146,8 @@ class _PeersViewState extends State<_PeersView>
 
   @override
   void onWindowMinimize() {
+    // Window minimize (on MacOS and Linux) also triggers `onWindowBlur()`.
+    if (!isWindows) return;
     _queryCount = _maxQueryCount;
     _isActive = false;
   }

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -89,6 +89,7 @@ class _PeersViewState extends State<_PeersView>
   var _lastChangeTime = DateTime.now();
   var _lastQueryPeers = <String>{};
   var _lastQueryTime = DateTime.now();
+  var _lastWindowRestoreTime = DateTime.now();
   var _queryCount = 0;
   var _exit = false;
   bool _isActive = true;
@@ -122,6 +123,13 @@ class _PeersViewState extends State<_PeersView>
 
   @override
   void onWindowBlur() {
+    // We need this comparison because window restore also triggers `onWindowBlur()`.
+    // Although `onWindowRestore()` is called after `onWindowBlur()` in my test,
+    // we need the following comparison to ensure that `_isActive` is true in the end.
+    if (DateTime.now().difference(_lastWindowRestoreTime) <
+        const Duration(milliseconds: 300)) {
+      return;
+    }
     _isActive = false;
   }
 
@@ -129,6 +137,7 @@ class _PeersViewState extends State<_PeersView>
   void onWindowRestore() {
     _queryCount = 0;
     _isActive = true;
+    _lastWindowRestoreTime = DateTime.now();
   }
 
   @override
@@ -247,10 +256,11 @@ class _PeersViewState extends State<_PeersView>
                             physics: DraggableNeverScrollableScrollPhysics(),
                             itemCount: peers.length,
                             itemBuilder: (BuildContext context, int index) {
-                              return buildOnePeer(peers[index], false).marginOnly(
-                                  right: space,
-                                  top: index == 0 ? 0 : space / 2,
-                                  bottom: space / 2);
+                              return buildOnePeer(peers[index], false)
+                                  .marginOnly(
+                                      right: space,
+                                      top: index == 0 ? 0 : space / 2,
+                                      bottom: space / 2);
                             }),
                       )
                     : DesktopScrollWrapper(

--- a/flutter/lib/models/peer_model.dart
+++ b/flutter/lib/models/peer_model.dart
@@ -194,10 +194,14 @@ class Peers extends ChangeNotifier {
   }
 
   void _updateOnlineState(Map<String, dynamic> evt) {
+    int changedCount = 0;
     evt['onlines'].split(',').forEach((online) {
       for (var i = 0; i < peers.length; i++) {
         if (peers[i].id == online) {
-          peers[i].online = true;
+          if (!peers[i].online) {
+            changedCount += 1;
+            peers[i].online = true;
+          }
         }
       }
     });
@@ -205,13 +209,18 @@ class Peers extends ChangeNotifier {
     evt['offlines'].split(',').forEach((offline) {
       for (var i = 0; i < peers.length; i++) {
         if (peers[i].id == offline) {
-          peers[i].online = false;
+          if (peers[i].online) {
+            changedCount += 1;
+            peers[i].online = false;
+          }
         }
       }
     });
 
-    event = UpdateEvent.online;
-    notifyListeners();
+    if (changedCount > 0) {
+      event = UpdateEvent.online;
+      notifyListeners();
+    }
   }
 
   void _updatePeers(Map<String, dynamic> evt) {


### PR DESCRIPTION
This is just an improvement commit. I'm still looking for memory leaks.


Restoring window on Windows also triggers `onWindowBlur()`.



https://github.com/user-attachments/assets/8f6b1b74-3c01-4cf1-beaf-8182b5b21367

