### PR TITLE
fix: win, file clipboard, try empty

### DIFF
--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -107,6 +107,7 @@ pub enum ClipboardFile {
         stream_id: i32,
         requested_data: Vec<u8>,
     },
+    TryEmpty,
 }
 
 struct MsgChannel {
@@ -223,6 +224,16 @@ fn send_data_to_channel(conn_id: i32, data: ClipboardFile) -> ResultType<()> {
         Ok(())
     } else {
         bail!("conn_id not found");
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub fn send_data_exclude(conn_id: i32, data: ClipboardFile) {
+    use hbb_common::log;
+    for msg_channel in VEC_MSG_CHANNEL.read().unwrap().iter() {
+        if msg_channel.conn_id != conn_id {
+            allow_err!(msg_channel.sender.send(data.clone()));
+        }
     }
 }
 

--- a/libs/clipboard/src/platform/windows.rs
+++ b/libs/clipboard/src/platform/windows.rs
@@ -6,10 +6,10 @@
 #![allow(deref_nullptr)]
 
 use crate::{
-    allow_err, send_data, ClipboardFile, CliprdrError, CliprdrServiceContext, ResultType,
+    send_data, send_data_exclude, ClipboardFile, CliprdrError, CliprdrServiceContext, ResultType,
     ERR_CODE_INVALID_PARAMETER, ERR_CODE_SEND_MSG, ERR_CODE_SERVER_FUNCTION_NONE, VEC_MSG_CHANNEL,
 };
-use hbb_common::log;
+use hbb_common::{allow_err, log};
 use std::{
     boxed::Box,
     ffi::{CStr, CString},
@@ -643,6 +643,7 @@ pub fn server_clip_file(
                 conn_id,
                 &format_list
             );
+            send_data_exclude(conn_id as _, ClipboardFile::TryEmpty);
             ret = server_format_list(context, conn_id, format_list);
             log::debug!(
                 "server_format_list called, conn_id {}, return {}",
@@ -739,6 +740,11 @@ pub fn server_clip_file(
                 stream_id,
                 ret
             );
+        }
+        ClipboardFile::TryEmpty => {
+            log::debug!("empty_clipboard called");
+            let ret = empty_clipboard(context, conn_id);
+            log::debug!("empty_clipboard called, conn_id {}, return {}", conn_id, ret);
         }
     }
     ret

--- a/src/clipboard_file.rs
+++ b/src/clipboard_file.rs
@@ -134,6 +134,15 @@ pub fn clip_2_msg(clip: ClipboardFile) -> Message {
             })),
             ..Default::default()
         },
+        ClipboardFile::TryEmpty => Message {
+            union: Some(message::Union::Cliprdr(Cliprdr {
+                union: Some(cliprdr::Union::TryEmpty(CliprdrTryEmpty {
+                    ..Default::default()
+                })),
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
     }
 }
 
@@ -176,6 +185,7 @@ pub fn msg_2_clip(msg: Cliprdr) -> Option<ClipboardFile> {
                 requested_data: data.requested_data.into(),
             })
         }
+        Some(cliprdr::Union::TryEmpty(_)) => Some(ClipboardFile::TryEmpty),
         _ => None,
     }
 }


### PR DESCRIPTION
Fix some special cases for file copy&paste.

## cases

### Case 1

1. `A` -> `B`, `C`
2. Copy in `A`
3. Copy in `B`. `C` should empty the clipboard.
4. Paste in `C`

#### Before

Right click menu shows "Paste" is available

Win -> Win: Clicking "Paste" does nothing.
Win -> Linux (in dev): Clicking "Paste" causes dead lock.

#### After

Right click menu shows "Paste" is not available

### Case 2

1. `A`, `B` -> `C`
2. Copy in `C`
3. Copy in `A`. `B` should empty the clipboard.
4. Paste in `B`

#### Before

Right click menu shows "Paste" is available

Win -> Win: Clicking "Paste" does nothing.
Win -> Linux (in dev): Clicking "Paste" causes dead lock.

#### After

Right click menu shows "Paste" is not available

### Case 3

1. `A` -> `B` -> `C`
2. Copy in `B`
3. Copy in `A`. `C` should empty the clipboard.
4. Paste in `C`

#### Before

Right click menu shows "Paste" is available

Win -> Win: Clicking "Paste" does nothing.
Win -> Linux (in dev): Clicking "Paste" causes wrong files to be pasted.

#### After

Right click menu shows "Paste" is available

Win -> Win: Clicking "Paste" does nothing.
Win -> Linux (in dev): Clicking "Paste" does nothing.

## Note

1. Case 1. The change does not affect the sciter version, because the connection is a seperate process for the sciter version.
2. Case 3. `C` does not empty the clipboard, because `A` -> `B` and `B` -> `C` may be in different process. Sending this message between processes is a bit complicated, and this is a rarely case. The current fix will not cause an error.
3. Copy&paste with older version is tested.