### PR TITLE
feat, trackpad speed

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -1624,29 +1624,14 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
 }
 
 trackpadSpeedDialog(SessionID sessionId, FFI ffi) async {
-  final speed = await bind.sessionGetFlutterOption(
-      sessionId: sessionId, k: kKeyTrackpadSpeed);
-  var initSpeed = kDefaultTrackpadSpeed;
-  if (speed != null && speed.isNotEmpty) {
-    try {
-      initSpeed = double.parse(speed);
-    } catch (e) {
-      debugPrint('Failed to parse the trackpad speed, "$speed": $e');
-    }
-  }
-  if (initSpeed < kMinTrackpadSpeed || initSpeed > kMaxTrackpadSpeed) {
-    initSpeed = kDefaultTrackpadSpeed;
-  }
-
+  int initSpeed = ffi.inputModel.trackpadSpeed;
   final curSpeed = SimpleWrapper(initSpeed);
   final btnClose = dialogButton('Close', onPressed: () async {
     if (curSpeed.value <= kMaxTrackpadSpeed &&
         curSpeed.value >= kMinTrackpadSpeed &&
-        (curSpeed.value - initSpeed).abs() > 0.01) {
-      await bind.sessionSetFlutterOption(
-          sessionId: sessionId,
-          k: kKeyTrackpadSpeed,
-          v: curSpeed.value.toString());
+        curSpeed.value != initSpeed) {
+      await bind.sessionSetTrackpadSpeed(
+          sessionId: sessionId, value: curSpeed.value);
       await ffi.inputModel.updateTrackpadSpeed();
     }
     ffi.dialogManager.dismissAll();

--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -1623,6 +1623,43 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
   msgBoxCommon(ffi.dialogManager, 'Custom Image Quality', content, [btnClose]);
 }
 
+trackpadSpeedDialog(SessionID sessionId, FFI ffi) async {
+  final speed = await bind.sessionGetFlutterOption(
+      sessionId: sessionId, k: kKeyTrackpadSpeed);
+  var initSpeed = kDefaultTrackpadSpeed;
+  if (speed != null && speed.isNotEmpty) {
+    try {
+      initSpeed = double.parse(speed);
+    } catch (e) {
+      debugPrint('Failed to parse the trackpad speed, "$speed": $e');
+    }
+  }
+  if (initSpeed < kMinTrackpadSpeed || initSpeed > kMaxTrackpadSpeed) {
+    initSpeed = kDefaultTrackpadSpeed;
+  }
+
+  final curSpeed = SimpleWrapper(initSpeed);
+  final btnClose = dialogButton('Close', onPressed: () async {
+    if (curSpeed.value <= kMaxTrackpadSpeed &&
+        curSpeed.value >= kMinTrackpadSpeed &&
+        (curSpeed.value - initSpeed).abs() > 0.01) {
+      await bind.sessionSetFlutterOption(
+          sessionId: sessionId,
+          k: kKeyTrackpadSpeed,
+          v: curSpeed.value.toString());
+      await ffi.inputModel.updateTrackpadSpeed();
+    }
+    ffi.dialogManager.dismissAll();
+  });
+  msgBoxCommon(
+      ffi.dialogManager,
+      'Trackpad speed',
+      TrackpadSpeedWidget(
+        value: curSpeed,
+      ),
+      [btnClose]);
+}
+
 void deleteConfirmDialog(Function onSubmit, String title) async {
   gFFI.dialogManager.show(
     (setState, close, context) {

--- a/flutter/lib/common/widgets/setting_widgets.dart
+++ b/flutter/lib/common/widgets/setting_widgets.dart
@@ -248,3 +248,76 @@ List<(String, String)> otherDefaultSettings() {
 
   return v;
 }
+
+class TrackpadSpeedWidget extends StatefulWidget {
+  final SimpleWrapper<double> value;
+
+  TrackpadSpeedWidget({Key? key, required this.value});
+
+  @override
+  TrackpadSpeedWidgetState createState() => TrackpadSpeedWidgetState();
+}
+
+class TrackpadSpeedWidgetState extends State<TrackpadSpeedWidget> {
+  final TextEditingController _controller = TextEditingController();
+
+  set value(double v) => widget.value.value = v;
+  double get value => widget.value.value;
+
+  void updateValue(double newValue) {
+    setState(() {
+      value = newValue.clamp(kMinTrackpadSpeed, kMaxTrackpadSpeed);
+      _controller.text = ((value * 100.0).round()).toString();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_controller.text.isEmpty) {
+      _controller.text = ((value * 100.0).round()).toString();
+    }
+    return Row(
+      children: [
+        Expanded(
+          flex: 3,
+          child: Slider(
+            value: value,
+            min: kMinTrackpadSpeed,
+            max: kMaxTrackpadSpeed,
+            divisions: ((kMaxTrackpadSpeed - kMinTrackpadSpeed) / 0.1).round(),
+            onChanged: (double v) => updateValue(v),
+          ),
+        ),
+        Expanded(
+            flex: 1,
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 56,
+                  child: TextField(
+                    controller: _controller,
+                    keyboardType: TextInputType.number,
+                    textAlign: TextAlign.center,
+                    onSubmitted: (text) {
+                      int? v = int.tryParse(text);
+                      if (v != null) {
+                        updateValue(v.toDouble() / 100.0);
+                      }
+                    },
+                    style: const TextStyle(fontSize: 13),
+                    decoration: InputDecoration(
+                      contentPadding:
+                          EdgeInsets.symmetric(vertical: 8.0, horizontal: 12.0),
+                    ),
+                  ),
+                ).marginOnly(right: 8.0),
+                Text(
+                  '%',
+                  style: const TextStyle(fontSize: 15),
+                )
+              ],
+            )),
+      ],
+    );
+  }
+}

--- a/flutter/lib/common/widgets/setting_widgets.dart
+++ b/flutter/lib/common/widgets/setting_widgets.dart
@@ -267,6 +267,7 @@ class TrackpadSpeedWidgetState extends State<TrackpadSpeedWidget> {
   void updateValue(double newValue) {
     setState(() {
       value = newValue.clamp(kMinTrackpadSpeed, kMaxTrackpadSpeed);
+      // Scale the trackpad speed value to a percentage for display purposes.
       _controller.text = ((value * 100.0).round()).toString();
     });
   }

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -226,6 +226,12 @@ const double kDefaultQuality = 50;
 const double kMaxQuality = 100;
 const double kMaxMoreQuality = 2000;
 
+// trackpad speed
+const String kKeyTrackpadSpeed = 'trackpad-speed';
+const double kMinTrackpadSpeed = 0.1;
+const double kDefaultTrackpadSpeed = 1.0;
+const double kMaxTrackpadSpeed = 10;
+
 // incomming (should be incoming) is kept, because change it will break the previous setting.
 const String kKeyPrinterIncomingJobAction = 'printer-incomming-job-action';
 const String kValuePrinterIncomingJobDismiss = 'dismiss';

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -228,9 +228,9 @@ const double kMaxMoreQuality = 2000;
 
 // trackpad speed
 const String kKeyTrackpadSpeed = 'trackpad-speed';
-const double kMinTrackpadSpeed = 0.1;
-const double kDefaultTrackpadSpeed = 1.0;
-const double kMaxTrackpadSpeed = 10;
+const int kMinTrackpadSpeed = 10;
+const int kDefaultTrackpadSpeed = 100;
+const int kMaxTrackpadSpeed = 1000;
 
 // incomming (should be incoming) is kept, because change it will break the previous setting.
 const String kKeyPrinterIncomingJobAction = 'printer-incomming-job-action';

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -76,7 +76,9 @@ class DesktopSettingPage extends StatefulWidget {
     if (!isWeb && !bind.isIncomingOnly() && bind.pluginFeatureIsEnabled())
       SettingsTabKey.plugin,
     if (!bind.isDisableAccount()) SettingsTabKey.account,
-    if (isWindows && bind.mainGetBuildinOption(key: kOptionHideRemotePrinterSetting) != 'Y') SettingsTabKey.printer,
+    if (isWindows &&
+        bind.mainGetBuildinOption(key: kOptionHideRemotePrinterSetting) != 'Y')
+      SettingsTabKey.printer,
     SettingsTabKey.about,
   ];
 
@@ -1602,6 +1604,7 @@ class _DisplayState extends State<_Display> {
       scrollStyle(context),
       imageQuality(context),
       codec(context),
+      if (isDesktop) trackpadSpeed(context),
       if (!isWeb) privacyModeImpl(context),
       other(context),
     ]).marginOnly(bottom: _kListViewBottomMargin);
@@ -1686,6 +1689,26 @@ class _DisplayState extends State<_Display> {
         offstage: groupValue != kRemoteImageQualityCustom,
         child: customImageQualitySetting(),
       )
+    ]);
+  }
+
+  Widget trackpadSpeed(BuildContext context) {
+    final initSpeed = (int.tryParse(
+            bind.mainGetUserDefaultOption(key: kKeyTrackpadSpeed)) ??
+        kDefaultTrackpadSpeed);
+    final curSpeed = SimpleWrapper(initSpeed);
+    void onDebouncer(int v) {
+      bind.mainSetUserDefaultOption(
+          key: kKeyTrackpadSpeed, value: v.toString());
+      // It's better to notify all sessions that the default speed is changed.
+      // But it may also be ok to take effect in the next connection.
+    }
+
+    return _Card(title: 'Default trackpad speed', children: [
+      TrackpadSpeedWidget(
+        value: curSpeed,
+        onDebouncer: onDebouncer,
+      ),
     ]);
   }
 

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hbb/common/widgets/audio_input.dart';
+import 'package:flutter_hbb/common/widgets/dialog.dart';
 import 'package:flutter_hbb/common/widgets/toolbar.dart';
 import 'package:flutter_hbb/models/chat_model.dart';
 import 'package:flutter_hbb/models/state_model.dart';
@@ -1594,8 +1595,26 @@ class _KeyboardMenu extends StatelessWidget {
               viewMode(),
               Divider(),
               ...toolbarToggles(),
+              ...mouseSpeed(),
               ...mobileActions(),
             ]);
+  }
+
+  mouseSpeed() {
+    final speedWidgets = [];
+    final sessionId = ffi.sessionId;
+    if (isDesktop) {
+      if (ffi.ffiModel.keyboard) {
+        final enabled = !ffi.ffiModel.viewOnly;
+        final trackpad = MenuButton(
+          child: Text(translate('Trackpad speed')).paddingOnly(left: 26.0),
+          onPressed: enabled ? () => trackpadSpeedDialog(sessionId, ffi) : null,
+          ffi: ffi,
+        );
+        speedWidgets.add(trackpad);
+      }
+    }
+    return speedWidgets;
   }
 
   keyboardMode() {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -387,6 +387,19 @@ class InputModel {
     }
   }
 
+  /// Updates the trackpad speed based on the session option value.
+  /// 
+  /// This function retrieves the trackpad speed setting from the session
+  /// using `sessionGetFlutterOption`. The expected format of the retrieved
+  /// value is a string that can be parsed into a double. If parsing fails
+  /// or the value is out of bounds (less than `kMinTrackpadSpeed` or greater
+  /// than `kMaxTrackpadSpeed`), the trackpad speed is reset to the default
+  /// value (`kDefaultTrackpadSpeed`).
+  /// 
+  /// Bounds:
+  /// - Minimum: `kMinTrackpadSpeed`
+  /// - Maximum: `kMaxTrackpadSpeed`
+  /// - Default: `kDefaultTrackpadSpeed`
   Future<void> updateTrackpadSpeed() async {
     final speed = await bind.sessionGetFlutterOption(
         sessionId: sessionId, k: kKeyTrackpadSpeed);

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2991,6 +2991,10 @@ class FFI {
       textureModel.updateCurrentDisplay(display ?? 0);
     }
 
+    if (isDesktop) {
+      inputModel.updateTrackpadSpeed();
+    }
+
     // CAUTION: `sessionStart()` and `sessionStartWithDisplays()` are an async functions.
     // Though the stream is returned immediately, the stream may not be ready.
     // Any operations that depend on the stream should be carefully handled.

--- a/src/client.rs
+++ b/src/client.rs
@@ -2105,6 +2105,12 @@ impl LoginConfigHandler {
         res
     }
 
+    pub fn save_trackpad_speed(&mut self, speed: i32) {
+        let mut config = self.load_config();
+        config.trackpad_speed = speed;
+        self.save_config(config);
+    }
+
     /// Create a [`Message`] for saving custom fps.
     ///
     /// # Arguments

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -492,6 +492,20 @@ pub fn session_set_custom_fps(session_id: SessionID, fps: i32) {
     }
 }
 
+pub fn session_get_trackpad_speed(session_id: SessionID) -> Option<i32> {
+    if let Some(session) = sessions::get_session_by_session_id(&session_id) {
+        Some(session.get_trackpad_speed())
+    } else {
+        None
+    }
+}
+
+pub fn session_set_trackpad_speed(session_id: SessionID, value: i32) {
+    if let Some(session) = sessions::get_session_by_session_id(&session_id) {
+        session.save_trackpad_speed(value);
+    }
+}
+
 pub fn session_lock_screen(session_id: SessionID) {
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
         session.lock_screen();

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", "安装方式检测失败。请点击\"下载\"按钮，从发布网址下载，并手动升级。"),
         ("websocket_tip", "使用 WebSocket 时，仅支持中继连接。"),
         ("Use WebSocket", "使用 WebSocket"),
+        ("Trackpad speed", "触控板速度"),
+        ("Default trackpad speed", "默认触控板速度"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", "Prüfung der Installationsmethode fehlgeschlagen. Bitte klicken Sie auf die Schaltfläche \"Herunterladen\", um von der Versionsseite herunterzuladen und manuell zu aktualisieren."),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", "Controllo metodo installazione non riuscito.\nSeleziona 'Download' per scaricare il programma e aggiornarlo manualmente."),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", "업데이트에 실패했습니다. .msi 설치 파일을 확인하세요."),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", "Kan de installatiemethode niet bepalen. Klik op “Downloaden” om de applicatie van de officiële website te downloaden en handmatig bij te werken."),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", "Sprawdzenie metody instalacji nie powiodło się. Kliknij przycisk \"Pobierz\", aby pobrać ze strony wydania i uaktualnić ręcznie."),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", "Невозможно определить метод установки. Нажмите кнопку \"Скачать\", чтобы скачать приложение с официального сайта и обновить его вручную."),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vn.rs
+++ b/src/lang/vn.rs
@@ -696,5 +696,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("update-failed-check-msi-tip", ""),
         ("websocket_tip", ""),
         ("Use WebSocket", ""),
+        ("Trackpad speed", ""),
+        ("Default trackpad speed", ""),
     ].iter().cloned().collect();
 }

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -230,6 +230,10 @@ impl<T: InvokeUiSession> Session<T> {
         self.lc.read().unwrap().version.clone()
     }
 
+    pub fn get_trackpad_speed(&self) -> i32 {
+        self.lc.read().unwrap().trackpad_speed
+    }
+
     pub fn fallback_keyboard_mode(&self) -> String {
         let peer_version = self.get_peer_version();
         let platform = self.peer_platform();
@@ -446,6 +450,10 @@ impl<T: InvokeUiSession> Session<T> {
                 self.send(Data::Message(msg));
             }
         }
+    }
+
+    pub fn save_trackpad_speed(&self, trackpad_speed: i32) {
+        self.lc.write().unwrap().save_trackpad_speed(trackpad_speed);
     }
 
     pub fn set_custom_fps(&self, custom_fps: i32) {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/5675
https://github.com/rustdesk/rustdesk/discussions/11576
https://github.com/rustdesk/rustdesk/discussions/10681

1. Adjust mac -> win, trackpad speed. `final _trackpadAdjustMacToWin = 2.50;`
2. Add a session setting for trackpad speed.

## Preview

https://github.com/user-attachments/assets/835a2db6-6a21-4b60-909c-949a135dffcf


https://github.com/user-attachments/assets/f5d1aa16-0e8c-415f-a9e2-bd162240f932



## Note

`Windows/macOS` -> `Windows/macOS/Linux`, are tested, only `macOS` -> `Windows` seems to be very slow.

`Linux` as the controlling side is not tested, because VM does not trigger the trackpad events. Flutter can only detect the mouse  events.

