### PR TITLE
refactor: replace &PathBuf with &Path to enhance generality

### DIFF
--- a/libs/clipboard/src/platform/unix/local_file.rs
+++ b/libs/clipboard/src/platform/unix/local_file.rs
@@ -3,7 +3,7 @@ use std::{
     fs::File,
     io::{BufRead, BufReader, Read, Seek},
     os::unix::prelude::PermissionsExt,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
     time::SystemTime,
 };
@@ -51,7 +51,7 @@ pub(super) struct LocalFile {
 }
 
 impl LocalFile {
-    pub fn try_open(path: &PathBuf) -> Result<Self, CliprdrError> {
+    pub fn try_open(path: &Path) -> Result<Self, CliprdrError> {
         let mt = std::fs::metadata(path).map_err(|e| CliprdrError::FileError {
             path: path.clone(),
             err: e,
@@ -219,7 +219,7 @@ impl LocalFile {
 
 pub(super) fn construct_file_list(paths: &[PathBuf]) -> Result<Vec<LocalFile>, CliprdrError> {
     fn constr_file_lst(
-        path: &PathBuf,
+        path: &Path,
         file_list: &mut Vec<LocalFile>,
         visited: &mut HashSet<PathBuf>,
     ) -> Result<(), CliprdrError> {

--- a/libs/clipboard/src/platform/unix/mod.rs
+++ b/libs/clipboard/src/platform/unix/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{mpsc::Sender, Arc},
     time::Duration,
 };
@@ -74,7 +74,7 @@ trait SysClipboard: Send + Sync {
 }
 
 #[cfg(target_os = "linux")]
-fn get_sys_clipboard(ignore_path: &PathBuf) -> Result<Box<dyn SysClipboard>, CliprdrError> {
+fn get_sys_clipboard(ignore_path: &Path) -> Result<Box<dyn SysClipboard>, CliprdrError> {
     #[cfg(feature = "wayland")]
     {
         unimplemented!()
@@ -88,7 +88,7 @@ fn get_sys_clipboard(ignore_path: &PathBuf) -> Result<Box<dyn SysClipboard>, Cli
 }
 
 #[cfg(target_os = "macos")]
-fn get_sys_clipboard(ignore_path: &PathBuf) -> Result<Box<dyn SysClipboard>, CliprdrError> {
+fn get_sys_clipboard(ignore_path: &Path) -> Result<Box<dyn SysClipboard>, CliprdrError> {
     use ns_clipboard::*;
     let ns_pb = NsPasteboard::new(ignore_path)?;
     Ok(Box::new(ns_pb) as Box<_>)

--- a/libs/clipboard/src/platform/unix/ns_clipboard.rs
+++ b/libs/clipboard/src/platform/unix/ns_clipboard.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeSet, path::PathBuf};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 use cacao::pasteboard::{Pasteboard, PasteboardName};
 use hbb_common::log;
@@ -30,7 +33,7 @@ pub struct NsPasteboard {
 }
 
 impl NsPasteboard {
-    pub fn new(ignore_path: &PathBuf) -> Result<Self, CliprdrError> {
+    pub fn new(ignore_path: &Path) -> Result<Self, CliprdrError> {
         Ok(Self {
             ignore_path: ignore_path.to_owned(),
             former_file_list: Mutex::new(vec![]),

--- a/libs/clipboard/src/platform/unix/url.rs
+++ b/libs/clipboard/src/platform/unix/url.rs
@@ -7,7 +7,7 @@ use crate::CliprdrError;
 // url encode and decode is needed
 const ENCODE_SET: percent_encoding::AsciiSet = percent_encoding::CONTROLS.add(b' ').remove(b'/');
 
-pub(super) fn encode_path_to_uri(path: &PathBuf) -> io::Result<String> {
+pub(super) fn encode_path_to_uri(path: &Path) -> io::Result<String> {
     let encoded =
         percent_encoding::percent_encode(path.to_str()?.as_bytes(), &ENCODE_SET).to_string();
     format!("file://{}", encoded)

--- a/libs/clipboard/src/platform/unix/x11.rs
+++ b/libs/clipboard/src/platform/unix/x11.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeSet, path::PathBuf};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 use hbb_common::log;
 use once_cell::sync::OnceCell;
@@ -26,7 +29,7 @@ pub struct X11Clipboard {
 }
 
 impl X11Clipboard {
-    pub fn new(ignore_path: &PathBuf) -> Result<Self, CliprdrError> {
+    pub fn new(ignore_path: &Path) -> Result<Self, CliprdrError> {
         let clipboard = get_clip()?;
         let text_uri_list = clipboard
             .setter

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -123,7 +123,7 @@ pub fn get_home_as_string() -> String {
 }
 
 fn read_dir_recursive(
-    path: &PathBuf,
+    path: &Path,
     prefix: &Path,
     include_hidden: bool,
 ) -> ResultType<Vec<FileEntry>> {
@@ -186,7 +186,7 @@ pub fn get_recursive_files(path: &str, include_hidden: bool) -> ResultType<Vec<F
 }
 
 fn read_empty_dirs_recursive(
-    path: &PathBuf,
+    path: &Path,
     prefix: &Path,
     include_hidden: bool,
 ) -> ResultType<Vec<FileDirectory>> {
@@ -854,7 +854,7 @@ pub async fn handle_read_jobs(
     Ok(job_log)
 }
 
-pub fn remove_all_empty_dir(path: &PathBuf) -> ResultType<()> {
+pub fn remove_all_empty_dir(path: &Path) -> ResultType<()> {
     let fd = read_dir(path, true)?;
     for entry in fd.entries.iter() {
         match entry.entry_type.enum_value() {

--- a/libs/portable/src/bin_reader.rs
+++ b/libs/portable/src/bin_reader.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::{self},
     io::{Cursor, Read},
-    path::PathBuf,
+    path::Path,
 };
 
 #[cfg(windows)]
@@ -42,7 +42,7 @@ impl BinaryData {
         buf
     }
 
-    pub fn write_to_file(&self, prefix: &PathBuf) {
+    pub fn write_to_file(&self, prefix: &Path) {
         let p = prefix.join(&self.path);
         if let Some(parent) = p.parent() {
             if !parent.exists() {
@@ -122,7 +122,7 @@ impl BinaryReader {
     }
 
     #[cfg(linux)]
-    pub fn configure_permission(&self, prefix: &PathBuf) {
+    pub fn configure_permission(&self, prefix: &Path) {
         use std::os::unix::prelude::PermissionsExt;
 
         let exe_path = prefix.join(&self.exe);

--- a/libs/portable/src/main.rs
+++ b/libs/portable/src/main.rs
@@ -1,7 +1,7 @@
 #![windows_subsystem = "windows"]
 
 use std::{
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
@@ -22,7 +22,7 @@ const APPNAME_RUNTIME_ENV_KEY: &str = "RUSTDESK_APPNAME";
 #[cfg(windows)]
 const SET_FOREGROUND_WINDOW_ENV_KEY: &str = "SET_FOREGROUND_WINDOW";
 
-fn is_timestamp_matches(dir: &PathBuf, ts: &mut u64) -> bool {
+fn is_timestamp_matches(dir: &Path, ts: &mut u64) -> bool {
     let Ok(app_metadata) = std::str::from_utf8(APP_METADATA) else {
         return true;
     };
@@ -50,7 +50,7 @@ fn is_timestamp_matches(dir: &PathBuf, ts: &mut u64) -> bool {
     false
 }
 
-fn write_meta(dir: &PathBuf, ts: u64) {
+fn write_meta(dir: &Path, ts: u64) {
     let meta_file = dir.join(APP_METADATA_CONFIG);
     if ts != 0 {
         let content = format!("{}{}", META_LINE_PREFIX_TIMESTAMP, ts);
@@ -169,13 +169,13 @@ fn main() {
 
 #[cfg(windows)]
 mod windows {
-    use std::{fs, os::windows::process::CommandExt, path::PathBuf, process::Command};
+    use std::{fs, os::windows::process::CommandExt, path::Path, process::Command};
 
     // Used for privacy mode(magnifier impl).
     pub const RUNTIME_BROKER_EXE: &'static str = "C:\\Windows\\System32\\RuntimeBroker.exe";
     pub const WIN_TOPMOST_INJECTED_PROCESS_EXE: &'static str = "RuntimeBroker_rustdesk.exe";
 
-    pub(super) fn copy_runtime_broker(dir: &PathBuf) {
+    pub(super) fn copy_runtime_broker(dir: &Path) {
         let src = RUNTIME_BROKER_EXE;
         let tgt = WIN_TOPMOST_INJECTED_PROCESS_EXE;
         let target_file = dir.join(tgt);

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -27,7 +27,7 @@ use include_dir::{include_dir, Dir};
 use objc::rc::autoreleasepool;
 use objc::{class, msg_send, sel, sel_impl};
 use scrap::{libc::c_void, quartz::ffi::*};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 static PRIVILEGES_SCRIPTS_DIR: Dir =
     include_dir!("$CARGO_MANIFEST_DIR/src/platform/privileges_scripts");
@@ -661,7 +661,7 @@ pub fn hide_dock() {
 }
 
 #[inline]
-fn get_server_start_time_of(p: &Process, path: &PathBuf) -> Option<i64> {
+fn get_server_start_time_of(p: &Process, path: &Path) -> Option<i64> {
     let cmd = p.cmd();
     if cmd.len() <= 1 {
         return None;
@@ -679,7 +679,7 @@ fn get_server_start_time_of(p: &Process, path: &PathBuf) -> Option<i64> {
 }
 
 #[inline]
-fn get_server_start_time(sys: &mut System, path: &PathBuf) -> Option<(i64, Pid)> {
+fn get_server_start_time(sys: &mut System, path: &Path) -> Option<(i64, Pid)> {
     sys.refresh_processes_specifics(ProcessRefreshKind::new());
     for (_, p) in sys.processes() {
         if let Some(t) = get_server_start_time_of(p, path) {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1460,15 +1460,13 @@ fn to_le(v: &mut [u16]) -> &[u8] {
     unsafe { v.align_to().1 }
 }
 
-fn get_undone_file(tmp: &PathBuf) -> ResultType<PathBuf> {
-    let mut tmp1 = tmp.clone();
-    tmp1.set_file_name(format!(
+fn get_undone_file(tmp: &Path) -> ResultType<PathBuf> {
+    Ok(tmp.with_file_name(format!(
         "{}.undone",
         tmp.file_name()
             .ok_or(anyhow!("Failed to get filename of {:?}", tmp))?
             .to_string_lossy()
-    ));
-    Ok(tmp1)
+    )))
 }
 
 fn run_cmds(cmds: String, show: bool, tip: &str) -> ResultType<()> {
@@ -1933,7 +1931,7 @@ pub fn create_process_with_logon(user: &str, pwd: &str, exe: &str, arg: &str) ->
     return Ok(());
 }
 
-pub fn set_path_permission(dir: &PathBuf, permission: &str) -> ResultType<()> {
+pub fn set_path_permission(dir: &Path, permission: &str) -> ResultType<()> {
     std::process::Command::new("icacls")
         .arg(dir.as_os_str())
         .arg("/grant")

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -452,7 +452,7 @@ pub(super) mod install {
     use std::{
         fs::File,
         io::{BufReader, BufWriter, Write},
-        path::PathBuf,
+        path::Path,
     };
     use zip::ZipArchive;
 
@@ -488,7 +488,7 @@ pub(super) mod install {
         Ok(())
     }
 
-    fn download_file(id: &str, url: &str, filename: &PathBuf) -> bool {
+    fn download_file(id: &str, url: &str, filename: &Path) -> bool {
         let file = match File::create(filename) {
             Ok(f) => f,
             Err(e) => {
@@ -505,7 +505,7 @@ pub(super) mod install {
         true
     }
 
-    fn do_install_file(filename: &PathBuf, target_dir: &PathBuf) -> ResultType<()> {
+    fn do_install_file(filename: &Path, target_dir: &Path) -> ResultType<()> {
         let mut zip = ZipArchive::new(BufReader::new(File::open(filename)?))?;
         for i in 0..zip.len() {
             let mut file = zip.by_index(i)?;

--- a/src/plugin/plugins.rs
+++ b/src/plugin/plugins.rs
@@ -13,7 +13,7 @@ use serde_derive::Serialize;
 use std::{
     collections::{HashMap, HashSet},
     ffi::{c_char, c_void},
-    path::PathBuf,
+    path::Path,
     sync::{Arc, RwLock},
 };
 
@@ -299,7 +299,7 @@ pub(super) fn load_plugins(uninstalled_ids: &HashSet<String>) -> ResultType<()> 
     Ok(())
 }
 
-fn load_plugin_dir(dir: &PathBuf) {
+fn load_plugin_dir(dir: &Path) {
     log::debug!("Begin load plugin dir: {}", dir.display());
     if let Ok(rd) = std::fs::read_dir(dir) {
         for entry in rd {

--- a/src/server/portable_service.rs
+++ b/src/server/portable_service.rs
@@ -15,7 +15,7 @@ use shared_memory::*;
 use std::{
     mem::size_of,
     ops::{Deref, DerefMut},
-    path::PathBuf,
+    path::Path,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -92,7 +92,7 @@ impl SharedMemory {
             }
         };
         log::info!("Create shared memory, size: {}, flink: {}", size, flink);
-        set_path_permission(&PathBuf::from(flink), "F").ok();
+        set_path_permission(Path::new(&flink), "F").ok();
         Ok(SharedMemory { inner: shmem })
     }
 
@@ -586,8 +586,8 @@ pub mod client {
                 let mut exe = std::env::current_exe()?.to_string_lossy().to_string();
                 #[cfg(feature = "flutter")]
                 {
-                    if let Some(dir) = PathBuf::from(&exe).parent() {
-                        if set_path_permission(&PathBuf::from(dir), "RX").is_err() {
+                    if let Some(dir) = Path::new(&exe).parent() {
+                        if set_path_permission(Path::new(dir), "RX").is_err() {
                             *SHMEM.lock().unwrap() = None;
                             bail!("Failed to set permission of {:?}", dir);
                         }


### PR DESCRIPTION
- `&Path` provides better generality than `&PathBuf` in function parameters.