### PR TITLE
fix pull ab twice in log

### DIFF
--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -775,7 +775,10 @@ abstract class BaseAb {
 
   final pullError = "".obs;
   final pushError = "".obs;
-  final abLoading = false.obs;
+  final abLoading = false
+      .obs; // Indicates whether the UI should show a loading state for the address book.
+  var abPulling =
+      false; // Tracks whether a pull operation is currently in progress to prevent concurrent pulls. Unlike abLoading, this is not tied to UI updates.
   bool initialized = false;
 
   String name();
@@ -790,17 +793,22 @@ abstract class BaseAb {
   }
 
   Future<void> pullAb({quiet = false}) async {
-    debugPrint("pull ab \"${name()}\"");
-    if (abLoading.value) return;
+    if (abPulling) return;
+    abPulling = true;
     if (!quiet) {
       abLoading.value = true;
       pullError.value = "";
     }
     initialized = false;
+    debugPrint("pull ab \"${name()}\"");
     try {
       initialized = await pullAbImpl(quiet: quiet);
-    } catch (_) {}
-    abLoading.value = false;
+    } catch (e) {
+      debugPrint("Error occurred while pulling address book: $e");
+    } finally {
+      abLoading.value = false;
+      abPulling = false;
+    }
   }
 
   Future<bool> pullAbImpl({quiet = false});


### PR DESCRIPTION
The reason for calling `pullAb` twice is that when `pullAb` is called for the first time, `setCurrentName` is also called. In `setCurrentName`, if the current address book has not been initialized, it will also attempt to pull. Because `quiet` is false during the first call and `setCurrentName` is not `await` synchronously, the `abLoading` can prevent the two calls. However, `abLoading` depends on `quiet`, so we would better to add a new variable `abPulling`.


https://github.com/rustdesk/rustdesk/blob/1a8e3005cdc4e8fef080dafc0e8720ae980daf4c/flutter/lib/models/ab_model.dart#L170

https://github.com/rustdesk/rustdesk/blob/1a8e3005cdc4e8fef080dafc0e8720ae980daf4c/flutter/lib/models/ab_model.dart#L175

https://github.com/rustdesk/rustdesk/blob/1a8e3005cdc4e8fef080dafc0e8720ae980daf4c/flutter/lib/models/ab_model.dart#L691


before:

![image](https://github.com/user-attachments/assets/e1f55cc1-e967-43cc-bd82-41a68fcc5911)

after:

https://github.com/user-attachments/assets/8889a2aa-2b3d-435d-8fe0-8d14c514dd78

