### PR TITLE
fix: use default camera, first element in query result might not be a camera

### DIFF
--- a/libs/scrap/src/common/camera.rs
+++ b/libs/scrap/src/common/camera.rs
@@ -49,7 +49,7 @@ impl Cameras {
                         let Some(info) = cameras.first() else {
                             bail!("No camera found")
                         };
-                        let camera = Self::create_camera(info.index())?;
+                        let camera = Self::create_camera(&CameraIndex::Index(0))?;
                         let resolution = camera.resolution();
                         let (width, height) = (resolution.width() as i32, resolution.height() as i32);
                         camera_displays.push(DisplayInfo {
@@ -112,7 +112,7 @@ impl Cameras {
     fn create_camera(index: &CameraIndex) -> ResultType<Camera> {
         let result = Camera::new(
             index.clone(),
-            RequestedFormat::new::<RgbAFormat>(RequestedFormatType::AbsoluteHighestResolution),
+            RequestedFormat::new::<RgbAFormat>(RequestedFormatType::None),
         );
         match result {
             Ok(camera) => Ok(camera),


### PR DESCRIPTION
from the nokhwa example, sometimes /dev/video0 is not the first element in query result
this can cause camera_display init failed
since /dev/video0 is the default camera on linux, should be safer to use index 0 here
```
lc@pi4:~/repos/nokhwa$ ./target/debug/nokhwactl list-devices
Nokhwa Initalized: true
There are 15 available cameras.
Name: bcm2835-codec-encode_image, Description: Video4Linux Device @ /dev/video31, Extra: , Index: 31
Name: camera0, Description: Video4Linux Device @ /dev/video0, Extra: , Index: 0
Name: bcm2835-codec-image_fx, Description: Video4Linux Device @ /dev/video18, Extra: , Index: 18
```

camera request with RequestedFormatType::None using the default yuv format by v4l2 config
should be better than AbsoluteHighestResolution, user can change config by v4l2-ctl cmd

need to test on windows