### PR TITLE
Update reference to flutter web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Please ensure that you are running these commands from the root of the RustDesk 
 - **[src/rendezvous_mediator.rs](https://github.com/rustdesk/rustdesk/tree/master/src/rendezvous_mediator.rs)**: Communicate with [rustdesk-server](https://github.com/rustdesk/rustdesk-server), wait for remote direct (TCP hole punching) or relayed connection
 - **[src/platform](https://github.com/rustdesk/rustdesk/tree/master/src/platform)**: platform specific code
 - **[flutter](https://github.com/rustdesk/rustdesk/tree/master/flutter)**: Flutter code for desktop and mobile
-- **[flutter/web/js](https://github.com/rustdesk/rustdesk/tree/master/flutter/web/js)**: JavaScript for Flutter web client
+- **[flutter/web/js](https://github.com/rustdesk/rustdesk/tree/master/flutter/web/v1/js)**: JavaScript for Flutter web client
 
 > [!Caution]
 > **Misuse Disclaimer:** <br>


### PR DESCRIPTION
- the src js web UI has moved to directory v1 in flutter/web/js as v2 is under development . The link in README.md is returning 404 currently and needs update