### PR TITLE
Add `Priority:` to Debian control

### DIFF
--- a/build.py
+++ b/build.py
@@ -284,6 +284,7 @@ def generate_control_file(version):
 
     content = """Package: rustdesk
 Section: net
+Priority: optional
 Version: %s
 Architecture: %s
 Maintainer: rustdesk <info@rustdesk.com>


### PR DESCRIPTION
#9584 

I forgot `Priority:` is also missing, both of them aren't missing in RustDesk Server.

https://github.com/rustdesk/rustdesk-server/blob/6f18a97644cc3176b923ce5a6aad88bec41d6046/debian/control.tpl#L2-L3