### PR TITLE
fix: mobile view style, on conn

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1275,13 +1275,6 @@ class ImageModel with ChangeNotifier {
       if (isDesktop || isWebDesktop) {
         await parent.target?.canvasModel.updateViewStyle();
         await parent.target?.canvasModel.updateScrollStyle();
-      } else {
-        final size = MediaQueryData.fromWindow(ui.window).size;
-        final canvasWidth = size.width;
-        final canvasHeight = size.height;
-        final xscale = canvasWidth / image.width;
-        final yscale = canvasHeight / image.height;
-        parent.target?.canvasModel.scale = min(xscale, yscale);
       }
       if (parent.target != null) {
         await initializeCursorAndCanvas(parent.target!);
@@ -1679,6 +1672,7 @@ class CanvasModel with ChangeNotifier {
     _x = 0;
     _y = 0;
     _scale = 1.0;
+    _lastViewStyle = ViewStyle.defaultViewStyle();
   }
 
   updateScrollPercent() {

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1710,6 +1710,9 @@ impl UserDefaultConfig {
 
     pub fn get(&self, key: &str) -> String {
         match key {
+            #[cfg(any(target_os = "android", target_os = "ios"))]
+            keys::OPTION_VIEW_STYLE => self.get_string(key, "adaptive", vec!["original"]),
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
             keys::OPTION_VIEW_STYLE => self.get_string(key, "original", vec!["adaptive"]),
             keys::OPTION_SCROLL_STYLE => self.get_string(key, "scrollauto", vec!["scrollbar"]),
             keys::OPTION_IMAGE_QUALITY => {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/9781

## Desc


1. Remove `parent.target?.canvasModel.scale = min(xscale, yscale);` when the first image is updated.

Because `updateViewStyle()` will always be called here

https://github.com/rustdesk/rustdesk/blob/32dbc0c8fb0245bd57249828a9f815c1bb5ae668/flutter/lib/models/model.dart#L2652

2. Reset `_lastViewStyle` on close. So `updateViewStyle()` can work on the next conn. Or the `scale` may be incorrect(`1.0` in `reset()`) because `updateViewStyle()` will not work.

https://github.com/rustdesk/rustdesk/blob/32dbc0c8fb0245bd57249828a9f815c1bb5ae668/flutter/lib/models/model.dart#L1498

3. Set default view style to `adaptive` for mobile. Because `parent.target?.canvasModel.scale = min(xscale, yscale);` will always set the scale to `adaptive`. But it's removed in this PR.


## Tests

Android as the controlling side.

1. Remote desktop, display landscape/portait.
2. Remote mobile, landscape/portait.


## TODOs

Wrong images sometimes.

1. Remote phone landscape.
3. Connect.

![image](https://github.com/user-attachments/assets/133fa74b-e8bc-476c-8b9b-67cfde81bca4)

