### PR TITLE
fix: workaround physical display rotation

### DIFF
--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -156,7 +156,7 @@ pub trait TraitPixelBuffer {
 #[cfg(not(any(target_os = "ios")))]
 pub enum Frame<'a> {
     PixelBuffer(PixelBuffer<'a>),
-    Texture(*mut c_void),
+    Texture((*mut c_void, usize)),
 }
 
 #[cfg(not(any(target_os = "ios")))]
@@ -164,7 +164,7 @@ impl Frame<'_> {
     pub fn valid<'a>(&'a self) -> bool {
         match self {
             Frame::PixelBuffer(pixelbuffer) => !pixelbuffer.data().is_empty(),
-            Frame::Texture(texture) => !texture.is_null(),
+            Frame::Texture((texture, _)) => !texture.is_null(),
         }
     }
 
@@ -186,7 +186,7 @@ impl Frame<'_> {
 
 pub enum EncodeInput<'a> {
     YUV(&'a [u8]),
-    Texture(*mut c_void),
+    Texture((*mut c_void, usize)),
 }
 
 impl<'a> EncodeInput<'a> {
@@ -197,7 +197,7 @@ impl<'a> EncodeInput<'a> {
         }
     }
 
-    pub fn texture(&self) -> ResultType<*mut c_void> {
+    pub fn texture(&self) -> ResultType<(*mut c_void, usize)> {
         match self {
             Self::Texture(f) => Ok(*f),
             _ => bail!("not texture frame"),

--- a/libs/scrap/src/common/vram.rs
+++ b/libs/scrap/src/common/vram.rs
@@ -101,7 +101,12 @@ impl EncoderApi for VRamEncoder {
         frame: EncodeInput,
         ms: i64,
     ) -> ResultType<hbb_common::message_proto::VideoFrame> {
-        let texture = frame.texture()?;
+        let (texture, rotation) = frame.texture()?;
+        if rotation != 0 {
+            // to-do: support rotation
+            // Both the encoder and display(w,h) information need to be changed.
+            bail!("rotation not supported");
+        }
         let mut vf = VideoFrame::new();
         let mut frames = Vec::new();
         for frame in self

--- a/libs/scrap/src/dxgi/mod.rs
+++ b/libs/scrap/src/dxgi/mod.rs
@@ -253,7 +253,17 @@ impl Capturer {
 
     pub fn frame<'a>(&'a mut self, timeout: UINT) -> io::Result<Frame<'a>> {
         if self.output_texture {
-            Ok(Frame::Texture(self.get_texture(timeout)?))
+            let rotation = match self.display.rotation() {
+                DXGI_MODE_ROTATION_IDENTITY | DXGI_MODE_ROTATION_UNSPECIFIED => 0,
+                DXGI_MODE_ROTATION_ROTATE90 => 90,
+                DXGI_MODE_ROTATION_ROTATE180 => 180,
+                DXGI_MODE_ROTATION_ROTATE270 => 270,
+                _ => {
+                    // Unsupported rotation, try anyway
+                    0
+                }
+            };
+            Ok(Frame::Texture((self.get_texture(timeout)?, rotation)))
         } else {
             let width = self.width;
             let height = self.height;


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/8322

https://github.com/rustdesk/rustdesk/issues/9301

## Preview



https://github.com/user-attachments/assets/430b2c7a-2597-4718-8f73-9417e836b574



## Desc

The only change is returning error if rotation is not 0 for `vram` encoder. 

![image](https://github.com/user-attachments/assets/6b49656e-37b2-4347-bc74-d28d7dfd7377)

The capture will fallback `PixelBuffer` to and  the encoder will fallback to HwRamEncoding.

https://github.com/rustdesk/rustdesk/blob/675ffe038164c802233428736af013a1e0e1e844/libs/scrap/src/dxgi/mod.rs#L260


This is a simple workaround.

We cannot just rotate the image in GPU memory. The only way to do it is rotate in encoding. But it need more changes besides `shader`.
