### PR TITLE
feat: take screenshot

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -38,7 +38,7 @@ env:
   #  https://github.com/rustdesk/rustdesk/actions/runs/14414119794/job/40427970174
   # 2. Update the `VCPKG_COMMIT_ID` in `ci.yml` and `playground.yml`.
   VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
-  VERSION: "1.3.10"
+  VERSION: "1.4.0"
   NDK_VERSION: "r27c"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -38,7 +38,7 @@ env:
   #  https://github.com/rustdesk/rustdesk/actions/runs/14414119794/job/40427970174
   # 2. Update the `VCPKG_COMMIT_ID` in `ci.yml` and `playground.yml`.
   VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
-  VERSION: "1.3.9"
+  VERSION: "1.3.10"
   NDK_VERSION: "r27c"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -17,7 +17,7 @@ env:
   TAG_NAME: "nightly"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
   VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
-  VERSION: "1.3.9"
+  VERSION: "1.3.10"
   NDK_VERSION: "r26d"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -17,7 +17,7 @@ env:
   TAG_NAME: "nightly"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
   VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
-  VERSION: "1.3.10"
+  VERSION: "1.4.0"
   NDK_VERSION: "r26d"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5857,7 +5857,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk"
-version = "1.3.9"
+version = "1.3.10"
 dependencies = [
  "android-wakelock",
  "android_logger",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk-portable-packer"
-version = "1.3.9"
+version = "1.3.10"
 dependencies = [
  "brotli",
  "dirs 5.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5857,7 +5857,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "android-wakelock",
  "android_logger",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk-portable-packer"
-version = "1.3.10"
+version = "1.4.0"
 dependencies = [
  "brotli",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk"
-version = "1.3.10"
+version = "1.4.0"
 authors = ["rustdesk <info@rustdesk.com>"]
 edition = "2021"
 build= "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk"
-version = "1.3.9"
+version = "1.3.10"
 authors = ["rustdesk <info@rustdesk.com>"]
 edition = "2021"
 build= "build.rs"

--- a/appimage/AppImageBuilder-aarch64.yml
+++ b/appimage/AppImageBuilder-aarch64.yml
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.3.9
+    version: 1.3.10
     exec: usr/share/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/appimage/AppImageBuilder-aarch64.yml
+++ b/appimage/AppImageBuilder-aarch64.yml
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.3.10
+    version: 1.4.0
     exec: usr/share/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/appimage/AppImageBuilder-x86_64.yml
+++ b/appimage/AppImageBuilder-x86_64.yml
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.3.9
+    version: 1.3.10
     exec: usr/share/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/appimage/AppImageBuilder-x86_64.yml
+++ b/appimage/AppImageBuilder-x86_64.yml
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.3.10
+    version: 1.4.0
     exec: usr/share/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -304,7 +304,9 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
         sessionId: sessionId, key: 'is_screenshot_supported', param: '');
     if ('true' == isScreenshotSupported) {
       v.add(TTextMenu(
-        child: Text(translate('Take screenshot')),
+        child: Text(ffi.ffiModel.timerScreenshot != null
+            ? '${translate('Taking screenshot')}...'
+            : translate('Take screenshot')),
         onPressed: ffi.ffiModel.timerScreenshot != null
             ? null
             : () {

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -15,7 +16,7 @@ bool isEditOsPassword = false;
 
 class TTextMenu {
   final Widget child;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
   Widget? trailingIcon;
   bool divider;
   TTextMenu(
@@ -293,6 +294,39 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
           ],
         ),
         onPressed: () => ffi.recordingModel.toggle()));
+  }
+
+  // to-do:
+  // 1. Web desktop
+  // 2. Mobile, copy the image to the clipboard
+  if (isDesktop) {
+    final isScreenshotSupported = bind.sessionGetCommonSync(
+        sessionId: sessionId, key: 'is_screenshot_supported', param: '');
+    if ('true' == isScreenshotSupported) {
+      v.add(TTextMenu(
+        child: Text(translate('Take screenshot')),
+        onPressed: ffi.ffiModel.timerScreenshot != null
+            ? null
+            : () {
+                if (pi.currentDisplay == kAllDisplayValue) {
+                  msgBox(
+                      sessionId,
+                      'custom-nook-nocancel-hasclose-info',
+                      'Take screenshot',
+                      'screenshot-merged-screen-not-supported-tip',
+                      '',
+                      ffi.dialogManager);
+                } else {
+                  bind.sessionTakeScreenshot(
+                      sessionId: sessionId, display: pi.currentDisplay);
+                  ffi.ffiModel.timerScreenshot =
+                      Timer(Duration(seconds: 30), () {
+                    ffi.ffiModel.timerScreenshot = null;
+                  });
+                }
+              },
+      ));
+    }
   }
   // fingerprint
   if (!(isDesktop || isWebDesktop)) {

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -305,7 +305,7 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
     if ('true' == isScreenshotSupported) {
       v.add(TTextMenu(
         child: Text(ffi.ffiModel.timerScreenshot != null
-            ? '${translate('Taking screenshot')}...'
+            ? '${translate('Taking screenshot')} ...'
             : translate('Take screenshot')),
         onPressed: ffi.ffiModel.timerScreenshot != null
             ? null

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -220,7 +220,8 @@ const double kDefaultQuality = 50;
 const double kMaxQuality = 100;
 const double kMaxMoreQuality = 2000;
 
-const String kKeyPrinterIncommingJobAction = 'printer-incomming-job-action';
+// incomming (should be incoming) is kept, because change it will break the previous setting.
+const String kKeyPrinterIncomingJobAction = 'printer-incomming-job-action';
 const String kValuePrinterIncomingJobDismiss = 'dismiss';
 const String kValuePrinterIncomingJobDefault = '';
 const String kValuePrinterIncomingJobSelected = 'selected';

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1908,7 +1908,7 @@ class __PrinterState extends State<_Printer> {
     final scrollController = ScrollController();
     return ListView(controller: scrollController, children: [
       outgoing(context),
-      incomming(context),
+      incoming(context),
     ]).marginOnly(bottom: _kListViewBottomMargin);
   }
 
@@ -1995,15 +1995,15 @@ class __PrinterState extends State<_Printer> {
     return _Card(title: 'Outgoing Print Jobs', children: children);
   }
 
-  Widget incomming(BuildContext context) {
+  Widget incoming(BuildContext context) {
     onRadioChanged(String value) async {
       await bind.mainSetLocalOption(
-          key: kKeyPrinterIncommingJobAction, value: value);
+          key: kKeyPrinterIncomingJobAction, value: value);
       setState(() {});
     }
 
     PrinterOptions printerOptions = PrinterOptions.load();
-    return _Card(title: 'Incomming Print Jobs', children: [
+    return _Card(title: 'Incoming Print Jobs', children: [
       _Radio(context,
           value: kValuePrinterIncomingJobDismiss,
           groupValue: printerOptions.action,

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -695,9 +695,9 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
       );
       if (index != null) {
         if (index < mobileActionMenus.length) {
-          mobileActionMenus[index].onPressed.call();
+          mobileActionMenus[index].onPressed?.call();
         } else if (index < mobileActionMenus.length + more.length) {
-          menus[index - mobileActionMenus.length].onPressed.call();
+          menus[index - mobileActionMenus.length].onPressed?.call();
         }
       }
     }();
@@ -770,7 +770,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
         elevation: 8,
       );
       if (index != null && index < menus.length) {
-        menus[index].onPressed.call();
+        menus[index].onPressed?.call();
       }
     });
   }
@@ -1267,7 +1267,7 @@ void showOptions(
         title: resolution.child,
         onTap: () {
           close();
-          resolution.onPressed();
+          resolution.onPressed?.call();
         },
       ));
     }
@@ -1279,7 +1279,7 @@ void showOptions(
         title: virtualDisplayMenu.child,
         onTap: () {
           close();
-          virtualDisplayMenu.onPressed();
+          virtualDisplayMenu.onPressed?.call();
         },
       ));
     }

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -243,7 +243,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
   Widget build(BuildContext context) {
     Provider.of<FfiModel>(context);
     final outgoingOnly = bind.isOutgoingOnly();
-    final incommingOnly = bind.isIncomingOnly();
+    final incomingOnly = bind.isIncomingOnly();
     final customClientSection = CustomSettingsSection(
         child: Column(
       children: [
@@ -728,7 +728,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
                           });
                         },
                 ),
-              if (!incommingOnly)
+              if (!incomingOnly)
                 SettingsTile.switchTile(
                   title:
                       Text(translate('Automatically record outgoing sessions')),

--- a/flutter/lib/mobile/pages/view_camera_page.dart
+++ b/flutter/lib/mobile/pages/view_camera_page.dart
@@ -478,9 +478,9 @@ class _ViewCameraPageState extends State<ViewCameraPage>
       );
       if (index != null) {
         if (index < mobileActionMenus.length) {
-          mobileActionMenus[index].onPressed.call();
+          mobileActionMenus[index].onPressed?.call();
         } else if (index < mobileActionMenus.length + more.length) {
-          menus[index - mobileActionMenus.length].onPressed.call();
+          menus[index - mobileActionMenus.length].onPressed?.call();
         }
       }
     }();
@@ -553,7 +553,7 @@ class _ViewCameraPageState extends State<ViewCameraPage>
         elevation: 8,
       );
       if (index != null && index < menus.length) {
-        menus[index].onPressed.call();
+        menus[index].onPressed?.call();
       }
     });
   }

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -34,6 +34,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 import 'package:uuid/uuid.dart';
 import 'package:window_manager/window_manager.dart';
+import 'package:file_picker/file_picker.dart';
 
 import '../common.dart';
 import '../utils/image.dart' as img;
@@ -118,6 +119,8 @@ class FfiModel with ChangeNotifier {
   Timer? waitForImageTimer;
   RxBool waitForFirstImage = true.obs;
   bool isRefreshing = false;
+
+  Timer? timerScreenshot;
 
   Rect? get rect => _rect;
   bool get isOriginalResolutionSet =>
@@ -216,6 +219,7 @@ class FfiModel with ChangeNotifier {
     _timer = null;
     clearPermissions();
     waitForImageTimer?.cancel();
+    timerScreenshot?.cancel();
   }
 
   setConnectionType(String peerId, bool secure, bool direct) {
@@ -414,10 +418,80 @@ class FfiModel with ChangeNotifier {
         }
       } else if (name == "printer_request") {
         _handlePrinterRequest(evt, sessionId, peerId);
+      } else if (name == 'screenshot') {
+        _handleScreenshot(evt, sessionId, peerId);
       } else {
         debugPrint('Event is not handled in the fixed branch: $name');
       }
     };
+  }
+
+  _handleScreenshot(
+      Map<String, dynamic> evt, SessionID sessionId, String peerId) {
+    timerScreenshot?.cancel();
+    timerScreenshot = null;
+    final msg = evt['msg'] ?? '';
+    final msgBoxType = 'custom-nook-nocancel-hasclose';
+    final msgBoxTitle = 'Take screenshot';
+    final dialogManager = parent.target!.dialogManager;
+    if (msg.isNotEmpty) {
+      msgBox(sessionId, msgBoxType, msgBoxTitle, msg, '', dialogManager);
+    } else {
+      final msgBoxText = 'screenshot-action-tip';
+
+      close() {
+        dialogManager.dismissAll();
+      }
+
+      saveAs() {
+        close();
+        Future.delayed(Duration.zero, () async {
+          final ts = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          String? outputFile = await FilePicker.platform.saveFile(
+            dialogTitle: '${translate('Save as')}...',
+            fileName: 'screenshot_$ts.png',
+            allowedExtensions: ['png'],
+            type: FileType.custom,
+          );
+          if (outputFile == null) {
+            bind.sessionHandleScreenshot(sessionId: sessionId, action: '2');
+          } else {
+            final res = await bind.sessionHandleScreenshot(
+                sessionId: sessionId, action: '0:$outputFile');
+            if (res.isNotEmpty) {
+              msgBox(sessionId, 'custom-nook-nocancel-hasclose-error',
+                  'Take screenshot', res, '', dialogManager);
+            }
+          }
+        });
+      }
+
+      copyToClipboard() {
+        bind.sessionHandleScreenshot(sessionId: sessionId, action: '1');
+        close();
+      }
+
+      cancel() {
+        bind.sessionHandleScreenshot(sessionId: sessionId, action: '2');
+        close();
+      }
+
+      final List<Widget> buttons = [
+        dialogButton('${translate('Save as')}...', onPressed: saveAs),
+        dialogButton('Copy to clipboard', onPressed: copyToClipboard),
+        dialogButton('Cancel', onPressed: cancel),
+      ];
+      dialogManager.dismissAll();
+      dialogManager.show(
+        (setState, close, context) => CustomAlertDialog(
+          title: null,
+          content: SelectionArea(
+              child: msgboxContent(msgBoxType, msgBoxTitle, msgBoxText)),
+          actions: buttons,
+        ),
+        tag: '$msgBoxType-$msgBoxTitle-$msgBoxTitle',
+      );
+    }
   }
 
   _handlePrinterRequest(

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -525,7 +525,7 @@ class FfiModel with ChangeNotifier {
         if (saveSettings.value || dontShowAgain.value) {
           bind.mainSetLocalOption(key: kKeyPrinterSelected, value: printerName);
           bind.mainSetLocalOption(
-              key: kKeyPrinterIncommingJobAction,
+              key: kKeyPrinterIncomingJobAction,
               value: defaultOrSelectedGroupValue.value);
         }
         if (dontShowAgain.value) {
@@ -537,7 +537,7 @@ class FfiModel with ChangeNotifier {
       onCancel() {
         if (dontShowAgain.value) {
           bind.mainSetLocalOption(
-              key: kKeyPrinterIncommingJobAction,
+              key: kKeyPrinterIncomingJobAction,
               value: kValuePrinterIncomingJobDismiss);
         }
         close();

--- a/flutter/lib/models/printer_model.dart
+++ b/flutter/lib/models/printer_model.dart
@@ -13,7 +13,7 @@ class PrinterOptions {
       required this.printerName});
 
   static PrinterOptions load() {
-    var action = bind.mainGetLocalOption(key: kKeyPrinterIncommingJobAction);
+    var action = bind.mainGetLocalOption(key: kKeyPrinterIncomingJobAction);
     if (![
       kValuePrinterIncomingJobDismiss,
       kValuePrinterIncomingJobDefault,
@@ -28,7 +28,7 @@ class PrinterOptions {
       if (action == kValuePrinterIncomingJobSelected) {
         action = kValuePrinterIncomingJobDefault;
         bind.mainSetLocalOption(
-            key: kKeyPrinterIncommingJobAction,
+            key: kKeyPrinterIncomingJobAction,
             value: kValuePrinterIncomingJobDefault);
         if (printerNames.isEmpty) {
           selectedPrinterName = '';

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # 1.1.9-1 works for android, but for ios it becomes 1.1.91, need to set it to 1.1.9-a.1 for iOS, will get 1.1.9.1, but iOS store not allow 4 numbers
-version: 1.3.10+58
+version: 1.4.0+58
 
 environment:
   sdk: '^3.1.0'

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # 1.1.9-1 works for android, but for ios it becomes 1.1.91, need to set it to 1.1.9-a.1 for iOS, will get 1.1.9.1, but iOS store not allow 4 numbers
-version: 1.3.9+57
+version: 1.3.10+58
 
 environment:
   sdk: '^3.1.0'

--- a/libs/portable/Cargo.toml
+++ b/libs/portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk-portable-packer"
-version = "1.3.9"
+version = "1.3.10"
 edition = "2021"
 description = "RustDesk Remote Desktop"
 

--- a/libs/portable/Cargo.toml
+++ b/libs/portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk-portable-packer"
-version = "1.3.10"
+version = "1.4.0"
 edition = "2021"
 description = "RustDesk Remote Desktop"
 

--- a/libs/scrap/src/common/convert.rs
+++ b/libs/scrap/src/common/convert.rs
@@ -197,3 +197,35 @@ pub fn convert_to_yuv(
     }
     Ok(())
 }
+
+#[cfg(not(target_os = "ios"))]
+pub fn convert(captured: &PixelBuffer, pixfmt: crate::Pixfmt, dst: &mut Vec<u8>) -> ResultType<()> {
+    let src = captured.data();
+    let src_stride = captured.stride();
+    let src_pixfmt = captured.pixfmt();
+    let src_width = captured.width();
+    let src_height = captured.height();
+
+    let unsupported = format!(
+        "unsupported pixfmt conversion: {src_pixfmt:?} -> {:?}",
+        pixfmt
+    );
+
+    match (src_pixfmt, pixfmt) {
+        (crate::Pixfmt::BGRA, crate::Pixfmt::RGBA) | (crate::Pixfmt::RGBA, crate::Pixfmt::BGRA) => {
+            dst.resize(src.len(), 0);
+            call_yuv!(ABGRToARGB(
+                src.as_ptr(),
+                src_stride[0] as _,
+                dst.as_mut_ptr(),
+                src_stride[0] as _,
+                src_width as _,
+                src_height as _,
+            ));
+        }
+        _ => {
+            bail!(unsupported);
+        }
+    }
+    Ok(())
+}

--- a/libs/scrap/src/common/convert.rs
+++ b/libs/scrap/src/common/convert.rs
@@ -200,6 +200,11 @@ pub fn convert_to_yuv(
 
 #[cfg(not(target_os = "ios"))]
 pub fn convert(captured: &PixelBuffer, pixfmt: crate::Pixfmt, dst: &mut Vec<u8>) -> ResultType<()> {
+    if captured.pixfmt() == pixfmt {
+        dst.extend_from_slice(captured.data());
+        return Ok(());
+    }
+
     let src = captured.data();
     let src_stride = captured.stride();
     let src_pixfmt = captured.pixfmt();

--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -63,6 +63,7 @@ pub enum ImageFormat {
 }
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct ImageRgb {
     pub raw: Vec<u8>,
     pub w: usize,

--- a/res/PKGBUILD
+++ b/res/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=rustdesk
-pkgver=1.3.9
+pkgver=1.3.10
 pkgrel=0
 epoch=
 pkgdesc=""

--- a/res/PKGBUILD
+++ b/res/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=rustdesk
-pkgver=1.3.10
+pkgver=1.4.0
 pkgrel=0
 epoch=
 pkgdesc=""

--- a/res/rpm-flutter-suse.spec
+++ b/res/rpm-flutter-suse.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.3.10
+Version:    1.4.0
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm-flutter-suse.spec
+++ b/res/rpm-flutter-suse.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.3.9
+Version:    1.3.10
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.3.10
+Version:    1.4.0
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.3.9
+Version:    1.3.10
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.3.10
+Version:    1.4.0
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.3.9
+Version:    1.3.10
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/src/client.rs
+++ b/src/client.rs
@@ -85,6 +85,7 @@ pub use super::lang::*;
 pub mod file_trait;
 pub mod helper;
 pub mod io_loop;
+pub mod screenshot;
 
 pub const MILLI1: Duration = Duration::from_millis(1);
 pub const SEC30: Duration = Duration::from_secs(30);
@@ -3320,6 +3321,7 @@ pub enum Data {
     CloseVoiceCall,
     ResetDecoder(Option<usize>),
     RenameFile((i32, String, String, bool)),
+    TakeScreenshot((i32, String)),
 }
 
 /// Keycode for key events.

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -962,6 +962,15 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                 }
             },
+            Data::TakeScreenshot((display, sid)) => {
+                let mut msg = Message::new();
+                msg.set_screenshot_request(ScreenshotRequest {
+                    display,
+                    sid,
+                    ..Default::default()
+                });
+                allow_err!(peer.send(&msg).await);
+            }
             _ => {}
         }
         true
@@ -1908,6 +1917,11 @@ impl<T: InvokeUiSession> Remote<T> {
                 Some(message::Union::PeerInfo(pi)) => {
                     self.handler.set_displays(&pi.displays);
                     self.handler.set_platform_additions(&pi.platform_additions);
+                }
+                Some(message::Union::ScreenshotResponse(response)) => {
+                    crate::client::screenshot::set_screenshot(response.data);
+                    self.handler
+                        .handle_screenshot_resp(response.sid, response.msg);
                 }
                 _ => {}
             }

--- a/src/client/screenshot.rs
+++ b/src/client/screenshot.rs
@@ -1,0 +1,95 @@
+use crate::clipboard::{update_clipboard, ClipboardSide};
+use hbb_common::{message_proto::*, ResultType};
+use std::sync::Mutex;
+
+lazy_static::lazy_static! {
+    static ref SCREENSHOT: Mutex<Screenshot> = Default::default();
+}
+
+pub enum ScreenshotAction {
+    SaveAs(String),
+    CopyToClipboard,
+    Discard,
+}
+
+impl Default for ScreenshotAction {
+    fn default() -> Self {
+        Self::Discard
+    }
+}
+
+impl From<&str> for ScreenshotAction {
+    fn from(value: &str) -> Self {
+        match value.chars().next() {
+            Some('0') => {
+                if let Some((pos, _)) = value.char_indices().nth(2) {
+                    let substring = &value[pos..];
+                    Self::SaveAs(substring.to_string())
+                } else {
+                    Self::default()
+                }
+            }
+            Some('1') => Self::CopyToClipboard,
+            Some('2') => Self::default(),
+            _ => Self::default(),
+        }
+    }
+}
+
+impl Into<String> for ScreenshotAction {
+    fn into(self) -> String {
+        match self {
+            Self::SaveAs(p) => format!("0:{p}"),
+            Self::CopyToClipboard => "1".to_owned(),
+            Self::Discard => "2".to_owned(),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Screenshot {
+    data: Option<bytes::Bytes>,
+}
+
+impl Screenshot {
+    fn set_screenshot(&mut self, data: bytes::Bytes) {
+        self.data.replace(data);
+    }
+
+    fn handle_screenshot(&mut self, action: String) -> String {
+        let Some(data) = self.data.take() else {
+            return "No cached screenshot".to_owned();
+        };
+        match Self::handle_screenshot_(data, action) {
+            Ok(()) => "".to_owned(),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    fn handle_screenshot_(data: bytes::Bytes, action: String) -> ResultType<()> {
+        match ScreenshotAction::from(&action as &str) {
+            ScreenshotAction::SaveAs(p) => {
+                std::fs::write(p, data)?;
+            }
+            ScreenshotAction::CopyToClipboard => {
+                let clips = vec![Clipboard {
+                    compress: false,
+                    content: data,
+                    format: ClipboardFormat::ImagePng.into(),
+                    ..Default::default()
+                }];
+                update_clipboard(clips, ClipboardSide::Client);
+            }
+            ScreenshotAction::Discard => {}
+        }
+        Ok(())
+    }
+}
+
+pub fn set_screenshot(data: bytes::Bytes) {
+    SCREENSHOT.lock().unwrap().set_screenshot(data);
+}
+
+pub fn handle_screenshot(action: String) -> String {
+    SCREENSHOT.lock().unwrap().handle_screenshot(action)
+}

--- a/src/client/screenshot.rs
+++ b/src/client/screenshot.rs
@@ -1,3 +1,4 @@
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::clipboard::{update_clipboard, ClipboardSide};
 use hbb_common::{message_proto::*, ResultType};
 use std::sync::Mutex;
@@ -72,13 +73,16 @@ impl Screenshot {
                 std::fs::write(p, data)?;
             }
             ScreenshotAction::CopyToClipboard => {
-                let clips = vec![Clipboard {
-                    compress: false,
-                    content: data,
-                    format: ClipboardFormat::ImagePng.into(),
-                    ..Default::default()
-                }];
-                update_clipboard(clips, ClipboardSide::Client);
+                #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                {
+                    let clips = vec![Clipboard {
+                        compress: false,
+                        content: data,
+                        format: ClipboardFormat::ImagePng.into(),
+                        ..Default::default()
+                    }];
+                    update_clipboard(clips, ClipboardSide::Client);
+                }
             }
             ScreenshotAction::Discard => {}
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -147,6 +147,16 @@ pub fn is_support_file_paste_if_macos(ver: &str) -> bool {
     hbb_common::get_version_number(ver) >= hbb_common::get_version_number("1.3.9")
 }
 
+#[inline]
+pub fn is_support_screenshot(ver: &str) -> bool {
+    is_support_multi_ui_session_num(hbb_common::get_version_number(ver))
+}
+
+#[inline]
+pub fn is_support_screenshot_num(ver: i64) -> bool {
+    ver >= hbb_common::get_version_number("1.3.10")
+}
+
 // is server process, with "--server" args
 #[inline]
 pub fn is_server() -> bool {

--- a/src/common.rs
+++ b/src/common.rs
@@ -154,7 +154,7 @@ pub fn is_support_screenshot(ver: &str) -> bool {
 
 #[inline]
 pub fn is_support_screenshot_num(ver: i64) -> bool {
-    ver >= hbb_common::get_version_number("1.3.10")
+    ver >= hbb_common::get_version_number("1.4.0")
 }
 
 // is server process, with "--server" args

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -544,17 +544,45 @@ impl FlutterHandler {
     where
         V: Sized + Serialize + Clone,
     {
+        self.push_event_(name, event, &[], excludes);
+    }
+
+    pub fn push_event_to<V>(&self, name: &str, event: &[(&str, V)], include: &[&SessionID])
+    where
+        V: Sized + Serialize + Clone,
+    {
+        self.push_event_(name, event, include, &[]);
+    }
+
+    pub fn push_event_<V>(
+        &self,
+        name: &str,
+        event: &[(&str, V)],
+        includes: &[&SessionID],
+        excludes: &[&SessionID],
+    ) where
+        V: Sized + Serialize + Clone,
+    {
         let mut h: HashMap<&str, serde_json::Value> =
             event.iter().map(|(k, v)| (*k, json!(*v))).collect();
         debug_assert!(h.get("name").is_none());
         h.insert("name", json!(name));
         let out = serde_json::ser::to_string(&h).unwrap_or("".to_owned());
         for (sid, session) in self.session_handlers.read().unwrap().iter() {
-            if excludes.contains(&sid) {
-                continue;
+            let mut push = false;
+            if includes.is_empty() {
+                if !excludes.contains(&sid) {
+                    push = true;
+                }
+            } else {
+                if includes.contains(&sid) {
+                    push = true;
+                }
             }
-            if let Some(stream) = &session.event_stream {
-                stream.add(EventToUI::Event(out.clone()));
+            if push {
+                if let Some(stream) = &session.event_stream {
+                    stream.add(EventToUI::Event(out.clone()));
+                }
             }
         }
     }
@@ -1066,6 +1094,16 @@ impl InvokeUiSession for FlutterHandler {
             &[("id", json!(id)), ("path", json!(path))],
             &[],
         );
+    }
+
+    fn handle_screenshot_resp(&self, sid: String, msg: String) {
+        match SessionID::from_str(&sid) {
+            Ok(sid) => self.push_event_to("screenshot", &[("msg", json!(msg))], &[&sid]),
+            Err(e) => {
+                // Unreachable!
+                log::error!("Failed to parse sid \"{}\", {}", sid, e);
+            }
+        }
     }
 }
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -250,6 +250,16 @@ pub fn session_refresh(session_id: SessionID, display: usize) {
     }
 }
 
+pub fn session_take_screenshot(session_id: SessionID, display: usize) {
+    if let Some(s) = sessions::get_session_by_session_id(&session_id) {
+        s.take_screenshot(display as _, session_id.to_string());
+    }
+}
+
+pub fn session_handle_screenshot(session_id: SessionID, action: String) -> String {
+    crate::client::screenshot::handle_screenshot(action)
+}
+
 pub fn session_is_multi_ui_session(session_id: SessionID) -> SyncReturn<bool> {
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
         SyncReturn(session.is_multi_ui_session())
@@ -2458,6 +2468,27 @@ pub fn main_set_common(_key: String, _value: String) {
                 serde_json::ser::to_string(&data).unwrap_or("".to_owned()),
             );
         });
+    }
+}
+
+pub fn session_get_common_sync(
+    session_id: SessionID,
+    key: String,
+    param: String,
+) -> SyncReturn<Option<String>> {
+    SyncReturn(session_get_common(session_id, key, param))
+}
+
+pub fn session_get_common(session_id: SessionID, key: String, param: String) -> Option<String> {
+    if let Some(s) = sessions::get_session_by_session_id(&session_id) {
+        let v = if key == "is_screenshot_supported" {
+            s.is_screenshot_supported().to_string()
+        } else {
+            "".to_owned()
+        };
+        Some(v)
+    } else {
+        None
     }
 }
 

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "الطباعة عن بُعد غير مسموح بها على هذا الجهاز"),
         ("save-settings-tip", "حفظ الإعدادات"),
         ("dont-show-again-tip", "لا تظهر هذا مرة أخرى"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "حفظ الإعدادات"),
         ("dont-show-again-tip", "لا تظهر هذا مرة أخرى"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "الطابعة {} جاهزة"),
         ("Install {} Printer", "تثبيت طابعة {}"),
         ("Outgoing Print Jobs", "وظائف الطباعة الصادرة"),
-        ("Incomming Print Jobs", "وظائف الطباعة الواردة"),
+        ("Incoming Print Jobs", "وظائف الطباعة الواردة"),
         ("Incoming Print Job", "وظيفة طباعة واردة"),
         ("use-the-default-printer-tip", "استخدم الطابعة الافتراضية"),
         ("use-the-selected-printer-tip", "استخدم الطابعة المحددة"),

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -653,7 +653,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Upload folder", "上传文件夹"),
         ("Upload files", "上传文件"),
         ("Clipboard is synchronized", "剪贴板已同步"),
-        ("Update client clipboard", "更新客户端的粘贴板"),
+        ("Update client clipboard", "更新客户端的剪贴板"),
         ("Untagged", "无标签"),
         ("new-version-of-{}-tip", "{} 版本更新"),
         ("Accessible devices", "可访问的设备"),
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "被控端的权限设置拒绝了远程打印。"),
         ("save-settings-tip", "保存设置"),
         ("dont-show-again-tip", "不再显示此信息"),
+        ("Take screenshot", "截屏"),
+        ("screenshot-merged-screen-not-supported-tip", "当前不支持多个屏幕的合并截屏，请切换到单个屏幕重试。"),
+        ("screenshot-action-tip", "请选择如何继续截屏。"),
+        ("Save as", "另存为"),
+        ("Copy to clipboard", "复制到剪贴板"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "{} 打印机已安装，您可以使用打印功能了。"),
         ("Install {} Printer", "安装 {} 打印机"),
         ("Outgoing Print Jobs", "传出的打印任务"),
-        ("Incomming Print Jobs", "传入的打印任务"),
+        ("Incoming Print Jobs", "传入的打印任务"),
         ("Incoming Print Job", "传入的打印任务"),
         ("use-the-default-printer-tip", "使用默认的打印机执行"),
         ("use-the-selected-printer-tip", "使用选择的打印机执行"),

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "保存设置"),
         ("dont-show-again-tip", "不再显示此信息"),
         ("Take screenshot", "截屏"),
+        ("Taking screenshot", "正在截屏"),
         ("screenshot-merged-screen-not-supported-tip", "当前不支持多个屏幕的合并截屏，请切换到单个屏幕重试。"),
         ("screenshot-action-tip", "请选择如何继续截屏。"),
         ("Save as", "另存为"),

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "Der Drucker {} ist installiert und einsatzbereit."),
         ("Install {} Printer", "Drucker {} installieren"),
         ("Outgoing Print Jobs", "Ausgehende Druckaufträge"),
-        ("Incomming Print Jobs", "Eingehende Druckaufträge"),
+        ("Incoming Print Jobs", "Eingehende Druckaufträge"),
         ("Incoming Print Job", "Eingehender Druckauftrag"),
         ("use-the-default-printer-tip", "Standarddrucker verwenden"),
         ("use-the-selected-printer-tip", "Ausgewählten Drucker verwenden"),

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Einstellungen speichern"),
         ("dont-show-again-tip", "Nicht mehr anzeigen"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Die Berechtigungseinstellungen der kontrollierten Seite verweigern den entfernten Druck."),
         ("save-settings-tip", "Einstellungen speichern"),
         ("dont-show-again-tip", "Nicht mehr anzeigen"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -253,5 +253,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "The permission settings of the controlled side deny Remote Printing."),
         ("save-settings-tip", "Save settings"),
         ("dont-show-again-tip", "Don't show this again"),
+        ("screenshot-merged-screen-not-supported-tip", "Merging screenshots of multiple displays is currently not supported. Please switch to a single display and try again."),
+        ("screenshot-action-tip", "Please select how to continue with the screenshot."),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "La impresora {} está instalada y lista para usar."),
         ("Install {} Printer", "Instalar la impresora {}"),
         ("Outgoing Print Jobs", "Tareas salientes de impresión"),
-        ("Incomming Print Jobs", "Tareas entrantes de impresión"),
+        ("Incoming Print Jobs", "Tareas entrantes de impresión"),
         ("Incoming Print Job", "Trabajo entrante de impresión"),
         ("use-the-default-printer-tip", "Usar la impresora predeterminada"),
         ("use-the-selected-printer-tip", "Usar la impresora seleccionada"),

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Los ajustes de permisos del lado controlado no permiten la impresión remota."),
         ("save-settings-tip", "Guardar ajustes"),
         ("dont-show-again-tip", "No volver a mostrar"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Guardar ajustes"),
         ("dont-show-again-tip", "No volver a mostrar"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "شما مجوز لازم برای چاپ از راه دور را ندارید"),
         ("save-settings-tip", "تنظیمات را ذخیره کنید"),
         ("dont-show-again-tip", "دیگر نمایش داده نشود"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "چاپگر {} آماده است"),
         ("Install {} Printer", "نصب چاپگر {}"),
         ("Outgoing Print Jobs", "وظایف چاپ خروجی"),
-        ("Incomming Print Jobs", "وظایف چاپ ورودی"),
+        ("Incoming Print Jobs", "وظایف چاپ ورودی"),
         ("Incoming Print Job", "وظیفه چاپ ورودی"),
         ("use-the-default-printer-tip", "از چاپگر پیش‌فرض استفاده کنید"),
         ("use-the-selected-printer-tip", "از چاپگر انتخاب‌شده استفاده کنید"),

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "تنظیمات را ذخیره کنید"),
         ("dont-show-again-tip", "دیگر نمایش داده نشود"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "L’imprimante {} est installée et opérationnelle."),
         ("Install {} Printer", "Installer l’imprimante {}"),
         ("Outgoing Print Jobs", "Impressions sortantes"),
-        ("Incomming Print Jobs", "Impressions entrantes"),
+        ("Incoming Print Jobs", "Impressions entrantes"),
         ("Incoming Print Job", "Impression entrante"),
         ("use-the-default-printer-tip", "Utiliser l’imprimante par défaut"),
         ("use-the-selected-printer-tip", "Utiliser l’imprimante sélectionnée"),

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Les paramètres de l’appareil contrôlé n’autorisent pas l’impression à distance."),
         ("save-settings-tip", "Enregistrer les paramètres"),
         ("dont-show-again-tip", "Ne plus afficher"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Enregistrer les paramètres"),
         ("dont-show-again-tip", "Ne plus afficher"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "პარამეტრების შენახვა"),
         ("dont-show-again-tip", "აღარ აჩვენოთ"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "პრინტერი {} დაინსტალირებულია და მზად არის გამოსაყენებლად."),
         ("Install {} Printer", "დააინსტალირეთ პრინტერი {}"),
         ("Outgoing Print Jobs", "გამავალი ბეჭდვის დავალება"),
-        ("Incomming Print Jobs", "შემომავალი ბეჭდვის დავალება"),
+        ("Incoming Print Jobs", "შემომავალი ბეჭდვის დავალება"),
         ("Incoming Print Job", "შემომავალი ბეჭდვის დავალება"),
         ("use-the-default-printer-tip", "ნაგულისხმევი პრინტერის გამოყენება"),
         ("use-the-selected-printer-tip", "არჩეული პრინტერის გამოყენება"),

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -239,7 +239,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Empty", "ცარიელი"),
         ("Invalid folder name", "არასწორი საქაღალდის სახელი"),
         ("Socks5 Proxy", "SOCKS5-პროქსი"),
-        ("Proxy", "პროქსი"),
+        ("Socks5/Http(s) Proxy", ""),
         ("Discovered", "ნაპოვნია"),
         ("install_daemon_tip", "ჩატვირთვისას გასაშვებად საჭიროა სისტემური სერვისის დაყენება"),
         ("Remote ID", "დაშორებული ID"),
@@ -567,7 +567,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("id_input_tip", "შეგიძლიათ შეიყვანოთ იდენტიფიკატორი, პირდაპირი IP მისამართი ან დომენი პორტით (<დომენი>:<პორტი>).\nთუ გჭირდებათ წვდომა მოწყობილობაზე სხვა სერვერზე, დაამატეთ სერვერის მისამართი (<id>@<სერვერის_მისამართი>?key=<გასაღების_მნიშვნელობა>), მაგალითად:\n9123456234@192.168.16.1:21117?key=5Qbwsde3unUcJBtrx9ZkvUmwFNoExHzpryHuPUdqlWM=.\nთუ გჭირდებათ წვდომა მოწყობილობაზე საჯარო სერვერზე, შეიყვანეთ \"<id>@public\", გასაღები საჯარო სერვერისთვის არ არის საჭირო."),
         ("privacy_mode_impl_mag_tip", "რეჟიმი 1"),
         ("privacy_mode_impl_virtual_display_tip", "რეჟიმი 2"),
-        ("privacy_mode_impl_virtual_display_tip", "რეჟიმი 2"),
         ("Enter privacy mode", "კონფიდენციალურობის რეჟიმის ჩართვა"),
         ("Exit privacy mode", "კონფიდენციალურობის რეჟიმის გამორთვა"),
         ("idd_not_support_under_win10_2004_tip", "არაპირდაპირი ჩვენების დრაივერი არ არის მხარდაჭერილი. საჭიროა Windows 10 ვერსია 2004 ან უფრო ახალი."),
@@ -659,7 +658,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("new-version-of-{}-tip", "ხელმისაწვდომია ახალი ვერსია {}"),
         ("Accessible devices", "ხელმისაწვდომი მოწყობილობები"),
         ("View camera", "კამერის ნახვა"),
-        ("upgrade_remote_rustdesk_client_to{}_tip", "განაახლეთ RustDesk კლიენტი ვერსიამდე {} ან უფრო ახალი დისტანციურ მხარეზე!"),
+        ("upgrade_remote_rustdesk_client_to_{}_tip", ""),
         ("view_camera_unsupported_tip", "დისტანციური მოწყობილობა არ უჭერს მხარს კამერის ნახვას."),
         ("Enable camera", "კამერის ჩართვა"),
         ("No cameras", "კამერა არ არის"),
@@ -682,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "მართულ მხარეზე უფლებების პარამეტრები კრძალავს დისტანციურ ბეჭდვას."),
         ("save-settings-tip", "პარამეტრების შენახვა"),
         ("dont-show-again-tip", "აღარ აჩვენოთ"),
-  ].iter().cloned().collect();
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
+    ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "A(z) {} nyomtató készen áll"),
         ("Install {} Printer", "A(z) {} nyomtató nyomtató telepítése"),
         ("Outgoing Print Jobs", "Kimenő nyomtatási feladatok"),
-        ("Incomming Print Jobs", "Bejövő nyomtatási feladatok"),
+        ("Incoming Print Jobs", "Bejövő nyomtatási feladatok"),
         ("Incoming Print Job", "Bejövő nyomtatási feladat"),
         ("use-the-default-printer-tip", "Alapértelmezett nyomtató használata"),
         ("use-the-selected-printer-tip", "Kiválasztott nyomtató használata"),

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Beállítások mentése"),
         ("dont-show-again-tip", "Ne jelenítse meg újra"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "A távoli nyomtatás nincs engedélyezve"),
         ("save-settings-tip", "Beállítások mentése"),
         ("dont-show-again-tip", "Ne jelenítse meg újra"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Salva impostazioni"),
         ("dont-show-again-tip", "Non visualizzare più questo messaggio"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Le impostazioni di autorizzazione del lato controllato negano la stampa remota."),
         ("save-settings-tip", "Salva impostazioni"),
         ("dont-show-again-tip", "Non visualizzare più questo messaggio"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "La stampante {} è installata e pronta all'uso."),
         ("Install {} Printer", "Installa la stampante {}"),
         ("Outgoing Print Jobs", "Lavori di stampa in uscita"),
-        ("Incomming Print Jobs", "Lavori di stampa in entrata"),
+        ("Incoming Print Jobs", "Lavori di stampa in entrata"),
         ("Incoming Print Job", "Lavoro di stampa in entrata"),
         ("use-the-default-printer-tip", "Usa la stampante predefinita"),
         ("use-the-selected-printer-tip", "Usa la stampante selezionata"),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "Printeris {} ir instalēts un gatavs lietošanai."),
         ("Install {} Printer", "Instalēt {} printeri"),
         ("Outgoing Print Jobs", "Izejošie drukas darbi"),
-        ("Incomming Print Jobs", "Ienākošie drukas darbi"),
+        ("Incoming Print Jobs", "Ienākošie drukas darbi"),
         ("Incoming Print Job", "Ienākošais drukas darbs"),
         ("use-the-default-printer-tip", "Izmantot noklusējuma printeri"),
         ("use-the-selected-printer-tip", "Izmantot atlasīto printeri"),

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Saglabāt iestatījumus"),
         ("dont-show-again-tip", "Nerādīt šo vēlreiz"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Kontrolētās puses atļauju iestatījumi liedz attālo drukāšanu."),
         ("save-settings-tip", "Saglabāt iestatījumus"),
         ("dont-show-again-tip", "Nerādīt šo vēlreiz"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Machtigingsinstellingen aan beheerde zijde verhinderen afdrukken op afstand."),
         ("save-settings-tip", "Instellingen opslaan"),
         ("dont-show-again-tip", "Dit bericht wordt niet meer weergegeven"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Instellingen opslaan"),
         ("dont-show-again-tip", "Dit bericht wordt niet meer weergegeven"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "De printer {} is geïnstalleerd en klaar voor gebruik."),
         ("Install {} Printer", "Installeer {} Printer"),
         ("Outgoing Print Jobs", "Uitgaande Afdruktaken"),
-        ("Incomming Print Jobs", "Inkomende Afdruktaken"),
+        ("Incoming Print Jobs", "Inkomende Afdruktaken"),
         ("Incoming Print Job", "Inkomende Afdruktaak"),
         ("use-the-default-printer-tip", "Gebruik de standaard printer"),
         ("use-the-selected-printer-tip", "Gebruik de geselecteerde printer"),

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Ustawienia uprawnień po zdalnej stronie uniemożliwiają zdalne drukowanie."),
         ("save-settings-tip", "Zapisz ustawienia"),
         ("dont-show-again-tip", "Nie pokazuj więcej"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Zapisz ustawienia"),
         ("dont-show-again-tip", "Nie pokazuj więcej"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "Drukarka {} jest zainstalowana i gotowa do użycia."),
         ("Install {} Printer", "Zainstaluj drukarkę {}"),
         ("Outgoing Print Jobs", "Wychodzące zadania drukowania"),
-        ("Incomming Print Jobs", "Przychodzące zadania drukowania"),
+        ("Incoming Print Jobs", "Przychodzące zadania drukowania"),
         ("Incoming Print Job", "Przychodzące zadanie drukowania"),
         ("use-the-default-printer-tip", "Użyj domyślnej drukarki"),
         ("use-the-selected-printer-tip", "Użyj wybranej drukarki"),

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "A impressora {} está instalada e operacional."),
         ("Install {} Printer", "Instalar impressora {}"),
         ("Outgoing Print Jobs", "Trabalhos de impressão enviados"),
-        ("Incomming Print Jobs", "Trabalhos de impressão recebidos"),
+        ("Incoming Print Jobs", "Trabalhos de impressão recebidos"),
         ("Incoming Print Job", "Impressão recebida"),
         ("use-the-default-printer-tip", "Usar impressora padrão"),
         ("use-the-selected-printer-tip", "Usar impressora selecionada"),

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "As configurações do dispositivo controlado não permitem impressão remota."),
         ("save-settings-tip", "Salvar configurações"),
         ("dont-show-again-tip", "Não mostrar novamente"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Salvar configurações"),
         ("dont-show-again-tip", "Não mostrar novamente"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Настройки разрешений на управляемой стороне запрещают удалённую печать."),
         ("save-settings-tip", "Сохранить настройки"),
         ("dont-show-again-tip", "Больше не показывать"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "Принтер {} установлен и готов к использованию."),
         ("Install {} Printer", "Установить принтер {}"),
         ("Outgoing Print Jobs", "Исходящее задание печати"),
-        ("Incomming Print Jobs", "Входящее задание печати"),
+        ("Incoming Print Jobs", "Входящее задание печати"),
         ("Incoming Print Job", "Входящее задание печати"),
         ("use-the-default-printer-tip", "Использовать принтер по умолчанию"),
         ("use-the-selected-printer-tip", "Использовать выбранный принтер"),

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Сохранить настройки"),
         ("dont-show-again-tip", "Больше не показывать"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "S'imprentadora {} est installada e pronta pro s'impreu."),
         ("Install {} Printer", "Installa s'imprentadora {}"),
         ("Outgoing Print Jobs", "Traballos de imprenta in essida"),
-        ("Incomming Print Jobs", "Traballos de imprenta in intrada"),
+        ("Incoming Print Jobs", "Traballos de imprenta in intrada"),
         ("Incoming Print Job", "Traballu de imprenta in intrada"),
         ("use-the-default-printer-tip", "Imprea s'imprentadora predefinida"),
         ("use-the-selected-printer-tip", "Imprea s'imprentadora seletzionada"),

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "Sarva sas impostatziones"),
         ("dont-show-again-tip", "Non mustres prus custu messàgiu"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "Sas impostatziones de sos permissos de s'ala controllada negant s'imprenta remota."),
         ("save-settings-tip", "Sarva sas impostatziones"),
         ("dont-show-again-tip", "Non mustres prus custu messàgiu"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", "儲存設定"),
         ("dont-show-again-tip", "不再顯示此訊息"),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", "{} 印表機已安裝，您可以使用列印功能了。"),
         ("Install {} Printer", "安裝 {} 印表機"),
         ("Outgoing Print Jobs", "傳出的列印任務"),
-        ("Incomming Print Jobs", "傳入的列印任務"),
+        ("Incoming Print Jobs", "傳入的列印任務"),
         ("Incoming Print Job", "傳入的列印任務"),
         ("use-the-default-printer-tip", "使用預設的印表機"),
         ("use-the-selected-printer-tip", "使用選取的印表機"),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", "被控端的權限設置拒絕了遠端列印。"),
         ("save-settings-tip", "儲存設定"),
         ("dont-show-again-tip", "不再顯示此訊息"),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -671,7 +671,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("printer-{}-ready-tip", ""),
         ("Install {} Printer", ""),
         ("Outgoing Print Jobs", ""),
-        ("Incomming Print Jobs", ""),
+        ("Incoming Print Jobs", ""),
         ("Incoming Print Job", ""),
         ("use-the-default-printer-tip", ""),
         ("use-the-selected-printer-tip", ""),

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -682,6 +682,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
         ("Take screenshot", ""),
+        ("Taking screenshot", ""),
         ("screenshot-merged-screen-not-supported-tip", ""),
         ("screenshot-action-tip", ""),
         ("Save as", ""),

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -681,5 +681,10 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("remote-printing-disallowed-text-tip", ""),
         ("save-settings-tip", ""),
         ("dont-show-again-tip", ""),
+        ("Take screenshot", ""),
+        ("screenshot-merged-screen-not-supported-tip", ""),
+        ("screenshot-action-tip", ""),
+        ("Save as", ""),
+        ("Copy to clipboard", ""),
     ].iter().cloned().collect();
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2827,15 +2827,6 @@ impl Connection {
                             tx,
                         );
                         self.refresh_video_display(Some(request.display as usize));
-                    } else {
-                        let mut msg_out = Message::new();
-                        msg_out.set_screenshot_response(ScreenshotResponse {
-                            msg: "Unable to capture display at this time, please try again later."
-                                .to_owned(),
-                            sid: request.sid,
-                            ..Default::default()
-                        });
-                        self.send(msg_out).await;
                     }
                 }
                 _ => {}

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2819,6 +2819,25 @@ impl Connection {
                 Some(message::Union::VoiceCallResponse(_response)) => {
                     // TODO: Maybe we can do a voice call from cm directly.
                 }
+                Some(message::Union::ScreenshotRequest(request)) => {
+                    if let Some(tx) = self.inner.tx.clone() {
+                        crate::video_service::set_take_screenshot(
+                            request.display as _,
+                            request.sid.clone(),
+                            tx,
+                        );
+                        self.refresh_video_display(Some(request.display as usize));
+                    } else {
+                        let mut msg_out = Message::new();
+                        msg_out.set_screenshot_response(ScreenshotResponse {
+                            msg: "Unable to capture display at this time, please try again later."
+                                .to_owned(),
+                            sid: request.sid,
+                            ..Default::default()
+                        });
+                        self.send(msg_out).await;
+                    }
+                }
                 _ => {}
             }
         }

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -230,6 +230,7 @@ class Header: Reactor.Component {
                 {restart_enabled && (pi.platform == "Linux" || pi.platform == "Windows" || pi.platform == "Mac OS") ? <li #restart_remote_device>{translate('Restart remote device')}</li> : ""}
                 {keyboard_enabled ? <li #lock-screen>{translate('Insert Lock')}</li> : ""}
                 {keyboard_enabled && pi.platform == "Windows" && pi.sas_enabled ? <li #block-input>{translate("Block user input")}</li> : ""}
+                {handler.is_screenshot_supported() ? <li #take-screenshot>{translate('Take screenshot')}</li> : "" }
                 <li #refresh>{translate('Refresh')}</li>
             </menu>
         </popup>;
@@ -375,6 +376,10 @@ class Header: Reactor.Component {
 
     event click $(#lock-screen) {
         handler.lock_screen();
+    }
+
+    event click $(#take-screenshot) {
+        handler.take_screenshot(pi.current_display, "");
     }
     
     event click $(#refresh) {
@@ -543,6 +548,26 @@ handler.setCurrentDisplay = function(v) {
     header.update();
     if (is_port_forward) {
         view.windowState = View.WINDOW_MINIMIZED;
+    }
+}
+
+handler.screenshot = function(msg) {
+    if (msg) {
+        msgbox(
+            "custom-nocancel-nook-hasclose-error",
+            translate("Take screenshot"),
+            msg,
+            "",
+            function() {}
+        );
+    } else {
+        msgbox(
+            "custom-take-screenshot-nocancel-nook",
+            translate("Take screenshot"),
+            translate("screenshot-action-tip"),
+            "",
+            function() {}
+        );
     }
 }
 

--- a/src/ui/msgbox.tis
+++ b/src/ui/msgbox.tis
@@ -132,6 +132,17 @@ class MsgboxComponent: Reactor.Component {
         return this.type.indexOf("skip") >= 0;
     }
 
+    function getScreenshotButtons() {
+        var isScreenshot = this.type.indexOf("take-screenshot") >= 0;
+        return isScreenshot 
+            ? <div>
+                <button .button #screenshotSaveAs .outline>{translate('Save as')}...</button>
+                <button .button #screenshotCopyToClip .outline>{translate('Copy to clipboard')}</button>
+                <button .button #screenshotCancel .outline>{translate('Cancel')}</button>
+            </div>
+            : "";
+    }
+
     function render() {
         this.set_outline_focus();
         var color = this.getColor();
@@ -170,6 +181,7 @@ class MsgboxComponent: Reactor.Component {
                     {hasOk || this.hasRetry ? <button .button #submit>{translate(this.hasRetry ? "Retry" : "OK")}</button> : ""}
                     {hasLink ? <button .button #jumplink .outline>{translate('JumpLink')}</button> : ""}
                     {hasClose ? <button .button #cancel .outline>{translate('Close')}</button> : ""}
+                    {this.getScreenshotButtons()}
                 </div>
             </div>
             </div>
@@ -244,6 +256,39 @@ class MsgboxComponent: Reactor.Component {
         } else {
             this.close();
         }
+    }
+
+    event click $(button#screenshotSaveAs) {
+        this.close();
+
+        handler.leave(handler.get_keyboard_mode());
+        const filter = "Png file (*.png)";
+        const defaultExt = "png";
+        const initialPath = System.path(#USER_DOCUMENTS, "screenshot");
+        const caption = "Save as";
+        var url = view.selectFile(#save, filter, defaultExt, initialPath, caption);
+        handler.enter(handler.get_keyboard_mode());
+        if(url) {
+            var res = handler.handle_screenshot("0:" + URL.toPath(url));
+            if (res) {
+                msgbox("custom-error-nocancel-nook-hasclose", "Take screenshot", res, "", function() {});
+            }
+        } else {
+            handler.handle_screenshot("2");
+        }
+    }
+
+    event click $(button#screenshotCopyToClip) {
+        this.close();
+        var res = handler.handle_screenshot("1");
+        if (res) {
+            msgbox("custom-error-nocancel-nook-hasclose", "Take screenshot", res, "", function() {});
+        }
+    }
+
+    event click $(button#screenshotCancel) {
+        this.close();
+        handler.handle_screenshot("2");
     }
     
     event keydown (evt) {

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -383,6 +383,10 @@ impl InvokeUiSession for SciterHandler {
     fn printer_request(&self, id: i32, path: String) {
         self.call("printerRequest", &make_args!(id, path));
     }
+
+    fn handle_screenshot_resp(&self, _sid: String, msg: String) {
+        self.call("screenshot", &make_args!(msg));
+    }
 }
 
 pub struct SciterSession(Session<SciterHandler>);
@@ -529,6 +533,9 @@ impl sciter::EventHandler for SciterSession {
         fn save_custom_image_quality(i32);
         fn refresh_video(i32);
         fn record_screen(bool);
+        fn is_screenshot_supported();
+        fn take_screenshot(i32, String);
+        fn handle_screenshot(String);
         fn get_toggle_option(String);
         fn is_privacy_mode_supported();
         fn toggle_option(String);
@@ -865,6 +872,10 @@ impl SciterSession {
 
     fn on_printer_selected(&self, id: i32, path: String, printer_name: String) {
         self.printer_response(id, path, printer_name);
+    }
+
+    fn handle_screenshot(&self, action: String) -> String {
+        crate::client::screenshot::handle_screenshot(action)
     }
 }
 

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -412,6 +412,14 @@ impl<T: InvokeUiSession> Session<T> {
         self.send(Data::RecordScreen(start));
     }
 
+    pub fn is_screenshot_supported(&self) -> bool {
+        crate::common::is_support_screenshot_num(self.lc.read().unwrap().version)
+    }
+
+    pub fn take_screenshot(&self, display: i32, sid: String) {
+        self.send(Data::TakeScreenshot((display, sid)));
+    }
+
     pub fn is_recording(&self) -> bool {
         self.lc.read().unwrap().record_state
     }
@@ -1586,6 +1594,7 @@ pub trait InvokeUiSession: Send + Sync + Clone + 'static + Sized + Default {
     fn update_record_status(&self, start: bool);
     fn update_empty_dirs(&self, _res: ReadEmptyDirsResponse) {}
     fn printer_request(&self, id: i32, path: String);
+    fn handle_screenshot_resp(&self, sid: String, msg: String);
 }
 
 impl<T: InvokeUiSession> Deref for Session<T> {


### PR DESCRIPTION
## Preview

https://github.com/user-attachments/assets/ea4d3bca-7660-4fe0-b34a-5ef0783c34dc


https://github.com/user-attachments/assets/f0e93fd0-a478-4411-9bcd-0c0944a9e5bb


https://github.com/user-attachments/assets/2fc96762-d269-445c-8121-a8b9ef063965

## Note

1. Taking screenshot is very slow, because encoding png is slow.
2. Windows, Linux, MacOS are tested. "Save as...", "Copy to clipboard", "Cancel".
3. Default png filename in sciter version does not contain the timestamp, because `Date` in sciter is different to js. I did not find a way to get the timestamp.
4. The sciter version does not disable the action "Take screenshot" for now. Because we can't cancel a timer in sciter, `self.timer()` always return `undefined` in sciter.
