### PR TITLE
fix: TextFormField onChanged event triggered multiple times when Korean input

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -524,6 +524,8 @@ class _RemotePageState extends State<RemotePage> {
                       keyboardType: TextInputType.multiline,
                       onChanged: (newValue) async {
                         if (isIOS) {
+                          // fix: TextFormField onChanged event triggered multiple times when Korean input
+                          // https://github.com/rustdesk/rustdesk/pull/9644
                           await Future.delayed(const Duration(milliseconds: 10));
 
                           if (newValue != _textController.text) return;

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -242,15 +242,6 @@ class _RemotePageState extends State<RemotePage> {
     }
   }
 
-  // handle mobile virtual keyboard
-  void handleSoftKeyboardInput(String newValue) {
-    if (isIOS) {
-      _handleIOSSoftKeyboardInput(newValue);
-    } else {
-      _handleNonIOSSoftKeyboardInput(newValue);
-    }
-  }
-
   void inputChar(String char) {
     if (char == '\n') {
       char = 'VK_RETURN';
@@ -531,12 +522,15 @@ class _RemotePageState extends State<RemotePage> {
                       controller: _textController,
                       // trick way to make backspace work always
                       keyboardType: TextInputType.multiline,
-                      // onChanged: handleSoftKeyboardInput,
                       onChanged: (newValue) async {
-                        await Future.delayed(const Duration(milliseconds: 10));
+                        if (isIOS) {
+                          await Future.delayed(const Duration(milliseconds: 10));
 
-                        if (newValue != _textController.text) return;
-                        return handleSoftKeyboardInput(_textController.text);
+                          if (newValue != _textController.text) return;
+                          return _handleIOSSoftKeyboardInput(_textController.text);
+                        } else {
+                          return _handleNonIOSSoftKeyboardInput(newValue);
+                        }
                       },
                     ),
             ),

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -242,6 +242,19 @@ class _RemotePageState extends State<RemotePage> {
     }
   }
 
+  async void handleSoftKeyboardInput(String newValue) {
+    if (isIOS) {
+      // fix: TextFormField onChanged event triggered multiple times when Korean input
+      // https://github.com/rustdesk/rustdesk/pull/9644
+      await Future.delayed(const Duration(milliseconds: 10));
+
+      if (newValue != _textController.text) return;
+      return _handleIOSSoftKeyboardInput(_textController.text);
+    } else {
+      return _handleNonIOSSoftKeyboardInput(newValue);
+    }
+  }
+
   void inputChar(String char) {
     if (char == '\n') {
       char = 'VK_RETURN';
@@ -522,18 +535,7 @@ class _RemotePageState extends State<RemotePage> {
                       controller: _textController,
                       // trick way to make backspace work always
                       keyboardType: TextInputType.multiline,
-                      onChanged: (newValue) async {
-                        if (isIOS) {
-                          // fix: TextFormField onChanged event triggered multiple times when Korean input
-                          // https://github.com/rustdesk/rustdesk/pull/9644
-                          await Future.delayed(const Duration(milliseconds: 10));
-
-                          if (newValue != _textController.text) return;
-                          return _handleIOSSoftKeyboardInput(_textController.text);
-                        } else {
-                          return _handleNonIOSSoftKeyboardInput(newValue);
-                        }
-                      },
+                      onChanged: handleSoftKeyboardInput,
                     ),
             ),
           ];

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -531,7 +531,13 @@ class _RemotePageState extends State<RemotePage> {
                       controller: _textController,
                       // trick way to make backspace work always
                       keyboardType: TextInputType.multiline,
-                      onChanged: handleSoftKeyboardInput,
+                      // onChanged: handleSoftKeyboardInput,
+                      onChanged: (newValue) async {
+                        await Future.delayed(const Duration(milliseconds: 10));
+
+                        if (newValue != _textController.text) return;
+                        return handleSoftKeyboardInput(_textController.text);
+                      },
                     ),
             ),
           ];


### PR DESCRIPTION
issue: [(8786)](https://github.com/rustdesk/rustdesk/issues/8786#issuecomment-2401286686)

The cause of this bug has been identified. When entering and clicking on Korean content, the onChanged event of the TextFormField is triggered multiple times.

For example: 
When inputting ㅎ → ㅏ → 하, the onChanged event is triggered 4 times: ㅎ → ' ' → ㅏ → ' ' → 하. 
When inputting ㄱ → ㅏ → ㅇ → 강, the event is triggered 6 times: ㄱ → ' ' → ㅏ → ' ' → ㅇ → ' ' → 강.

This issue is caused by the positional changes of Korean characters with each new symbol. These multiple unnecessary onChanged triggers cause our _handleIOSSoftKeyboardInput function to execute incorrectly, which leads to the previous bug.

We only need to give a little more time to allow the keyboard input engine to finish constructing the Korean characters before triggering the onChanged event. Of course, this is somewhat of a hacky fix.