### PR TITLE
Refact/win tray

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1244,7 +1244,10 @@ pub fn check_process(arg: &str, same_session_id: bool) -> bool {
         arg,
         same_session_id,
     ) {
-        Ok(pids) => !pids.is_empty(),
+        Ok(pids) => {
+            let self_pid = hbb_common::sysinfo::Pid::from_u32(std::process::id());
+            pids.into_iter().filter(|pid| *pid != self_pid).count() > 0
+        }
         Err(e) => {
             log::error!("Failed to check process with arg: \"{}\", {}", arg, e);
             false

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -259,7 +259,7 @@ pub fn core_main() -> Option<Vec<String>> {
             }
         } else if args[0] == "--tray" {
             if !crate::check_process("--tray", true) {
-                crate::tray::start_tray();
+                crate::tray::start_tray(false);
             }
             return None;
         } else if args[0] == "--install-service" {
@@ -295,7 +295,7 @@ pub fn core_main() -> Option<Vec<String>> {
             #[cfg(target_os = "macos")]
             {
                 let handler = std::thread::spawn(move || crate::start_server(true, false));
-                crate::tray::start_tray();
+                crate::tray::start_tray(true);
                 // prevent server exit when encountering errors from tray
                 hbb_common::allow_err!(handler.join());
             }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", "请选择如何继续截屏。"),
         ("Save as", "另存为"),
         ("Copy to clipboard", "复制到剪贴板"),
+        ("Exit tray", "推出托盘"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", "Выберите, что делать с полученным снимком экрана."),
         ("Save as", "Сохранить в файл"),
         ("Copy to clipboard", "Копировать в буфер обмена"),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -687,5 +687,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", ""),
         ("Save as", ""),
         ("Copy to clipboard", ""),
+        ("Exit tray", ""),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
1. Fix `check_process` on Windows x86 process. By using `wmic` to get the command line arguments.
2. Refactor the tray menu. Remove `Exit`, add `Exit tray` and `Stop service`. `Exit tray` will only exit the tray process, `Stop service` does the same thing to the old `Exit`.