### PR TITLE
fix: macos, workaround app close

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2498,9 +2498,19 @@ Future<void> onActiveWindowChanged() async {
         // But the app will not close.
         //
         // No idea why we need to delay here, `terminate()` itself is also an async function.
-        Future.delayed(Duration.zero, () {
-          RdPlatformChannel.instance.terminate();
-        });
+        //
+        // A quick workaround, use `Timer.periodic` to avoid the app not closing.
+        // Because `await windowManager.close()` and `RdPlatformChannel.instance.terminate()`
+        // may not work since `Flutter 3.24.4`, see the following logs.
+        // A delay will allow the app to close.
+        //
+        //```
+        // embedder.cc (2725): 'FlutterPlatformMessageCreateResponseHandle' returned 'kInvalidArguments'. Engine handle was invalid.
+        // 2024-11-11 11:41:11.546 RustDesk[90272:2567686] Failed to create a FlutterPlatformMessageResponseHandle (2)
+        // embedder.cc (2672): 'FlutterEngineSendPlatformMessage' returned 'kInvalidArguments'. Invalid engine handle.
+        // 2024-11-11 11:41:11.565 RustDesk[90272:2567686] Failed to send message to Flutter engine on channel 'flutter/lifecycle' (2).
+        // ```
+        periodic_immediate(Duration(milliseconds: 500), RdPlatformChannel.instance.terminate);
       }
     }
   }

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2510,7 +2510,7 @@ Future<void> onActiveWindowChanged() async {
         // embedder.cc (2672): 'FlutterEngineSendPlatformMessage' returned 'kInvalidArguments'. Invalid engine handle.
         // 2024-11-11 11:41:11.565 RustDesk[90272:2567686] Failed to send message to Flutter engine on channel 'flutter/lifecycle' (2).
         // ```
-        periodic_immediate(Duration(milliseconds: 500), RdPlatformChannel.instance.terminate);
+        periodic_immediate(Duration(milliseconds: 30), RdPlatformChannel.instance.terminate);
       }
     }
   }


### PR DESCRIPTION
## Preview

### Bug


https://github.com/user-attachments/assets/5aaced38-6178-4b36-a10c-d991d42c2d05


### Fixed



https://github.com/user-attachments/assets/fea2c434-6334-475a-85f4-4f2c480d5b7d


## Desc

This bug does not occur every time on my machine. It may be related to the multile view support of flutter. `Engine handle was invalid.`

`Close` after a delay works for me.
