### PR TITLE
Trim whitespace from Import server config

### DIFF
--- a/flutter/lib/common/widgets/setting_widgets.dart
+++ b/flutter/lib/common/widgets/setting_widgets.dart
@@ -184,7 +184,7 @@ List<Widget> ServerConfigImportExportWidgets(
 ) {
   import() {
     Clipboard.getData(Clipboard.kTextPlain).then((value) {
-      importConfig(controllers, errMsgs, value?.text);
+      importConfig(controllers, errMsgs, value?.text.trim());
     });
   }
 


### PR DESCRIPTION
When emailing someone relay server settings they often copy extra whitespace at the end of the reversed base64 config string. 
This results in a "Invalid server configuration" message.
If the clipboard string was trimmed before it was checked for validity this would stop some support headaches.

I have not tested the included pull request but believe its such a simple change that anyone who regularly programs in dart will be easily able to make it work.
Thanks for such a great project!
mh