### PR TITLE
Fix/windows empty file clipboard on disconn

### DIFF
--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -211,6 +211,11 @@ struct wf_clipboard
 	BOOL sync;
 	UINT32 capabilities;
 
+	// This flag is not really needed,
+	// but we can use it to double confirm that files can only be pasted after `Ctrl+C`.
+	// Not sure `is_file_descriptor_from_remote()` is engough to check all cases on all Windows.
+	BOOL copied;
+
 	size_t map_size;
 	size_t map_capacity;
 	formatMapping *format_mappings;
@@ -262,6 +267,8 @@ static UINT cliprdr_send_unlock(wfClipboard *clipboard);
 static UINT cliprdr_send_request_filecontents(wfClipboard *clipboard, UINT32 connID, const void *streamid,
 											  ULONG index, UINT32 flag, DWORD positionhigh,
 											  DWORD positionlow, ULONG request);
+
+static BOOL is_file_descriptor_from_remote();
 
 static void CliprdrDataObject_Delete(CliprdrDataObject *instance);
 
@@ -711,6 +718,11 @@ static HRESULT STDMETHODCALLTYPE CliprdrDataObject_GetData(IDataObject *This, FO
 
 	if (!clipboard)
 		return E_INVALIDARG;
+
+	// If Ctrl+C is not pressed yet, do not handle the file paste.
+	if (!clipboard->copied) {
+		return E_UNEXPECTED;
+	}
 
 	if ((idx = cliprdr_lookup_format(instance, pFormatEtc)) == -1)
 	{
@@ -1479,6 +1491,8 @@ static UINT cliprdr_send_format_list(wfClipboard *clipboard, UINT32 connID)
 
 	// send
 	rc = clipboard->context->ClientFormatList(clipboard->context, &formatList);
+	// No need to check `rc`, `copied` is only used to indicate `Ctrl+C` is pressed.
+	clipboard->copied = TRUE;
 
 	for (index = 0; index < numFormats; index++)
 	{
@@ -2321,10 +2335,19 @@ static UINT wf_cliprdr_server_format_list(CliprdrClientContext *context,
 	UINT32 i;
 	formatMapping *mapping;
 	CLIPRDR_FORMAT *format;
-	wfClipboard *clipboard = (wfClipboard *)context->Custom;
+	wfClipboard *clipboard = NULL;
+
+	if (!context || !formatList)
+		return ERROR_INTERNAL_ERROR;
+	
+	clipboard = (wfClipboard *)context->Custom;
+	if (!clipboard)
+		return ERROR_INTERNAL_ERROR;
 
 	if (!clear_format_map(clipboard))
 		return ERROR_INTERNAL_ERROR;
+
+	clipboard->copied = TRUE;
 
 	for (i = 0; i < formatList->numFormats; i++)
 	{
@@ -3060,6 +3083,19 @@ wf_cliprdr_server_file_contents_response(CliprdrClientContext *context,
 	return rc;
 }
 
+BOOL is_file_descriptor_from_remote()
+{
+	UINT fsid = 0;
+	if (IsClipboardFormatAvailable(CF_HDROP)) {
+		return FALSE;
+	}
+	fsid = RegisterClipboardFormat(CFSTR_FILEDESCRIPTORW);
+	if (IsClipboardFormatAvailable(fsid)) {
+		return TRUE;
+	}
+	return FALSE;
+}
+
 BOOL wf_cliprdr_init(wfClipboard *clipboard, CliprdrClientContext *cliprdr)
 {
 	if (!clipboard || !cliprdr)
@@ -3071,6 +3107,7 @@ BOOL wf_cliprdr_init(wfClipboard *clipboard, CliprdrClientContext *cliprdr)
 	clipboard->map_size = 0;
 	clipboard->hUser32 = LoadLibraryA("user32.dll");
 	clipboard->data_obj = NULL;
+	clipboard->copied = FALSE;
 
 	if (clipboard->hUser32)
 	{
@@ -3126,14 +3163,18 @@ BOOL wf_cliprdr_uninit(wfClipboard *clipboard, CliprdrClientContext *cliprdr)
 	if (!clipboard || !cliprdr)
 		return FALSE;
 
+	clipboard->copied = FALSE;
 	cliprdr->Custom = NULL;
 
 	/* discard all contexts in clipboard */
 	if (try_open_clipboard(clipboard->hwnd))
 	{
-		if (!EmptyClipboard())
+		if (is_file_descriptor_from_remote())
 		{
-			DEBUG_CLIPRDR("EmptyClipboard failed with 0x%x", GetLastError());
+			if (!EmptyClipboard())
+			{
+				DEBUG_CLIPRDR("EmptyClipboard failed with 0x%x", GetLastError());
+			}
 		}
 		if (!CloseClipboard())
 		{
@@ -3227,6 +3268,8 @@ BOOL wf_do_empty_cliprdr(wfClipboard *clipboard)
 		return FALSE;
 	}
 
+	clipboard->copied = FALSE;
+
 	if (WaitForSingleObject(clipboard->data_obj_mutex, INFINITE) != WAIT_OBJECT_0)
 	{
 		return FALSE;
@@ -3248,10 +3291,14 @@ BOOL wf_do_empty_cliprdr(wfClipboard *clipboard)
 			break;
 		}
 
-		if (!EmptyClipboard())
+		if (is_file_descriptor_from_remote())
 		{
-			rc = FALSE;
+			if (!EmptyClipboard())
+			{
+				rc = FALSE;
+			}
 		}
+
 		if (!CloseClipboard())
 		{
 			// critical error!!!

--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -719,7 +719,7 @@ static HRESULT STDMETHODCALLTYPE CliprdrDataObject_GetData(IDataObject *This, FO
 	if (!clipboard)
 		return E_INVALIDARG;
 
-	// If Ctrl+C is not pressed yet, do not handle the file paste.
+	// If `Ctrl+C` is not pressed yet, do not handle the file paste.
 	if (!clipboard->copied) {
 		return E_UNEXPECTED;
 	}
@@ -2288,7 +2288,9 @@ static UINT wf_cliprdr_monitor_ready(CliprdrClientContext *context,
 	if (rc != CHANNEL_RC_OK)
 		return rc;
 
-	return cliprdr_send_format_list(clipboard, monitorReady->connID);
+	return rc;
+	// Don't send format list here, because we don't want to paste files copied before the connection.
+	// return cliprdr_send_format_list(clipboard, monitorReady->connID);
 }
 
 /**

--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -719,8 +719,12 @@ static HRESULT STDMETHODCALLTYPE CliprdrDataObject_GetData(IDataObject *This, FO
 	if (!clipboard)
 		return E_INVALIDARG;
 
-	// If `Ctrl+C` is not pressed yet, do not handle the file paste.
+	// If `Ctrl+C` is not pressed yet, do not handle the file paste, and empty the clipboard.
 	if (!clipboard->copied) {
+		if (try_open_clipboard(clipboard->hwnd)) {
+			EmptyClipboard();
+			CloseClipboard();
+		}
 		return E_UNEXPECTED;
 	}
 


### PR DESCRIPTION
## Empty clipboard

https://github.com/rustdesk/rustdesk/issues/10220

### Preview

https://github.com/user-attachments/assets/99455ad4-10c1-4f74-9f47-fecd58f039bb


### Test `copied`

Without `EmptyClipboard()` on disconnect, only use `copied` flag.

https://github.com/user-attachments/assets/4d486546-aef6-46e1-9f80-1e006fdce40d



### Desc

1. Only empty clipboard if current clipboard data is "copying files from the remote". 

```
!IsClipboardFormatAvailable(CF_HDROP) && (Clipboard formats contains `CFSTR_FILEDESCRIPTORW`)
```

![image](https://github.com/user-attachments/assets/bc2f7052-7ac0-419a-b8bc-effa7d578363)

2. Use `copied` to double confirm files are not pasted before pressing `Ctrl+C`.

## Do not paste files copied before the connection

### Preview


https://github.com/user-attachments/assets/00e9fd43-2a44-4fb9-b1d5-696fb7c50706



https://github.com/user-attachments/assets/95b8a357-b284-4da4-a3e9-336ae7b7b197


### Desc

Remove `return cliprdr_send_format_list(clipboard, monitorReady->connID);` in `wf_cliprdr_monitor_ready()` to avoid paste files copied before the connection.
