### PR TITLE
Flathub badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ RustDesk welcomes contribution from everyone. See [CONTRIBUTING.md](docs/CONTRIB
 [<img src="https://f-droid.org/badge/get-it-on.png"
     alt="Get it on F-Droid"
     height="80">](https://f-droid.org/en/packages/com.carriez.flutter_hbb)
-[<img src="https://flathub.org/api/badge?locale=en"
+[<img src="https://flathub.org/api/badge?svg&locale=en"
     alt="Get it on Flathub"
     height="80">](https://flathub.org/apps/com.rustdesk.RustDesk)
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ RustDesk welcomes contribution from everyone. See [CONTRIBUTING.md](docs/CONTRIB
 
 [**NIGHTLY BUILD**](https://github.com/rustdesk/rustdesk/releases/tag/nightly)
 
-[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
+[<img src="https://f-droid.org/badge/get-it-on.png"
     alt="Get it on F-Droid"
     height="80">](https://f-droid.org/en/packages/com.carriez.flutter_hbb)
+[<img src="https://flathub.org/api/badge?locale=en"
+    alt="Get it on Flathub"
+    height="80">](https://flathub.org/apps/com.rustdesk.RustDesk)
 
 ## Dependencies
 


### PR DESCRIPTION
Hello @rustdesk,

Your Flathub package is now verified and the builds are consistent. I think it would be beneficial to add a Flathub badge to your README file to reflect this. You can find the badge source at [Flathub Badges](https://flathub.org/badges).

This addition would provide a clear visual indicator of your package's status and make it easier for users to verify its authenticity.

I have also checked the [source of the F-Droid badge](https://gitlab.com/fdroid/artwork/tree/master/badge) and updated it too.