### PR TITLE
Feat/win auto update, macos update

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1152,15 +1152,23 @@ Widget createDialogContent(String text) {
 
 void msgBox(SessionID sessionId, String type, String title, String text,
     String link, OverlayDialogManager dialogManager,
-    {bool? hasCancel, ReconnectHandle? reconnect, int? reconnectTimeout}) {
+    {bool? hasCancel,
+    ReconnectHandle? reconnect,
+    int? reconnectTimeout,
+    VoidCallback? onSubmit,
+    int? submitTimeout}) {
   dialogManager.dismissAll();
   List<Widget> buttons = [];
   bool hasOk = false;
   submit() {
     dialogManager.dismissAll();
-    // https://github.com/rustdesk/rustdesk/blob/5e9a31340b899822090a3731769ae79c6bf5f3e5/src/ui/common.tis#L263
-    if (!type.contains("custom") && desktopType != DesktopType.portForward) {
-      closeConnection();
+    if (onSubmit != null) {
+      onSubmit.call();
+    } else {
+      // https://github.com/rustdesk/rustdesk/blob/5e9a31340b899822090a3731769ae79c6bf5f3e5/src/ui/common.tis#L263
+      if (!type.contains("custom") && desktopType != DesktopType.portForward) {
+        closeConnection();
+      }
     }
   }
 
@@ -1176,7 +1184,18 @@ void msgBox(SessionID sessionId, String type, String title, String text,
 
   if (type != "connecting" && type != "success" && !type.contains("nook")) {
     hasOk = true;
-    buttons.insert(0, dialogButton('OK', onPressed: submit));
+    late final Widget btn;
+    if (submitTimeout != null) {
+      btn = _CountDownButton(
+        text: 'OK',
+        second: submitTimeout,
+        onPressed: submit,
+        submitOnTimeout: true,
+      );
+    } else {
+      btn = dialogButton('OK', onPressed: submit);
+    }
+    buttons.insert(0, btn);
   }
   hasCancel ??= !type.contains("error") &&
       !type.contains("nocancel") &&
@@ -1197,7 +1216,8 @@ void msgBox(SessionID sessionId, String type, String title, String text,
       reconnectTimeout != null) {
     // `enabled` is used to disable the dialog button once the button is clicked.
     final enabled = true.obs;
-    final button = Obx(() => _ReconnectCountDownButton(
+    final button = Obx(() => _CountDownButton(
+          text: 'Reconnect',
           second: reconnectTimeout,
           onPressed: enabled.isTrue
               ? () {
@@ -3183,21 +3203,24 @@ parseParamScreenRect(Map<String, dynamic> params) {
 
 get isInputSourceFlutter => stateGlobal.getInputSource() == "Input source 2";
 
-class _ReconnectCountDownButton extends StatefulWidget {
-  _ReconnectCountDownButton({
+class _CountDownButton extends StatefulWidget {
+  _CountDownButton({
     Key? key,
+    required this.text,
     required this.second,
     required this.onPressed,
+    this.submitOnTimeout = false,
   }) : super(key: key);
+  final String text;
   final VoidCallback? onPressed;
   final int second;
+  final bool submitOnTimeout;
 
   @override
-  State<_ReconnectCountDownButton> createState() =>
-      _ReconnectCountDownButtonState();
+  State<_CountDownButton> createState() => _CountDownButtonState();
 }
 
-class _ReconnectCountDownButtonState extends State<_ReconnectCountDownButton> {
+class _CountDownButtonState extends State<_CountDownButton> {
   late int _countdownSeconds = widget.second;
 
   Timer? _timer;
@@ -3218,6 +3241,9 @@ class _ReconnectCountDownButtonState extends State<_ReconnectCountDownButton> {
     _timer = Timer.periodic(Duration(seconds: 1), (timer) {
       if (_countdownSeconds <= 0) {
         timer.cancel();
+        if (widget.submitOnTimeout) {
+          widget.onPressed?.call();
+        }
       } else {
         setState(() {
           _countdownSeconds--;
@@ -3229,7 +3255,7 @@ class _ReconnectCountDownButtonState extends State<_ReconnectCountDownButton> {
   @override
   Widget build(BuildContext context) {
     return dialogButton(
-      '${translate('Reconnect')} (${_countdownSeconds}s)',
+      '${translate(widget.text)} (${_countdownSeconds}s)',
       onPressed: widget.onPressed,
       isOutline: true,
     );

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -139,6 +139,7 @@ const String kOptionCurrentAbName = "current-ab-name";
 const String kOptionEnableConfirmClosingTabs = "enable-confirm-closing-tabs";
 const String kOptionAllowAlwaysSoftwareRender = "allow-always-software-render";
 const String kOptionEnableCheckUpdate = "enable-check-update";
+const String kOptionAllowAutoUpdate = "allow-auto-update";
 const String kOptionAllowLinuxHeadless = "allow-linux-headless";
 const String kOptionAllowRemoveWallpaper = "allow-remove-wallpaper";
 const String kOptionStopService = "stop-service";

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -435,17 +435,7 @@ class _DesktopHomePageState extends State<DesktopHomePage>
         !isCardClosed &&
         bind.mainUriPrefixSync().contains('rustdesk')) {
       String btnText = "Click to download";
-      var isToUpdate = false;
-      if (isWindows && bind.mainIsInstalled()) {
-        final String isMsiInstalled =
-            bind.mainGetCommonSync(key: 'is-msi-installed');
-        if ('false' == isMsiInstalled) {
-          isToUpdate = true;
-        } else if ('true' != isMsiInstalled) {
-          debugPrint(
-              "isMsiInstalled is not true or false, error: $isMsiInstalled");
-        }
-      }
+      var isToUpdate = isWindows && bind.mainIsInstalled();
       if (isToUpdate) {
         btnText = "Click to update";
       }

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -24,6 +24,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:window_size/window_size.dart' as window_size;
 
+import '../../common.dart';
 import '../widgets/button.dart';
 
 class DesktopHomePage extends StatefulWidget {
@@ -434,7 +435,7 @@ class _DesktopHomePageState extends State<DesktopHomePage>
         updateUrl.isNotEmpty &&
         !isCardClosed &&
         bind.mainUriPrefixSync().contains('rustdesk')) {
-      final isToUpdate = isWindows && bind.mainIsInstalled();
+      final isToUpdate = (isWindows || isMacOS) && bind.mainIsInstalled();
       String btnText = isToUpdate ? 'Click to update' : 'Click to download';
       GestureTapCallback onPressed = () async {
         final Uri url = Uri.parse('https://rustdesk.com/download');

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -12,6 +12,7 @@ import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/pages/connection_page.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_setting_page.dart';
 import 'package:flutter_hbb/desktop/pages/desktop_tab_page.dart';
+import 'package:flutter_hbb/desktop/widgets/update_progress.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:flutter_hbb/models/server_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
@@ -433,13 +434,36 @@ class _DesktopHomePageState extends State<DesktopHomePage>
         updateUrl.isNotEmpty &&
         !isCardClosed &&
         bind.mainUriPrefixSync().contains('rustdesk')) {
+      String btnText = "Click to download";
+      var isToUpdate = false;
+      if (isWindows && bind.mainIsInstalled()) {
+        final String isMsiInstalled =
+            bind.mainGetCommonSync(key: 'is-msi-installed');
+        if ('false' == isMsiInstalled) {
+          isToUpdate = true;
+        } else if ('true' != isMsiInstalled) {
+          debugPrint(
+              "isMsiInstalled is not true or false, error: $isMsiInstalled");
+        }
+      }
+      if (isToUpdate) {
+        btnText = "Click to update";
+      }
+      GestureTapCallback onPressed = () async {
+        final Uri url = Uri.parse('https://rustdesk.com/download');
+        await launchUrl(url);
+      };
+      if (isToUpdate) {
+        onPressed = () {
+          handleUpdate(updateUrl);
+        };
+      }
       return buildInstallCard(
           "Status",
           "${translate("new-version-of-{${bind.mainGetAppNameSync()}}-tip")} (${bind.mainGetNewVersion()}).",
-          "Click to download", () async {
-        final Uri url = Uri.parse('https://rustdesk.com/download');
-        await launchUrl(url);
-      }, closeButton: true);
+          btnText,
+          onPressed,
+          closeButton: true);
     }
     if (systemError.isNotEmpty) {
       return buildInstallCard("", systemError, "", () {});

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -434,11 +434,8 @@ class _DesktopHomePageState extends State<DesktopHomePage>
         updateUrl.isNotEmpty &&
         !isCardClosed &&
         bind.mainUriPrefixSync().contains('rustdesk')) {
-      String btnText = "Click to download";
-      var isToUpdate = isWindows && bind.mainIsInstalled();
-      if (isToUpdate) {
-        btnText = "Click to update";
-      }
+      final isToUpdate = isWindows && bind.mainIsInstalled();
+      String btnText = isToUpdate ? 'Click to update' : 'Click to download';
       GestureTapCallback onPressed = () async {
         final Uri url = Uri.parse('https://rustdesk.com/download');
         await launchUrl(url);

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -470,10 +470,8 @@ class _GeneralState extends State<_General> {
   }
 
   Widget other() {
-    final showAutoUpdate = isWindows &&
-        'false' == bind.mainGetCommonSync(key: 'is-msi-installed') &&
-        bind.mainIsInstalled() &&
-        !bind.isCustomClient();
+    final showAutoUpdate =
+        isWindows && bind.mainIsInstalled() && !bind.isCustomClient();
     final children = <Widget>[
       if (!isWeb && !bind.isIncomingOnly())
         _OptionCheckBox(context, 'Confirm before closing multiple tabs',

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -470,6 +470,10 @@ class _GeneralState extends State<_General> {
   }
 
   Widget other() {
+    final showAutoUpdate = isWindows &&
+        'false' == bind.mainGetCommonSync(key: 'is-msi-installed') &&
+        bind.mainIsInstalled() &&
+        !bind.isCustomClient();
     final children = <Widget>[
       if (!isWeb && !bind.isIncomingOnly())
         _OptionCheckBox(context, 'Confirm before closing multiple tabs',
@@ -523,12 +527,19 @@ class _GeneralState extends State<_General> {
             kOptionEnableCheckUpdate,
             isServer: false,
           ),
+        if (showAutoUpdate)
+          _OptionCheckBox(
+            context,
+            'Auto update',
+            kOptionAllowAutoUpdate,
+            isServer: true,
+          ),
         if (isWindows && !bind.isOutgoingOnly())
           _OptionCheckBox(
             context,
             'Capture screen using DirectX',
             kOptionDirectxCapture,
-          )
+          ),
       ],
     ];
     if (!isWeb && bind.mainShowOption(key: kOptionAllowLinuxHeadless)) {

--- a/flutter/lib/desktop/widgets/update_progress.dart
+++ b/flutter/lib/desktop/widgets/update_progress.dart
@@ -199,13 +199,19 @@ class UpdateProgressState extends State<UpdateProgress> {
           _onError('The download file size is 0.');
         } else {
           setState(() {});
-          Future.delayed(const Duration(milliseconds: 500), () {
-            msgBox(gFFI.sessionId, 'custom-nocancel', '{$appName} Update',
-                '{$appName}-to-update-tip', '', gFFI.dialogManager);
-            Future.delayed(const Duration(milliseconds: 1000), () {
+          msgBox(
+            gFFI.sessionId,
+            'custom-nocancel',
+            '{$appName} Update',
+            '{$appName}-to-update-tip',
+            '',
+            gFFI.dialogManager,
+            onSubmit: () {
+              debugPrint('Downloaded, update to new version now');
               bind.mainSetCommon(key: 'update-me', value: widget.downloadUrl);
-            });
-          });
+            },
+            submitTimeout: 5,
+          );
         }
       } else {
         setState(() {});

--- a/flutter/lib/desktop/widgets/update_progress.dart
+++ b/flutter/lib/desktop/widgets/update_progress.dart
@@ -20,7 +20,7 @@ void handleUpdate(String releasePageUrl) {
     } else {
       debugPrint(
           'Failed to check if is installed MSI package, error: $isMsiInstalled');
-      msgBox(gFFI.sessionId, 'custom-nocancel-hasclose', 'Error',
+      msgBox(gFFI.sessionId, 'custom-nocancel-nook-hasclose', 'Error',
           'update-failed-check-msi-tip', releasePageUrl, gFFI.dialogManager);
       return;
     }
@@ -122,7 +122,7 @@ class UpdateProgressState extends State<UpdateProgress> {
     cancelQueryTimer();
 
     debugPrint('Download new version error: $error');
-    final msgBoxType = 'custom-nocancel-hasclose';
+    final msgBoxType = 'custom-nocancel-nook-hasclose';
     final msgBoxTitle = 'Error';
     final msgBoxText = 'download-new-veresion-failed-tip';
     final dialogManager = gFFI.dialogManager;

--- a/flutter/lib/desktop/widgets/update_progress.dart
+++ b/flutter/lib/desktop/widgets/update_progress.dart
@@ -11,7 +11,19 @@ void handleUpdate(String releasePageUrl) {
   String downloadUrl = releasePageUrl.replaceAll('tag', 'download');
   String version = downloadUrl.substring(downloadUrl.lastIndexOf('/') + 1);
   if (isWindows) {
-    downloadUrl = '$downloadUrl/rustdesk-$version-x86_64.exe';
+    final String isMsiInstalled =
+        bind.mainGetCommonSync(key: 'is-msi-installed');
+    if (isMsiInstalled == 'true') {
+      downloadUrl = '$downloadUrl/rustdesk-$version-x86_64.msi';
+    } else if (isMsiInstalled == 'false') {
+      downloadUrl = '$downloadUrl/rustdesk-$version-x86_64.exe';
+    } else {
+      debugPrint(
+          'Failed to check if is installed MSI package, error: $isMsiInstalled');
+      msgBox(gFFI.sessionId, 'custom-nocancel-hasclose', 'Error',
+          'update-failed-check-msi-tip', releasePageUrl, gFFI.dialogManager);
+      return;
+    }
   }
   SimpleWrapper downloadId = SimpleWrapper('');
   SimpleWrapper<VoidCallback> onCanceled = SimpleWrapper(() {});

--- a/flutter/lib/desktop/widgets/update_progress.dart
+++ b/flutter/lib/desktop/widgets/update_progress.dart
@@ -124,7 +124,7 @@ class UpdateProgressState extends State<UpdateProgress> {
     debugPrint('Download new version error: $error');
     final msgBoxType = 'custom-nocancel-nook-hasclose';
     final msgBoxTitle = 'Error';
-    final msgBoxText = 'download-new-veresion-failed-tip';
+    final msgBoxText = 'download-new-version-failed-tip';
     final dialogManager = gFFI.dialogManager;
 
     close() {

--- a/flutter/lib/desktop/widgets/update_progress.dart
+++ b/flutter/lib/desktop/widgets/update_progress.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hbb/common.dart';
+import 'package:flutter_hbb/models/platform_model.dart';
+import 'package:get/get.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+void handleUpdate(String releasePageUrl) {
+  String downloadUrl = releasePageUrl.replaceAll('tag', 'download');
+  String version = downloadUrl.substring(downloadUrl.lastIndexOf('/') + 1);
+  if (isWindows) {
+    downloadUrl = '$downloadUrl/rustdesk-$version-x86_64.exe';
+  }
+  SimpleWrapper downloadId = SimpleWrapper('');
+  SimpleWrapper<VoidCallback> onCanceled = SimpleWrapper(() {});
+  gFFI.dialogManager.dismissAll();
+  gFFI.dialogManager.show((setState, close, context) {
+    return CustomAlertDialog(
+        title: Text(translate('Downloading {$appName}')),
+        content:
+            UpdateProgress(releasePageUrl, downloadUrl, downloadId, onCanceled)
+                .marginSymmetric(horizontal: 8)
+                .paddingOnly(top: 12),
+        actions: [
+          dialogButton(translate('Cancel'), onPressed: () async {
+            onCanceled.value();
+            await bind.mainSetCommon(
+                key: 'cancel-downloader', value: downloadId.value);
+            // Wait for the downloader to be removed.
+            for (int i = 0; i < 10; i++) {
+              await Future.delayed(const Duration(milliseconds: 300));
+              final isCanceled = 'error:Downloader not found' ==
+                  await bind.mainGetCommon(
+                      key: 'download-data-${downloadId.value}');
+              if (isCanceled) {
+                break;
+              }
+            }
+            close();
+          }, isOutline: true),
+        ]);
+  });
+}
+
+class UpdateProgress extends StatefulWidget {
+  final String releasePageUrl;
+  final String downloadUrl;
+  final SimpleWrapper downloadId;
+  final SimpleWrapper onCanceled;
+  UpdateProgress(
+      this.releasePageUrl, this.downloadUrl, this.downloadId, this.onCanceled,
+      {Key? key})
+      : super(key: key);
+
+  @override
+  State<UpdateProgress> createState() => UpdateProgressState();
+}
+
+class UpdateProgressState extends State<UpdateProgress> {
+  Timer? _timer;
+  int? _totalSize;
+  int _downloadedSize = 0;
+  int _getDataFailedCount = 0;
+  final String _eventKeyDownloadNewVersion = 'download-new-version';
+
+  @override
+  void initState() {
+    super.initState();
+    widget.onCanceled.value = () {
+      cancelQueryTimer();
+    };
+    platformFFI.registerEventHandler(_eventKeyDownloadNewVersion,
+        _eventKeyDownloadNewVersion, handleDownloadNewVersion,
+        replace: true);
+    bind.mainSetCommon(key: 'download-new-version', value: widget.downloadUrl);
+  }
+
+  @override
+  void dispose() {
+    cancelQueryTimer();
+    platformFFI.unregisterEventHandler(
+        _eventKeyDownloadNewVersion, _eventKeyDownloadNewVersion);
+    super.dispose();
+  }
+
+  void cancelQueryTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  Future<void> handleDownloadNewVersion(Map<String, dynamic> evt) async {
+    if (evt.containsKey('id')) {
+      widget.downloadId.value = evt['id'] as String;
+      _timer = Timer.periodic(const Duration(milliseconds: 300), (timer) {
+        _updateDownloadData();
+      });
+    } else {
+      if (evt.containsKey('error')) {
+        _onError(evt['error'] as String);
+      } else {
+        // unreachable
+        _onError('$evt');
+      }
+    }
+  }
+
+  void _onError(String error) {
+    cancelQueryTimer();
+
+    debugPrint('Download new version error: $error');
+    final msgBoxType = 'custom-nocancel-hasclose';
+    final msgBoxTitle = 'Error';
+    final msgBoxText = 'download-new-veresion-failed-tip';
+    final dialogManager = gFFI.dialogManager;
+
+    close() {
+      dialogManager.dismissAll();
+    }
+
+    jumplink() {
+      launchUrl(Uri.parse(widget.releasePageUrl));
+      dialogManager.dismissAll();
+    }
+
+    retry() {
+      dialogManager.dismissAll();
+      handleUpdate(widget.releasePageUrl);
+    }
+
+    final List<Widget> buttons = [
+      dialogButton('JumpLink', onPressed: jumplink),
+      dialogButton('Retry', onPressed: retry),
+      dialogButton('Close', onPressed: close),
+    ];
+    dialogManager.dismissAll();
+    dialogManager.show(
+      (setState, close, context) => CustomAlertDialog(
+        title: null,
+        content: SelectionArea(
+            child: msgboxContent(msgBoxType, msgBoxTitle, msgBoxText)),
+        actions: buttons,
+      ),
+      tag: '$msgBoxType-$msgBoxTitle-$msgBoxTitle',
+    );
+  }
+
+  void _updateDownloadData() {
+    String err = '';
+    String downloadData =
+        bind.mainGetCommonSync(key: 'download-data-${widget.downloadId.value}');
+    if (downloadData.startsWith('error:')) {
+      err = downloadData.substring('error:'.length);
+    } else {
+      try {
+        jsonDecode(downloadData).forEach((key, value) {
+          if (key == 'total_size') {
+            if (value != null && value is int) {
+              _totalSize = value;
+            }
+          } else if (key == 'downloaded_size') {
+            _downloadedSize = value as int;
+          } else if (key == 'error') {
+            if (value != null) {
+              err = value.toString();
+            }
+          }
+        });
+      } catch (e) {
+        _getDataFailedCount += 1;
+        debugPrint(
+            'Failed to get download data ${widget.downloadUrl}, error $e');
+        if (_getDataFailedCount > 3) {
+          err = e.toString();
+        }
+      }
+    }
+    if (err != '') {
+      _onError(err);
+    } else {
+      if (_totalSize != null && _downloadedSize >= _totalSize!) {
+        cancelQueryTimer();
+        bind.mainSetCommon(
+            key: 'remove-downloader', value: widget.downloadId.value);
+        if (_totalSize == 0) {
+          _onError('The download file size is 0.');
+        } else {
+          setState(() {});
+          Future.delayed(const Duration(milliseconds: 500), () {
+            msgBox(gFFI.sessionId, 'custom-nocancel', '{$appName} Update',
+                '{$appName}-to-update-tip', '', gFFI.dialogManager);
+            Future.delayed(const Duration(milliseconds: 1000), () {
+              bind.mainSetCommon(key: 'update-me', value: widget.downloadUrl);
+            });
+          });
+        }
+      } else {
+        setState(() {});
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return onDownloading(context);
+  }
+
+  Widget onDownloading(BuildContext context) {
+    final value = _totalSize == null
+        ? 0.0
+        : (_totalSize == 0 ? 1.0 : _downloadedSize / _totalSize!);
+    return LinearProgressIndicator(
+      value: value,
+      minHeight: 20,
+      borderRadius: BorderRadius.circular(5),
+      backgroundColor: Colors.grey[300],
+      valueColor: const AlwaysStoppedAnimation<Color>(Colors.blue),
+    );
+  }
+}

--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -56,7 +56,7 @@
 			<!-- Launch ClientLauncher if installing or already installed and not uninstalling -->
 			<!-- https://learn.microsoft.com/en-us/windows/win32/msi/uilevel -->
 			<Custom Action="LaunchApp" After="InstallFinalize" Condition="(NOT UILevel=2) AND (NOT (Installed AND REMOVE AND NOT UPGRADINGPRODUCTCODE)) "/>
-			<Custom Action="LaunchAppTray" After="InstallFinalize" Condition="(NOT (Installed AND REMOVE AND NOT UPGRADINGPRODUCTCODE)) AND (NOT STOP_SERVICE=&quot;&apos;Y&apos;&quot;) AND (NOT CC_CONNECTION_TYPE=&quot;outgoing&quot;)"/>
+			<Custom Action="LaunchAppTray" After="InstallFinalize" Condition="(LAUNCH_TRAY_APP=&quot;Y&quot; OR LAUNCH_TRAY_APP=&quot;1&quot;) AND (NOT (Installed AND REMOVE AND NOT UPGRADINGPRODUCTCODE)) AND (NOT STOP_SERVICE=&quot;&apos;Y&apos;&quot;) AND (NOT CC_CONNECTION_TYPE=&quot;outgoing&quot;)"/>
 
 			<!-- https://learn.microsoft.com/en-us/windows/win32/msi/operating-system-property-values -->
 			<!-- We have to use `VersionNT` to instead of `IsWindows10OrGreater()` in the custom action.

--- a/res/msi/Package/Fragments/AddRemoveProperties.wxs
+++ b/res/msi/Package/Fragments/AddRemoveProperties.wxs
@@ -9,6 +9,8 @@
 		<!--STOP_SERVICE is set to 'Y'. Because the cofig value may be empty or 'Y'-->
 		<Property Id="STOP_SERVICE" Value="&apos;Y&apos;" />
 
+		<Property Id="LAUNCH_TRAY_APP" Value="Y" />
+
 		<!--
 		Support entries shown when clicking "Click here for support information"
 		in Control Panel's Add/Remove Programs https://learn.microsoft.com/en-us/windows/win32/msi/property-reference

--- a/src/common.rs
+++ b/src/common.rs
@@ -835,12 +835,12 @@ pub fn check_software_update() {
     } 
     let opt = config::LocalConfig::get_option(config::keys::OPTION_ENABLE_CHECK_UPDATE);
     if config::option2bool(config::keys::OPTION_ENABLE_CHECK_UPDATE, &opt) {
-        std::thread::spawn(move || allow_err!(check_software_update_()));
+        std::thread::spawn(move || allow_err!(do_check_software_update()));
     }
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn check_software_update_() -> hbb_common::ResultType<()> {
+pub async fn do_check_software_update() -> hbb_common::ResultType<()> {
     let (request, url) =
         hbb_common::version_check_request(hbb_common::VER_TYPE_RUSTDESK_CLIENT.to_string());
     let latest_release_response = create_http_client_async()
@@ -864,6 +864,8 @@ async fn check_software_update_() -> hbb_common::ResultType<()> {
             }
         }
         *SOFTWARE_UPDATE_URL.lock().unwrap() = response_url;
+    } else {
+        *SOFTWARE_UPDATE_URL.lock().unwrap() = "".to_string();
     }
     Ok(())
 }

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -190,7 +190,7 @@ pub fn core_main() -> Option<Vec<String>> {
                 let text = match res {
                     Ok(_) => translate("Update successfully!".to_string()),
                     Err(err) => {
-                        println!("Failed with error: {err}");
+                        log::error!("Failed with error: {err}");
                         translate("Update failed!".to_string())
                     }
                 };

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -1,4 +1,4 @@
-#[cfg(windows)]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use crate::client::translate;
 #[cfg(not(debug_assertions))]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -260,6 +260,21 @@ pub fn core_main() -> Option<Vec<String>> {
                 hbb_common::allow_err!(
                     crate::virtual_display_manager::amyuni_idd::uninstall_driver()
                 );
+                return None;
+            }
+        }
+        #[cfg(target_os = "macos")]
+        {
+            use crate::platform;
+            if args[0] == "--update" {
+                let _text = match platform::update_me() {
+                    Ok(_) => {
+                        log::info!("{}", translate("Update successfully!".to_string()));
+                    }
+                    Err(err) => {
+                        log::error!("Update failed with error: {err}");
+                    }
+                };
                 return None;
             }
         }

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -182,6 +182,26 @@ pub fn core_main() -> Option<Vec<String>> {
                     log::error!("Failed to uninstall: {}", err);
                 }
                 return None;
+            } else if args[0] == "--update" {
+                if config::is_disable_installation() {
+                    return None;
+                }
+                let res = platform::update_me(false);
+                let text = match res {
+                    Ok(_) => translate("Update successfully!".to_string()),
+                    Err(err) => {
+                        println!("Failed with error: {err}");
+                        translate("Update failed!".to_string())
+                    }
+                };
+                Toast::new(Toast::POWERSHELL_APP_ID)
+                    .title(&config::APP_NAME.read().unwrap())
+                    .text1(&text)
+                    .sound(Some(Sound::Default))
+                    .duration(Duration::Short)
+                    .show()
+                    .ok();
+                return None;
             } else if args[0] == "--after-install" {
                 if let Err(err) = platform::run_after_install() {
                     log::error!("Failed to after-install: {}", err);
@@ -585,7 +605,8 @@ fn core_main_invoke_new_connection(mut args: std::env::Args) -> Option<Vec<Strin
     let mut param_array = vec![];
     while let Some(arg) = args.next() {
         match arg.as_str() {
-            "--connect" | "--play" | "--file-transfer" | "--view-camera" | "--port-forward" | "--rdp" => {
+            "--connect" | "--play" | "--file-transfer" | "--view-camera" | "--port-forward"
+            | "--rdp" => {
                 authority = Some((&arg.to_string()[2..]).to_owned());
                 id = args.next();
             }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1997,6 +1997,7 @@ pub mod sessions {
             }
         }
         let s = SESSIONS.write().unwrap().remove(&remove_peer_key?);
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         update_session_count_to_server();
         s
     }
@@ -2100,10 +2101,12 @@ pub mod sessions {
             .write()
             .unwrap()
             .insert(session_id, Default::default());
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         update_session_count_to_server();
     }
 
     #[inline]
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     fn update_session_count_to_server() {
         crate::ipc::update_controlling_session_count(SESSIONS.read().unwrap().len()).ok();
     }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1996,7 +1996,9 @@ pub mod sessions {
                 None => {}
             }
         }
-        SESSIONS.write().unwrap().remove(&remove_peer_key?)
+        let s = SESSIONS.write().unwrap().remove(&remove_peer_key?);
+        update_session_count_to_server();
+        s
     }
 
     fn check_remove_unused_displays(
@@ -2098,6 +2100,12 @@ pub mod sessions {
             .write()
             .unwrap()
             .insert(session_id, Default::default());
+        update_session_count_to_server();
+    }
+
+    #[inline]
+    fn update_session_count_to_server() {
+        crate::ipc::update_controlling_session_count(SESSIONS.read().unwrap().len()).ok();
     }
 
     #[inline]

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2519,7 +2519,7 @@ pub fn main_set_common(_key: String, _value: String) {
                             log::error!("Failed to run the update exe: {}", e);
                         }
                     } else if f.ends_with(".msi") {
-                        if let Err(e) = crate::platform::update_me_msi(f) {
+                        if let Err(e) = crate::platform::update_me_msi(f, false) {
                             log::error!("Failed to run the update msi: {}", e);
                         }
                     } else {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -21,11 +21,12 @@ use hbb_common::{
 };
 use std::{
     collections::HashMap,
+    path::PathBuf,
     sync::{
         atomic::{AtomicI32, Ordering},
         Arc,
     },
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 
 pub type SessionID = uuid::Uuid;
@@ -2417,8 +2418,28 @@ pub fn main_get_common(key: String) -> String {
         return false.to_string();
     } else if key == "transfer-job-id" {
         return hbb_common::fs::get_next_job_id().to_string();
+    } else if key == "is-msi-installed" {
+        #[cfg(target_os = "windows")]
+        {
+            return match crate::platform::windows::is_msi_installed() {
+                Ok(r) => r.to_string(),
+                Err(e) => e.to_string(),
+            };
+        }
+        #[cfg(not(target_os = "windows"))]
+        return false.to_string();
     } else {
-        "".to_owned()
+        if key.starts_with("download-data-") {
+            let id = key.replace("download-data-", "");
+            match crate::hbbs_http::downloader::get_download_data(&id) {
+                Ok(data) => serde_json::to_string(&data).unwrap_or_default(),
+                Err(e) => {
+                    format!("error:{}", e)
+                }
+            }
+        } else {
+            "".to_owned()
+        }
     }
 }
 
@@ -2458,6 +2479,48 @@ pub fn main_set_common(_key: String, _value: String) {
                 serde_json::ser::to_string(&data).unwrap_or("".to_owned()),
             );
         });
+    }
+    #[cfg(target_os = "windows")]
+    {
+        use crate::updater::get_download_file_from_url;
+        if _key == "download-new-version" {
+            let download_url = _value.clone();
+            let event_key = "download-new-version".to_owned();
+            let data = if let Some(download_file) = get_download_file_from_url(&download_url) {
+                std::fs::remove_file(&download_file).ok();
+                match crate::hbbs_http::downloader::download_file(
+                    download_url,
+                    Some(PathBuf::from(download_file)),
+                    Some(Duration::from_secs(3)),
+                ) {
+                    Ok(id) => HashMap::from([("name", event_key), ("id", id)]),
+                    Err(e) => HashMap::from([("name", event_key), ("error", e.to_string())]),
+                }
+            } else {
+                HashMap::from([
+                    ("name", event_key),
+                    ("error", "Invalid download url".to_string()),
+                ])
+            };
+            let _res = flutter::push_global_event(
+                flutter::APP_TYPE_MAIN,
+                serde_json::ser::to_string(&data).unwrap_or("".to_owned()),
+            );
+        } else if _key == "update-me" {
+            if let Some(new_version_file) = get_download_file_from_url(&_value) {
+                // 1.3.9 does not support "--update"
+                // But we can assume that the new version will support it.
+                if let Some(f) = new_version_file.to_str() {
+                    let _ = crate::platform::run_exe_in_cur_session(f, vec!["--update"], false);
+                }
+            }
+        }
+    }
+
+    if _key == "remove-downloader" {
+        crate::hbbs_http::downloader::remove(&_value);
+    } else if _key == "cancel-downloader" {
+        crate::hbbs_http::downloader::cancel(&_value);
     }
 }
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2511,7 +2511,13 @@ pub fn main_set_common(_key: String, _value: String) {
                 // 1.3.9 does not support "--update"
                 // But we can assume that the new version will support it.
                 if let Some(f) = new_version_file.to_str() {
-                    let _ = crate::platform::run_exe_in_cur_session(f, vec!["--update"], false);
+                    if f.ends_with(".exe") {
+                        let _ = crate::platform::run_exe_in_cur_session(f, vec!["--update"], false);
+                    } else if f.ends_with(".msi") {
+                        let _ = crate::platform::update_me_msi(f);
+                    } else {
+                        // unreachable!()
+                    }
                 }
             }
         }

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2508,13 +2508,19 @@ pub fn main_set_common(_key: String, _value: String) {
             );
         } else if _key == "update-me" {
             if let Some(new_version_file) = get_download_file_from_url(&_value) {
-                // 1.3.9 does not support "--update"
-                // But we can assume that the new version will support it.
                 if let Some(f) = new_version_file.to_str() {
                     if f.ends_with(".exe") {
-                        let _ = crate::platform::run_exe_in_cur_session(f, vec!["--update"], false);
+                        // 1.3.9 does not support "--update"
+                        // But we can assume that the new version supports it.
+                        if let Err(e) =
+                            crate::platform::run_exe_in_cur_session(f, vec!["--update"], false)
+                        {
+                            log::error!("Failed to run the update exe: {}", e);
+                        }
                     } else if f.ends_with(".msi") {
-                        let _ = crate::platform::update_me_msi(f);
+                        if let Err(e) = crate::platform::update_me_msi(f) {
+                            log::error!("Failed to run the update msi: {}", e);
+                        }
                     } else {
                         // unreachable!()
                     }

--- a/src/hbbs_http.rs
+++ b/src/hbbs_http.rs
@@ -7,6 +7,7 @@ pub mod account;
 mod http_client;
 pub mod record_upload;
 pub mod sync;
+pub mod downloader;
 pub use http_client::create_http_client;
 pub use http_client::create_http_client_async;
 

--- a/src/hbbs_http/downloader.rs
+++ b/src/hbbs_http/downloader.rs
@@ -206,6 +206,7 @@ async fn do_download(
                     }
                     Ok(None) => {
                         is_all_downloaded = true;
+                        break;
                     },
                     Err(e) => {
                         log::error!("Download {} failed: {}", id, e);

--- a/src/hbbs_http/downloader.rs
+++ b/src/hbbs_http/downloader.rs
@@ -1,0 +1,273 @@
+use super::create_http_client_async;
+use hbb_common::{
+    bail,
+    lazy_static::lazy_static,
+    log,
+    tokio::{
+        self,
+        fs::File,
+        io::AsyncWriteExt,
+        sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    },
+    ResultType,
+};
+use serde_derive::Serialize;
+use std::{collections::HashMap, path::PathBuf, sync::Mutex, time::Duration};
+
+lazy_static! {
+    static ref DOWNLOADERS: Mutex<HashMap<String, Downloader>> = Default::default();
+}
+
+/// This struct is used to return the download data to the caller.
+/// The caller should check if the file is downloaded successfully and remove the job from the map.
+/// If the file is not downloaded successfully, the `data` field will be empty.
+/// If the file is downloaded successfully, the `data` field will contain the downloaded data if `path` is None.
+#[derive(Serialize, Debug)]
+pub struct DownloadData {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub data: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_size: Option<u64>,
+    pub downloaded_size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+struct Downloader {
+    data: Vec<u8>,
+    path: Option<PathBuf>,
+    // Some file may be empty, so we use Option<u64> to indicate if the size is known
+    total_size: Option<u64>,
+    downloaded_size: u64,
+    error: Option<String>,
+    finished: bool,
+    tx_cancel: UnboundedSender<()>,
+}
+
+// The caller should check if the file is downloaded successfully and remove the job from the map.
+pub fn download_file(
+    url: String,
+    path: Option<PathBuf>,
+    auto_del_dur: Option<Duration>,
+) -> ResultType<String> {
+    let id = url.clone();
+    if DOWNLOADERS.lock().unwrap().contains_key(&id) {
+        return Ok(id);
+    }
+
+    if let Some(path) = path.as_ref() {
+        if path.exists() {
+            bail!("File {} already exists", path.display());
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let (tx, rx) = unbounded_channel();
+    let downloader = Downloader {
+        data: Vec::new(),
+        path: path.clone(),
+        total_size: None,
+        downloaded_size: 0,
+        error: None,
+        tx_cancel: tx,
+        finished: false,
+    };
+    let mut downloaders = DOWNLOADERS.lock().unwrap();
+    downloaders.insert(id.clone(), downloader);
+
+    let id2 = id.clone();
+    std::thread::spawn(
+        move || match do_download(&id2, url, path, auto_del_dur, rx) {
+            Ok(is_all_downloaded) => {
+                let mut downloaded_size = 0;
+                let mut total_size = 0;
+                DOWNLOADERS.lock().unwrap().get_mut(&id2).map(|downloader| {
+                    downloaded_size = downloader.downloaded_size;
+                    total_size = downloader.total_size.unwrap_or(0);
+                });
+                log::info!(
+                    "Download {} end, {}/{}, {:.2} %",
+                    &id2,
+                    downloaded_size,
+                    total_size,
+                    if total_size == 0 {
+                        0.0
+                    } else {
+                        downloaded_size as f64 / total_size as f64 * 100.0
+                    }
+                );
+
+                let is_canceled = !is_all_downloaded;
+                if is_canceled {
+                    if let Some(downloader) = DOWNLOADERS.lock().unwrap().remove(&id2) {
+                        if let Some(p) = downloader.path {
+                            if p.exists() {
+                                std::fs::remove_file(p).ok();
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                let err = e.to_string();
+                log::error!("Download {}, failed: {}", &id2, &err);
+                DOWNLOADERS.lock().unwrap().get_mut(&id2).map(|downloader| {
+                    downloader.error = Some(err);
+                });
+            }
+        },
+    );
+
+    Ok(id)
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn do_download(
+    id: &str,
+    url: String,
+    path: Option<PathBuf>,
+    auto_del_dur: Option<Duration>,
+    mut rx_cancel: UnboundedReceiver<()>,
+) -> ResultType<bool> {
+    let client = create_http_client_async();
+
+    let mut is_all_downloaded = false;
+    tokio::select! {
+        _ = rx_cancel.recv() => {
+            return Ok(is_all_downloaded);
+        }
+        head_resp = client.head(&url).send() => {
+            match head_resp {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        let total_size = resp
+                            .headers()
+                            .get(reqwest::header::CONTENT_LENGTH)
+                            .and_then(|ct_len| ct_len.to_str().ok())
+                            .and_then(|ct_len| ct_len.parse::<u64>().ok());
+                        let Some(total_size) = total_size else {
+                            bail!("Failed to get content length");
+                        };
+                        DOWNLOADERS.lock().unwrap().get_mut(id).map(|downloader| {
+                            downloader.total_size = Some(total_size);
+                        });
+                    } else {
+                        bail!("Failed to get content length: {}", resp.status());
+                    }
+                }
+                Err(e) => {
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+
+    let mut response;
+    tokio::select! {
+        _ = rx_cancel.recv() => {
+            return Ok(is_all_downloaded);
+        }
+        resp = client.get(url).send() => {
+            response = resp?;
+        }
+    }
+
+    let mut dest: Option<File> = None;
+    if let Some(p) = path {
+        dest = Some(File::create(p).await?);
+    }
+
+    loop {
+        tokio::select! {
+            _ = rx_cancel.recv() => {
+                break;
+            }
+            chunk = response.chunk() => {
+                match chunk {
+                    Ok(Some(chunk)) => {
+                        match dest {
+                            Some(ref mut f) => {
+                                f.write_all(&chunk).await?;
+                                f.flush().await?;
+                                DOWNLOADERS.lock().unwrap().get_mut(id).map(|downloader| {
+                                    downloader.downloaded_size += chunk.len() as u64;
+                                });
+                            }
+                            None => {
+                                DOWNLOADERS.lock().unwrap().get_mut(id).map(|downloader| {
+                                    downloader.data.extend_from_slice(&chunk);
+                                    downloader.downloaded_size += chunk.len() as u64;
+                                });
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        is_all_downloaded = true;
+                    },
+                    Err(e) => {
+                        log::error!("Download {} failed: {}", id, e);
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(mut f) = dest.take() {
+        f.flush().await?;
+    }
+
+    if let Some(ref mut downloader) = DOWNLOADERS.lock().unwrap().get_mut(id) {
+        downloader.finished = true;
+    }
+    if is_all_downloaded {
+        let id_del = id.to_string();
+        if let Some(dur) = auto_del_dur {
+            std::thread::spawn(move || {
+                std::thread::sleep(dur);
+                DOWNLOADERS.lock().unwrap().remove(&id_del);
+            });
+        }
+    }
+    Ok(is_all_downloaded)
+}
+
+pub fn get_download_data(id: &str) -> ResultType<DownloadData> {
+    let downloaders = DOWNLOADERS.lock().unwrap();
+    if let Some(downloader) = downloaders.get(id) {
+        let downloaded_size = downloader.downloaded_size;
+        let total_size = downloader.total_size.clone();
+        let error = downloader.error.clone();
+        let data = if total_size.unwrap_or(0) == downloaded_size && downloader.path.is_none() {
+            downloader.data.clone()
+        } else {
+            Vec::new()
+        };
+        let path = downloader.path.clone();
+        let download_data = DownloadData {
+            data,
+            path,
+            total_size,
+            downloaded_size,
+            error,
+        };
+        Ok(download_data)
+    } else {
+        bail!("Downloader not found")
+    }
+}
+
+pub fn cancel(id: &str) {
+    if let Some(downloader) = DOWNLOADERS.lock().unwrap().get(id) {
+        // downloader.is_canceled.store(true, Ordering::SeqCst);
+        // The receiver may not be able to receive the cancel signal, so we also set the atomic bool to true
+        let _ = downloader.tx_cancel.send(());
+    }
+}
+
+pub fn remove(id: &str) {
+    let _ = DOWNLOADERS.lock().unwrap().remove(id);
+}

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -276,6 +276,10 @@ pub enum Data {
     PrinterData(Vec<u8>),
     InstallOption(Option<(String, String)>),
     #[cfg(feature = "flutter")]
+    #[cfg(all(
+        feature = "flutter",
+        not(any(target_os = "android", target_os = "ios"))
+    ))]
     ControllingSessionCount(usize),
 }
 
@@ -601,10 +605,12 @@ async fn handle(data: Data, stream: &mut Connection) {
                     .await
             );
         }
-        #[cfg(feature = "flutter")]
-        Data::ControllingSessionCount(_count) => {
-            #[cfg(not(any(target_os = "android", target_os = "ios")))]
-            crate::updater::update_controlling_session_count(_count);
+        #[cfg(all(
+            feature = "flutter",
+            not(any(target_os = "android", target_os = "ios"))
+        ))]
+        Data::ControllingSessionCount(count) => {
+            crate::updater::update_controlling_session_count(count);
         }
         #[cfg(feature = "hwcodec")]
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -1287,7 +1293,10 @@ pub async fn clear_wayland_screencast_restore_token(key: String) -> ResultType<b
     return Ok(false);
 }
 
-#[cfg(feature = "flutter")]
+#[cfg(all(
+    feature = "flutter",
+    not(any(target_os = "android", target_os = "ios"))
+))]
 #[tokio::main(flavor = "current_thread")]
 pub async fn update_controlling_session_count(count: usize) -> ResultType<()> {
     let mut c = connect(1000, "").await?;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -275,7 +275,6 @@ pub enum Data {
     #[cfg(all(target_os = "windows", feature = "flutter"))]
     PrinterData(Vec<u8>),
     InstallOption(Option<(String, String)>),
-    #[cfg(feature = "flutter")]
     #[cfg(all(
         feature = "flutter",
         not(any(target_os = "android", target_os = "ios"))

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "الطباعة عن بُعد غير مسموح بها على هذا الجهاز"),
         ("save-settings-tip", "حفظ الإعدادات"),
         ("dont-show-again-tip", "لا تظهر هذا مرة أخرى"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "الطباعة عن بُعد غير مسموح بها على هذا الجهاز"),
         ("save-settings-tip", "حفظ الإعدادات"),
         ("dont-show-again-tip", "لا تظهر هذا مرة أخرى"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "被控端的权限设置拒绝了远程打印。"),
         ("save-settings-tip", "保存设置"),
         ("dont-show-again-tip", "不再显示此信息"),
+        ("Enable remote printer", "启用远程打印机"),
         ("Downloading {}", "下载 {}"),
         ("{} Update", "{} 更新"),
         ("{}-to-update-tip", "即将关闭 {} ，并安装新版本。"),

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "被控端的权限设置拒绝了远程打印。"),
         ("save-settings-tip", "保存设置"),
         ("dont-show-again-tip", "不再显示此信息"),
+        ("Downloading {}", "下载 {}"),
+        ("{} Update", "{} 更新"),
+        ("{}-to-update-tip", "即将关闭 {} ，并安装新版本。"),
+        ("download-new-veresion-failed-tip", "下载失败，您可以 重试 或者点击 查看 按钮，从发布网址下载，并手动升级。"),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", "下载 {}"),
         ("{} Update", "{} 更新"),
         ("{}-to-update-tip", "即将关闭 {} ，并安装新版本。"),
-        ("download-new-veresion-failed-tip", "下载失败，您可以 重试 或者点击 查看 按钮，从发布网址下载，并手动升级。"),
+        ("download-new-version-failed-tip", "下载失败，您可以 重试 或者点击 查看 按钮，从发布网址下载，并手动升级。"),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", "安装方式检测失败。请点击 查看 按钮，从发布网址下载，并手动升级。"),
     ].iter().cloned().collect();

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", "即将关闭 {} ，并安装新版本。"),
         ("download-new-veresion-failed-tip", "下载失败，您可以 重试 或者点击 查看 按钮，从发布网址下载，并手动升级。"),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", "安装方式检测失败。请点击 查看 按钮，从发布网址下载，并手动升级。"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Die Berechtigungseinstellungen der kontrollierten Seite verweigern den entfernten Druck."),
         ("save-settings-tip", "Einstellungen speichern"),
         ("dont-show-again-tip", "Nicht mehr anzeigen"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Die Berechtigungseinstellungen der kontrollierten Seite verweigern den entfernten Druck."),
         ("save-settings-tip", "Einstellungen speichern"),
         ("dont-show-again-tip", "Nicht mehr anzeigen"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -253,5 +253,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "The permission settings of the controlled side deny Remote Printing."),
         ("save-settings-tip", "Save settings"),
         ("dont-show-again-tip", "Don't show this again"),
+        ("{}-to-update-tip", "{} will close now and install the new version."),
+        ("download-new-veresion-failed-tip", "Download failed. You can try again or click the View button to download from the release page and upgrade manually.")
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -254,7 +254,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Save settings"),
         ("dont-show-again-tip", "Don't show this again"),
         ("{}-to-update-tip", "{} will close now and install the new version."),
-        ("download-new-veresion-failed-tip", "Download failed. You can try again or click the View button to download from the release page and upgrade manually."),
+        ("download-new-version-failed-tip", "Download failed. You can try again or click the View button to download from the release page and upgrade manually."),
         ("update-failed-check-msi-tip", "Installation method check failed. Please click the View button to download from the release page and upgrade manually.")
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -254,6 +254,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Save settings"),
         ("dont-show-again-tip", "Don't show this again"),
         ("{}-to-update-tip", "{} will close now and install the new version."),
-        ("download-new-veresion-failed-tip", "Download failed. You can try again or click the View button to download from the release page and upgrade manually.")
+        ("download-new-veresion-failed-tip", "Download failed. You can try again or click the View button to download from the release page and upgrade manually."),
+        ("update-failed-check-msi-tip", "Installation method check failed. Please click the View button to download from the release page and upgrade manually.")
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Los ajustes de permisos del lado controlado no permiten la impresión remota."),
         ("save-settings-tip", "Guardar ajustes"),
         ("dont-show-again-tip", "No volver a mostrar"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Los ajustes de permisos del lado controlado no permiten la impresión remota."),
         ("save-settings-tip", "Guardar ajustes"),
         ("dont-show-again-tip", "No volver a mostrar"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "شما مجوز لازم برای چاپ از راه دور را ندارید"),
         ("save-settings-tip", "تنظیمات را ذخیره کنید"),
         ("dont-show-again-tip", "دیگر نمایش داده نشود"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "شما مجوز لازم برای چاپ از راه دور را ندارید"),
         ("save-settings-tip", "تنظیمات را ذخیره کنید"),
         ("dont-show-again-tip", "دیگر نمایش داده نشود"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Les paramètres de l’appareil contrôlé n’autorisent pas l’impression à distance."),
         ("save-settings-tip", "Enregistrer les paramètres"),
         ("dont-show-again-tip", "Ne plus afficher"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Les paramètres de l’appareil contrôlé n’autorisent pas l’impression à distance."),
         ("save-settings-tip", "Enregistrer les paramètres"),
         ("dont-show-again-tip", "Ne plus afficher"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -239,7 +239,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Empty", "ცარიელი"),
         ("Invalid folder name", "არასწორი საქაღალდის სახელი"),
         ("Socks5 Proxy", "SOCKS5-პროქსი"),
-        ("Proxy", "პროქსი"),
+        ("Socks5/Http(s) Proxy", ""),
         ("Discovered", "ნაპოვნია"),
         ("install_daemon_tip", "ჩატვირთვისას გასაშვებად საჭიროა სისტემური სერვისის დაყენება"),
         ("Remote ID", "დაშორებული ID"),
@@ -567,7 +567,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("id_input_tip", "შეგიძლიათ შეიყვანოთ იდენტიფიკატორი, პირდაპირი IP მისამართი ან დომენი პორტით (<დომენი>:<პორტი>).\nთუ გჭირდებათ წვდომა მოწყობილობაზე სხვა სერვერზე, დაამატეთ სერვერის მისამართი (<id>@<სერვერის_მისამართი>?key=<გასაღების_მნიშვნელობა>), მაგალითად:\n9123456234@192.168.16.1:21117?key=5Qbwsde3unUcJBtrx9ZkvUmwFNoExHzpryHuPUdqlWM=.\nთუ გჭირდებათ წვდომა მოწყობილობაზე საჯარო სერვერზე, შეიყვანეთ \"<id>@public\", გასაღები საჯარო სერვერისთვის არ არის საჭირო."),
         ("privacy_mode_impl_mag_tip", "რეჟიმი 1"),
         ("privacy_mode_impl_virtual_display_tip", "რეჟიმი 2"),
-        ("privacy_mode_impl_virtual_display_tip", "რეჟიმი 2"),
         ("Enter privacy mode", "კონფიდენციალურობის რეჟიმის ჩართვა"),
         ("Exit privacy mode", "კონფიდენციალურობის რეჟიმის გამორთვა"),
         ("idd_not_support_under_win10_2004_tip", "არაპირდაპირი ჩვენების დრაივერი არ არის მხარდაჭერილი. საჭიროა Windows 10 ვერსია 2004 ან უფრო ახალი."),
@@ -659,7 +658,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("new-version-of-{}-tip", "ხელმისაწვდომია ახალი ვერსია {}"),
         ("Accessible devices", "ხელმისაწვდომი მოწყობილობები"),
         ("View camera", "კამერის ნახვა"),
-        ("upgrade_remote_rustdesk_client_to{}_tip", "განაახლეთ RustDesk კლიენტი ვერსიამდე {} ან უფრო ახალი დისტანციურ მხარეზე!"),
+        ("upgrade_remote_rustdesk_client_to_{}_tip", "განაახლეთ RustDesk კლიენტი ვერსიამდე {} ან უფრო ახალი დისტანციურ მხარეზე!"),
         ("view_camera_unsupported_tip", "დისტანციური მოწყობილობა არ უჭერს მხარს კამერის ნახვას."),
         ("Enable camera", "კამერის ჩართვა"),
         ("No cameras", "კამერა არ არის"),
@@ -682,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "მართულ მხარეზე უფლებების პარამეტრები კრძალავს დისტანციურ ბეჭდვას."),
         ("save-settings-tip", "პარამეტრების შენახვა"),
         ("dont-show-again-tip", "აღარ აჩვენოთ"),
-  ].iter().cloned().collect();
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
+    ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "მართულ მხარეზე უფლებების პარამეტრები კრძალავს დისტანციურ ბეჭდვას."),
         ("save-settings-tip", "პარამეტრების შენახვა"),
         ("dont-show-again-tip", "აღარ აჩვენოთ"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "A távoli nyomtatás nincs engedélyezve"),
         ("save-settings-tip", "Beállítások mentése"),
         ("dont-show-again-tip", "Ne jelenítse meg újra"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "A távoli nyomtatás nincs engedélyezve"),
         ("save-settings-tip", "Beállítások mentése"),
         ("dont-show-again-tip", "Ne jelenítse meg újra"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Le impostazioni di autorizzazione del lato controllato negano la stampa remota."),
         ("save-settings-tip", "Salva impostazioni"),
         ("dont-show-again-tip", "Non visualizzare più questo messaggio"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Le impostazioni di autorizzazione del lato controllato negano la stampa remota."),
         ("save-settings-tip", "Salva impostazioni"),
         ("dont-show-again-tip", "Non visualizzare più questo messaggio"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Kontrolētās puses atļauju iestatījumi liedz attālo drukāšanu."),
         ("save-settings-tip", "Saglabāt iestatījumus"),
         ("dont-show-again-tip", "Nerādīt šo vēlreiz"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Kontrolētās puses atļauju iestatījumi liedz attālo drukāšanu."),
         ("save-settings-tip", "Saglabāt iestatījumus"),
         ("dont-show-again-tip", "Nerādīt šo vēlreiz"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Machtigingsinstellingen aan beheerde zijde verhinderen afdrukken op afstand."),
         ("save-settings-tip", "Instellingen opslaan"),
         ("dont-show-again-tip", "Dit bericht wordt niet meer weergegeven"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Machtigingsinstellingen aan beheerde zijde verhinderen afdrukken op afstand."),
         ("save-settings-tip", "Instellingen opslaan"),
         ("dont-show-again-tip", "Dit bericht wordt niet meer weergegeven"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Ustawienia uprawnień po zdalnej stronie uniemożliwiają zdalne drukowanie."),
         ("save-settings-tip", "Zapisz ustawienia"),
         ("dont-show-again-tip", "Nie pokazuj więcej"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Ustawienia uprawnień po zdalnej stronie uniemożliwiają zdalne drukowanie."),
         ("save-settings-tip", "Zapisz ustawienia"),
         ("dont-show-again-tip", "Nie pokazuj więcej"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "As configurações do dispositivo controlado não permitem impressão remota."),
         ("save-settings-tip", "Salvar configurações"),
         ("dont-show-again-tip", "Não mostrar novamente"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "As configurações do dispositivo controlado não permitem impressão remota."),
         ("save-settings-tip", "Salvar configurações"),
         ("dont-show-again-tip", "Não mostrar novamente"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Настройки разрешений на управляемой стороне запрещают удалённую печать."),
         ("save-settings-tip", "Сохранить настройки"),
         ("dont-show-again-tip", "Больше не показывать"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Настройки разрешений на управляемой стороне запрещают удалённую печать."),
         ("save-settings-tip", "Сохранить настройки"),
         ("dont-show-again-tip", "Больше не показывать"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Sas impostatziones de sos permissos de s'ala controllada negant s'imprenta remota."),
         ("save-settings-tip", "Sarva sas impostatziones"),
         ("dont-show-again-tip", "Non mustres prus custu messàgiu"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Sas impostatziones de sos permissos de s'ala controllada negant s'imprenta remota."),
         ("save-settings-tip", "Sarva sas impostatziones"),
         ("dont-show-again-tip", "Non mustres prus custu messàgiu"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "被控端的權限設置拒絕了遠端列印。"),
         ("save-settings-tip", "儲存設定"),
         ("dont-show-again-tip", "不再顯示此訊息"),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "被控端的權限設置拒絕了遠端列印。"),
         ("save-settings-tip", "儲存設定"),
         ("dont-show-again-tip", "不再顯示此訊息"),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -681,6 +681,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Enable remote printer", ""),
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -686,5 +686,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("{}-to-update-tip", ""),
         ("download-new-veresion-failed-tip", ""),
         ("Auto update", ""),
+        ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -685,7 +685,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Downloading {}", ""),
         ("{} Update", ""),
         ("{}-to-update-tip", ""),
-        ("download-new-veresion-failed-tip", ""),
+        ("download-new-version-failed-tip", ""),
         ("Auto update", ""),
         ("update-failed-check-msi-tip", ""),
     ].iter().cloned().collect();

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Downloading {}", ""),
+        ("{} Update", ""),
+        ("{}-to-update-tip", ""),
+        ("download-new-veresion-failed-tip", ""),
+        ("Auto update", ""),
     ].iter().cloned().collect();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,14 +39,14 @@ use common::*;
 mod auth_2fa;
 #[cfg(feature = "cli")]
 pub mod cli;
+#[cfg(not(target_os = "ios"))]
+mod clipboard;
 #[cfg(not(any(target_os = "android", target_os = "ios", feature = "cli")))]
 pub mod core_main;
 mod custom_server;
 mod lang;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod port_forward;
-#[cfg(not(target_os = "ios"))]
-mod clipboard;
 
 #[cfg(all(feature = "flutter", feature = "plugin_framework"))]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -54,6 +54,12 @@ pub mod plugin;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod tray;
+
+#[cfg(all(
+    feature = "flutter",
+    not(any(target_os = "android", target_os = "ios"))
+))]
+mod updater;
 
 mod ui_cm_interface;
 mod ui_interface;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,7 @@ pub mod plugin;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod tray;
 
-#[cfg(all(
-    feature = "flutter",
-    not(any(target_os = "android", target_os = "ios"))
-))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod updater;
 
 mod ui_cm_interface;

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -27,11 +27,17 @@ use include_dir::{include_dir, Dir};
 use objc::rc::autoreleasepool;
 use objc::{class, msg_send, sel, sel_impl};
 use scrap::{libc::c_void, quartz::ffi::*};
-use std::path::{Path, PathBuf};
+use std::{
+    os::unix::process::CommandExt,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
 
 static PRIVILEGES_SCRIPTS_DIR: Dir =
     include_dir!("$CARGO_MANIFEST_DIR/src/platform/privileges_scripts");
 static mut LATEST_SEED: i32 = 0;
+
+const UPDATE_TEMP_DIR: &str = "/tmp/.rustdeskupdate";
 
 extern "C" {
     fn CGSCurrentCursorSeed() -> i32;
@@ -169,44 +175,65 @@ pub fn is_installed_daemon(prompt: bool) -> bool {
         return true;
     }
 
-    let Some(install_script) = PRIVILEGES_SCRIPTS_DIR.get_file("install.scpt") else {
-        return false;
+    install_update(agent_plist_file, None, false);
+    false
+}
+
+fn install_update(agent_plist_file: String, update_source_dir: Option<String>, sync: bool) {
+    let install_script_file = if update_source_dir.is_none() {
+        "install.scpt"
+    } else {
+        "update.scpt"
+    };
+    let Some(install_script) = PRIVILEGES_SCRIPTS_DIR.get_file(install_script_file) else {
+        return;
     };
     let Some(install_script_body) = install_script.contents_utf8().map(correct_app_name) else {
-        return false;
+        return;
     };
 
     let Some(daemon_plist) = PRIVILEGES_SCRIPTS_DIR.get_file("daemon.plist") else {
-        return false;
+        return;
     };
     let Some(daemon_plist_body) = daemon_plist.contents_utf8().map(correct_app_name) else {
-        return false;
+        return;
     };
-
     let Some(agent_plist) = PRIVILEGES_SCRIPTS_DIR.get_file("agent.plist") else {
-        return false;
+        return;
     };
     let Some(agent_plist_body) = agent_plist.contents_utf8().map(correct_app_name) else {
-        return false;
+        return;
     };
 
-    std::thread::spawn(move || {
-        match std::process::Command::new("osascript")
+    let func = move || {
+        let mut binding = std::process::Command::new("osascript");
+        let mut cmd = binding
             .arg("-e")
             .arg(install_script_body)
             .arg(daemon_plist_body)
             .arg(agent_plist_body)
-            .arg(&get_active_username())
-            .status()
-        {
+            .arg(&get_active_username());
+        if let Some(source_dir) = update_source_dir {
+            cmd = cmd.arg(std::process::id().to_string()).arg(source_dir);
+        }
+        match cmd.status() {
             Err(e) => {
                 log::error!("run osascript failed: {}", e);
             }
             _ => {
                 let installed = std::path::Path::new(&agent_plist_file).exists();
-                log::info!("Agent file {} installed: {}", agent_plist_file, installed);
+                log::info!("Agent file {} installed: {}", &agent_plist_file, installed);
                 if installed {
                     log::info!("launch server");
+                    // Unload first, or load may not work if already loaded.
+                    // We hope that the load operation can immediately trigger a start.
+                    std::process::Command::new("launchctl")
+                        .args(&["unload", "-w", &agent_plist_file])
+                        .stdin(Stdio::null())
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .status()
+                        .ok();
                     std::process::Command::new("launchctl")
                         .args(&["load", "-w", &agent_plist_file])
                         .status()
@@ -214,8 +241,12 @@ pub fn is_installed_daemon(prompt: bool) -> bool {
                 }
             }
         }
-    });
-    false
+    };
+    if sync {
+        func();
+    } else {
+        std::thread::spawn(func);
+    }
 }
 
 fn correct_app_name(s: &str) -> String {
@@ -632,6 +663,140 @@ pub fn quit_gui() {
     unsafe {
         let () = msg_send!(NSApp(), terminate: nil);
     };
+}
+
+pub fn update_me() -> ResultType<()> {
+    let is_installed_daemon = is_installed_daemon(false);
+    let option_stop_service = "stop-service";
+    let is_service_stopped = hbb_common::config::option2bool(
+        option_stop_service,
+        &crate::ui_interface::get_option(option_stop_service),
+    );
+
+    let cmd = std::env::current_exe()?;
+    // RustDesk.app/Contents/MacOS/RustDesk
+    let app_dir = cmd
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .map(|d| d.to_string_lossy().to_string());
+    let Some(app_dir) = app_dir else {
+        bail!("Unknown app directory of current exe file: {:?}", cmd);
+    };
+
+    if is_installed_daemon && !is_service_stopped {
+        let agent = format!("{}_server.plist", crate::get_full_name());
+        let agent_plist_file = format!("/Library/LaunchAgents/{}", agent);
+        std::process::Command::new("launchctl")
+            .args(&["unload", "-w", &agent_plist_file])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .ok();
+        install_update(agent_plist_file, Some(app_dir), true);
+    } else {
+        // `kill -9` may not work without "administrator privileges"
+        let update_body = format!(
+            r#"
+do shell script "
+pgrep -x 'RustDesk' | grep -v {} | xargs kill -9 && rm -rf /Applications/RustDesk.app && cp -R '{}' /Applications/ && chown -R {}:staff /Applications/RustDesk.app
+" with prompt "RustDesk wants to update itself" with administrator privileges
+    "#,
+            std::process::id(),
+            app_dir,
+            get_active_username()
+        );
+        match Command::new("osascript")
+            .arg("-e")
+            .arg(update_body)
+            .status()
+        {
+            Ok(status) if !status.success() => {
+                log::error!("osascript execution failed with status: {}", status);
+            }
+            Err(e) => {
+                log::error!("run osascript failed: {}", e);
+            }
+            _ => {}
+        }
+    }
+    std::process::Command::new("open")
+        .arg("-n")
+        .arg(&format!("/Applications/{}.app", crate::get_app_name()))
+        .spawn()
+        .ok();
+    // leave open a little time
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    Ok(())
+}
+
+pub fn update_to(file: &str) -> ResultType<()> {
+    extract_dmg(file, UPDATE_TEMP_DIR)?;
+    update_extracted(UPDATE_TEMP_DIR)?;
+    Ok(())
+}
+
+fn extract_dmg(dmg_path: &str, target_dir: &str) -> ResultType<()> {
+    let mount_point = "/Volumes/RustDeskUpdate";
+    let target_path = Path::new(target_dir);
+
+    if target_path.exists() {
+        std::fs::remove_dir_all(target_path)?;
+    }
+    std::fs::create_dir_all(target_path)?;
+
+    Command::new("hdiutil")
+        .args(&["attach", "-nobrowse", "-mountpoint", mount_point, dmg_path])
+        .status()?;
+
+    struct DmgGuard(&'static str);
+    impl Drop for DmgGuard {
+        fn drop(&mut self) {
+            let _ = Command::new("hdiutil")
+                .args(&["detach", self.0, "-force"])
+                .status();
+        }
+    }
+    let _guard = DmgGuard(mount_point);
+
+    let app_name = "RustDesk.app";
+    let src_path = format!("{}/{}", mount_point, app_name);
+    let dest_path = format!("{}/{}", target_dir, app_name);
+
+    let copy_status = Command::new("cp")
+        .args(&["-R", &src_path, &dest_path])
+        .status()?;
+
+    if !copy_status.success() {
+        bail!("Failed to copy application {:?}", copy_status);
+    }
+
+    if !Path::new(&dest_path).exists() {
+        bail!(
+            "Copy operation failed - destination not found at {}",
+            dest_path
+        );
+    }
+
+    Ok(())
+}
+
+fn update_extracted(target_dir: &str) -> ResultType<()> {
+    let exe_path = format!("{}/RustDesk.app/Contents/MacOS/RustDesk", target_dir);
+    let _child = unsafe {
+        Command::new(&exe_path)
+            .arg("--update")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .pre_exec(|| {
+                hbb_common::libc::setsid();
+                Ok(())
+            })
+            .spawn()?
+    };
+    Ok(())
 }
 
 pub fn get_double_click_time() -> u32 {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -150,7 +150,7 @@ fn get_pids_of_process_with_args<S1: AsRef<str>, S2: AsRef<str>>(
 ) -> Vec<Pid> {
     #[cfg(all(target_os = "windows", not(target_pointer_width = "64")))]
     {
-        return windows::get_pids_of_process_with_args_by_wmic(name, args);
+        return windows::get_pids_with_args_by_wmic(name, args);
     }
     #[cfg(not(all(target_os = "windows", not(target_pointer_width = "64"))))]
     {
@@ -181,7 +181,7 @@ pub fn get_pids_of_process_with_first_arg<S1: AsRef<str>, S2: AsRef<str>>(
 ) -> Vec<Pid> {
     #[cfg(all(target_os = "windows", not(target_pointer_width = "64")))]
     {
-        return windows::get_pids_of_process_with_first_arg_by_wmic(name, arg);
+        return windows::get_pids_with_first_arg_by_wmic(name, arg);
     }
     #[cfg(not(all(target_os = "windows", not(target_pointer_width = "64"))))]
     {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -27,7 +27,11 @@ pub mod linux_desktop_manager;
 pub mod gtk_sudo;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-use hbb_common::{message_proto::CursorData, ResultType};
+use hbb_common::{
+    message_proto::CursorData,
+    sysinfo::{Pid, System},
+    ResultType,
+};
 use std::sync::{Arc, Mutex};
 #[cfg(not(any(target_os = "macos", target_os = "android", target_os = "ios")))]
 pub const SERVICE_INTERVAL: u64 = 300;
@@ -135,6 +139,63 @@ impl Drop for InstallingService {
 #[inline]
 pub fn is_prelogin() -> bool {
     false
+}
+
+// Note: This function does not work when the process is 32-bit and the OS is 64-bit Windows,
+// `process.cmd()` always returns [] in this case.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn get_pids_of_process_with_args<S1: AsRef<str>, S2: AsRef<str>>(
+    name: S1,
+    args: &[S2],
+) -> Vec<Pid> {
+    let name = name.as_ref().to_lowercase();
+    let mut system = System::new_all();
+    system.refresh_processes();
+    system
+        .processes()
+        .iter()
+        .filter(|(_, process)| {
+            process.name().to_lowercase() == name
+                && process.cmd().len() == args.len() + 1
+                && args.iter().enumerate().all(|(i, arg)| {
+                    process.cmd()[i + 1].to_lowercase() == arg.as_ref().to_lowercase()
+                })
+        })
+        .map(|(&pid, _)| pid)
+        .collect()
+}
+
+// Note: This function does not work when the process is 32-bit and the OS is 64-bit Windows,
+// `process.cmd()` always returns [] in this case.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn get_pids_of_process_with_first_arg<S1: AsRef<str>, S2: AsRef<str>>(
+    name: S1,
+    arg: S2,
+) -> Vec<Pid> {
+    let name = name.as_ref().to_lowercase();
+    let mut system = System::new_all();
+    system.refresh_processes();
+    system
+        .processes()
+        .iter()
+        .filter(|(_, process)| {
+            process.name().to_lowercase() == name
+                && process.cmd().len() >= 2
+                && process.cmd()[1].to_lowercase() == arg.as_ref().to_lowercase()
+        })
+        .map(|(&pid, _)| pid)
+        .collect()
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn kill_process_by_pid(pid: Pid) -> ResultType<()> {
+    let s = System::new_all();
+    if let Some(process) = s.process(pid) {
+        process.kill();
+        Ok(())
+    } else {
+        hbb_common::bail!("Process with PID {} not found", pid)
+    }
 }
 
 #[cfg(test)]

--- a/src/platform/privileges_scripts/install.scpt
+++ b/src/platform/privileges_scripts/install.scpt
@@ -12,5 +12,5 @@ on run {daemon_file, agent_file, user}
 
   set sh to sh1 & sh2 & sh3 & sh4 & sh5
 
-  do shell script sh with prompt "RustDesk want to install daemon and agent" with administrator privileges
+  do shell script sh with prompt "RustDesk wants to install daemon and agent" with administrator privileges
 end run

--- a/src/platform/privileges_scripts/uninstall.scpt
+++ b/src/platform/privileges_scripts/uninstall.scpt
@@ -3,4 +3,4 @@ set sh2 to "/bin/rm /Library/LaunchDaemons/com.carriez.RustDesk_service.plist;"
 set sh3 to "/bin/rm /Library/LaunchAgents/com.carriez.RustDesk_server.plist;"
 
 set sh to sh1 & sh2 & sh3
-do shell script sh with prompt "RustDesk want to unload daemon" with administrator privileges
+do shell script sh with prompt "RustDesk wants to unload daemon" with administrator privileges

--- a/src/platform/privileges_scripts/update.scpt
+++ b/src/platform/privileges_scripts/update.scpt
@@ -1,0 +1,18 @@
+on run {daemon_file, agent_file, user, cur_pid, source_dir}
+
+  set unload_service to "launchctl unload -w /Library/LaunchDaemons/com.carriez.RustDesk_service.plist || true;"
+
+  set kill_others to "pgrep -x 'RustDesk' | grep -v " & cur_pid & " | xargs kill -9;"
+
+  set copy_files to "rm -rf /Applications/RustDesk.app && cp -r " & source_dir & " /Applications && chown -R " & quoted form of user & ":staff /Applications/RustDesk.app;"
+
+  set sh1 to "echo " & quoted form of daemon_file & " > /Library/LaunchDaemons/com.carriez.RustDesk_service.plist && chown root:wheel /Library/LaunchDaemons/com.carriez.RustDesk_service.plist;"
+
+  set sh2 to "echo " & quoted form of agent_file & " > /Library/LaunchAgents/com.carriez.RustDesk_server.plist && chown root:wheel /Library/LaunchAgents/com.carriez.RustDesk_server.plist;"
+
+  set sh3 to "launchctl load -w /Library/LaunchDaemons/com.carriez.RustDesk_service.plist;"
+
+  set sh to unload_service & kill_others & copy_files & sh1 & sh2 & sh3
+
+  do shell script sh with prompt "RustDesk wants to update itself" with administrator privileges
+end run

--- a/src/platform/windows.cc
+++ b/src/platform/windows.cc
@@ -230,7 +230,7 @@ extern "C"
         return IsWindows10OrGreater();
     }
 
-    HANDLE LaunchProcessWin(LPCWSTR cmd, DWORD dwSessionId, BOOL as_user, DWORD *pDwTokenPid)
+    HANDLE LaunchProcessWin(LPCWSTR cmd, DWORD dwSessionId, BOOL as_user, BOOL show, DWORD *pDwTokenPid)
     {
         HANDLE hProcess = NULL;
         HANDLE hToken = NULL;
@@ -240,6 +240,11 @@ extern "C"
             ZeroMemory(&si, sizeof si);
             si.cb = sizeof si;
             si.dwFlags = STARTF_USESHOWWINDOW;
+            if (show)
+            {
+                si.lpDesktop = (LPWSTR)L"winsta0\\default";
+                si.wShowWindow = SW_SHOW;
+            }
             wchar_t buf[MAX_PATH];
             wcscpy_s(buf, sizeof(buf), cmd);
             PROCESS_INFORMATION pi;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2521,15 +2521,25 @@ taskkill /F /IM {app_name}.exe{filter}
     Ok(())
 }
 
+// Don't launch tray app when updating msi.
+// 1. Because `/qn` requires administrator permission and the tray app should be launched with user permission.
+//   Or launching the main window from the tray app will cause the main window to be launched with administrator permission.
+// 2. We are not able to launch the tray app if the UI is in the login screen.
+// `fn update_me()` can handle the above cases, but for msi update, we need to do more work to handle the above cases.
+//    1. Record the tray app session ids
+//    2. Do the update
+//    3. Restore the tray app sessions.
+//    `1` and `3` must be done in custom actions.
+//    We need also to handle the command line parsing to find the tray processes.
 pub fn update_me_msi(msi: &str) -> ResultType<()> {
-    let output = std::process::Command::new("msiexec")
-        .args(&["/i", msi, "/qn", "/norestart"])
-        .output()?;
-    if output.status.success() {
-        Ok(())
-    } else {
-        bail!("{}", String::from_utf8_lossy(&output.stderr))
-    }
+    let cmds = format!(
+        "
+    chcp 65001
+    msiexec /i {msi} /qn LAUNCH_TRAY_APP=N
+    "
+    );
+    run_cmds(cmds, false, "update-msi")?;
+    Ok(())
 }
 
 pub fn get_tray_shortcut(exe: &str, tmp_path: &str) -> ResultType<String> {
@@ -3148,4 +3158,127 @@ pub fn is_msi_installed() -> std::io::Result<bool> {
         crate::get_app_name()
     ))?;
     Ok(1 == uninstall_key.get_value::<u32, _>("WindowsInstaller")?)
+}
+
+// Note the args are not compared strictly, only check if the args are contained in the command line.
+// If we want to check the args strictly, we need to parse the command line and compare each arg.
+// Maybe we have to introduce some external crate like `shell_words` to do this.
+#[cfg(not(target_pointer_width = "64"))]
+pub(super) fn get_pids_of_process_with_args_by_wmic<S1: AsRef<str>, S2: AsRef<str>>(
+    name: S1,
+    args: &[S2],
+) -> Vec<hbb_common::sysinfo::Pid> {
+    let name = name.as_ref().to_lowercase();
+    std::process::Command::new("wmic.exe")
+        .args([
+            "process",
+            "where",
+            &format!("name='{}'", name),
+            "get",
+            "commandline,processid",
+            "/value",
+        ])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map(|output| {
+            let output = String::from_utf8_lossy(&output.stdout);
+            // CommandLine=
+            // ProcessId=33796
+            //
+            // CommandLine=
+            // ProcessId=34668
+            //
+            // CommandLine="C:\Program Files\RustDesk\RustDesk.exe" --tray
+            // ProcessId=13728
+            //
+            // CommandLine="C:\Program Files\RustDesk\RustDesk.exe"
+            // ProcessId=10136
+            let mut pids = Vec::new();
+            let mut proc_found = false;
+            for line in output.lines() {
+                if line.starts_with("ProcessId=") {
+                    if proc_found {
+                        if let Ok(pid) = line["ProcessId=".len()..].trim().parse::<u32>() {
+                            pids.push(hbb_common::sysinfo::Pid::from_u32(pid));
+                        }
+                        proc_found = false;
+                    }
+                } else if line.starts_with("CommandLine=") {
+                    proc_found = false;
+                    let cmd = line["CommandLine=".len()..].trim().to_lowercase();
+                    if args.is_empty() {
+                        if cmd.ends_with(&name) || cmd.ends_with(&format!("{}\"", &name)) {
+                            proc_found = true;
+                        }
+                    } else {
+                        proc_found = args.iter().all(|arg| cmd.contains(arg.as_ref()));
+                    }
+                }
+            }
+            pids
+        })
+        .unwrap_or_default()
+}
+
+// Note the args are not compared strictly, only check if the args are contained in the command line.
+// If we want to check the args strictly, we need to parse the command line and compare each arg.
+// Maybe we have to introduce some external crate like `shell_words` to do this.
+#[cfg(not(target_pointer_width = "64"))]
+pub(super) fn get_pids_of_process_with_first_arg_by_wmic<S1: AsRef<str>, S2: AsRef<str>>(
+    name: S1,
+    arg: S2,
+) -> Vec<hbb_common::sysinfo::Pid> {
+    let name = name.as_ref().to_lowercase();
+    let arg = arg.as_ref().to_lowercase();
+    std::process::Command::new("wmic.exe")
+        .args([
+            "process",
+            "where",
+            &format!("name='{}'", name),
+            "get",
+            "commandline,processid",
+            "/value",
+        ])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map(|output| {
+            let output = String::from_utf8_lossy(&output.stdout);
+            let mut pids = Vec::new();
+            let mut proc_found = false;
+            for line in output.lines() {
+                if line.starts_with("ProcessId=") {
+                    if proc_found {
+                        if let Ok(pid) = line["ProcessId=".len()..].trim().parse::<u32>() {
+                            pids.push(hbb_common::sysinfo::Pid::from_u32(pid));
+                        }
+                        proc_found = false;
+                    }
+                } else if line.starts_with("CommandLine=") {
+                    proc_found = false;
+                    let cmd = line["CommandLine=".len()..].trim().to_lowercase();
+                    if cmd.is_empty() {
+                        continue;
+                    }
+                    if !arg.is_empty() && cmd.starts_with(&arg) {
+                        proc_found = true;
+                    } else {
+                        for x in [&format!("{}\"", &name), &format!("{}", &name)] {
+                            if cmd.contains(x) {
+                                let cmd = cmd.split(x).collect::<Vec<_>>()[1..].join("");
+                                if arg.is_empty() {
+                                    if cmd.trim().is_empty() {
+                                        proc_found = true;
+                                    }
+                                } else if cmd.trim().starts_with(&arg) {
+                                    proc_found = true;
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            pids
+        })
+        .unwrap_or_default()
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2544,18 +2544,21 @@ fn kill_process_by_pids(name: &str, pids: Vec<Pid>) -> ResultType<()> {
     Ok(())
 }
 
-// Don't launch tray app when updating msi.
+// Don't launch tray app when running with `\qn`.
 // 1. Because `/qn` requires administrator permission and the tray app should be launched with user permission.
 //   Or launching the main window from the tray app will cause the main window to be launched with administrator permission.
 // 2. We are not able to launch the tray app if the UI is in the login screen.
 // `fn update_me()` can handle the above cases, but for msi update, we need to do more work to handle the above cases.
-//    1. Record the tray app session ids
-//    2. Do the update
+//    1. Record the tray app session ids.
+//    2. Do the update.
 //    3. Restore the tray app sessions.
 //    `1` and `3` must be done in custom actions.
 //    We need also to handle the command line parsing to find the tray processes.
-pub fn update_me_msi(msi: &str) -> ResultType<()> {
-    let cmds = format!("chcp 65001 && msiexec /i {msi} /qn LAUNCH_TRAY_APP=N",);
+pub fn update_me_msi(msi: &str, quiet: bool) -> ResultType<()> {
+    let cmds = format!(
+        "chcp 65001 && msiexec /i {msi} {}",
+        if quiet { "/qn LAUNCH_TRAY_APP=N" } else { "" }
+    );
     run_cmds(cmds, false, "update-msi")?;
     Ok(())
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2521,6 +2521,17 @@ taskkill /F /IM {app_name}.exe{filter}
     Ok(())
 }
 
+pub fn update_me_msi(msi: &str) -> ResultType<()> {
+    let output = std::process::Command::new("msiexec")
+        .args(&["/i", msi, "/qn", "/norestart"])
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        bail!("{}", String::from_utf8_lossy(&output.stderr))
+    }
+}
+
 pub fn get_tray_shortcut(exe: &str, tmp_path: &str) -> ResultType<String> {
     Ok(write_cmds(
         format!(

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -62,6 +62,8 @@ impl RendezvousMediator {
             }
         }
         crate::hbbs_http::sync::start();
+        #[cfg(all(target_os = "windows", feature = "flutter"))]
+        crate::updater::start_auto_update();
         let mut nat_tested = false;
         check_zombie();
         let server = new_server();

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -62,7 +62,7 @@ impl RendezvousMediator {
             }
         }
         crate::hbbs_http::sync::start();
-        #[cfg(all(target_os = "windows", feature = "flutter"))]
+        #[cfg(target_os = "windows")]
         crate::updater::start_auto_update();
         let mut nat_tested = false;
         check_zombie();

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -338,6 +338,7 @@ class MyIdMenu: Reactor.Component {
                 <div .separator />
                 <li #allow-darktheme><span>{svg_checkmark}</span>{translate('Dark Theme')}</li>
                 <Languages />
+                <li #allow-auto-update><span>{svg_checkmark}</span>{translate('Auto update')}</li> 
                 <li #about>{translate('About')} {" "}{handler.get_app_name()}</li>
             </menu>
         </popup>;

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -202,7 +202,7 @@ fn update_new_version(is_msi: bool, version: &str, file_path: &PathBuf) {
     if let Some(p) = file_path.to_str() {
         if let Some(session_id) = crate::platform::get_current_process_session_id() {
             if is_msi {
-                match crate::platform::update_me_msi(p) {
+                match crate::platform::update_me_msi(p, true) {
                     Ok(_) => {
                         log::debug!("New version \"{}\" updated.", version);
                     }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,0 +1,206 @@
+use crate::{
+    common::{do_check_software_update, is_custom_client},
+    hbbs_http::create_http_client,
+};
+use hbb_common::{bail, config, log, ResultType};
+use std::{
+    io::{self, Write},
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc::{channel, Receiver, Sender},
+        Mutex,
+    },
+    time::{Duration, Instant},
+};
+
+enum UpdateMsg {
+    CheckUpdate,
+    Exit,
+}
+
+lazy_static::lazy_static! {
+    static ref TX_MSG : Mutex<Sender<UpdateMsg>> = Mutex::new(start_auto_update_check());
+}
+
+static CONTROLLING_SESSION_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+const DUR_ONE_DAY: Duration = Duration::from_secs(60 * 60 * 24);
+
+pub fn update_controlling_session_count(count: usize) {
+    CONTROLLING_SESSION_COUNT.store(count, Ordering::SeqCst);
+}
+
+pub fn start_auto_update() {
+    let _sender = TX_MSG.lock().unwrap();
+}
+
+#[allow(dead_code)]
+pub fn manually_check_update() -> ResultType<()> {
+    let sender = TX_MSG.lock().unwrap();
+    sender.send(UpdateMsg::CheckUpdate)?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub fn stop_auto_update() {
+    let sender = TX_MSG.lock().unwrap();
+    sender.send(UpdateMsg::Exit).unwrap_or_default();
+}
+
+#[inline]
+fn has_no_active_conns() -> bool {
+    let conns = crate::Connection::alive_conns();
+    conns.is_empty() && CONTROLLING_SESSION_COUNT.load(Ordering::SeqCst) == 0
+}
+
+fn start_auto_update_check() -> Sender<UpdateMsg> {
+    let (tx, rx) = channel();
+    std::thread::spawn(move || start_auto_update_check_(rx));
+    return tx;
+}
+
+fn start_auto_update_check_(rx_msg: Receiver<UpdateMsg>) {
+    std::thread::sleep(Duration::from_secs(30));
+    if let Err(e) = check_update(false) {
+        log::error!("Error checking for updates: {}", e);
+    }
+
+    const MIN_INTERVAL: Duration = Duration::from_secs(60 * 5);
+    const RETRY_INTERVAL: Duration = Duration::from_secs(60 * 30);
+    let mut last_check_time = Instant::now();
+    let mut check_interval = DUR_ONE_DAY;
+    loop {
+        let recv_res = rx_msg.recv_timeout(check_interval);
+        match &recv_res {
+            Ok(UpdateMsg::CheckUpdate) | Err(_) => {
+                if last_check_time.elapsed() < MIN_INTERVAL {
+                    // log::debug!("Update check skipped due to minimum interval.");
+                    continue;
+                }
+                // Don't check update if there are alive connections.
+                if !has_no_active_conns() {
+                    check_interval = RETRY_INTERVAL;
+                    continue;
+                }
+                if let Err(e) = check_update(matches!(recv_res, Ok(UpdateMsg::CheckUpdate))) {
+                    log::error!("Error checking for updates: {}", e);
+                    check_interval = RETRY_INTERVAL;
+                } else {
+                    last_check_time = Instant::now();
+                    check_interval = DUR_ONE_DAY;
+                }
+            }
+            Ok(UpdateMsg::Exit) => break,
+        }
+    }
+}
+
+fn check_update(manually: bool) -> ResultType<()> {
+    #[cfg(target_os = "windows")]
+    let is_win_msi = crate::platform::is_msi_installed()?;
+    #[cfg(not(target_os = "windows"))]
+    let is_win_msi = false;
+    if is_custom_client() || !crate::platform::is_installed() || is_win_msi {
+        return Ok(());
+    }
+    if manually || config::Config::get_bool_option(config::keys::OPTION_ALLOW_AUTO_UPDATE) {
+        if do_check_software_update().is_ok() {
+            let update_url = crate::common::SOFTWARE_UPDATE_URL.lock().unwrap().clone();
+            if update_url.is_empty() {
+                log::debug!("No update available.");
+            } else {
+                let download_url = update_url.replace("tag", "download");
+                let version = download_url.split('/').last().unwrap_or_default();
+                #[cfg(target_os = "windows")]
+                let download_url = format!("{}/rustdesk-{}-x86_64.exe", download_url, version);
+                log::debug!("New version available: {}", &version);
+                let client = create_http_client();
+                let Some(file_path) = get_download_file_from_url(&download_url) else {
+                    bail!("Failed to get the file path from the URL: {}", download_url);
+                };
+                let mut is_file_exists = false;
+                if file_path.exists() {
+                    // Check if the file size is the same as the server file size
+                    // If the file size is the same, we don't need to download it again.
+                    let file_size = std::fs::metadata(&file_path)?.len();
+                    let response = client.head(&download_url).send()?;
+                    if !response.status().is_success() {
+                        bail!("Failed to get the file size: {}", response.status());
+                    }
+                    let total_size = response
+                        .headers()
+                        .get(reqwest::header::CONTENT_LENGTH)
+                        .and_then(|ct_len| ct_len.to_str().ok())
+                        .and_then(|ct_len| ct_len.parse::<u64>().ok());
+                    let Some(total_size) = total_size else {
+                        bail!("Failed to get content length");
+                    };
+                    if file_size == total_size {
+                        is_file_exists = true;
+                    } else {
+                        std::fs::remove_file(&file_path)?;
+                    }
+                }
+                if !is_file_exists {
+                    let response = client.get(&download_url).send()?;
+                    if !response.status().is_success() {
+                        bail!(
+                            "Failed to download the new version file: {}",
+                            response.status()
+                        );
+                    }
+                    let file_data = response.bytes()?;
+                    let mut file = std::fs::File::create(&file_path)?;
+                    file.write_all(&file_data)?;
+                }
+                // We have checked if the `conns`` is empty before, but we need to check again.
+                // No need to care about the downloaded file here, because it's rare case that the `conns` are empty
+                // before the download, but not empty after the download.
+                if has_no_active_conns() {
+                    #[cfg(target_os = "windows")]
+                    if let Some(p) = file_path.to_str() {
+                        if let Some(session_id) = crate::platform::get_current_process_session_id()
+                        {
+                            match crate::platform::launch_privileged_process(
+                                session_id,
+                                &format!("{} --update", p),
+                            ) {
+                                Ok(h) => {
+                                    if h.is_null() {
+                                        log::error!(
+                                            "Failed to update to the new version: {}",
+                                            version
+                                        );
+                                    } else {
+                                        log::debug!("New version \"{}\" updated.", version);
+                                    }
+                                }
+                                Err(e) => {
+                                    log::error!("Failed to run the new version: {}", e);
+                                }
+                            }
+                        } else {
+                            log::error!(
+                                "Failed to get the current process session id, Error {}",
+                                io::Error::last_os_error()
+                            );
+                        }
+                    } else {
+                        // unreachable!()
+                        log::error!(
+                            "Failed to convert the file path to string: {}",
+                            file_path.display()
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn get_download_file_from_url(url: &str) -> Option<PathBuf> {
+    let filename = url.split('/').last()?;
+    Some(std::env::temp_dir().join(filename))
+}


### PR DESCRIPTION
## Desc

1. Easy update when clicking "Click to update" on Windows/MacOS. The main code is in `update_progress.dart`.
2. Provide an "Auto update" option on Windows. The main code is in `updater.rs`. Auto update will check for update 30 seconds after startup, then every 24 hours

<img width="480" src="https://github.com/user-attachments/assets/2105875b-b57b-492d-afe4-a7b36de4302a" />

<img width="480" src="https://github.com/user-attachments/assets/3dcfe10f-9629-45ce-9051-ad32a7f0e47f" />


The update logic is `stop service` -> `kill all instances` -> `update reg values` -> `copy files` -> `restore service` -> `restore main window and tray process`.

The main function is `update_me()` in `windows.rs`.

## Preview


https://github.com/user-attachments/assets/692b4dfc-43c7-4d48-ba20-922c56c8e58e


https://github.com/user-attachments/assets/a899dd16-9c41-4ff7-bea1-a55982108eaa



https://github.com/user-attachments/assets/a1eef3dc-b26b-4f06-996a-eee5d6eb8087



https://github.com/user-attachments/assets/a057c99e-c494-41bb-8526-20d7db5cc524




## Note

### Win

1. MSI does not start the tray app after auto updating to the new version.
2. Sciter version does not have the easy update feature like flutter. (Click, download & update)
3. Crate `sysinfo` can't detect the process command line if is x86 builds. But we need to check `--connect`, `----file-transfer` before updating. So we have to use `get_pids_of_process_with_first_arg_by_wmic()` as a workaround.

### MacOS

1. Downloads are not tested. The logic is the same to Windows.



