### PR TITLE
fix: android, pan, canvas, remove `toInt()`

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -1080,7 +1080,7 @@ class InputModel {
         onExit: true,
       );
 
-  static int tryGetNearestRange(int v, int min, int max, int n) {
+  static double tryGetNearestRange(double v, double min, double max, double n) {
     if (v < min && v >= min - n) {
       v = min;
     }
@@ -1138,8 +1138,8 @@ class InputModel {
         return;
       }
       evtValue = {
-        'x': pos.x,
-        'y': pos.y,
+        'x': pos.x.toInt(),
+        'y': pos.y.toInt(),
       };
     }
 
@@ -1221,8 +1221,8 @@ class InputModel {
       evt['x'] = '0';
       evt['y'] = '0';
     } else {
-      evt['x'] = '${pos.x}';
-      evt['y'] = '${pos.y}';
+      evt['x'] = '${pos.x.toInt()}';
+      evt['y'] = '${pos.y.toInt()}';
     }
 
     Map<int, String> mapButtons = {
@@ -1362,31 +1362,27 @@ class InputModel {
       y = pos.dy;
     }
 
-    var evtX = 0;
-    var evtY = 0;
-    try {
-      evtX = x.round();
-      evtY = y.round();
-    } catch (e) {
-      debugPrintStack(label: 'canvas.scale value ${canvas.scale}, $e');
-      return null;
-    }
-
     return InputModel.getPointInRemoteRect(
-        true, peerPlatform, kind, evtType, evtX, evtY, rect,
+        true, peerPlatform, kind, evtType, x, y, rect,
         buttons: buttons);
   }
 
-  static Point? getPointInRemoteRect(bool isLocalDesktop, String? peerPlatform,
-      String kind, String evtType, int evtX, int evtY, Rect rect,
+  static Point<double>? getPointInRemoteRect(
+      bool isLocalDesktop,
+      String? peerPlatform,
+      String kind,
+      String evtType,
+      double evtX,
+      double evtY,
+      Rect rect,
       {int buttons = kPrimaryMouseButton}) {
-    int minX = rect.left.toInt();
+    double minX = rect.left;
     // https://github.com/rustdesk/rustdesk/issues/6678
     // For Windows, [0,maxX], [0,maxY] should be set to enable window snapping.
-    int maxX = (rect.left + rect.width).toInt() -
+    double maxX = (rect.left + rect.width) -
         (peerPlatform == kPeerPlatformWindows ? 0 : 1);
-    int minY = rect.top.toInt();
-    int maxY = (rect.top + rect.height).toInt() -
+    double minY = rect.top;
+    double maxY = (rect.top + rect.height) -
         (peerPlatform == kPeerPlatformWindows ? 0 : 1);
     evtX = InputModel.tryGetNearestRange(evtX, minX, maxX, 5);
     evtY = InputModel.tryGetNearestRange(evtY, minY, maxY, 5);

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2184,7 +2184,7 @@ class CursorModel with ChangeNotifier {
 
     if (dx == 0 && dy == 0) return;
 
-    Point? newPos;
+    Point<double>? newPos;
     final rect = parent.target?.ffiModel.rect;
     if (rect == null) {
       // unreachable
@@ -2195,8 +2195,8 @@ class CursorModel with ChangeNotifier {
         parent.target?.ffiModel.pi.platform,
         kPointerEventKindMouse,
         kMouseEventTypeDefault,
-        (_x + dx).toInt(),
-        (_y + dy).toInt(),
+        _x + dx,
+        _y + dy,
         rect,
         buttons: kPrimaryButton);
     if (newPos == null) {
@@ -2204,8 +2204,8 @@ class CursorModel with ChangeNotifier {
     }
     dx = newPos.x - _x;
     dy = newPos.y - _y;
-    _x = newPos.x.toDouble();
-    _y = newPos.y.toDouble();
+    _x = newPos.x;
+    _y = newPos.y;
     if (tryMoveCanvasX && dx != 0) {
       parent.target?.canvasModel.panX(-dx * scale);
     }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/10084

## Preview


https://github.com/user-attachments/assets/d2089d8f-5277-4e88-a96a-3d75ce379cf2

## Desc

Use double to compare the positions, to avoid `toInt()` ro `toRound()` errors.

Pan delta may be much less than `1.0`, the max scale is `1.5`, then `(dx,dy) = delta/scale`, `(_x + dx).toInt()` will be wrong.

## Tests

- [x] Android -> Windows
- [x] Windows -> Windows. Some `int`s are changed to `double`s.
