### PR TITLE
feat: mobile, key help tool, more keys

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -963,17 +963,13 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
         wrap('ScrollLock', () {
           inputModel.inputKey('VK_SCROLL');
         }),
-      if (isWin || (isLinux && pi.isWayland))
+      if (isWin || isLinux)
         wrap('Pause', () {
           inputModel.inputKey('VK_PAUSE');
         }),
-      if (isWin || (isLinux && !pi.isWayland))
+      if (isWin || isLinux)
         // Maybe it's better to call it "Menu"
         // https://en.wikipedia.org/wiki/Menu_key
-        //
-        // Wayland uses evdev(https://github.com/rustdesk-org/evdev), which does not handle the Menu key properly.
-        // `Menu` results `keycode 147 (keysym 0x1008ff65, XF86MenuKB)`
-        // The actual key code is `keycode 135 (keysym 0xff67, Menu)`
         wrap('Menu', () {
           inputModel.inputKey('Apps');
         }),

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -872,6 +872,8 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
 
     final pi = gFFI.ffiModel.pi;
     final isMac = pi.platform == kPeerPlatformMacOS;
+    final isWin = pi.platform == kPeerPlatformWindows;
+    final isLinux = pi.platform == kPeerPlatformLinux;
     final modifiers = <Widget>[
       wrap('Ctrl ', () {
         setState(() => inputModel.ctrl = !inputModel.ctrl);
@@ -952,6 +954,15 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
       wrap('PgDn', () {
         inputModel.inputKey('VK_NEXT');
       }),
+      // to-do: support PrtScr on Mac
+      if (isWin || isLinux)
+        wrap('PrtScr', () {
+          inputModel.inputKey('VK_SNAPSHOT');
+        }),
+      if (isWin)
+        wrap('ScrollLock', () {
+          inputModel.inputKey('VK_SCROLL');
+        }),
       wrap('Enter', () {
         inputModel.inputKey('VK_ENTER');
       }),

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -959,9 +959,23 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
         wrap('PrtScr', () {
           inputModel.inputKey('VK_SNAPSHOT');
         }),
-      if (isWin)
+      if (isWin || isLinux)
         wrap('ScrollLock', () {
           inputModel.inputKey('VK_SCROLL');
+        }),
+      if (isWin || (isLinux && pi.isWayland))
+        wrap('Pause', () {
+          inputModel.inputKey('VK_PAUSE');
+        }),
+      if (isWin || (isLinux && !pi.isWayland))
+        // Maybe it's better to call it "Menu"
+        // https://en.wikipedia.org/wiki/Menu_key
+        //
+        // Wayland uses evdev(https://github.com/rustdesk-org/evdev), which does not handle the Menu key properly.
+        // `Menu` results `keycode 147 (keysym 0x1008ff65, XF86MenuKB)`
+        // The actual key code is `keycode 135 (keysym 0xff67, Menu)`
+        wrap('Menu', () {
+          inputModel.inputKey('Apps');
         }),
       wrap('Enter', () {
         inputModel.inputKey('VK_ENTER');

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -952,6 +952,9 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
       wrap('PgDn', () {
         inputModel.inputKey('VK_NEXT');
       }),
+      wrap('Enter', () {
+        inputModel.inputKey('VK_ENTER');
+      }),
       SizedBox(width: 9999),
       wrap('', () {
         inputModel.inputKey('VK_LEFT');

--- a/libs/enigo/src/linux/nix_impl.rs
+++ b/libs/enigo/src/linux/nix_impl.rs
@@ -345,7 +345,7 @@ fn convert_to_tfc_key(key: Key) -> Option<TFC_Key> {
         Key::Numpad9 => TFC_Key::N9,
         Key::Decimal => TFC_Key::NumpadDecimal,
         Key::Clear => TFC_Key::NumpadClear,
-        Key::Pause => TFC_Key::PlayPause,
+        Key::Pause => TFC_Key::Pause,
         Key::Print => TFC_Key::Print,
         Key::Snapshot => TFC_Key::PrintScreen,
         Key::Insert => TFC_Key::Insert,

--- a/src/client.rs
+++ b/src/client.rs
@@ -3293,6 +3293,7 @@ lazy_static::lazy_static! {
         ("VK_PRINT", Key::ControlKey(ControlKey::Print)),
         ("VK_EXECUTE", Key::ControlKey(ControlKey::Execute)),
         ("VK_SNAPSHOT", Key::ControlKey(ControlKey::Snapshot)),
+        ("VK_SCROLL", Key::ControlKey(ControlKey::Scroll)),
         ("VK_INSERT", Key::ControlKey(ControlKey::Insert)),
         ("VK_DELETE", Key::ControlKey(ControlKey::Delete)),
         ("VK_HELP", Key::ControlKey(ControlKey::Help)),

--- a/src/server/uinput.rs
+++ b/src/server/uinput.rs
@@ -247,7 +247,7 @@ pub mod service {
             (enigo::Key::Scroll, evdev::Key::KEY_SCROLLLOCK),
             (enigo::Key::NumLock, evdev::Key::KEY_NUMLOCK),
             (enigo::Key::RWin, evdev::Key::KEY_RIGHTMETA),
-            (enigo::Key::Apps, evdev::Key::KEY_MENU),
+            (enigo::Key::Apps, evdev::Key::KEY_COMPOSE),    // it's a little strange that the key is mapped to KEY_COMPOSE, not KEY_MENU
             (enigo::Key::Multiply, evdev::Key::KEY_KPASTERISK),
             (enigo::Key::Add, evdev::Key::KEY_KPPLUS),
             (enigo::Key::Subtract, evdev::Key::KEY_KPMINUS),

--- a/src/server/uinput.rs
+++ b/src/server/uinput.rs
@@ -247,7 +247,7 @@ pub mod service {
             (enigo::Key::Scroll, evdev::Key::KEY_SCROLLLOCK),
             (enigo::Key::NumLock, evdev::Key::KEY_NUMLOCK),
             (enigo::Key::RWin, evdev::Key::KEY_RIGHTMETA),
-            (enigo::Key::Apps, evdev::Key::KEY_CONTEXT_MENU),
+            (enigo::Key::Apps, evdev::Key::KEY_MENU),
             (enigo::Key::Multiply, evdev::Key::KEY_KPASTERISK),
             (enigo::Key::Add, evdev::Key::KEY_KPPLUS),
             (enigo::Key::Subtract, evdev::Key::KEY_KPMINUS),

--- a/src/server/uinput.rs
+++ b/src/server/uinput.rs
@@ -239,7 +239,7 @@ pub mod service {
             (enigo::Key::Select, evdev::Key::KEY_SELECT),
             (enigo::Key::Print, evdev::Key::KEY_PRINT),
             // (enigo::Key::Execute, evdev::Key::KEY_EXECUTE),
-            // (enigo::Key::Snapshot, evdev::Key::KEY_SNAPSHOT),
+            (enigo::Key::Snapshot, evdev::Key::KEY_SYSRQ),
             (enigo::Key::Insert, evdev::Key::KEY_INSERT),
             (enigo::Key::Help, evdev::Key::KEY_HELP),
             (enigo::Key::Sleep, evdev::Key::KEY_SLEEP),


### PR DESCRIPTION
Related https://github.com/rustdesk/rustdesk/discussions/6918

## Preview

https://github.com/user-attachments/assets/92e875d2-e786-40f9-b2a4-6faa55fca024


https://github.com/user-attachments/assets/aeffda59-8391-490c-911c-a1c5a31092ec



https://github.com/user-attachments/assets/9dcaf542-1519-48ac-b20e-16387c9338df


## Desc

1. Add `PrtScr`, `ScrollLock`, `Pause`, `Menu`, `Enter` virtual keys on mobile.
2. Fix some key mapping errors.

## Tests

- [x] Android -> Windows. `Enter`, `PrtScr`, `ScrollLock`(Excel), `Pause`, `Menu`
- [x] Android -> Linux (x11, Wayland). `Enter`, `PrtScr`, `ScrollLock`, `Pause`, `Menu`
- [x] Android -> MacOS. `Enter`
- [x] Android -> Android. `Enter`
