### PR TITLE
fix wrong display of custom clients when approve mode is not set

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1029,7 +1029,9 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
             translate('Accept sessions via both'),
           ];
           var modeInitialKey = model.approveMode;
-          if (!modeKeys.contains(modeInitialKey)) modeInitialKey = '';
+          if (!modeKeys.contains(modeInitialKey)) {
+            modeInitialKey = defaultOptionApproveMode;
+          }
           final usePassword = model.approveMode != 'click';
 
           final isApproveModeFixed = isOptionFixed(kOptionApproveMode);


### PR DESCRIPTION
when approve-mode is not set, the approve mode option shows as password, it's `both` approve mode in rust, so only ui is wrong.
before:
![before-default-approve-mode](https://github.com/user-attachments/assets/57fa1a46-7226-4a7f-817c-ded28a3959be)
after:
![after-default-approve-mode](https://github.com/user-attachments/assets/9f764574-0c4d-4b22-a50e-5ef2f2e109cf)
