### PR TITLE
fix: parameter error

### DIFF
--- a/src/platform/windows.cc
+++ b/src/platform/windows.cc
@@ -246,7 +246,7 @@ extern "C"
                 si.wShowWindow = SW_SHOW;
             }
             wchar_t buf[MAX_PATH];
-            wcscpy_s(buf, sizeof(buf), cmd);
+            wcscpy_s(buf, MAX_PATH, cmd);
             PROCESS_INFORMATION pi;
             LPVOID lpEnvironment = NULL;
             DWORD dwCreationFlags = DETACHED_PROCESS;


### PR DESCRIPTION
```c++
_Check_return_wat_
_ACRTIMP errno_t __cdecl wcscpy_s(
    _Out_writes_z_(_SizeInWords) wchar_t* _Destination,
    _In_ rsize_t _SizeInWords,
    _In_z_ wchar_t const* _Source
    );
```
Size In Words