### PR TITLE
fix: web/mobile, skip querying onlines, if not in main page

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -684,6 +684,7 @@ closeConnection({String? id}) {
   } else {
     if (isWeb) {
       Navigator.popUntil(globalKey.currentContext!, ModalRoute.withName("/"));
+      stateGlobal.isInWebMainPage = true;
     } else {
       final controller = Get.find<DesktopTabController>();
       controller.closeBy(id);
@@ -2324,6 +2325,10 @@ connect(BuildContext context, String id,
     bool forceRelay = false,
     String? password,
     bool? isSharedPassword}) async {
+  if (isWeb) {
+    stateGlobal.isInWebMainPage = false;
+  }
+
   if (id == '') return;
   if (!isDesktop || desktopType == DesktopType.main) {
     try {

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2326,8 +2326,6 @@ connect(BuildContext context, String id,
     bool forceRelay = false,
     String? password,
     bool? isSharedPassword}) async {
-  stateGlobal.isInMainPage = false;
-
   if (id == '') return;
   if (!isDesktop || desktopType == DesktopType.main) {
     try {
@@ -2409,6 +2407,7 @@ connect(BuildContext context, String id,
         );
       }
     }
+    stateGlobal.isInMainPage = false;
   }
 
   FocusScopeNode currentFocus = FocusScope.of(context);

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -680,11 +680,12 @@ closeConnection({String? id}) {
           overlays: SystemUiOverlay.values);
       gFFI.chatModel.hideChatOverlay();
       Navigator.popUntil(globalKey.currentContext!, ModalRoute.withName("/"));
+      stateGlobal.isInMainPage = true;
     }();
   } else {
     if (isWeb) {
       Navigator.popUntil(globalKey.currentContext!, ModalRoute.withName("/"));
-      stateGlobal.isInWebMainPage = true;
+      stateGlobal.isInMainPage = true;
     } else {
       final controller = Get.find<DesktopTabController>();
       controller.closeBy(id);
@@ -2325,9 +2326,7 @@ connect(BuildContext context, String id,
     bool forceRelay = false,
     String? password,
     bool? isSharedPassword}) async {
-  if (isWeb) {
-    stateGlobal.isInWebMainPage = false;
-  }
+  stateGlobal.isInMainPage = false;
 
   if (id == '') return;
   if (!isDesktop || desktopType == DesktopType.main) {

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -332,7 +332,11 @@ class _PeersViewState extends State<_PeersView>
             _queryOnlines(false);
           }
         } else {
-          if (_isActive && (_queryCount < _maxQueryCount || !p)) {
+          final skipIfIsWeb = isWeb &&
+              !(stateGlobal.isWebVisible && stateGlobal.isInWebMainPage);
+          if (!skipIfIsWeb &&
+              _isActive &&
+              (_queryCount < _maxQueryCount || !p)) {
             if (now.difference(_lastQueryTime) >= _queryInterval) {
               if (_curPeers.isNotEmpty) {
                 bind.queryOnlines(ids: _curPeers.toList(growable: false));

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -332,11 +332,12 @@ class _PeersViewState extends State<_PeersView>
             _queryOnlines(false);
           }
         } else {
-          final skipIfIsWeb = isWeb &&
-              !(stateGlobal.isWebVisible && stateGlobal.isInWebMainPage);
-          if (!skipIfIsWeb &&
-              _isActive &&
-              (_queryCount < _maxQueryCount || !p)) {
+          final skipIfIsWeb =
+              isWeb && !(stateGlobal.isWebVisible && stateGlobal.isInMainPage);
+          final skipIfMobile =
+              (isAndroid || isIOS) && !stateGlobal.isInMainPage;
+          final skipIfNotActive = skipIfIsWeb || skipIfMobile || !_isActive;
+          if (!skipIfNotActive && (_queryCount < _maxQueryCount || !p)) {
             if (now.difference(_lastQueryTime) >= _queryInterval) {
               if (_curPeers.isNotEmpty) {
                 bind.queryOnlines(ids: _curPeers.toList(growable: false));

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -23,6 +23,7 @@ import 'package:flutter_hbb/desktop/widgets/scroll_wrapper.dart';
 
 import '../../common/widgets/dialog.dart';
 import '../../common/widgets/login.dart';
+import '../../models/state_model.dart';
 
 const double _kTabWidth = 200;
 const double _kTabHeight = 42;
@@ -209,34 +210,50 @@ class _DesktopSettingPageState extends State<DesktopSettingPage>
   @override
   Widget build(BuildContext context) {
     super.build(context);
+
+    final child = Row(
+      children: <Widget>[
+        SizedBox(
+          width: _kTabWidth,
+          child: Column(
+            children: [
+              _header(context),
+              Flexible(child: _listView(tabs: _settingTabs())),
+            ],
+          ),
+        ),
+        const VerticalDivider(width: 1),
+        Expanded(
+          child: Container(
+            color: Theme.of(context).scaffoldBackgroundColor,
+            child: DesktopScrollWrapper(
+                scrollController: controller,
+                child: PageView(
+                  controller: controller,
+                  physics: NeverScrollableScrollPhysics(),
+                  children: _children(),
+                )),
+          ),
+        )
+      ],
+    );
+
+    final Widget body;
+    if (isWeb) {
+      body = PopScope(
+          onPopInvoked: (bool didPop) {
+            if (didPop) {
+              stateGlobal.isInWebMainPage = true;
+            }
+          },
+          child: child);
+    } else {
+      body = child;
+    }
+
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
-      body: Row(
-        children: <Widget>[
-          SizedBox(
-            width: _kTabWidth,
-            child: Column(
-              children: [
-                _header(context),
-                Flexible(child: _listView(tabs: _settingTabs())),
-              ],
-            ),
-          ),
-          const VerticalDivider(width: 1),
-          Expanded(
-            child: Container(
-              color: Theme.of(context).scaffoldBackgroundColor,
-              child: DesktopScrollWrapper(
-                  scrollController: controller,
-                  child: PageView(
-                    controller: controller,
-                    physics: NeverScrollableScrollPhysics(),
-                    children: _children(),
-                  )),
-            ),
-          )
-        ],
-      ),
+      body: body,
     );
   }
 

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -23,7 +23,6 @@ import 'package:flutter_hbb/desktop/widgets/scroll_wrapper.dart';
 
 import '../../common/widgets/dialog.dart';
 import '../../common/widgets/login.dart';
-import '../../models/state_model.dart';
 
 const double _kTabWidth = 200;
 const double _kTabHeight = 42;
@@ -210,50 +209,34 @@ class _DesktopSettingPageState extends State<DesktopSettingPage>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-
-    final child = Row(
-      children: <Widget>[
-        SizedBox(
-          width: _kTabWidth,
-          child: Column(
-            children: [
-              _header(context),
-              Flexible(child: _listView(tabs: _settingTabs())),
-            ],
-          ),
-        ),
-        const VerticalDivider(width: 1),
-        Expanded(
-          child: Container(
-            color: Theme.of(context).scaffoldBackgroundColor,
-            child: DesktopScrollWrapper(
-                scrollController: controller,
-                child: PageView(
-                  controller: controller,
-                  physics: NeverScrollableScrollPhysics(),
-                  children: _children(),
-                )),
-          ),
-        )
-      ],
-    );
-
-    final Widget body;
-    if (isWeb) {
-      body = PopScope(
-          onPopInvoked: (bool didPop) {
-            if (didPop) {
-              stateGlobal.isInWebMainPage = true;
-            }
-          },
-          child: child);
-    } else {
-      body = child;
-    }
-
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.background,
-      body: body,
+      body: Row(
+        children: <Widget>[
+          SizedBox(
+            width: _kTabWidth,
+            child: Column(
+              children: [
+                _header(context),
+                Flexible(child: _listView(tabs: _settingTabs())),
+              ],
+            ),
+          ),
+          const VerticalDivider(width: 1),
+          Expanded(
+            child: Container(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              child: DesktopScrollWrapper(
+                  scrollController: controller,
+                  child: PageView(
+                    controller: controller,
+                    physics: NeverScrollableScrollPhysics(),
+                    children: _children(),
+                  )),
+            ),
+          )
+        ],
+      ),
     );
   }
 

--- a/flutter/lib/mobile/pages/home_page.dart
+++ b/flutter/lib/mobile/pages/home_page.dart
@@ -6,6 +6,7 @@ import 'package:get/get.dart';
 import '../../common.dart';
 import '../../common/widgets/chat_page.dart';
 import '../../models/platform_model.dart';
+import '../../models/state_model.dart';
 import 'connection_page.dart';
 
 abstract class PageShape extends Widget {
@@ -159,6 +160,7 @@ class WebHomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    stateGlobal.isInWebMainPage = true;
     return Scaffold(
       // backgroundColor: MyTheme.grayBg,
       appBar: AppBar(

--- a/flutter/lib/mobile/pages/home_page.dart
+++ b/flutter/lib/mobile/pages/home_page.dart
@@ -160,7 +160,7 @@ class WebHomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    stateGlobal.isInWebMainPage = true;
+    stateGlobal.isInMainPage = true;
     return Scaffold(
       // backgroundColor: MyTheme.grayBg,
       appBar: AppBar(

--- a/flutter/lib/models/state_model.dart
+++ b/flutter/lib/models/state_model.dart
@@ -19,6 +19,8 @@ class StateGlobal {
   final RxBool showRemoteToolBar = false.obs;
   final svcStatus = SvcStatus.notReady.obs;
   final RxBool isFocused = false.obs;
+  bool isInWebMainPage = true;
+  bool isWebVisible = true;
 
   final isPortrait = false.obs;
 

--- a/flutter/lib/models/state_model.dart
+++ b/flutter/lib/models/state_model.dart
@@ -19,7 +19,8 @@ class StateGlobal {
   final RxBool showRemoteToolBar = false.obs;
   final svcStatus = SvcStatus.notReady.obs;
   final RxBool isFocused = false.obs;
-  bool isInWebMainPage = true;
+  // for mobile and web
+  bool isInMainPage = true;
   bool isWebVisible = true;
 
   final isPortrait = false.obs;

--- a/flutter/lib/models/web_model.dart
+++ b/flutter/lib/models/web_model.dart
@@ -7,6 +7,7 @@ import 'dart:html';
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_hbb/models/state_model.dart';
 
 import 'package:flutter_hbb/web/bridge.dart';
 import 'package:flutter_hbb/common.dart';
@@ -28,7 +29,15 @@ class PlatformFFI {
     context.callMethod('setByName', [name, value]);
   }
 
-  PlatformFFI._();
+  PlatformFFI._() {
+    window.document.addEventListener(
+        'visibilitychange',
+        (event) => {
+              stateGlobal.isWebVisible =
+                  window.document.visibilityState == 'visible'
+            });
+  }
+
   static final PlatformFFI instance = PlatformFFI._();
 
   static get localeName => window.navigator.language;

--- a/flutter/lib/web/settings_page.dart
+++ b/flutter/lib/web/settings_page.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import '../../common.dart';
 import '../../common/widgets/login.dart';
 import '../../models/model.dart';
+import '../models/state_model.dart';
 
 class WebSettingsPage extends StatelessWidget {
   const WebSettingsPage({Key? key}) : super(key: key);
@@ -24,6 +25,7 @@ class WebSettingsPage extends StatelessWidget {
     return IconButton(
       icon: const Icon(Icons.more_vert),
       onPressed: () {
+        stateGlobal.isInWebMainPage = false;
         Navigator.push(
           context,
           MaterialPageRoute(

--- a/flutter/lib/web/settings_page.dart
+++ b/flutter/lib/web/settings_page.dart
@@ -7,7 +7,6 @@ import 'package:provider/provider.dart';
 import '../../common.dart';
 import '../../common/widgets/login.dart';
 import '../../models/model.dart';
-import '../models/state_model.dart';
 
 class WebSettingsPage extends StatelessWidget {
   const WebSettingsPage({Key? key}) : super(key: key);
@@ -25,7 +24,6 @@ class WebSettingsPage extends StatelessWidget {
     return IconButton(
       icon: const Icon(Icons.more_vert),
       onPressed: () {
-        stateGlobal.isInWebMainPage = false;
         Navigator.push(
           context,
           MaterialPageRoute(
@@ -97,4 +95,3 @@ class WebSettingsPage extends StatelessWidget {
         });
   }
 }
-


### PR DESCRIPTION
Introduce two global variables to check if skip querying onlines:
1. `isWebVisible`. Tab is active, window is minimized, window is hidden by other windows.
2. `isInMainPage`. Page is main or remote.