### PR TITLE
auto codec, av1 over vp9

### DIFF
--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -264,15 +264,19 @@ impl Encoder {
             .unwrap_or((PreferCodec::Auto.into(), 0));
         let preference = most_frequent.enum_value_or(PreferCodec::Auto);
 
-        // auto: h265 > h264 > vp9/vp8
-        let mut auto_codec = CodecFormat::VP9;
+        // auto: h265 > h264 > av1 > vp9
+        let mut auto_codec = if av1_useable {
+            CodecFormat::AV1
+        } else {
+            CodecFormat::VP9
+        };
         if h264_useable {
             auto_codec = CodecFormat::H264;
         }
         if h265_useable {
             auto_codec = CodecFormat::H265;
         }
-        if auto_codec == CodecFormat::VP9 {
+        if auto_codec == CodecFormat::VP9 || auto_codec == CodecFormat::AV1 {
             let mut system = System::new();
             system.refresh_memory();
             if vp8_useable && system.total_memory() <= 4 * 1024 * 1024 * 1024 {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/9915

1. AV1 performs better than VP9, ​​except maybe slower.We previously replaced AV1 with VP9 due to poor performance on x86 sicter. 5.6 https://github.com/rustdesk/rustdesk/pull/7921, 5.7 https://github.com/rustdesk/rustdesk/pull/7928
2. This is a av1 test branch, https://github.com/21pages/rustdesk/commit/09b76a8b1dfacf336ce320162d8b32046056b2ae#diff-0b40fcbe3606278ecc2eaaee09f903dbc3f9d7ac51a3d0a33dec148aabf46b29R279, however, I don't know to what extent it can be effective, and since H265 is currently the highest priority, so it's not in this pr.
3. Tested 1.1.9 as control side,  nightly as control side when hwcodec enabled/disabled.
