### PR TITLE
fix: macos, lock screen, input password

### DIFF
--- a/libs/enigo/src/macos/macos_impl.rs
+++ b/libs/enigo/src/macos/macos_impl.rs
@@ -142,7 +142,9 @@ impl Enigo {
     }
 
     fn post(&self, event: CGEvent) {
-        // event.set_flags(CGEventFlags::CGEventFlagNull); will cause `F11` not working. no idea why.
+        // Some key events require the flags to work.
+        // We can't simply set the flag to `CGEventFlags::CGEventFlagNull`.
+        // eg. `F11` requires flags `CGEventFlags::CGEventFlagSecondaryFn | 0x20000000` to work.
         if !self.ignore_flags && self.flags != CGEventFlags::CGEventFlagNull {
             event.set_flags(self.flags);
         }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/11802

This issue is introduced in https://github.com/rustdesk/rustdesk/pull/11371.

Because locking the screen will affect subsequent key event flags.

