### PR TITLE
fix: remote id, update text and reserve selection

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3705,3 +3705,18 @@ Widget workaroundWindowBorder(BuildContext context, Widget child) {
     ],
   );
 }
+
+void updateTextAndPreserveSelection(TextEditingController controller, String text) {
+  final preSelectionStart = controller.selection.start;
+  final preSelectionEnd = controller.selection.end;
+  // Only care about select all for now.
+  final isSelected = preSelectionEnd > preSelectionStart;
+
+  // Set text will make the selection invalid.
+  controller.text = text;
+
+  if (isSelected) {
+    controller.selection = TextSelection(
+        baseOffset: 0, extentOffset: controller.value.text.length);
+  }
+}

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -225,6 +225,7 @@ class _ConnectionPageState extends State<ConnectionPage>
         }
       });
     }
+    Get.put<TextEditingController>(_idEditingController);
     Get.put<IDTextEditingController>(_idController);
     windowManager.addListener(this);
   }
@@ -395,8 +396,8 @@ class _ConnectionPageState extends State<ConnectionPage>
                     FocusNode fieldFocusNode,
                     VoidCallback onFieldSubmitted,
                   ) {
-                    fieldTextEditingController.text = _idController.text;
-                    Get.put<TextEditingController>(fieldTextEditingController);
+                    updateTextAndPreserveSelection(
+                        fieldTextEditingController, _idController.text);
                     return Obx(() => TextField(
                           autocorrect: false,
                           enableSuggestions: false,

--- a/flutter/lib/mobile/pages/connection_page.dart
+++ b/flutter/lib/mobile/pages/connection_page.dart
@@ -74,6 +74,7 @@ class _ConnectionPageState extends State<ConnectionPage> {
         }
       });
     }
+    Get.put<TextEditingController>(_idEditingController);
   }
 
   @override
@@ -214,9 +215,8 @@ class _ConnectionPageState extends State<ConnectionPage> {
                         TextEditingController fieldTextEditingController,
                         FocusNode fieldFocusNode,
                         VoidCallback onFieldSubmitted) {
-                      fieldTextEditingController.text = _idController.text;
-                      Get.put<TextEditingController>(
-                          fieldTextEditingController);
+                      updateTextAndPreserveSelection(
+                          fieldTextEditingController, _idController.text);
                       return AutoSizeTextField(
                         controller: fieldTextEditingController,
                         focusNode: fieldFocusNode,


### PR DESCRIPTION
Fix setting text in `TextEditingController` with reserving selection in the remote id text field.

## Tests

- [x] Selection. Android and Windows.
- [x] Connect. Android and Windows.