### PR TITLE
Fix/android keyboard map mode workaround

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1019,7 +1019,7 @@ void showToast(String text, {Duration timeout = const Duration(seconds: 3)}) {
 // - Remove argument "contentPadding", no need for it, all should look the same.
 // - Remove "required" for argument "content". See simple confirm dialog "delete peer", only title and actions are used. No need to "content: SizedBox.shrink()".
 // - Make dead code alive, transform arguments "onSubmit" and "onCancel" into correspondenting buttons "ConfirmOkButton", "CancelButton".
-class CustomAlertDialog extends StatefulWidget {
+class CustomAlertDialog extends StatelessWidget {
   const CustomAlertDialog(
       {Key? key,
       this.title,
@@ -1042,66 +1042,6 @@ class CustomAlertDialog extends StatefulWidget {
   final Function()? onCancel;
 
   @override
-  CustomAlertDialogState createState() => CustomAlertDialogState(
-      title,
-      titlePadding,
-      content,
-      actions,
-      contentPadding,
-      contentBoxConstraints,
-      onSubmit,
-      onCancel);
-}
-
-class CustomAlertDialogState extends State<CustomAlertDialog> {
-  CustomAlertDialogState(
-      this.title,
-      this.titlePadding,
-      this.content,
-      this.actions,
-      this.contentPadding,
-      this.contentBoxConstraints,
-      this.onSubmit,
-      this.onCancel);
-
-  final Widget? title;
-  final EdgeInsetsGeometry? titlePadding;
-  final Widget content;
-  final List<Widget>? actions;
-  final double? contentPadding;
-  final BoxConstraints contentBoxConstraints;
-  final Function()? onSubmit;
-  final Function()? onCancel;
-  // Android only, enable soft keyboard when dialog is shown
-  bool? enableSoftKeyboard;
-
-  @override
-  void initState() {
-    super.initState();
-    if (isAndroid) {
-      gFFI.invokeMethod("enable_soft_keyboard", true);
-    }
-  }
-
-  @override
-  void dispose() {
-    if (isAndroid) {
-      // It's Ok to set `enable_soft_keyboard` to false when disposing the dialog, because no soft keyboard is shown right now.
-      // There's also a guarrantee in `RemotePage.dispose()`, `await gFFI.invokeMethod("enable_soft_keyboard", true);` is always called.
-      // So it Ok to switch back to the other UI.
-      //
-      // When connecting a physical keyboard, `KeyEvent.physicalKey.usbHidUsage` are wrong is using Microsoft SwiftKey keyboard.
-      // `window.addFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM)` is a workaround for this issue.
-      // https://github.com/flutter/flutter/issues/159384
-      // https://github.com/flutter/flutter/issues/159383
-      if (!gFFI.closed) {
-        gFFI.invokeMethod("enable_soft_keyboard", false);
-      }
-    }
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     // request focus
     FocusScopeNode scopeNode = FocusScopeNode();
@@ -1109,6 +1049,7 @@ class CustomAlertDialogState extends State<CustomAlertDialog> {
       if (!scopeNode.hasFocus) scopeNode.requestFocus();
     });
     bool tabTapped = false;
+    if (isAndroid) gFFI.invokeMethod("enable_soft_keyboard", true);
 
     return FocusScope(
       node: scopeNode,

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1019,7 +1019,7 @@ void showToast(String text, {Duration timeout = const Duration(seconds: 3)}) {
 // - Remove argument "contentPadding", no need for it, all should look the same.
 // - Remove "required" for argument "content". See simple confirm dialog "delete peer", only title and actions are used. No need to "content: SizedBox.shrink()".
 // - Make dead code alive, transform arguments "onSubmit" and "onCancel" into correspondenting buttons "ConfirmOkButton", "CancelButton".
-class CustomAlertDialog extends StatelessWidget {
+class CustomAlertDialog extends StatefulWidget {
   const CustomAlertDialog(
       {Key? key,
       this.title,
@@ -1042,6 +1042,66 @@ class CustomAlertDialog extends StatelessWidget {
   final Function()? onCancel;
 
   @override
+  CustomAlertDialogState createState() => CustomAlertDialogState(
+      title,
+      titlePadding,
+      content,
+      actions,
+      contentPadding,
+      contentBoxConstraints,
+      onSubmit,
+      onCancel);
+}
+
+class CustomAlertDialogState extends State<CustomAlertDialog> {
+  CustomAlertDialogState(
+      this.title,
+      this.titlePadding,
+      this.content,
+      this.actions,
+      this.contentPadding,
+      this.contentBoxConstraints,
+      this.onSubmit,
+      this.onCancel);
+
+  final Widget? title;
+  final EdgeInsetsGeometry? titlePadding;
+  final Widget content;
+  final List<Widget>? actions;
+  final double? contentPadding;
+  final BoxConstraints contentBoxConstraints;
+  final Function()? onSubmit;
+  final Function()? onCancel;
+  // Android only, enable soft keyboard when dialog is shown
+  bool? enableSoftKeyboard;
+
+  @override
+  void initState() {
+    super.initState();
+    if (isAndroid) {
+      gFFI.invokeMethod("enable_soft_keyboard", true);
+    }
+  }
+
+  @override
+  void dispose() {
+    if (isAndroid) {
+      // It's Ok to set `enable_soft_keyboard` to false when disposing the dialog, because no soft keyboard is shown right now.
+      // There's also a guarrantee in `RemotePage.dispose()`, `await gFFI.invokeMethod("enable_soft_keyboard", true);` is always called.
+      // So it Ok to switch back to the other UI.
+      //
+      // When connecting a physical keyboard, `KeyEvent.physicalKey.usbHidUsage` are wrong is using Microsoft SwiftKey keyboard.
+      // `window.addFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM)` is a workaround for this issue.
+      // https://github.com/flutter/flutter/issues/159384
+      // https://github.com/flutter/flutter/issues/159383
+      if (!gFFI.closed) {
+        gFFI.invokeMethod("enable_soft_keyboard", false);
+      }
+    }
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     // request focus
     FocusScopeNode scopeNode = FocusScopeNode();
@@ -1049,7 +1109,6 @@ class CustomAlertDialog extends StatelessWidget {
       if (!scopeNode.hasFocus) scopeNode.requestFocus();
     });
     bool tabTapped = false;
-    if (isAndroid) gFFI.invokeMethod("enable_soft_keyboard", true);
 
     return FocusScope(
       node: scopeNode,

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -99,6 +99,13 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
       if (gFFI.recordingModel.start) {
         showToast(translate('Automatically record outgoing sessions'));
       }
+      if (isAndroid && !keyboardVisibilityController.isVisible) {
+        // When connecting a physical keyboard, `KeyEvent.physicalKey.usbHidUsage` are wrong is using Microsoft SwiftKey keyboard.
+        // `window.addFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM)` is a workaround for this issue.
+        // https://github.com/flutter/flutter/issues/159384
+        // https://github.com/flutter/flutter/issues/159383
+        gFFI.invokeMethod("enable_soft_keyboard", false);
+      }
     });
     WidgetsBinding.instance.addObserver(this);
   }

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -26,6 +26,19 @@ import '../widgets/dialog.dart';
 
 final initText = '1' * 1024;
 
+// Workaround for Android (default input method, Microsoft SwiftKey keyboard) when using physical keyboard.
+// When connecting a physical keyboard, `KeyEvent.physicalKey.usbHidUsage` are wrong is using Microsoft SwiftKey keyboard.
+// https://github.com/flutter/flutter/issues/159384
+// https://github.com/flutter/flutter/issues/159383
+void _disableAndroidSoftKeyboard({bool? isKeyboardVisible}) {
+  if (isAndroid) {
+    if (isKeyboardVisible != true) {
+      // `enable_soft_keyboard` will be set to `true` when clicking the keyboard icon, in `openKeyboard()`.
+      gFFI.invokeMethod("enable_soft_keyboard", false);
+    }
+  }
+}
+
 class RemotePage extends StatefulWidget {
   RemotePage({Key? key, required this.id, this.password, this.isSharedPassword})
       : super(key: key);
@@ -99,13 +112,8 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
       if (gFFI.recordingModel.start) {
         showToast(translate('Automatically record outgoing sessions'));
       }
-      if (isAndroid && !keyboardVisibilityController.isVisible) {
-        // When connecting a physical keyboard, `KeyEvent.physicalKey.usbHidUsage` are wrong is using Microsoft SwiftKey keyboard.
-        // `window.addFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM)` is a workaround for this issue.
-        // https://github.com/flutter/flutter/issues/159384
-        // https://github.com/flutter/flutter/issues/159383
-        gFFI.invokeMethod("enable_soft_keyboard", false);
-      }
+      _disableAndroidSoftKeyboard(
+          isKeyboardVisible: keyboardVisibilityController.isVisible);
     });
     WidgetsBinding.instance.addObserver(this);
   }
@@ -1251,7 +1259,9 @@ void showOptions(
               toggles +
               [privacyModeWidget]),
     );
-  }, clickMaskDismiss: true, backDismiss: true);
+  }, clickMaskDismiss: true, backDismiss: true).then((value) {
+    _disableAndroidSoftKeyboard();
+  });
 }
 
 TTextMenu? getVirtualDisplayMenu(FFI ffi, String id) {
@@ -1270,7 +1280,9 @@ TTextMenu? getVirtualDisplayMenu(FFI ffi, String id) {
             children: children,
           ),
         );
-      }, clickMaskDismiss: true, backDismiss: true);
+      }, clickMaskDismiss: true, backDismiss: true).then((value) {
+        _disableAndroidSoftKeyboard();
+      });
     },
   );
 }
@@ -1312,7 +1324,9 @@ TTextMenu? getResolutionMenu(FFI ffi, String id) {
             children: children,
           ),
         );
-      }, clickMaskDismiss: true, backDismiss: true);
+      }, clickMaskDismiss: true, backDismiss: true).then((value) {
+        _disableAndroidSoftKeyboard();
+      });
     },
   );
 }

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2859,6 +2859,7 @@ class FFI {
           canvasModel.scale,
           ffiModel.pi.currentDisplay);
     }
+    imageModel.callbacksOnFirstImage.clear();
     await imageModel.update(null);
     cursorModel.clear();
     ffiModel.clear();


### PR DESCRIPTION
1. Disable soft keyboard on remote pate for Android. Workaround of this issue https://github.com/flutter/flutter/issues/159384

```
gFFI.invokeMethod("enable_soft_keyboard", false);
```

There're four case to disable soft keyboard.
  1. In `gFFI.imageModel.addCallbackOnFirstImage()`, disable if soft keyboard is not visible.
  2. The other three are after showing `CustomAlertDialog`. The soft keyboard should not show at that time.

`gFFI.invokeMethod("enable_soft_keyboard", true);` will be called on clicking the keyboard icon.

2. Clear first image callbacks on disconnect. Mobile use `gFFI`, the callbacks should be clear.

```
imageModel.callbacksOnFirstImage.clear();
```

## Tests

- [x] Android swiftkey, physical keyboard, soft keyboard
- [x] Android gboard, physical keyboard, soft keyboard

## Known issue

https://github.com/flutter/flutter/issues/157279
