### PR TITLE
fix gtk-sudo in non-English linux

### DIFF
--- a/src/platform/gtk_sudo.rs
+++ b/src/platform/gtk_sudo.rs
@@ -505,7 +505,7 @@ fn child(su_user: Option<String>, args: Vec<String>) -> ResultType<()> {
         command = format!("'{}'", quote_shell_arg(&command, false));
     }
     params.push(command);
-    std::env::set_var("LC_ALL", "C.UTF-8");
+    std::env::set_var("LC_ALL", "C");
 
     if let Some(user) = &su_user {
         let su_subcommand = params


### PR DESCRIPTION
change LC_ALL from C.UTF-8 to C

[before.webm](https://github.com/user-attachments/assets/8e1c66ae-3281-4802-87c0-2e50a46f2bf6)

[after.webm](https://github.com/user-attachments/assets/31e0f428-ec7d-4c26-927c-6e32f877a879)
