### PR TITLE
fix: android input, Backspace and Enter

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -556,13 +556,14 @@ class InputModel {
     // The correct PhysicalKeyboardKey should be
     // PhysicalKeyboardKey#e14a9(usbHidUsage: "0x00070028", debugName: "Enter")
     // https://github.com/flutter/flutter/issues/157771
-    final isKeyMatch =
-        isIOS || isAndroid && e.logicalKey.debugName == e.physicalKey.debugName;
+    // We cannot use the debugName to determine the key is correct or not, because it's null in release mode.
+    // to-do: `isLegacyModeKeys` is not the best workaround, we need to find a better way to fix this issue.
+    final isLegacyModeKeys = ['Backspace', 'Enter'].contains(e.logicalKey.keyLabel);
     final isMobileAndPeerNotAndroid =
         isMobile && peerPlatform != kPeerPlatformAndroid;
     final isDesktopAndMapMode =
         isDesktop || isWebDesktop && keyboardMode == kKeyMapMode;
-    if (isKeyMatch && (isMobileAndPeerNotAndroid || isDesktopAndMapMode)) {
+    if (!isLegacyModeKeys && (isMobileAndPeerNotAndroid || isDesktopAndMapMode)) {
       // FIXME: e.character is wrong for dead keys, eg: ^ in de
       newKeyboardMode(
           e.character ?? '',


### PR DESCRIPTION
Fix the issue introduced by https://github.com/rustdesk/rustdesk/pull/9717

The workaround in https://github.com/rustdesk/rustdesk/pull/9769 does not fix the issue.

## Desc

`debugName` in the `KeyEvent` can not be used in release mode.

We just check `['Backspace', 'Enter']` for now. Because these two keys in the soft keyboard also cause `KeyEvent`.

## TODO

Use a better way to compare the events, implement `debugName()`.
