### PR TITLE
fix: sequentially post conn audit

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -973,16 +973,8 @@ impl Connection {
     }
 
     async fn post_seq_loop(mut rx: mpsc::UnboundedReceiver<(String, Value)>) {
-        loop {
-            match rx.recv().await {
-                Some((url, v)) => {
-                    allow_err!(Self::post_audit_async(url, v).await);
-                }
-                None => {
-                    // No need to log here.
-                    break;
-                }
-            }
+        while let Some((url, v)) = rx.recv().await {
+            allow_err!(Self::post_audit_async(url, v).await);
         }
     }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -247,6 +247,9 @@ pub struct Connection {
     multi_ui_session: bool,
     tx_from_authed: mpsc::UnboundedSender<ipc::Data>,
     printer_data: Vec<(Instant, String, Vec<u8>)>,
+    // For post requests that need to be sent sequentially.
+    // eg. post_conn_audit
+    tx_post_seq: mpsc::UnboundedSender<(String, Value)>,
 }
 
 impl ConnInner {
@@ -320,6 +323,11 @@ impl Connection {
         #[cfg(target_os = "linux")]
         let linux_headless_handle =
             LinuxHeadlessHandle::new(_rx_cm_stream_ready, _tx_desktop_ready);
+
+        let (tx_post_seq, rx_post_seq) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            Self::post_seq_loop(rx_post_seq).await;
+        });
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         let tx_cloned = tx.clone();
@@ -401,6 +409,7 @@ impl Connection {
             retina: Retina::default(),
             tx_from_authed,
             printer_data: Vec::new(),
+            tx_post_seq,
         };
         let addr = hbb_common::try_into_v4(addr);
         if !conn.on_open(addr).await {
@@ -963,6 +972,20 @@ impl Connection {
         log::info!("Input thread exited");
     }
 
+    async fn post_seq_loop(mut rx: mpsc::UnboundedReceiver<(String, Value)>) {
+        loop {
+            match rx.recv().await {
+                Some((url, v)) => {
+                    allow_err!(Self::post_audit_async(url, v).await);
+                }
+                None => {
+                    // No need to log here.
+                    break;
+                }
+            }
+        }
+    }
+
     async fn try_port_forward_loop(
         &mut self,
         rx_from_cm: &mut mpsc::UnboundedReceiver<Data>,
@@ -1117,9 +1140,9 @@ impl Connection {
         v["uuid"] = json!(crate::encode64(hbb_common::get_uuid()));
         v["conn_id"] = json!(self.inner.id);
         v["session_id"] = json!(self.lr.session_id);
-        tokio::spawn(async move {
-            allow_err!(Self::post_audit_async(url, v).await);
-        });
+        if let Err(e) = self.tx_post_seq.send((url, v)) {
+            log::error!("Failed to send post conn audit: {}", e);
+        }
     }
 
     fn get_files_for_audit(job_type: fs::JobType, mut files: Vec<FileEntry>) -> Vec<(String, i64)> {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1140,9 +1140,7 @@ impl Connection {
         v["uuid"] = json!(crate::encode64(hbb_common::get_uuid()));
         v["conn_id"] = json!(self.inner.id);
         v["session_id"] = json!(self.lr.session_id);
-        if let Err(e) = self.tx_post_seq.send((url, v)) {
-            log::error!("Failed to send post conn audit: {}", e);
-        }
+        allow_err!(self.tx_post_seq.send((url, v)));
     }
 
     fn get_files_for_audit(job_type: fs::JobType, mut files: Vec<FileEntry>) -> Vec<(String, i64)> {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -969,13 +969,14 @@ impl Connection {
         }
         #[cfg(target_os = "linux")]
         clear_remapped_keycode();
-        log::info!("Input thread exited");
+        log::debug!("Input thread exited");
     }
 
     async fn post_seq_loop(mut rx: mpsc::UnboundedReceiver<(String, Value)>) {
         while let Some((url, v)) = rx.recv().await {
             allow_err!(Self::post_audit_async(url, v).await);
         }
+        log::debug!("post_seq_loop exited");
     }
 
     async fn try_port_forward_loop(


### PR DESCRIPTION
Connection audit logs need to be posted in sequence, otherwise some logs may be missed.
