### PR TITLE
no password required for file transfer action in remote control menu

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2304,16 +2304,19 @@ connectMainDesktop(String id,
     required bool isRDP,
     bool? forceRelay,
     String? password,
+    String? connToken,
     bool? isSharedPassword}) async {
   if (isFileTransfer) {
     await rustDeskWinManager.newFileTransfer(id,
         password: password,
         isSharedPassword: isSharedPassword,
+        connToken: connToken,
         forceRelay: forceRelay);
   } else if (isTcpTunneling || isRDP) {
     await rustDeskWinManager.newPortForward(id, isRDP,
         password: password,
         isSharedPassword: isSharedPassword,
+        connToken: connToken,
         forceRelay: forceRelay);
   } else {
     await rustDeskWinManager.newRemoteDesktop(id,
@@ -2333,6 +2336,7 @@ connect(BuildContext context, String id,
     bool isRDP = false,
     bool forceRelay = false,
     String? password,
+    String? connToken,
     bool? isSharedPassword}) async {
   if (id == '') return;
   if (!isDesktop || desktopType == DesktopType.main) {
@@ -2374,6 +2378,7 @@ connect(BuildContext context, String id,
         'password': password,
         'isSharedPassword': isSharedPassword,
         'forceRelay': forceRelay,
+        'connToken': connToken,
       });
     }
   } else {

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -147,12 +147,23 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
         child: Text(translate('Reset canvas')),
         onPressed: () => ffi.cursorModel.reset()));
   }
+
+  connectWithToken(
+      {required bool isFileTransfer, required bool isTcpTunneling}) {
+    final connToken = bind.sessionGetConnToken(sessionId: ffi.sessionId);
+    connect(context, id,
+        isFileTransfer: isFileTransfer,
+        isTcpTunneling: isTcpTunneling,
+        connToken: connToken);
+  }
+
   // transferFile
   if (isDesktop) {
     v.add(
       TTextMenu(
           child: Text(translate('Transfer file')),
-          onPressed: () => connect(context, id, isFileTransfer: true)),
+          onPressed: () =>
+              connectWithToken(isFileTransfer: true, isTcpTunneling: false)),
     );
   }
   // tcpTunneling
@@ -160,7 +171,8 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
     v.add(
       TTextMenu(
           child: Text(translate('TCP tunneling')),
-          onPressed: () => connect(context, id, isTcpTunneling: true)),
+          onPressed: () =>
+              connectWithToken(isFileTransfer: false, isTcpTunneling: true)),
     );
   }
   // note

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -774,6 +774,7 @@ class _DesktopHomePageState extends State<DesktopHomePage>
           isRDP: call.arguments['isRDP'],
           password: call.arguments['password'],
           forceRelay: call.arguments['forceRelay'],
+          connToken: call.arguments['connToken'],
         );
       } else if (call.method == kWindowEventMoveTabToNewWindow) {
         final args = call.arguments.split(',');

--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -58,12 +58,14 @@ class FileManagerPage extends StatefulWidget {
       required this.password,
       required this.isSharedPassword,
       this.tabController,
+      this.connToken,
       this.forceRelay})
       : super(key: key);
   final String id;
   final String? password;
   final bool? isSharedPassword;
   final bool? forceRelay;
+  final String? connToken;
   final DesktopTabController? tabController;
 
   @override
@@ -90,6 +92,7 @@ class _FileManagerPageState extends State<FileManagerPage>
         isFileTransfer: true,
         password: widget.password,
         isSharedPassword: widget.isSharedPassword,
+        connToken: widget.connToken,
         forceRelay: widget.forceRelay);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _ffi.dialogManager

--- a/flutter/lib/desktop/pages/file_manager_tab_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_tab_page.dart
@@ -48,6 +48,7 @@ class _FileManagerTabPageState extends State<FileManagerTabPage> {
           isSharedPassword: params['isSharedPassword'],
           tabController: tabController,
           forceRelay: params['forceRelay'],
+          connToken: params['connToken'],
         )));
   }
 
@@ -56,7 +57,7 @@ class _FileManagerTabPageState extends State<FileManagerTabPage> {
     super.initState();
 
     rustDeskWinManager.setMethodHandler((call, fromWindowId) async {
-      print(
+      debugPrint(
           "[FileTransfer] call ${call.method} with args ${call.arguments} from window $fromWindowId to ${windowId()}");
       // for simplify, just replace connectionId
       if (call.method == kWindowEventNewFileTransfer) {
@@ -76,6 +77,7 @@ class _FileManagerTabPageState extends State<FileManagerTabPage> {
               isSharedPassword: args['isSharedPassword'],
               tabController: tabController,
               forceRelay: args['forceRelay'],
+              connToken: args['connToken'],
             )));
       } else if (call.method == "onDestroy") {
         tabController.clear();

--- a/flutter/lib/desktop/pages/port_forward_page.dart
+++ b/flutter/lib/desktop/pages/port_forward_page.dart
@@ -33,6 +33,7 @@ class PortForwardPage extends StatefulWidget {
     required this.isRDP,
     required this.isSharedPassword,
     this.forceRelay,
+    this.connToken,
   }) : super(key: key);
   final String id;
   final String? password;
@@ -40,6 +41,7 @@ class PortForwardPage extends StatefulWidget {
   final bool isRDP;
   final bool? forceRelay;
   final bool? isSharedPassword;
+  final String? connToken;
 
   @override
   State<PortForwardPage> createState() => _PortForwardPageState();
@@ -62,6 +64,7 @@ class _PortForwardPageState extends State<PortForwardPage>
         password: widget.password,
         isSharedPassword: widget.isSharedPassword,
         forceRelay: widget.forceRelay,
+        connToken: widget.connToken,
         isRdp: widget.isRDP);
     Get.put<FFI>(_ffi, tag: 'pf_${widget.id}');
     debugPrint("Port forward page init success with id ${widget.id}");

--- a/flutter/lib/desktop/pages/port_forward_tab_page.dart
+++ b/flutter/lib/desktop/pages/port_forward_tab_page.dart
@@ -48,6 +48,7 @@ class _PortForwardTabPageState extends State<PortForwardTabPage> {
           tabController: tabController,
           isRDP: isRDP,
           forceRelay: params['forceRelay'],
+          connToken: params['connToken'],
         )));
   }
 
@@ -82,6 +83,7 @@ class _PortForwardTabPageState extends State<PortForwardTabPage> {
               isRDP: isRDP,
               tabController: tabController,
               forceRelay: args['forceRelay'],
+              connToken: args['connToken'],
             )));
       } else if (call.method == "onDestroy") {
         tabController.clear();

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -395,7 +395,7 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
       RemoteCountState.find().value = tabController.length;
 
   Future<dynamic> _remoteMethodHandler(call, fromWindowId) async {
-    print(
+    debugPrint(
         "[Remote Page] call ${call.method} with args ${call.arguments} from window $fromWindowId");
 
     dynamic returnValue;

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -375,7 +375,7 @@ class FfiModel with ChangeNotifier {
       } else if (name == 'plugin_option') {
         handleOption(evt);
       } else if (name == "sync_peer_hash_password_to_personal_ab") {
-        if (desktopType == DesktopType.main || isWeb) {
+        if (desktopType == DesktopType.main || isWeb || isMobile) {
           final id = evt['id'];
           final hash = evt['hash'];
           if (id != null && hash != null) {
@@ -2462,6 +2462,7 @@ class FFI {
     String? switchUuid,
     String? password,
     bool? isSharedPassword,
+    String? connToken,
     bool? forceRelay,
     int? tabWindowId,
     int? display,
@@ -2498,6 +2499,7 @@ class FFI {
         forceRelay: forceRelay ?? false,
         password: password ?? '',
         isSharedPassword: isSharedPassword ?? false,
+        connToken: connToken,
       );
     } else if (display != null) {
       if (displays == null) {

--- a/flutter/lib/utils/multi_window_manager.dart
+++ b/flutter/lib/utils/multi_window_manager.dart
@@ -201,6 +201,7 @@ class RustDeskMultiWindowManager {
     String? switchUuid,
     bool? isRDP,
     bool? isSharedPassword,
+    String? connToken,
   }) async {
     var params = {
       "type": type.index,
@@ -216,6 +217,9 @@ class RustDeskMultiWindowManager {
     }
     if (isSharedPassword != null) {
       params['isSharedPassword'] = isSharedPassword;
+    }
+    if (connToken != null) {
+      params['connToken'] = connToken;
     }
     final msg = jsonEncode(params);
 
@@ -254,8 +258,13 @@ class RustDeskMultiWindowManager {
     );
   }
 
-  Future<MultiWindowCallResult> newFileTransfer(String remoteId,
-      {String? password, bool? isSharedPassword, bool? forceRelay}) async {
+  Future<MultiWindowCallResult> newFileTransfer(
+    String remoteId, {
+    String? password,
+    bool? isSharedPassword,
+    bool? forceRelay,
+    String? connToken,
+  }) async {
     return await newSession(
       WindowType.FileTransfer,
       kWindowEventNewFileTransfer,
@@ -264,11 +273,18 @@ class RustDeskMultiWindowManager {
       password: password,
       forceRelay: forceRelay,
       isSharedPassword: isSharedPassword,
+      connToken: connToken,
     );
   }
 
-  Future<MultiWindowCallResult> newPortForward(String remoteId, bool isRDP,
-      {String? password, bool? isSharedPassword, bool? forceRelay}) async {
+  Future<MultiWindowCallResult> newPortForward(
+    String remoteId,
+    bool isRDP, {
+    String? password,
+    bool? isSharedPassword,
+    bool? forceRelay,
+    String? connToken,
+  }) async {
     return await newSession(
       WindowType.PortForward,
       kWindowEventNewPortForward,
@@ -278,6 +294,7 @@ class RustDeskMultiWindowManager {
       forceRelay: forceRelay,
       isRDP: isRDP,
       isSharedPassword: isSharedPassword,
+      connToken: connToken,
     );
   }
 

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1126,6 +1126,7 @@ pub fn session_add(
     force_relay: bool,
     password: String,
     is_shared_password: bool,
+    conn_token: Option<String>,
 ) -> ResultType<FlutterSession> {
     let conn_type = if is_file_transfer {
         ConnType::FILE_TRANSFER
@@ -1180,6 +1181,7 @@ pub fn session_add(
         force_relay,
         get_adapter_luid(),
         shared_password,
+        conn_token,
     );
 
     let session = Arc::new(session.clone());

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -121,6 +121,7 @@ pub fn session_add_sync(
     force_relay: bool,
     password: String,
     is_shared_password: bool,
+    conn_token: Option<String>,
 ) -> SyncReturn<String> {
     if let Err(e) = session_add(
         &session_id,
@@ -132,6 +133,7 @@ pub fn session_add_sync(
         force_relay,
         password,
         is_shared_password,
+        conn_token,
     ) {
         SyncReturn(format!("Failed to add session with id {}, {}", &id, e))
     } else {
@@ -1334,6 +1336,14 @@ pub fn session_request_voice_call(session_id: SessionID) {
 pub fn session_close_voice_call(session_id: SessionID) {
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
         session.close_voice_call();
+    }
+}
+
+pub fn session_get_conn_token(session_id: SessionID) -> SyncReturn<Option<String>> {
+    if let Some(session) = sessions::get_session_by_session_id(&session_id) {
+        SyncReturn(session.get_conn_token())
+    } else {
+        SyncReturn(None)
     }
 }
 

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -506,7 +506,7 @@ impl sciter::EventHandler for SciterSession {
 impl SciterSession {
     pub fn new(cmd: String, id: String, password: String, args: Vec<String>) -> Self {
         let force_relay = args.contains(&"--relay".to_string());
-        let mut session: Session<SciterHandler> = Session {
+        let session: Session<SciterHandler> = Session {
             password: password.clone(),
             args,
             server_keyboard_enabled: Arc::new(RwLock::new(true)),
@@ -529,7 +529,7 @@ impl SciterSession {
             .lc
             .write()
             .unwrap()
-            .initialize(id, conn_type, None, force_relay, None, None);
+            .initialize(id, conn_type, None, force_relay, None, None, None);
 
         Self(session)
     }

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1489,6 +1489,10 @@ impl<T: InvokeUiSession> Session<T> {
         msg.set_misc(misc);
         self.send(Data::Message(msg));
     }
+
+    pub fn get_conn_token(&self) -> Option<String> {
+        self.lc.read().unwrap().get_conn_token()
+    }
 }
 
 pub trait InvokeUiSession: Send + Sync + Clone + 'static + Sized + Default {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/9723

> Does not work for connection established by "accept".

1. No password required for file transfer/TCP tunnel actions in remote control menu
* Reuse the session ID, password and password source from the remote connection for file transfer and TCP tunnel actions. Tested password sync.
* Not remove the session in connection.rs  if it isn't the last one, unless the last one is a port-forward connection.
* Most changes in connection.rs are related to the inability of the TCP tunnel to update the last received time; therefore, it should not be added to SESSIONS if another session exists.
* Test random/permanent password with/without 2fa for file transfer/tcp tunnel,  reproduce 2 times tcp tunnel still need password/2fa, but may be click accept mistake.

2. Fix mobile doesn't sync recent passwords to personal address book

https://github.com/user-attachments/assets/d013f3a4-4bb1-4d99-8745-63d0553ecf37


https://github.com/user-attachments/assets/4ba0d6d2-2c46-4001-8201-91bc91eb98f0


https://github.com/user-attachments/assets/5a077211-c8a4-4235-848c-d45a773fe96f


https://github.com/user-attachments/assets/f5309db3-0125-4977-85c6-2c098340110e


https://github.com/user-attachments/assets/6e8a6b02-4f22-489a-b851-6ba0e930191b

https://github.com/user-attachments/assets/f8913a1f-92bd-4089-b455-d7954d540aee



https://github.com/user-attachments/assets/9d499ea8-ab2c-4fc6-8786-c041623a8f36


https://github.com/user-attachments/assets/26f99f55-30d2-4838-842f-f79d133d4816


https://github.com/user-attachments/assets/bab29692-0dfb-4321-8ad0-8f4357ce5e09


https://github.com/user-attachments/assets/840a099f-66e7-452b-8888-888eb016fea1

