### PR TITLE
fix: ci macos

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -690,7 +690,13 @@ jobs:
 
       - name: Install build runtime
         run: |
-          brew install llvm create-dmg nasm cmake gcc wget ninja pkg-config
+          brew install llvm create-dmg nasm cmake gcc wget ninja
+          # pkg-config is handled in a separate step, because it may be already installed by `macos-latest`(14.7.1) runner
+          if command -v pkg-config &>/dev/null; then
+              echo "pkg-config is already installed"
+          else
+              brew install pkg-config
+          fi
 
       - name: Install flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
https://github.com/fufesou/rustdesk/actions/runs/11977265515/job/33394838861

![image](https://github.com/user-attachments/assets/e159f7ef-6f8d-43cf-8c3c-d4edbcb49e48)

## Desc

`macos-latset` sometimes uses `macos-14.7.1`, which may have `pkg-config` installed. Then `brew intall pkg-config` will fail.

Note: `brew list pkg-config` shows `Error: No such keg: /opt/homebrew/Cellar/pkg-config`.
So we can only uses `command -v pkg-config` or `pkg-config --version` to check if `pkg-config` is installed.

