### PR TITLE
fix online status indicator

### DIFF
--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -736,10 +736,8 @@ impl Config {
                 .next()
                 .unwrap_or_default();
         }
-        if !rendezvous_server.contains(':') {
-            rendezvous_server = format!("{rendezvous_server}:{RENDEZVOUS_PORT}");
-        }
-        rendezvous_server
+
+        crate::socket_client::check_port(rendezvous_server, RENDEZVOUS_PORT)
     }
 
     pub fn get_rendezvous_servers() -> Vec<String> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -3607,7 +3607,11 @@ pub mod peer_online {
             let tmp = hbb_common::socket_client::check_port(server_addr.clone(), hbb_common::config::RENDEZVOUS_PORT);
             if let Some(pos) = tmp.rfind(':') {
                 host = tmp[.. pos].to_string();
-                port = tmp[pos + 1 ..].parse().unwrap_or(0);
+                port = if pos + 1 < tmp.len() {
+                    tmp[pos + 1..].parse().unwrap_or(0)
+                } else {
+                    0
+                };
             } else {
                 help_query_error(ids).await;
                 bail!("Invalid server address: {server_addr}");

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -2104,7 +2104,8 @@ pub(super) mod async_tasks {
         let _ = TX_QUERY_ONLINES.lock().unwrap().take();
     }
 
-    #[tokio::main(flavor = "current_thread")]
+    // #[tokio::main(flavor = "current_thread")]
+    #[tokio::main(flavor = "multi_thread")]
     async fn start_flutter_async_runner_() {
         // Only one task is allowed to run at the same time.
         let (tx_onlines, rx_onlines) = sync_channel::<Vec<String>>(1);


### PR DESCRIPTION
#10005 

The original online status query simply checked whether the rendezvous_server contained the given ID. After the modification, the server address is obtained from the original set of IDs, and then a socket connection is established with that server in order to query the online status.

By using a HashMap, the same server address only needs one socket connection to send a batch of IDs at once. In the HashMap’s key, “rendezvous_server” is used to store cases where there is no “@” in the ID (i.e., the original situation where IDs only have an ID). “public” is used when the string after “@” is “public”. In other scenarios, the string after “@” is treated as a domain name or IP address (which can be IPv4 or IPv6, with optional ports; if a port is provided with an IPv6 address, it should be enclosed in brackets; no brackets are needed if there is no port). The value in the HashMap contains all IDs that need to be queried on the server corresponding to that key.

Originally, config.rs’s get_rendezvous_server function simply checked for the presence of “:” to determine if there was a port, ignoring IPv6. Therefore, IPv6 detection has been added by counting the number of “:” to handle IPv6 addresses.

I’ve tested the scenario between two Windows 10 machines myself, covering ID, ID@public, ID@IPv4 , ID@IPv4 :port, ID@IPv6, and ID@[IPv6]:port. The “online indicator” lights up as expected in all cases, but turning it off responds a bit slowly

![PixPin_2025-01-01_06-54-39](https://github.com/user-attachments/assets/97ef2a53-df23-44ee-9e1b-7fd3fbd2f785)
