### PR TITLE
Fix: DEBIAN Control md5sums

### DIFF
--- a/build.py
+++ b/build.py
@@ -354,7 +354,7 @@ def build_flutter_deb(version, features):
     system2('mkdir -p tmpdeb/DEBIAN')
     generate_control_file(version)
     system2('cp -a ../res/DEBIAN/* tmpdeb/DEBIAN/')
-    md5_file('usr/share/rustdesk/files/systemd/rustdesk.service')
+    md5_file_folder("tmpdeb/")
     system2('dpkg-deb -b tmpdeb rustdesk.deb;')
 
     system2('/bin/rm -rf tmpdeb/')
@@ -391,7 +391,7 @@ def build_deb_from_folder(version, binary_folder):
     system2('mkdir -p tmpdeb/DEBIAN')
     generate_control_file(version)
     system2('cp -a ../res/DEBIAN/* tmpdeb/DEBIAN/')
-    md5_file('usr/share/rustdesk/files/systemd/rustdesk.service')
+    md5_file_folder("tmpdeb/")
     system2('dpkg-deb -b tmpdeb rustdesk.deb;')
 
     system2('/bin/rm -rf tmpdeb/')
@@ -624,18 +624,21 @@ def main():
                 system2('mkdir -p tmpdeb/usr/share/rustdesk')
                 system2('mv tmpdeb/usr/bin/rustdesk tmpdeb/usr/share/rustdesk/')
                 system2('cp libsciter-gtk.so tmpdeb/usr/share/rustdesk/')
-                md5_file('usr/share/rustdesk/files/systemd/rustdesk.service')
-                md5_file('etc/rustdesk/startwm.sh')
-                md5_file('etc/X11/rustdesk/xorg.conf')
-                md5_file('etc/pam.d/rustdesk')
-                md5_file('usr/share/rustdesk/libsciter-gtk.so')
+                md5_file_folder("tmpdeb/")
                 system2('dpkg-deb -b tmpdeb rustdesk.deb; /bin/rm -rf tmpdeb/')
                 os.rename('rustdesk.deb', 'rustdesk-%s.deb' % version)
 
 
 def md5_file(fn):
     md5 = hashlib.md5(open('tmpdeb/' + fn, 'rb').read()).hexdigest()
-    system2('echo "%s %s" >> tmpdeb/DEBIAN/md5sums' % (md5, fn))
+    system2('echo "%s  /%s" >> tmpdeb/DEBIAN/md5sums' % (md5, fn))
+
+def md5_file_folder(base_dir):
+    base_path = Path(base_dir)
+    for file in base_path.rglob('*'):
+        if file.is_file() and 'DEBIAN' not in file.parts:
+            relative_path = file.relative_to(base_path)
+            md5_file(str(relative_path))
 
 
 if __name__ == "__main__":

--- a/build.py
+++ b/build.py
@@ -9,6 +9,7 @@ import shutil
 import hashlib
 import argparse
 import sys
+from pathlib import Path
 
 windows = platform.platform().startswith('Windows')
 osx = platform.platform().startswith(


### PR DESCRIPTION
Fix: https://github.com/rustdesk/rustdesk/discussions/10354

### First, checking current `/var/lib/dpkg/info/rustdesk.md5sums`

```
b810fb09ba4f1b55c095f83d1077ab8b usr/share/rustdesk/files/systemd/rustdesk.service
```
1. The `/` on the path is missing
2. The checksum and the path of the file should separated by **two** spaces (By checking others like `wget.md5sums`) 

```diff
def md5_file(fn):
    md5 = hashlib.md5(open('tmpdeb/' + fn, 'rb').read()).hexdigest()
-   system2('echo "%s %s" >> tmpdeb/DEBIAN/md5sums' % (md5, fn))
+   system2('echo "%s  /%s" >> tmpdeb/DEBIAN/md5sums' % (md5, fn))
```

### Second
The checksums should be generated by ***file list***, not just specify single file, otherwise the integrity can't be guaranteed.
* Create a new def `md5_file_folder` that will generate file list and send to `md5_file` to generate md5 checksum