### PR TITLE
fix peers view ChangeNotifierProvider update

### DIFF
--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -128,8 +128,9 @@ class _PeersViewState extends State<_PeersView>
     //
     // Although `onWindowRestore()` is called after `onWindowBlur()` in my test,
     // we need the following comparison to ensure that `_isActive` is true in the end.
-    if (isWindows && DateTime.now().difference(_lastWindowRestoreTime) <
-        const Duration(milliseconds: 300)) {
+    if (isWindows &&
+        DateTime.now().difference(_lastWindowRestoreTime) <
+            const Duration(milliseconds: 300)) {
       return;
     }
     _queryCount = _maxQueryCount;
@@ -170,8 +171,9 @@ class _PeersViewState extends State<_PeersView>
     // We should avoid too many rebuilds. MacOS(m1, 14.6.1) on Flutter 3.19.6.
     // Continious rebuilds of `ChangeNotifierProvider` will cause memory leak.
     // Simple demo can reproduce this issue.
-    return ChangeNotifierProvider<Peers>(
-      create: (context) => widget.peers,
+    return ChangeNotifierProvider<Peers>.value(
+      // https://pub.dev/packages/provider: If you already have an object instance and want to expose it, it would be best to use the .value constructor of a provider.
+      value: widget.peers,
       child: Consumer<Peers>(builder: (context, peers, child) {
         if (peers.peers.isEmpty) {
           gFFI.peerTabModel.setCurrentTabCachedPeers([]);
@@ -186,7 +188,7 @@ class _PeersViewState extends State<_PeersView>
                 ).paddingOnly(bottom: 10),
                 Text(
                   translate(
-                    _emptyMessages[widget.peers.loadEvent] ?? 'Empty',
+                    _emptyMessages[peers.loadEvent] ?? 'Empty',
                   ),
                   textAlign: TextAlign.center,
                   style: TextStyle(


### PR DESCRIPTION
Fix https://github.com/rustdesk/rustdesk/issues/9455
* This can be reproduced on 1.3.1 android release, 1.3.0 android debug, can't be reproduced on desktop, 1.3.0 mobile release
* Reason: The value of `peers` and `widget.peers` are different, `peers` doesn't update.
![bug](https://github.com/user-attachments/assets/f4221335-bfac-4f1f-804a-686359988325)
* Fix: One way is using `ChangeNotifierProvider<Peers>.value`, https://pub.dev/packages/provider: `If you already have an object instance and want to expose it, it would be best to use the .value constructor of a provider`, all other places in souce code use `ChangeNotifierProvider.value`, another way is using `widget.peers` in `Consumer`.

https://github.com/user-attachments/assets/d3d5ced5-8503-4b4c-8f77-1fa99eceb58a


https://github.com/user-attachments/assets/196d5bdb-7b80-4ab7-b2a3-cb195f4edd0e

