### PR TITLE
fix: repeated keys, linux as controlled side

### DIFF
--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1801,6 +1801,26 @@ class RustdeskImpl {
     throw UnimplementedError("mainMaxEncryptLen");
   }
 
+  bool mainAudioSupportLoopback({dynamic hint}) {
+    return false;
+  }
+
+  Future<String> sessionReadLocalEmptyDirsRecursiveSync(
+      {required UuidValue sessionId,
+      required String path,
+      required bool includeHidden,
+      dynamic hint}) {
+    throw UnimplementedError("mainMaxEncryptLen");
+  }
+
+  Future<void> sessionReadRemoteEmptyDirsRecursiveSync(
+      {required UuidValue sessionId,
+      required String path,
+      required bool includeHidden,
+      dynamic hint}) {
+    throw UnimplementedError("mainMaxEncryptLen");
+  }
+
   Future<void> sessionRenameFile(
       {required UuidValue sessionId,
       required int actId,

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -284,7 +284,9 @@ enum ControlKey {
 }
 
 message KeyEvent {
+  // `down` indicates the key's state(down or up).
   bool down = 1;
+  // `press` indicates a click event(down and up).
   bool press = 2;
   oneof union {
     ControlKey control_key = 3;

--- a/src/client.rs
+++ b/src/client.rs
@@ -2742,6 +2742,7 @@ fn _input_os_password(p: String, activate: bool, interface: impl Interface) {
         return;
     }
     let mut key_event = KeyEvent::new();
+    key_event.mode = KeyboardMode::Legacy.into();
     key_event.press = true;
     let mut msg_out = Message::new();
     key_event.set_seq(p);


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/6793
https://github.com/rustdesk/rustdesk/issues/10052

Remove workaround on the controlling side. Use "press" as the click flag, like "Legacy mode".

**This PR breaks web version**. The PR of the web version must be merged first. Or there will generate double letters on the controlled side when connecting from web.

## Tests

- [ ] Windows, flutter keyboard, `AltGr` is wrong.
- [ ] Web js listener, `AltGr` key generates `ControlLeft` + `AltGraph` events. Then `AltGr` + `E` cannot generate `€` on the controlled side. No proper workaround for now.

- [x] Windows -> 
  - [x] Linux x11
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] System keys
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 1 - Translate mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] System keys
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Linux Wayland(rdp)
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Linux Wayland(uinput)
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [ ] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
- [x] Linux x11
  - [x] Linux x11
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] System keys
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 1 - Translate mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] System keys
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Linux Wayland(rdp)
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Linux Wayland(uinput)
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
- [ ] MacOS
  - [x] Linux x11
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] System keys
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [ ] Input Source 1 - Translate mode
      - [ ] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
          - [x] fr-FR -> en-US
            - [ ] Dead keys
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [ ] Dead keys
      - [x] Shortcuts
      - [x] System keys
      - [x] Navigation keys
      - [x] Function keys
      - [ ] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Linux Wayland(rdp)
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Linux Wayland(uinput)
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
- [x] Web -> 
  - [x] Linux x11
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 1 - Translate mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Linux Wayland(rdp)
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Linux Wayland(uinput)
    - [x] Input Source 1 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
    - [x] Input Source 2 - Map mode
      - [x] Character keys
          - [x] en-US -> en-US
          - [x] en-US -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
          - [x] fr-FR -> en-US
          - [x] fr-FR -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
- [x] Android -> 
  - [ ] System keys (Alt + Tab, Meta)
  - [x] Linux x11
    - [x] Map mode
      - [x] Character keys
          - [x] -> en-US
          - [x] -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Linux Wayland(rdp)
    - [x] Map mode
      - [x] Character keys
          - [x] -> en-US
          - [x] -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad (**NumLock does not work**)
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Linux Wayland(uinput)
    - [x] Map mode
      - [x] Character keys
          - [x] -> en-US
          - [x] -> fr-FR
            - [x] Normal keys
            - [x] AltGr keys
            - [x] Dead keys
      - [x] Shortcuts
      - [x] Navigation keys
      - [x] Function keys
      - [x] Numeric keypad
      - [x] Lock keys
      - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793


## Note

There's also an issue of flutter(3.24.5) key event on macOS.
RustDesk cannot listen the key events when meeting the following logs.
The app must be restarted to work again.

But it's hard to reproduce.

```
Another exception was thrown: A KeyUpEvent is dispatched, but the state shows that the physical key is pressed on a different logical key. If this
occurs in real application, please report this bug to Flutter. If this occurs in unit tests, please ensure that simulated events follow Flutter's event
model as documented in `HardwareKeyboard`. This was the event: KeyUpEvent#5ce17(physicalKey: PhysicalKeyboardKey#7b545(usbHidUsage: "0x00070004",
debugName: "Key A"), logicalKey: LogicalKeyboardKey#43f11(keyId: "0x1400070004", keyLabel: "", debugName: "Key with ID 0x01400070004"), character:
null, timeStamp: 5:23:37.145293) and the recorded logical key LogicalKeyboardKey#12bb1(keyId: "0x00000061", keyLabel: "A", debugName: "Key A")
```

## TODOs

macOS -> RustDesk, "Translate mode", "CapsLock" and "Dead keys", will file another two separate PRs.