### PR TITLE
test nat type for outgoing-only client

### DIFF
--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -64,6 +64,7 @@ fn initialize(app_dir: &str, custom_client_config: &str) {
     {
         use hbb_common::env_logger::*;
         init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "debug"));
+        crate::common::test_nat_type();
     }
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     {

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -57,6 +57,7 @@ impl RendezvousMediator {
     }
 
     pub async fn start_all() {
+        crate::test_nat_type();
         if config::is_outgoing_only() {
             loop {
                 sleep(1.).await;
@@ -69,7 +70,6 @@ impl RendezvousMediator {
         }
         check_zombie();
         let server = new_server();
-        crate::test_nat_type();
         if config::option2bool("stop-service", &Config::get_option("stop-service")) {
             crate::test_rendezvous_server();
         }


### PR DESCRIPTION
The outgoing-only client does not test NAT upon startup, and the NAT is set to `UNKNOWN` by default. 
If the nat type of the controlled endpoint is not `SYMMETRIC`, hole punching will still proceed.
If the nat type of the controll side is actually `SYMMETRIC`, then the controlled end's `accept_connection` will time out.

![Screenshot from 2025-06-03 08-02-14](https://github.com/user-attachments/assets/71a84d6a-6902-40a4-9853-d997246a465e)


![relay-dialog](https://github.com/user-attachments/assets/e0f2b656-7a35-4261-a8d5-0708ca91c42a)

ios:

before pr:
![Screenshot from 2025-06-03 08-42-08](https://github.com/user-attachments/assets/5bb213fd-bde3-4fe4-aa3b-8289a045ce56)
