### PR TITLE
Fix issues spotted during 1.3.7 fdroid build

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -6,6 +6,7 @@ on:
   workflow_call:
 
 env:
+  CARGO_EXPAND_VERSION: "1.0.95"
   FLUTTER_VERSION: "3.22.3"
   FLUTTER_RUST_BRIDGE_VERSION: "1.80.1"
   RUST_VERSION: "1.75" # https://github.com/rustdesk/rustdesk/discussions/7503
@@ -75,6 +76,7 @@ jobs:
       - name: Install flutter rust bridge deps
         shell: bash
         run: |
+          cargo install cargo-expand --version ${{ env.CARGO_EXPAND_VERSION }} --locked
           cargo install flutter_rust_bridge_codegen --version ${{ env.FLUTTER_RUST_BRIDGE_VERSION }} --features "uuid" --locked
           pushd flutter && sed -i -e 's/extended_text: 14.0.0/extended_text: 13.0.0/g' pubspec.yaml && flutter pub get && popd
 

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -1043,16 +1043,6 @@ jobs:
           prefix-key: rustdesk-lib-cache-android # TODO: drop '-android' part after caches are invalidated
           key: ${{ matrix.job.target }}
 
-      - name: fix android for flutter 3.13
-        if: ${{ env.ANDROID_FLUTTER_VERSION == '3.13.9' }}
-        run: |
-          cd flutter
-          sed -i 's/uni_links_desktop/#uni_links_desktop/g' pubspec.yaml
-          sed -i 's/extended_text: .*/extended_text: 11.1.0/' pubspec.yaml
-          flutter pub get
-          cd lib
-          find . | grep dart | xargs sed -i 's/textScaler: TextScaler.linear(\(.*\)),/textScaleFactor: \1,/g'
-
       - name: Build rustdesk lib
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
@@ -1294,16 +1284,6 @@ jobs:
         with:
           name: librustdesk.so.i686-linux-android
           path: ./flutter/android/app/src/main/jniLibs/x86
-
-      - name: fix android for flutter 3.13
-        if: ${{ env.ANDROID_FLUTTER_VERSION == '3.13.9' }}
-        run: |
-          cd flutter
-          sed -i 's/uni_links_desktop/#uni_links_desktop/g' pubspec.yaml
-          sed -i 's/extended_text: .*/extended_text: 11.1.0/' pubspec.yaml
-          flutter pub get
-          cd lib
-          find . | grep dart | xargs sed -i 's/textScaler: TextScaler.linear(\(.*\)),/textScaleFactor: \1,/g'
 
       - name: Build rustdesk
         shell: bash

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -31,8 +31,8 @@ env:
   FLUTTER_ELINUX_VERSION: "3.16.9"
   TAG_NAME: "${{ inputs.upload-tag }}"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-  # vcpkg version: 2024.11.16
-  VCPKG_COMMIT_ID: "b2cb0da531c2f1f740045bfe7c4dac59f0b2b69c"
+  # vcpkg version: 2025.01.13
+  VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
   VERSION: "1.3.7"
   NDK_VERSION: "r27c"
   #signing keys env variable checks

--- a/flutter/build_fdroid.sh
+++ b/flutter/build_fdroid.sh
@@ -150,6 +150,10 @@ prebuild)
 
 	# Flutter used to compile Flutter<->Rust bridge files
 
+	CARGO_EXPAND_VERSION="$(yq -r \
+		.env.CARGO_EXPAND_VERSION \
+		.github/workflows/bridge.yml)"
+
 	FLUTTER_BRIDGE_VERSION="$(yq -r \
 		.env.FLUTTER_VERSION \
 		.github/workflows/bridge.yml)"
@@ -239,6 +243,7 @@ prebuild)
 
 	cargo install \
 		cargo-expand \
+		--version "${CARGO_EXPAND_VERSION}" \
 		--locked
 	cargo install flutter_rust_bridge_codegen \
 		--version "${FLUTTER_RUST_BRIDGE_VERSION}" \


### PR DESCRIPTION
- **bridge.yml: Explicitly install cargo-expand of certain version**
- **flutter-build.yml: drop workarounds for flutter 3.13**
- **Bump vcpkg baseline to 2025.01.13**
