### PR TITLE
refact: mouse scroll, remote tabs

### DIFF
--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -651,7 +651,9 @@ class _DesktopTabState extends State<DesktopTab>
                                     controller.state.value.scrollController;
                                 if (!sc.canScroll) return;
                                 _scrollDebounce.call(() {
-                                  sc.animateTo(sc.offset + e.scrollDelta.dy,
+                                  double adjust = 2.5;
+                                  sc.animateTo(
+                                      sc.offset + e.scrollDelta.dy * adjust,
                                       duration: Duration(milliseconds: 200),
                                       curve: Curves.ease);
                                 });


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/11705

## Preview

https://github.com/user-attachments/assets/906dd021-6029-4fff-b2df-8e54b516a164


https://github.com/user-attachments/assets/fc3d1ffd-d841-41cc-b54c-f7bbea4783db


With `2.5`x rate applied, when peer ID is 10 digits, one mouse scroll distance is slightly larger than one tab.

## Note

A better way to switch between the tabs is using the dropdown list.

<img width="373" alt="1746939466120" src="https://github.com/user-attachments/assets/583b4c6f-c1fb-4dde-aecc-9c44119bae4a" />
