### PR TITLE
set id/relay server with a dialog

### DIFF
--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -828,11 +828,6 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
   }
 }
 
-void showServerSettings(OverlayDialogManager dialogManager) async {
-  Map<String, dynamic> options = jsonDecode(await bind.mainGetOptions());
-  showServerSettingsWithValue(ServerConfig.fromOptions(options), dialogManager);
-}
-
 void showLanguageSettings(OverlayDialogManager dialogManager) async {
   try {
     final langs = json.decode(await bind.mainGetLangs()) as List<dynamic>;


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/10145
https://github.com/rustdesk/rustdesk/discussions/7766

It is likely that refreshing TextFields during unlock triggers a Flutter bug, so it's best to place server configurations in a dialog.

https://github.com/flutter/flutter/issues/154072
https://github.com/flutter/flutter/issues/143047

## Video or screenshot

[desktop.webm](https://github.com/user-attachments/assets/a4d907cb-7e07-43c0-bdba-156645f7d2de)

![mobile](https://github.com/user-attachments/assets/3c6a4af2-4c73-4547-bc83-fa5fe629b0f5)
