### PR TITLE
fix: wayland CapsLock

### DIFF
--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -175,6 +175,22 @@ impl LockModesHandler {
         }
     }
 
+    #[cfg(target_os = "linux")]
+    fn sleep_to_ensure_locked(v: bool, k: enigo::Key, en: &mut Enigo) {
+        if wayland_use_uinput() {
+            // Sleep at most 500ms to ensure the lock state is applied.
+            for _ in 0..50 {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                if en.get_key_state(k) == v {
+                    break;
+                }
+            }
+        } else if wayland_use_rdp_input() {
+            // We can't call `en.get_key_state(k)` because there's no api for this.
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     fn new(key_event: &KeyEvent, is_numpad_key: bool) -> Self {
         let mut en = ENIGO.lock().unwrap();
@@ -183,12 +199,15 @@ impl LockModesHandler {
         let caps_lock_changed = event_caps_enabled != local_caps_enabled;
         if caps_lock_changed {
             en.key_click(enigo::Key::CapsLock);
+            #[cfg(target_os = "linux")]
+            Self::sleep_to_ensure_locked(event_caps_enabled, enigo::Key::CapsLock, &mut en);
         }
 
         let mut num_lock_changed = false;
+        let mut event_num_enabled = false;
         if is_numpad_key {
             let local_num_enabled = en.get_key_state(enigo::Key::NumLock);
-            let event_num_enabled = Self::is_modifier_enabled(key_event, ControlKey::NumLock);
+            event_num_enabled = Self::is_modifier_enabled(key_event, ControlKey::NumLock);
             num_lock_changed = event_num_enabled != local_num_enabled;
         } else if is_legacy_mode(key_event) {
             #[cfg(target_os = "windows")]
@@ -199,6 +218,8 @@ impl LockModesHandler {
         }
         if num_lock_changed {
             en.key_click(enigo::Key::NumLock);
+            #[cfg(target_os = "linux")]
+            Self::sleep_to_ensure_locked(event_num_enabled, enigo::Key::NumLock, &mut en);
         }
 
         Self {
@@ -236,6 +257,14 @@ impl LockModesHandler {
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 impl Drop for LockModesHandler {
     fn drop(&mut self) {
+        // Do not change led state if is Wayland uinput.
+        // Because there must be a delay to ensure the lock state is applied on Wayland uinput,
+        // which may affect the user experience.
+        #[cfg(target_os = "linux")]
+        if wayland_use_uinput() {
+            return;
+        }
+
         let mut en = ENIGO.lock().unwrap();
         if self.caps_lock_changed {
             en.key_click(enigo::Key::CapsLock);
@@ -1609,36 +1638,39 @@ pub fn handle_key_(evt: &KeyEvent) {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     let mut _lock_mode_handler = None;
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    match &evt.union {
-        Some(key_event::Union::Unicode(..)) | Some(key_event::Union::Seq(..)) => {
-            _lock_mode_handler = Some(LockModesHandler::new_handler(&evt, false));
-        }
-        Some(key_event::Union::ControlKey(ck)) => {
-            let key = ck.enum_value_or(ControlKey::Unknown);
-            if !skip_led_sync_control_key(&key) {
-                #[cfg(target_os = "macos")]
-                let is_numpad_key = false;
-                #[cfg(any(target_os = "windows", target_os = "linux"))]
-                let is_numpad_key = is_numpad_control_key(&key);
-                _lock_mode_handler = Some(LockModesHandler::new_handler(&evt, is_numpad_key));
+    if evt.down {
+        match &evt.union {
+            Some(key_event::Union::Unicode(..)) | Some(key_event::Union::Seq(..)) => {
+                _lock_mode_handler = Some(LockModesHandler::new_handler(&evt, false));
             }
-        }
-        Some(key_event::Union::Chr(code)) => {
-            if is_legacy_mode(&evt) {
-                _lock_mode_handler = Some(LockModesHandler::new_handler(evt, false));
-            } else {
-                let key = crate::keyboard::keycode_to_rdev_key(*code);
-                if !skip_led_sync_rdev_key(&key) {
+            Some(key_event::Union::ControlKey(ck)) => {
+                let key = ck.enum_value_or(ControlKey::Unknown);
+                if !skip_led_sync_control_key(&key) {
                     #[cfg(target_os = "macos")]
                     let is_numpad_key = false;
                     #[cfg(any(target_os = "windows", target_os = "linux"))]
-                    let is_numpad_key = crate::keyboard::is_numpad_rdev_key(&key);
-                    _lock_mode_handler = Some(LockModesHandler::new_handler(evt, is_numpad_key));
+                    let is_numpad_key = is_numpad_control_key(&key);
+                    _lock_mode_handler = Some(LockModesHandler::new_handler(&evt, is_numpad_key));
                 }
             }
+            Some(key_event::Union::Chr(code)) => {
+                if is_legacy_mode(&evt) {
+                    _lock_mode_handler = Some(LockModesHandler::new_handler(evt, false));
+                } else {
+                    let key = crate::keyboard::keycode_to_rdev_key(*code);
+                    if !skip_led_sync_rdev_key(&key) {
+                        #[cfg(target_os = "macos")]
+                        let is_numpad_key = false;
+                        #[cfg(any(target_os = "windows", target_os = "linux"))]
+                        let is_numpad_key = crate::keyboard::is_numpad_rdev_key(&key);
+                        _lock_mode_handler =
+                            Some(LockModesHandler::new_handler(evt, is_numpad_key));
+                    }
+                }
+            }
+            _ => {}
         }
-        _ => {}
-    };
+    }
 
     match evt.mode.enum_value() {
         Ok(KeyboardMode::Map) => {

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1638,7 +1638,6 @@ pub fn handle_key_(evt: &KeyEvent) {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     let mut _lock_mode_handler = None;
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    if evt.down {
     match &evt.union {
         Some(key_event::Union::Unicode(..)) | Some(key_event::Union::Seq(..)) => {
             _lock_mode_handler = Some(LockModesHandler::new_handler(&evt, false));
@@ -1669,7 +1668,6 @@ pub fn handle_key_(evt: &KeyEvent) {
             }
         }
         _ => {}
-    }
     }
 
     match evt.mode.enum_value() {

--- a/src/server/uinput.rs
+++ b/src/server/uinput.rs
@@ -431,8 +431,8 @@ pub mod service {
                 allow_err!(keyboard.emit(&[down_event]));
             }
             DataKeyboard::KeyUp(enigo::Key::Raw(code)) => {
-                let down_event = InputEvent::new(EventType::KEY, *code - 8, 0);
-                allow_err!(keyboard.emit(&[down_event]));
+                let up_event = InputEvent::new(EventType::KEY, *code - 8, 0);
+                allow_err!(keyboard.emit(&[up_event]));
             }
             DataKeyboard::KeyDown(key) => {
                 if let Ok((k, is_shift)) = map_key(key) {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/8760

Fix `CapsLock` when the remote side is Wayland.

Flatpak and Appimage, which use rdp input(xdg desktop portal) is still not fixed. https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.RemoteDesktop.html

## Preview

### uinput

https://github.com/user-attachments/assets/72865cd3-11fe-4506-b9cd-a0d900ed9e89

### rdp

https://github.com/user-attachments/assets/b864c90a-785f-463e-8eec-873d6ae03025

## Desc

RustDesk sends keys with additional `CapsLock` state to the remote side.

The remote side will 
1. Click `CapsLock`.
2. Simulate key.
3. Click `CapsLock` to revert the state.

But for uinput and rdp input, there should be a delay to ensure the `CapsLock` state take effect.

### Uinput

The remote side will click `CapsLock` and wait the state to be changed when it finds current state is not the same to the key event from the local side.

But it will not change the `CapsLock` state back.
Because there must be a delay to ensure the lock state is applied on Wayland uinput, which may affect the user experience.

**Note**: So there's a side effect that the `CapsLock` state may be changed after the remote control

### Rdp input

Rdp input just add a delay to wait the `CapsLock` state be changed. So the letters may not be correct.

Because there's no api to query the `CapsLock` state.
`/usr/input/eventX` also requires the root permission.

## Tests

The following test are `Windows -> `, "Map mode" and "Translate mode".

- [x] Linux
  - [x] X11
  - [x] Wayland
    - [x] Installed version
    - [x] Appimage and Flatpak.
- [x] Windows
- [x] MacOS

**Note**: Appimage and Flatpak are not good as descripted above.


