### PR TITLE
feat: win, update

### DIFF
--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -139,6 +139,7 @@ const String kOptionCurrentAbName = "current-ab-name";
 const String kOptionEnableConfirmClosingTabs = "enable-confirm-closing-tabs";
 const String kOptionAllowAlwaysSoftwareRender = "allow-always-software-render";
 const String kOptionEnableCheckUpdate = "enable-check-update";
+const String kOptionAllowAutoUpdate = "allow-auto-update";
 const String kOptionAllowLinuxHeadless = "allow-linux-headless";
 const String kOptionAllowRemoveWallpaper = "allow-remove-wallpaper";
 const String kOptionStopService = "stop-service";

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -12,6 +12,7 @@ import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/pages/connection_page.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_setting_page.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_tab_page.dart';
+import 'package:flutter_hbb/desktop/widgets/update_progress.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:flutter_hbb/models/server_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
@@ -433,13 +434,36 @@ class _DesktopHomePageState extends State<DesktopHomePage>
         updateUrl.isNotEmpty &&
         !isCardClosed &&
         bind.mainUriPrefixSync().contains('rustdesk')) {
+      String btnText = "Click to download";
+      var isToUpdate = false;
+      if (isWindows && bind.mainIsInstalled()) {
+        final String isMsiInstalled =
+            bind.mainGetCommonSync(key: 'is-msi-installed');
+        if ('false' == isMsiInstalled) {
+          isToUpdate = true;
+        } else if ('true' != isMsiInstalled) {
+          debugPrint(
+              "isMsiInstalled is not true or false, error: $isMsiInstalled");
+        }
+      }
+      if (isToUpdate) {
+        btnText = "Click to update";
+      }
+      GestureTapCallback onPressed = () async {
+        final Uri url = Uri.parse('https://rustdesk.com/download');
+        await launchUrl(url);
+      };
+      if (isToUpdate) {
+        onPressed = () {
+          handleUpdate(updateUrl);
+        };
+      }
       return buildInstallCard(
           "Status",
           "${translate("new-version-of-{${bind.mainGetAppNameSync()}}-tip")} (${bind.mainGetNewVersion()}).",
-          "Click to download", () async {
-        final Uri url = Uri.parse('https://rustdesk.com/download');
-        await launchUrl(url);
-      }, closeButton: true);
+          btnText,
+          onPressed,
+          closeButton: true);
     }
     if (systemError.isNotEmpty) {
       return buildInstallCard("", systemError, "", () {});

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -470,6 +470,10 @@ class _GeneralState extends State<_General> {
   }
 
   Widget other() {
+    final showAutoUpdate = isWindows &&
+        'false' == bind.mainGetCommonSync(key: 'is-msi-installed') &&
+        bind.mainIsInstalled() &&
+        !bind.isCustomClient();
     final children = <Widget>[
       if (!isWeb && !bind.isIncomingOnly())
         _OptionCheckBox(context, 'Confirm before closing multiple tabs',
@@ -523,12 +527,19 @@ class _GeneralState extends State<_General> {
             kOptionEnableCheckUpdate,
             isServer: false,
           ),
+        if (showAutoUpdate)
+          _OptionCheckBox(
+            context,
+            'Auto update',
+            kOptionAllowAutoUpdate,
+            isServer: true,
+          ),
         if (isWindows && !bind.isOutgoingOnly())
           _OptionCheckBox(
             context,
             'Capture screen using DirectX',
             kOptionDirectxCapture,
-          )
+          ),
       ],
     ];
     if (!isWeb && bind.mainShowOption(key: kOptionAllowLinuxHeadless)) {

--- a/flutter/lib/desktop/widgets/update_progress.dart
+++ b/flutter/lib/desktop/widgets/update_progress.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hbb/common.dart';
+import 'package:flutter_hbb/models/platform_model.dart';
+import 'package:get/get.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+void handleUpdate(String releasePageUrl) {
+  String downloadUrl = releasePageUrl.replaceAll('tag', 'download');
+  String version = downloadUrl.substring(downloadUrl.lastIndexOf('/') + 1);
+  if (isWindows) {
+    downloadUrl = '$downloadUrl/rustdesk-$version-x86_64.exe';
+  }
+  SimpleWrapper downloadId = SimpleWrapper('');
+  SimpleWrapper<VoidCallback> onCanceled = SimpleWrapper(() {});
+  gFFI.dialogManager.dismissAll();
+  gFFI.dialogManager.show((setState, close, context) {
+    return CustomAlertDialog(
+        title: Text(translate('Downloading {$appName}')),
+        content:
+            UpdateProgress(releasePageUrl, downloadUrl, downloadId, onCanceled)
+                .marginSymmetric(horizontal: 8)
+                .paddingOnly(top: 12),
+        actions: [
+          dialogButton(translate('Cancel'), onPressed: () async {
+            onCanceled.value();
+            await bind.mainSetCommon(
+                key: 'cancel-downloader', value: downloadId.value);
+            // Wait for the downloader to be removed.
+            for (int i = 0; i < 10; i++) {
+              await Future.delayed(const Duration(milliseconds: 300));
+              final isCanceled = 'error:Downloader not found' ==
+                  await bind.mainGetCommon(
+                      key: 'download-data-${downloadId.value}');
+              if (isCanceled) {
+                break;
+              }
+            }
+            close();
+          }, isOutline: true),
+        ]);
+  });
+}
+
+class UpdateProgress extends StatefulWidget {
+  final String releasePageUrl;
+  final String downloadUrl;
+  final SimpleWrapper downloadId;
+  final SimpleWrapper onCanceled;
+  UpdateProgress(
+      this.releasePageUrl, this.downloadUrl, this.downloadId, this.onCanceled,
+      {Key? key})
+      : super(key: key);
+
+  @override
+  State<UpdateProgress> createState() => UpdateProgressState();
+}
+
+class UpdateProgressState extends State<UpdateProgress> {
+  Timer? _timer;
+  int? _totalSize;
+  int _downloadedSize = 0;
+  int _getDataFailedCount = 0;
+  final String _eventKeyDownloadNewVersion = 'download-new-version';
+
+  @override
+  void initState() {
+    super.initState();
+    widget.onCanceled.value = () {
+      cancelQueryTimer();
+    };
+    platformFFI.registerEventHandler(_eventKeyDownloadNewVersion,
+        _eventKeyDownloadNewVersion, handleDownloadNewVersion,
+        replace: true);
+    bind.mainSetCommon(key: 'download-new-version', value: widget.downloadUrl);
+  }
+
+  @override
+  void dispose() {
+    cancelQueryTimer();
+    platformFFI.unregisterEventHandler(
+        _eventKeyDownloadNewVersion, _eventKeyDownloadNewVersion);
+    super.dispose();
+  }
+
+  void cancelQueryTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  Future<void> handleDownloadNewVersion(Map<String, dynamic> evt) async {
+    if (evt.containsKey('id')) {
+      widget.downloadId.value = evt['id'] as String;
+      _timer = Timer.periodic(const Duration(milliseconds: 300), (timer) {
+        _updateDownloadData();
+      });
+    } else {
+      if (evt.containsKey('error')) {
+        _onError(evt['error'] as String);
+      } else {
+        // unreachable
+        _onError('$evt');
+      }
+    }
+  }
+
+  void _onError(String error) {
+    cancelQueryTimer();
+
+    debugPrint('Download new version error: $error');
+    final msgBoxType = 'custom-nocancel-hasclose';
+    final msgBoxTitle = 'Error';
+    final msgBoxText = 'download-new-veresion-failed-tip';
+    final dialogManager = gFFI.dialogManager;
+
+    close() {
+      dialogManager.dismissAll();
+    }
+
+    jumplink() {
+      launchUrl(Uri.parse(widget.releasePageUrl));
+      dialogManager.dismissAll();
+    }
+
+    retry() {
+      dialogManager.dismissAll();
+      handleUpdate(widget.releasePageUrl);
+    }
+
+    final List<Widget> buttons = [
+      dialogButton('JumpLink', onPressed: jumplink),
+      dialogButton('Retry', onPressed: retry),
+      dialogButton('Close', onPressed: close),
+    ];
+    dialogManager.dismissAll();
+    dialogManager.show(
+      (setState, close, context) => CustomAlertDialog(
+        title: null,
+        content: SelectionArea(
+            child: msgboxContent(msgBoxType, msgBoxTitle, msgBoxText)),
+        actions: buttons,
+      ),
+      tag: '$msgBoxType-$msgBoxTitle-$msgBoxTitle',
+    );
+  }
+
+  void _updateDownloadData() {
+    String err = '';
+    String downloadData =
+        bind.mainGetCommonSync(key: 'download-data-${widget.downloadId.value}');
+    if (downloadData.startsWith('error:')) {
+      err = downloadData.substring('error:'.length);
+    } else {
+      try {
+        jsonDecode(downloadData).forEach((key, value) {
+          if (key == 'total_size') {
+            if (value != null && value is int) {
+              _totalSize = value;
+            }
+          } else if (key == 'downloaded_size') {
+            _downloadedSize = value as int;
+          } else if (key == 'error') {
+            if (value != null) {
+              err = value.toString();
+            }
+          }
+        });
+      } catch (e) {
+        _getDataFailedCount += 1;
+        debugPrint(
+            'Failed to get download data ${widget.downloadUrl}, error $e');
+        if (_getDataFailedCount > 3) {
+          err = e.toString();
+        }
+      }
+    }
+    if (err != '') {
+      _onError(err);
+    } else {
+      if (_totalSize != null && _downloadedSize >= _totalSize!) {
+        cancelQueryTimer();
+        bind.mainSetCommon(
+            key: 'remove-downloader', value: widget.downloadId.value);
+        if (_totalSize == 0) {
+          _onError('The download file size is 0.');
+        } else {
+          setState(() {});
+          Future.delayed(const Duration(milliseconds: 500), () {
+            msgBox(gFFI.sessionId, 'custom-nocancel', '{$appName} Update',
+                '{$appName}-to-update-tip', '', gFFI.dialogManager);
+            Future.delayed(const Duration(milliseconds: 1000), () {
+              bind.mainSetCommon(key: 'update-me', value: widget.downloadUrl);
+            });
+          });
+        }
+      } else {
+        setState(() {});
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return onDownloading(context);
+  }
+
+  Widget onDownloading(BuildContext context) {
+    final value = _totalSize == null
+        ? 0.0
+        : (_totalSize == 0 ? 1.0 : _downloadedSize / _totalSize!);
+    return LinearProgressIndicator(
+      value: value,
+      minHeight: 20,
+      borderRadius: BorderRadius.circular(5),
+      backgroundColor: Colors.grey[300],
+      valueColor: const AlwaysStoppedAnimation<Color>(Colors.blue),
+    );
+  }
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -835,12 +835,12 @@ pub fn check_software_update() {
     } 
     let opt = config::LocalConfig::get_option(config::keys::OPTION_ENABLE_CHECK_UPDATE);
     if config::option2bool(config::keys::OPTION_ENABLE_CHECK_UPDATE, &opt) {
-        std::thread::spawn(move || allow_err!(check_software_update_()));
+        std::thread::spawn(move || allow_err!(do_check_software_update()));
     }
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn check_software_update_() -> hbb_common::ResultType<()> {
+pub async fn do_check_software_update() -> hbb_common::ResultType<()> {
     let (request, url) =
         hbb_common::version_check_request(hbb_common::VER_TYPE_RUSTDESK_CLIENT.to_string());
     let latest_release_response = create_http_client_async()
@@ -864,6 +864,8 @@ async fn check_software_update_() -> hbb_common::ResultType<()> {
             }
         }
         *SOFTWARE_UPDATE_URL.lock().unwrap() = response_url;
+    } else {
+        *SOFTWARE_UPDATE_URL.lock().unwrap() = "".to_string();
     }
     Ok(())
 }

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -182,6 +182,26 @@ pub fn core_main() -> Option<Vec<String>> {
                     log::error!("Failed to uninstall: {}", err);
                 }
                 return None;
+            } else if args[0] == "--update" {
+                if config::is_disable_installation() {
+                    return None;
+                }
+                let res = platform::update_me(false);
+                let text = match res {
+                    Ok(_) => translate("Update successfully!".to_string()),
+                    Err(err) => {
+                        println!("Failed with error: {err}");
+                        translate("Update failed!".to_string())
+                    }
+                };
+                Toast::new(Toast::POWERSHELL_APP_ID)
+                    .title(&config::APP_NAME.read().unwrap())
+                    .text1(&text)
+                    .sound(Some(Sound::Default))
+                    .duration(Duration::Short)
+                    .show()
+                    .ok();
+                return None;
             } else if args[0] == "--after-install" {
                 if let Err(err) = platform::run_after_install() {
                     log::error!("Failed to after-install: {}", err);
@@ -589,7 +609,8 @@ fn core_main_invoke_new_connection(mut args: std::env::Args) -> Option<Vec<Strin
     let mut param_array = vec![];
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--connect" | "--play" | "--file-transfer" | "--view-camera" | "--port-forward" | "--rdp" => {
+            "--connect" | "--play" | "--file-transfer" | "--view-camera" | "--port-forward"
+            | "--rdp" => {
                 authority = Some((&arg.to_string()[2..]).to_owned());
                 id = args.next();
             }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1996,7 +1996,9 @@ pub mod sessions {
                 None => {}
             }
         }
-        SESSIONS.write().unwrap().remove(&remove_peer_key?)
+        let s = SESSIONS.write().unwrap().remove(&remove_peer_key?);
+        update_session_count_to_server();
+        s
     }
 
     fn check_remove_unused_displays(
@@ -2098,6 +2100,12 @@ pub mod sessions {
             .write()
             .unwrap()
             .insert(session_id, Default::default());
+        update_session_count_to_server();
+    }
+
+    #[inline]
+    fn update_session_count_to_server() {
+        crate::ipc::update_controlling_session_count(SESSIONS.read().unwrap().len()).ok();
     }
 
     #[inline]

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -21,11 +21,12 @@ use hbb_common::{
 };
 use std::{
     collections::HashMap,
+    path::PathBuf,
     sync::{
         atomic::{AtomicI32, Ordering},
         Arc,
     },
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 
 pub type SessionID = uuid::Uuid;
@@ -2417,8 +2418,28 @@ pub fn main_get_common(key: String) -> String {
         return false.to_string();
     } else if key == "transfer-job-id" {
         return hbb_common::fs::get_next_job_id().to_string();
+    } else if key == "is-msi-installed" {
+        #[cfg(target_os = "windows")]
+        {
+            return match crate::platform::windows::is_msi_installed() {
+                Ok(r) => r.to_string(),
+                Err(e) => e.to_string(),
+            };
+        }
+        #[cfg(not(target_os = "windows"))]
+        return false.to_string();
     } else {
-        "".to_owned()
+        if key.starts_with("download-data-") {
+            let id = key.replace("download-data-", "");
+            match crate::hbbs_http::downloader::get_download_data(&id) {
+                Ok(data) => serde_json::to_string(&data).unwrap_or_default(),
+                Err(e) => {
+                    format!("error:{}", e)
+                }
+            }
+        } else {
+            "".to_owned()
+        }
     }
 }
 
@@ -2448,6 +2469,48 @@ pub fn main_set_common(_key: String, _value: String) {
                 serde_json::ser::to_string(&data).unwrap_or("".to_owned()),
             );
         });
+    }
+    #[cfg(target_os = "windows")]
+    {
+        use crate::updater::get_download_file_from_url;
+        if _key == "download-new-version" {
+            let download_url = _value.clone();
+            let event_key = "download-new-version".to_owned();
+            let data = if let Some(download_file) = get_download_file_from_url(&download_url) {
+                std::fs::remove_file(&download_file).ok();
+                match crate::hbbs_http::downloader::download_file(
+                    download_url,
+                    Some(PathBuf::from(download_file)),
+                    Some(Duration::from_secs(3)),
+                ) {
+                    Ok(id) => HashMap::from([("name", event_key), ("id", id)]),
+                    Err(e) => HashMap::from([("name", event_key), ("error", e.to_string())]),
+                }
+            } else {
+                HashMap::from([
+                    ("name", event_key),
+                    ("error", "Invalid download url".to_string()),
+                ])
+            };
+            let _res = flutter::push_global_event(
+                flutter::APP_TYPE_MAIN,
+                serde_json::ser::to_string(&data).unwrap_or("".to_owned()),
+            );
+        } else if _key == "update-me" {
+            if let Some(new_version_file) = get_download_file_from_url(&_value) {
+                // 1.3.9 does not support "--update"
+                // But we can assume that the new version will support it.
+                if let Some(f) = new_version_file.to_str() {
+                    let _ = crate::platform::run_exe_in_cur_session(f, vec!["--update"], false);
+                }
+            }
+        }
+    }
+
+    if _key == "remove-downloader" {
+        crate::hbbs_http::downloader::remove(&_value);
+    } else if _key == "cancel-downloader" {
+        crate::hbbs_http::downloader::cancel(&_value);
     }
 }
 

--- a/src/hbbs_http.rs
+++ b/src/hbbs_http.rs
@@ -7,6 +7,7 @@ pub mod account;
 mod http_client;
 pub mod record_upload;
 pub mod sync;
+pub mod downloader;
 pub use http_client::create_http_client;
 pub use http_client::create_http_client_async;
 

--- a/src/hbbs_http/downloader.rs
+++ b/src/hbbs_http/downloader.rs
@@ -1,0 +1,273 @@
+use super::create_http_client_async;
+use hbb_common::{
+    bail,
+    lazy_static::lazy_static,
+    log,
+    tokio::{
+        self,
+        fs::File,
+        io::AsyncWriteExt,
+        sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    },
+    ResultType,
+};
+use serde_derive::Serialize;
+use std::{collections::HashMap, path::PathBuf, sync::Mutex, time::Duration};
+
+lazy_static! {
+    static ref DOWNLOADERS: Mutex<HashMap<String, Downloader>> = Default::default();
+}
+
+/// This struct is used to return the download data to the caller.
+/// The caller should check if the file is downloaded successfully and remove the job from the map.
+/// If the file is not downloaded successfully, the `data` field will be empty.
+/// If the file is downloaded successfully, the `data` field will contain the downloaded data if `path` is None.
+#[derive(Serialize, Debug)]
+pub struct DownloadData {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub data: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_size: Option<u64>,
+    pub downloaded_size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+struct Downloader {
+    data: Vec<u8>,
+    path: Option<PathBuf>,
+    // Some file may be empty, so we use Option<u64> to indicate if the size is known
+    total_size: Option<u64>,
+    downloaded_size: u64,
+    error: Option<String>,
+    finished: bool,
+    tx_cancel: UnboundedSender<()>,
+}
+
+// The caller should check if the file is downloaded successfully and remove the job from the map.
+pub fn download_file(
+    url: String,
+    path: Option<PathBuf>,
+    auto_del_dur: Option<Duration>,
+) -> ResultType<String> {
+    let id = url.clone();
+    if DOWNLOADERS.lock().unwrap().contains_key(&id) {
+        return Ok(id);
+    }
+
+    if let Some(path) = path.as_ref() {
+        if path.exists() {
+            bail!("File {} already exists", path.display());
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let (tx, rx) = unbounded_channel();
+    let downloader = Downloader {
+        data: Vec::new(),
+        path: path.clone(),
+        total_size: None,
+        downloaded_size: 0,
+        error: None,
+        tx_cancel: tx,
+        finished: false,
+    };
+    let mut downloaders = DOWNLOADERS.lock().unwrap();
+    downloaders.insert(id.clone(), downloader);
+
+    let id2 = id.clone();
+    std::thread::spawn(
+        move || match do_download(&id2, url, path, auto_del_dur, rx) {
+            Ok(is_all_downloaded) => {
+                let mut downloaded_size = 0;
+                let mut total_size = 0;
+                DOWNLOADERS.lock().unwrap().get_mut(&id2).map(|downloader| {
+                    downloaded_size = downloader.downloaded_size;
+                    total_size = downloader.total_size.unwrap_or(0);
+                });
+                log::info!(
+                    "Download {} end, {}/{}, {:.2} %",
+                    &id2,
+                    downloaded_size,
+                    total_size,
+                    if total_size == 0 {
+                        0.0
+                    } else {
+                        downloaded_size as f64 / total_size as f64 * 100.0
+                    }
+                );
+
+                let is_canceled = !is_all_downloaded;
+                if is_canceled {
+                    if let Some(downloader) = DOWNLOADERS.lock().unwrap().remove(&id2) {
+                        if let Some(p) = downloader.path {
+                            if p.exists() {
+                                std::fs::remove_file(p).ok();
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                let err = e.to_string();
+                log::error!("Download {}, failed: {}", &id2, &err);
+                DOWNLOADERS.lock().unwrap().get_mut(&id2).map(|downloader| {
+                    downloader.error = Some(err);
+                });
+            }
+        },
+    );
+
+    Ok(id)
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn do_download(
+    id: &str,
+    url: String,
+    path: Option<PathBuf>,
+    auto_del_dur: Option<Duration>,
+    mut rx_cancel: UnboundedReceiver<()>,
+) -> ResultType<bool> {
+    let client = create_http_client_async();
+
+    let mut is_all_downloaded = false;
+    tokio::select! {
+        _ = rx_cancel.recv() => {
+            return Ok(is_all_downloaded);
+        }
+        head_resp = client.head(&url).send() => {
+            match head_resp {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        let total_size = resp
+                            .headers()
+                            .get(reqwest::header::CONTENT_LENGTH)
+                            .and_then(|ct_len| ct_len.to_str().ok())
+                            .and_then(|ct_len| ct_len.parse::<u64>().ok());
+                        let Some(total_size) = total_size else {
+                            bail!("Failed to get content length");
+                        };
+                        DOWNLOADERS.lock().unwrap().get_mut(id).map(|downloader| {
+                            downloader.total_size = Some(total_size);
+                        });
+                    } else {
+                        bail!("Failed to get content length: {}", resp.status());
+                    }
+                }
+                Err(e) => {
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+
+    let mut response;
+    tokio::select! {
+        _ = rx_cancel.recv() => {
+            return Ok(is_all_downloaded);
+        }
+        resp = client.get(url).send() => {
+            response = resp?;
+        }
+    }
+
+    let mut dest: Option<File> = None;
+    if let Some(p) = path {
+        dest = Some(File::create(p).await?);
+    }
+
+    loop {
+        tokio::select! {
+            _ = rx_cancel.recv() => {
+                break;
+            }
+            chunk = response.chunk() => {
+                match chunk {
+                    Ok(Some(chunk)) => {
+                        match dest {
+                            Some(ref mut f) => {
+                                f.write_all(&chunk).await?;
+                                f.flush().await?;
+                                DOWNLOADERS.lock().unwrap().get_mut(id).map(|downloader| {
+                                    downloader.downloaded_size += chunk.len() as u64;
+                                });
+                            }
+                            None => {
+                                DOWNLOADERS.lock().unwrap().get_mut(id).map(|downloader| {
+                                    downloader.data.extend_from_slice(&chunk);
+                                    downloader.downloaded_size += chunk.len() as u64;
+                                });
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        is_all_downloaded = true;
+                    },
+                    Err(e) => {
+                        log::error!("Download {} failed: {}", id, e);
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(mut f) = dest.take() {
+        f.flush().await?;
+    }
+
+    if let Some(ref mut downloader) = DOWNLOADERS.lock().unwrap().get_mut(id) {
+        downloader.finished = true;
+    }
+    if is_all_downloaded {
+        let id_del = id.to_string();
+        if let Some(dur) = auto_del_dur {
+            std::thread::spawn(move || {
+                std::thread::sleep(dur);
+                DOWNLOADERS.lock().unwrap().remove(&id_del);
+            });
+        }
+    }
+    Ok(is_all_downloaded)
+}
+
+pub fn get_download_data(id: &str) -> ResultType<DownloadData> {
+    let downloaders = DOWNLOADERS.lock().unwrap();
+    if let Some(downloader) = downloaders.get(id) {
+        let downloaded_size = downloader.downloaded_size;
+        let total_size = downloader.total_size.clone();
+        let error = downloader.error.clone();
+        let data = if total_size.unwrap_or(0) == downloaded_size && downloader.path.is_none() {
+            downloader.data.clone()
+        } else {
+            Vec::new()
+        };
+        let path = downloader.path.clone();
+        let download_data = DownloadData {
+            data,
+            path,
+            total_size,
+            downloaded_size,
+            error,
+        };
+        Ok(download_data)
+    } else {
+        bail!("Downloader not found")
+    }
+}
+
+pub fn cancel(id: &str) {
+    if let Some(downloader) = DOWNLOADERS.lock().unwrap().get(id) {
+        // downloader.is_canceled.store(true, Ordering::SeqCst);
+        // The receiver may not be able to receive the cancel signal, so we also set the atomic bool to true
+        let _ = downloader.tx_cancel.send(());
+    }
+}
+
+pub fn remove(id: &str) {
+    let _ = DOWNLOADERS.lock().unwrap().remove(id);
+}

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "الطباعة عن بُعد غير مسموح بها على هذا الجهاز"),
         ("save-settings-tip", "حفظ الإعدادات"),
         ("dont-show-again-tip", "لا تظهر هذا مرة أخرى"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "被控端的权限设置拒绝了远程打印。"),
         ("save-settings-tip", "保存设置"),
         ("dont-show-again-tip", "不再显示此信息"),
+        ("Downloading {}", "下载 {}"),
+        ("{} Update", "{} 更新"),
+        ("{}-to-update-tip", "即将关闭 {} ，并安装新版本。"),
+        ("download-new-veresion-failed-tip", "下载失败，您可以 重试 或者点击 查看 按钮，从发布网址下载，并手动升级。"),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Die Berechtigungseinstellungen der kontrollierten Seite verweigern den entfernten Druck."),
         ("save-settings-tip", "Einstellungen speichern"),
         ("dont-show-again-tip", "Nicht mehr anzeigen"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -253,5 +253,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "The permission settings of the controlled side deny Remote Printing."),
         ("save-settings-tip", "Save settings"),
         ("dont-show-again-tip", "Don't show this again"),
+        ("{}-to-update-tip", "{} will close now and install the new version."),
+        ("download-new-veresion-failed-tip", "Download failed. You can try again or click the View button to download from the release page and upgrade manually.")
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Los ajustes de permisos del lado controlado no permiten la impresión remota."),
         ("save-settings-tip", "Guardar ajustes"),
         ("dont-show-again-tip", "No volver a mostrar"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "شما مجوز لازم برای چاپ از راه دور را ندارید"),
         ("save-settings-tip", "تنظیمات را ذخیره کنید"),
         ("dont-show-again-tip", "دیگر نمایش داده نشود"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Les paramètres de l’appareil contrôlé n’autorisent pas l’impression à distance."),
         ("save-settings-tip", "Enregistrer les paramètres"),
         ("dont-show-again-tip", "Ne plus afficher"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -239,7 +239,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Empty", "ცარიელი"),
         ("Invalid folder name", "არასწორი საქაღალდის სახელი"),
         ("Socks5 Proxy", "SOCKS5-პროქსი"),
-        ("Proxy", "პროქსი"),
+        ("Socks5/Http(s) Proxy", ""),
         ("Discovered", "ნაპოვნია"),
         ("install_daemon_tip", "ჩატვირთვისას გასაშვებად საჭიროა სისტემური სერვისის დაყენება"),
         ("Remote ID", "დაშორებული ID"),
@@ -567,7 +567,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("id_input_tip", "შეგიძლიათ შეიყვანოთ იდენტიფიკატორი, პირდაპირი IP მისამართი ან დომენი პორტით (<დომენი>:<პორტი>).\nთუ გჭირდებათ წვდომა მოწყობილობაზე სხვა სერვერზე, დაამატეთ სერვერის მისამართი (<id>@<სერვერის_მისამართი>?key=<გასაღების_მნიშვნელობა>), მაგალითად:\n9123456234@192.168.16.1:21117?key=5Qbwsde3unUcJBtrx9ZkvUmwFNoExHzpryHuPUdqlWM=.\nთუ გჭირდებათ წვდომა მოწყობილობაზე საჯარო სერვერზე, შეიყვანეთ \"<id>@public\", გასაღები საჯარო სერვერისთვის არ არის საჭირო."),
         ("privacy_mode_impl_mag_tip", "რეჟიმი 1"),
         ("privacy_mode_impl_virtual_display_tip", "რეჟიმი 2"),
-        ("privacy_mode_impl_virtual_display_tip", "რეჟიმი 2"),
         ("Enter privacy mode", "კონფიდენციალურობის რეჟიმის ჩართვა"),
         ("Exit privacy mode", "კონფიდენციალურობის რეჟიმის გამორთვა"),
         ("idd_not_support_under_win10_2004_tip", "არაპირდაპირი ჩვენების დრაივერი არ არის მხარდაჭერილი. საჭიროა Windows 10 ვერსია 2004 ან უფრო ახალი."),
@@ -659,7 +658,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("new-version-of-{}-tip", "ხელმისაწვდომია ახალი ვერსია {}"),
         ("Accessible devices", "ხელმისაწვდომი მოწყობილობები"),
         ("View camera", "კამერის ნახვა"),
-        ("upgrade_remote_rustdesk_client_to{}_tip", "განაახლეთ RustDesk კლიენტი ვერსიამდე {} ან უფრო ახალი დისტანციურ მხარეზე!"),
+        ("upgrade_remote_rustdesk_client_to_{}_tip", "განაახლეთ RustDesk კლიენტი ვერსიამდე {} ან უფრო ახალი დისტანციურ მხარეზე!"),
         ("view_camera_unsupported_tip", "დისტანციური მოწყობილობა არ უჭერს მხარს კამერის ნახვას."),
         ("Enable camera", "კამერის ჩართვა"),
         ("No cameras", "კამერა არ არის"),
@@ -682,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "მართულ მხარეზე უფლებების პარამეტრები კრძალავს დისტანციურ ბეჭდვას."),
         ("save-settings-tip", "პარამეტრების შენახვა"),
         ("dont-show-again-tip", "აღარ აჩვენოთ"),
-  ].iter().cloned().collect();
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
+    ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Le impostazioni di autorizzazione del lato controllato negano la stampa remota."),
         ("save-settings-tip", "Salva impostazioni"),
         ("dont-show-again-tip", "Non visualizzare più questo messaggio"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Kontrolētās puses atļauju iestatījumi liedz attālo drukāšanu."),
         ("save-settings-tip", "Saglabāt iestatījumus"),
         ("dont-show-again-tip", "Nerādīt šo vēlreiz"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Machtigingsinstellingen aan beheerde zijde verhinderen afdrukken op afstand."),
         ("save-settings-tip", "Instellingen opslaan"),
         ("dont-show-again-tip", "Dit bericht wordt niet meer weergegeven"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Ustawienia uprawnień po zdalnej stronie uniemożliwiają zdalne drukowanie."),
         ("save-settings-tip", "Zapisz ustawienia"),
         ("dont-show-again-tip", "Nie pokazuj więcej"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "As configurações do dispositivo controlado não permitem impressão remota."),
         ("save-settings-tip", "Salvar configurações"),
         ("dont-show-again-tip", "Não mostrar novamente"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Настройки разрешений на управляемой стороне запрещают удалённую печать."),
         ("save-settings-tip", "Сохранить настройки"),
         ("dont-show-again-tip", "Больше не показывать"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Sas impostatziones de sos permissos de s'ala controllada negant s'imprenta remota."),
         ("save-settings-tip", "Sarva sas impostatziones"),
         ("dont-show-again-tip", "Non mustres prus custu messàgiu"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "被控端的權限設置拒絕了遠端列印。"),
         ("save-settings-tip", "儲存設定"),
         ("dont-show-again-tip", "不再顯示此訊息"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,14 +39,14 @@ use common::*;
 mod auth_2fa;
 #[cfg(feature = "cli")]
 pub mod cli;
+#[cfg(not(target_os = "ios"))]
+mod clipboard;
 #[cfg(not(any(target_os = "android", target_os = "ios", feature = "cli")))]
 pub mod core_main;
 mod custom_server;
 mod lang;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod port_forward;
-#[cfg(not(target_os = "ios"))]
-mod clipboard;
 
 #[cfg(all(feature = "flutter", feature = "plugin_framework"))]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -54,6 +54,12 @@ pub mod plugin;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod tray;
+
+#[cfg(all(
+    feature = "flutter",
+    not(any(target_os = "android", target_os = "ios"))
+))]
+mod updater;
 
 mod ui_cm_interface;
 mod ui_interface;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -27,7 +27,11 @@ pub mod linux_desktop_manager;
 pub mod gtk_sudo;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-use hbb_common::{message_proto::CursorData, ResultType};
+use hbb_common::{
+    message_proto::CursorData,
+    sysinfo::{Pid, System},
+    ResultType,
+};
 use std::sync::{Arc, Mutex};
 #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "ios")))]
 pub const SERVICE_INTERVAL: u64 = 300;
@@ -135,6 +139,63 @@ impl Drop for InstallingService {
 #[inline]
 pub fn is_prelogin() -> bool {
     false
+}
+
+// Note: This function does not work when the process is 32-bit and the OS is 64-bit Windows,
+// `process.cmd()` always returns [] in this case.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn get_pids_of_process_with_args<S1: AsRef<str>, S2: AsRef<str>>(
+    name: S1,
+    args: &[S2],
+) -> Vec<Pid> {
+    let name = name.as_ref().to_lowercase();
+    let mut system = System::new_all();
+    system.refresh_processes();
+    system
+        .processes()
+        .iter()
+        .filter(|(_, process)| {
+            process.name().to_lowercase() == name
+                && process.cmd().len() == args.len() + 1
+                && args.iter().enumerate().all(|(i, arg)| {
+                    process.cmd()[i + 1].to_lowercase() == arg.as_ref().to_lowercase()
+                })
+        })
+        .map(|(&pid, _)| pid)
+        .collect()
+}
+
+// Note: This function does not work when the process is 32-bit and the OS is 64-bit Windows,
+// `process.cmd()` always returns [] in this case.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn get_pids_of_process_with_first_arg<S1: AsRef<str>, S2: AsRef<str>>(
+    name: S1,
+    arg: S2,
+) -> Vec<Pid> {
+    let name = name.as_ref().to_lowercase();
+    let mut system = System::new_all();
+    system.refresh_processes();
+    system
+        .processes()
+        .iter()
+        .filter(|(_, process)| {
+            process.name().to_lowercase() == name
+                && process.cmd().len() >= 2
+                && process.cmd()[1].to_lowercase() == arg.as_ref().to_lowercase()
+        })
+        .map(|(&pid, _)| pid)
+        .collect()
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn kill_process_by_pid(pid: Pid) -> ResultType<()> {
+    let s = System::new_all();
+    if let Some(process) = s.process(pid) {
+        process.kill();
+        Ok(())
+    } else {
+        hbb_common::bail!("Process with PID {} not found", pid)
+    }
 }
 
 #[cfg(test)]

--- a/src/platform/windows.cc
+++ b/src/platform/windows.cc
@@ -230,7 +230,7 @@ extern "C"
         return IsWindows10OrGreater();
     }
 
-    HANDLE LaunchProcessWin(LPCWSTR cmd, DWORD dwSessionId, BOOL as_user, DWORD *pDwTokenPid)
+    HANDLE LaunchProcessWin(LPCWSTR cmd, DWORD dwSessionId, BOOL as_user, BOOL show, DWORD *pDwTokenPid)
     {
         HANDLE hProcess = NULL;
         HANDLE hToken = NULL;
@@ -240,6 +240,11 @@ extern "C"
             ZeroMemory(&si, sizeof si);
             si.cb = sizeof si;
             si.dwFlags = STARTF_USESHOWWINDOW;
+            if (show)
+            {
+                si.lpDesktop = (LPWSTR)L"winsta0\\default";
+                si.wShowWindow = SW_SHOW;
+            }
             wchar_t buf[MAX_PATH];
             wcscpy_s(buf, sizeof(buf), cmd);
             PROCESS_INFORMATION pi;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -474,6 +474,7 @@ extern "C" {
         cmd: *const u16,
         session_id: DWORD,
         as_user: BOOL,
+        show: BOOL,
         token_pid: &mut DWORD,
     ) -> HANDLE;
     fn GetSessionUserTokenWin(
@@ -659,6 +660,10 @@ async fn launch_server(session_id: DWORD, close_first: bool) -> ResultType<HANDL
         "\"{}\" --server",
         std::env::current_exe()?.to_str().unwrap_or("")
     );
+    launch_privileged_process(session_id, &cmd)
+}
+
+pub fn launch_privileged_process(session_id: DWORD, cmd: &str) -> ResultType<HANDLE> {
     use std::os::windows::ffi::OsStrExt;
     let wstr: Vec<u16> = std::ffi::OsStr::new(&cmd)
         .encode_wide()
@@ -666,9 +671,12 @@ async fn launch_server(session_id: DWORD, close_first: bool) -> ResultType<HANDL
         .collect();
     let wstr = wstr.as_ptr();
     let mut token_pid = 0;
-    let h = unsafe { LaunchProcessWin(wstr, session_id, FALSE, &mut token_pid) };
+    let h = unsafe { LaunchProcessWin(wstr, session_id, FALSE, FALSE, &mut token_pid) };
     if h.is_null() {
-        log::error!("Failed to launch server: {}", io::Error::last_os_error());
+        log::error!(
+            "Failed to launch privileged process: {}",
+            io::Error::last_os_error()
+        );
         if token_pid == 0 {
             log::error!("No process winlogon.exe");
         }
@@ -677,22 +685,43 @@ async fn launch_server(session_id: DWORD, close_first: bool) -> ResultType<HANDL
 }
 
 pub fn run_as_user(arg: Vec<&str>) -> ResultType<Option<std::process::Child>> {
-    let cmd = format!(
-        "\"{}\" {}",
-        std::env::current_exe()?.to_str().unwrap_or(""),
-        arg.join(" "),
-    );
+    run_exe_in_cur_session(std::env::current_exe()?.to_str().unwrap_or(""), arg, false)
+}
+
+pub fn run_exe_in_cur_session(
+    exe: &str,
+    arg: Vec<&str>,
+    show: bool,
+) -> ResultType<Option<std::process::Child>> {
     let Some(session_id) = get_current_process_session_id() else {
         bail!("Failed to get current process session id");
     };
+    run_exe_in_session(exe, arg, session_id, show)
+}
+
+pub fn run_exe_in_session(
+    exe: &str,
+    arg: Vec<&str>,
+    session_id: DWORD,
+    show: bool,
+) -> ResultType<Option<std::process::Child>> {
     use std::os::windows::ffi::OsStrExt;
+    let cmd = format!("\"{}\" {}", exe, arg.join(" "),);
     let wstr: Vec<u16> = std::ffi::OsStr::new(&cmd)
         .encode_wide()
         .chain(Some(0).into_iter())
         .collect();
     let wstr = wstr.as_ptr();
     let mut token_pid = 0;
-    let h = unsafe { LaunchProcessWin(wstr, session_id, TRUE, &mut token_pid) };
+    let h = unsafe {
+        LaunchProcessWin(
+            wstr,
+            session_id,
+            TRUE,
+            if show { TRUE } else { FALSE },
+            &mut token_pid,
+        )
+    };
     if h.is_null() {
         if token_pid == 0 {
             bail!(
@@ -790,8 +819,12 @@ pub fn set_share_rdp(enable: bool) {
 }
 
 pub fn get_current_process_session_id() -> Option<u32> {
+    get_session_id_of_process(unsafe { GetCurrentProcessId() })
+}
+
+pub fn get_session_id_of_process(pid: DWORD) -> Option<u32> {
     let mut sid = 0;
-    if unsafe { ProcessIdToSessionId(GetCurrentProcessId(), &mut sid) == TRUE } {
+    if unsafe { ProcessIdToSessionId(pid, &mut sid) == TRUE } {
         Some(sid)
     } else {
         None
@@ -1201,16 +1234,13 @@ fn get_after_install(
     ", create_service=get_create_service(&exe))
 }
 
-pub fn install_me(options: &str, path: String, silent: bool, debug: bool) -> ResultType<()> {
-    let uninstall_str = get_uninstall(false);
-    let mut path = path.trim_end_matches('\\').to_owned();
-    let (subkey, _path, start_menu, exe) = get_default_install_info();
-    let mut exe = exe;
-    if path.is_empty() {
-        path = _path;
-    } else {
-        exe = exe.replace(&_path, &path);
-    }
+fn get_install_reg_subkey_cmd(
+    subkey: &str,
+    app_name: &str,
+    exe: &str,
+    path: &str,
+    is_install: bool,
+) -> ResultType<String> {
     let mut version_major = "0";
     let mut version_minor = "0";
     let mut version_build = "0";
@@ -1223,6 +1253,50 @@ pub fn install_me(options: &str, path: String, silent: bool, debug: bool) -> Res
     }
     if versions.len() > 2 {
         version_build = versions[2];
+    }
+    let meta = std::fs::symlink_metadata(std::env::current_exe()?)?;
+    let size = meta.len() / 1024;
+
+    let reg_install_values = if is_install {
+        format!(
+            "
+reg add {subkey} /f /v DisplayName /t REG_SZ /d \"{app_name}\"
+reg add {subkey} /f /v InstallLocation /t REG_SZ /d \"{path}\"
+reg add {subkey} /f /v Publisher /t REG_SZ /d \"{app_name}\"
+reg add {subkey} /f /v UninstallString /t REG_SZ /d \"\\\"{exe}\\\" --uninstall\"
+reg add {subkey} /f /v WindowsInstaller /t REG_DWORD /d 0
+            "
+        )
+    } else {
+        "".to_owned()
+    };
+    let cmd = format!(
+        "
+reg add {subkey} /f /v DisplayIcon /t REG_SZ /d \"{exe}\"
+{reg_install_values}
+reg add {subkey} /f /v DisplayVersion /t REG_SZ /d \"{version}\"
+reg add {subkey} /f /v Version /t REG_SZ /d \"{version}\"
+reg add {subkey} /f /v BuildDate /t REG_SZ /d \"{build_date}\"
+reg add {subkey} /f /v VersionMajor /t REG_DWORD /d {version_major}
+reg add {subkey} /f /v VersionMinor /t REG_DWORD /d {version_minor}
+reg add {subkey} /f /v VersionBuild /t REG_DWORD /d {version_build}
+reg add {subkey} /f /v EstimatedSize /t REG_DWORD /d {size}
+    ",
+        version = crate::VERSION.replace("-", "."),
+        build_date = crate::BUILD_DATE,
+    );
+    Ok(cmd)
+}
+
+pub fn install_me(options: &str, path: String, silent: bool, debug: bool) -> ResultType<()> {
+    let uninstall_str = get_uninstall(false);
+    let mut path = path.trim_end_matches('\\').to_owned();
+    let (subkey, _path, start_menu, exe) = get_default_install_info();
+    let mut exe = exe;
+    if path.is_empty() {
+        path = _path;
+    } else {
+        exe = exe.replace(&_path, &path);
     }
     let app_name = crate::get_app_name();
 
@@ -1291,8 +1365,6 @@ copy /Y \"{tmp_path}\\Uninstall {app_name}.lnk\" \"{start_menu}\\\"
         reg_value_printer = "1".to_owned();
     }
 
-    let meta = std::fs::symlink_metadata(std::env::current_exe()?)?;
-    let size = meta.len() / 1024;
     // https://docs.microsoft.com/zh-cn/windows/win32/msi/uninstall-registry-key?redirectedfrom=MSDNa
     // https://www.windowscentral.com/how-edit-registry-using-command-prompt-windows-10
     // https://www.tenforums.com/tutorials/70903-add-remove-allowed-apps-through-windows-firewall-windows-10-a.html
@@ -1325,6 +1397,7 @@ copy /Y \"{tmp_path}\\{app_name} Tray.lnk\" \"%PROGRAMDATA%\\Microsoft\\Windows\
 ")
     };
 
+    let install_reg_subkey_cmd = get_install_reg_subkey_cmd(&subkey, &app_name, &exe, &path, true)?;
     let cmds = format!(
         "
 {uninstall_str}
@@ -1332,19 +1405,7 @@ chcp 65001
 md \"{path}\"
 {copy_exe}
 reg add {subkey} /f
-reg add {subkey} /f /v DisplayIcon /t REG_SZ /d \"{exe}\"
-reg add {subkey} /f /v DisplayName /t REG_SZ /d \"{app_name}\"
-reg add {subkey} /f /v DisplayVersion /t REG_SZ /d \"{version}\"
-reg add {subkey} /f /v Version /t REG_SZ /d \"{version}\"
-reg add {subkey} /f /v BuildDate /t REG_SZ /d \"{build_date}\"
-reg add {subkey} /f /v InstallLocation /t REG_SZ /d \"{path}\"
-reg add {subkey} /f /v Publisher /t REG_SZ /d \"{app_name}\"
-reg add {subkey} /f /v VersionMajor /t REG_DWORD /d {version_major}
-reg add {subkey} /f /v VersionMinor /t REG_DWORD /d {version_minor}
-reg add {subkey} /f /v VersionBuild /t REG_DWORD /d {version_build}
-reg add {subkey} /f /v UninstallString /t REG_SZ /d \"\\\"{exe}\\\" --uninstall\"
-reg add {subkey} /f /v EstimatedSize /t REG_DWORD /d {size}
-reg add {subkey} /f /v WindowsInstaller /t REG_DWORD /d 0
+{install_reg_subkey_cmd}
 cscript \"{mk_shortcut}\"
 cscript \"{uninstall_shortcut}\"
 {tray_shortcuts}
@@ -1355,8 +1416,6 @@ copy /Y \"{tmp_path}\\Uninstall {app_name}.lnk\" \"{path}\\\"
 {after_install}
 {sleep}
     ",
-        version = crate::VERSION.replace("-", "."),
-        build_date = crate::BUILD_DATE,
         after_install = get_after_install(
             &exe,
             Some(reg_value_start_menu_shortcuts),
@@ -2314,6 +2373,102 @@ if exist \"{tray_shortcut}\" del /f /q \"{tray_shortcut}\"
     std::process::exit(0);
 }
 
+pub fn update_me(debug: bool) -> ResultType<()> {
+    let src_exe = std::env::current_exe()?.to_string_lossy().to_string();
+    let (subkey, path, _, exe) = get_install_info();
+    let is_installed = std::fs::metadata(&exe).is_ok();
+    if !is_installed {
+        bail!("RustDesk is not installed.");
+    }
+
+    let app_name = crate::get_app_name();
+    let main_window_pids = crate::platform::get_pids_of_process_with_args::<_, &str>(
+        &format!("{}.exe", &app_name),
+        &[],
+    );
+    let main_window_sessions = main_window_pids
+        .iter()
+        .map(|pid| get_session_id_of_process(pid.as_u32()))
+        .flatten()
+        .collect::<Vec<_>>();
+    for pid in main_window_pids {
+        let _ = crate::platform::kill_process_by_pid(pid);
+    }
+    let tray_pids =
+        crate::platform::get_pids_of_process_with_args(&format!("{}.exe", &app_name), &["--tray"]);
+    let tray_sessions = tray_pids
+        .iter()
+        .map(|pid| get_session_id_of_process(pid.as_u32()))
+        .flatten()
+        .collect::<Vec<_>>();
+    for pid in tray_pids {
+        let _ = crate::platform::kill_process_by_pid(pid);
+    }
+    let is_service_running = is_self_service_running();
+
+    let install_reg_cmd = get_install_reg_subkey_cmd(&subkey, &app_name, &exe, &path, false)?;
+
+    let filter = format!(" /FI \"PID ne {}\"", get_current_pid());
+    let restore_service_cmd = if is_service_running {
+        format!("sc start {}", &app_name)
+    } else {
+        "".to_owned()
+    };
+    // We need `taskkill` because:
+    // 1. There may be some other processes like `rustdesk --connect` are running.
+    // 2. Sometimes, the main window and the tray icon are showing
+    // while I cannot find them by `tasklist` or the methods above.
+    // There's should be 4 processes running: service, server, tray and main window.
+    // But only 2 processes are shown in the tasklist.
+    let cmds = format!(
+        "
+chcp 65001
+sc stop {app_name}
+taskkill /F /IM {app_name}.exe{filter}
+{install_reg_cmd}
+{copy_exe}
+{restore_service_cmd}
+{sleep}
+    ",
+        app_name = app_name,
+        copy_exe = copy_exe_cmd(&src_exe, &exe, &path)?,
+        sleep = if debug { "timeout 300" } else { "" },
+    );
+
+    run_cmds(cmds, debug, "update")?;
+
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+    if tray_sessions.is_empty() {
+        log::info!("No tray process found.");
+    } else {
+        log::info!("Try to restore the tray process...");
+        log::info!(
+            "Try to restore the tray process..., sessions: {:?}",
+            &tray_sessions
+        );
+        for s in tray_sessions {
+            if s != 0 {
+                allow_err!(run_exe_in_session(&exe, vec!["--tray"], s, true));
+            }
+        }
+    }
+    if main_window_sessions.is_empty() {
+        log::info!("No main window process found.");
+    } else {
+        log::info!("Try to restore the main window process...");
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+        for s in main_window_sessions {
+            if s != 0 {
+                allow_err!(run_exe_in_session(&exe, vec![], s, true));
+            }
+        }
+    }
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    log::info!("Update completed.");
+
+    Ok(())
+}
+
 pub fn get_tray_shortcut(exe: &str, tmp_path: &str) -> ResultType<String> {
     Ok(write_cmds(
         format!(
@@ -2886,4 +3041,13 @@ pub fn send_raw_data_to_printer(printer_name: Option<String>, data: Vec<u8>) -> 
     }
 
     Ok(())
+}
+
+pub fn is_msi_installed() -> std::io::Result<bool> {
+    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+    let uninstall_key = hklm.open_subkey(format!(
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{}",
+        crate::get_app_name()
+    ))?;
+    Ok(1 == uninstall_key.get_value::<u32, _>("WindowsInstaller")?)
 }

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -62,6 +62,8 @@ impl RendezvousMediator {
             }
         }
         crate::hbbs_http::sync::start();
+        #[cfg(all(target_os = "windows", feature = "flutter"))]
+        crate::updater::start_auto_update();
         let mut nat_tested = false;
         check_zombie();
         let server = new_server();

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,0 +1,206 @@
+use crate::{
+    common::{do_check_software_update, is_custom_client},
+    hbbs_http::create_http_client,
+};
+use hbb_common::{bail, config, log, ResultType};
+use std::{
+    io::{self, Write},
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc::{channel, Receiver, Sender},
+        Mutex,
+    },
+    time::{Duration, Instant},
+};
+
+enum UpdateMsg {
+    CheckUpdate,
+    Exit,
+}
+
+lazy_static::lazy_static! {
+    static ref TX_MSG : Mutex<Sender<UpdateMsg>> = Mutex::new(start_auto_update_check());
+}
+
+static CONTROLLING_SESSION_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+const DUR_ONE_DAY: Duration = Duration::from_secs(60 * 60 * 24);
+
+pub fn update_controlling_session_count(count: usize) {
+    CONTROLLING_SESSION_COUNT.store(count, Ordering::SeqCst);
+}
+
+pub fn start_auto_update() {
+    let _sender = TX_MSG.lock().unwrap();
+}
+
+#[allow(dead_code)]
+pub fn manually_check_update() -> ResultType<()> {
+    let sender = TX_MSG.lock().unwrap();
+    sender.send(UpdateMsg::CheckUpdate)?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub fn stop_auto_update() {
+    let sender = TX_MSG.lock().unwrap();
+    sender.send(UpdateMsg::Exit).unwrap_or_default();
+}
+
+#[inline]
+fn has_no_active_conns() -> bool {
+    let conns = crate::Connection::alive_conns();
+    conns.is_empty() && CONTROLLING_SESSION_COUNT.load(Ordering::SeqCst) == 0
+}
+
+fn start_auto_update_check() -> Sender<UpdateMsg> {
+    let (tx, rx) = channel();
+    std::thread::spawn(move || start_auto_update_check_(rx));
+    return tx;
+}
+
+fn start_auto_update_check_(rx_msg: Receiver<UpdateMsg>) {
+    std::thread::sleep(Duration::from_secs(30));
+    if let Err(e) = check_update(false) {
+        log::error!("Error checking for updates: {}", e);
+    }
+
+    const MIN_INTERVAL: Duration = Duration::from_secs(60 * 5);
+    const RETRY_INTERVAL: Duration = Duration::from_secs(60 * 30);
+    let mut last_check_time = Instant::now();
+    let mut check_interval = DUR_ONE_DAY;
+    loop {
+        let recv_res = rx_msg.recv_timeout(check_interval);
+        match &recv_res {
+            Ok(UpdateMsg::CheckUpdate) | Err(_) => {
+                if last_check_time.elapsed() < MIN_INTERVAL {
+                    // log::debug!("Update check skipped due to minimum interval.");
+                    continue;
+                }
+                // Don't check update if there are alive connections.
+                if !has_no_active_conns() {
+                    check_interval = RETRY_INTERVAL;
+                    continue;
+                }
+                if let Err(e) = check_update(matches!(recv_res, Ok(UpdateMsg::CheckUpdate))) {
+                    log::error!("Error checking for updates: {}", e);
+                    check_interval = RETRY_INTERVAL;
+                } else {
+                    last_check_time = Instant::now();
+                    check_interval = DUR_ONE_DAY;
+                }
+            }
+            Ok(UpdateMsg::Exit) => break,
+        }
+    }
+}
+
+fn check_update(manually: bool) -> ResultType<()> {
+    #[cfg(target_os = "windows")]
+    let is_win_msi = crate::platform::is_msi_installed()?;
+    #[cfg(not(target_os = "windows"))]
+    let is_win_msi = false;
+    if is_custom_client() || !crate::platform::is_installed() || is_win_msi {
+        return Ok(());
+    }
+    if manually || config::Config::get_bool_option(config::keys::OPTION_ALLOW_AUTO_UPDATE) {
+        if do_check_software_update().is_ok() {
+            let update_url = crate::common::SOFTWARE_UPDATE_URL.lock().unwrap().clone();
+            if update_url.is_empty() {
+                log::debug!("No update available.");
+            } else {
+                let download_url = update_url.replace("tag", "download");
+                let version = download_url.split('/').last().unwrap_or_default();
+                #[cfg(target_os = "windows")]
+                let download_url = format!("{}/rustdesk-{}-x86_64.exe", download_url, version);
+                log::debug!("New version available: {}", &version);
+                let client = create_http_client();
+                let Some(file_path) = get_download_file_from_url(&download_url) else {
+                    bail!("Failed to get the file path from the URL: {}", download_url);
+                };
+                let mut is_file_exists = false;
+                if file_path.exists() {
+                    // Check if the file size is the same as the server file size
+                    // If the file size is the same, we don't need to download it again.
+                    let file_size = std::fs::metadata(&file_path)?.len();
+                    let response = client.head(&download_url).send()?;
+                    if !response.status().is_success() {
+                        bail!("Failed to get the file size: {}", response.status());
+                    }
+                    let total_size = response
+                        .headers()
+                        .get(reqwest::header::CONTENT_LENGTH)
+                        .and_then(|ct_len| ct_len.to_str().ok())
+                        .and_then(|ct_len| ct_len.parse::<u64>().ok());
+                    let Some(total_size) = total_size else {
+                        bail!("Failed to get content length");
+                    };
+                    if file_size == total_size {
+                        is_file_exists = true;
+                    } else {
+                        std::fs::remove_file(&file_path)?;
+                    }
+                }
+                if !is_file_exists {
+                    let response = client.get(&download_url).send()?;
+                    if !response.status().is_success() {
+                        bail!(
+                            "Failed to download the new version file: {}",
+                            response.status()
+                        );
+                    }
+                    let file_data = response.bytes()?;
+                    let mut file = std::fs::File::create(&file_path)?;
+                    file.write_all(&file_data)?;
+                }
+                // We have checked if the `conns`` is empty before, but we need to check again.
+                // No need to care about the downloaded file here, because it's rare case that the `conns` are empty
+                // before the download, but not empty after the download.
+                if has_no_active_conns() {
+                    #[cfg(target_os = "windows")]
+                    if let Some(p) = file_path.to_str() {
+                        if let Some(session_id) = crate::platform::get_current_process_session_id()
+                        {
+                            match crate::platform::launch_privileged_process(
+                                session_id,
+                                &format!("{} --update", p),
+                            ) {
+                                Ok(h) => {
+                                    if h.is_null() {
+                                        log::error!(
+                                            "Failed to update to the new version: {}",
+                                            version
+                                        );
+                                    } else {
+                                        log::debug!("New version \"{}\" updated.", version);
+                                    }
+                                }
+                                Err(e) => {
+                                    log::error!("Failed to run the new version: {}", e);
+                                }
+                            }
+                        } else {
+                            log::error!(
+                                "Failed to get the current process session id, Error {}",
+                                io::Error::last_os_error()
+                            );
+                        }
+                    } else {
+                        // unreachable!()
+                        log::error!(
+                            "Failed to convert the file path to string: {}",
+                            file_path.display()
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn get_download_file_from_url(url: &str) -> Option<PathBuf> {
+    let filename = url.split('/').last()?;
+    Some(std::env::temp_dir().join(filename))
+}


### PR DESCRIPTION
## Desc

1. Easy update when clicking "Click to update" on Windows, exe installed version. The main code is in `update_progress.dart`.
2. Provide an "Auto update" option. The main code is in `updater.rs`. Auto update will check for update 30 seconds after startup, then every 24 hours

![image](https://github.com/user-attachments/assets/2105875b-b57b-492d-afe4-a7b36de4302a)


The update logic is `stop service` -> `kill all instances` -> `update reg values` -> `copy files` -> `restore service` -> `restore main window and tray process`.

The main function is `update_me()` in `windows.rs`.

## Preview


https://github.com/user-attachments/assets/692b4dfc-43c7-4d48-ba20-922c56c8e58e


https://github.com/user-attachments/assets/a899dd16-9c41-4ff7-bea1-a55982108eaa

## Note

1. msi versions are not installed.
2. The sciter version is not supported. Because I can't get the process arguments when running the exe from github, my local machine works fine. The possible reason may be my local machine is 64-bit, while the exe from github is 32-bit. RustDesk need to find the process arguments to get the `pid and session id` of the tray process.
