### PR TITLE
docs: Correct the path to CONTRIBUTING.md links

### DIFF
--- a/docs/README-DA.md
+++ b/docs/README-DA.md
@@ -15,7 +15,7 @@ Chat med os: [Discord](https://discord.gg/nDceKgxnkV) | [Twitter](https://twitte
 
 Endnu en fjernskrivebordssoftware, skrevet i Rust. Fungerer ud af æsken, ingen konfiguration påkrævet. Du har fuld kontrol over dine data uden bekymringer om sikkerhed. Du kan bruge vores rendezvous/relay-server, [opsætte din egen](https://rustdesk.com/server), eller [skrive din egen rendezvous/relay-server](https://github.com/rustdesk/rustdesk- server-demo).
 
-RustDesk hilser bidrag fra alle velkommen. Se [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) for at få hjælp til at komme i gang.
+RustDesk hilser bidrag fra alle velkommen. Se [`docs/CONTRIBUTING.md`](CONTRIBUTING.md) for at få hjælp til at komme i gang.
 
 [**PROGRAM DOWNLOAD**](https://github.com/rustdesk/rustdesk/releases)
 

--- a/docs/README-GR.md
+++ b/docs/README-GR.md
@@ -17,7 +17,7 @@
 
 ![image](https://user-images.githubusercontent.com/71636191/171661982-430285f0-2e12-4b1d-9957-4a58e375304d.png)
 
-Το RustDesk ενθαρρύνει τη συνεισφορά όλων. Διαβάστε το [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) για βοήθεια στο πως να ξεκινήσετε.
+Το RustDesk ενθαρρύνει τη συνεισφορά όλων. Διαβάστε το [`docs/CONTRIBUTING.md`](CONTRIBUTING.md) για βοήθεια στο πως να ξεκινήσετε.
 
 [**Συχνές ερωτήσεις**](https://github.com/rustdesk/rustdesk/wiki/FAQ)
 

--- a/docs/README-JP.md
+++ b/docs/README-JP.md
@@ -18,7 +18,7 @@ Rustで書かれた、設定不要ですぐに使えるリモートデスクト�
 ![image](https://user-images.githubusercontent.com/71636191/171661982-430285f0-2e12-4b1d-9957-4a58e375304d.png)
 
 RustDeskは皆さんの貢献を歓迎します。  
-貢献の方法については[CONTRIBUTING.md](docs/CONTRIBUTING.md)をご確認ください。
+貢献の方法については[CONTRIBUTING.md](CONTRIBUTING.md)をご確認ください。
 
 [**よくある質問**](https://github.com/rustdesk/rustdesk/wiki/FAQ)
 

--- a/docs/README-NO.md
+++ b/docs/README-NO.md
@@ -17,7 +17,7 @@ Enda en annen fjernstyrt desktop programvare, skrevet i Rust. Virker rett ut av 
 
 ![image](https://user-images.githubusercontent.com/71636191/171661982-430285f0-2e12-4b1d-9957-4a58e375304d.png)
 
-RustDesk er velkommen for bidrag fra alle. Se [CONTRIBUTING.md](docs/CONTRIBUTING-NO.md) for hjelp med oppstart.
+RustDesk er velkommen for bidrag fra alle. Se [CONTRIBUTING.md](CONTRIBUTING-NO.md) for hjelp med oppstart.
 
 [**FAQ**](https://github.com/rustdesk/rustdesk/wiki/FAQ)
 

--- a/docs/README-TR.md
+++ b/docs/README-TR.md
@@ -18,7 +18,7 @@ Başka bir uzak masaüstü yazılımı daha, Rust dilinde yazılmış. Hemen kul
 
 ![image](https://user-images.githubusercontent.com/71636191/171661982-430285f0-2e12-4b1d-9957-4a58e375304d.png)
 
-RustDesk, herkesten katkıyı kabul eder. Başlamak için [CONTRIBUTING.md](docs/CONTRIBUTING-TR.md) belgesine göz atın.
+RustDesk, herkesten katkıyı kabul eder. Başlamak için [CONTRIBUTING.md](CONTRIBUTING-TR.md) belgesine göz atın.
 
 [**SSS**](https://github.com/rustdesk/rustdesk/wiki/FAQ)
 

--- a/docs/README-UA.md
+++ b/docs/README-UA.md
@@ -17,7 +17,7 @@
 
 ![image](https://user-images.githubusercontent.com/71636191/171661982-430285f0-2e12-4b1d-9957-4a58e375304d.png)
 
-RustDesk вітає внесок кожного. Ознайомтеся з [CONTRIBUTING.md](docs/CONTRIBUTING.md), щоб отримати допомогу на початковому етапі.
+RustDesk вітає внесок кожного. Ознайомтеся з [CONTRIBUTING.md](CONTRIBUTING.md), щоб отримати допомогу на початковому етапі.
 
 [**ЧаПи**](https://github.com/rustdesk/rustdesk/wiki/FAQ)
 


### PR DESCRIPTION
Correct the path to CONTRIBUTING.md links in the README files for each language to ensure that you point to the correct file location.
Some document links to 404:
![image](https://github.com/user-attachments/assets/2b92265b-0a9e-4954-b8bc-5cd3065dd6de)
