### PR TITLE
fix: terminal connection on Linux and MacOS

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1981,7 +1981,7 @@ impl Connection {
                             o.terminal_persistent.enum_value() == Ok(BoolOption::Yes);
                     }
                     self.terminal_service_id = terminal.service_id;
-                    #[cfg(target_os = "windows")]
+                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
                     if let Some(msg) =
                         self.fill_terminal_user_token(&lr.os_login.username, &lr.os_login.password)
                     {
@@ -2941,6 +2941,12 @@ impl Connection {
             }
         }
         true
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn fill_terminal_user_token(&mut self, _username: &str, _password: &str) -> Option<&'static str> {
+        self.terminal_user_token = Some(TerminalUserToken::SelfUser);
+        None
     }
 
     // Try to fill user token for terminal connection.


### PR DESCRIPTION
`terminal_user_token` needs to be set, or https://github.com/rustdesk/rustdesk/blob/69af5f2fa609ce8cdccb39147056cb911ac1a4c0/src/server/connection.rs#L3975 will fail.