### PR TITLE
fix: login 2fa

### DIFF
--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -188,7 +188,9 @@ class UserModel {
       rethrow;
     }
 
-    if (loginResponse.user != null) {
+    final isLogInDone = loginResponse.type == HttpType.kAuthResTypeToken &&
+        loginResponse.access_token != null;
+    if (isLogInDone && loginResponse.user != null) {
       _parseAndUpdateUser(loginResponse.user!);
     }
 


### PR DESCRIPTION
Fixed login issue so username is set even if no `access_token` is obtained.

Only call `_parseAndUpdateUser()` when login done on `login()`.


## Tests

- [x] Username/Password login, with and without 2fa.
- [x] OIDC login, with and without 2fa.
