### PR TITLE
fix: mobile -> mobile, long press

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -185,7 +185,9 @@ class _RawTouchGestureDetectorRegionState
       ffi.cursorModel
           .move(_cacheLongPressPosition.dx, _cacheLongPressPosition.dy);
     }
-    inputModel.tap(MouseButtons.right);
+    if (!ffi.ffiModel.isPeerMobile) {
+      inputModel.tap(MouseButtons.right);
+    }
   }
 
   onDoubleFinerTapDown(TapDownDetails d) {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -142,6 +142,7 @@ class FfiModel with ChangeNotifier {
   bool get touchMode => _touchMode;
 
   bool get isPeerAndroid => _pi.platform == kPeerPlatformAndroid;
+  bool get isPeerMobile => isPeerAndroid;
 
   bool get viewOnly => _viewOnly;
 


### PR DESCRIPTION
`inputModel.tap(MouseButtons.right);` will be interpreted as "Back" on Android.