### PR TITLE
fix: mobile mouse mode, cursor range

### DIFF
--- a/flutter/lib/common/widgets/gestures.dart
+++ b/flutter/lib/common/widgets/gestures.dart
@@ -86,7 +86,7 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
       // end
       switch (_currentState) {
         case GestureState.oneFingerPan:
-          debugPrint("TwoFingerState.pan onEnd");
+          debugPrint("OneFingerState.pan onEnd");
           if (onOneFingerPanEnd != null) {
             onOneFingerPanEnd!(_getDragEndDetails(d));
           }

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -169,6 +169,13 @@ const int kWindowMainId = 0;
 const String kPointerEventKindTouch = "touch";
 const String kPointerEventKindMouse = "mouse";
 
+const String kMouseEventTypeDefault = "";
+const String kMouseEventTypePanStart = "pan_start";
+const String kMouseEventTypePanUpdate = "pan_update";
+const String kMouseEventTypePanEnd = "pan_end";
+const String kMouseEventTypeDown = "down";
+const String kMouseEventTypeUp = "up";
+
 const String kKeyFlutterKey = "flutter_key";
 
 const String kKeyShowDisplaysAsIndividualWindows =


### PR DESCRIPTION

1. Limit the mouse movement range of the controlled side.

Use `getPointInRemoteRect()` to ensure current movement is in the display's range.

### Preview


https://github.com/user-attachments/assets/e2d084a8-4041-4d93-8e5e-181b443a8963



2. Do not reset the cursor position after swithing view style.


Modify `updateViewStyle()`

![image](https://github.com/user-attachments/assets/fe0db674-c1c0-4908-9387-8bacc2524e44)


### Bug


https://github.com/user-attachments/assets/d0e7f632-0c62-4f91-911a-b7ad009acc0f



### Fixed


https://github.com/user-attachments/assets/4c7ca7d3-4dbc-4286-91c4-60a5f83effe3



4. Fix canvas offset on pan.

```dart
-      parent.target?.canvasModel.panX(-dx);
+     parent.target?.canvasModel.panX(-dx * scale);
```

### Bug


https://github.com/user-attachments/assets/0153592a-c41e-4509-8a59-acd4166a8105



### Fixed

https://github.com/user-attachments/assets/2db631a5-639e-4856-8a23-7423283fe4d5


## Tests

- [x] mobile -> desktop, multiple displays.
- [x] desktop -> desktop, mouse mode
- [x] mobile -> mobile

## TODOs

1. Touch mode, ignore eventswhen touch/pan out of the image.

https://github.com/rustdesk/rustdesk/blob/040253b3199ee9fe95a4d91f16634a9504b83ce0/flutter/lib/common/widgets/remote_input.dart#L368

`onTap()` should check if current point is in the display. But this callback does not provide the localtion.





