### PR TITLE
fix: mobile never connecting with password from url scheme

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -2317,7 +2317,7 @@ List<String>? urlLinkToCmdArgs(Uri uri) {
   if (isMobile) {
     if (id != null) {
       final forceRelay = queryParameters["relay"] != null;
-      connect(Get.context!, id, forceRelay: forceRelay);
+      connect(Get.context!, id, forceRelay: forceRelay, password: queryParameters["password"]);
       return null;
     }
   }


### PR DESCRIPTION
Launching RustDesk via scheme `rustdesk://1234?password=abc` didn't work on mobile.
Is now fixed.