### PR TITLE
refact: remove redundant escape

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3616,3 +3616,7 @@ List<SubWindowResizeEdge>? get subWindowManagerEnableResizeEdges => isWindows
         SubWindowResizeEdge.topRight,
       ]
     : null;
+
+void earlyAssert() {
+  assert('\1' == '1');
+}

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -36,6 +36,7 @@ WindowType? kWindowType;
 late List<String> kBootArgs;
 
 Future<void> main(List<String> args) async {
+  earlyAssert();
   WidgetsFlutterBinding.ensureInitialized();
 
   debugPrint("launch args: $args");

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -155,9 +155,9 @@ class _RemotePageState extends State<RemotePage> {
     var oldValue = _value;
     _value = newValue;
     var i = newValue.length - 1;
-    for (; i >= 0 && newValue[i] != '\1'; --i) {}
+    for (; i >= 0 && newValue[i] != '1'; --i) {}
     var j = oldValue.length - 1;
-    for (; j >= 0 && oldValue[j] != '\1'; --j) {}
+    for (; j >= 0 && oldValue[j] != '1'; --j) {}
     if (i < j) j = i;
     var subNewValue = newValue.substring(j + 1);
     var subOldValue = oldValue.substring(j + 1);
@@ -206,8 +206,8 @@ class _RemotePageState extends State<RemotePage> {
     _value = newValue;
     if (oldValue.isNotEmpty &&
         newValue.isNotEmpty &&
-        oldValue[0] == '\1' &&
-        newValue[0] != '\1') {
+        oldValue[0] == '1' &&
+        newValue[0] != '1') {
       // clipboard
       oldValue = '';
     }


### PR DESCRIPTION
`'\1'` is equal to `'1'` in dart, as they are both string `"1"`.

Dart has **its own** escape rule, which is different to `C/C++`.

![image](https://github.com/user-attachments/assets/ae338d4d-b462-4774-a283-b2d1c6f7ba66)


early assert `assert('\1' != '1');` for test

![image](https://github.com/user-attachments/assets/9b7e887b-7b71-4d44-830e-0d273cdf19e6)
