### PR TITLE
fix: option OPTION_ONE_WAY_FILE_TRANSFER

### DIFF
--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -132,7 +132,7 @@ impl ClipboardFile {
         )
     }
 
-    pub fn is_stopping_allowed_from_peer(&self) -> bool {
+    pub fn is_beginning_message(&self) -> bool {
         matches!(
             self,
             ClipboardFile::MonitorReady | ClipboardFile::FormatList { .. }

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1895,7 +1895,7 @@ impl<T: InvokeUiSession> Remote<T> {
             return;
         };
 
-        let is_stopping_allowed = clip.is_stopping_allowed_from_peer();
+        let is_stopping_allowed = clip.is_beginning_message();
         let file_transfer_enabled = self.handler.lc.read().unwrap().enable_file_copy_paste.v;
         let stop = is_stopping_allowed && !file_transfer_enabled;
         log::debug!(

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -440,7 +440,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                                 Data::ClipboardFile(_clip) => {
                                     #[cfg(any(target_os = "windows", target_os="linux", target_os = "macos"))]
                                     {
-                                        let is_stopping_allowed = _clip.is_stopping_allowed_from_peer();
+                                        let is_stopping_allowed = _clip.is_beginning_message();
                                         let is_clipboard_enabled = ContextSend::is_enabled();
                                         let file_transfer_enabled = self.file_transfer_enabled;
                                         let stop = !is_stopping_allowed && !(is_clipboard_enabled && file_transfer_enabled);
@@ -565,10 +565,15 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                             log::debug!(
                                 "Process clipboard message from clip, stop: {}, is_stopping_allowed: {}, is_clipboard_enabled: {}, file_transfer_enabled: {}, file_transfer_enabled_peer: {}",
                                 stop, is_stopping_allowed, is_clipboard_enabled, file_transfer_enabled, file_transfer_enabled_peer);
-                            if stop || crate::get_builtin_option(OPTION_ONE_WAY_FILE_TRANSFER) == "Y"{
+                            if stop {
                                 ContextSend::set_is_stopped();
                             } else {
-                                allow_err!(self.tx.send(Data::ClipboardFile(_clip)));
+                                if _clip.is_beginning_message() && crate::get_builtin_option(OPTION_ONE_WAY_FILE_TRANSFER) == "Y" {
+                                    // If one way file transfer is enabled, don't send clipboard file to client
+                                    // Don't call `ContextSend::set_is_stopped()`, because it will stop bidirectional file copy&paste.
+                                } else {
+                                    allow_err!(self.tx.send(Data::ClipboardFile(_clip)));
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fix, copy&paste files one direction. https://rustdesk.com/docs/en/self-host/client-configuration/advanced-settings/#one-way-clipboard-redirection

1. Rename `is_stopping_allowed_from_peer()` to `is_beginning_message()` in `ClipboardFile`.
2. Check `_clip.is_beginning_message()` and then option `OPTION_ONE_WAY_FILE_TRANSFER`. Because some messages must be sent back to the control side when "coping&pasting".