### PR TITLE
fix: mobile cursor focus

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -139,8 +139,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     _timerDidChangeMetrics = Timer(Duration(milliseconds: 100), () async {
       // We need this comparation because poping up the floating action will also trigger `didChangeMetrics()`.
       if (newBottom != _viewInsetsBottom) {
-        await gFFI.canvasModel.updateViewStyle(refreshMousePos: false);
-        gFFI.canvasModel.moveToCenterCursor();
+        gFFI.canvasModel.mobileFocusCanvasCursor();
         _viewInsetsBottom = newBottom;
       }
     });


### PR DESCRIPTION
Focus cursor after soft keyboard showing/hiding.

1. Update the view style.
2. Update the canvas offset.
3. Move local cursor position if it is not in the visible rectangle.

## Preview

https://github.com/user-attachments/assets/706acc3d-548f-405e-8bb8-c09dfc422284

## Tests

- [x] Cursor outof the display.
- [x] Multiple displays on the controlled side.