### PR TITLE
update appindicator and recommends install it

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -884,7 +884,7 @@ jobs:
                git \
                g++ \
                g++-multilib \
-               libappindicator3-dev \
+               libayatana-appindicator3-dev \
                libasound2-dev \
                libc6-dev \
                libclang-10-dev \
@@ -1147,7 +1147,7 @@ jobs:
                git \
                g++ \
                g++-multilib \
-               libappindicator3-dev \
+               libayatana-appindicator3-dev \
                libasound2-dev \
                libc6-dev \
                libclang-10-dev \
@@ -1424,7 +1424,7 @@ jobs:
                gcc \
                git \
                g++ \
-               libappindicator3-dev \
+               libayatana-appindicator3-dev \
                libasound2-dev \
                libclang-10-dev \
                libgstreamer1.0-dev \
@@ -1681,7 +1681,7 @@ jobs:
                gcc \
                git \
                g++ \
-               libappindicator3-dev \
+               libayatana-appindicator3-dev \
                libasound2-dev \
                libclang-dev \
                libdbus-1-dev \

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -262,7 +262,7 @@ jobs:
                git \
                g++ \
                g++-multilib \
-               libappindicator3-dev \
+               libayatana-appindicator3-dev\
                libasound2-dev \
                libc6-dev \
                libclang-10-dev \

--- a/build.py
+++ b/build.py
@@ -287,7 +287,8 @@ Version: %s
 Architecture: %s
 Maintainer: rustdesk <info@rustdesk.com>
 Homepage: https://rustdesk.com
-Depends: libgtk-3-0, libxcb-randr0, libxdo3, libxfixes3, libxcb-shape0, libxcb-xfixes0, libasound2, libsystemd0, curl, libva-drm2, libva-x11-2, libvdpau1, libgstreamer-plugins-base1.0-0, libpam0g, libappindicator3-1, gstreamer1.0-pipewire%s
+Depends: libgtk-3-0, libxcb-randr0, libxdo3, libxfixes3, libxcb-shape0, libxcb-xfixes0, libasound2, libsystemd0, curl, libva-drm2, libva-x11-2, libvdpau1, libgstreamer-plugins-base1.0-0, libpam0g, gstreamer1.0-pipewire%s
+Recommends: libayatana-appindicator3-1
 Description: A remote control software.
 
 """ % (version, get_deb_arch(), get_deb_extra_depends())

--- a/res/rpm-flutter-suse.spec
+++ b/res/rpm-flutter-suse.spec
@@ -3,7 +3,8 @@ Version:    1.3.1
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0
-Requires:   gtk3 libxcb1 xdotool libXfixes3 alsa-utils libXtst6 libappindicator-gtk3 libvdpau1 libva2 pam gstreamer-plugins-base gstreamer-plugin-pipewire
+Requires:   gtk3 libxcb1 xdotool libXfixes3 alsa-utils libXtst6 libvdpau1 libva2 pam gstreamer-plugins-base gstreamer-plugin-pipewire
+Recommends: libayatana-appindicator3-1
 Provides:   libdesktop_drop_plugin.so()(64bit), libdesktop_multi_window_plugin.so()(64bit), libfile_selector_linux_plugin.so()(64bit), libflutter_custom_cursor_plugin.so()(64bit), libflutter_linux_gtk.so()(64bit), libscreen_retriever_plugin.so()(64bit), libtray_manager_plugin.so()(64bit), liburl_launcher_linux_plugin.so()(64bit), libwindow_manager_plugin.so()(64bit), libwindow_size_plugin.so()(64bit), libtexture_rgba_renderer_plugin.so()(64bit)
 
 %description

--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -3,7 +3,8 @@ Version:    1.3.1
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0
-Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libappindicator-gtk3 libvdpau libva pam gstreamer1-plugins-base
+Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libvdpau libva pam gstreamer1-plugins-base
+Recommends: libayatana-appindicator-gtk3
 Provides:   libdesktop_drop_plugin.so()(64bit), libdesktop_multi_window_plugin.so()(64bit), libfile_selector_linux_plugin.so()(64bit), libflutter_custom_cursor_plugin.so()(64bit), libflutter_linux_gtk.so()(64bit), libscreen_retriever_plugin.so()(64bit), libtray_manager_plugin.so()(64bit), liburl_launcher_linux_plugin.so()(64bit), libwindow_manager_plugin.so()(64bit), libwindow_size_plugin.so()(64bit), libtexture_rgba_renderer_plugin.so()(64bit)
 
 %description

--- a/res/rpm-suse.spec
+++ b/res/rpm-suse.spec
@@ -3,7 +3,8 @@ Version:    1.1.9
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0
-Requires:   gtk3 libxcb1 xdotool libXfixes3 alsa-utils libXtst6 libayatana-appindicator3-1 libvdpau1 libva2 pam gstreamer-plugins-base gstreamer-plugin-pipewire
+Requires:   gtk3 libxcb1 xdotool libXfixes3 alsa-utils libXtst6 libvdpau1 libva2 pam gstreamer-plugins-base gstreamer-plugin-pipewire
+Recommends: libayatana-appindicator3-1
 
 %description
 The best open-source remote desktop client software, written in Rust.

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -3,7 +3,8 @@ Version:    1.3.1
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0
-Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libappindicator libvdpau1 libva2 pam gstreamer1-plugins-base
+Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libvdpau1 libva2 pam gstreamer1-plugins-base
+Recommends: libayatana-appindicator-gtk3
 
 %description
 The best open-source remote desktop client software, written in Rust.


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/pull/9138

| format   | test os              | package                      | success |
| -------- | -------------------- | ---------------------------- | ------- |
| deb   | ubuntu 22.04         | libayatana-appindicator3-1   | Y       |
| rpm      | centos 9 / fedora 38 | libayatana-appindicator-gtk3 | Y       |
| suse.rpm | suse 15.6            | libayatana-appindicator3-1   | Y       |

1. With `Recommends`, all operating systems  above will install appindicator by default, with `Suggests` not, all use `Recommends`.
2. If a package is unknown, such as `Recommends:abcxyzhello`, it can be installed on all operating systems above.
3. Arch and Flatpak remain unchanged.