### PR TITLE
fix: android w&h, refresh when no connection

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -300,9 +300,9 @@ class MainService : Service() {
                 SCREEN_INFO.dpi = dpi
                 if (isStart) {
                     stopCapture()
-                    FFI.refreshScreen()
                     startCapture()
                 }
+                FFI.refreshScreen()
             }
 
         }


### PR DESCRIPTION
Always refresh `w&h` on rotating screen.

## issue

TODO in https://github.com/rustdesk/rustdesk/pull/9786

## Desc

`updateScreenInfo()` will be called after rotating the screen.
But if `isStart` is false, the `w&h` will not be refreshed in rust side.

1. Rotate the screen (Android) when there's no connection
2. Connect to Android

Then the `w&h` are wrong.
