### PR TITLE
fix: file clipboard, init disabled

### DIFF
--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -310,6 +310,12 @@ impl<T: InvokeUiSession> Remote<T> {
                 Ok(())
             });
         }
+
+        // It's better to check if the peers are windows, but it's not necessary.
+        #[cfg(feature = "flutter")]
+        if !crate::flutter::sessions::has_sessions_running(ConnType::DEFAULT_CONN) {
+            ContextSend::enable(false);
+        }
     }
 
     #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
@@ -1199,6 +1205,7 @@ impl<T: InvokeUiSession> Remote<T> {
                         let peer_platform = pi.platform.clone();
                         self.set_peer_info(&pi);
                         self.handler.handle_peer_info(pi);
+                        #[cfg(not(feature = "flutter"))]
                         self.check_clipboard_file_context();
                         if !(self.handler.is_file_transfer() || self.handler.is_port_forward()) {
                             #[cfg(feature = "flutter")]
@@ -1898,6 +1905,7 @@ impl<T: InvokeUiSession> Remote<T> {
         true
     }
 
+    #[cfg(not(feature = "flutter"))]
     fn check_clipboard_file_context(&self) {
         #[cfg(any(
             target_os = "windows",


### PR DESCRIPTION

Don't call `check_clipboard_file_context()` for flutter version. Because it may disable the file clipboard context.

The clients of sciter version are seperated processes. It's ok to change the `clipboard::ContextSend` for each option.
While the clients of the flutter version are one process. We need always enable the context for simple.

If `check_clipboard_file_context()` disables the file clipboard context:
1. It affects other connections.
2. A toggle option on the local side cannot enable the context again. Because https://github.com/rustdesk/rustdesk/blob/06bc554216922edbcd262426613f4b84003b1f65/src/ui_session_interface.rs#L327
