### PR TITLE
fix: mobile, soft keyboard

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -134,6 +134,13 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
 
   @override
   void didChangeMetrics() {
+    // If the soft keyboard is visible and the canvas has been changed(panned or scaled)
+    // Don't try reset the view style and focus the cursor.
+    if (gFFI.cursorModel.lastKeyboardIsVisible &&
+        gFFI.canvasModel.isMobileCanvasChanged) {
+      return;
+    }
+
     final newBottom = MediaQueryData.fromView(ui.window).viewInsets.bottom;
     _timerDidChangeMetrics?.cancel();
     _timerDidChangeMetrics = Timer(Duration(milliseconds: 100), () async {
@@ -563,7 +570,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
                       // `onChanged` may be called depending on the input method if this widget is wrapped in
                       // `Focus(onKeyEvent: ..., child: ...)`
                       // For `Backspace` button in the soft keyboard:
-                      // en/fr input method: 
+                      // en/fr input method:
                       //      1. The button will not trigger `onKeyEvent` if the text field is not empty.
                       //      2. The button will trigger `onKeyEvent` if the text field is empty.
                       // ko/zh/ja input method: the button will trigger `onKeyEvent`

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1424,6 +1424,10 @@ class CanvasModel with ChangeNotifier {
 
   Timer? _timerMobileFocusCanvasCursor;
 
+  // `isMobileCanvasChanged` is used to avoid canvas reset when changing the input method
+  // after showing the soft keyboard.
+  bool isMobileCanvasChanged = false;
+
   final ScrollController _horizontal = ScrollController();
   final ScrollController _vertical = ScrollController();
 
@@ -1639,6 +1643,9 @@ class CanvasModel with ChangeNotifier {
 
   panX(double dx) {
     _x += dx;
+    if (isMobile) {
+      isMobileCanvasChanged = true;
+    }
     notifyListeners();
   }
 
@@ -1653,6 +1660,9 @@ class CanvasModel with ChangeNotifier {
 
   panY(double dy) {
     _y += dy;
+    if (isMobile) {
+      isMobileCanvasChanged = true;
+    }
     notifyListeners();
   }
 
@@ -1672,6 +1682,9 @@ class CanvasModel with ChangeNotifier {
     // (focalPoint.dy - _y_1 - adjust) / s1 + displayOriginY = (focalPoint.dy - _y_2 - adjust) / s2 + displayOriginY
     // _y_2 = focalPoint.dy - adjust - (focalPoint.dy - _y_1 - adjust) / s1 * s2
     _y = focalPoint.dy - adjust - (focalPoint.dy - _y - adjust) / s * _scale;
+    if (isMobile) {
+      isMobileCanvasChanged = true;
+    }
     notifyListeners();
   }
 
@@ -1941,6 +1954,8 @@ class CursorModel with ChangeNotifier {
   bool _lastIsBlocked = false;
   bool _lastKeyboardIsVisible = false;
 
+  bool get lastKeyboardIsVisible => _lastKeyboardIsVisible;
+
   Rect? get keyHelpToolsRectToAdjustCanvas =>
       _lastKeyboardIsVisible ? _keyHelpToolsRect : null;
   keyHelpToolsVisibilityChanged(Rect? r, bool keyboardIsVisible) {
@@ -1955,6 +1970,7 @@ class CursorModel with ChangeNotifier {
     }
     if (isMobile && _lastKeyboardIsVisible != keyboardIsVisible) {
       parent.target?.canvasModel.mobileFocusCanvasCursor();
+      parent.target?.canvasModel.isMobileCanvasChanged = false;
     }
     _lastKeyboardIsVisible = keyboardIsVisible;
   }


### PR DESCRIPTION
Switching the input method, don't affect the canvas.

## Preview

### bug


https://github.com/user-attachments/assets/cb778a9e-d30d-4f11-a385-cd14bcdf4bad

### fixed


https://github.com/user-attachments/assets/aae63014-51f8-4cdb-82e8-77a3ced2dd20

## Desc

Skip applying canvas changes when the soft keyboard is showing and the canvas is panned or scaled in `didChangeMetrics()`.

```dart
    // If the soft keyboard is visible and the canvas has been changed(panned or scaled)
    // Don't try reset the view style and focus the cursor.
    if (gFFI.cursorModel.lastKeyboardIsVisible &&
        gFFI.canvasModel.isCanvasChanged) {
      return;
    }
```