### PR TITLE
fix german translation

### DIFF
--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -130,7 +130,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show quality monitor", "Qualitätsüberwachung anzeigen"),
         ("Disable clipboard", "Zwischenablage deaktivieren"),
         ("Lock after session end", "Nach Sitzungsende sperren"),
-        ("Insert Ctrl + Alt + Del", "Einfügen Ctrl + Alt + Del"),
+        ("Insert Ctrl + Alt + Del", "Strg + Alt + Entf senden"),
         ("Insert Lock", "Win+L (Sperren) senden"),
         ("Refresh", "Aktualisieren"),
         ("ID does not exist", "Diese ID existiert nicht."),


### PR DESCRIPTION
Better translation for german keyboard key and more logic wording.