### PR TITLE
fix, accessible peers filter considering device group name

### DIFF
--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -562,21 +562,24 @@ class MyGroupPeerView extends BasePeersView {
         );
 
   static bool filter(Peer peer) {
-    if (gFFI.groupModel.searchAccessibleItemNameText.isNotEmpty) {
-      if (!peer.loginName
-          .contains(gFFI.groupModel.searchAccessibleItemNameText)) {
+    final model = gFFI.groupModel;
+    if (model.searchAccessibleItemNameText.isNotEmpty) {
+      final text = model.searchAccessibleItemNameText.value;
+      final searchPeersOfUser = peer.loginName.contains(text) &&
+          model.users.any((user) => user.name == peer.loginName);
+      final searchPeersOfDeviceGroup = peer.device_group_name.contains(text) &&
+          model.deviceGroups.any((g) => g.name == peer.device_group_name);
+      if (!searchPeersOfUser && !searchPeersOfDeviceGroup) {
         return false;
       }
     }
-    if (gFFI.groupModel.selectedAccessibleItemName.isNotEmpty) {
-      if (gFFI.groupModel.isSelectedDeviceGroup.value) {
-        if (gFFI.groupModel.selectedAccessibleItemName.value !=
-            peer.device_group_name) {
+    if (model.selectedAccessibleItemName.isNotEmpty) {
+      if (model.isSelectedDeviceGroup.value) {
+        if (model.selectedAccessibleItemName.value != peer.device_group_name) {
           return false;
         }
       } else {
-        if (gFFI.groupModel.selectedAccessibleItemName.value !=
-            peer.loginName) {
+        if (model.selectedAccessibleItemName.value != peer.loginName) {
           return false;
         }
       }


### PR DESCRIPTION
1. Fix, accessible peers filter considering device group name
2. Consider sources of accessible peers when searching

Device's user and group
![1739783861734](https://github.com/user-attachments/assets/7ca28018-0be2-476c-8faa-560be695b516)
Without filter
![1739783957737](https://github.com/user-attachments/assets/fc8593d3-131e-4dec-ba6f-a4616999cc7e)


**Before fix:**

![1739783919970](https://github.com/user-attachments/assets/43339b4a-95a2-46e0-b84e-1a6db55e2062)

![1739783940723](https://github.com/user-attachments/assets/a6596c4d-29f6-49b9-a2b8-b97e532a9beb)

**After fix:**

ID "1227624460" is from user `user1`, althrough its device group is `device_group2`, it is still filtered out because `device_group2` is not in the list
![1739784054691](https://github.com/user-attachments/assets/703b9695-dec4-49a6-91ab-317abc75c8f0)

ID "a123456" is from device group `same_name`, althrough its username is `user2`, it is still filtered out because `user2` is not in the list
![1739784078042](https://github.com/user-attachments/assets/28bcb38e-b19a-4613-b6a2-9a8999542102)
![1739784745492](https://github.com/user-attachments/assets/8b35a336-2bdf-4718-907b-b7dbd40ce698)


