### PR TITLE
fix: enigo, macos, F11

### DIFF
--- a/libs/enigo/src/macos/macos_impl.rs
+++ b/libs/enigo/src/macos/macos_impl.rs
@@ -142,7 +142,8 @@ impl Enigo {
     }
 
     fn post(&self, event: CGEvent) {
-        if !self.ignore_flags {
+        // event.set_flags(CGEventFlags::CGEventFlagNull); will cause `F11` not working. no idea why.
+        if !self.ignore_flags && self.flags != CGEventFlags::CGEventFlagNull {
             event.set_flags(self.flags);
         }
         event.set_integer_value_field(EventField::EVENT_SOURCE_USER_DATA, ENIGO_INPUT_EXTRA_VALUE);


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/11366#discussioncomment-12731839

## Desc

mobile -> macOS, virtual keys are handled by the legacy keyboard mode.

`event.set_flags(self.flags);` affects `F11`.
Though `rdev` can listen the `F11` key event, the event does actually not work.

## Tests

1. `Shift`/`Command` + Mouse. (Win -> macOS, Legacy mode)
2. `Command` + `C`/`V`, `Shift` + `Arrows`,   (Win -> macOS, Legacy mode)
3. `F11` (mobile -> macOS, Win -> macOS, Legacy mode)
4. `F1`, `F3`, `F5`, `F6`, `F7`, `F9`, `F11`, `F12` (-> macOS, Legacy mode)

## Note

`Control` + `F4` does not work in "Legacy mode", but works in "Map mode" and "Translate mode".


