### PR TITLE
fix: android, mouse mode, right menu, unexpected click

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -339,7 +339,9 @@ class _RawTouchGestureDetectorRegionState
     if (isDesktop || isWebDesktop) {
       ffi.cursorModel.clearRemoteWindowCoords();
     }
-    await inputModel.sendMouse('up', MouseButtons.left);
+    if (handleTouch) {
+        await inputModel.sendMouse('up', MouseButtons.left);
+    }
   }
 
   // scale + pan event


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/5345#discussioncomment-11595216


## Desc

mobile -> Windows, mouse mode.

After the right menu is displayed, `onOneFingerPanEnd()` triggers `await inputModel.sendMouse('up', MouseButtons.left);`.

Some applications (such as chrome and vscode) can handle the Up event, which behaves the same as a click.

Although Windows system does not handle this event.

vscode on linux and macOS do no have this issue.

## Tests

- [x] Android -> Windows, mouse mode. Mouse movement. `onOneFingerPanStart()`, `onOneFingerPanUpdate()`, `onOneFingerPanEnd()`
- [x] Android -> Windows, mouse mode. Hod and drag. `onHoldDragStart()`, `onHoldDragUpdate()`, `onHoldDragEnd()`

