### PR TITLE
feat: android clipboard, multi-formats

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
@@ -304,12 +304,22 @@ class FloatingWindowService : Service(), View.OnTouchListener {
          val popupMenu = PopupMenu(this, floatingView)
          val idShowRustDesk = 0
          popupMenu.menu.add(0, idShowRustDesk, 0, translate("Show RustDesk"))
-         val idStopService = 1
+         // For host side, clipboard sync
+         val idSyncClipboard = 1
+         val isClipboardListenerEnabled = MainActivity.rdClipboardManager?.isListening ?: false
+         if (isClipboardListenerEnabled) {
+             popupMenu.menu.add(0, idSyncClipboard, 0, translate("Update client clipboard"))
+         }
+         val idStopService = 2
          popupMenu.menu.add(0, idStopService, 0, translate("Stop service"))
          popupMenu.setOnMenuItemClickListener { menuItem ->
              when (menuItem.itemId) {
                  idShowRustDesk -> {
                      openMainActivity()
+                     true
+                 }
+                idSyncClipboard -> {
+                     syncClipboard()
                      true
                  }
                  idStopService -> {
@@ -338,6 +348,10 @@ class FloatingWindowService : Service(), View.OnTouchListener {
         } catch (e: PendingIntent.CanceledException) {
             e.printStackTrace()
         }
+    }
+
+    private fun syncClipboard() {
+        MainActivity.rdClipboardManager?.syncClipboard(false)
     }
 
     private fun stopMainService() {

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -13,6 +13,8 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
+import android.content.ClipboardManager
+import android.os.Bundle
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
@@ -40,6 +42,9 @@ import kotlin.concurrent.thread
 class MainActivity : FlutterActivity() {
     companion object {
         var flutterMethodChannel: MethodChannel? = null
+        private var _rdClipboardManager: RdClipboardManager? = null
+        val rdClipboardManager: RdClipboardManager?
+            get() = _rdClipboardManager;
     }
 
     private val channelTag = "mChannel"
@@ -90,11 +95,20 @@ class MainActivity : FlutterActivity() {
         }
     }
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (_rdClipboardManager == null) {
+            _rdClipboardManager = RdClipboardManager(getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
+            FFI.setClipboardManager(_rdClipboardManager!!)
+        }
+    }
+
     override fun onDestroy() {
         Log.e(logTag, "onDestroy")
         mainService?.let {
             unbindService(serviceConnection)
         }
+        rdClipboardManager?.rustEnableServiceClipboard(false)
         super.onDestroy()
     }
 
@@ -392,6 +406,15 @@ class MainActivity : FlutterActivity() {
     override fun onStart() {
         super.onStart()
         stopService(Intent(this, FloatingWindowService::class.java))
+    }
+
+    // For client side
+    // When swithing from other app to this app, try to sync clipboard.
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus) {
+            rdClipboardManager?.syncClipboard(true)
+        }
     }
 }
 

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/RdClipboardManager.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/RdClipboardManager.kt
@@ -1,0 +1,224 @@
+package com.carriez.flutter_hbb
+
+import java.nio.ByteBuffer
+import java.util.Timer
+import java.util.TimerTask
+
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.util.Log
+import androidx.annotation.Keep
+
+import hbb.MessageOuterClass.ClipboardFormat
+import hbb.MessageOuterClass.Clipboard
+import hbb.MessageOuterClass.MultiClipboards
+
+import ffi.FFI
+
+class RdClipboardManager(private val clipboardManager: ClipboardManager) {
+    private val logTag = "RdClipboardManager"
+    private val supportedMimeTypes = arrayOf(
+        ClipDescription.MIMETYPE_TEXT_PLAIN,
+        ClipDescription.MIMETYPE_TEXT_HTML
+    )
+
+    // 1. Avoid listening to the same clipboard data updated by `rustUpdateClipboard`.
+    // 2. Avoid sending the clipboard data before enabling client clipboard.
+    //    1) Disable clipboard
+    //    2) Copy text "a"
+    //    3) Enable clipboard
+    //    4) Switch to another app
+    //    5) Switch back to the app
+    //    6) "a" should not be sent to the client, because it's copied before enabling clipboard
+    //
+    // It's okay to that `rustEnableClientClipboard(false)` is called after `rustUpdateClipboard`,
+    // though the `lastUpdatedClipData` will be set to null once.
+    private var lastUpdatedClipData: ClipData? = null
+    private var isClientEnabled = true;
+    private var _isListening = false;
+    val isListening: Boolean
+        get() = _isListening
+
+    fun checkPrimaryClip(isClient: Boolean, isSync: Boolean) {
+        val clipData = clipboardManager.primaryClip
+        if (clipData != null && clipData.itemCount > 0) {
+            // Only handle the first item in the clipboard for now.
+            val clip = clipData.getItemAt(0)
+            val isHostSync = !isClient && isSync
+            // Ignore the `isClipboardDataEqual()` check if it's a host sync operation.
+            // Because it's a action manually triggered by the user.
+            if (!isHostSync) {
+                if (lastUpdatedClipData != null && isClipboardDataEqual(clipData, lastUpdatedClipData!!)) {
+                    Log.d(logTag, "Clipboard data is the same as last update, ignore")
+                    return
+                }
+            }
+            val mimeTypeCount = clipData.description.getMimeTypeCount()
+            val mimeTypes = mutableListOf<String>()
+            for (i in 0 until mimeTypeCount) {
+                mimeTypes.add(clipData.description.getMimeType(i))
+            }
+            var text: CharSequence? = null;
+            var html: String? = null;
+            if (isSupportedMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
+                text = clip?.text
+            }
+            if (isSupportedMimeType(ClipDescription.MIMETYPE_TEXT_HTML)) {
+                text = clip?.text
+                html = clip?.htmlText
+            }
+            var count = 0
+            val clips = MultiClipboards.newBuilder()
+            if (text != null) {
+                val content = com.google.protobuf.ByteString.copyFromUtf8(text.toString())
+                    clips.addClipboards(Clipboard.newBuilder().setFormat(ClipboardFormat.Text).setContent(content).build())
+                    count++
+                }
+            if (html != null) {
+                val content = com.google.protobuf.ByteString.copyFromUtf8(html)
+                clips.addClipboards(Clipboard.newBuilder().setFormat(ClipboardFormat.Html).setContent(content).build())
+                count++
+            }
+            if (count > 0) {
+                val clipsBytes = clips.build().toByteArray()
+                val isClientFlag = if (isClient) 1 else 0
+                val clipsBuf = ByteBuffer.allocateDirect(clipsBytes.size + 1).apply {
+                    put(isClientFlag.toByte())
+                    put(clipsBytes)
+                }
+                clipsBuf.flip()
+                lastUpdatedClipData = clipData
+                Log.d(logTag, "${if (isClient) "client" else "host"}, send clipboard data to the remote")
+                FFI.onClipboardUpdate(clipsBuf)
+            }
+        }
+    }
+
+    private val clipboardListener = object : ClipboardManager.OnPrimaryClipChangedListener {
+        override fun onPrimaryClipChanged() {
+            Log.d(logTag, "onPrimaryClipChanged")
+            checkPrimaryClip(true, false)
+        }
+    }
+
+    private fun isSupportedMimeType(mimeType: String): Boolean {
+        return supportedMimeTypes.contains(mimeType)
+    }
+
+    private fun isClipboardDataEqual(left: ClipData, right: ClipData): Boolean {
+        if (left.description.getMimeTypeCount() != right.description.getMimeTypeCount()) {
+            return false
+        }
+        val mimeTypeCount = left.description.getMimeTypeCount()
+        for (i in 0 until mimeTypeCount) {
+            if (left.description.getMimeType(i) != right.description.getMimeType(i)) {
+                return false
+            }
+        }
+
+        if (left.itemCount != right.itemCount) {
+            return false
+        }
+        for (i in 0 until left.itemCount) {
+            val mimeType = left.description.getMimeType(i)
+            if (!isSupportedMimeType(mimeType)) {
+                continue
+            }
+            val leftItem = left.getItemAt(i)
+            val rightItem = right.getItemAt(i)
+            if (mimeType == ClipDescription.MIMETYPE_TEXT_PLAIN || mimeType == ClipDescription.MIMETYPE_TEXT_HTML) {
+                if (leftItem.text != rightItem.text || leftItem.htmlText != rightItem.htmlText) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    @Keep
+    fun rustEnableServiceClipboard(enable: Boolean) {
+        Log.d(logTag, "rustEnableServiceClipboard: enable: $enable, _isListening: $_isListening")
+        if (enable) {
+            if (!_isListening) {
+                clipboardManager.addPrimaryClipChangedListener(clipboardListener)
+                _isListening = true
+            }
+        } else {
+            if (_isListening) {
+                clipboardManager.removePrimaryClipChangedListener(clipboardListener)
+                _isListening = false
+                lastUpdatedClipData = null
+            }
+        }
+    }
+
+    @Keep
+    fun rustEnableClientClipboard(enable: Boolean) {
+        Log.d(logTag, "rustEnableClientClipboard: enable: $enable")
+        isClientEnabled = enable
+        if (enable) {
+            lastUpdatedClipData = clipboardManager.primaryClip
+        } else {
+            lastUpdatedClipData = null
+        }
+    }
+
+    fun syncClipboard(isClient: Boolean) {
+        Log.d(logTag, "syncClipboard: isClient: $isClient, isClientEnabled: $isClientEnabled, _isListening: $_isListening")
+        if (isClient && !isClientEnabled) {
+            return
+        }
+        if (!isClient && !_isListening) {
+            return
+        }
+        checkPrimaryClip(isClient, true)
+    }
+
+    @Keep
+    fun rustUpdateClipboard(clips: ByteArray) {
+        val clips = MultiClipboards.parseFrom(clips)
+        var mimeTypes = mutableListOf<String>()
+        var text: String? = null
+        var html: String? = null
+        for (clip in clips.getClipboardsList()) {
+            when (clip.format) {
+                    ClipboardFormat.Text -> {
+                        mimeTypes.add(ClipDescription.MIMETYPE_TEXT_PLAIN)
+                    text = String(clip.content.toByteArray(), Charsets.UTF_8)
+                }
+                ClipboardFormat.Html -> {
+                    mimeTypes.add(ClipDescription.MIMETYPE_TEXT_HTML)
+                    html = String(clip.content.toByteArray(), Charsets.UTF_8)
+                }
+                ClipboardFormat.ImageRgba -> {
+                }
+                ClipboardFormat.ImagePng -> {
+                }
+                else -> {
+                    Log.e(logTag, "Unsupported clipboard format: ${clip.format}")
+                }
+            }
+        }
+
+        val clipDescription = ClipDescription("clipboard", mimeTypes.toTypedArray())
+        var item: ClipData.Item? = null
+        if (text == null) {
+            Log.e(logTag, "No text content in clipboard")
+            return
+        } else {
+            if (html == null) {
+                item = ClipData.Item(text)
+            } else {
+                item = ClipData.Item(text, html)
+            }
+        }
+        if (item == null) {
+            Log.e(logTag, "No item in clipboard")
+            return
+        }
+        val clipData = ClipData(clipDescription, item)
+        lastUpdatedClipData = clipData
+        clipboardManager.setPrimaryClip(clipData)
+    }
+}

--- a/flutter/android/app/src/main/kotlin/ffi.kt
+++ b/flutter/android/app/src/main/kotlin/ffi.kt
@@ -5,6 +5,8 @@ package ffi
 import android.content.Context
 import java.nio.ByteBuffer
 
+import com.carriez.flutter_hbb.RdClipboardManager
+
 object FFI {
     init {
         System.loadLibrary("rustdesk")
@@ -12,6 +14,7 @@ object FFI {
 
     external fun init(ctx: Context)
     external fun initContext(ctx: Context)
+    external fun setClipboardManager(clipboardManager: RdClipboardManager)
     external fun startServer(app_dir: String, custom_client_config: String)
     external fun startService()
     external fun onVideoFrameUpdate(buf: ByteBuffer)
@@ -21,4 +24,5 @@ object FFI {
     external fun setFrameRawEnable(name: String, value: Boolean)
     external fun setCodecInfo(info: String)
     external fun getLocalOption(key: String): String
+    external fun onClipboardUpdate(clips: ByteBuffer)
 }

--- a/flutter/lib/mobile/pages/server_page.dart
+++ b/flutter/lib/mobile/pages/server_page.dart
@@ -596,7 +596,9 @@ class _PermissionCheckerState extends State<PermissionChecker> {
                     translate("android_version_audio_tip"),
                     style: const TextStyle(color: MyTheme.darkGray),
                   ))
-                ])
+                ]),
+          PermissionRow(translate("Enable clipboard"), serverModel.clipboardOk,
+              serverModel.toggleClipboard),
         ]));
   }
 }

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -30,6 +30,7 @@ class ServerModel with ChangeNotifier {
   bool _inputOk = false;
   bool _audioOk = false;
   bool _fileOk = false;
+  bool _clipboardOk = false;
   bool _showElevation = false;
   bool hideCm = false;
   int _connectStatus = 0; // Rendezvous Server status
@@ -58,6 +59,8 @@ class ServerModel with ChangeNotifier {
   bool get audioOk => _audioOk;
 
   bool get fileOk => _fileOk;
+
+  bool get clipboardOk => _clipboardOk;
 
   bool get showElevation => _showElevation;
 
@@ -209,6 +212,10 @@ class ServerModel with ChangeNotifier {
       _fileOk = fileOption != 'N';
     }
 
+    // clipboard
+    final clipOption = await bind.mainGetOption(key: kOptionEnableClipboard);
+    _clipboardOk = clipOption != 'N';
+
     notifyListeners();
   }
 
@@ -312,6 +319,14 @@ class ServerModel with ChangeNotifier {
     bind.mainSetOption(
         key: kOptionEnableFileTransfer,
         value: _fileOk ? defaultOptionYes : 'N');
+    notifyListeners();
+  }
+
+  toggleClipboard() async {
+    _clipboardOk = !_clipboardOk;
+    bind.mainSetOption(
+        key: kOptionEnableClipboard,
+        value: _clipboardOk ? defaultOptionYes : 'N');
     notifyListeners();
   }
 

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1250,15 +1250,17 @@ fn try_send_close_event(event_stream: &Option<StreamSink<EventToUI>>) {
     }
 }
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
+#[cfg(not(target_os = "ios"))]
 pub fn update_text_clipboard_required() {
     let is_required = sessions::get_sessions()
         .iter()
         .any(|s| s.is_text_clipboard_required());
+    #[cfg(target_os = "android")]
+    let _ = scrap::android::ffi::call_clipboard_manager_enable_client_clipboard(is_required);
     Client::set_is_text_clipboard_required(is_required);
 }
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
+#[cfg(not(target_os = "ios"))]
 pub fn send_text_clipboard_msg(msg: Message) {
     for s in sessions::get_sessions() {
         if s.is_text_clipboard_required() {
@@ -2051,7 +2053,7 @@ pub mod sessions {
     }
 
     #[inline]
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    #[cfg(not(target_os = "ios"))]
     pub fn has_sessions_running(conn_type: ConnType) -> bool {
         SESSIONS.read().unwrap().iter().any(|((_, r#type), s)| {
             *r#type == conn_type && s.session_handlers.read().unwrap().len() != 0

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "上传文件夹"),
         ("Upload files", "上传文件"),
         ("Clipboard is synchronized", "剪贴板已同步"),
+        ("Update client clipboard", "更新客户端的粘贴板"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "Ordner hochladen"),
         ("Upload files", "Dateien hochladen"),
         ("Clipboard is synchronized", "Zwischenablage ist synchronisiert"),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "Subir carpeta"),
         ("Upload files", "Subir archivos"),
         ("Clipboard is synchronized", "Portapapeles sincronizado"),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "Mappa feltöltése"),
         ("Upload files", "Fájlok feltöltése"),
         ("Clipboard is synchronized", "A vágólap szinkronizálva van"),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "Cartella upload"),
         ("Upload files", "File upload"),
         ("Clipboard is synchronized", "Gli appunti sono sincronizzati"),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "폴더 업로드"),
         ("Upload files", "파일 업로드"),
         ("Clipboard is synchronized", "클립보드가 동기화됨"),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "Augšupielādēt mapi"),
         ("Upload files", "Augšupielādēt failus"),
         ("Clipboard is synchronized", "Starpliktuve ir sinhronizēta"),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "Map uploaden"),
         ("Upload files", "Bestanden uploaden"),
         ("Clipboard is synchronized", "Klembord is gesynchroniseerd"),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "Wyślij folder"),
         ("Upload files", "Wyślij pliki"),
         ("Clipboard is synchronized", "Schowek jest zsynchronizowany"),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "Загрузить папку"),
         ("Upload files", "Загрузить файлы"),
         ("Clipboard is synchronized", "Буфер обмена синхронизирован"),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "上傳資料夾"),
         ("Upload files", "上傳檔案"),
         ("Clipboard is synchronized", "剪貼簿已同步"),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -653,5 +653,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", ""),
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
+        ("Update client clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ mod custom_server;
 mod lang;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod port_forward;
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
+#[cfg(not(target_os = "ios"))]
 mod clipboard;
 
 #[cfg(all(feature = "flutter", feature = "plugin_framework"))]

--- a/src/server.rs
+++ b/src/server.rs
@@ -32,7 +32,7 @@ use crate::ipc::Data;
 
 pub mod audio_service;
 cfg_if::cfg_if! {
-if #[cfg(not(any(target_os = "android", target_os = "ios")))] {
+if #[cfg(not(target_os = "ios"))] {
 mod clipboard_service;
 #[cfg(target_os = "linux")]
 pub(crate) mod wayland;
@@ -42,17 +42,20 @@ pub mod uinput;
 pub mod rdp_input;
 #[cfg(target_os = "linux")]
 pub mod dbus;
+#[cfg(not(target_os = "android"))]
 pub mod input_service;
 } else {
 mod clipboard_service {
 pub const NAME: &'static str = "";
 }
+}
+}
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
 pub mod input_service {
-pub const NAME_CURSOR: &'static str = "";
-pub const NAME_POS: &'static str = "";
-pub const NAME_WINDOW_FOCUS: &'static str = "";
-}
-}
+    pub const NAME_CURSOR: &'static str = "";
+    pub const NAME_POS: &'static str = "";
+    pub const NAME_WINDOW_FOCUS: &'static str = "";
 }
 
 mod connection;
@@ -99,10 +102,12 @@ pub fn new() -> ServerPtr {
     };
     server.add_service(Box::new(audio_service::new()));
     #[cfg(not(target_os = "ios"))]
-    server.add_service(Box::new(display_service::new()));
+    {
+        server.add_service(Box::new(display_service::new()));
+        server.add_service(Box::new(clipboard_service::new()));
+    }
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     {
-        server.add_service(Box::new(clipboard_service::new()));
         if !display_service::capture_cursor_embedded() {
             server.add_service(Box::new(input_service::new_cursor()));
             server.add_service(Box::new(input_service::new_pos()));

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2076,7 +2076,7 @@ impl Connection {
                         update_clipboard(vec![cb], ClipboardSide::Host);
                         // ios as the controlled side is actually not supported for now.
                         // The following code is only used to preserve the logic of handling text clipboard on mobile.
-                        #[cfg(all(feature = "flutter", target_os = "ios"))]
+                        #[cfg(target_os = "ios")]
                         {
                             let content = if cb.compress {
                                 hbb_common::compress::decompress(&cb.content)

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -690,7 +690,7 @@ impl Connection {
                             }
                         }
                         Some(message::Union::MultiClipboards(_multi_clipboards)) => {
-                            #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                            #[cfg(not(target_os = "ios"))]
                             if let Some(msg_out) = crate::clipboard::get_msg_if_not_support_multi_clip(&conn.lr.version, &conn.lr.my_platform, _multi_clipboards) {
                                 if let Err(err) = conn.stream.send(&msg_out).await {
                                     conn.on_close(&err.to_string(), false).await;
@@ -2074,7 +2074,9 @@ impl Connection {
                     if self.clipboard {
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         update_clipboard(vec![cb], ClipboardSide::Host);
-                        #[cfg(all(feature = "flutter", target_os = "android"))]
+                        // ios as the controlled side is actually not supported for now.
+                        // The following code is only used to preserve the logic of handling text clipboard on mobile.
+                        #[cfg(all(feature = "flutter", target_os = "ios"))]
                         {
                             let content = if cb.compress {
                                 hbb_common::compress::decompress(&cb.content)
@@ -2092,14 +2094,17 @@ impl Connection {
                                 }
                             }
                         }
+                        #[cfg(target_os = "android")]
+                        crate::clipboard::handle_msg_clipboard(cb);
                     }
                 }
-                Some(message::Union::MultiClipboards(_mcb)) =>
-                {
+                Some(message::Union::MultiClipboards(_mcb)) => {
                     #[cfg(not(any(target_os = "android", target_os = "ios")))]
                     if self.clipboard {
                         update_clipboard(_mcb.clipboards, ClipboardSide::Host);
                     }
+                    #[cfg(target_os = "android")]
+                    crate::clipboard::handle_msg_multi_clipboards(_mcb);
                 }
                 Some(message::Union::Cliprdr(_clip)) =>
                 {

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -312,6 +312,17 @@ pub fn switch_permission(id: i32, name: String, enabled: bool) {
     };
 }
 
+#[inline]
+#[cfg(target_os = "android")]
+pub fn switch_permission_all(name: String, enabled: bool) {
+    for (_, client) in CLIENTS.read().unwrap().iter() {
+        allow_err!(client.tx.send(Data::SwitchPermission {
+            name: name.clone(),
+            enabled
+        }));
+    }
+}
+
 #[cfg(any(target_os = "android", target_os = "ios", feature = "flutter"))]
 #[inline]
 pub fn get_clients_state() -> String {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -354,7 +354,7 @@ impl<T: InvokeUiSession> Session<T> {
         self.lc.read().unwrap().is_privacy_mode_supported()
     }
 
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    #[cfg(not(target_os = "ios"))]
     pub fn is_text_clipboard_required(&self) -> bool {
         *self.server_clipboard_enabled.read().unwrap()
             && *self.server_keyboard_enabled.read().unwrap()

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -526,10 +526,7 @@ impl<T: InvokeUiSession> Session<T> {
     #[cfg(not(feature = "flutter"))]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn is_xfce(&self) -> bool {
-        #[cfg(not(any(target_os = "ios")))]
-        return crate::platform::is_xfce();
-        #[cfg(any(target_os = "ios"))]
-        false
+        crate::platform::is_xfce()
     }
 
     pub fn remove_port_forward(&self, port: i32) {


### PR DESCRIPTION
Support `text` copy&paste on Android.

## Preview


https://github.com/user-attachments/assets/84d73391-a9d4-4fe0-afe3-631331ed27c0


https://github.com/user-attachments/assets/9c7dc8e8-6cd2-4298-b4ee-b9748694d990

## Desc

1. Android cannot read the clipboard data if it is not the focused front app.
  a. For client(controlling) side, we can only read it after switching back to RustDesk.
  b. For host(controlled) side, we need to add an action in the floating menu.

```kotlin
    // For client side
    // When swithing from other app to this app, try to sync clipboard.
    override fun onWindowFocusChanged(hasFocus: Boolean) {
        super.onWindowFocusChanged(hasFocus)
        if (hasFocus) {
            rdClipboardManager?.syncClipboard(true)
        }
    }
```

```kotlin
         // For host side, clipboard sync
         val idSyncClipboard = 1
         val isClipboardListenerEnabled = MainActivity.rdClipboardManager?.isListening ?: false
         if (isClipboardListenerEnabled) {
             popupMenu.menu.add(0, idSyncClipboard, 0, translate("Update client clipboard"))
         }
```

2. `sync_init_clipboard` in `io_loop.rs` is not applied for Android. Not sure if it is readlly needed.

3. Stop sending clipboard data to flutter on Android. Call ffi `call_clipboard_manager_update_clipboard()` instead.

```rust
#[cfg(target_os = "android")]
pub fn handle_msg_multi_clipboards(mut mcb: MultiClipboards) {
    use hbb_common::protobuf::Message;

    for cb in mcb.clipboards.iter_mut() {
        if cb.compress {
            cb.content = bytes::Bytes::from(hbb_common::compress::decompress(&cb.content));
        }
    }
    if let Ok(bytes) = mcb.write_to_bytes() {
        let _ = scrap::android::ffi::call_clipboard_manager_update_clipboard(&bytes);
    }
}
```

4. Remove unused code. Because `#[cfg(not(any(target_os = "android", target_os = "ios")))]` limits all non-iOS. Though `cfg` of `flutter` and `ios` is duplicated,  `#[cfg(not(any(target_os = "android", target_os = "ios")))]` is kept for clear.

![image](https://github.com/user-attachments/assets/1af2326e-f739-4007-ac6f-19e944a026b7)


## Tests

- [x] Android -> Windows
- [x] Windows -> Android
- [x] iOS -> Windows. text copy&paste, from Windows to iOS.
- [x] Windows -> Windows Mutliple formats.

## TODOs

`html` copy&paste does not work on some Android devices, `text` copy&paste works fine.



