### PR TITLE
win7 uses soft rendering by default

### DIFF
--- a/src/platform/windows.cc
+++ b/src/platform/windows.cc
@@ -222,6 +222,11 @@ extern "C"
         return IsWindowsServer();
     }
 
+    bool is_windows_10_or_greater()
+    {
+        return IsWindows10OrGreater();
+    }
+
     HANDLE LaunchProcessWin(LPCWSTR cmd, DWORD dwSessionId, BOOL as_user, DWORD *pDwTokenPid)
     {
         HANDLE hProcess = NULL;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -479,6 +479,7 @@ extern "C" {
     fn selectInputDesktop() -> BOOL;
     fn inputDesktopSelected() -> BOOL;
     fn is_windows_server() -> BOOL;
+    fn is_windows_10_or_greater() -> BOOL;
     fn handleMask(
         out: *mut u8,
         mask: *const u8,
@@ -1557,6 +1558,11 @@ pub fn get_license_from_exe_name() -> ResultType<CustomServer> {
 #[inline]
 pub fn is_win_server() -> bool {
     unsafe { is_windows_server() > 0 }
+}
+
+#[inline]
+pub fn is_win_10_or_greater() -> bool {
+    unsafe { is_windows_10_or_greater() > 0 }
 }
 
 pub fn bootstrap() {

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -173,21 +173,36 @@ pub fn get_option<T: AsRef<str>>(key: T) -> String {
 }
 
 #[inline]
-#[cfg(target_os = "macos")]
 pub fn use_texture_render() -> bool {
-    cfg!(feature = "flutter") && LocalConfig::get_option(config::keys::OPTION_TEXTURE_RENDER) == "Y"
-}
+    #[cfg(target_os = "android")]
+    return false;
+    #[cfg(target_os = "ios")]
+    return false;
 
-#[inline]
-#[cfg(any(target_os = "windows", target_os = "linux"))]
-pub fn use_texture_render() -> bool {
-    cfg!(feature = "flutter") && LocalConfig::get_option(config::keys::OPTION_TEXTURE_RENDER) != "N"
-}
+    #[cfg(target_os = "macos")]
+    return cfg!(feature = "flutter")
+        && LocalConfig::get_option(config::keys::OPTION_TEXTURE_RENDER) == "Y";
 
-#[inline]
-#[cfg(any(target_os = "android", target_os = "ios"))]
-pub fn use_texture_render() -> bool {
-    false
+    #[cfg(target_os = "linux")]
+    return cfg!(feature = "flutter")
+        && LocalConfig::get_option(config::keys::OPTION_TEXTURE_RENDER) != "N";
+
+    #[cfg(target_os = "windows")]
+    {
+        if !cfg!(feature = "flutter") {
+            return false;
+        }
+        // https://learn.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1
+        #[cfg(debug_assertions)]
+        let default_texture = true;
+        #[cfg(not(debug_assertions))]
+        let default_texture = crate::platform::is_win_10_or_greater();
+        if default_texture {
+            LocalConfig::get_option(config::keys::OPTION_TEXTURE_RENDER) != "N"
+        } else {
+            return LocalConfig::get_option(config::keys::OPTION_TEXTURE_RENDER) == "Y";
+        }
+    }
 }
 
 #[inline]


### PR DESCRIPTION
win7 vm got black screen on remote window with texture rendering. 

## Test:
Tested  `IsWindows10OrGreater` on win7/win10/win11/windows server 2019, it's false only on win7. This function requires windows manifest, so only works on github build.