### PR TITLE
update flutter texture rgba renderer plugin, remove switch rgba

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1268,7 +1268,9 @@ class ImageModel with ChangeNotifier {
       rgba,
       rect?.width.toInt() ?? 0,
       rect?.height.toInt() ?? 0,
-      isWeb ? ui.PixelFormat.rgba8888 : ui.PixelFormat.bgra8888,
+      isWeb | isWindows | isLinux
+          ? ui.PixelFormat.rgba8888
+          : ui.PixelFormat.bgra8888,
     );
     if (parent.target?.id != pid) return;
     await update(image);

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -1277,10 +1277,11 @@ packages:
   texture_rgba_renderer:
     dependency: "direct main"
     description:
-      name: texture_rgba_renderer
-      sha256: cb048abdd800468ca40749ca10d1db9d1e6a055d1cde6234c05191293f0c7d61
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "42797e0f03141dc2b585f76c64a13974508058b4"
+      resolved-ref: "42797e0f03141dc2b585f76c64a13974508058b4"
+      url: "https://github.com/rustdesk-org/flutter_texture_rgba_renderer"
+    source: git
     version: "0.0.16"
   timing:
     dependency: transitive

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -91,7 +91,10 @@ dependencies:
   password_strength: ^0.2.0
   flutter_launcher_icons: ^0.13.1
   flutter_keyboard_visibility: ^5.4.0
-  texture_rgba_renderer: ^0.0.16
+  texture_rgba_renderer:
+    git:
+      url: https://github.com/rustdesk-org/flutter_texture_rgba_renderer
+      ref: 42797e0f03141dc2b585f76c64a13974508058b4
   percent_indicator: ^4.2.2
   dropdown_button2: ^2.0.0
   flutter_gpu_texture_renderer:

--- a/src/client.rs
+++ b/src/client.rs
@@ -1188,9 +1188,15 @@ impl VideoHandler {
     pub fn new(format: CodecFormat, _display: usize) -> Self {
         let luid = Self::get_adapter_luid();
         log::info!("new video handler for display #{_display}, format: {format:?}, luid: {luid:?}");
+        let rgba_format =
+            if cfg!(feature = "flutter") && (cfg!(windows) || cfg!(target_os = "linux")) {
+                ImageFormat::ABGR
+            } else {
+                ImageFormat::ARGB
+            };
         VideoHandler {
             decoder: Decoder::new(format, luid),
-            rgb: ImageRgb::new(ImageFormat::ARGB, crate::get_dst_align_rgba()),
+            rgb: ImageRgb::new(rgba_format, crate::get_dst_align_rgba()),
             texture: Default::default(),
             recorder: Default::default(),
             record: false,


### PR DESCRIPTION
https://github.com/rustdesk-org/flutter_texture_rgba_renderer/pull/1
To render RGBA textures, macOS requires BGRA format, while Windows and Linux use RGBA format. Convert to the target format directly, and make rgba image render uses the same format.
# Test

https://github.com/user-attachments/assets/c0e3f1b3-dff2-4ede-bcc0-595bfe9bfc1a

https://github.com/user-attachments/assets/ab7090c8-d5d0-4baa-aa42-77790e84c437

[linux.webm](https://github.com/user-attachments/assets/fb0493cb-d54a-4861-b062-f403d98bf7f5)

https://github.com/user-attachments/assets/81142357-0e34-4e4d-b310-64f3ba79bdd5

https://github.com/user-attachments/assets/44f28175-38bf-4b9c-8e6b-fe86a7b3e774

windows debug program, 1080p

before:
![before](https://github.com/user-attachments/assets/987a3e56-20f2-49a8-a8b5-d30ea7fd6007)

after:
![afterpng](https://github.com/user-attachments/assets/1c5b27f2-2a5a-4e97-b727-3836e0f35b99)
