### PR TITLE
refact: optimize, ID search peers

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -822,7 +822,11 @@ class OverlayDialogManager {
 
     close([res]) {
       _dialogs.remove(dialogTag);
-      dialog.complete(res);
+      try {
+        dialog.complete(res);
+      } catch (e) {
+        debugPrint("Dialog complete catch error: $e");
+      }
       BackButtonInterceptor.removeByName(dialogTag);
     }
 

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -716,18 +716,18 @@ abstract class BasePeerCard extends StatelessWidget {
           switch (tab) {
             case PeerTabIndex.recent:
               await bind.mainRemovePeer(id: id);
-              await bind.mainLoadRecentPeers();
+              bind.mainLoadRecentPeers();
               break;
             case PeerTabIndex.fav:
               final favs = (await bind.mainGetFav()).toList();
               if (favs.remove(id)) {
                 await bind.mainStoreFav(favs: favs);
-                await bind.mainLoadFavPeers();
+                bind.mainLoadFavPeers();
               }
               break;
             case PeerTabIndex.lan:
               await bind.mainRemoveDiscovered(id: id);
-              await bind.mainLoadLanPeers();
+              bind.mainLoadLanPeers();
               break;
             case PeerTabIndex.ab:
               await gFFI.abModel.deletePeers([id]);

--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -404,7 +404,7 @@ class _PeerTabPageState extends State<PeerTabPage>
                 for (var p in peers) {
                   await bind.mainRemovePeer(id: p.id);
                 }
-                await bind.mainLoadRecentPeers();
+                bind.mainLoadRecentPeers();
                 break;
               case 1:
                 final favs = (await bind.mainGetFav()).toList();
@@ -412,13 +412,13 @@ class _PeerTabPageState extends State<PeerTabPage>
                   favs.remove(p.id);
                 }).toList();
                 await bind.mainStoreFav(favs: favs);
-                await bind.mainLoadFavPeers();
+                bind.mainLoadFavPeers();
                 break;
               case 2:
                 for (var p in peers) {
                   await bind.mainRemoveDiscovered(id: p.id);
                 }
-                await bind.mainLoadLanPeers();
+                bind.mainLoadLanPeers();
                 break;
               case 3:
                 await gFFI.abModel.deletePeers(peers.map((p) => p.id).toList());

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -205,7 +205,7 @@ class _ConnectionPageState extends State<ConnectionPage>
 
   bool isWindowMinimized = false;
 
-  AllPeersLoader allPeersLoader = AllPeersLoader();
+  final AllPeersLoader _allPeersLoader = AllPeersLoader();
 
   // https://github.com/flutter/flutter/issues/157244
   Iterable<Peer> _autocompleteOpts = [];
@@ -213,6 +213,7 @@ class _ConnectionPageState extends State<ConnectionPage>
   @override
   void initState() {
     super.initState();
+    _allPeersLoader.init(setState);
     _idFocusNode.addListener(onFocusChanged);
     if (_idController.text.isEmpty) {
       WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -232,6 +233,7 @@ class _ConnectionPageState extends State<ConnectionPage>
   void dispose() {
     _idController.dispose();
     windowManager.removeListener(this);
+    _allPeersLoader.clear();
     _idFocusNode.removeListener(onFocusChanged);
     _idFocusNode.dispose();
     _idEditingController.dispose();
@@ -280,8 +282,8 @@ class _ConnectionPageState extends State<ConnectionPage>
 
   void onFocusChanged() {
     _idInputFocused.value = _idFocusNode.hasFocus;
-    if (_idFocusNode.hasFocus && !allPeersLoader.isPeersLoading) {
-      allPeersLoader.getAllPeers(setState);
+    if (_idFocusNode.hasFocus && !_allPeersLoader.isPeersLoading) {
+      _allPeersLoader.getAllPeers();
     }
   }
 
@@ -336,8 +338,8 @@ class _ConnectionPageState extends State<ConnectionPage>
                   optionsBuilder: (TextEditingValue textEditingValue) {
                     if (textEditingValue.text == '') {
                       _autocompleteOpts = const Iterable<Peer>.empty();
-                    } else if (allPeersLoader.peers.isEmpty &&
-                        !allPeersLoader.isLoaded) {
+                    } else if (_allPeersLoader.peers.isEmpty &&
+                        !_allPeersLoader.isPeersLoaded) {
                       Peer emptyPeer = Peer(
                         id: '',
                         username: '',
@@ -364,7 +366,7 @@ class _ConnectionPageState extends State<ConnectionPage>
                         );
                       }
                       String textToFind = textEditingValue.text.toLowerCase();
-                      _autocompleteOpts = allPeersLoader.peers
+                      _autocompleteOpts = _allPeersLoader.peers
                           .where((peer) =>
                               peer.id.toLowerCase().contains(textToFind) ||
                               peer.username
@@ -471,8 +473,8 @@ class _ConnectionPageState extends State<ConnectionPage>
                                     maxHeight: maxHeight,
                                     maxWidth: 319,
                                   ),
-                                  child: allPeersLoader.peers.isEmpty &&
-                                          !allPeersLoader.isLoaded
+                                  child: _allPeersLoader.peers.isEmpty &&
+                                          !_allPeersLoader.isPeersLoaded
                                       ? Container(
                                           height: 80,
                                           child: Center(

--- a/flutter/lib/mobile/pages/connection_page.dart
+++ b/flutter/lib/mobile/pages/connection_page.dart
@@ -44,7 +44,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
   final FocusNode _idFocusNode = FocusNode();
   final TextEditingController _idEditingController = TextEditingController();
 
-  AllPeersLoader allPeersLoader = AllPeersLoader();
+  final AllPeersLoader _allPeersLoader = AllPeersLoader();
 
   StreamSubscription? _uniLinksSubscription;
 
@@ -62,6 +62,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
   @override
   void initState() {
     super.initState();
+    _allPeersLoader.init(setState);
     _idFocusNode.addListener(onFocusChanged);
     if (_idController.text.isEmpty) {
       WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -103,8 +104,8 @@ class _ConnectionPageState extends State<ConnectionPage> {
 
   void onFocusChanged() {
     _idEmpty.value = _idEditingController.text.isEmpty;
-    if (_idFocusNode.hasFocus && !allPeersLoader.isPeersLoading) {
-      allPeersLoader.getAllPeers(setState);
+    if (_idFocusNode.hasFocus && !_allPeersLoader.isPeersLoading) {
+      _allPeersLoader.getAllPeers();
     }
   }
 
@@ -157,8 +158,8 @@ class _ConnectionPageState extends State<ConnectionPage> {
                     optionsBuilder: (TextEditingValue textEditingValue) {
                       if (textEditingValue.text == '') {
                         _autocompleteOpts = const Iterable<Peer>.empty();
-                      } else if (allPeersLoader.peers.isEmpty &&
-                          !allPeersLoader.isLoaded) {
+                      } else if (_allPeersLoader.peers.isEmpty &&
+                          !_allPeersLoader.isPeersLoaded) {
                         Peer emptyPeer = Peer(
                           id: '',
                           username: '',
@@ -186,7 +187,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
                         }
                         String textToFind = textEditingValue.text.toLowerCase();
 
-                        _autocompleteOpts = allPeersLoader.peers
+                        _autocompleteOpts = _allPeersLoader.peers
                             .where((peer) =>
                                 peer.id.toLowerCase().contains(textToFind) ||
                                 peer.username
@@ -296,8 +297,9 @@ class _ConnectionPageState extends State<ConnectionPage> {
                                             maxHeight: maxHeight,
                                             maxWidth: 320,
                                           ),
-                                          child: allPeersLoader.peers.isEmpty &&
-                                                  !allPeersLoader.isLoaded
+                                          child: _allPeersLoader
+                                                      .peers.isEmpty &&
+                                                  !_allPeersLoader.isPeersLoaded
                                               ? Container(
                                                   height: 80,
                                                   child: Center(
@@ -361,6 +363,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
     _uniLinksSubscription?.cancel();
     _idController.dispose();
     _idFocusNode.removeListener(onFocusChanged);
+    _allPeersLoader.clear();
     _idFocusNode.dispose();
     _idEditingController.dispose();
     if (Get.isRegistered<IDTextEditingController>()) {

--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -58,6 +58,9 @@ class AbModel {
   String? _personalAbGuid;
   RxBool legacyMode = false.obs;
 
+  // Only handles peers add/remove
+  final Map<String, VoidCallback> _peerIdUpdateListeners = {};
+
   final sortTags = shouldSortTags().obs;
   final filterByIntersection = filterAbTagByIntersection().obs;
 
@@ -188,6 +191,7 @@ class AbModel {
         debugPrint("pull current Ab error: $e");
       }
     }
+    _callbackPeerUpdate();
     if (listInitialized && current.initialized) {
       _saveCache();
     }
@@ -419,6 +423,7 @@ class AbModel {
         }
       });
     }
+    _callbackPeerUpdate();
     return ret;
   }
 
@@ -620,6 +625,9 @@ class AbModel {
           }
         }
       }
+      if (abEntries.isNotEmpty) {
+        _callbackPeerUpdate();
+      }
     }
   }
 
@@ -740,6 +748,20 @@ class AbModel {
     } else {
       return name;
     }
+  }
+
+  void _callbackPeerUpdate() {
+    for (var listener in _peerIdUpdateListeners.values) {
+      listener();
+    }
+  }
+
+  void addPeerUpdateListener(String key, VoidCallback listener) {
+    _peerIdUpdateListeners[key] = listener;
+  }
+
+  void removePeerUpdateListener(String key) {
+    _peerIdUpdateListeners.remove(key);
   }
 
 // #endregion

--- a/flutter/lib/models/group_model.dart
+++ b/flutter/lib/models/group_model.dart
@@ -23,6 +23,8 @@ class GroupModel {
   var _cacheLoadOnceFlag = false;
   var _statusCode = 200;
 
+  final Map<String, VoidCallback> _peerIdUpdateListeners = {};
+
   bool get emtpy => deviceGroups.isEmpty && users.isEmpty && peers.isEmpty;
 
   late final Peers peersModel;
@@ -92,6 +94,7 @@ class GroupModel {
         .map((e) => e.online = true)
         .toList();
     groupLoadError.value = '';
+    _callbackPeerUpdate();
   }
 
   Future<bool> _getDeviceGroups(
@@ -329,6 +332,7 @@ class GroupModel {
         for (final peer in data['peers']) {
           peers.add(Peer.fromJson(peer));
         }
+        _callbackPeerUpdate();
       }
     } catch (e) {
       debugPrint("load group cache: $e");
@@ -342,5 +346,19 @@ class GroupModel {
     peers.clear();
     selectedAccessibleItemName.value = '';
     await bind.mainClearGroup();
+  }
+
+  void _callbackPeerUpdate() {
+    for (var listener in _peerIdUpdateListeners.values) {
+      listener();
+    }
+  }
+
+  void addPeerUpdateListener(String key, VoidCallback listener) {
+    _peerIdUpdateListeners[key] = listener;
+  }
+
+  void removePeerUpdateListener(String key) {
+    _peerIdUpdateListeners.remove(key);
   }
 }

--- a/flutter/lib/models/peer_model.dart
+++ b/flutter/lib/models/peer_model.dart
@@ -165,6 +165,11 @@ class Peers extends ChangeNotifier {
   final String name;
   final String loadEvent;
   List<Peer> peers = List.empty(growable: true);
+  // Part of the peers that are not in the rest peers list.
+  // When there're too many peers, we may want to load the front 100 peers first,
+  // so we can see peers in UI quickly. `restPeerIds` is the rest peers' ids.
+  // And then load all peers later.
+  List<String> restPeerIds = List.empty(growable: true);
   final GetInitPeers? getInitPeers;
   UpdateEvent event = UpdateEvent.load;
   static const _cbQueryOnlines = 'callback_query_onlines';
@@ -238,6 +243,12 @@ class Peers extends ChangeNotifier {
     } else {
       peers = _decodePeers(evt['peers']);
     }
+
+    restPeerIds = [];
+    if (evt['ids'] != null) {
+      restPeerIds = (evt['ids'] as String).split(',');
+    }
+
     for (var peer in peers) {
       final state = onlineStates[peer.id];
       peer.online = state != null && state != false;

--- a/flutter/lib/plugin/utils/dialogs.dart
+++ b/flutter/lib/plugin/utils/dialogs.dart
@@ -10,7 +10,7 @@ void showPeerSelectionDialog(
   // The plugin is not used for now, so just left it empty here.
   final peers = '';
   if (peers.isEmpty) {
-    debugPrint("load recent peers failed.");
+    // debugPrint("load recent peers failed.");
     return;
   }
 

--- a/flutter/lib/plugin/utils/dialogs.dart
+++ b/flutter/lib/plugin/utils/dialogs.dart
@@ -2,12 +2,13 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_hbb/common.dart';
-import 'package:flutter_hbb/models/platform_model.dart';
 
 void showPeerSelectionDialog(
     {bool singleSelection = false,
     required Function(List<String>) onPeersCallback}) async {
-  final peers = await bind.mainGetRecentPeers(getAll: true);
+  // load recent peers, we can directly use the peers in `gFFI.recentPeersModel`.
+  // The plugin is not used for now, so just left it empty here.
+  final peers = '';
   if (peers.isEmpty) {
     debugPrint("load recent peers failed.");
     return;


### PR DESCRIPTION
1. Use callback to update peers in `AllPeersLoader`.
2. Remove `await` before `mainLoadRecentPeers` to avoid waiting to long if there're too many peers.
