### PR TITLE
refact: reduce try_get_displays() on login

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1279,26 +1279,6 @@ impl Connection {
                 self.send(msg_out).await;
             }
 
-            #[cfg(not(any(target_os = "android", target_os = "ios")))]
-            {
-                #[cfg(not(windows))]
-                let displays = display_service::try_get_displays();
-                #[cfg(windows)]
-                let displays = display_service::try_get_displays_add_amyuni_headless();
-                pi.resolutions = Some(SupportedResolutions {
-                    resolutions: displays
-                        .map(|displays| {
-                            displays
-                                .get(self.display_idx)
-                                .map(|d| crate::platform::resolutions(&d.name()))
-                                .unwrap_or(vec![])
-                        })
-                        .unwrap_or(vec![]),
-                    ..Default::default()
-                })
-                .into();
-            }
-
             try_activate_screen();
 
             match super::display_service::update_get_sync_displays().await {
@@ -1314,6 +1294,18 @@ impl Connection {
                     }
                     pi.displays = displays;
                     pi.current_display = self.display_idx as _;
+                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                    {
+                        pi.resolutions = Some(SupportedResolutions {
+                            resolutions: pi
+                                .displays
+                                .get(self.display_idx)
+                                .map(|d| crate::platform::resolutions(&d.name))
+                                .unwrap_or(vec![]),
+                            ..Default::default()
+                        })
+                        .into();
+                    }
                     res.set_peer_info(pi);
                     sub_service = true;
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1281,7 +1281,7 @@ impl Connection {
 
             try_activate_screen();
 
-            match super::display_service::update_get_sync_displays().await {
+            match super::display_service::update_get_sync_displays_on_login().await {
                 Err(err) => {
                     res.set_error(format!("{}", err));
                 }

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -344,7 +344,7 @@ pub fn is_inited_msg() -> Option<Message> {
     None
 }
 
-pub async fn update_get_sync_displays() -> ResultType<Vec<DisplayInfo>> {
+pub async fn update_get_sync_displays_on_login() -> ResultType<Vec<DisplayInfo>> {
     #[cfg(target_os = "linux")]
     {
         if !is_x11() {

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -351,7 +351,11 @@ pub async fn update_get_sync_displays() -> ResultType<Vec<DisplayInfo>> {
             return super::wayland::get_displays().await;
         }
     }
-    check_update_displays(&try_get_displays()?);
+    #[cfg(not(windows))]
+    let displays = display_service::try_get_displays();
+    #[cfg(windows)]
+    let displays = display_service::try_get_displays_add_amyuni_headless();
+    check_update_displays(&displays?);
     Ok(SYNC_DISPLAYS.lock().unwrap().displays.clone())
 }
 


### PR DESCRIPTION
`display_service::update_get_sync_displays` is only used in one place, so it's safe to make the chagnes.

![image](https://github.com/user-attachments/assets/32f17001-1e1c-4b1b-81df-84ab1b65781c)

Tested on Windows, Linux (Wayland, installed and non-installed) as the controlled side.