### PR TITLE
fix: vcpkg, cmake, compatibility 3.5

### DIFF
--- a/res/vcpkg/mfx-dispatch/0003-upgrade-cmake-3.14.patch
+++ b/res/vcpkg/mfx-dispatch/0003-upgrade-cmake-3.14.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a8a3288..7d01d97 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.6)
++cmake_minimum_required(VERSION 3.14)
+ 
+ project( libmfx )
+ 

--- a/res/vcpkg/mfx-dispatch/fix-pkgconf.patch
+++ b/res/vcpkg/mfx-dispatch/fix-pkgconf.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9446bc4..a8a3288 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,16 +3,7 @@ cmake_minimum_required(VERSION 2.6)
+ project( libmfx )
+ 
+ # FIXME Adds support for using system/other install of intel media sdk
+-find_path ( INTELMEDIASDK_PATH mfx/mfxvideo.h
+-  HINTS "${CMAKE_SOURCE_DIR}"
+-)
+-
+-if (INTELMEDIASDK_PATH_NOTFOUND)
+-  message( FATAL_ERROR "Intel MEDIA SDK include not found" )
+-else (INTELMEDIASDK_PATH_NOTFOUND)
+-  message(STATUS "Intel Media SDK is here: ${INTELMEDIASDK_PATH}")
+-endif (INTELMEDIASDK_PATH_NOTFOUND)
+-
++set(INTELMEDIASDK_PATH "${CMAKE_CURRENT_LIST_DIR}")
+ 
+ set(SOURCES
+   src/main.cpp
+diff --git a/libmfx.pc.cmake b/libmfx.pc.cmake
+index fabb541..5d248fe 100644
+--- a/libmfx.pc.cmake
++++ b/libmfx.pc.cmake
+@@ -6,9 +6,9 @@ Requires.private:
+ Name: libmfx
+ Description: Intel Media SDK Dispatched static library
+-Version: 2013
++Version: 1.35
+ Requires:
+ Requires.private:
+ Conflicts:
+-Libs: -L${libdir} -lsupc++ ${libdir}/libmfx.lib
++Libs: -L${libdir} -llibmfx
+ Libs.private:
+-Cflags: -I${includedir} -I@INTELMEDIASDK_PATH@
++Cflags: -I${includedir}

--- a/res/vcpkg/mfx-dispatch/fix-unresolved-symbol.patch
+++ b/res/vcpkg/mfx-dispatch/fix-unresolved-symbol.patch
@@ -1,0 +1,66 @@
+Subject: [PATCH] fix for vcpkg
+fix missing mfx_driver_store_loader related symbols
+---
+Index: CMakeLists.txt
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	(revision 7e4d221c36c630c1250b23a5dfa15657bc04c10c)
++++ b/CMakeLists.txt	(revision 5ebef171699530ca01594a5cef10a68811f4d105)
+@@ -40,6 +39,7 @@
+     src/mfx_load_plugin.cpp
+     src/mfx_plugin_hive.cpp
+     src/mfx_win_reg_key.cpp
++    src/mfx_driver_store_loader.cpp
+   )
+ endif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+ 
+@@ -56,6 +56,12 @@
+ configure_file (${CMAKE_SOURCE_DIR}/libmfx.pc.cmake ${CMAKE_BINARY_DIR}/libmfx.pc @ONLY)
+ 
+ add_library( mfx STATIC ${SOURCES} )
++
++if (CMAKE_SYSTEM_NAME MATCHES "Windows")
++  set_target_properties(mfx
++          PROPERTIES PREFIX lib)
++endif (CMAKE_SYSTEM_NAME MATCHES "Windows")
++
+ install (DIRECTORY ${CMAKE_SOURCE_DIR}/mfx DESTINATION ${CMAKE_INSTALL_PREFIX}/include FILES_MATCHING PATTERN "*.h")
+ install (FILES ${CMAKE_BINARY_DIR}/libmfx.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+ install (TARGETS mfx ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+Index: libmfx.pc.cmake
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/libmfx.pc.cmake b/libmfx.pc.cmake
+--- a/libmfx.pc.cmake	(revision 7e4d221c36c630c1250b23a5dfa15657bc04c10c)
++++ b/libmfx.pc.cmake	(revision 388559e9e8234eb0989e1598a9beea4035a04132)
+@@ -9,6 +9,6 @@
+ Requires:
+ Requires.private:
+ Conflicts:
+-Libs: -L${libdir} -lsupc++ ${libdir}/libmfx.a
++Libs: -L${libdir} -lsupc++ ${libdir}/libmfx.lib
+ Libs.private:
+ Cflags: -I${includedir} -I@INTELMEDIASDK_PATH@
+Index: src/mfx_driver_store_loader.cpp
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/src/mfx_driver_store_loader.cpp b/src/mfx_driver_store_loader.cpp
+--- a/src/mfx_driver_store_loader.cpp	(revision 388559e9e8234eb0989e1598a9beea4035a04132)
++++ b/src/mfx_driver_store_loader.cpp	(revision 5ebef171699530ca01594a5cef10a68811f4d105)
+@@ -24,6 +24,9 @@
+ #include "mfx_dispatcher_log.h"
+ #include "mfx_load_dll.h"
+ 
++#pragma comment(lib, "Ole32.lib")
++#pragma comment(lib, "Advapi32.lib")
++
+ namespace MFX
+ {
+ 

--- a/res/vcpkg/mfx-dispatch/portfile.cmake
+++ b/res/vcpkg/mfx-dispatch/portfile.cmake
@@ -1,0 +1,40 @@
+vcpkg_download_distfile(
+    MISSING_CSTDINT_IMPORT_PATCH
+    URLS https://github.com/lu-zero/mfx_dispatch/commit/d6241243f85a0d947bdfe813006686a930edef24.patch?full_index=1
+    FILENAME fix-missing-cstdint-import-d6241243f85a0d947bdfe813006686a930edef24.patch
+    SHA512 5d2ffc4ec2ba0e5859d01d2e072f75436ebc3e62e0f6580b5bb8b9f82fe588e7558a46a1fdfa0297a782c0eeb8f50322258d0dd9e41d927cc9be496727b61e44
+)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lu-zero/mfx_dispatch
+    REF "${VERSION}"
+    SHA512 12517338342d3e653043a57e290eb9cffd190aede0c3a3948956f1c7f12f0ea859361cf3e534ab066b96b1c211f68409c67ef21fd6d76b68cc31daef541941b0
+    HEAD_REF master
+    PATCHES
+        fix-unresolved-symbol.patch
+        fix-pkgconf.patch
+        0003-upgrade-cmake-3.14.patch
+        ${MISSING_CSTDINT_IMPORT_PATCH}
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    vcpkg_cmake_configure(
+        SOURCE_PATH "${SOURCE_PATH}" 
+    )
+    vcpkg_cmake_install()
+    vcpkg_copy_pdbs()
+else()
+    if(VCPKG_TARGET_IS_MINGW)
+        vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+    endif()
+    vcpkg_configure_make(
+        SOURCE_PATH "${SOURCE_PATH}"
+        AUTOCONFIG
+    )
+    vcpkg_install_make()
+endif()
+vcpkg_fixup_pkgconfig()
+  
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/res/vcpkg/mfx-dispatch/vcpkg.json
+++ b/res/vcpkg/mfx-dispatch/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "mfx-dispatch",
+  "version": "1.35.1",
+  "port-version": 5,
+  "description": "Open source Intel media sdk dispatcher",
+  "homepage": "https://github.com/lu-zero/mfx_dispatch",
+  "license": "BSD-3-Clause",
+  "supports": "((x86 | x64) & (android | linux)) | (windows & !uwp)",
+  "dependencies": [
+    {
+    "name": "vcpkg-cmake",
+    "host": true,
+    "platform": "windows & !mingw"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -49,6 +49,16 @@
       "host": false
     },
     {
+      "name": "mfx-dispatch",
+      "host": true,
+      "platform": "((x86 | x64) & (android | linux)) | (windows & !uwp)"
+    },
+    {
+      "name": "mfx-dispatch",
+      "host": false,
+      "platform": "((x86 | x64) & (android | linux)) | (windows & !uwp)"
+    },
+    {
       "name": "ffmpeg",
       "host": true,
       "features": [
@@ -90,10 +100,6 @@
     {
       "name": "amd-amf",
       "version": "1.4.35"
-    },
-    {
-      "name": "mfx-dispatch",
-      "version": "1.35.1"
     }
   ]
 }


### PR DESCRIPTION
The CMake version is `4.0` now.

https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md


CI reports `Error:   Compatibility with CMake < 3.5 has been removed from CMake.`


All files except `0003-upgrade-cmake-3.14.patch` are from https://github.com/microsoft/vcpkg/tree/9b75e789ece3f942159b8500584e35aafe3979ff/ports/mfx-dispatch


## Test

Codec `av1`, `h264`, `h265`, all work fine.
