### PR TITLE
Fix/android check normal usbhid usage

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -224,7 +224,9 @@ class _RemotePageState extends State<RemotePage> {
 
   void _handleNonIOSSoftKeyboardInput(String newValue) {
     _lastComposingChangeValid = _textController.value.isComposingRangeValid;
-    if (_lastComposingChangeValid) {
+    if (_lastComposingChangeValid && newValue.length > _value.length) {
+      // Only early return if is composing new words.
+      // We need to send `backspace` immediately if is deleting letters.
       return;
     }
     var oldValue = _value;

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -544,26 +544,40 @@ class InputModel {
       handleKeyDownEventModifiers(e);
     }
 
-    // The physicalKey.usbHidUsage may be not correct for soft keyboard on Android.
-    // iOS does not have this issue.
-    // 1. Open the soft keyboard on Android
-    // 2. Switch to input method like zh/ko/ja
-    // 3. Click Backspace and Enter on the soft keyboard or physical keyboard
-    // 4. The physicalKey.usbHidUsage is not correct.
-    // PhysicalKeyboardKey#8ac83(usbHidUsage: "0x1100000042", debugName: "Key with ID 0x1100000042")
-    // LogicalKeyboardKey#2604c(keyId: "0x10000000d", keyLabel: "Enter", debugName: "Enter")
-    //
-    // The correct PhysicalKeyboardKey should be
-    // PhysicalKeyboardKey#e14a9(usbHidUsage: "0x00070028", debugName: "Enter")
-    // https://github.com/flutter/flutter/issues/157771
-    // We cannot use the debugName to determine the key is correct or not, because it's null in release mode.
-    // to-do: `isLegacyModeKeys` is not the best workaround, we need to find a better way to fix this issue.
-    final isLegacyModeKeys = ['Backspace', 'Enter'].contains(e.logicalKey.keyLabel);
-    final isMobileAndPeerNotAndroid =
-        isMobile && peerPlatform != kPeerPlatformAndroid;
+    bool isMobileAndMapMode = false;
+    if (isMobile) {
+      // Do not use map mode if mobile -> Android. Android does not support map mode for now.
+      // Because simulating the physical key events(uhid) which requires root permission is not supported.
+      if (peerPlatform != kPeerPlatformAndroid) {
+        if (isIOS) {
+          isMobileAndMapMode = true;
+        } else {
+          // The physicalKey.usbHidUsage may be not correct for soft keyboard on Android.
+          // iOS does not have this issue.
+          // 1. Open the soft keyboard on Android
+          // 2. Switch to input method like zh/ko/ja
+          // 3. Click Backspace and Enter on the soft keyboard or physical keyboard
+          // 4. The physicalKey.usbHidUsage is not correct.
+          // PhysicalKeyboardKey#8ac83(usbHidUsage: "0x1100000042", debugName: "Key with ID 0x1100000042")
+          // LogicalKeyboardKey#2604c(keyId: "0x10000000d", keyLabel: "Enter", debugName: "Enter")
+          //
+          // The correct PhysicalKeyboardKey should be
+          // PhysicalKeyboardKey#e14a9(usbHidUsage: "0x00070028", debugName: "Enter")
+          // https://github.com/flutter/flutter/issues/157771
+          // We cannot use the debugName to determine the key is correct or not, because it's null in release mode.
+          // The normal `usbHidUsage` for keyboard shoud be between [0x00000010, 0x000c029f]
+          // https://github.com/flutter/flutter/blob/c051b69e2a2224300e20d93dbd15f4b91e8844d1/packages/flutter/lib/src/services/keyboard_key.g.dart#L5332 - 5600
+          final isNormalHsbHidUsage = (e.physicalKey.usbHidUsage >> 20) == 0;
+          isMobileAndMapMode = isNormalHsbHidUsage &&
+              // No need to check `!['Backspace', 'Enter'].contains(e.logicalKey.keyLabel)`
+              // But we still add it for more reliability.
+              !['Backspace', 'Enter'].contains(e.logicalKey.keyLabel);
+        }
+      }
+    }
     final isDesktopAndMapMode =
-        isDesktop || isWebDesktop && keyboardMode == kKeyMapMode;
-    if (!isLegacyModeKeys && (isMobileAndPeerNotAndroid || isDesktopAndMapMode)) {
+        isDesktop || (isWebDesktop && keyboardMode == kKeyMapMode);
+    if (isMobileAndMapMode || isDesktopAndMapMode) {
       // FIXME: e.character is wrong for dead keys, eg: ^ in de
       newKeyboardMode(
           e.character ?? '',


### PR DESCRIPTION
## Preview


https://github.com/user-attachments/assets/52750a12-fad9-450d-9519-54be8434b39c


## Desc

1. Fix input "Backspace".
2. Refactor `isMobileAndMapMode`. Check if is mobile and should use "Map mode".

## Tests

1. Composing new words. Only send words to the controlled side after composing.
2. Deleting words. "Backspace" will be sent immediately.
3. Update words when deleting.
    a. Input "hello", remote "hello".
    b. Backspace two times, then input "g", "o". Local is "helgo"
    c. Select word "helgo", remote is changed from "hello" to "helgo"
4. Korean and Pinyin inputs, "Backspace", "Enter" and "Space" are tested.