### PR TITLE
Add `Section: net` to Debian control

### DIFF
--- a/build.py
+++ b/build.py
@@ -283,6 +283,7 @@ def generate_control_file(version):
     system2('/bin/rm -rf %s' % control_file_path)
 
     content = """Package: rustdesk
+Section: net
 Version: %s
 Architecture: %s
 Maintainer: rustdesk <info@rustdesk.com>


### PR DESCRIPTION
https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections

RustDesk have no `Section: ` in Debian control, it is needed if RustDesk want to submit to big/official repos in the future.