### PR TITLE
adding missing --recurse-submodule in the Build section of the README…

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ cd
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
-git clone https://github.com/rustdesk/rustdesk
+git clone --recurse-submodules https://github.com/rustdesk/rustdesk
 cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so


### PR DESCRIPTION
…. Should be present to ensure no issues arise for hbb_common