### PR TITLE
fix: check server running on Windows

### DIFF
--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -77,7 +77,14 @@ pub fn core_main() -> Option<Vec<String>> {
     }
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     if args.is_empty() {
-        if crate::check_process("--server", false) && !crate::check_process("--tray", true) {
+        #[cfg(target_os = "linux")]
+        let is_server_running = crate::check_process("--server", false);
+        // We can use `crate::check_process("--server", false)` on Windows.
+        // Because `--server` process is the System user's process. We can't get the arguments in `check_process()`.
+        // We can assume that self service running means the server is also running on Windows.
+        #[cfg(target_os = "windows")]
+        let is_server_running = crate::platform::is_self_service_running();
+        if is_server_running && !crate::check_process("--tray", true) {
             #[cfg(target_os = "linux")]
             hbb_common::allow_err!(crate::platform::check_autostart_config());
             hbb_common::allow_err!(crate::run_me(vec!["--tray"]));


### PR DESCRIPTION
Tested with privileged user and normal user.

1. Install RustDesk.
2. End task (current user processes) in Task Manager.
3. Click to run the main window.

Click without installation does not start the tray process.

