### PR TITLE
try fix FFmpeg amf encode hang

### DIFF
--- a/res/vcpkg/ffmpeg/patch/0008-remove-amf-loop-query.patch
+++ b/res/vcpkg/ffmpeg/patch/0008-remove-amf-loop-query.patch
@@ -1,0 +1,26 @@
+From 1440f556234d135ce58a2ef38916c6a63b05870e Mon Sep 17 00:00:00 2001
+From: 21pages <sunboeasy@gmail.com>
+Date: Sat, 14 Dec 2024 21:39:44 +0800
+Subject: [PATCH] remove amf loop query
+
+Signed-off-by: 21pages <sunboeasy@gmail.com>
+---
+ libavcodec/amfenc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/amfenc.c b/libavcodec/amfenc.c
+index f70f0109f6..a53a05b16b 100644
+--- a/libavcodec/amfenc.c
++++ b/libavcodec/amfenc.c
+@@ -886,7 +886,7 @@ int ff_amf_receive_packet(AVCodecContext *avctx, AVPacket *avpkt)
+                 av_usleep(1000);
+             }
+         }
+-    } while (block_and_wait);
++    } while (false); // already set query timeout
+ 
+     if (res_query == AMF_EOF) {
+         ret = AVERROR_EOF;
+-- 
+2.43.0.windows.1
+

--- a/res/vcpkg/ffmpeg/portfile.cmake
+++ b/res/vcpkg/ffmpeg/portfile.cmake
@@ -23,6 +23,7 @@ vcpkg_from_github(
     patch/0005-mediacodec-changing-bitrate.patch
     patch/0006-dlopen-libva.patch
     patch/0007-fix-linux-configure.patch
+    patch/0008-remove-amf-loop-query.patch
 )
 
 if(SOURCE_PATH MATCHES " ")


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/5609#issuecomment-2536362667

## Possible Causes
 
* GPU API Call Hangs: This could occur, though it's less likely.
* Infinite Loop: If `QueryOutput` always fails and `hwsurfaces_in_queue_max` is zero (because we set `initial_pool_size` to 1,https://github.com/FFmpeg/FFmpeg/blob/b08d7969c550a804a59511c7b83f2dd8cc0499b8/libavcodec/amfenc.c#L332), the loop will continue indefinitely. https://github.com/FFmpeg/FFmpeg/blob/b08d7969c550a804a59511c7b83f2dd8cc0499b8/libavcodec/amfenc.c#L865. This pr fix this condition.

![hwsurfaces_in_queue_max](https://github.com/user-attachments/assets/b52b78ec-4493-49a0-8976-fd72680f3749)


## Fix
  * A query_timeout [patch ](https://github.com/rustdesk/rustdesk/blob/master/res/vcpkg/ffmpeg/patch/0001-avcodec-amfenc-add-query_timeout-option-for-h264-hev.patch)has been added to FFmpeg with a value of 1000ms, which exceeds the time required to encode a single frame. This allows us to remove the loop.

![6e5f560796c3b5a0512d14b62b80db6](https://github.com/user-attachments/assets/be67c24c-f508-4e06-92e8-fe2074044322)


## Test
  * After removing the loop, no frame encoding failures were encountered during testing. A single call to QueryOutput is sufficient, as it typically consumes about 12ms on a 2K screen.
 

![QueryOutput](https://github.com/user-attachments/assets/f2c86157-d4cc-463e-a360-b4cab03d0e45)
