### PR TITLE
feat: Implement Local Address Book Mode

### DIFF
--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -23,6 +23,7 @@ import 'package:provider/provider.dart';
 import 'package:pull_down_button/pull_down_button.dart';
 
 import '../../common.dart';
+import '../../models/ab_model.dart'; // Required for isLocalAddressBookMode
 import '../../models/platform_model.dart';
 
 class PeerTabPage extends StatefulWidget {
@@ -461,7 +462,7 @@ class _PeerTabPageState extends State<PeerTabPage>
       addressbooks.remove(gFFI.abModel.currentName.value);
     }
     return Offstage(
-      offstage: !gFFI.userModel.isLogin || addressbooks.isEmpty,
+      offstage: (!gFFI.userModel.isLogin && !isLocalAddressBookMode()) || addressbooks.isEmpty,
       child: _hoverAction(
         context: context,
         toolTip: translate('Add to address book'),
@@ -478,7 +479,7 @@ class _PeerTabPageState extends State<PeerTabPage>
   Widget editSelectionTags() {
     final model = Provider.of<PeerTabModel>(context);
     return Offstage(
-      offstage: !gFFI.userModel.isLogin ||
+      offstage: (!gFFI.userModel.isLogin && !isLocalAddressBookMode()) ||
           model.currentTab != PeerTabIndex.ab.index ||
           gFFI.abModel.currentAbTags.isEmpty,
       child: _hoverAction(

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -146,6 +146,7 @@ const String kOptionStopService = "stop-service";
 const String kOptionDirectxCapture = "enable-directx-capture";
 const String kOptionAllowRemoteCmModification = "allow-remote-cm-modification";
 const String kOptionEnableTrustedDevices = "enable-trusted-devices";
+const String kOptionLocalAddressBookMode = "local-address-book-mode";
 
 // network options
 const String kOptionAllowWebSocket = "allow-websocket";

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -540,6 +540,12 @@ class _GeneralState extends State<_General> {
             'Capture screen using DirectX',
             kOptionDirectxCapture,
           ),
+      _OptionCheckBox(
+        context,
+        'Enable Local Address Book Mode',
+        kOptionLocalAddressBookMode,
+        isServer: false, // This is a local client option
+      ),
       ],
     ];
     if (!isWeb && bind.mainShowOption(key: kOptionAllowLinuxHeadless)) {

--- a/flutter/lib/models/peer_tab_model.dart
+++ b/flutter/lib/models/peer_tab_model.dart
@@ -8,6 +8,7 @@ import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:get/get.dart';
 
 import '../common.dart';
+import 'ab_model.dart'; // Import for isLocalAddressBookMode
 import 'model.dart';
 
 enum PeerTabIndex {
@@ -42,7 +43,8 @@ class PeerTabModel with ChangeNotifier {
     true,
     !isWeb,
     !(bind.isDisableAb() || bind.isDisableAccount()),
-    !(bind.isDisableGroupPanel() || bind.isDisableAccount()),
+    // For Group Tab:
+    !(bind.isDisableGroupPanel() || bind.isDisableAccount()) && !isLocalAddressBookMode(),
   ]);
   final List<bool> _isVisible = List.filled(maxTabCount, true, growable: false);
   List<bool> get isVisibleEnabled => () {
@@ -126,6 +128,9 @@ class PeerTabModel with ChangeNotifier {
 
   String tabTooltip(int index) {
     if (index >= 0 && index < tabNames.length) {
+      if (index == PeerTabIndex.ab.index && isLocalAddressBookMode()) {
+        return translate('Address Book (Local)'); // New tooltip for local mode
+      }
       return translate(tabNames[index]);
     }
     return index.toString();


### PR DESCRIPTION
This commit introduces a "Local Address Book Mode" that allows you to use the address book without requiring a login or server connection. Entries are stored locally on your device.

Key changes:

- Added a setting in General Settings to toggle Local Address Book Mode.
- Modified `AbModel` to handle data loading and persistence from/to local storage (using existing FFI `mainSaveAb`/`mainLoadAb` calls) when local mode is active.
- Server interactions and login requirements for the address book are bypassed in local mode.
- Flutter UI has been adapted:
    - The "Group" tab is hidden in local mode.
    - The Address Book tab tooltip indicates when it's operating locally.
    - Actions like "Add to Address Book" and "Edit Tag" are enabled in local mode without needing a server login.
- Passive data migration is possible: if you sync your address book from the server and then enable local mode, the cached data will be used as the local address book.

The Sciter UI (`src/ui/ab.tis`) was not modified in this iteration.