### PR TITLE
fix: wayland, rdp input, mouse, scale

### DIFF
--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -7,6 +7,9 @@ lazy_static::lazy_static! {
 
 pub const DISPLAY_SERVER_WAYLAND: &str = "wayland";
 pub const DISPLAY_SERVER_X11: &str = "x11";
+pub const DISPLAY_DESKTOP_KDE: &str = "KDE";
+
+pub const XDG_CURRENT_DESKTOP: &str = "XDG_CURRENT_DESKTOP";
 
 pub struct Distro {
     pub name: String,
@@ -26,6 +29,15 @@ impl Distro {
             .trim_matches('"')
             .to_string();
         Self { name, version_id }
+    }
+}
+
+#[inline]
+pub fn is_kde() -> bool {
+    if let Ok(env) = std::env::var(XDG_CURRENT_DESKTOP) {
+        env == DISPLAY_DESKTOP_KDE
+    } else {
+        false
     }
 }
 

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -27,39 +27,40 @@ use super::screencast_portal::OrgFreedesktopPortalScreenCast as screencast_porta
 use lazy_static::lazy_static;
 
 lazy_static! {
-    pub static ref RDP_RESPONSE: Mutex<Option<RdpResponse>> = Mutex::new(None);
+    pub static ref RDP_SESSION_INFO: Mutex<Option<RdpSessionInfo>> = Mutex::new(None);
 }
 
 #[inline]
 pub fn close_session() {
-    let _ = RDP_RESPONSE.lock().unwrap().take();
+    let _ = RDP_SESSION_INFO.lock().unwrap().take();
 }
 
 #[inline]
 pub fn is_rdp_session_hold() -> bool {
-    RDP_RESPONSE.lock().unwrap().is_some()
+    RDP_SESSION_INFO.lock().unwrap().is_some()
 }
 
 pub fn try_close_session() {
-    let mut rdp_res = RDP_RESPONSE.lock().unwrap();
+    let mut rdp_info = RDP_SESSION_INFO.lock().unwrap();
     let mut close = false;
-    if let Some(rdp_res) = &*rdp_res {
+    if let Some(rdp_info) = &*rdp_info {
         // If is server running and restore token is supported, there's no need to keep the session.
-        if is_server_running() && rdp_res.is_support_restore_token {
+        if is_server_running() && rdp_info.is_support_restore_token {
             close = true;
         }
     }
     if close {
-        *rdp_res = None;
+        *rdp_info = None;
     }
 }
 
-pub struct RdpResponse {
+pub struct RdpSessionInfo {
     pub conn: Arc<SyncConnection>,
     pub streams: Vec<PwStreamInfo>,
     pub fd: OwnedFd,
     pub session: dbus::Path<'static>,
     pub is_support_restore_token: bool,
+    pub resolution: Arc<Mutex<Option<(usize, usize)>>>,
 }
 #[derive(Debug, Clone, Copy)]
 pub struct PwStreamInfo {
@@ -67,6 +68,12 @@ pub struct PwStreamInfo {
     source_type: u64,
     position: (i32, i32),
     size: (usize, usize),
+}
+
+impl PwStreamInfo {
+    pub fn get_size(&self) -> (usize, usize) {
+        self.size
+    }
 }
 
 #[derive(Debug)]
@@ -105,24 +112,31 @@ pub struct PipeWireCapturable {
 }
 
 impl PipeWireCapturable {
-    fn new(conn: Arc<SyncConnection>, fd: OwnedFd, stream: PwStreamInfo) -> Self {
+    fn new(
+        conn: Arc<SyncConnection>,
+        fd: OwnedFd,
+        resolution: Arc<Mutex<Option<(usize, usize)>>>,
+        stream: PwStreamInfo,
+    ) -> Self {
         // alternative to get screen resolution as stream.size is not always correct ex: on fractional scaling
         // https://github.com/rustdesk/rustdesk/issues/6116#issuecomment-1817724244
-        let res = get_res(Self {
+        let size = get_res(Self {
             dbus_conn: conn.clone(),
             fd: fd.clone(),
             path: stream.path,
             source_type: stream.source_type,
             position: stream.position,
             size: stream.size,
-        });
+        })
+        .unwrap_or(stream.size);
+        *resolution.lock().unwrap() = Some(size);
         Self {
             dbus_conn: conn,
             fd,
             path: stream.path,
             source_type: stream.source_type,
             position: stream.position,
-            size: res.unwrap_or(stream.size),
+            size,
         }
     }
 }
@@ -813,7 +827,7 @@ fn on_start_response(
 }
 
 pub fn get_capturables() -> Result<Vec<PipeWireCapturable>, Box<dyn Error>> {
-    let mut rdp_connection = match RDP_RESPONSE.lock() {
+    let mut rdp_connection = match RDP_SESSION_INFO.lock() {
         Ok(conn) => conn,
         Err(err) => return Err(Box::new(err)),
     };
@@ -822,28 +836,36 @@ pub fn get_capturables() -> Result<Vec<PipeWireCapturable>, Box<dyn Error>> {
         let (conn, fd, streams, session, is_support_restore_token) = request_remote_desktop()?;
         let conn = Arc::new(conn);
 
-        let rdp_res = RdpResponse {
+        let rdp_info = RdpSessionInfo {
             conn,
             streams,
             fd,
             session,
             is_support_restore_token,
+            resolution: Arc::new(Mutex::new(None)),
         };
-        *rdp_connection = Some(rdp_res);
+        *rdp_connection = Some(rdp_info);
     }
 
-    let rdp_res = match rdp_connection.as_ref() {
+    let rdp_info = match rdp_connection.as_ref() {
         Some(res) => res,
         None => {
             return Err(Box::new(DBusError("RDP response is None.".into())));
         }
     };
 
-    Ok(rdp_res
+    Ok(rdp_info
         .streams
         .clone()
         .into_iter()
-        .map(|s| PipeWireCapturable::new(rdp_res.conn.clone(), rdp_res.fd.clone(), s))
+        .map(|s| {
+            PipeWireCapturable::new(
+                rdp_info.conn.clone(),
+                rdp_info.fd.clone(),
+                rdp_info.resolution.clone(),
+                s,
+            )
+        })
         .collect())
 }
 

--- a/src/server/rdp_input.rs
+++ b/src/server/rdp_input.rs
@@ -90,7 +90,11 @@ pub mod client {
             // Logic coordinate from (0,0) to (200x150).
             // Or physical coordinate from (0,0) to (400,300).
             let scale = if is_kde() {
-                Some(resolution.0 as f64 / stream.get_size().0 as f64)
+                if resolution.0 == 0 || stream.get_size().0 == 0 {
+                    Some(1.0f64)
+                } else {
+                    Some(resolution.0 as f64 / stream.get_size().0 as f64)
+                }
             } else {
                 None
             };

--- a/src/server/rdp_input.rs
+++ b/src/server/rdp_input.rs
@@ -8,6 +8,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 pub mod client {
+    use hbb_common::platform::linux::is_kde;
+
     use super::*;
 
     const EVDEV_MOUSE_LEFT: i32 = 272;
@@ -67,6 +69,8 @@ pub mod client {
         conn: Arc<SyncConnection>,
         session: Path<'static>,
         stream: PwStreamInfo,
+        resolution: (usize, usize),
+        scale: Option<f64>,
     }
 
     impl RdpInputMouse {
@@ -74,11 +78,28 @@ pub mod client {
             conn: Arc<SyncConnection>,
             session: Path<'static>,
             stream: PwStreamInfo,
+            resolution: (usize, usize),
         ) -> ResultType<Self> {
+            // https://github.com/rustdesk/rustdesk/pull/9019#issuecomment-2295252388
+            // There may be a bug in Rdp input on Gnome util Ubuntu 24.04 (Gnome 46)
+            //
+            // eg. Resultion 800x600, Fractional scale: 200% (logic size: 400x300)
+            // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.RemoteDesktop.html#:~:text=new%20pointer%20position-,in%20the%20streams%20logical%20coordinate%20space,-.
+            // Then (x,y) in `mouse_move_to()` and `mouse_move_relative()` should be scaled to the logic size(stream.get_size()), which is from (0,0) to (400,300).
+            // For Ubuntu 24.04(Gnome 46), (x,y) is restricted from (0,0) to (400,300), but the actual range in screen is:
+            // Logic coordinate from (0,0) to (200x150).
+            // Or physical coordinate from (0,0) to (400,300).
+            let scale = if is_kde() {
+                Some(resolution.0 as f64 / stream.get_size().0 as f64)
+            } else {
+                None
+            };
             Ok(Self {
                 conn,
                 session,
                 stream,
+                resolution,
+                scale,
             })
         }
     }
@@ -93,24 +114,44 @@ pub mod client {
         }
 
         fn mouse_move_to(&mut self, x: i32, y: i32) {
+            let x = if let Some(s) = self.scale {
+                x as f64 / s
+            } else {
+                x as f64
+            };
+            let y = if let Some(s) = self.scale {
+                y as f64 / s
+            } else {
+                y as f64
+            };
             let portal = get_portal(&self.conn);
             let _ = remote_desktop_portal::notify_pointer_motion_absolute(
                 &portal,
                 &self.session,
                 HashMap::new(),
                 self.stream.path as u32,
-                x as f64,
-                y as f64,
+                x,
+                y,
             );
         }
         fn mouse_move_relative(&mut self, x: i32, y: i32) {
+            let x = if let Some(s) = self.scale {
+                x as f64 / s
+            } else {
+                x as f64
+            };
+            let y = if let Some(s) = self.scale {
+                y as f64 / s
+            } else {
+                y as f64
+            };
             let portal = get_portal(&self.conn);
             let _ = remote_desktop_portal::notify_pointer_motion(
                 &portal,
                 &self.session,
                 HashMap::new(),
-                x as f64,
-                y as f64,
+                x,
+                y,
             );
         }
         fn mouse_down(&mut self, button: MouseButton) -> enigo::ResultType {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/8524
https://github.com/rustdesk/rustdesk/pull/9019

## Preview

https://github.com/user-attachments/assets/cb1efe05-6df2-4100-9f07-1fd2daedb154


https://github.com/user-attachments/assets/d3b533ea-16f9-4c49-b07a-71ab2a60d8be


https://github.com/user-attachments/assets/f2cdb9d2-859b-419c-84d8-293d2fe09927



## Desc

1. Rename `RdpResponse` to `RdpSessionInfo`, because a new filed `pub resolution: Arc<Mutex<Option<(usize, usize)>>>` is added in this struct.
2. Refactor fractional scale.

https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.RemoteDesktop.html#:~:text=The%20(dx%2C%20dy)%20vector%20represents%20the%20new%20pointer%20position%20in%20the%20streams%20logical%20coordinate%20space.

> The (dx, dy) vector represents the new pointer position in the streams logical coordinate space.

So we can just scale the pointer from picture size to the stream logic size.

## Tests


### One display

| OS  | DESKTOP  | RESULT  | REMARK |
| :--: | :---: | :--- | :--- |
| Manjaro-kde-24.0.5 | KDE |   :white_check_mark: |   |
| Archlinux-20240601 | Gnome |   :white_check_mark: |  |
| Ubuntu 24.04 | Gnome |   :white_check_mark: | history issue https://github.com/rustdesk/rustdesk/pull/9019#issuecomment-2295252388 |
| Fedora 40 | Gnome |   :white_check_mark: | |
| Fedora 40 | KDE |  :white_check_mark: | |
| openSUSE-Tumbleweed | KDE |  :white_check_mark: | |
| openSUSE-Tumbleweed | Gnome | :white_check_mark: | |


**Note**:
Only Ubuntu can enable fractional scaling.
While other distributions can set fractional scaling in the terminal `gsettings set org.gnome.desktop.interface scaling-factor 1.5`, the physical and logical sizes are the same.

### Two displays

| OS  | DESKTOP  | RESULT  | REMARK |
| :--: | :---: | :--- | :--- |
| Manjaro-kde-24.0.5 | KDE |  :white_check_mark: |   |
| Fedora 40 | KDE | :white_check_mark: | |

**Note**:
I cannot enable multi-displays for Distros with Gnome in VM VirtualBox.

## Issue

https://github.com/rustdesk/rustdesk/pull/9019#issuecomment-2295252388

It may be a bug of Gnome, as commented in the source code.