### PR TITLE
fix: Android 29, crash on restart and reconn

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -32,10 +32,6 @@ import com.hjq.permissions.XXPermissions
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
-import io.flutter.embedding.engine.plugins.FlutterPlugin
-import io.flutter.plugin.common.MethodCall
-import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import io.flutter.plugin.common.MethodChannel.Result
 import kotlin.concurrent.thread
 
 
@@ -66,7 +62,6 @@ class MainActivity : FlutterActivity() {
             channelTag
         )
         initFlutterChannel(flutterMethodChannel!!)
-        flutterEngine.plugins.add(ContextPlugin())
         thread { setCodecInfo() }
     }
 
@@ -415,18 +410,5 @@ class MainActivity : FlutterActivity() {
         if (hasFocus) {
             rdClipboardManager?.syncClipboard(true)
         }
-    }
-}
-
-// https://cjycode.com/flutter_rust_bridge/guides/how-to/ndk-init
-class ContextPlugin : FlutterPlugin, MethodCallHandler {
-    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        FFI.initContext(flutterPluginBinding.applicationContext)
-    }
-    override fun onMethodCall(call: MethodCall, result: Result) {
-        result.notImplemented()
-    }
-
-    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     }
 }

--- a/flutter/android/app/src/main/kotlin/ffi.kt
+++ b/flutter/android/app/src/main/kotlin/ffi.kt
@@ -13,7 +13,6 @@ object FFI {
     }
 
     external fun init(ctx: Context)
-    external fun initContext(ctx: Context)
     external fun setClipboardManager(clipboardManager: RdClipboardManager)
     external fun startServer(app_dir: String, custom_client_config: String)
     external fun startService()

--- a/libs/scrap/src/android/ffi.rs
+++ b/libs/scrap/src/android/ffi.rs
@@ -206,18 +206,6 @@ pub extern "system" fn Java_ffi_FFI_init(env: JNIEnv, _class: JClass, ctx: JObje
 }
 
 #[no_mangle]
-pub extern "system" fn Java_ffi_FFI_initContext(env: JNIEnv, _class: JClass, ctx: JObject) {
-    log::debug!("MainActivity initContext from java");
-    if let Ok(jvm) = env.get_java_vm() {
-        if let Ok(context) = env.new_global_ref(ctx) {
-            let java_vm = jvm.get_java_vm_pointer() as *mut c_void;
-            let context_jobject = context.as_obj().as_raw() as *mut c_void;
-            init_ndk_context(java_vm, context_jobject);
-        }
-    }
-}
-
-#[no_mangle]
 pub extern "system" fn Java_ffi_FFI_setClipboardManager(
     env: JNIEnv,
     _class: JClass,
@@ -482,12 +470,12 @@ fn init_ndk_context(java_vm: *mut c_void, context_jobject: *mut c_void) {
     *lock = true;
 }
 
-// // https://cjycode.com/flutter_rust_bridge/guides/how-to/ndk-init
-// #[no_mangle]
-// pub extern "C" fn JNI_OnLoad(vm: jni::JavaVM, res: *mut std::os::raw::c_void) -> jni::sys::jint {
-//     if let Ok(env) = vm.get_env() {
-//         let vm = vm.get_java_vm_pointer() as *mut std::os::raw::c_void;
-//         init_ndk_context(vm, res);
-//     }
-//     jni::JNIVersion::V6.into()
-// }
+// https://cjycode.com/flutter_rust_bridge/guides/how-to/ndk-init
+#[no_mangle]
+pub extern "C" fn JNI_OnLoad(vm: jni::JavaVM, res: *mut std::os::raw::c_void) -> jni::sys::jint {
+    if let Ok(env) = vm.get_env() {
+        let vm = vm.get_java_vm_pointer() as *mut std::os::raw::c_void;
+        init_ndk_context(vm, res);
+    }
+    jni::JNIVersion::V6.into()
+}


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/10045

## Preview

https://github.com/user-attachments/assets/515df608-55f5-426c-ac0f-f5bdf679242e

## Desc

The cause of the crash is not yet clear.

The log prints the following lines before crash. It seems to be related to Flutter.

```
E iez.flutter_hb: JNI ERROR (app bug): attempt to use stale Global 0x2936 (should be 0x2932)
F iez.flutter_hb: java_vm_ext.cc:570] JNI DETECTED ERROR IN APPLICATION: use of deleted global reference 0x2936
```

## Tests

Android -> Linux, audio.
