### PR TITLE
Fix for Docker Build failure  due to minimum  Cmake version update and arm based compilation of vcpkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:bullseye-slim
 
 WORKDIR /
 ARG DEBIAN_FRONTEND=noninteractive
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
 RUN apt update -y && \
     apt install --yes --no-install-recommends \
         g++ \
@@ -21,7 +22,8 @@ RUN apt update -y && \
         libpam0g-dev \
         libpulse-dev \
         make \
-        cmake \
+        wget \
+        libssl-dev \
         unzip \
         zip \
         sudo \
@@ -30,6 +32,13 @@ RUN apt update -y && \
         ca-certificates \
         ninja-build && \
         rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.30.6/cmake-3.30.6.tar.gz --no-check-certificate && \
+    tar xzf cmake-3.30.6.tar.gz && \
+    cd cmake-3.30.6 && \
+    ./configure  --prefix=/usr/local && \
+    make && \
+    make install
 
 RUN git clone --branch 2023.04.15 --depth=1 https://github.com/microsoft/vcpkg && \
     /vcpkg/bootstrap-vcpkg.sh -disableMetrics && \


### PR DESCRIPTION
two fixes are here with Dockerfile

1. Minimum Cmake version requirement for rustdesk is now 3.21, However default cmake given by base image debian bullseye-slim is 3.18 https://packages.debian.org/source/bullseye/cmake, so docker build used to fail earlier, now using cmake built from source 3.30 for long term purpose.
2. Second fix, for ARM based system environment variable  should be VCPKG_FORCE_SYSTEM_BINARIES=1, otherwise docker build will fail on arm based system like macos m1,m2 m3 etc.


wget is needed to fetch cmake from source.
libssl-dev is dependency for cmake3.30.

with this change Docker build gets succesful on macos 
