### PR TITLE
Change RPM compression to zstd

### DIFF
--- a/res/rpm-flutter-suse.spec
+++ b/res/rpm-flutter-suse.spec
@@ -9,6 +9,9 @@ Requires:   gtk3 libxcb1 xdotool libXfixes3 alsa-utils libXtst6 libvdpau1 libva2
 Recommends: libayatana-appindicator3-1
 Provides:   libdesktop_drop_plugin.so()(64bit), libdesktop_multi_window_plugin.so()(64bit), libfile_selector_linux_plugin.so()(64bit), libflutter_custom_cursor_plugin.so()(64bit), libflutter_linux_gtk.so()(64bit), libscreen_retriever_plugin.so()(64bit), libtray_manager_plugin.so()(64bit), liburl_launcher_linux_plugin.so()(64bit), libwindow_manager_plugin.so()(64bit), libwindow_size_plugin.so()(64bit), libtexture_rgba_renderer_plugin.so()(64bit)
 
+%define _source_payload w19.zstdio
+%define _binary_payload w19.zstdio
+
 %description
 The best open-source remote desktop client software, written in Rust.
 

--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -9,6 +9,9 @@ Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libvdpau libva pam gstreamer1-
 Recommends: libayatana-appindicator-gtk3
 Provides:   libdesktop_drop_plugin.so()(64bit), libdesktop_multi_window_plugin.so()(64bit), libfile_selector_linux_plugin.so()(64bit), libflutter_custom_cursor_plugin.so()(64bit), libflutter_linux_gtk.so()(64bit), libscreen_retriever_plugin.so()(64bit), libtray_manager_plugin.so()(64bit), liburl_launcher_linux_plugin.so()(64bit), libwindow_manager_plugin.so()(64bit), libwindow_size_plugin.so()(64bit), libtexture_rgba_renderer_plugin.so()(64bit)
 
+%define _source_payload w19.zstdio
+%define _binary_payload w19.zstdio
+
 %description
 The best open-source remote desktop client software, written in Rust.
 

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -8,6 +8,9 @@ Vendor:     rustdesk <info@rustdesk.com>
 Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libvdpau1 libva2 pam gstreamer1-plugins-base
 Recommends: libayatana-appindicator-gtk3
 
+%define _source_payload w19.zstdio
+%define _binary_payload w19.zstdio
+
 %description
 The best open-source remote desktop client software, written in Rust.
 


### PR DESCRIPTION
## Summry

Almost all RPM ecosystems are support `rpm` package file that using `zstd` compression and changing default compression method to `zstd`. Some very old enterprise distributions may affected, check *Affect platforms* section.

## Benefit

* Reduce package size, in latest nightly for example, from 25.4 MB to 20.9 MB
* Reduce bandwidth cost

## Requirement

[RPM >= 4.14.0](https://rpm.org/wiki/Releases/4.14.0)

## Affect platforms

* All CentOS non Stream (All EOL)
* Red Hat Enterprise Linux <= 7
* SUSE Linux Enterprise Server 12 SP5  (Maybe, can't verify because they may backport)

## Verify the compression method of the RPM package

Run:

```
bash-5.2# rpm -q --queryformat '%{PAYLOADCOMPRESSOR}\n' -p rustdesk-1.3.3-0.x86_64.rpm 
zstd
```
If not specified while building package, it will uses `gzip`.


## References

[Fedora Proposal: 
Changes/Switch RPMs to zstd compression
](https://fedoraproject.org/wiki/Changes/Switch_RPMs_to_zstd_compression)
[pagure.io/fesco/issue/2144: F31 System-Wide Change: Switch RPMs to zstd compression](https://pagure.io/fesco/issue/2144)

https://endoflife.date/centos (ALL EOL)
https://endoflife.date/rhel

## Note

If merged, refer this PR in release notes, in case someone really need `gzip` compression.
