### PR TITLE
fix: load local peers, called two times on select tab

### DIFF
--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -33,8 +33,8 @@ class PeerTabPage extends StatefulWidget {
 
 class _TabEntry {
   final Widget widget;
-  final Function({dynamic hint}) load;
-  _TabEntry(this.widget, this.load);
+  final Function({dynamic hint})? load;
+  _TabEntry(this.widget, [this.load]);
 }
 
 EdgeInsets? _menuPadding() {
@@ -44,21 +44,15 @@ EdgeInsets? _menuPadding() {
 class _PeerTabPageState extends State<PeerTabPage>
     with SingleTickerProviderStateMixin {
   final List<_TabEntry> entries = [
-    _TabEntry(
-        RecentPeersView(
-          menuPadding: _menuPadding(),
-        ),
-        bind.mainLoadRecentPeers),
-    _TabEntry(
-        FavoritePeersView(
-          menuPadding: _menuPadding(),
-        ),
-        bind.mainLoadFavPeers),
-    _TabEntry(
-        DiscoveredPeersView(
-          menuPadding: _menuPadding(),
-        ),
-        bind.mainDiscover),
+    _TabEntry(RecentPeersView(
+      menuPadding: _menuPadding(),
+    )),
+    _TabEntry(FavoritePeersView(
+      menuPadding: _menuPadding(),
+    )),
+    _TabEntry(DiscoveredPeersView(
+      menuPadding: _menuPadding(),
+    )),
     _TabEntry(
         AddressBook(
           menuPadding: _menuPadding(),
@@ -100,7 +94,7 @@ class _PeerTabPageState extends State<PeerTabPage>
         gFFI.peerTabModel.setCurrentTabCachedPeers([]);
       }
       gFFI.peerTabModel.setCurrentTab(tabIndex);
-      entries[tabIndex].load(hint: false);
+      entries[tabIndex].load?.call(hint: false);
     }
   }
 
@@ -225,7 +219,7 @@ class _PeerTabPageState extends State<PeerTabPage>
         child: RefreshWidget(
             onPressed: () {
               if (gFFI.peerTabModel.currentTab < entries.length) {
-                entries[gFFI.peerTabModel.currentTab].load();
+                entries[gFFI.peerTabModel.currentTab].load?.call();
               }
             },
             spinning: loading,


### PR DESCRIPTION
Remove loading function in `_TabEntry`, because:

1. Loading function will also be called in the widget build call.
2. The loading function in `_TabEntry` is only called on switch tabs, it does not load peers on startup.

![image](https://github.com/user-attachments/assets/16a2a53b-4ae9-4826-8532-6dc88098180f)
