### PR TITLE
fix: typos in src/ and subdirectories

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1762,7 +1762,7 @@ impl LoginConfigHandler {
     ///
     // It's Ok to check the option empty in this function.
     // `toggle_option()` is only called in a session.
-    // Custom client advanced settings will not affact this function.
+    // Custom client advanced settings will not effect this function.
     pub fn toggle_option(&mut self, name: String) -> Option<Message> {
         let mut option = OptionMessage::default();
         let mut config = self.load_config();
@@ -2006,7 +2006,7 @@ impl LoginConfigHandler {
     ///
     // It's Ok to check the option empty in this function.
     // `get_toggle_option()` is only called in a session.
-    // Custom client advanced settings will not affact this function.
+    // Custom client advanced settings will not effect this function.
     pub fn get_toggle_option(&self, name: &str) -> bool {
         if name == "show-remote-cursor" {
             self.config.show_remote_cursor.v

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -256,7 +256,7 @@ impl ClipboardContext {
             let mut i = 1;
             loop {
                 // Try 5 times to create clipboard
-                // Arboard::new() connect to X server or Wayland compositor, which shoud be ok at most time
+                // Arboard::new() connect to X server or Wayland compositor, which should be OK most times
                 // But sometimes, the connection may fail, so we retry here.
                 match arboard::Clipboard::new() {
                     Ok(x) => {
@@ -313,7 +313,7 @@ impl ClipboardContext {
 
     pub fn get(&mut self, side: ClipboardSide, force: bool) -> ResultType<Vec<ClipboardData>> {
         let data = self.get_formats_filter(SUPPORTED_FORMATS, side, force)?;
-        // We have a seperate service named `file-clipboard` to handle file copy-paste.
+        // We have a separate service named `file-clipboard` to handle file copy-paste.
         // We need to read the file urls because file copy may set the other clipboard formats such as text.
         #[cfg(feature = "unix-file-copy-paste")]
         {
@@ -755,7 +755,7 @@ pub fn get_clipboards_msg(client: bool) -> Option<Message> {
 }
 
 // We need this mod to notify multiple subscribers when the clipboard changes.
-// Because only one clipboard master(listener) can tigger the clipboard change event multiple listeners are created on Linux(x11).
+// Because only one clipboard master(listener) can trigger the clipboard change event multiple listeners are created on Linux(x11).
 // https://github.com/rustdesk-org/clipboard-master/blob/4fb62e5b62fb6350d82b571ec7ba94b3cd466695/src/master/x11.rs#L226
 #[cfg(not(target_os = "android"))]
 pub mod clipboard_listener {

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1918,7 +1918,7 @@ pub(super) fn session_update_virtual_display(session: &FlutterSession, index: i3
             let mut vdisplays = displays.split(',').collect::<Vec<_>>();
             let len = vdisplays.len();
             if index == 0 {
-                // 0 means we cann't toggle the virtual display by index.
+                // 0 means we can't toggle the virtual display by index.
                 vdisplays.remove(vdisplays.len() - 1);
             } else {
                 if let Some(i) = vdisplays.iter().position(|&x| x == index.to_string()) {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -268,7 +268,7 @@ pub enum Data {
     CheckHwcodec,
     #[cfg(feature = "flutter")]
     VideoConnCount(Option<usize>),
-    // Although the key is not neccessary, it is used to avoid hardcoding the key.
+    // Although the key is not necessary, it is used to avoid hardcoding the key.
     WaylandScreencastRestoreToken((String, String)),
     HwCodecConfig(Option<String>),
     RemoveTrustedDevices(Vec<Bytes>),

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -902,7 +902,7 @@ fn _map_keyboard_mode(_peer: &str, event: &Event, mut key_event: KeyEvent) -> Op
     let keycode = match _peer {
         OS_LOWER_WINDOWS => {
             // https://github.com/rustdesk/rustdesk/issues/1371
-            // Filter scancodes that are greater than 255 and the hight word is not 0xE0.
+            // Filter scancodes that are greater than 255 and the height word is not 0xE0.
             if event.position_code > 255 && (event.position_code >> 8) != 0xE0 {
                 return None;
             }

--- a/src/platform/linux_desktop_manager.rs
+++ b/src/platform/linux_desktop_manager.rs
@@ -321,7 +321,7 @@ impl DesktopManager {
             ),
             // ("DISPLAY", self.display.clone()),
             // ("XAUTHORITY", self.xauth.clone()),
-            // (ENV_DESKTOP_PROTOCAL, XProtocal::X11.to_string()),
+            // (ENV_DESKTOP_PROTOCOL, XProtocol::X11.to_string()),
         ]);
         self.child_exit.store(false, Ordering::SeqCst);
         let is_child_running = self.is_child_running.clone();

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2234,7 +2234,7 @@ pub fn user_accessible_folder() -> ResultType<PathBuf> {
     } else if dir2.exists() {
         dir = dir2;
     } else {
-        bail!("no vaild user accessible folder");
+        bail!("no valid user accessible folder");
     }
     Ok(dir)
 }

--- a/src/server/rdp_input.rs
+++ b/src/server/rdp_input.rs
@@ -83,7 +83,7 @@ pub mod client {
             // https://github.com/rustdesk/rustdesk/pull/9019#issuecomment-2295252388
             // There may be a bug in Rdp input on Gnome util Ubuntu 24.04 (Gnome 46)
             //
-            // eg. Resultion 800x600, Fractional scale: 200% (logic size: 400x300)
+            // eg. Resolution 800x600, Fractional scale: 200% (logic size: 400x300)
             // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.RemoteDesktop.html#:~:text=new%20pointer%20position-,in%20the%20streams%20logical%20coordinate%20space,-.
             // Then (x,y) in `mouse_move_to()` and `mouse_move_relative()` should be scaled to the logic size(stream.get_size()), which is from (0,0) to (400,300).
             // For Ubuntu 24.04(Gnome 46), (x,y) is restricted from (0,0) to (400,300), but the actual range in screen is:

--- a/src/server/video_qos.rs
+++ b/src/server/video_qos.rs
@@ -19,7 +19,7 @@ b. 3 seconds timeout => update ratio according to network delay
     When network delay < DELAY_THRESHOLD_150MS, increase ratio, max 150kbps;
     When network delay >= DELAY_THRESHOLD_150MS, decrease ratio;
 
-adjust betwen FPS and ratio:
+adjust between FPS and ratio:
     When network delay < DELAY_THRESHOLD_150MS, fps is always higher than the minimum fps, and ratio is increasing;
     When network delay >= DELAY_THRESHOLD_150MS, fps is always lower than the minimum fps, and ratio is decreasing;
 

--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -667,8 +667,8 @@ pub mod amyuni_idd {
         // we still forcibly plug out all virtual displays.
         //
         // 1. RustDesk plug in 2 virtual displays. (RustDesk)
-        // 2. Other process plug out all virtual displays. (User mannually)
-        // 3. Other process plug in 1 virtual display. (User mannually)
+        // 2. Other process plug out all virtual displays. (User manually)
+        // 3. Other process plug in 1 virtual display. (User manually)
         // 4. RustDesk plug out all virtual displays in this call. (RustDesk disconnect)
         //
         // This is not a normal scenario, RustDesk will plug out virtual display unexpectedly.


### PR DESCRIPTION
Found via codespell