### PR TITLE
install vaapi dependencies before vcpkg installs ffmpeg

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -1441,6 +1441,7 @@ jobs:
       - name: Install vcpkg dependencies
         if: matrix.job.arch == 'x86_64' || env.UPLOAD_ARTIFACT == 'true'
         run: |
+          sudo apt install -y libva-dev libvdpau-dev
           if ! $VCPKG_ROOT/vcpkg \
             install \
             --triplet ${{ matrix.job.vcpkg-triplet }} \


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/9532

linux vaapi encoding/decoding lost since installing ffmpeg with vcpkg

Before:
![before](https://github.com/user-attachments/assets/14023fd9-927e-4a43-ad90-e7e8d5786da0)

After:
![after](https://github.com/user-attachments/assets/88a2ef2f-eebc-4b52-aa22-8c1d3a0aced9)
