### PR TITLE
fix: macos, main window, dark theme, border

### DIFF
--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -133,7 +133,8 @@ void runMainApp(bool startService) async {
   runApp(App());
 
   // Set window option.
-  WindowOptions windowOptions = getHiddenTitleBarWindowOptions();
+  WindowOptions windowOptions =
+      getHiddenTitleBarWindowOptions(isMainWindow: true);
   windowManager.waitUntilReadyToShow(windowOptions, () async {
     // Restore the location of the main window before window hide or show.
     await restoreWindowPosition(WindowType.Main);
@@ -354,7 +355,10 @@ void runInstallPage() async {
 }
 
 WindowOptions getHiddenTitleBarWindowOptions(
-    {Size? size, bool center = false, bool? alwaysOnTop}) {
+    {bool isMainWindow = false,
+    Size? size,
+    bool center = false,
+    bool? alwaysOnTop}) {
   var defaultTitleBarStyle = TitleBarStyle.hidden;
   // we do not hide titlebar on win7 because of the frame overflow.
   if (kUseCompatibleUiMode) {
@@ -363,7 +367,7 @@ WindowOptions getHiddenTitleBarWindowOptions(
   return WindowOptions(
     size: size,
     center: center,
-    backgroundColor: Colors.transparent,
+    backgroundColor: (isMacOS && isMainWindow) ? null : Colors.transparent,
     skipTaskbar: false,
     titleBarStyle: defaultTitleBarStyle,
     alwaysOnTop: alwaysOnTop,


### PR DESCRIPTION
## Preview

### Border issue

The border color seems black when using the dark theme. It should be white or gray.

<img width="512" alt="3a0fc0837109ea9edcdd4fa2a26880b" src="https://github.com/user-attachments/assets/e34a83d1-e4f5-479b-8024-1cbbe3d46e29" />

### Fixed

https://github.com/user-attachments/assets/565f7d02-11b4-4b8a-8302-16e98b8857a3

## Note

No idea why set `backgroundColor` to `Colors.transparent` here. This issue is introduced since `1.2.0`.

The main window works fine after unsetting `backgroundColor`.
