### PR TITLE
fix andriod update button cannot be clicked

### DIFF
--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -834,10 +834,6 @@ class _DesktopHomePageState extends State<DesktopHomePage>
     _uniLinksSubscription?.cancel();
     Get.delete<RxBool>(tag: 'stop-service');
     _updateTimer?.cancel();
-    if (!bind.isCustomClient()) {
-      platformFFI.unregisterEventHandler(
-          kCheckSoftwareUpdateFinish, kCheckSoftwareUpdateFinish);
-    }
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }

--- a/flutter/lib/mobile/pages/connection_page.dart
+++ b/flutter/lib/mobile/pages/connection_page.dart
@@ -107,7 +107,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
         : InkWell(
             onTap: () async {
               final url = 'https://rustdesk.com/download';
-              // https://pub.dev/packages/url_launcher#configuration 
+              // https://pub.dev/packages/url_launcher#configuration
               // https://developer.android.com/training/package-visibility/use-cases#open-urls-custom-tabs
               //
               // `await launchUrl(Uri.parse(url))` can also run if skip
@@ -115,9 +115,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
               // 2. `<action android:name="android.support.customtabs.action.CustomTabsService" />` in AndroidManifest.xml
               //
               // But it is better to add the check.
-              if (await canLaunchUrl(Uri.parse(url))) {
-                await launchUrl(Uri.parse(url));
-              }
+              await launchUrl(Uri.parse(url));
             },
             child: Container(
                 alignment: AlignmentDirectional.center,
@@ -369,10 +367,6 @@ class _ConnectionPageState extends State<ConnectionPage> {
     }
     if (Get.isRegistered<TextEditingController>()) {
       Get.delete<TextEditingController>();
-    }
-    if (!bind.isCustomClient()) {
-      platformFFI.unregisterEventHandler(
-          kCheckSoftwareUpdateFinish, kCheckSoftwareUpdateFinish);
     }
     super.dispose();
   }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/9407#discussioncomment-11690318

1. Remove `canLaunchUrl`, which fix the issue
2. Remove `unregisterEventHandler` of `kCheckSoftwareUpdateFinish` when connection page dispose, it's registered on main.
https://github.com/rustdesk/rustdesk/blob/39a430f96f9600a2ef19a7191d3f323c7ba4b8b5/flutter/lib/main.dart#L160
https://github.com/rustdesk/rustdesk/blob/39a430f96f9600a2ef19a7191d3f323c7ba4b8b5/flutter/lib/main.dart#L123
https://github.com/rustdesk/rustdesk/blob/39a430f96f9600a2ef19a7191d3f323c7ba4b8b5/flutter/lib/common.dart#L3616