### PR TITLE
add env VCPKG_INSTALLED_ROOT

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -61,7 +61,11 @@ fn install_android_deps() {
     let target = format!("{}-android", target_arch);
     let vcpkg_root = std::env::var("VCPKG_ROOT").unwrap();
     let mut path: std::path::PathBuf = vcpkg_root.into();
-    path.push("installed");
+    if let Ok(vcpkg_root) = std::env::var("VCPKG_INSTALLED_ROOT") {
+        path = vcpkg_root.into();
+    } else {
+        path.push("installed");
+    }
     path.push(target);
     println!(
         "{}",

--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -55,7 +55,11 @@ fn link_vcpkg(mut path: PathBuf, name: &str) -> PathBuf {
         target = target.replace("x64", "x86");
     }
     println!("cargo:info={}", target);
-    path.push("installed");
+    if let Ok(vcpkg_root) = std::env::var("VCPKG_INSTALLED_ROOT") {
+        path = vcpkg_root.into();
+    } else {
+        path.push("installed");
+    }
     path.push(target);
     println!(
         "{}",


### PR DESCRIPTION
add env VCPKG_INSTALLED_ROOT

VCPKG_INSTALLED_ROOT used with vcpkg.json can be used with compiled dependencies in the project directory to make it easier to lock down versions