### PR TITLE
Reduce the possibility of vaapi being created twice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "default_net"
 version = "0.1.0"
-source = "git+https://github.com/rustdesk-org/default_net#c400b0bbf49a987129796221fbc41a8a385b812e"
+source = "git+https://github.com/rustdesk-org/default_net#78f8f70cd85151a3a2c4a3230d80d5272703c02e"
 dependencies = [
  "anyhow",
  "regex",


### PR DESCRIPTION
vaapi does not support dynamically changing the bitrate. If the bitrate changes at the beginning, it will be created twice, so not do bitrate adjustment when the first TestDelay message is received on linux.

in `user_network_delay`, `adjust_ratio = user.delay.fps.is_none();`

before:
![e91f02a11e40a4ba2d6d09e8395e5d1](https://github.com/user-attachments/assets/8da064a8-7350-4292-92a7-d4025f2974f0)

after:
![b149fd0f6102f699d81747987538206](https://github.com/user-attachments/assets/9eb61bdf-42e9-4ccf-95ce-dcfe8918a306)
