### PR TITLE
fix ffmpeg videotoolbox wrong log

### DIFF
--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -193,7 +193,7 @@ impl EncoderApi for HwRamEncoder {
     }
 
     fn support_abr(&self) -> bool {
-        ["qsv", "vaapi"].iter().all(|&x| !self.config.name.contains(x))
+        ["vaapi"].iter().all(|&x| !self.config.name.contains(x))
     }
 
     fn support_changing_quality(&self) -> bool {

--- a/res/vcpkg/ffmpeg/patch/0004-videotoolbox-changing-bitrate.patch
+++ b/res/vcpkg/ffmpeg/patch/0004-videotoolbox-changing-bitrate.patch
@@ -58,7 +58,7 @@ index da7b291b03..3c866177f5 100644
 +                int status = VTSessionSetProperty(vtctx->session,
 +                                            kVTCompressionPropertyKey_AverageBitRate,
 +                                            bit_rate_num);
-+                if (!status) {
++                if (status) {
 +                    av_log(avctx, AV_LOG_ERROR, "Error: cannot set average bit rate: %d\n", status);
 +                }
 +            }


### PR DESCRIPTION
* Fix ffmpeg videotoolbox wrong log when changing bitrate. Clear cache needed.
https://github.com/FFmpeg/FFmpeg/blob/0457aaf0d3a05331dc599bea573809fd0317c624/libavcodec/videotoolboxenc.c#L1342
* Let qsv support abr, it's safe for qsv to change bitrate frequently.

