### PR TITLE
fix: repeated keys, linux as controlled side

### DIFF
--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -284,7 +284,9 @@ enum ControlKey {
 }
 
 message KeyEvent {
+  // `down` indicates the key's state(down or up).
   bool down = 1;
+  // `press` indicates a click event(down and up).
   bool press = 2;
   oneof union {
     ControlKey control_key = 3;

--- a/src/client.rs
+++ b/src/client.rs
@@ -2748,6 +2748,7 @@ fn _input_os_password(p: String, activate: bool, interface: impl Interface) {
         return;
     }
     let mut key_event = KeyEvent::new();
+    key_event.mode = KeyboardMode::Legacy.into();
     key_event.press = true;
     let mut msg_out = Message::new();
     key_event.set_seq(p);


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/6793
https://github.com/rustdesk/rustdesk/issues/10052

Remove workaround on the controlling side. Use "press" as the click flag, like "Legacy mode".

## Tests

https://github.com/rustdesk/rustdesk/pull/10086

- [ ] Windows, flutter keyboard, `AltGr` is wrong.
- [ ] Web js listener, `AltGr` key generates `ControlLeft` + `AltGraph` events. Then `AltGr` + `E` cannot generate `€` on the controlled side. No proper workaround for now.

## TODOs

- [ ] macOS -> RustDesk, "Translate mode", "CapsLock" and "Dead keys", will submit another two separate PRs.

## Note

There's also an issue of flutter(3.24.5) key event on macOS.
RustDesk cannot listen the key events when meeting the following logs.
The app must be restarted to work again.

But it's hard to reproduce.

```
Another exception was thrown: A KeyUpEvent is dispatched, but the state shows that the physical key is pressed on a different logical key. If this
occurs in real application, please report this bug to Flutter. If this occurs in unit tests, please ensure that simulated events follow Flutter's event
model as documented in `HardwareKeyboard`. This was the event: KeyUpEvent#5ce17(physicalKey: PhysicalKeyboardKey#7b545(usbHidUsage: "0x00070004",
debugName: "Key A"), logicalKey: LogicalKeyboardKey#43f11(keyId: "0x1400070004", keyLabel: "", debugName: "Key with ID 0x01400070004"), character:
null, timeStamp: 5:23:37.145293) and the recorded logical key LogicalKeyboardKey#12bb1(keyId: "0x00000061", keyLabel: "A", debugName: "Key A")
```

