### PR TITLE
Update fr.rs to fix the install tip wall of text

### DIFF
--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -145,7 +145,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Failed to make direct connection to remote desktop", "Impossible d'établir une connexion directe"),
         ("Set Password", "Définir le mot de passe"),
         ("OS Password", "Mot de passe du système d'exploitation"),
-        ("install_tip", "Vous utilisez une version non installée. En raison des restrictions UAC, en tant que terminal contrôlé, dans certains cas, il ne sera pas en mesure de contrôler la souris et le clavier ou d'enregistrer l'écran. Veuillez cliquer sur le bouton ci-dessous pour installer RustDesk au système pour éviter la question ci-dessus."),
+        ("install_tip", "RustDesk n'est pas installé, ce qui peut limiter son utilisation à cause de l'UAC. Cliquez ci-dessous pour l'installer."),
         ("Click to upgrade", "Cliquer pour mettre à niveau"),
         ("Click to download", "Cliquer pour télécharger"),
         ("Click to update", "Cliquer pour mettre à jour"),


### PR DESCRIPTION
Discussed in https://github.com/rustdesk/rustdesk/discussions/10074

Changed it to
`RustDesk n'est pas installé, ce qui peut limiter son utilisation à cause de l'UAC. Cliquez ci-dessous pour l'installer.`

Literally:
`RustDesk is not installed, which may limit its use due to UAC. Click below to install it.`