### PR TITLE
fix: windows, window, restore from minimized state

### DIFF
--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -335,7 +335,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "80b063b9d4e015f62e17f42a5aa0b3d20a365926"
+      resolved-ref: af2e9a51f18effd9796bebb2fa75e0b7ef079613
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/9481

https://github.com/rustdesk/rustdesk/issues/9479

https://github.com/rustdesk-org/rustdesk_desktop_multi_window/pull/23

## Tests

### Single monitor

- [x] "Minimize, Restore/Maximize, Close" buttons.
  - [x] Remote window
- [x] Window edges, normal, maximized, fullscreen.  Whether the edges can be shown.
  - [x] Remote window

![a](https://github.com/user-attachments/assets/9443f8d2-d70f-43fc-b0c7-c8a112099b56)


- [x] Resizing
  - [x] Remote window
  - [x] Corner resize
  - [x] Edge resize
- [x] Show all contents, without crops. Remote window, normal, maximized, fullscreen. eg. https://github.com/rustdesk/rustdesk/issues/8979

### Multiple monitors

- [ ] Different arrangements.

<img width="559" alt="a" src="https://github.com/user-attachments/assets/429fa757-ff0c-453c-8001-2c881bfcf472">

- [x] Different main display.
  - [x] Display 1 as main display
  - [x] Display 2 as main display
  - [x] Display 3 as main display

- [x] Different scale on some monitors.
  - [x] Display 1 (100), Display 2 (150), Display 3(200)
  - [x] Display 1 (150), Display 2 (120), Display 3(100)

- [ ] Get window monitor, restore from minimized state. 
  - [x] https://github.com/rustdesk/rustdesk/issues/9481
  - [x] https://github.com/rustdesk/rustdesk/issues/9479
