### PR TITLE
if av1 is not slow in test, av1 takes precedence over vp9

### DIFF
--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -2238,6 +2238,7 @@ pub mod keys {
     pub const OPTION_ENABLE_ANDROID_SOFTWARE_ENCODING_HALF_SCALE: &str =
         "enable-android-software-encoding-half-scale";
     pub const OPTION_ENABLE_TRUSTED_DEVICES: &str = "enable-trusted-devices";
+    pub const OPTION_AV1_TEST: &str = "av1-test";
 
     // buildin options
     pub const OPTION_DISPLAY_NAME: &str = "display-name";

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2332,6 +2332,7 @@ pub mod server_side {
             }
         }
         std::thread::spawn(move || start_server(true));
+        scrap::codec::test_av1();
     }
 
     #[no_mangle]

--- a/src/server.rs
+++ b/src/server.rs
@@ -500,8 +500,8 @@ pub async fn start_server(is_server: bool, no_server: bool) {
         #[cfg(target_os = "windows")]
         crate::platform::try_kill_broker();
         #[cfg(feature = "hwcodec")]
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         scrap::hwcodec::start_check_process();
+        scrap::codec::test_av1();
         crate::RendezvousMediator::start_all().await;
     } else {
         match crate::ipc::connect(1000, "").await {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/9915

1. AV1 performs better than VP9, ​​except maybe slower.We previously replaced AV1 with VP9 due to poor performance on x86 sicter. 5.6 https://github.com/rustdesk/rustdesk/pull/7921, 5.7 https://github.com/rustdesk/rustdesk/pull/7928
2. Tested 1.1.9 as control side,  nightly as control side when hwcodec enabled/disabled.
3. In the test, if av1 time < 250ms or 2/3 av1 time < vp9 time, av1 will be preferred.  Here are some test results(ms).

win 3 av1 can reach 30 fps when playing video, but every codec in win vm can only reach up to 10fps, even through win vm has 8 cpu, 5G ram. Sometimes av1 time of win vm < 200ms. This test can only roughly measure encoding ability.

| device  | flutter av1 | flutter vp9 | sciter av1 | sciter vp9 |
| ------- | ----------- | ----------------- | ---------- | ---------- |
| win 1   | 140         | 52                | 882        | 42         |
| win 2   | 130         | 60                | 1000+      | 33         |
| win 3   | 270         | 44                | 1500+      | 46         |
| win vm  | 210 | 61 |            |            |
| mac m1  | 49          | 17                |            |            |
| linux   | 92          | 58                |            |            |
| andriod | 166         | 92                |            |            |