### PR TITLE
add "Untagged" to filter addressbook peers without tags

### DIFF
--- a/flutter/lib/common/widgets/address_book.dart
+++ b/flutter/lib/common/widgets/address_book.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:bot_toast/bot_toast.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 import 'package:dynamic_layouts/dynamic_layouts.dart';
 import 'package:flutter/material.dart';
@@ -316,13 +317,14 @@ class _AddressBookState extends State<AddressBook> {
 
   Widget _buildTags() {
     return Obx(() {
-      final List tags;
+      List tags;
       if (gFFI.abModel.sortTags.value) {
         tags = gFFI.abModel.currentAbTags.toList();
         tags.sort();
       } else {
-        tags = gFFI.abModel.currentAbTags;
+        tags = gFFI.abModel.currentAbTags.toList();
       }
+      tags = [kUntagged, ...tags].toList();
       final editPermission = gFFI.abModel.current.canWrite();
       tagBuilder(String e) {
         return AddressBookTag(
@@ -669,6 +671,14 @@ class _AddressBookState extends State<AddressBook> {
         } else {
           final tags = field.trim().split(RegExp(r"[\s,;\n]+"));
           field = tags.join(',');
+          for (var t in [kUntagged, translate(kUntagged)]) {
+            if (tags.contains(t)) {
+              BotToast.showText(
+                  contentColor: Colors.red, text: 'Tag name cannot be "$t"');
+              isInProgress = false;
+              return;
+            }
+          }
           gFFI.abModel.addTags(tags);
           // final currentPeers
         }
@@ -741,12 +751,14 @@ class AddressBookTag extends StatelessWidget {
     }
 
     const double radius = 8;
+    final isUnTagged = name == kUntagged;
+    final showAction = showActionMenu && !isUnTagged;
     return GestureDetector(
       onTap: onTap,
-      onTapDown: showActionMenu ? setPosition : null,
-      onSecondaryTapDown: showActionMenu ? setPosition : null,
-      onSecondaryTap: showActionMenu ? () => _showMenu(context, pos) : null,
-      onLongPress: showActionMenu ? () => _showMenu(context, pos) : null,
+      onTapDown: showAction ? setPosition : null,
+      onSecondaryTapDown: showAction ? setPosition : null,
+      onSecondaryTap: showAction ? () => _showMenu(context, pos) : null,
+      onLongPress: showAction ? () => _showMenu(context, pos) : null,
       child: Obx(() => Container(
             decoration: BoxDecoration(
                 color: tags.contains(name)
@@ -758,17 +770,18 @@ class AddressBookTag extends StatelessWidget {
             child: IntrinsicWidth(
               child: Row(
                 children: [
-                  Container(
-                    width: radius,
-                    height: radius,
-                    decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: tags.contains(name)
-                            ? Colors.white
-                            : gFFI.abModel.getCurrentAbTagColor(name)),
-                  ).marginOnly(right: radius / 2),
+                  if (!isUnTagged)
+                    Container(
+                      width: radius,
+                      height: radius,
+                      decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: tags.contains(name)
+                              ? Colors.white
+                              : gFFI.abModel.getCurrentAbTagColor(name)),
+                    ).marginOnly(right: radius / 2),
                   Expanded(
-                    child: Text(name,
+                    child: Text(isUnTagged ? translate(name) : name,
                         style: TextStyle(
                             overflow: TextOverflow.ellipsis,
                             color: tags.contains(name) ? Colors.white : null)),

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/widgets/scroll_wrapper.dart';
+import 'package:flutter_hbb/models/ab_model.dart';
 import 'package:flutter_hbb/models/peer_tab_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
 import 'package:get/get.dart';
@@ -532,15 +533,22 @@ class AddressBookPeersView extends BasePeersView {
     if (selectedTags.isEmpty) {
       return true;
     }
+    // The result of a no-tag union with normal tags, still allows normal tags to perform union or intersection operations.
+    final selectedNormalTags =
+        selectedTags.where((tag) => tag != kUntagged).toList();
+    if (selectedTags.contains(kUntagged)) {
+      if (idents.isEmpty) return true;
+      if (selectedNormalTags.isEmpty) return false;
+    }
     if (gFFI.abModel.filterByIntersection.value) {
-      for (final tag in selectedTags) {
+      for (final tag in selectedNormalTags) {
         if (!idents.contains(tag)) {
           return false;
         }
       }
       return true;
     } else {
-      for (final tag in selectedTags) {
+      for (final tag in selectedNormalTags) {
         if (idents.contains(tag)) {
           return true;
         }

--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -33,6 +33,8 @@ bool filterAbTagByIntersection() {
 const _personalAddressBookName = "My address book";
 const _legacyAddressBookName = "Legacy address book";
 
+const kUntagged = "Untagged";
+
 enum ForcePullAb {
   listAndCurrent,
   current,
@@ -424,6 +426,7 @@ class AbModel {
 
 // #region tags
   Future<bool> addTags(List<String> tagList) async {
+    tagList.removeWhere((e) => e == kUntagged);
     final ret = await current.addTags(tagList, {});
     await pullNonLegacyAfterChange();
     _saveCache();

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "上传文件"),
         ("Clipboard is synchronized", "剪贴板已同步"),
         ("Update client clipboard", "更新客户端的粘贴板"),
+        ("Untagged", "无标签"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "Dateien hochladen"),
         ("Clipboard is synchronized", "Zwischenablage ist synchronisiert"),
         ("Update client clipboard", "Client-Zwischenablage aktualisieren"),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "Subir archivos"),
         ("Clipboard is synchronized", "Portapapeles sincronizado"),
         ("Update client clipboard", "Actualizar portapapeles del cliente"),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "Fájlok feltöltése"),
         ("Clipboard is synchronized", "A vágólap szinkronizálva van"),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "File upload"),
         ("Clipboard is synchronized", "Gli appunti sono sincronizzati"),
         ("Update client clipboard", "Aggiorna appunti client"),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "파일 업로드"),
         ("Clipboard is synchronized", "클립보드가 동기화됨"),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "Augšupielādēt failus"),
         ("Clipboard is synchronized", "Starpliktuve ir sinhronizēta"),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "Bestanden uploaden"),
         ("Clipboard is synchronized", "Klembord is gesynchroniseerd"),
         ("Update client clipboard", "Klembord van client bijwerken"),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "Wyślij pliki"),
         ("Clipboard is synchronized", "Schowek jest zsynchronizowany"),
         ("Update client clipboard", "Uaktualnij schowek klienta"),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "Загрузить файлы"),
         ("Clipboard is synchronized", "Буфер обмена синхронизирован"),
         ("Update client clipboard", "Обновить буфер обмена клиента"),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "上傳檔案"),
         ("Clipboard is synchronized", "剪貼簿已同步"),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", "Надіслати файли"),
         ("Clipboard is synchronized", "Буфер обміну синхронізовано"),
         ("Update client clipboard", "Оновити буфер обміну клієнта"),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -654,5 +654,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload files", ""),
         ("Clipboard is synchronized", ""),
         ("Update client clipboard", ""),
+        ("Untagged", ""),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
The result of a "Untagged" union with normal tags, still allows normal tags to perform union or intersection operations. When selecting a tag, the client filters peers from previously pulled data.


https://github.com/user-attachments/assets/18b4b0a9-0def-4401-97ff-0751641e375e


Ignore cases where there is an existing tag named "Untagged".


https://github.com/user-attachments/assets/b9c89a22-00e7-4b71-b183-a4fe6449a6fd


