### PR TITLE
fix: macos, keyboard, translate mode, capslock and deadkeys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,7 +5219,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/rustdesk-org/rdev#01ac3ec8009f04f7615842b9152338844b806184"
+source = "git+https://github.com/rustdesk-org/rdev#f9b60b1dd0f3300a1b797d7a74c116683cd232c8"
 dependencies = [
  "cocoa 0.24.1",
  "core-foundation 0.9.4",


### PR DESCRIPTION
fix: macOS -> RustDesk, translate mode

1. CapsLock
2. Dead keys
3. Forward delete

https://github.com/rustdesk-org/rdev/pull/9

https://github.com/rustdesk-org/rdev/pull/10

https://github.com/rustdesk-org/rdev/pull/11

## Tests

- [x] MacOS -> Windows
  - [x] Input Source 1 - Translate mode
    - [x] Character keys
        - [x] en-US -> en-US
        - [x] en-US -> fr-FR
          - [x] Normal keys
          - [x] AltGr keys
        - [x] fr-FR -> en-US
          - [x] Dead keys
        - [x] fr-FR -> fr-FR
          - [x] Normal keys
          - [x] AltGr keys
          - [x] Dead keys
    - [x] Shortcuts. Shift + Arrows/Home/End/Insert
    - [x] System keys
    - [x] Navigation keys
    - [x] Function keys
    - [x] Lock keys
    - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
  - [x] Input Source 1 - Map mode
    - [x] Character keys
        - [x] en-US -> en-US
        - [x] en-US -> fr-FR
          - [x] Normal keys
          - [x] AltGr keys
          - [x] Dead keys
        - [x] fr-FR -> en-US
        - [x] fr-FR -> fr-FR
          - [x] Normal keys
          - [x] AltGr keys
          - [x] Dead keys
    - [x] Shortcuts
    - [x] System keys
    - [x] Navigation keys
    - [x] Function keys
    - [x] Numeric keypad
    - [x] Lock keys
    - [x] Long press. https://github.com/rustdesk/rustdesk/issues/6793
