### PR TITLE
remove flutter install cache flag

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -103,7 +103,6 @@ jobs:
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          cache: true
 
       # https://github.com/flutter/flutter/issues/155685
       - name: Replace engine with rustdesk custom flutter engine
@@ -117,11 +116,9 @@ jobs:
       - name: Patch flutter
         shell: bash
         run: |
+          cp .github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff $(dirname $(dirname $(which flutter)))
           cd $(dirname $(dirname $(which flutter)))
-          # https://github.com/flutter/flutter/commit/b5847d364a26d727af58ab885a6123e0e5304b2b#diff-634a338bd9ed19b66a27beba35a8acf4defffd8beff256113e6811771a0c4821R543
-          PATCH_PATH="${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff"
-          PATCH_PATH=$(echo "$PATCH_PATH" | sed 's/\\/\//g')
-          [[ "3.24.4" == ${{env.FLUTTER_VERSION}} ]] && git apply "$PATCH_PATH"
+          [[ "3.24.4" == ${{env.FLUTTER_VERSION}} ]] && git apply flutter_3.24.4_dropdown_menu_enableFilter.diff
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -2055,7 +2052,6 @@ jobs:
         with:
           channel: "stable"
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          cache: true
 
       - name: Patch flutter
         shell: bash


### PR DESCRIPTION
The Windows build of Flutter has a cache flag. Remove the cache flag or reset Flutter to HEAD before patch

![f0c6ede506f871600e5b076f8f70167](https://github.com/user-attachments/assets/67091097-dc99-49d0-962e-45ff0fab90bd)
![d82c7adfb7ab28696d28a583a7accad](https://github.com/user-attachments/assets/203ae4a5-e9ca-4fad-b805-110c6a4cf218)
