### PR TITLE
android wait 3s for isStart flag

### DIFF
--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -845,14 +845,15 @@ fn check_change_scale(hardware: bool) -> ResultType<()> {
     use hbb_common::config::keys::OPTION_ENABLE_ANDROID_SOFTWARE_ENCODING_HALF_SCALE as SCALE_SOFT;
 
     // isStart flag is set at the end of startCapture() in Android, wait it to be set.
-    for i in 0..6 {
+    let n = 60; // 3s
+    for i in 0..n {
         if scrap::is_start() == Some(true) {
             log::info!("start flag is set");
             break;
         }
         log::info!("wait for start, {i}");
         std::thread::sleep(Duration::from_millis(50));
-        if i == 5 {
+        if i == n - 1 {
             log::error!("wait for start timeout");
         }
     }


### PR DESCRIPTION
The normal process is that `startCapture` and `VideoService::run` run in parallel,  the `run` function waits for startCapture to complete, then sets the scale, and subsequently calls `stopCapture` and `startCapture`. If the `run` function does not wait long enough, `startCapture` initializes the surface with the original width and height, but the `start` flag is still false, meaning it can't call `stopCapture` and `startCapture` . This results in only capturing the upper-left portion of the virtual display.


Bug:

![top-left](https://github.com/user-attachments/assets/6e652509-1607-45a2-88da-e36475c1e280)

Set it wait 150ms to make it easy to reproduce, usually `startCapture`  takes no more than 400ms

![wait_startCapture_timeout](https://github.com/user-attachments/assets/c4c224cd-2b66-4ccf-a654-7081a20b19d9)

Fix: wait at most 3000ms
![startCapture_takes_300ms](https://github.com/user-attachments/assets/7d6b9655-3fed-401b-945e-31bad57907fa)
