### PR TITLE
fix: win VD, do not plug out if not plugged in

### DIFF
--- a/src/privacy_mode/win_virtual_display.rs
+++ b/src/privacy_mode/win_virtual_display.rs
@@ -150,8 +150,11 @@ impl PrivacyModeImpl {
     }
 
     fn restore_plug_out_monitor(&mut self) {
-        let _ =
-            virtual_display_manager::plug_out_monitor_indices(&self.virtual_displays_added, true);
+        let _ = virtual_display_manager::plug_out_monitor_indices(
+            &self.virtual_displays_added,
+            true,
+            false,
+        );
         self.virtual_displays_added.clear();
     }
 
@@ -312,7 +315,7 @@ impl PrivacyModeImpl {
 
             // No physical displays, no need to use the privacy mode.
             if self.displays.is_empty() {
-                virtual_display_manager::plug_out_monitor_indices(&displays, false)?;
+                virtual_display_manager::plug_out_monitor_indices(&displays, false, false)?;
                 bail!(NO_PHYSICAL_DISPLAYS);
             }
 
@@ -509,7 +512,7 @@ pub fn restore_reg_connectivity(plug_out_monitors: bool) {
         return;
     }
     if plug_out_monitors {
-        let _ = virtual_display_manager::plug_out_monitor(-1, true);
+        let _ = virtual_display_manager::plug_out_monitor(-1, true, false);
     }
     if let Ok(reg_recovery) =
         serde_json::from_str::<reg_display_settings::RegRecovery>(&config_recovery_value)

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2713,7 +2713,7 @@ impl Connection {
                 }
             }
         } else {
-            if let Err(e) = virtual_display_manager::plug_out_monitor(t.display, false) {
+            if let Err(e) = virtual_display_manager::plug_out_monitor(t.display, false, true) {
                 log::error!("Failed to plug out virtual display {}: {}", t.display, e);
                 self.send(make_msg(format!(
                     "Failed to plug out virtual displays: {}",


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/9366

## Desc

Do not plug out virtual displays that were not plugged in.

Use a count variable `VIRTUAL_DISPLAY_COUNT` to plug out virtual displays if is plugging out all (The following button and on disconnect).

<img width="281" alt="1" src="https://github.com/user-attachments/assets/a4ab1f77-938b-4326-b0b8-fdd9337594a6">

`VIRTUAL_DISPLAY_COUNT` is only used in the following places.

![image](https://github.com/user-attachments/assets/e7eedba9-450c-463d-a60c-70a26bf6221f)


## TODO

Do not remove the driver if it's already there before installing RustDesk.

Maybe low priority.
Now this is not a big issue as users should always have the driver files if they use amyuni idd.

