### PR TITLE
fix: win, only start tray if is installed exe

### DIFF
--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -78,13 +78,14 @@ pub fn core_main() -> Option<Vec<String>> {
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     if args.is_empty() {
         #[cfg(target_os = "linux")]
-        let is_server_running = crate::check_process("--server", false);
+        let should_check_start_tray = crate::check_process("--server", false);
         // We can use `crate::check_process("--server", false)` on Windows.
         // Because `--server` process is the System user's process. We can't get the arguments in `check_process()`.
         // We can assume that self service running means the server is also running on Windows.
         #[cfg(target_os = "windows")]
-        let is_server_running = crate::platform::is_self_service_running();
-        if is_server_running && !crate::check_process("--tray", true) {
+        let should_check_start_tray = crate::platform::is_self_service_running()
+            && crate::platform::is_cur_exe_the_installed();
+        if should_check_start_tray && !crate::check_process("--tray", true) {
             #[cfg(target_os = "linux")]
             hbb_common::allow_err!(crate::platform::check_autostart_config());
             hbb_common::allow_err!(crate::run_me(vec!["--tray"]));

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3177,6 +3177,20 @@ pub fn is_msi_installed() -> std::io::Result<bool> {
     Ok(1 == uninstall_key.get_value::<u32, _>("WindowsInstaller")?)
 }
 
+pub fn is_cur_exe_the_installed() -> bool {
+    let (_, _, _, exe) = get_install_info();
+    // Check if is installed, because `exe` is the default path if is not installed.
+    if !std::fs::metadata(&exe).is_ok() {
+        return false;
+    }
+    let mut path = std::env::current_exe().unwrap_or_default();
+    if let Ok(linked) = path.read_link() {
+        path = linked;
+    }
+    let path = path.to_string_lossy().to_lowercase();
+    path == exe.to_lowercase()
+}
+
 #[cfg(not(target_pointer_width = "64"))]
 pub fn get_pids_with_first_arg_check_session<S1: AsRef<str>, S2: AsRef<str>>(
     name: S1,


### PR DESCRIPTION
Fix multiple sys tray icons.

1. https://github.com/rustdesk/rustdesk/discussions/11734
2. Click the portable exe after installation.


