### PR TITLE
fix: enigo, osx, always reset event flags

### DIFF
--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1205,7 +1205,7 @@ pub fn handle_key(evt: &KeyEvent) {
     // If we don't sleep, the key press/release events may not take effect.
     //
     // For example, the controlled side osx `12.7.6` or `15.1.1`
-    // If we input characters quickly and continuously, and press or release "Shift" for a short period of time, 
+    // If we input characters quickly and continuously, and press or release "Shift" for a short period of time,
     // it is possible that after releasing "Shift", the controlled side will still print uppercase characters.
     // Though it is not very easy to reproduce.
     key_sleep();


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/11802

This issue is introduced in https://github.com/rustdesk/rustdesk/pull/11371.

1. Revert https://github.com/rustdesk/rustdesk/pull/11371 to avoid the other potential flags issues.
2. Check `F11` to keep the event flags.


`rdev` does not have this issue, because `rdev` does not use modifiers, it just simulates key press/up events.

