### PR TITLE
fix mis-align problem when converting &[u8] to &[f32]

### DIFF
--- a/libs/hbb_common/src/lib.rs
+++ b/libs/hbb_common/src/lib.rs
@@ -27,6 +27,7 @@ pub use anyhow::{self, bail};
 pub use futures_util;
 pub mod config;
 pub mod fs;
+pub mod mem;
 pub use lazy_static;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub use mac_address;

--- a/libs/hbb_common/src/mem.rs
+++ b/libs/hbb_common/src/mem.rs
@@ -1,0 +1,14 @@
+/// SAFETY: the returned Vec must not be resized or reserverd
+pub unsafe fn aligned_u8_vec(cap: usize, align: usize) -> Vec<u8> {
+    use std::alloc::*;
+
+    let layout =
+        Layout::from_size_align(cap, align).expect("invalid aligned value, must be power of 2");
+    unsafe {
+        let ptr = alloc(layout);
+        if ptr.is_null() {
+            panic!("failed to allocate {} bytes", cap);
+        }
+        Vec::from_raw_parts(ptr, 0, cap)
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -118,7 +118,7 @@ pub const SCRAP_X11_REQUIRED: &str = "x11 expected";
 pub const SCRAP_X11_REF_URL: &str = "https://rustdesk.com/docs/en/manual/linux/#x11-required";
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
-pub const AUDIO_BUFFER_MS: usize = 150;
+pub const AUDIO_BUFFER_MS: usize = 3000;
 
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -904,36 +904,102 @@ pub struct AudioHandler {
 }
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
-struct AudioBuffer(pub Arc<std::sync::Mutex<ringbuf::HeapRb<f32>>>);
+struct AudioBuffer(
+    pub Arc<std::sync::Mutex<ringbuf::HeapRb<f32>>>,
+    usize,
+    [usize; 30],
+);
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 impl Default for AudioBuffer {
     fn default() -> Self {
-        Self(Arc::new(std::sync::Mutex::new(
-            ringbuf::HeapRb::<f32>::new(48000 * 2 * AUDIO_BUFFER_MS / 1000), // 48000hz, 2 channel
-        )))
+        Self(
+            Arc::new(std::sync::Mutex::new(
+                ringbuf::HeapRb::<f32>::new(48000 * 2 * AUDIO_BUFFER_MS / 1000), // 48000hz, 2 channel
+            )),
+            48000 * 2,
+            [0; 30],
+        )
     }
 }
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 impl AudioBuffer {
-    pub fn resize(&self, sample_rate: usize, channels: usize) {
+    pub fn resize(&mut self, sample_rate: usize, channels: usize) {
         let capacity = sample_rate * channels * AUDIO_BUFFER_MS / 1000;
         let old_capacity = self.0.lock().unwrap().capacity();
         if capacity != old_capacity {
             *self.0.lock().unwrap() = ringbuf::HeapRb::<f32>::new(capacity);
+            self.1 = sample_rate * channels;
             log::info!("Audio buffer resized from {old_capacity} to {capacity}");
         }
     }
 
-    // clear when full to avoid long time noise
-    #[inline]
-    pub fn clear_if_full(&self) {
-        let full = self.0.lock().unwrap().is_full();
-        if full {
-            self.0.lock().unwrap().clear();
-            log::trace!("Audio buffer cleared");
+    fn try_shrink(&mut self, having: usize) {
+        extern crate chrono;
+        use chrono::prelude::*;
+
+        static mut tms: i64 = 0;
+        let dt = Local::now().timestamp_millis();
+        unsafe {
+            if tms == 0 {
+                tms = dt;
+                return;
+            } else if dt < tms + 12000 {
+                return;
+            }
+            tms = dt;
         }
+
+        let mut i = (having * 10) / self.1;
+        if i > 29 {
+            i = 29;
+        }
+        self.2[i] += 1;
+
+        let mut max = 0;
+        for i in 1..30 {
+            if self.2[i] > self.2[max] {
+                self.2[max] = 0;
+                max = i;
+            } else {
+                self.2[i] = 0;
+            }
+        }
+        self.2[max] = 0;
+        if max < 6 {
+            return;
+        }
+
+        let mut lock = self.0.lock().unwrap();
+        let cap = lock.capacity();
+        let having = lock.occupied_len();
+        let skip = cap * max / (30 * 4);
+        if having > skip * 3 {
+            lock.skip(skip);
+            println!("skip {skip}");
+        }
+    }
+
+    fn append_pcm2(&self, buffer: &[f32]) -> usize {
+        let mut lock = self.0.lock().unwrap();
+        let cap = lock.capacity();
+        if buffer.len() > cap {
+            lock.push_slice_overwrite(buffer);
+            return cap;
+        }
+
+        let having = lock.occupied_len() + buffer.len();
+        if having > cap {
+            lock.skip(having - cap);
+        }
+        lock.push_slice_overwrite(buffer);
+        lock.occupied_len()
+    }
+
+    pub fn append_pcm(&mut self, buffer: &[f32]) {
+        let having = self.append_pcm2(buffer);
+        self.try_shrink(having);
     }
 }
 
@@ -993,7 +1059,9 @@ impl AudioHandler {
         let sample_format = config.sample_format();
         log::info!("Default output format: {:?}", config);
         log::info!("Remote input format: {:?}", format0);
-        let config: StreamConfig = config.into();
+        let mut config: StreamConfig = config.into();
+        config.buffer_size = cpal::BufferSize::Fixed(64);
+
         self.sample_rate = (format0.sample_rate, config.sample_rate.0);
         let mut build_output_stream = |config: StreamConfig| match sample_format {
             cpal::SampleFormat::I8 => self.build_output_stream::<i8>(&config, &device),
@@ -1062,7 +1130,6 @@ impl AudioHandler {
                 {
                     let sample_rate0 = self.sample_rate.0;
                     let sample_rate = self.sample_rate.1;
-                    let audio_buffer = self.audio_buffer.0.clone();
                     let mut buffer = buffer[0..n].to_owned();
                     if sample_rate != sample_rate0 {
                         buffer = crate::audio_resample(
@@ -1081,8 +1148,7 @@ impl AudioHandler {
                             self.device_channel,
                         );
                     }
-                    self.audio_buffer.clear_if_full();
-                    audio_buffer.lock().unwrap().push_slice_overwrite(&buffer);
+                    self.audio_buffer.append_pcm(&buffer);
                 }
                 #[cfg(target_os = "android")]
                 {
@@ -1117,18 +1183,36 @@ impl AudioHandler {
         let timeout = None;
         let stream = device.build_output_stream(
             config,
-            move |data: &mut [T], _: &_| {
+            move |data: &mut [T], info: &cpal::OutputCallbackInfo| {
                 if !*ready.lock().unwrap() {
                     *ready.lock().unwrap() = true;
                 }
-                let mut lock = audio_buffer.lock().unwrap();
+
                 let mut n = data.len();
-                if lock.occupied_len() < n {
-                    n = lock.occupied_len();
+                let mut lock = audio_buffer.lock().unwrap();
+                let mut having = lock.occupied_len();
+                if having < n {
+                    drop(lock);
+
+                    let tms = info.timestamp();
+                    let how_long = tms.playback.duration_since(&tms.callback).unwrap();
+                    if how_long > Duration::from_millis(6) {
+                        std::thread::sleep(how_long.div_f32(2.0));
+                    }
+
+                    lock = audio_buffer.lock().unwrap();
+                    having = lock.occupied_len();
+                    if having < n {
+                        n = having;
+                    }
                 }
+
                 let mut elems = vec![0.0f32; n];
-                lock.pop_slice(&mut elems);
+                if n > 0 {
+                    lock.pop_slice(&mut elems);
+                }
                 drop(lock);
+
                 let mut input = elems.into_iter();
                 for sample in data.iter_mut() {
                     *sample = match input.next() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -118,7 +118,7 @@ pub const SCRAP_X11_REQUIRED: &str = "x11 expected";
 pub const SCRAP_X11_REF_URL: &str = "https://rustdesk.com/docs/en/manual/linux/#x11-required";
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
-pub const AUDIO_BUFFER_MS: usize = 3000;
+pub const AUDIO_BUFFER_MS: usize = 150;
 
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -904,123 +904,36 @@ pub struct AudioHandler {
 }
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
-struct AudioBuffer(
-    pub Arc<std::sync::Mutex<ringbuf::HeapRb<f32>>>,
-    usize,
-    [usize; 30],
-);
+struct AudioBuffer(pub Arc<std::sync::Mutex<ringbuf::HeapRb<f32>>>);
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 impl Default for AudioBuffer {
     fn default() -> Self {
-        Self(
-            Arc::new(std::sync::Mutex::new(
-                ringbuf::HeapRb::<f32>::new(48000 * 2 * AUDIO_BUFFER_MS / 1000), // 48000hz, 2 channel
-            )),
-            48000 * 2,
-            [0; 30],
-        )
+        Self(Arc::new(std::sync::Mutex::new(
+            ringbuf::HeapRb::<f32>::new(48000 * 2 * AUDIO_BUFFER_MS / 1000), // 48000hz, 2 channel
+        )))
     }
 }
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 impl AudioBuffer {
-    pub fn resize(&mut self, sample_rate: usize, channels: usize) {
+    pub fn resize(&self, sample_rate: usize, channels: usize) {
         let capacity = sample_rate * channels * AUDIO_BUFFER_MS / 1000;
         let old_capacity = self.0.lock().unwrap().capacity();
         if capacity != old_capacity {
             *self.0.lock().unwrap() = ringbuf::HeapRb::<f32>::new(capacity);
-            self.1 = sample_rate * channels;
             log::info!("Audio buffer resized from {old_capacity} to {capacity}");
         }
     }
 
-    fn try_shrink(&mut self, having: usize) {
-        extern crate chrono;
-        use chrono::prelude::*;
-
-        let mut i = (having * 10) / self.1;
-        if i > 29 {
-            i = 29;
+    // clear when full to avoid long time noise
+    #[inline]
+    pub fn clear_if_full(&self) {
+        let full = self.0.lock().unwrap().is_full();
+        if full {
+            self.0.lock().unwrap().clear();
+            log::trace!("Audio buffer cleared");
         }
-        self.2[i] += 1;
-
-        static mut tms: i64 = 0;
-        let dt = Local::now().timestamp_millis();
-        unsafe {
-            if tms == 0 {
-                tms = dt;
-                return;
-            } else if dt < tms + 12000 {
-                return;
-            }
-            tms = dt;
-        }
-
-        // the safer water mark to drop
-        let mut zero = 0;
-        // the water mark taking most of time
-        let mut max = 0;
-        for i in 0..30 {
-            if self.2[i] == 0 && zero == i {
-                zero += 1;
-            }
-
-            if self.2[i] > self.2[max] {
-                self.2[max] = 0;
-                max = i;
-            } else {
-                self.2[i] = 0;
-            }
-        }
-        zero = zero * 2 / 3;
-
-        // how many data can be dropped:
-        // 1. will not drop if buffered data is less than 600ms
-        // 2. choose based on min(zero, max)
-        const N: usize = 4;
-        self.2[max] = 0;
-        if max < 6 {
-            return;
-        } else if max > zero * N {
-            max = zero * N;
-        }
-
-        let mut lock = self.0.lock().unwrap();
-        let cap = lock.capacity();
-        let having = lock.occupied_len();
-        let skip = (cap * max / (30 * N) + 1) & (!1);
-        if (having > skip * 3) && (skip > 0) {
-            lock.skip(skip);
-            log::info!("skip {skip}, based {max} {zero}");
-        }
-    }
-
-    /// append pcm to audio buffer, if buffered data
-    /// exceeds AUDIO_BUFFER_MS,  only AUDIO_BUFFER_MS
-    /// will be kept.
-    fn append_pcm2(&self, buffer: &[f32]) -> usize {
-        let mut lock = self.0.lock().unwrap();
-        let cap = lock.capacity();
-        if buffer.len() > cap {
-            lock.push_slice_overwrite(buffer);
-            return cap;
-        }
-
-        let having = lock.occupied_len() + buffer.len();
-        if having > cap {
-            lock.skip(having - cap);
-        }
-        lock.push_slice_overwrite(buffer);
-        lock.occupied_len()
-    }
-
-    /// append pcm to audio buffer, trying to drop data
-    /// when data is too much (per 12 seconds) based
-    /// statistics.
-    pub fn append_pcm(&mut self, buffer: &[f32]) {
-        let having = self.append_pcm2(buffer);
-        self.try_shrink(having);
     }
 }
 
@@ -1080,9 +993,7 @@ impl AudioHandler {
         let sample_format = config.sample_format();
         log::info!("Default output format: {:?}", config);
         log::info!("Remote input format: {:?}", format0);
-        let mut config: StreamConfig = config.into();
-        config.buffer_size = cpal::BufferSize::Fixed(64);
-
+        let config: StreamConfig = config.into();
         self.sample_rate = (format0.sample_rate, config.sample_rate.0);
         let mut build_output_stream = |config: StreamConfig| match sample_format {
             cpal::SampleFormat::I8 => self.build_output_stream::<i8>(&config, &device),
@@ -1151,6 +1062,7 @@ impl AudioHandler {
                 {
                     let sample_rate0 = self.sample_rate.0;
                     let sample_rate = self.sample_rate.1;
+                    let audio_buffer = self.audio_buffer.0.clone();
                     let mut buffer = buffer[0..n].to_owned();
                     if sample_rate != sample_rate0 {
                         buffer = crate::audio_resample(
@@ -1169,7 +1081,8 @@ impl AudioHandler {
                             self.device_channel,
                         );
                     }
-                    self.audio_buffer.append_pcm(&buffer);
+                    self.audio_buffer.clear_if_full();
+                    audio_buffer.lock().unwrap().push_slice_overwrite(&buffer);
                 }
                 #[cfg(target_os = "android")]
                 {
@@ -1204,40 +1117,18 @@ impl AudioHandler {
         let timeout = None;
         let stream = device.build_output_stream(
             config,
-            move |data: &mut [T], info: &cpal::OutputCallbackInfo| {
+            move |data: &mut [T], _: &_| {
                 if !*ready.lock().unwrap() {
                     *ready.lock().unwrap() = true;
                 }
-
-                let mut n = data.len();
                 let mut lock = audio_buffer.lock().unwrap();
-                let mut having = lock.occupied_len();
-                if having < n {
-                    let tms = info.timestamp();
-                    let how_long = tms
-                        .playback
-                        .duration_since(&tms.callback)
-                        .unwrap_or(Duration::from_millis(0));
-
-                    // must long enough to fight back scheuler delay
-                    if how_long > Duration::from_millis(6) {
-                        drop(lock);
-                        std::thread::sleep(how_long.div_f32(1.2));
-                        lock = audio_buffer.lock().unwrap();
-                        having = lock.occupied_len();
-                    }
-
-                    if having < n {
-                        n = having;
-                    }
+                let mut n = data.len();
+                if lock.occupied_len() < n {
+                    n = lock.occupied_len();
                 }
-
                 let mut elems = vec![0.0f32; n];
-                if n > 0 {
-                    lock.pop_slice(&mut elems);
-                }
+                lock.pop_slice(&mut elems);
                 drop(lock);
-
                 let mut input = elems.into_iter();
                 for sample in data.iter_mut() {
                     *sample = match input.next() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1192,16 +1192,16 @@ impl AudioHandler {
                 let mut lock = audio_buffer.lock().unwrap();
                 let mut having = lock.occupied_len();
                 if having < n {
-                    drop(lock);
-
                     let tms = info.timestamp();
                     let how_long = tms.playback.duration_since(&tms.callback).unwrap();
+
                     if how_long > Duration::from_millis(6) {
+                        drop(lock);
                         std::thread::sleep(how_long.div_f32(2.0));
+                        lock = audio_buffer.lock().unwrap();
+                        having = lock.occupied_len();
                     }
 
-                    lock = audio_buffer.lock().unwrap();
-                    having = lock.occupied_len();
                     if having < n {
                         n = having;
                     }

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -132,8 +132,8 @@ mod pa_impl {
                     continue;
                 }
 
-                let ptr = unsafe { align_to_32(data.into()).as_ptr() };
-                let data = unsafe { std::slice::from_raw_parts::<f32>(ptr as _, nb / 4) };
+                let data = unsafe { align_to_32(data.into()) };
+                let data = unsafe { std::slice::from_raw_parts::<f32>(data.ptr() as _, nb / 4) };
                 send_f32(data, &mut encoder, &sp);
             }
 

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -112,8 +112,6 @@ mod pa_impl {
         );
         #[cfg(target_os = "linux")]
         let zero_audio_frame: Vec<f32> = vec![0.; AUDIO_DATA_SIZE_U8 / 4];
-        #[cfg(target_os = "android")]
-        let mut android_data = vec![];
         while sp.ok() && !RESTARTING.load(Ordering::SeqCst) {
             sp.snapshot(|sps| {
                 sps.send(create_format_msg(crate::platform::PA_SAMPLE_RATE, 2));
@@ -139,9 +137,8 @@ mod pa_impl {
 
             #[cfg(target_os = "android")]
             {
-                let b =
-                    scrap::android::ffi::get_audio_raw(&mut android_data, &mut vec![]).is_some();
-                if b {
+                let mut android_data = vec![];
+                if scrap::android::ffi::get_audio_raw(&mut android_data, &mut vec![]).is_some() {
                     let data = unsafe {
                         let nb = android_data.len();
                         let ptr = align_to_32(android_data).as_ptr();

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -138,15 +138,19 @@ mod pa_impl {
             }
 
             #[cfg(target_os = "android")]
-            if scrap::android::ffi::get_audio_raw(&mut android_data, &mut vec![]).is_some() {
-                let data = unsafe {
-                    let nb = android_data.len();
-                    let ptr = align_to_32(android_data).as_ptr();
-                    std::slice::from_raw_parts::<f32>(ptr as _, nb / 4)
-                };
-                send_f32(data, &mut encoder, &sp);
-            } else {
-                hbb_common::sleep(0.1).await;
+            {
+                let b =
+                    scrap::android::ffi::get_audio_raw(&mut android_data, &mut vec![]).is_some();
+                if b {
+                    let data = unsafe {
+                        let nb = android_data.len();
+                        let ptr = align_to_32(android_data).as_ptr();
+                        std::slice::from_raw_parts::<f32>(ptr as _, nb / 4)
+                    };
+                    send_f32(data, &mut encoder, &sp);
+                } else {
+                    hbb_common::sleep(0.1).await;
+                }
             }
         }
         Ok(())

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -127,13 +127,14 @@ mod pa_impl {
                     continue;
                 }
 
-                let nb = data.len();
-                if nb != AUDIO_DATA_SIZE_U8 {
+                if data.len() != AUDIO_DATA_SIZE_U8 {
                     continue;
                 }
 
                 let data = unsafe { align_to_32(data.into()) };
-                let data = unsafe { std::slice::from_raw_parts::<f32>(data.as_ptr() as _, nb / 4) };
+                let data = unsafe {
+                    std::slice::from_raw_parts::<f32>(data.as_ptr() as _, data.len() / 4)
+                };
                 send_f32(data, &mut encoder, &sp);
             }
 

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -78,6 +78,18 @@ pub fn restart() {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod pa_impl {
     use super::*;
+
+    unsafe fn align_to_32(data: Vec<u8>) -> Vec<u8> {
+        if (data.as_ptr() as usize & 3) == 0 {
+            return data;
+        }
+
+        let mut buf = vec![];
+        buf = unsafe { hbb_common::mem::aligned_u8_vec(data.len(), 4) };
+        buf.extend_from_slice(data.as_ref());
+        buf
+    }
+
     #[tokio::main(flavor = "current_thread")]
     pub async fn run(sp: EmptyExtraFieldService) -> ResultType<()> {
         hbb_common::sleep(0.1).await; // one moment to wait for _pa ipc
@@ -106,27 +118,30 @@ mod pa_impl {
                 sps.send(create_format_msg(crate::platform::PA_SAMPLE_RATE, 2));
                 Ok(())
             })?;
+
             #[cfg(target_os = "linux")]
             if let Ok(data) = stream.next_raw().await {
                 if data.len() == 0 {
                     send_f32(&zero_audio_frame, &mut encoder, &sp);
                     continue;
                 }
-                if data.len() != AUDIO_DATA_SIZE_U8 {
+
+                let nb = data.len();
+                if nb != AUDIO_DATA_SIZE_U8 {
                     continue;
                 }
-                let data = unsafe {
-                    std::slice::from_raw_parts::<f32>(data.as_ptr() as _, data.len() / 4)
-                };
+
+                let ptr = unsafe { align_to_32(data.into()).as_ptr() };
+                let data = unsafe { std::slice::from_raw_parts::<f32>(ptr as _, nb / 4) };
                 send_f32(data, &mut encoder, &sp);
             }
+
             #[cfg(target_os = "android")]
             if scrap::android::ffi::get_audio_raw(&mut android_data, &mut vec![]).is_some() {
                 let data = unsafe {
-                    std::slice::from_raw_parts::<f32>(
-                        android_data.as_ptr() as _,
-                        android_data.len() / 4,
-                    )
+                    let nb = android_data.len();
+                    let ptr = align_to_32(android_data).as_ptr();
+                    std::slice::from_raw_parts::<f32>(ptr as _, nb / 4)
                 };
                 send_f32(data, &mut encoder, &sp);
             } else {

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -133,7 +133,7 @@ mod pa_impl {
                 }
 
                 let data = unsafe { align_to_32(data.into()) };
-                let data = unsafe { std::slice::from_raw_parts::<f32>(data.ptr() as _, nb / 4) };
+                let data = unsafe { std::slice::from_raw_parts::<f32>(data.as_ptr() as _, nb / 4) };
                 send_f32(data, &mut encoder, &sp);
             }
 

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -79,6 +79,7 @@ pub fn restart() {
 mod pa_impl {
     use super::*;
 
+    // SAFETY: constrains of hbb_common::mem::aligned_u8_vec must be held
     unsafe fn align_to_32(data: Vec<u8>) -> Vec<u8> {
         if (data.as_ptr() as usize & 3) == 0 {
             return data;


### PR DESCRIPTION
fix mis-align problem when converting &[u8] to &[f32] using a new function added to hbb_common