### PR TITLE
fix: command line --config option incompatible with server config exported from the GUI.

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2603,7 +2603,7 @@ class ServerConfig {
     config['relay'] = relayServer.trim();
     config['api'] = apiServer.trim();
     config['key'] = key.trim();
-    return base64Encode(Uint8List.fromList(jsonEncode(config).codeUnits))
+    return base64UrlEncode(Uint8List.fromList(jsonEncode(config).codeUnits))
         .split('')
         .reversed
         .join();


### PR DESCRIPTION
The server configuration string exported from the GUI is encoded in Base64 format, 
![image](https://github.com/user-attachments/assets/45b7635c-4c43-4ed2-aac1-74a063df443f)
https://github.com/rustdesk/rustdesk/blob/35b4535ebc619e6def057ad8ef2fb84c6cb98610/flutter/lib/common.dart#L2606

whereas the command line --config option expects a URL_SAFE_NO_PAD format. 
https://github.com/rustdesk/rustdesk/blob/35b4535ebc619e6def057ad8ef2fb84c6cb98610/src/custom_server.rs#L28C1-L28C45

This mismatch results in the --config option having no effect.