### PR TITLE
fix: win, privacy mode 2

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -991,17 +991,12 @@ class FfiModel with ChangeNotifier {
       String link,
       bool hasRetry,
       OverlayDialogManager dialogManager) {
-    if (text == 'no_need_privacy_mode_no_physical_displays_tip' ||
-        text == 'Enter privacy mode') {
-      // There are display changes on the remote side,
-      // which will cause some messages to refresh the canvas and dismiss dialogs.
-      // So we add a delay here to ensure the dialog is displayed.
-      Future.delayed(Duration(milliseconds: 3000), () {
-        showMsgBox(sessionId, type, title, text, link, hasRetry, dialogManager);
-      });
-    } else {
+    // There are display changes on the remote side,
+    // which will cause some messages to refresh the canvas and dismiss dialogs.
+    // So we add a delay here to ensure the dialog is displayed.
+    Future.delayed(Duration(milliseconds: 3000), () {
       showMsgBox(sessionId, type, title, text, link, hasRetry, dialogManager);
-    }
+    });
   }
 
   _updateSessionWidthHeight(SessionID sessionId) {

--- a/src/privacy_mode.rs
+++ b/src/privacy_mode.rs
@@ -219,9 +219,10 @@ async fn turn_on_privacy_async(impl_key: String, conn_id: i32) -> Option<ResultT
         let res = turn_on_privacy_sync(&impl_key, conn_id);
         let _ = tx.send(res);
     });
-    // Wait at most 5 seconds for the result.
+    // Wait at most 7.5 seconds for the result.
     // Because it may take a long time to turn on the privacy mode with amyuni idd.
-    match hbb_common::timeout(5000, rx).await {
+    // Some laptops may take time to plug in a virtual display.
+    match hbb_common::timeout(7500, rx).await {
         Ok(res) => match res {
             Ok(res) => res,
             Err(e) => Some(Err(anyhow!(e.to_string()))),


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/10540


1. Show all message boxes about privacy mode after 3 seconds delay. `if (text =='no_need_privacy_mode_no_physical_displays_tip' || text == 'Enter privacy mode')` can't cover all cases, the message box does not show sometimes.
2. Fix `ChangeDisplaySettingsEx()` failure with -1. The virtual display must be changed first on `Windows 24H2`, no idea why.
3. Add some delay waiting for the virtual display to be plugged in.

## issues

1. This line may fail sometimes https://github.com/rustdesk/rustdesk/blob/87545791813287feaceb4364aa5aa7564dac912c/src/privacy_mode/win_virtual_display.rs#L437 , causing the resolution to be `1024x768`. Maybe we could add a retry here.
2. The privacy mode may fail if the display settings are some like

![95be8ff9136500a22d58a8f7b5238cc](https://github.com/user-attachments/assets/8acee064-8b9a-40d0-b3a4-a6a67a869480)

3. If there're some virtual diplays created by the other virtual display drivers, the virtual display may be hidden after exiting the privacy mode 2.

## todos

1. Issue 3 above in another PR.
2. Replace the virtual display implementation. So Issue 1 will be fixed completely.
