### PR TITLE
block remote modification, replace mouse move time with video connection count

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2784,16 +2784,7 @@ Future<void> shouldBeBlocked(RxBool block, WhetherUseRemoteBlock? use) async {
     block.value = false;
     return;
   }
-  var time0 = DateTime.now().millisecondsSinceEpoch;
-  await bind.mainCheckMouseTime();
-  Timer(const Duration(milliseconds: 120), () async {
-    var d = time0 - await bind.mainGetMouseTime();
-    if (d < 120) {
-      block.value = true;
-    } else {
-      block.value = false;
-    }
-  });
+  block.value = await bind.mainGetVideoConnCount() > 0;
 }
 
 typedef WhetherUseRemoteBlock = Future<bool> Function();

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1329,12 +1329,8 @@ class RustdeskImpl {
     throw UnimplementedError("mainCheckSuperUserPermission");
   }
 
-  Future<void> mainCheckMouseTime({dynamic hint}) {
-    throw UnimplementedError("mainCheckMouseTime");
-  }
-
-  Future<double> mainGetMouseTime({dynamic hint}) {
-    throw UnimplementedError("mainGetMouseTime");
+  Future<int> mainGetVideoConnCount({dynamic hint}) {
+    throw UnimplementedError("mainGetVideoConnCount");
   }
 
   Future<void> mainWol({required String id, dynamic hint}) {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1696,19 +1696,8 @@ pub fn main_set_unlock_pin(pin: String) -> SyncReturn<String> {
     SyncReturn(set_unlock_pin(pin))
 }
 
-pub fn main_check_mouse_time() {
-    check_mouse_time();
-}
-
-pub fn main_get_mouse_time() -> f64 {
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    {
-        get_mouse_time()
-    }
-    #[cfg(any(target_os = "android", target_os = "ios"))]
-    {
-        0.0
-    }
+pub fn main_get_video_conn_count() -> usize {
+    video_conn_count()
 }
 
 pub fn main_wol(id: String) {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -213,8 +213,6 @@ pub enum Data {
     },
     SystemInfo(Option<String>),
     ClickTime(i64),
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    MouseMoveTime(i64),
     Authorize,
     Close,
     #[cfg(target_os = "android")]
@@ -385,11 +383,6 @@ async fn handle(data: Data, stream: &mut Connection) {
         Data::ClickTime(_) => {
             let t = crate::server::CLICK_TIME.load(Ordering::SeqCst);
             allow_err!(stream.send(&Data::ClickTime(t)).await);
-        }
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        Data::MouseMoveTime(_) => {
-            let t = crate::server::MOUSE_MOVE_TIME.load(Ordering::SeqCst);
-            allow_err!(stream.send(&Data::MouseMoveTime(t)).await);
         }
         Data::Close => {
             log::info!("Receive close message");

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -76,8 +76,6 @@ lazy_static::lazy_static! {
     static ref WALLPAPER_REMOVER: Arc<Mutex<Option<WallPaperRemover>>> = Default::default();
 }
 pub static CLICK_TIME: AtomicI64 = AtomicI64::new(0);
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-pub static MOUSE_MOVE_TIME: AtomicI64 = AtomicI64::new(0);
 
 #[cfg(all(feature = "flutter", feature = "plugin_framework"))]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -1917,8 +1915,6 @@ impl Connection {
                     if self.peer_keyboard_enabled() {
                         if is_left_up(&me) {
                             CLICK_TIME.store(get_time(), Ordering::SeqCst);
-                        } else {
-                            MOUSE_MOVE_TIME.store(get_time(), Ordering::SeqCst);
                         }
                         #[cfg(target_os = "macos")]
                         self.retina.on_mouse_event(&mut me, self.display_idx);
@@ -1957,7 +1953,6 @@ impl Connection {
                     }
                     #[cfg(not(any(target_os = "android", target_os = "ios")))]
                     if self.peer_keyboard_enabled() {
-                        MOUSE_MOVE_TIME.store(get_time(), Ordering::SeqCst);
                         self.input_pointer(pde, self.inner.id());
                     }
                     self.update_auto_disconnect_timer();
@@ -2022,9 +2017,6 @@ impl Connection {
                         if is_enter(&me) {
                             CLICK_TIME.store(get_time(), Ordering::SeqCst);
                         }
-                        // https://github.com/rustdesk/rustdesk/issues/8633
-                        MOUSE_MOVE_TIME.store(get_time(), Ordering::SeqCst);
-
                         let key = match me.mode.enum_value() {
                             Ok(KeyboardMode::Map) => {
                                 Some(crate::keyboard::keycode_to_rdev_key(me.chr()))

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -366,12 +366,12 @@ impl UI {
         Value::from_iter(v)
     }
 
-    fn get_mouse_time(&self) -> f64 {
-        get_mouse_time()
+    fn start_option_status_sync(&self) {
+        start_option_status_sync();
     }
 
-    fn check_mouse_time(&self) {
-        check_mouse_time()
+    fn video_conn_count(&self) -> i32 {
+        video_conn_count() as i32
     }
 
     fn get_connect_status(&mut self) -> Value {
@@ -669,8 +669,8 @@ impl sciter::EventHandler for UI {
         fn remove_peer(String);
         fn remove_discovered(String);
         fn get_connect_status();
-        fn get_mouse_time();
-        fn check_mouse_time();
+        fn start_option_status_sync();
+        fn video_conn_count();
         fn get_recent_sessions();
         fn get_peer(String);
         fn get_fav();

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -6,6 +6,7 @@ stdout.println("is_xfce: ", is_xfce);
 view.windowMinSize = (scaleIt(560), scaleIt(300));
 
 var app;
+handler.start_option_status_sync();
 var tmp = handler.get_connect_status();
 var connect_status = tmp[0];
 var service_stopped = handler.get_option("stop-service") == "Y";
@@ -1151,7 +1152,6 @@ function showSettings() {
 }
 
 function checkConnectStatus() {
-    handler.check_mouse_time(); // trigger connection status updater
     self.timer(1s, function() {
         var tmp = handler.get_option("stop-service") == "Y";
         if (tmp != service_stopped) {
@@ -1213,13 +1213,8 @@ function self.onMouse(evt) {
 
 function check_if_overlay() {
     if (handler.get_option('allow-remote-config-modification') != 'Y') {
-        var time0 = getTime();
-        handler.check_mouse_time();
-        self.timer(120ms, function() {
-            if (!enter) return;
-            var d = time0 - handler.get_mouse_time();
-            if (d < 120) $(#overlay).style#display = 'block';
-        });
+        if (!enter) return;
+        if (handler.video_conn_count() > 0) $(#overlay).style#display = 'block';
     }
 }
 

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -43,8 +43,6 @@ pub struct UiStatus {
     pub status_num: i32,
     #[cfg(not(feature = "flutter"))]
     pub key_confirmed: bool,
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    pub mouse_time: i64,
     #[cfg(not(feature = "flutter"))]
     pub id: String,
 }
@@ -61,8 +59,6 @@ lazy_static::lazy_static! {
         status_num: 0,
         #[cfg(not(feature = "flutter"))]
         key_confirmed: false,
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        mouse_time: 0,
         #[cfg(not(feature = "flutter"))]
         id: "".to_owned(),
     }));
@@ -536,18 +532,8 @@ pub fn is_installed_lower_version() -> bool {
 }
 
 #[inline]
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-pub fn get_mouse_time() -> f64 {
-    UI_STATUS.lock().unwrap().mouse_time as f64
-}
-
-#[inline]
-pub fn check_mouse_time() {
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    {
-        let sender = SENDER.lock().unwrap();
-        allow_err!(sender.send(ipc::Data::MouseMoveTime(0)));
-    }
+pub fn video_conn_count() -> usize {
+    VIDEO_CONN_COUNT.load(Ordering::Relaxed)
 }
 
 #[inline]
@@ -1143,7 +1129,6 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
     #[cfg(not(feature = "flutter"))]
     let mut key_confirmed = false;
     let mut rx = rx;
-    let mut mouse_time = 0;
     #[cfg(not(feature = "flutter"))]
     let mut id = "".to_owned();
     #[cfg(any(
@@ -1169,11 +1154,6 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
                                     crate::ui_cm_interface::quit_cm();
                                 }
                                 break;
-                            }
-                            #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                            Ok(Some(ipc::Data::MouseMoveTime(v))) => {
-                                mouse_time = v;
-                                UI_STATUS.lock().unwrap().mouse_time = v;
                             }
                             Ok(Some(ipc::Data::Options(Some(v)))) => {
                                 *OPTIONS.lock().unwrap() = v;
@@ -1219,8 +1199,6 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
                                     status_num: x as _,
                                     #[cfg(not(feature = "flutter"))]
                                     key_confirmed: _c,
-                                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                                    mouse_time,
                                     #[cfg(not(feature = "flutter"))]
                                     id: id.clone(),
                                 };
@@ -1252,8 +1230,6 @@ async fn check_connect_status_(reconnect: bool, rx: mpsc::UnboundedReceiver<ipc:
             status_num: -1,
             #[cfg(not(feature = "flutter"))]
             key_confirmed,
-            #[cfg(not(any(target_os = "android", target_os = "ios")))]
-            mouse_time,
             #[cfg(not(feature = "flutter"))]
             id: id.clone(),
         };


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/2680#issuecomment-2520569869

If this option is set to Disable remote modification, it is disabled when an authenticated video connection exists. After this change, the controlled end cannot operate the rustdesk ui during a video connection.
CM still use click check.


https://github.com/user-attachments/assets/e37c0c53-0419-4432-a9ab-dc6ea4110d79

https://github.com/user-attachments/assets/4a4f826d-f243-4bc4-90f2-d4bd8f81394d

