### PR TITLE
refact: linux, chcon, bin_t

### DIFF
--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -59,6 +59,15 @@ cp /usr/share/rustdesk/files/rustdesk.service /etc/systemd/system/rustdesk.servi
 cp /usr/share/rustdesk/files/rustdesk.desktop /usr/share/applications/
 cp /usr/share/rustdesk/files/rustdesk-link.desktop /usr/share/applications/
 ln -s /usr/lib/rustdesk/rustdesk /usr/bin/rustdesk
+# Change the security context of /usr/lib/rustdesk/rustdesk from `lib_t` to `bin_t`.
+if command -v getenforce >/dev/null 2>&1; then
+  if [ "$(getenforce)" == "Enforcing" ]; then
+    file_security_context=$(ls -lZ /usr/lib/rustdesk/rustdesk 2>/dev/null | awk -F':' '{print $3}')
+    if [ "${file_security_context}" == "lib_t" ]; then
+      chcon -t bin_t /usr/lib/rustdesk/rustdesk || true
+    fi
+  fi
+fi
 systemctl daemon-reload
 systemctl enable rustdesk
 systemctl start rustdesk

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -63,6 +63,15 @@ esac
 cp /usr/share/rustdesk/files/rustdesk.service /etc/systemd/system/rustdesk.service
 cp /usr/share/rustdesk/files/rustdesk.desktop /usr/share/applications/
 cp /usr/share/rustdesk/files/rustdesk-link.desktop /usr/share/applications/
+# Change the security context of /usr/lib/rustdesk/rustdesk from `lib_t` to `bin_t`.
+if command -v getenforce >/dev/null 2>&1; then
+  if [ "$(getenforce)" == "Enforcing" ]; then
+    file_security_context=$(ls -lZ /usr/lib/rustdesk/rustdesk 2>/dev/null | awk -F':' '{print $3}')
+    if [ "${file_security_context}" == "lib_t" ]; then
+      chcon -t bin_t /usr/lib/rustdesk/rustdesk || true
+    fi
+  fi
+fi
 systemctl daemon-reload
 systemctl enable rustdesk
 systemctl start rustdesk


### PR DESCRIPTION
Fix SELinux limits on Fedora.

https://github.com/rustdesk/rustdesk/issues/6116
https://github.com/rustdesk/rustdesk/issues/4267
https://github.com/rustdesk/rustdesk/issues/7107
https://github.com/rustdesk/rustdesk/issues/5458
https://github.com/rustdesk/rustdesk/issues/5098
https://github.com/rustdesk/rustdesk/issues/7164
https://github.com/rustdesk/rustdesk/issues/6301


## Desc

Change the security context of `/usr/lib/rustdesk/rustdesk` from `lib_t` to `bin_t`.

Then the process security context will be `system_u:system_r:unconfined_service_t:s0`.

Although the service spec uses `/usr/bin/rustdesk` and the security context of the soft symlink is `bin_t`. The process actually uses the security context of `/usr/lib/rustdesk/rustdesk`.

All distros can apply the following changes. But we only do it for `rpm` packages for now.
Because the other distros dose not support `chcon` well (or maybe SELinux) for now.

```bash
# Change the security context of /usr/lib/rustdesk/rustdesk from `lib_t` to `bin_t`.
if command -v getenforce >/dev/null 2>&1; then
  if [ "$(getenforce)" == "Enforcing" ]; then
    file_security_context=$(ls -lZ /usr/lib/rustdesk/rustdesk 2>/dev/null | awk -F':' '{print $3}')
    if [ "${file_security_context}" == "lib_t" ]; then
      chcon -t bin_t /usr/lib/rustdesk/rustdesk || true
    fi
  fi
fi
```

The above code can also be applied to Ubuntu, openSUSE, Archlinux. But it takes no effect.
1. SELinux is not enabled by default, even command `getenforce` is not included.
2. `ls -lZ /usr/lib/rustdesk/rustdesk` results no security context
  `-rwxr-xr-x 1 root root ? 19184 Sep 20 14:10 /usr/lib/rustdesk//rustdesk`
3. `chcon -t bin_t /usr/lib/rustdesk/rustdesk` results errors.
  `chcon: can't apply partial context to unlabeled file '/usr/lib/rustdesk/rustdesk'`
  `chcon: failed to get security context of '/usr/lib/rustdesk/rustdesk': Operation not supported`


This documentation may no longer be needed https://rustdesk.com/docs/en/client/linux/selinux/.

## Tests

1. debian 12.7.0, Ubuntu 24.04, openSUSE Leap 15.6.

```
# ps -eZ | grep rustdesk
unconfined                          587 ?        00:00:01 rustdesk
# ls -lZ | /usr/lib/rustdesk/rustdesk
-rwxr-xr-x 1 root root ? 26096 Nov 26 08:31 /usr/lib/rustdesk/rustdesk
# chcon -t bin_t /usr/lib/rustdesk/rustdesk
chcon: can't apply partial context to unlabeled file '/usr/lib/rustdesk/rustdesk'
```

2. Fedora 37, Fedora 40, Fedora 41, CentOS-8-5-2111 (before)

```
# ps -eZ | grep rustdesk
system_u:system_r:init_t:s0         965 ?        00:00:00 rustdesk
# ls -lZ | /usr/lib/rustdesk/rustdesk
-rwxr-xr-x. 1 root root system_u:object_r:lib_t:s0 30608 Dec  5 19:01 /usr/lib/rustdesk/rustdesk
```

3. Fedora 37, Fedora 40, Fedora 41, CentOS-8-5-2111 (after)

```
# ps -eZ | grep rustdesk
system_u:system_r:unconfined_service_t:s0 3442 ? 00:00:00 rustdesk
# ls -lZ | /usr/lib/rustdesk/rustdesk
-rwxr-xr-x. 1 root root system_u:object_r:bin_t:s0 30608 Dec 16 10:26 /usr/lib/rustdesk/rustdesk
```

5. `deb` package with the adding code in `postinst`. Installation is done, nothing changes.


## Refs

1. https://documentation.suse.com/en-us/sle-micro/5.5/html/SLE-Micro-all/cha-selinux-slemicro.html#id-1.7.3.10.5:~:text=ls%20%2DZ,PATH
2. https://www.dbi-services.com/blog/selinux-setup-and-configuration-for-linux/#:~:text=Here%20is%20a%20list%20of%20the%20most%20used%20SELinux%20security%20context%20types%3A