### PR TITLE
Using new Stream type adapted to the update of submodules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,6 +3108,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "toml 0.7.8",
+ "tungstenite",
  "url",
  "uuid",
  "winapi 0.3.9",

--- a/src/client.rs
+++ b/src/client.rs
@@ -58,7 +58,6 @@ use hbb_common::{
     sha2::{Digest, Sha256},
     socket_client::{connect_tcp, connect_tcp_local, ipv4_to_ipv6},
     sodiumoxide::{base64, crypto::sign},
-    tcp::FramedStream,
     timeout,
     tokio::{
         self,
@@ -3557,8 +3556,7 @@ pub mod peer_online {
         rendezvous_proto::*,
         sleep,
         socket_client::connect_tcp,
-        tcp::FramedStream,
-        ResultType,
+        ResultType, Stream,
     };
 
     pub async fn query_online_states<F: FnOnce(Vec<String>, Vec<String>)>(ids: Vec<String>, f: F) {
@@ -3581,7 +3579,7 @@ pub mod peer_online {
         }
     }
 
-    async fn create_online_stream() -> ResultType<FramedStream> {
+    async fn create_online_stream() -> ResultType<Stream> {
         let (rendezvous_server, _servers, _contained) =
             crate::get_rendezvous_server(READ_TIMEOUT).await;
         let tmp: Vec<&str> = rendezvous_server.split(":").collect();

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -351,7 +351,7 @@ impl<T: InvokeUiSession> Remote<T> {
     #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]
     async fn handle_local_clipboard_msg(
         &self,
-        peer: &mut crate::client::FramedStream,
+        peer: &mut Stream,
         msg: Option<clipboard::ClipboardFile>,
     ) {
         match msg {

--- a/src/common.rs
+++ b/src/common.rs
@@ -27,7 +27,7 @@ use hbb_common::{
         self,
         time::{Duration, Instant, Interval},
     },
-    ResultType,
+    ResultType, Stream,
 };
 
 use crate::{
@@ -832,7 +832,7 @@ pub fn is_modifier(evt: &KeyEvent) -> bool {
 pub fn check_software_update() {
     if is_custom_client() {
         return;
-    } 
+    }
     let opt = config::LocalConfig::get_option(config::keys::OPTION_ENABLE_CHECK_UPDATE);
     if config::option2bool(config::keys::OPTION_ENABLE_CHECK_UPDATE, &opt) {
         std::thread::spawn(move || allow_err!(check_software_update_()));
@@ -1196,7 +1196,7 @@ pub fn pk_to_fingerprint(pk: Vec<u8>) -> String {
 
 #[inline]
 pub async fn get_next_nonkeyexchange_msg(
-    conn: &mut FramedStream,
+    conn: &mut Stream,
     timeout: Option<u64>,
 ) -> Option<RendezvousMessage> {
     let timeout = timeout.unwrap_or(READ_TIMEOUT);
@@ -1265,7 +1265,7 @@ pub fn check_process(arg: &str, mut same_uid: bool) -> bool {
     false
 }
 
-pub async fn secure_tcp(conn: &mut FramedStream, key: &str) -> ResultType<()> {
+pub async fn secure_tcp(conn: &mut Stream, key: &str) -> ResultType<()> {
     let rs_pk = get_rs_pk(key);
     let Some(rs_pk) = rs_pk else {
         bail!("Handshake failed: invalid public key from rendezvous server");

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -20,10 +20,9 @@ use hbb_common::{
     rendezvous_proto::*,
     sleep,
     socket_client::{self, connect_tcp, is_ipv4},
-    tcp::FramedStream,
     tokio::{self, select, sync::Mutex, time::interval},
     udp::FramedSocket,
-    AddrMangle, IntoTargetAddr, ResultType, TargetAddr,
+    AddrMangle, IntoTargetAddr, ResultType, Stream, TargetAddr,
 };
 
 use crate::{
@@ -706,7 +705,7 @@ async fn direct_server(server: ServerPtr) {
 
 enum Sink<'a> {
     Framed(&'a mut FramedSocket, &'a TargetAddr<'a>),
-    Stream(&'a mut FramedStream),
+    Stream(&'a mut Stream),
 }
 
 impl Sink<'_> {


### PR DESCRIPTION
The update submitted this time updates the hash values of the sub-modules to the latest level and modifies the corresponding interfaces to the new `Stream` type to adapted the updated sub-modules. Currently, the `tcp` function can be used normally, while websocket can be enabled by starting with `ws://` when establishing a connection.

A simple example to use `websocket`
```rs
// origin
let host = check_port(&rendezvous_server, RENDEZVOUS_PORT);
let mut conn = connect_tcp(host.clone(), CONNECT_TIMEOUT).await?;

// establish a websocket stream
let host = check_port(&rendezvous_server, RENDEZVOUS_PORT);
let host = format!("ws://{}", host);
let mut conn = connect_tcp(host.clone(), CONNECT_TIMEOUT).await?;
```

This pr maintains the tcp function completely unchanged, only providing the ability to enable websocket. Additionally, to use websocket, the 21119(instead of 21117) port of the relay server needs to be used.