### PR TITLE
fix: linux, nokhwa, camera index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,7 +4252,7 @@ dependencies = [
 [[package]]
 name = "nokhwa"
 version = "0.10.7"
-source = "git+https://github.com/rustdesk-org/nokhwa.git?branch=fix_from_raw_parts#744dea9d277dfb18954cef389973c622dd15a85e"
+source = "git+https://github.com/rustdesk-org/nokhwa.git?branch=fix_from_raw_parts#f32e7d68be61db9b1e99016b24edb14543d0383b"
 dependencies = [
  "flume",
  "image 0.25.1",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "nokhwa-bindings-linux"
 version = "0.1.1"
-source = "git+https://github.com/rustdesk-org/nokhwa.git?branch=fix_from_raw_parts#744dea9d277dfb18954cef389973c622dd15a85e"
+source = "git+https://github.com/rustdesk-org/nokhwa.git?branch=fix_from_raw_parts#f32e7d68be61db9b1e99016b24edb14543d0383b"
 dependencies = [
  "nokhwa-core",
  "v4l",
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "nokhwa-bindings-macos"
 version = "0.2.2"
-source = "git+https://github.com/rustdesk-org/nokhwa.git?branch=fix_from_raw_parts#744dea9d277dfb18954cef389973c622dd15a85e"
+source = "git+https://github.com/rustdesk-org/nokhwa.git?branch=fix_from_raw_parts#f32e7d68be61db9b1e99016b24edb14543d0383b"
 dependencies = [
  "block",
  "cocoa-foundation",
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "nokhwa-bindings-windows"
 version = "0.4.2"
-source = "git+https://github.com/rustdesk-org/nokhwa.git?branch=fix_from_raw_parts#744dea9d277dfb18954cef389973c622dd15a85e"
+source = "git+https://github.com/rustdesk-org/nokhwa.git?branch=fix_from_raw_parts#f32e7d68be61db9b1e99016b24edb14543d0383b"
 dependencies = [
  "dlopen",
  "lazy_static",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "nokhwa-core"
 version = "0.1.5"
-source = "git+https://github.com/rustdesk-org/nokhwa.git?branch=fix_from_raw_parts#744dea9d277dfb18954cef389973c622dd15a85e"
+source = "git+https://github.com/rustdesk-org/nokhwa.git?branch=fix_from_raw_parts#f32e7d68be61db9b1e99016b24edb14543d0383b"
 dependencies = [
  "bytes",
  "image 0.25.1",

--- a/libs/scrap/src/common/camera.rs
+++ b/libs/scrap/src/common/camera.rs
@@ -49,7 +49,18 @@ impl Cameras {
                         let Some(info) = cameras.first() else {
                             bail!("No camera found")
                         };
-                        let camera = Self::create_camera(&CameraIndex::Index(0))?;
+                        // Use index (0) camera as main camera, fallback to the first camera if index (0) is not available.
+                        // But maybe we also need to check index (1) or the lowest index camera.
+                        //
+                        // https://askubuntu.com/questions/234362/how-to-fix-this-problem-where-sometimes-dev-video0-becomes-automatically-dev
+                        // https://github.com/rustdesk/rustdesk/pull/12010#issue-3125329069
+                        let mut camera_index = info.index().clone();
+                        if !matches!(camera_index, CameraIndex::Index(0)) {
+                            if cameras.iter().any(|cam| matches!(cam.index(), CameraIndex::Index(0))) {
+                                camera_index = CameraIndex::Index(0);
+                            }
+                        }
+                        let camera = Self::create_camera(&camera_index)?;
                         let resolution = camera.resolution();
                         let (width, height) = (resolution.width() as i32, resolution.height() as i32);
                         camera_displays.push(DisplayInfo {
@@ -110,9 +121,14 @@ impl Cameras {
     }
 
     fn create_camera(index: &CameraIndex) -> ResultType<Camera> {
+        let format_type = if cfg!(target_os = "linux") {
+            RequestedFormatType::None
+        } else {
+            RequestedFormatType::AbsoluteHighestResolution
+        };
         let result = Camera::new(
             index.clone(),
-            RequestedFormat::new::<RgbAFormat>(RequestedFormatType::None),
+            RequestedFormat::new::<RgbAFormat>(format_type),
         );
         match result {
             Ok(camera) => Ok(camera),


### PR DESCRIPTION
1.  Use `index (0)` camera as main camera, fallback to the first camera if `index (0)` is not available.  https://askubuntu.com/questions/234362/how-to-fix-this-problem-where-sometimes-dev-video0-becomes-automatically-dev
2. Use `RequestedFormatType::None` only on Linux when creating the camera.