### PR TITLE
fix: lan discovery

### DIFF
--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -501,6 +501,7 @@ class DiscoveredPeersView extends BasePeersView {
   Widget build(BuildContext context) {
     final widget = super.build(context);
     bind.mainLoadLanPeers();
+    bind.mainDiscover();
     return widget;
   }
 }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/11589

`bind.mainDiscover()` was removed in this PR https://github.com/rustdesk/rustdesk/pull/10859

