### PR TITLE
fix: deb, build, prerm

### DIFF
--- a/res/DEBIAN/prerm
+++ b/res/DEBIAN/prerm
@@ -14,15 +14,10 @@ case $1 in
 			rm /etc/systemd/system/rustdesk.service /usr/lib/systemd/system/rustdesk.service || true
 			
 			# workaround temp dev build between 1.1.9 and 1.2.0
-			ubuntuVersion=$(grep -oP 'VERSION_ID="\K[\d]+' /etc/os-release | awk '{print $1}')
-			waylandSupportVersion=21
-			if [ "$ubuntuVersion" != "" ] && [ "$ubuntuVersion" -ge "$waylandSupportVersion" ]
+			serverUser=$(ps -ef | grep -E 'rustdesk +--server' | grep -v 'sudo ' | awk '{print $1}' | head -1)
+			if [ "$serverUser" != "" ] && [ "$serverUser" != "root" ]
 			then
-				serverUser=$(ps -ef | grep -E 'rustdesk +--server' | grep -v 'sudo ' | awk '{print $1}' | head -1)
-				if [ "$serverUser" != "" ] && [ "$serverUser" != "root" ]
-				then
-					systemctl --machine=${serverUser}@.host --user stop rustdesk >/dev/null 2>&1 || true
-				fi
+				systemctl --machine=${serverUser}@.host --user stop rustdesk >/dev/null 2>&1 || true
 			fi
 			rm /usr/lib/systemd/user/rustdesk.service >/dev/null 2>&1 || true
 		fi


### PR DESCRIPTION
User service is added in https://github.com/rustdesk/rustdesk/pull/932 and removed in https://github.com/rustdesk/rustdesk/pull/1741

But it's always safe to run the following commands in on `remove|upgrade` in `res/DEBIAN/prerm`
```bash
			serverUser=$(ps -ef | grep -E 'rustdesk +--server' | grep -v 'sudo ' | awk '{print $1}' | head -1)
			if [ "$serverUser" != "" ] && [ "$serverUser" != "root" ]
			then
				systemctl --machine=${serverUser}@.host --user stop rustdesk >/dev/null 2>&1 || true
			fi
```

No need to check current OS version at all.


The check is added in https://github.com/rustdesk/rustdesk/pull/1510 without specific description.
