### PR TITLE
fix: Android, try sync clipboard on connecting

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
@@ -306,7 +306,7 @@ class FloatingWindowService : Service(), View.OnTouchListener {
          popupMenu.menu.add(0, idShowRustDesk, 0, translate("Show RustDesk"))
          // For host side, clipboard sync
          val idSyncClipboard = 1
-         val isClipboardListenerEnabled = MainActivity.rdClipboardManager?.isListening ?: false
+         val isClipboardListenerEnabled = MainActivity.rdClipboardManager?.isCaptureStarted ?: false
          if (isClipboardListenerEnabled) {
              popupMenu.menu.add(0, idSyncClipboard, 0, translate("Update client clipboard"))
          }

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -221,6 +221,11 @@ class MainActivity : FlutterActivity() {
                     result.success(true)
 
                 }
+                "try_sync_clipboard" -> {
+                    val force = call.arguments as Boolean
+                    rdClipboardManager?.syncClipboard(true, force)
+                    result.success(true)
+                }
                 GET_START_ON_BOOT_OPT -> {
                     val prefs = getSharedPreferences(KEY_SHARED_PREFERENCES, MODE_PRIVATE)
                     result.success(prefs.getBoolean(KEY_START_ON_BOOT_OPT, false))
@@ -401,14 +406,5 @@ class MainActivity : FlutterActivity() {
     override fun onStart() {
         super.onStart()
         stopService(Intent(this, FloatingWindowService::class.java))
-    }
-
-    // For client side
-    // When swithing from other app to this app, try to sync clipboard.
-    override fun onWindowFocusChanged(hasFocus: Boolean) {
-        super.onWindowFocusChanged(hasFocus)
-        if (hasFocus) {
-            rdClipboardManager?.syncClipboard(true)
-        }
     }
 }

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -103,7 +103,6 @@ class MainActivity : FlutterActivity() {
         mainService?.let {
             unbindService(serviceConnection)
         }
-        rdClipboardManager?.rustEnableServiceClipboard(false)
         super.onDestroy()
     }
 
@@ -222,8 +221,7 @@ class MainActivity : FlutterActivity() {
 
                 }
                 "try_sync_clipboard" -> {
-                    val force = call.arguments as Boolean
-                    rdClipboardManager?.syncClipboard(true, force)
+                    rdClipboardManager?.syncClipboard(true)
                     result.success(true)
                 }
                 GET_START_ON_BOOT_OPT -> {

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -433,6 +433,7 @@ class MainService : Service() {
         checkMediaPermission()
         _isStart = true
         FFI.setFrameRawEnable("video",true)
+        MainActivity.rdClipboardManager?.setServiceStarted(_isStart)
         return true
     }
 
@@ -441,6 +442,7 @@ class MainService : Service() {
         Log.d(logTag, "Stop Capture")
         FFI.setFrameRawEnable("video",false)
         _isStart = false
+        MainActivity.rdClipboardManager?.setServiceStarted(_isStart)
         // release video
         if (reuseVirtualDisplay) {
             // The virtual display video projection can be paused by calling `setSurface(null)`.

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -433,7 +433,7 @@ class MainService : Service() {
         checkMediaPermission()
         _isStart = true
         FFI.setFrameRawEnable("video",true)
-        MainActivity.rdClipboardManager?.setServiceStarted(_isStart)
+        MainActivity.rdClipboardManager?.setCaptureStarted(_isStart)
         return true
     }
 
@@ -442,7 +442,7 @@ class MainService : Service() {
         Log.d(logTag, "Stop Capture")
         FFI.setFrameRawEnable("video",false)
         _isStart = false
-        MainActivity.rdClipboardManager?.setServiceStarted(_isStart)
+        MainActivity.rdClipboardManager?.setCaptureStarted(_isStart)
         // release video
         if (reuseVirtualDisplay) {
             // The virtual display video projection can be paused by calling `setSurface(null)`.

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/RdClipboardManager.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/RdClipboardManager.kt
@@ -96,10 +96,9 @@ class RdClipboardManager(private val clipboardManager: ClipboardManager) {
     }
 
     private val serviceClipboardListener = object : ClipboardManager.OnPrimaryClipChangedListener {
-        // One machine triggers `onPrimaryClipChanged()` twice on clipboard update in RustDesk.
-        // Another machine triggers `onPrimaryClipChanged()` once on clipboard update in RustDesk.
+        // to-do: `onPrimaryClipChanged()` is called twice on clipboard update in RustDesk.
         // But we only added the listener once.
-        // We've added the check for the same clipboard data in `checkPrimaryClip()`.
+        // Though we've added the check for the same clipboard data in `checkPrimaryClip()`.
         override fun onPrimaryClipChanged() {
             Log.d(logTag, "onPrimaryClipChanged")
             checkPrimaryClip(false, false)
@@ -155,6 +154,9 @@ class RdClipboardManager(private val clipboardManager: ClipboardManager) {
         Log.d(logTag, "updateListening: isServiceStarted: $isServiceStarted, isServiceEnabled: $isServiceEnabled, _isListening: $_isListening")
         if (isServiceStarted && isServiceEnabled) {
             if (!_isListening) {
+                // to-do: `onPrimaryClipChanged()` is called twice on clipboard update in RustDesk.
+                // But we only added the listener once.
+                // Though we've added the check for the same clipboard data in `checkPrimaryClip()`.
                 clipboardManager.addPrimaryClipChangedListener(serviceClipboardListener)
                 _isListening = true
             }

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/RdClipboardManager.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/RdClipboardManager.kt
@@ -96,6 +96,10 @@ class RdClipboardManager(private val clipboardManager: ClipboardManager) {
     }
 
     private val serviceClipboardListener = object : ClipboardManager.OnPrimaryClipChangedListener {
+        // One machine triggers `onPrimaryClipChanged()` twice on clipboard update in RustDesk.
+        // Another machine triggers `onPrimaryClipChanged()` once on clipboard update in RustDesk.
+        // But we only added the listener once.
+        // We've added the check for the same clipboard data in `checkPrimaryClip()`.
         override fun onPrimaryClipChanged() {
             Log.d(logTag, "onPrimaryClipChanged")
             checkPrimaryClip(false, false)
@@ -179,7 +183,7 @@ class RdClipboardManager(private val clipboardManager: ClipboardManager) {
             return
         }
         // Ignore the `isClipboardDataEqual()` check if it's a host sync operation.
-        // Because it's a action manually triggered by the user.
+        // Because it's an action manually triggered by the user.
         val skipSameCheck = !isClient || force
         checkPrimaryClip(isClient, skipSameCheck)
     }

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -583,14 +583,9 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
     v.add(TToggleMenu(
         value: value,
         onChanged: enabled
-            ? (value) async {
+            ? (value) {
                 if (value == null) return;
-                await bind.sessionToggleOption(sessionId: sessionId, value: option);
-                if (isAndroid) {
-                  if (!value && gFFI.serverModel.clipboardOk) {
-                    gFFI.invokeMethod("try_sync_clipboard", true);
-                  }
-                }
+                bind.sessionToggleOption(sessionId: sessionId, value: option);
               }
             : null,
         child: Text(translate('Disable clipboard'))));

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -583,9 +583,14 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
     v.add(TToggleMenu(
         value: value,
         onChanged: enabled
-            ? (value) {
+            ? (value) async {
                 if (value == null) return;
-                bind.sessionToggleOption(sessionId: sessionId, value: option);
+                await bind.sessionToggleOption(sessionId: sessionId, value: option);
+                if (isAndroid) {
+                  if (!value && gFFI.serverModel.clipboardOk) {
+                    gFFI.invokeMethod("try_sync_clipboard", true);
+                  }
+                }
               }
             : null,
         child: Text(translate('Disable clipboard'))));

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -84,7 +84,6 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
-    gFFI.serverModel.initOptionClipboard();
     gFFI.ffiModel.updateEventListener(sessionId, widget.id);
     gFFI.start(
       widget.id,
@@ -158,11 +157,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   // For client side
   // When swithing from other app to this app, try to sync clipboard.
   void trySyncClipboard() {
-    // We also check if clipboard is enabled in the "Share screen" page.
-    // Though there's one option "Disable clipboard" in the Remote page.
-    if (gFFI.serverModel.clipboardOk) {
-      gFFI.invokeMethod("try_sync_clipboard", false);
-    }
+    gFFI.invokeMethod("try_sync_clipboard");
   }
 
   @override

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -84,6 +84,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    gFFI.serverModel.initOptionClipboard();
     gFFI.ffiModel.updateEventListener(sessionId, widget.id);
     gFFI.start(
       widget.id,
@@ -145,6 +146,23 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     // The inner logic of `on_voice_call_closed` will check if the voice call is active.
     // Only one client is considered here for now.
     gFFI.chatModel.onVoiceCallClosed("End connetion");
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      trySyncClipboard();
+    }
+  }
+
+  // For client side
+  // When swithing from other app to this app, try to sync clipboard.
+  void trySyncClipboard() {
+    // We also check if clipboard is enabled in the "Share screen" page.
+    // Though there's one option "Disable clipboard" in the Remote page.
+    if (gFFI.serverModel.clipboardOk) {
+      gFFI.invokeMethod("try_sync_clipboard", false);
+    }
   }
 
   @override

--- a/flutter/lib/mobile/pages/server_page.dart
+++ b/flutter/lib/mobile/pages/server_page.dart
@@ -597,6 +597,10 @@ class _PermissionCheckerState extends State<PermissionChecker> {
                     style: const TextStyle(color: MyTheme.darkGray),
                   ))
                 ]),
+          // This options controls the clipboard sharing for both client and host. Clipboard sharing:
+          // 1. On the client side, is controlled in the remote page.(flutter -> remote_page.dart)
+          // 2. On the host side, front app is not RustDesk, is controlled in the floating ball.(kotlin -> FloatingWindowService.kt)
+          // 3. On the host side, front app is RustDesk, is controlled in the clipboard listener.(kotlin -> RdClipboardManager.kt)
           PermissionRow(translate("Enable clipboard"), serverModel.clipboardOk,
               serverModel.toggleClipboard),
         ]));

--- a/flutter/lib/mobile/pages/server_page.dart
+++ b/flutter/lib/mobile/pages/server_page.dart
@@ -597,12 +597,6 @@ class _PermissionCheckerState extends State<PermissionChecker> {
                     style: const TextStyle(color: MyTheme.darkGray),
                   ))
                 ]),
-          // This options controls the clipboard sharing for both client and host. Clipboard sharing:
-          // 1. On the client side, is controlled in the remote page.(flutter -> remote_page.dart)
-          // 2. On the host side, front app is not RustDesk, is controlled in the floating ball.(kotlin -> FloatingWindowService.kt)
-          // 3. On the host side, front app is RustDesk, is controlled in the clipboard listener.(kotlin -> RdClipboardManager.kt)
-          PermissionRow(translate("Enable clipboard"), serverModel.clipboardOk,
-              serverModel.toggleClipboard),
         ]));
   }
 }

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -30,7 +30,7 @@ class ServerModel with ChangeNotifier {
   bool _inputOk = false;
   bool _audioOk = false;
   bool _fileOk = false;
-  bool _clipboardOk = false;
+  bool? _clipboardOk;
   bool _showElevation = false;
   bool hideCm = false;
   int _connectStatus = 0; // Rendezvous Server status
@@ -60,7 +60,7 @@ class ServerModel with ChangeNotifier {
 
   bool get fileOk => _fileOk;
 
-  bool get clipboardOk => _clipboardOk;
+  bool get clipboardOk => _clipboardOk ?? false;
 
   bool get showElevation => _showElevation;
 
@@ -213,10 +213,17 @@ class ServerModel with ChangeNotifier {
     }
 
     // clipboard
-    final clipOption = await bind.mainGetOption(key: kOptionEnableClipboard);
-    _clipboardOk = clipOption != 'N';
+    await initOptionClipboard();
 
     notifyListeners();
+  }
+
+  Future<bool> initOptionClipboard() async {
+    if (_clipboardOk == null) {
+      final clipOption = await bind.mainGetOption(key: kOptionEnableClipboard);
+      _clipboardOk = clipOption != 'N';
+    }
+    return _clipboardOk ?? false;
   }
 
   updatePasswordModel() async {
@@ -323,10 +330,13 @@ class ServerModel with ChangeNotifier {
   }
 
   toggleClipboard() async {
-    _clipboardOk = !_clipboardOk;
+    if (_clipboardOk == null) {
+      await initOptionClipboard();
+    }
+    _clipboardOk = !clipboardOk;
     bind.mainSetOption(
         key: kOptionEnableClipboard,
-        value: _clipboardOk ? defaultOptionYes : 'N');
+        value: clipboardOk ? defaultOptionYes : 'N');
     notifyListeners();
   }
 

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -30,7 +30,6 @@ class ServerModel with ChangeNotifier {
   bool _inputOk = false;
   bool _audioOk = false;
   bool _fileOk = false;
-  bool? _clipboardOk;
   bool _showElevation = false;
   bool hideCm = false;
   int _connectStatus = 0; // Rendezvous Server status
@@ -59,8 +58,6 @@ class ServerModel with ChangeNotifier {
   bool get audioOk => _audioOk;
 
   bool get fileOk => _fileOk;
-
-  bool get clipboardOk => _clipboardOk ?? false;
 
   bool get showElevation => _showElevation;
 
@@ -212,18 +209,7 @@ class ServerModel with ChangeNotifier {
       _fileOk = fileOption != 'N';
     }
 
-    // clipboard
-    await initOptionClipboard();
-
     notifyListeners();
-  }
-
-  Future<bool> initOptionClipboard() async {
-    if (_clipboardOk == null) {
-      final clipOption = await bind.mainGetOption(key: kOptionEnableClipboard);
-      _clipboardOk = clipOption != 'N';
-    }
-    return _clipboardOk ?? false;
   }
 
   updatePasswordModel() async {
@@ -326,17 +312,6 @@ class ServerModel with ChangeNotifier {
     bind.mainSetOption(
         key: kOptionEnableFileTransfer,
         value: _fileOk ? defaultOptionYes : 'N');
-    notifyListeners();
-  }
-
-  toggleClipboard() async {
-    if (_clipboardOk == null) {
-      await initOptionClipboard();
-    }
-    _clipboardOk = !clipboardOk;
-    bind.mainSetOption(
-        key: kOptionEnableClipboard,
-        value: clipboardOk ? defaultOptionYes : 'N');
     notifyListeners();
   }
 

--- a/libs/scrap/src/android/ffi.rs
+++ b/libs/scrap/src/android/ffi.rs
@@ -371,14 +371,6 @@ pub fn call_clipboard_manager_update_clipboard(data: &[u8]) -> JniResult<()> {
     }
 }
 
-pub fn call_clipboard_manager_enable_service_clipboard(enable: bool) -> JniResult<()> {
-    _call_clipboard_manager(
-        "rustEnableServiceClipboard",
-        "(Z)V",
-        &[JValue::Bool(jboolean::from(enable))],
-    )
-}
-
 pub fn call_clipboard_manager_enable_client_clipboard(enable: bool) -> JniResult<()> {
     _call_clipboard_manager(
         "rustEnableClientClipboard",

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -831,17 +831,6 @@ pub fn main_show_option(_key: String) -> SyncReturn<bool> {
     SyncReturn(false)
 }
 
-#[inline]
-#[cfg(target_os = "android")]
-fn enable_server_clipboard(keyboard_enabled: &str, clip_enabled: &str) {
-    use scrap::android::ffi::call_clipboard_manager_enable_service_clipboard;
-    let keyboard_enabled =
-        config::option2bool(config::keys::OPTION_ENABLE_KEYBOARD, &keyboard_enabled);
-    let clip_enabled = config::option2bool(config::keys::OPTION_ENABLE_CLIPBOARD, &clip_enabled);
-    crate::ui_cm_interface::switch_permission_all("clipboard".to_owned(), clip_enabled);
-    let _ = call_clipboard_manager_enable_service_clipboard(keyboard_enabled && clip_enabled);
-}
-
 pub fn main_set_option(key: String, value: String) {
     #[cfg(target_os = "android")]
     if key.eq(config::keys::OPTION_ENABLE_KEYBOARD) {
@@ -849,11 +838,6 @@ pub fn main_set_option(key: String, value: String) {
             config::keys::OPTION_ENABLE_KEYBOARD,
             &value,
         ));
-        enable_server_clipboard(&value, &get_option(config::keys::OPTION_ENABLE_CLIPBOARD));
-    }
-    #[cfg(target_os = "android")]
-    if key.eq(config::keys::OPTION_ENABLE_CLIPBOARD) {
-        enable_server_clipboard(&get_option(config::keys::OPTION_ENABLE_KEYBOARD), &value);
     }
     if key.eq("custom-rendezvous-server") {
         set_option(key, value.clone());

--- a/src/server/clipboard_service.rs
+++ b/src/server/clipboard_service.rs
@@ -8,8 +8,6 @@ use crate::ipc::{self, ClipboardFile, ClipboardNonFile, Data};
 use clipboard_master::{CallbackResult, ClipboardHandler};
 #[cfg(target_os = "android")]
 use hbb_common::config::{keys, option2bool};
-#[cfg(target_os = "android")]
-use scrap::android::ffi::call_clipboard_manager_enable_service_clipboard;
 use std::{
     io,
     sync::mpsc::{channel, RecvTimeoutError, Sender},
@@ -225,23 +223,12 @@ impl Handler {
 }
 
 #[cfg(target_os = "android")]
-fn is_clipboard_enabled() -> bool {
-    let keyboard_enabled = crate::ui_interface::get_option(keys::OPTION_ENABLE_KEYBOARD);
-    let keyboard_enabled = option2bool(keys::OPTION_ENABLE_KEYBOARD, &keyboard_enabled);
-    let clip_enabled = crate::ui_interface::get_option(keys::OPTION_ENABLE_CLIPBOARD);
-    let clip_enabled = option2bool(keys::OPTION_ENABLE_CLIPBOARD, &clip_enabled);
-    keyboard_enabled && clip_enabled
-}
-
-#[cfg(target_os = "android")]
 fn run(sp: EmptyExtraFieldService) -> ResultType<()> {
-    let _res = call_clipboard_manager_enable_service_clipboard(is_clipboard_enabled());
     while sp.ok() {
         if let Some(msg) = crate::clipboard::get_clipboards_msg(false) {
             sp.send(msg);
         }
         std::thread::sleep(Duration::from_millis(INTERVAL));
     }
-    let _res = call_clipboard_manager_enable_service_clipboard(false);
     Ok(())
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1372,8 +1372,14 @@ impl Connection {
                 if !self.follow_remote_window {
                     noperms.push(NAME_WINDOW_FOCUS);
                 }
-                if !self.clipboard_enabled()
-                    || !self.peer_keyboard_enabled()
+                // Do not consider the clipboard and keyboard permissions on Android.
+                // Because syncing the clipboard on Android is manually triggered by the user in the floating ball.
+                #[cfg(target_os = "android")]
+                let keyboard_clip_noperm = self.disable_keyboard || self.disable_clipboard;
+                #[cfg(not(target_os = "android"))]
+                let keyboard_clip_noperm =
+                    !self.clipboard_enabled() || !self.peer_keyboard_enabled();
+                if keyboard_clip_noperm
                     || crate::get_builtin_option(keys::OPTION_ONE_WAY_CLIPBOARD_REDIRECTION) == "Y"
                 {
                     noperms.push(super::clipboard_service::NAME);

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -312,17 +312,6 @@ pub fn switch_permission(id: i32, name: String, enabled: bool) {
     };
 }
 
-#[inline]
-#[cfg(target_os = "android")]
-pub fn switch_permission_all(name: String, enabled: bool) {
-    for (_, client) in CLIENTS.read().unwrap().iter() {
-        allow_err!(client.tx.send(Data::SwitchPermission {
-            name: name.clone(),
-            enabled
-        }));
-    }
-}
-
 #[cfg(any(target_os = "android", target_os = "ios", feature = "flutter"))]
 #[inline]
 pub fn get_clients_state() -> String {


### PR DESCRIPTION
Fix unexpected android clipboard reading.


## Preview

https://github.com/user-attachments/assets/6caf4c34-9e17-411c-bf0c-e00d2c0f1539


https://github.com/user-attachments/assets/60488309-9881-4f23-b05b-1410e143ab74



## Desc


1. Client side. Don't trigger clipboard `client -> host` in `onWindowFocusChanged()`. Use `try_sync_clipboard` message from the remote page instead.
2. Host side. Only enable clipboard sharing when there's a connection.
3. Remove option "Enable clipboard" in the "Share screen" page.
4. Remove clipboard listener.

