### PR TITLE
fix: mobile autocomplete options

### DIFF
--- a/flutter/lib/mobile/pages/connection_page.dart
+++ b/flutter/lib/mobile/pages/connection_page.dart
@@ -48,6 +48,9 @@ class _ConnectionPageState extends State<ConnectionPage> {
   bool isPeersLoaded = false;
   StreamSubscription? _uniLinksSubscription;
 
+  // https://github.com/flutter/flutter/issues/157244
+  Iterable<Peer> _autocompleteOpts = [];
+
   _ConnectionPageState() {
     if (!isWeb) _uniLinksSubscription = listenUniLinks();
     _idController.addListener(() {
@@ -166,7 +169,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
                   child: Autocomplete<Peer>(
                     optionsBuilder: (TextEditingValue textEditingValue) {
                       if (textEditingValue.text == '') {
-                        return const Iterable<Peer>.empty();
+                        _autocompleteOpts = const Iterable<Peer>.empty();
                       } else if (peers.isEmpty && !isPeersLoaded) {
                         Peer emptyPeer = Peer(
                           id: '',
@@ -182,7 +185,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
                           rdpUsername: '',
                           loginName: '',
                         );
-                        return [emptyPeer];
+                        _autocompleteOpts = [emptyPeer];
                       } else {
                         String textWithoutSpaces =
                             textEditingValue.text.replaceAll(" ", "");
@@ -194,7 +197,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
                         }
                         String textToFind = textEditingValue.text.toLowerCase();
 
-                        return peers
+                        _autocompleteOpts = peers
                             .where((peer) =>
                                 peer.id.toLowerCase().contains(textToFind) ||
                                 peer.username
@@ -206,6 +209,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
                                 peer.alias.toLowerCase().contains(textToFind))
                             .toList();
                       }
+                      return _autocompleteOpts;
                     },
                     fieldViewBuilder: (BuildContext context,
                         TextEditingController fieldTextEditingController,
@@ -274,6 +278,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
                     optionsViewBuilder: (BuildContext context,
                         AutocompleteOnSelected<Peer> onSelected,
                         Iterable<Peer> options) {
+                      options = _autocompleteOpts;
                       double maxHeight = options.length * 50;
                       if (options.length == 1) {
                         maxHeight = 52;


### PR DESCRIPTION
Workaround https://github.com/flutter/flutter/issues/157244

Desktop has already applied the workaround.

## Preview

https://github.com/user-attachments/assets/fd065460-2103-4477-8013-55636dddb886

https://github.com/user-attachments/assets/b90eb9d7-c10c-4943-988e-c533cb66ba2a

