### PR TITLE
scrap: fixed build warnning

### DIFF
--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -189,7 +189,7 @@ impl Frame<'_> {
         yuvfmt: EncodeYuvFormat,
         yuv: &'a mut Vec<u8>,
         mid_data: &mut Vec<u8>,
-    ) -> ResultType<EncodeInput> {
+    ) -> ResultType<EncodeInput<'a>> {
         match self {
             Frame::PixelBuffer(pixelbuffer) => {
                 convert_to_yuv(&pixelbuffer, yuvfmt, yuv, mid_data)?;


### PR DESCRIPTION
```shell
warning: elided lifetime has a name
   --> src/common/mod.rs:192:21
    |
187 |     pub fn to<'a>(
    |               -- lifetime `'a` declared here
...
192 |     ) -> ResultType<EncodeInput> {
    |                     ^^^^^^^^^^^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default
```