### PR TITLE
fix ab peers view,  all peer tab use global peers model

### DIFF
--- a/flutter/lib/common/widgets/address_book.dart
+++ b/flutter/lib/common/widgets/address_book.dart
@@ -241,14 +241,15 @@ class _AddressBookState extends State<AddressBook> {
                 bind.setLocalFlutterOption(k: kOptionCurrentAbName, v: value);
               }
             },
-      customButton: Obx(()=>Container(
-        height: stateGlobal.isPortrait.isFalse ? 48 : 40,
-        child: Row(children: [
-          Expanded(
-              child: buildItem(gFFI.abModel.currentName.value, button: true)),
-          Icon(Icons.arrow_drop_down),
-        ]),
-      )),
+      customButton: Obx(() => Container(
+            height: stateGlobal.isPortrait.isFalse ? 48 : 40,
+            child: Row(children: [
+              Expanded(
+                  child:
+                      buildItem(gFFI.abModel.currentName.value, button: true)),
+              Icon(Icons.arrow_drop_down),
+            ]),
+          )),
       underline: Container(
         height: 0.7,
         color: Theme.of(context).dividerColor.withOpacity(0.1),
@@ -358,7 +359,6 @@ class _AddressBookState extends State<AddressBook> {
           alignment: Alignment.topLeft,
           child: AddressBookPeersView(
             menuPadding: widget.menuPadding,
-            getInitPeers: () => gFFI.abModel.currentAbPeers,
           )),
     );
   }
@@ -509,19 +509,19 @@ class _AddressBookState extends State<AddressBook> {
 
       row({required Widget lable, required Widget input}) {
         makeChild(bool isPortrait) => Row(
-          children: [
-            !isPortrait
-                ? ConstrainedBox(
-                    constraints: const BoxConstraints(minWidth: 100),
-                    child: lable.marginOnly(right: 10))
-                : SizedBox.shrink(),
-            Expanded(
-              child: ConstrainedBox(
-                  constraints: const BoxConstraints(minWidth: 200),
-                  child: input),
-            ),
-          ],
-        ).marginOnly(bottom: !isPortrait ? 8 : 0);
+              children: [
+                !isPortrait
+                    ? ConstrainedBox(
+                        constraints: const BoxConstraints(minWidth: 100),
+                        child: lable.marginOnly(right: 10))
+                    : SizedBox.shrink(),
+                Expanded(
+                  child: ConstrainedBox(
+                      constraints: const BoxConstraints(minWidth: 200),
+                      child: input),
+                ),
+              ],
+            ).marginOnly(bottom: !isPortrait ? 8 : 0);
         return Obx(() => makeChild(stateGlobal.isPortrait.isTrue));
       }
 
@@ -546,23 +546,28 @@ class _AddressBookState extends State<AddressBook> {
                       ],
                     ),
                     input: Obx(() => TextField(
-                      controller: idController,
-                      inputFormatters: [IDTextInputFormatter()],
-                      decoration: InputDecoration(
-                          labelText: stateGlobal.isPortrait.isFalse ? null : translate('ID'),
-                          errorText: errorMsg,
-                          errorMaxLines: 5),
-                    ))),
+                          controller: idController,
+                          inputFormatters: [IDTextInputFormatter()],
+                          decoration: InputDecoration(
+                              labelText: stateGlobal.isPortrait.isFalse
+                                  ? null
+                                  : translate('ID'),
+                              errorText: errorMsg,
+                              errorMaxLines: 5),
+                        ))),
                 row(
                   lable: Text(
                     translate('Alias'),
                     style: style,
                   ),
                   input: Obx(() => TextField(
-                      controller: aliasController,
-                      decoration: InputDecoration(
-                        labelText: stateGlobal.isPortrait.isFalse ? null : translate('Alias'),
-                      ),)),
+                        controller: aliasController,
+                        decoration: InputDecoration(
+                          labelText: stateGlobal.isPortrait.isFalse
+                              ? null
+                              : translate('Alias'),
+                        ),
+                      )),
                 ),
                 if (isCurrentAbShared)
                   row(
@@ -570,25 +575,29 @@ class _AddressBookState extends State<AddressBook> {
                         translate('Password'),
                         style: style,
                       ),
-                      input: Obx(() => TextField(
-                        controller: passwordController,
-                        obscureText: !passwordVisible,
-                        decoration: InputDecoration(
-                          labelText: stateGlobal.isPortrait.isFalse ? null : translate('Password'),
-                          suffixIcon: IconButton(
-                            icon: Icon(
-                                passwordVisible
-                                    ? Icons.visibility
-                                    : Icons.visibility_off,
-                                color: MyTheme.lightTheme.primaryColor),
-                            onPressed: () {
-                              setState(() {
-                                passwordVisible = !passwordVisible;
-                              });
-                            },
+                      input: Obx(
+                        () => TextField(
+                          controller: passwordController,
+                          obscureText: !passwordVisible,
+                          decoration: InputDecoration(
+                            labelText: stateGlobal.isPortrait.isFalse
+                                ? null
+                                : translate('Password'),
+                            suffixIcon: IconButton(
+                              icon: Icon(
+                                  passwordVisible
+                                      ? Icons.visibility
+                                      : Icons.visibility_off,
+                                  color: MyTheme.lightTheme.primaryColor),
+                              onPressed: () {
+                                setState(() {
+                                  passwordVisible = !passwordVisible;
+                                });
+                              },
+                            ),
                           ),
                         ),
-                      ),)),
+                      )),
                 if (gFFI.abModel.currentAbTags.isNotEmpty)
                   Align(
                     alignment: Alignment.centerLeft,

--- a/flutter/lib/common/widgets/my_group.dart
+++ b/flutter/lib/common/widgets/my_group.dart
@@ -83,8 +83,8 @@ class _MyGroupState extends State<MyGroup> {
           child: Align(
               alignment: Alignment.topLeft,
               child: MyGroupPeerView(
-                  menuPadding: widget.menuPadding,
-                  getInitPeers: () => gFFI.groupModel.peers)),
+                menuPadding: widget.menuPadding,
+              )),
         )
       ],
     );
@@ -115,8 +115,8 @@ class _MyGroupState extends State<MyGroup> {
           child: Align(
               alignment: Alignment.topLeft,
               child: MyGroupPeerView(
-                  menuPadding: widget.menuPadding,
-                  getInitPeers: () => gFFI.groupModel.peers)),
+                menuPadding: widget.menuPadding,
+              )),
         )
       ],
     );

--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -66,10 +66,16 @@ class AbModel {
   var listInitialized = false;
   var _maxPeerOneAb = 0;
 
+  late final Peers peersModel;
+
   WeakReference<FFI> parent;
 
   AbModel(this.parent) {
     addressbooks.clear();
+    peersModel = Peers(
+        name: PeersModelName.addressBook,
+        getInitPeers: () => currentAbPeers,
+        loadEvent: LoadEvent.addressBook);
     if (desktopType == DesktopType.main) {
       Timer.periodic(Duration(milliseconds: 500), (timer) async {
         if (_timerCounter++ % 6 == 0) {

--- a/flutter/lib/models/group_model.dart
+++ b/flutter/lib/models/group_model.dart
@@ -23,7 +23,14 @@ class GroupModel {
 
   bool get emtpy => users.isEmpty && peers.isEmpty;
 
-  GroupModel(this.parent);
+  late final Peers peersModel;
+
+  GroupModel(this.parent) {
+    peersModel = Peers(
+        name: PeersModelName.group,
+        getInitPeers: () => peers,
+        loadEvent: LoadEvent.group);
+  }
 
   Future<void> pull({force = true, quiet = false}) async {
     if (bind.isDisableGroupPanel()) return;

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -7,12 +7,14 @@ import 'dart:ui' as ui;
 import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_hbb/common/widgets/peers_view.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/models/ab_model.dart';
 import 'package:flutter_hbb/models/chat_model.dart';
 import 'package:flutter_hbb/models/cm_file_model.dart';
 import 'package:flutter_hbb/models/file_model.dart';
 import 'package:flutter_hbb/models/group_model.dart';
+import 'package:flutter_hbb/models/peer_model.dart';
 import 'package:flutter_hbb/models/peer_tab_model.dart';
 import 'package:flutter_hbb/models/server_model.dart';
 import 'package:flutter_hbb/models/user_model.dart';
@@ -2397,6 +2399,9 @@ class FFI {
   late final ElevationModel elevationModel; // session
   late final CmFileModel cmFileModel; // cm
   late final TextureModel textureModel; //session
+  late final Peers recentPeersModel; // global
+  late final Peers favoritePeersModel; // global
+  late final Peers lanPeersModel; // global
 
   FFI(SessionID? sId) {
     sessionId = sId ?? (isDesktop ? Uuid().v4obj() : _constSessionId);
@@ -2417,6 +2422,16 @@ class FFI {
     elevationModel = ElevationModel(WeakReference(this));
     cmFileModel = CmFileModel(WeakReference(this));
     textureModel = TextureModel(WeakReference(this));
+    recentPeersModel = Peers(
+        name: PeersModelName.recent,
+        loadEvent: LoadEvent.recent,
+        getInitPeers: null);
+    favoritePeersModel = Peers(
+        name: PeersModelName.favorite,
+        loadEvent: LoadEvent.favorite,
+        getInitPeers: null);
+    lanPeersModel = Peers(
+        name: PeersModelName.lan, loadEvent: LoadEvent.lan, getInitPeers: null);
   }
 
   /// Mobile reuse FFI


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/9122#discussioncomment-10759247 https://github.com/rustdesk/rustdesk/pull/9459

Use `ChangeNotifierProvider<Peers>.value`, and each peer tab has a global unique `Peers` model, then "load Peers" and "build Peers" will always be the same one.


[desktop.webm](https://github.com/user-attachments/assets/c38ad306-552b-4f61-97af-25782eaa9a8b)

https://github.com/user-attachments/assets/8db0cd79-392b-4cd0-b5e5-e0f2799476c2

