### PR TITLE
fix: linux workaround cmd path

### DIFF
--- a/src/platform/gtk_sudo.rs
+++ b/src/platform/gtk_sudo.rs
@@ -5,7 +5,9 @@ use crate::lang::translate;
 use gtk::{glib, prelude::*};
 use hbb_common::{
     anyhow::{bail, Error},
-    log, ResultType,
+    log,
+    platform::linux::CMD_SH,
+    ResultType,
 };
 use nix::{
     libc::{fcntl, kill},
@@ -468,7 +470,7 @@ fn child(su_user: Option<String>, args: Vec<String>) -> ResultType<()> {
     if su_user.is_some() {
         params.push("-S".to_string());
     }
-    params.push("/bin/sh".to_string());
+    params.push(CMD_SH.to_string());
     params.push("-c".to_string());
 
     let command = args

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -10,6 +10,7 @@ use hbb_common::{
     libc::{c_char, c_int, c_long, c_void},
     log,
     message_proto::{DisplayInfo, Resolution},
+    platform::linux::{CMD_PS, CMD_SH},
     regex::{Captures, Regex},
 };
 use std::{
@@ -320,7 +321,7 @@ fn set_x11_env(desktop: &Desktop) {
 #[inline]
 fn stop_rustdesk_servers() {
     let _ = run_cmds(&format!(
-        r##"ps -ef | grep -E '{} +--server' | awk '{{printf("kill -9 %d\n", $2)}}' | bash"##,
+        r##"ps -ef | grep -E '{} +--server' | awk '{{print $2}}' | xargs -r kill -9"##,
         crate::get_app_name().to_lowercase(),
     ));
 }
@@ -328,11 +329,11 @@ fn stop_rustdesk_servers() {
 #[inline]
 fn stop_subprocess() {
     let _ = run_cmds(&format!(
-        r##"ps -ef | grep '/etc/{}/xorg.conf' | grep -v grep | awk '{{printf("kill -9 %d\n", $2)}}' | bash"##,
+        r##"ps -ef | grep '/etc/{}/xorg.conf' | grep -v grep | awk '{{print $2}}' | xargs -r kill -9"##,
         crate::get_app_name().to_lowercase(),
     ));
     let _ = run_cmds(&format!(
-        r##"ps -ef | grep -E '{} +--cm-no-ui' | grep -v grep | awk '{{printf("kill -9 %d\n", $2)}}' | bash"##,
+        r##"ps -ef | grep -E '{} +--cm-no-ui' | grep -v grep | awk '{{print $2}}' | xargs -r kill -9"##,
         crate::get_app_name().to_lowercase(),
     ));
 }
@@ -517,7 +518,8 @@ pub fn get_active_userid() -> String {
 }
 
 fn get_cm() -> bool {
-    if let Ok(output) = Command::new("ps").args(vec!["aux"]).output() {
+    // We use `CMD_PS` instead of `ps` to suppress some audit messages on some systems.
+    if let Ok(output) = Command::new(CMD_PS.as_str()).args(vec!["aux"]).output() {
         for line in String::from_utf8_lossy(&output.stdout).lines() {
             if line.contains(&format!(
                 "{} --cm",
@@ -1355,7 +1357,8 @@ pub fn run_me_with(secs: u32) {
         .unwrap_or("".into())
         .to_string_lossy()
         .to_string();
-    std::process::Command::new("sh")
+    // We use `CMD_SH` instead of `sh` to suppress some audit messages on some systems.
+    std::process::Command::new(CMD_SH.as_str())
         .arg("-c")
         .arg(&format!("sleep {secs}; {exe}"))
         .spawn()


### PR DESCRIPTION
May fix https://github.com/rustdesk/rustdesk/discussions/11959

I only reproduced it once on debian 12, and it can't reproduce after rebooting.

Commands to view the audit logs:

1. `sudo apt install -y auditd && sudo systemctl start auditd`
2. `sudo aureport -x --summary`
3. `sudo ausearch -x /usr/share/rustdesk/rustdesk`
4. `sudo ausearch -x /usr/share/rustdesk/rustdesk | grep "name=" | awk -F'name=' '{print $2}' | cut -d'"' -f2 | sort | uniq -c`
