### PR TITLE
Fix F-Droid build and bump Android NDK

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -34,7 +34,7 @@ env:
   # vcpkg version: 2024.07.12
   VCPKG_COMMIT_ID: "1de2026f28ead93ff1773e6e680387643e914ea1"
   VERSION: "1.3.1"
-  NDK_VERSION: "r27"
+  NDK_VERSION: "r27b"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"
   MACOS_P12_BASE64: "${{ secrets.MACOS_P12_BASE64 }}"

--- a/flutter/build_fdroid.sh
+++ b/flutter/build_fdroid.sh
@@ -302,6 +302,7 @@ prebuild)
 
 		sed \
 			-i \
+			-e 's/extended_text: .*/extended_text: 11.1.0/' \
 			-e 's/uni_links_desktop/#uni_links_desktop/g' \
 			flutter/pubspec.yaml
 


### PR DESCRIPTION
Second attempt to fix F-Droid build after @21pages showed that the flutter-build CI fix was not propagated to `build_fdroid.sh`.

Alsobump Android NDK to r27b from r27.
