### PR TITLE
revert missing retry and opt keep session

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1174,33 +1174,21 @@ void msgBox(SessionID sessionId, String type, String title, String text,
           dialogManager.dismissAll();
         }));
   }
-  if (reconnect != null && title == "Connection Error") {
+  if (reconnect != null &&
+      title == "Connection Error" &&
+      reconnectTimeout != null) {
     // `enabled` is used to disable the dialog button once the button is clicked.
     final enabled = true.obs;
-    final button = reconnectTimeout != null
-        ? Obx(() => _ReconnectCountDownButton(
-              second: reconnectTimeout,
-              onPressed: enabled.isTrue
-                  ? () {
-                      // Disable the button
-                      enabled.value = false;
-                      reconnect(dialogManager, sessionId, false);
-                    }
-                  : null,
-            ))
-        : Obx(
-            () => dialogButton(
-              'Reconnect',
-              isOutline: true,
-              onPressed: enabled.isTrue
-                  ? () {
-                      // Disable the button
-                      enabled.value = false;
-                      reconnect(dialogManager, sessionId, false);
-                    }
-                  : null,
-            ),
-          );
+    final button = Obx(() => _ReconnectCountDownButton(
+          second: reconnectTimeout,
+          onPressed: enabled.isTrue
+              ? () {
+                  // Disable the button
+                  enabled.value = false;
+                  reconnect(dialogManager, sessionId, false);
+                }
+              : null,
+        ));
     buttons.insert(0, button);
   }
   if (link.isNotEmpty) {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -638,7 +638,7 @@ class FfiModel with ChangeNotifier {
       {bool? hasCancel}) {
     msgBox(sessionId, type, title, text, link, dialogManager,
         hasCancel: hasCancel,
-        reconnect: reconnect,
+        reconnect: hasRetry ? reconnect : null,
         reconnectTimeout: hasRetry ? _reconnects : null);
     _timer?.cancel();
     if (hasRetry) {


### PR DESCRIPTION
1. Revert https://github.com/rustdesk/rustdesk/pull/8750: When `hasRetry` is set to false, there should not be a reconnect button. In the original issue discussed in https://github.com/rustdesk/rustdesk/discussions/8748#discussioncomment-10081038, when a session is closed due to inactivity, `hasRetry` is false. Version 1.2.3 always displaying the reconnect button is not ideal,  https://github.com/rustdesk/rustdesk/blob/cf0e3ec303990a48e0b3a6beedd3587079a6526c/flutter/lib/models/model.dart#L444.
2. Session Management: Retain a session only if there is another active remote session. If there are two connections within one session—such as a remote connection and a file transfe, when the remote connection is closed. if a reconnect button is present on the remote window, it can still use the session token, It still make sense but goes against common sense, the remote connection is the "main connection", a file transfer reconnection makes sense. Older versions do not share the same session ID, while newer versions lack a reconnect button if hasRetry is false, hence this is just in case.

sciter:
![5ec0855b01d80c5b8ae24ea5024d61b](https://github.com/user-attachments/assets/9bd66f62-ff10-4ffa-9fd3-f74501870f46)
before:
![c0b69469dca913e1ca9e850336ac204](https://github.com/user-attachments/assets/f83c8486-fedc-49cb-a500-9ec7103d1115)
after:
![c28a13b8eb7b7cbb2994c96ddcd80bc](https://github.com/user-attachments/assets/9e96a269-3dd4-474e-8b56-bc2cf1694215)

nightly connect to pr, open file transfer in remote connection
* remote closed by remote user, reconnect does not works.
* file closed by remote user, reconnect works.

[nightly-connect-to-pr.webm](https://github.com/user-attachments/assets/8ba7eeff-ca01-4f90-b216-ea0aaca1f7c0)

pr connect to pr, no reconnect button when closed by the remote user.

https://github.com/user-attachments/assets/e14714bb-8b76-41c4-a79d-d4799b75a268

