### PR TITLE
Change the minimum value of the bitrate slider to 5

### DIFF
--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -446,7 +446,7 @@ function handle_custom_image_quality() {
     var extendedBitrate = bitrate > 100;
     var maxRate = extendedBitrate ? 2000 : 100;
     msgbox("custom-image-quality", "Custom Image Quality", "<div .form> \
-          <div><input #bitrate-slider type=\"hslider\" style=\"width: 50%\" name=\"bitrate\" max=\"" + maxRate + "\" min=\"10\" value=\"" + bitrate + "\"/ buddy=\"bitrate-buddy\"><b #bitrate-buddy>x</b>% Bitrate <button|checkbox #extended-slider .custom-event " + (extendedBitrate ? "checked" : "") + ">More</button></div> \
+          <div><input #bitrate-slider type=\"hslider\" style=\"width: 50%\" name=\"bitrate\" max=\"" + maxRate + "\" min=\"5\" value=\"" + bitrate + "\"/ buddy=\"bitrate-buddy\"><b #bitrate-buddy>x</b>% Bitrate <button|checkbox #extended-slider .custom-event " + (extendedBitrate ? "checked" : "") + ">More</button></div> \
       </div>", "", function(res=null) {
         if (!res) return;
         if (res.id === "extended-slider") {


### PR DESCRIPTION
When cellular communication is under a speed restriction and there are significant changes on the screen, there was some lag when the minimum bitrate was set to 10%. Therefore, I would like the minimum value to be set to 5%.