### PR TITLE
fix: http proxy

### DIFF
--- a/src/hbbs_http/http_client.rs
+++ b/src/hbbs_http/http_client.rs
@@ -6,15 +6,17 @@ use reqwest::Client as AsyncClient;
 
 macro_rules! configure_http_client {
     ($builder:expr, $Client: ty) => {{
-        let mut builder = $builder;
+        // https://github.com/rustdesk/rustdesk/issues/11569
+        // https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.no_proxy
+        let mut builder = $builder.no_proxy();
         let client = if let Some(conf) = Config::get_socks() {
             let proxy_result = Proxy::from_conf(&conf, None);
 
             match proxy_result {
                 Ok(proxy) => {
                     let proxy_setup = match &proxy.intercept {
-                        ProxyScheme::Http { host, .. } =>{ reqwest::Proxy::http(format!("http://{}", host))},
-                        ProxyScheme::Https { host, .. } => {reqwest::Proxy::https(format!("https://{}", host))},
+                        ProxyScheme::Http { host, .. } =>{ reqwest::Proxy::all(format!("http://{}", host))},
+                        ProxyScheme::Https { host, .. } => {reqwest::Proxy::all(format!("https://{}", host))},
                         ProxyScheme::Socks5 { addr, .. } => { reqwest::Proxy::all(&format!("socks5://{}", addr)) }
                     };
 


### PR DESCRIPTION
1. Fix https://github.com/rustdesk/rustdesk/issues/11569  https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.no_proxy   Reproduced and tested.
2. Fix proxy all.  https://docs.rs/reqwest/latest/reqwest/struct.Proxy.html `reqwest::Proxy::http()` means "Proxy all HTTP traffic to the passed URL.".  eg. `reqwest::Proxy::http("http://aaaaa")` does not work for `https://google.com`, while `reqwest::Proxy::https("http://aaaaa")` works. 


