### PR TITLE
Feat/easy upgrade

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1273,7 +1273,7 @@ Widget msgboxContent(String type, String title, String text) {
       text = words.join(': ');
     } else {
       List<String> words = text.split(' ');
-      if (words.length > 1 && words[0].endsWith('_tip')) {
+      if (words.length > 1 && (words[0].endsWith('_tip') || words[0].endsWith('-tip'))) {
         words[0] = translate(words[0]);
         final rest = text.substring(words[0].length + 1);
         text = '${words[0]} ${translate(rest)}';

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -12,6 +12,7 @@ import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/pages/connection_page.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_setting_page.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_tab_page.dart';
+import 'package:flutter_hbb/desktop/widgets/upgrade_progress.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:flutter_hbb/models/server_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
@@ -433,13 +434,36 @@ class _DesktopHomePageState extends State<DesktopHomePage>
         updateUrl.isNotEmpty &&
         !isCardClosed &&
         bind.mainUriPrefixSync().contains('rustdesk')) {
+      String btnText = "Click to download";
+      var isToUpgrade = false;
+      if (isWindows && bind.mainIsInstalled()) {
+        final String isMsiInstalled =
+            bind.mainGetCommonSync(key: 'is-msi-installed');
+        if ('false' == isMsiInstalled) {
+          isToUpgrade = true;
+        } else if ('true' != isMsiInstalled) {
+          debugPrint(
+              "isMsiInstalled is not true or false, error: $isMsiInstalled");
+        }
+      }
+      if (isToUpgrade) {
+        btnText = "Click to upgrade";
+      }
+      GestureTapCallback onPressed = () async {
+        final Uri url = Uri.parse('https://rustdesk.com/download');
+        await launchUrl(url);
+      };
+      if (isToUpgrade) {
+        onPressed = () {
+          handleUpgrade(updateUrl);
+        };
+      }
       return buildInstallCard(
           "Status",
           "${translate("new-version-of-{${bind.mainGetAppNameSync()}}-tip")} (${bind.mainGetNewVersion()}).",
-          "Click to download", () async {
-        final Uri url = Uri.parse('https://rustdesk.com/download');
-        await launchUrl(url);
-      }, closeButton: true);
+          btnText,
+          onPressed,
+          closeButton: true);
     }
     if (systemError.isNotEmpty) {
       return buildInstallCard("", systemError, "", () {});
@@ -556,6 +580,30 @@ class _DesktopHomePageState extends State<DesktopHomePage>
       ).marginAll(14);
     }
     return Container();
+  }
+
+  void handleUpgrade(String updateUrl) {
+    String downloadUrl = updateUrl.replaceAll('tag', 'download');
+    String version = downloadUrl.substring(downloadUrl.lastIndexOf('/') + 1);
+    if (isWindows) {
+      downloadUrl = '$downloadUrl/rustdesk-$version-x86_64.exe';
+    }
+    SimpleWrapper downloadId = SimpleWrapper('');
+    gFFI.dialogManager.dismissAll();
+    gFFI.dialogManager.show((setState, close, context) {
+      return CustomAlertDialog(
+          title: Text(translate('Downloading {$appName}')),
+          content: UpgradeProgress(updateUrl, downloadUrl, downloadId)
+              .marginSymmetric(horizontal: 8)
+              .paddingOnly(top: 12),
+          actions: [
+            dialogButton(translate('Cancel'), onPressed: () {
+              close();
+              bind.mainSetCommon(
+                  key: 'cancel-downloader', value: downloadId.value);
+            }, isOutline: true),
+          ]);
+    });
   }
 
   Widget buildInstallCard(String title, String content, String btnText,

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -582,30 +582,6 @@ class _DesktopHomePageState extends State<DesktopHomePage>
     return Container();
   }
 
-  void handleUpgrade(String updateUrl) {
-    String downloadUrl = updateUrl.replaceAll('tag', 'download');
-    String version = downloadUrl.substring(downloadUrl.lastIndexOf('/') + 1);
-    if (isWindows) {
-      downloadUrl = '$downloadUrl/rustdesk-$version-x86_64.exe';
-    }
-    SimpleWrapper downloadId = SimpleWrapper('');
-    gFFI.dialogManager.dismissAll();
-    gFFI.dialogManager.show((setState, close, context) {
-      return CustomAlertDialog(
-          title: Text(translate('Downloading {$appName}')),
-          content: UpgradeProgress(updateUrl, downloadUrl, downloadId)
-              .marginSymmetric(horizontal: 8)
-              .paddingOnly(top: 12),
-          actions: [
-            dialogButton(translate('Cancel'), onPressed: () {
-              close();
-              bind.mainSetCommon(
-                  key: 'cancel-downloader', value: downloadId.value);
-            }, isOutline: true),
-          ]);
-    });
-  }
-
   Widget buildInstallCard(String title, String content, String btnText,
       GestureTapCallback onPressed,
       {double marginTop = 20.0,

--- a/flutter/lib/desktop/widgets/upgrade_progress.dart
+++ b/flutter/lib/desktop/widgets/upgrade_progress.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hbb/common.dart';
+import 'package:flutter_hbb/models/platform_model.dart';
+
+class UpgradeProgress extends StatefulWidget {
+  final String releasePageUrl;
+  final String downloadUrl;
+  final SimpleWrapper downloadId;
+  UpgradeProgress(this.releasePageUrl, this.downloadUrl, this.downloadId,
+      {Key? key})
+      : super(key: key);
+
+  @override
+  State<UpgradeProgress> createState() => UpgradeProgressState();
+}
+
+class UpgradeProgressState extends State<UpgradeProgress> {
+  Timer? _timer;
+  String get downloadUrl => widget.downloadUrl;
+  int? totalSize;
+  int downloadedSize = 0;
+  String error = '';
+  int getDataFailedCount = 0;
+  final String _eventKeyDownloadNewVersion = 'download-new-version';
+
+  @override
+  void initState() {
+    super.initState();
+    platformFFI.registerEventHandler(_eventKeyDownloadNewVersion,
+        _eventKeyDownloadNewVersion, handleDownloadNewVersion,
+        replace: true);
+    bind.mainSetCommon(key: 'download-new-version', value: downloadUrl);
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    platformFFI.unregisterEventHandler(
+        _eventKeyDownloadNewVersion, _eventKeyDownloadNewVersion);
+    super.dispose();
+  }
+
+  Future<void> handleDownloadNewVersion(Map<String, dynamic> evt) async {
+    if (evt.containsKey('id')) {
+      widget.downloadId.value = evt['id'] as String;
+      _timer = Timer.periodic(const Duration(milliseconds: 300), (timer) {
+        _updateDownloadData();
+      });
+    } else {
+      if (evt.containsKey('error')) {
+        _onError(evt['error'] as String);
+      } else {
+        // unreachable
+        _onError('$evt');
+      }
+    }
+  }
+
+  void _onError(String error) {
+    msgBox(
+        gFFI.sessionId,
+        'custom-nocancel',
+        'Error',
+        'download-new-veresion-failed-tip',
+        widget.releasePageUrl,
+        gFFI.dialogManager);
+  }
+
+  void _updateDownloadData() {
+    String downloadData = bind.mainGetCommonSync(key: 'download-data-${widget.downloadId.value}');
+    if (downloadData.startsWith('error:')) {
+      error = downloadData.substring('error:'.length);
+    } else {
+      try {
+        jsonDecode(downloadData).forEach((key, value) {
+          if (key == 'total_size') {
+            if (value != null && value is int) {
+              totalSize = value;
+            }
+          } else if (key == 'downloaded_size') {
+            downloadedSize = value as int;
+          } else if (key == 'error') {
+            if (value != null) {
+              error = value.toString();
+            }
+          }
+        });
+      } catch (e) {
+        getDataFailedCount += 1;
+        debugPrint('Failed to get download data $downloadUrl, error $e');
+        if (getDataFailedCount > 3) {
+          error = e.toString();
+        }
+      }
+    }
+    if (error != '') {
+      _onError(error);
+    } else {
+      if (totalSize != null && downloadedSize >= totalSize!) {
+        _timer?.cancel();
+        _timer = null;
+        bind.mainSetCommon(key: 'remove-downloader', value: widget.downloadId.value);
+        if (totalSize == 0) {
+          _onError('The download file size is 0.');
+        } else {
+          setState(() {});
+          Future.delayed(const Duration(milliseconds: 500), () {
+            msgBox(gFFI.sessionId, 'custom-nocancel', '{$appName} Upgrade',
+                '{$appName}-to-upgrade-tip', '', gFFI.dialogManager);
+            Future.delayed(const Duration(milliseconds: 1000), () {
+              bind.mainSetCommon(key: 'upgrade-me', value: '');
+            });
+          });
+        }
+      } else {
+        setState(() {});
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return onDownloading(context);
+  }
+
+  Widget onDownloading(BuildContext context) {
+    final value = totalSize == null
+        ? 0.0
+        : (totalSize == 0 ? 1.0 : downloadedSize / totalSize!);
+    return LinearProgressIndicator(
+      value: value,
+      minHeight: 20,
+      borderRadius: BorderRadius.circular(5),
+      backgroundColor: Colors.grey[300],
+      valueColor: const AlwaysStoppedAnimation<Color>(Colors.blue),
+    );
+  }
+}

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -183,18 +183,15 @@ pub fn core_main() -> Option<Vec<String>> {
                 }
                 return None;
             } else if args[0] == "--upgrade" {
-                use crate::ui_interface::{directly_install_options, install_path};
-                // Simply call install_me to upgrade, it may break something.
-                // If the user does not install the printer driver on installation,
-                // but the printer driver is installed later manually in the settings page.
-                // The upgrade will uninstall the printer driver and not install it again.
-                let res =
-                    platform::install_me(&directly_install_options(), install_path(), false, false);
+                if config::is_disable_installation() {
+                    return None;
+                }
+                let res = platform::upgrade_me(false);
                 let text = match res {
-                    Ok(_) => translate("Installation Successful!".to_string()),
+                    Ok(_) => translate("Upgrade successfully!".to_string()),
                     Err(err) => {
                         println!("Failed with error: {err}");
-                        translate("Installation failed!".to_string())
+                        translate("Upgrade failed!".to_string())
                     }
                 };
                 Toast::new(Toast::POWERSHELL_APP_ID)

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1975,7 +1975,7 @@ pub fn install_install_path() -> SyncReturn<String> {
 }
 
 pub fn install_install_options() -> SyncReturn<String> {
-    SyncReturn(serde_json::to_string(&install_options()).unwrap_or("{}".to_owned()))
+    SyncReturn(install_options())
 }
 
 pub fn main_account_auth(op: String, remember_me: bool) {
@@ -2448,7 +2448,7 @@ pub fn main_get_common_sync(key: String) -> SyncReturn<String> {
 }
 
 #[cfg(target_os = "windows")]
-fn get_download_file() -> PathBuf {
+fn get_new_version_download_file() -> PathBuf {
     std::env::temp_dir().join(format!("{}.exe", crate::get_app_name()))
 }
 
@@ -2478,7 +2478,7 @@ pub fn main_set_common(_key: String, _value: String) {
     #[cfg(target_os = "windows")]
     {
         if _key == "download-new-version" {
-            let download_file = get_download_file();
+            let download_file = get_new_version_download_file();
             let download_url = _value.clone();
             let event_key = "download-new-version".to_owned();
             std::fs::remove_file(&download_file).ok();
@@ -2495,7 +2495,9 @@ pub fn main_set_common(_key: String, _value: String) {
                 serde_json::ser::to_string(&data).unwrap_or("".to_owned()),
             );
         } else if _key == "upgrade-me" {
-            let new_version_file = get_download_file().to_string_lossy().to_string();
+            let new_version_file = get_new_version_download_file()
+                .to_string_lossy()
+                .to_string();
             // 1.3.9 does not support "--upgrade"
             // But we can assume that the new version will support it.
             let _ = crate::platform::run_exe_as_user(&new_version_file, vec!["--upgrade"]);

--- a/src/hbbs_http.rs
+++ b/src/hbbs_http.rs
@@ -7,6 +7,7 @@ pub mod account;
 mod http_client;
 pub mod record_upload;
 pub mod sync;
+pub mod downloader;
 pub use http_client::create_http_client;
 pub use http_client::create_http_client_async;
 

--- a/src/hbbs_http/downloader.rs
+++ b/src/hbbs_http/downloader.rs
@@ -1,0 +1,271 @@
+use super::create_http_client_async;
+use hbb_common::{
+    bail,
+    lazy_static::lazy_static,
+    log,
+    tokio::{
+        self,
+        fs::File,
+        io::AsyncWriteExt,
+        sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    },
+    ResultType,
+};
+use serde_derive::Serialize;
+use std::{collections::HashMap, path::PathBuf, sync::Mutex, time::Duration};
+
+lazy_static! {
+    static ref DOWNLOADERS: Mutex<HashMap<String, Downloader>> = Default::default();
+}
+
+/// This struct is used to return the download data to the caller.
+/// The caller should check if the file is downloaded successfully and remove the job from the map.
+/// If the file is not downloaded successfully, the `data` field will be empty.
+/// If the file is downloaded successfully, the `data` field will contain the downloaded data if `path` is None.
+#[derive(Serialize, Debug)]
+pub struct DownloadData {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub data: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_size: Option<u64>,
+    pub downloaded_size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+struct Downloader {
+    data: Vec<u8>,
+    path: Option<PathBuf>,
+    // Some file may be empty, so we use Option<u64> to indicate if the size is known
+    total_size: Option<u64>,
+    downloaded_size: u64,
+    error: Option<String>,
+    finished: bool,
+    tx_cancel: UnboundedSender<()>,
+}
+
+// The caller should check if the file is downloaded successfully and remove the job from the map.
+pub fn download_file(
+    url: String,
+    path: Option<PathBuf>,
+    auto_del_dur: Option<Duration>,
+) -> ResultType<String> {
+    let id = url.clone();
+    if DOWNLOADERS.lock().unwrap().contains_key(&id) {
+        return Ok(id);
+    }
+
+    if let Some(path) = path.as_ref() {
+        if path.exists() {
+            bail!("File {} already exists", path.display());
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let (tx, rx) = unbounded_channel();
+    let downloader = Downloader {
+        data: Vec::new(),
+        path: path.clone(),
+        total_size: None,
+        downloaded_size: 0,
+        error: None,
+        tx_cancel: tx,
+        finished: false,
+    };
+    let mut downloaders = DOWNLOADERS.lock().unwrap();
+    downloaders.insert(id.clone(), downloader);
+
+    let id2 = id.clone();
+    std::thread::spawn(
+        move || match do_download(&id2, url, path, auto_del_dur, rx) {
+            Ok(is_all_downloaded) => {
+                let mut downloaded_size = 0;
+                let mut total_size = 0;
+                DOWNLOADERS.lock().unwrap().get_mut(&id2).map(|downloader| {
+                    downloaded_size = downloader.downloaded_size;
+                    total_size = downloader.total_size.unwrap_or(0);
+                });
+                log::info!(
+                    "Download {} end, {}/{}, {:.2} %",
+                    &id2,
+                    downloaded_size,
+                    total_size,
+                    if total_size == 0 {
+                        0.0
+                    } else {
+                        downloaded_size as f64 / total_size as f64 * 100.0
+                    }
+                );
+
+                let is_canceled = !is_all_downloaded;
+                if is_canceled {
+                    if let Some(downloader) = DOWNLOADERS.lock().unwrap().remove(&id2) {
+                        if let Some(p) = downloader.path {
+                            if p.exists() {
+                                std::fs::remove_file(p).ok();
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                let err = e.to_string();
+                log::error!("Download {}, failed: {}", &id2, &err);
+                DOWNLOADERS.lock().unwrap().get_mut(&id2).map(|downloader| {
+                    downloader.error = Some(err);
+                });
+            }
+        },
+    );
+
+    Ok(id)
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn do_download(
+    id: &str,
+    url: String,
+    path: Option<PathBuf>,
+    auto_del_dur: Option<Duration>,
+    mut rx_cancenl: UnboundedReceiver<()>,
+) -> ResultType<bool> {
+    let client = create_http_client_async();
+
+    let mut is_all_downloaded = false;
+    tokio::select! {
+        _ = rx_cancenl.recv() => {
+            return Ok(is_all_downloaded);
+        }
+        head_resp = client.head(&url).send() => {
+            match head_resp {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        let total_size = resp
+                            .headers()
+                            .get(reqwest::header::CONTENT_LENGTH)
+                            .and_then(|ct_len| ct_len.to_str().ok())
+                            .and_then(|ct_len| ct_len.parse::<u64>().ok());
+                        let Some(total_size) = total_size else {
+                            bail!("Failed to get content length");
+                        };
+                        DOWNLOADERS.lock().unwrap().get_mut(id).map(|downloader| {
+                            downloader.total_size = Some(total_size);
+                        });
+                    } else {
+                        bail!("Failed to get content length: {}", resp.status());
+                    }
+                }
+                Err(e) => {
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+
+    let mut response;
+    tokio::select! {
+        _ = rx_cancenl.recv() => {
+            return Ok(is_all_downloaded);
+        }
+        resp = client.get(url).send() => {
+            response = resp?;
+        }
+    }
+
+    let mut dest: Option<File> = None;
+    if let Some(p) = path {
+        dest = Some(File::create(p).await?);
+    }
+
+    loop {
+        tokio::select! {
+            _ = rx_cancenl.recv() => {
+                break;
+            }
+            chunk = response.chunk() => {
+                match chunk {
+                    Ok(Some(chunk)) => {
+                        match dest {
+                            Some(ref mut f) => {
+                                f.write_all(&chunk).await?;
+                                f.flush().await?;
+                                DOWNLOADERS.lock().unwrap().get_mut(id).map(|downloader| {
+                                    downloader.downloaded_size += chunk.len() as u64;
+                                });
+                            }
+                            None => {
+                                DOWNLOADERS.lock().unwrap().get_mut(id).map(|downloader| {
+                                    downloader.data.extend_from_slice(&chunk);
+                                    downloader.downloaded_size += chunk.len() as u64;
+                                });
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        is_all_downloaded = true;
+                    },
+                    Err(e) => {
+                        log::error!("Download {} failed: {}", id, e);
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(mut f) = dest.take() {
+        f.flush().await?;
+    }
+
+    if let Some(ref mut downloader) = DOWNLOADERS.lock().unwrap().get_mut(id) {
+        downloader.finished = true;
+    }
+    let id_del = id.to_string();
+    if let Some(dur) = auto_del_dur {
+        std::thread::spawn(move || {
+            std::thread::sleep(dur);
+            DOWNLOADERS.lock().unwrap().remove(&id_del);
+        });
+    }
+    Ok(is_all_downloaded)
+}
+
+pub fn get_download_data(id: &str) -> ResultType<DownloadData> {
+    let downloaders = DOWNLOADERS.lock().unwrap();
+    if let Some(downloader) = downloaders.get(id) {
+        let downloaded_size = downloader.downloaded_size;
+        let total_size = downloader.total_size.clone();
+        let error = downloader.error.clone();
+        let data = if total_size.unwrap_or(0) == downloaded_size && downloader.path.is_none() {
+            downloader.data.clone()
+        } else {
+            Vec::new()
+        };
+        let path = downloader.path.clone();
+        let download_data = DownloadData {
+            data,
+            path,
+            total_size,
+            downloaded_size,
+            error,
+        };
+        Ok(download_data)
+    } else {
+        bail!("Downloader not found")
+    }
+}
+
+pub fn cancel(id: &str) {
+    if let Some(downloader) = DOWNLOADERS.lock().unwrap().get(id) {
+        // downloader.is_canceled.store(true, Ordering::SeqCst);
+        // The receiver may not be able to receive the cancel signal, so we also set the atomic bool to true
+        let _ = downloader.tx_cancel.send(());
+    }
+}
+
+pub fn remove(id: &str) {
+    let _ = DOWNLOADERS.lock().unwrap().remove(id);
+}

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "الطباعة عن بُعد غير مسموح بها على هذا الجهاز"),
         ("save-settings-tip", "حفظ الإعدادات"),
         ("dont-show-again-tip", "لا تظهر هذا مرة أخرى"),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "被控端的权限设置拒绝了远程打印。"),
         ("save-settings-tip", "保存设置"),
         ("dont-show-again-tip", "不再显示此信息"),
+        ("Downloading {}", "下载 {}"),
+        ("{} Upgrade", "{} 升级"),
+        ("{}-to-upgrade-tip", "即将关闭 {} ，并安装新版本。"),
+        ("download-new-veresion-failed-tip", "下载失败，请点击 查看 按钮，从发布网址手动下载，并升级。"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -684,6 +684,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", "下载 {}"),
         ("{} Upgrade", "{} 升级"),
         ("{}-to-upgrade-tip", "即将关闭 {} ，并安装新版本。"),
-        ("download-new-veresion-failed-tip", "下载失败，请点击 查看 按钮，从发布网址手动下载，并升级。"),
+        ("download-new-veresion-failed-tip", "下载失败，您可以 重试 或者点击 查看 按钮，从发布网址下载，并手动升级。"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Die Berechtigungseinstellungen der kontrollierten Seite verweigern den entfernten Druck."),
         ("save-settings-tip", "Einstellungen speichern"),
         ("dont-show-again-tip", "Nicht mehr anzeigen"),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -254,6 +254,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Save settings"),
         ("dont-show-again-tip", "Don't show this again"),
         ("{}-to-upgrade-tip", "{} will close now and install the new version."),
-        ("download-new-veresion-failed-tip", "Download failed. Please click the View button to manually download from the release page and upgrade.")
+        ("download-new-veresion-failed-tip", "Download failed. You can try again or click the View button to download from the release page and upgrade manually.")
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -253,5 +253,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "The permission settings of the controlled side deny Remote Printing."),
         ("save-settings-tip", "Save settings"),
         ("dont-show-again-tip", "Don't show this again"),
+        ("{}-to-upgrade-tip", "{} will close now and install the new version."),
+        ("download-new-veresion-failed-tip", "Download failed. Please click the View button to manually download from the release page and upgrade.")
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "شما مجوز لازم برای چاپ از راه دور را ندارید"),
         ("save-settings-tip", "تنظیمات را ذخیره کنید"),
         ("dont-show-again-tip", "دیگر نمایش داده نشود"),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Les paramètres de l’appareil contrôlé n’autorisent pas l’impression à distance."),
         ("save-settings-tip", "Enregistrer les paramètres"),
         ("dont-show-again-tip", "Ne plus afficher"),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Le impostazioni di autorizzazione del lato controllato negano la stampa remota."),
         ("save-settings-tip", "Salva impostazioni"),
         ("dont-show-again-tip", "Non visualizzare più questo messaggio"),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Kontrolētās puses atļauju iestatījumi liedz attālo drukāšanu."),
         ("save-settings-tip", "Saglabāt iestatījumus"),
         ("dont-show-again-tip", "Nerādīt šo vēlreiz"),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "As configurações do dispositivo controlado não permitem impressão remota."),
         ("save-settings-tip", "Salvar configurações"),
         ("dont-show-again-tip", "Não mostrar novamente"),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Настройки разрешений на управляемой стороне запрещают удалённую печать."),
         ("save-settings-tip", "Сохранить настройки"),
         ("dont-show-again-tip", "Больше не показывать"),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Sas impostatziones de sos permissos de s'ala controllada negant s'imprenta remota."),
         ("save-settings-tip", "Sarva sas impostatziones"),
         ("dont-show-again-tip", "Non mustres prus custu messàgiu"),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "被控端的權限設置拒絕了遠端列印。"),
         ("save-settings-tip", "儲存設定"),
         ("dont-show-again-tip", "不再顯示此訊息"),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -681,5 +681,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Upgrade", ""),
+        ("{}-to-upgrade-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -441,11 +441,19 @@ pub fn install_path() -> String {
 }
 
 #[inline]
-pub fn install_options() -> String {
+pub fn install_options() -> HashMap<&'static str, String> {
     #[cfg(windows)]
     return crate::platform::windows::get_install_options();
     #[cfg(not(windows))]
-    return "{}".to_owned();
+    return HashMap::new();
+}
+
+#[inline]
+pub fn directly_install_options() -> String {
+    #[cfg(windows)]
+    return crate::platform::windows::get_directly_install_options();
+    #[cfg(not(windows))]
+    return "".to_owned();
 }
 
 #[inline]

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -441,19 +441,11 @@ pub fn install_path() -> String {
 }
 
 #[inline]
-pub fn install_options() -> HashMap<&'static str, String> {
+pub fn install_options() -> String {
     #[cfg(windows)]
     return crate::platform::windows::get_install_options();
     #[cfg(not(windows))]
-    return HashMap::new();
-}
-
-#[inline]
-pub fn directly_install_options() -> String {
-    #[cfg(windows)]
-    return crate::platform::windows::get_directly_install_options();
-    #[cfg(not(windows))]
-    return "".to_owned();
+    return "{}".to_owned();
 }
 
 #[inline]


### PR DESCRIPTION
## Preview

https://github.com/user-attachments/assets/53095fdd-e004-48d8-b5b6-e4dd969eee8c


https://github.com/user-attachments/assets/091258a6-9b56-403c-b590-b2244a6dbc4a


## Desc

1. Add option `--upgrade` for easy upgrade. `stop service` -> `kill all instances` -> `update reg values` -> `copy files` -> `restore service` -> `restore main window and tray process`
2. MSI version is not supported.
