### PR TITLE
fix: android, controlled side, gesture

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -65,8 +65,8 @@ class MainService : Service() {
     @Keep
     @RequiresApi(Build.VERSION_CODES.N)
     fun rustPointerInput(kind: Int, mask: Int, x: Int, y: Int) {
-        // turn on screen with LIFT_DOWN when screen off
-        if (!powerManager.isInteractive && (kind == 0 || mask == LIFT_DOWN)) {
+        // turn on screen with LEFT_DOWN when screen off
+        if (!powerManager.isInteractive && (kind == 0 || mask == LEFT_DOWN)) {
             if (wakeLock.isHeld) {
                 Log.d(logTag, "Turn on Screen, WakeLock release")
                 wakeLock.release()


### PR DESCRIPTION
1. Fix RustDesk -> Android. Mouse events are only dispatched after actions are done.
2. Fix `mouse`(Desktop) -> Android. Long press and move.
3. Fix `touch` -> Android. Long press and move.

## Preview

### Issue

https://github.com/user-attachments/assets/5efb70c7-79bd-4019-bfe0-1f1b01cdf32b

### Fixed

https://github.com/user-attachments/assets/9b4d56c0-4520-4c9c-9af4-0cf6f8294a11

## Tests

- [x] `mouse`(Desktop)/`touch` -> Android. Long press and move/select.
- [x] Swipe and click.