### PR TITLE
rotate ID3D11Texture2D

### DIFF
--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -971,6 +971,7 @@ fn handle_one_frame(
             }
             match e.to_string().as_str() {
                 scrap::codec::ENCODE_NEED_SWITCH => {
+                    encoder.disable();
                     log::error!("switch due to encoder need switch");
                     bail!("SWITCH");
                 }


### PR DESCRIPTION
* Rotate ID3D11Texture2D after duplication using the D3D11 video processor.
* If the display is not rotated, no new ComPtr will be created;  If the rotation fails, it will reuse the previous fallback logic in https://github.com/rustdesk/rustdesk/pull/9696
* During testing with incorrect width/height parameters, encoding succeeded but produced black images, triggering the error at [this line](https://github.com/rustdesk/rustdesk/blob/1c9b456456d866b73003a58d97c28c7c788eee76/libs/scrap/src/common/vram.rs#L131). In such cases, disable the encoder instead of just switching.

TODO:

When switching from Landscape to Landscape (flipped) during capture, the resolution does not change, causing the video service to fallback to GDI directly.


https://github.com/user-attachments/assets/b7b90099-4f7a-4976-98d9-b008648f8ab4
