### PR TITLE
fix: clipboard, client side, update is required on conn

### DIFF
--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1260,7 +1260,8 @@ impl<T: InvokeUiSession> Remote<T> {
                             // to-do: Android, is `sync_init_clipboard` really needed?
                             // https://github.com/rustdesk/rustdesk/discussions/9010
 
-                            #[cfg(target_os = "android")]
+                            #[cfg(feature = "flutter")]
+                            #[cfg(not(target_os = "ios"))]
                             crate::flutter::update_text_clipboard_required();
 
                             // on connection established client


### PR DESCRIPTION
Update `is required` for text clipboard on the client side for desktop.

If update is not called, the client clipboard will not work if last connection disabled the clipboard until the option is toggled agian.
The flat is not reset after ending the connection.
