### PR TITLE
fix: macos, input, workaround sticky `Fn`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/rustdesk-org/rdev#961d25cc00c6b3ef80f444e6a7bed9872e2c35ea"
+source = "git+https://github.com/rustdesk-org/rdev#01ac3ec8009f04f7615842b9152338844b806184"
 dependencies = [
  "cocoa 0.24.1",
  "core-foundation 0.9.4",


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/10126

https://github.com/rustdesk-org/rdev/pull/7

https://github.com/rustdesk-org/rdev/pull/8

## Desc

1. Workaround sticky `Fn` for more keys.
2. Workaround sticky `Help`. Windows/Linux/MacOS -> MacOS, Input source 1, map mode, `Insert` -> `Help`, will cause sticky `Help`, the controlling side cannot input any key, util the controlled side click any key or click the mouse.

## Tests

- [x] Windows -> macOS (x64)
- [x] Windows -> macOS (aarch64)

## Key simulation sample code

https://stackoverflow.com/questions/74938870/sticky-fn-after-home-is-simulated-programmatically-macos

```C
#include <stdio.h>
#include <Carbon/Carbon.h>

void simulate_key(CGEventSourceRef source, CGKeyCode key, bool key_down)
{
    CGEventRef event = CGEventCreateKeyboardEvent(source, key, key_down);
    // CGEventSetFlags(event, 0);
    CGEventFlags flags = CGEventGetFlags(event);
    printf("event flags: %llX\n", (int64_t)flags);
    CGEventPost(kCGSessionEventTap, event);
    CFRelease(event);
    sleep(1);
}

void print33(int code) {
    CGEventSourceRef source = CGEventSourceCreate(kCGEventSourceStatePrivate);
    
    printf("kCGEventFlagMaskAlphaShift: %llX\n", (int64_t)kCGEventFlagMaskAlphaShift);
    printf("kCGEventFlagMaskShift: %llX\n", (int64_t)kCGEventFlagMaskShift);
    printf("kCGEventFlagMaskControl: %llX\n", (int64_t)kCGEventFlagMaskControl);
    printf("kCGEventFlagMaskAlternate: %llX\n", (int64_t)kCGEventFlagMaskAlternate);
    printf("kCGEventFlagMaskCommand: %llX\n", (int64_t)kCGEventFlagMaskCommand);
    printf("kCGEventFlagMaskHelp: %llX\n", (int64_t)kCGEventFlagMaskHelp);
    printf("kCGEventFlagMaskSecondaryFn: %llX\n", (int64_t)kCGEventFlagMaskSecondaryFn);
    printf("kCGEventFlagMaskNumericPad: %llX\n", (int64_t)kCGEventFlagMaskNumericPad);
    printf("kCGEventFlagMaskNonCoalesced: %llX\n", (int64_t)kCGEventFlagMaskNonCoalesced);
    
    // sticky Fn, after clicking Home.
    simulate_key(source, code, true);
    simulate_key(source, code, false);
    
    printf("\n\nSimulate h after Home.\n");
    fflush(stdout);
    
    // Simulate h. The behavior seems Fn + h.
    simulate_key(source, kVK_ANSI_H, true);
    simulate_key(source, kVK_ANSI_H, false);
    
    // So as simulating e and d...
    
    CFRelease(source);
}

int main(int argc, const char * argv[]) {
    print33(atoi(argv[1]));
    return 0;
}
```

Test with the codes: 

https://github.com/fufesou/rdev/blob/8d7cd68cea7f765428a185f2f4b9e6ce752838dc/src/macos/simulate.rs#L26

```
64,71,79,80,96,97,98,99,100,101,103,105,106,107,109,111,113,114,115,116,117,118,119,120,121,122
129,130,131,144,145
123,124,125,126(arraw keys)
```