### PR TITLE
Update main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use librustdesk::*;
 #[cfg(any(target_os = "android", target_os = "ios", feature = "flutter"))]
 fn main() {
     if !common::global_init() {
+        eprintln!("Global initialization failed.");
         return;
     }
     common::test_rendezvous_server();


### PR DESCRIPTION
common::global_init() might fail silently. Since return is used without any error logging, the user won’t know why the application didn't start so that is why added error print statement in case if it fails