### PR TITLE
fix auto record outgoing sessions ignore record permission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3065,7 +3065,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "hwcodec"
 version = "0.7.1"
-source = "git+https://github.com/rustdesk-org/hwcodec#7ee119a58b6ee6ca255a438af69ad0785ba44797"
+source = "git+https://github.com/rustdesk-org/hwcodec#6376b41da010b87ae984e843cedca2b52c79b1cd"
 dependencies = [
  "bindgen 0.59.2",
  "cc",

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1,3 +1,5 @@
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+use crate::keyboard::input_source::{change_input_source, get_cur_session_input_source};
 use crate::{
     client::file_trait::FileManager,
     common::{make_fd_to_json, make_vec_fd_to_json},
@@ -6,11 +8,6 @@ use crate::{
     },
     input::*,
     ui_interface::{self, *},
-};
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-use crate::{
-    common::get_default_sound_input,
-    keyboard::input_source::{change_input_source, get_cur_session_input_source},
 };
 use flutter_rust_bridge::{StreamSink, SyncReturn};
 #[cfg(feature = "plugin_framework")]

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -390,16 +390,11 @@ impl<T: InvokeUiSession> Session<T> {
     }
 
     pub fn record_screen(&self, start: bool) {
-        let mut misc = Misc::new();
-        misc.set_client_record_status(start);
-        let mut msg = Message::new();
-        msg.set_misc(misc);
-        self.send(Data::Message(msg));
         self.send(Data::RecordScreen(start));
     }
 
     pub fn is_recording(&self) -> bool {
-        self.lc.read().unwrap().record
+        self.lc.read().unwrap().record_state
     }
 
     pub fn save_custom_image_quality(&self, custom_image_quality: i32) {


### PR DESCRIPTION
1. Fix auto record outgoing sessions ignore record permission
2. Stop record if record permission changed
3. Update hwcodec
4. Make video thread finish faster when connection closed

Video: not auto record if no permission and stop record if permission changed

https://github.com/user-attachments/assets/29328643-a8ac-433d-9a0b-dff7faa6c7a1

https://doc.rust-lang.org/std/sync/mpsc/struct.Receiver.html#method.recv

![image](https://github.com/user-attachments/assets/2c5cd731-5169-4ca7-b620-3e501dfaf246)


![channel](https://github.com/user-attachments/assets/ef90efb1-4d6e-4ad9-93f4-7856a75083d9)
