### PR TITLE
set rgba_data.valid to false when open a new single display on the old session

### DIFF
--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -2026,6 +2026,8 @@ pub mod sessions {
                     // This operation will also cause the peer to send a switch display message.
                     // The switch display message will contain `SupportedResolutions`, which is useful when changing resolutions.
                     s.switch_display(value[0]);
+                    // Reset the valid flag of the display.
+                    s.next_rgba(value[0] as usize);
 
                     if !is_desktop {
                         s.capture_displays(vec![], vec![], value);
@@ -2103,6 +2105,11 @@ pub mod sessions {
                 .write()
                 .unwrap()
                 .insert(session_id, h);
+            // If the session is a single display session, it may be a software rgba rendered display.
+            // If this is the second time the display is opened, the old valid flag may be true.
+            if displays.len() == 1 {
+                s.ui_handler.next_rgba(displays[0] as usize);
+            }
             true
         } else {
             false


### PR DESCRIPTION
## Bug

For software(non-texture) render, when the window is closed, the `rgba.valid` flag may still be true. If open this window again, rgba will not be passed to flutter.

During closing window:
1. `next_rgba` is not called in rust
![89c3f07ab9a0088e401f908ae213d05](https://github.com/user-attachments/assets/777f90ac-6c84-4f82-a088-40afd8cc2f53)

2. `rgba.valid` is set to true but `get_rgba` is not called.
![d1f84ed9fd259555d08272a47432333](https://github.com/user-attachments/assets/3402c874-3544-44b0-a459-fd75158cc5ef)

## Fix
* When open display with a new window, `session_add_existed` is called. Because software-render doesn't support multi display, when the length of `displays` is 1, it may be a software render display, set the `rgba.valid` flag to false for that display.
* When switch display, set rgba.valid flag to false for the new display. 

## Videos:

1. Currently one display, open another display in a new window

https://github.com/user-attachments/assets/00d13863-40a1-4dc4-8d95-97e6176a0d1c

https://github.com/user-attachments/assets/e75b4c86-cdfa-4ec8-b0b1-32a135a48ae2

2. Currently two displays, open another display in a new window

https://github.com/user-attachments/assets/24d6edd7-cc0b-4cd8-a680-81370411d130

https://github.com/user-attachments/assets/ea621ebd-6495-4e1f-888e-db7611d449bc

3. Currently one display, open another 2 displays in a new window, close the first window, switch display to that old display.

https://github.com/user-attachments/assets/117e1cc0-ce2f-411e-9037-cb588b7e927e


https://github.com/user-attachments/assets/3fc2e92f-2957-441c-97ab-8fcb9bd3bb3a


