### PR TITLE
refact: optimize, loading recent peers

### DIFF
--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -200,18 +200,20 @@ class _ConnectionPageState extends State<ConnectionPage>
   final _idController = IDTextEditingController();
 
   final RxBool _idInputFocused = false.obs;
+  final FocusNode _idFocusNode = FocusNode();
+  final TextEditingController _idEditingController = TextEditingController();
 
   bool isWindowMinimized = false;
-  List<Peer> peers = [];
 
-  bool isPeersLoading = false;
-  bool isPeersLoaded = false;
+  AllPeersLoader allPeersLoader = AllPeersLoader();
+
   // https://github.com/flutter/flutter/issues/157244
   Iterable<Peer> _autocompleteOpts = [];
 
   @override
   void initState() {
     super.initState();
+    _idFocusNode.addListener(onFocusChanged);
     if (_idController.text.isEmpty) {
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         final lastRemoteId = await bind.mainGetLastRemoteId();
@@ -230,6 +232,9 @@ class _ConnectionPageState extends State<ConnectionPage>
   void dispose() {
     _idController.dispose();
     windowManager.removeListener(this);
+    _idFocusNode.removeListener(onFocusChanged);
+    _idFocusNode.dispose();
+    _idEditingController.dispose();
     if (Get.isRegistered<IDTextEditingController>()) {
       Get.delete<IDTextEditingController>();
     }
@@ -273,6 +278,13 @@ class _ConnectionPageState extends State<ConnectionPage>
     bind.mainOnMainWindowClose();
   }
 
+  void onFocusChanged() {
+    _idInputFocused.value = _idFocusNode.hasFocus;
+    if (_idFocusNode.hasFocus && !allPeersLoader.isPeersLoading) {
+      allPeersLoader.getAllPeers(setState);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final isOutgoingOnly = bind.isOutgoingOnly();
@@ -304,18 +316,6 @@ class _ConnectionPageState extends State<ConnectionPage>
     connect(context, id, isFileTransfer: isFileTransfer);
   }
 
-  Future<void> _fetchPeers() async {
-    setState(() {
-      isPeersLoading = true;
-    });
-    await Future.delayed(Duration(milliseconds: 100));
-    peers = await getAllPeers();
-    setState(() {
-      isPeersLoading = false;
-      isPeersLoaded = true;
-    });
-  }
-
   /// UI for the remote ID TextField.
   /// Search for a peer.
   Widget _buildRemoteIDTextField(BuildContext context) {
@@ -332,11 +332,12 @@ class _ConnectionPageState extends State<ConnectionPage>
             Row(
               children: [
                 Expanded(
-                    child: Autocomplete<Peer>(
+                    child: RawAutocomplete<Peer>(
                   optionsBuilder: (TextEditingValue textEditingValue) {
                     if (textEditingValue.text == '') {
                       _autocompleteOpts = const Iterable<Peer>.empty();
-                    } else if (peers.isEmpty && !isPeersLoaded) {
+                    } else if (allPeersLoader.peers.isEmpty &&
+                        !allPeersLoader.isLoaded) {
                       Peer emptyPeer = Peer(
                         id: '',
                         username: '',
@@ -363,7 +364,7 @@ class _ConnectionPageState extends State<ConnectionPage>
                         );
                       }
                       String textToFind = textEditingValue.text.toLowerCase();
-                      _autocompleteOpts = peers
+                      _autocompleteOpts = allPeersLoader.peers
                           .where((peer) =>
                               peer.id.toLowerCase().contains(textToFind) ||
                               peer.username
@@ -377,6 +378,8 @@ class _ConnectionPageState extends State<ConnectionPage>
                     }
                     return _autocompleteOpts;
                   },
+                  focusNode: _idFocusNode,
+                  textEditingController: _idEditingController,
                   fieldViewBuilder: (
                     BuildContext context,
                     TextEditingController fieldTextEditingController,
@@ -385,17 +388,17 @@ class _ConnectionPageState extends State<ConnectionPage>
                   ) {
                     fieldTextEditingController.text = _idController.text;
                     Get.put<TextEditingController>(fieldTextEditingController);
-                    fieldFocusNode.addListener(() async {
-                      _idInputFocused.value = fieldFocusNode.hasFocus;
-                      if (fieldFocusNode.hasFocus && !isPeersLoading) {
-                        _fetchPeers();
-                      }
-                    });
-                    final textLength =
-                        fieldTextEditingController.value.text.length;
-                    // select all to facilitate removing text, just following the behavior of address input of chrome
-                    fieldTextEditingController.selection =
-                        TextSelection(baseOffset: 0, extentOffset: textLength);
+
+                    // The listener will be added multiple times when the widget is rebuilt.
+                    // We may need to use the `RawAutocomplete` to get the focus node.
+
+                    // Temporarily remove Selection because Selection can cause users to accidentally delete previously entered content during input.
+                    // final textLength =
+                    //     fieldTextEditingController.value.text.length;
+                    // // Select all to facilitate removing text, just following the behavior of address input of chrome.
+                    // fieldTextEditingController.selection =
+                    //     TextSelection(baseOffset: 0, extentOffset: textLength);
+
                     return Obx(() => TextField(
                           autocorrect: false,
                           enableSuggestions: false,
@@ -468,7 +471,8 @@ class _ConnectionPageState extends State<ConnectionPage>
                                     maxHeight: maxHeight,
                                     maxWidth: 319,
                                   ),
-                                  child: peers.isEmpty && isPeersLoading
+                                  child: allPeersLoader.peers.isEmpty &&
+                                          !allPeersLoader.isLoaded
                                       ? Container(
                                           height: 80,
                                           child: Center(

--- a/flutter/lib/plugin/utils/dialogs.dart
+++ b/flutter/lib/plugin/utils/dialogs.dart
@@ -6,12 +6,13 @@ import 'package:flutter_hbb/models/platform_model.dart';
 
 void showPeerSelectionDialog(
     {bool singleSelection = false,
-    required Function(List<String>) onPeersCallback}) {
-  final peers = bind.mainLoadRecentPeersSync();
+    required Function(List<String>) onPeersCallback}) async {
+  final peers = await bind.mainGetRecentPeers(getAll: true);
   if (peers.isEmpty) {
-    debugPrint("load recent peers sync failed.");
+    debugPrint("load recent peers failed.");
     return;
   }
+
   Map<String, dynamic> map = jsonDecode(peers);
   List<dynamic> peersList = map['peers'] ?? [];
   final selected = List<String>.empty(growable: true);

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -169,6 +169,8 @@ pub fn core_main() -> Option<Vec<String>> {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     init_plugins(&args);
     if args.is_empty() || crate::common::is_empty_uni_link(&args[0]) {
+        #[cfg(windows)]
+        hbb_common::config::PeerConfig::preload_peers();
         std::thread::spawn(move || crate::start_server(false, no_server));
     } else {
         #[cfg(windows)]

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -319,6 +319,9 @@ impl InvokeUiSession for SciterHandler {
             ConnType::DEFAULT_CONN => {
                 crate::keyboard::client::start_grab_loop();
             }
+            // Left empty code from compilation.
+            // Please replace the code in the PR.
+            ConnType::VIEW_CAMERA => {}
         }
     }
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/10695

https://github.com/rustdesk/rustdesk/issues/10795

https://github.com/rustdesk/hbb_common/pull/24

## Desc

1. Fix. The first time the system loads peers after boot(Windows) is very slow. Load peers two times, the first time(100 peers), the second time, the rest.
2. Peers for ID search will also be loaded two times. The first time load 100 peers and all IDs. The second time load all peers.

3. Fix. Potential deadlock when loading peers.
4. Fix. Use `RawAutocomplete` instead of `Autocomplete`. Because `Autocomplete` does not expose `FocusNode`. The listener will be added multiple times on my desktop.

![image](https://github.com/user-attachments/assets/4afe8d23-c250-425c-b46e-80d37d4daf21)

5. Refact. Temporarily remove auto selection because Selection can cause users to accidentally delete previously entered content during input. I'll submit a seperate PR to handle the selection.

6. Sciter version is not changed. Though there's no two-time loading, preloading peers still works.

## Preview



https://github.com/user-attachments/assets/8be4f931-2a1e-4ef0-80b0-cc31cf4892f1

