### PR TITLE
refact: restore terminals

### DIFF
--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -64,6 +64,7 @@ const String kWindowEventNewFileTransfer = "new_file_transfer";
 const String kWindowEventNewViewCamera = "new_view_camera";
 const String kWindowEventNewPortForward = "new_port_forward";
 const String kWindowEventNewTerminal = "new_terminal";
+const String kWindowEventRestoreTerminalSessions = "restore_terminal_sessions";
 const String kWindowEventActiveSession = "active_session";
 const String kWindowEventActiveDisplaySession = "active_display_session";
 const String kWindowEventGetRemoteList = "get_remote_list";

--- a/flutter/lib/desktop/pages/terminal_tab_page.dart
+++ b/flutter/lib/desktop/pages/terminal_tab_page.dart
@@ -171,6 +171,8 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
           forceRelay: args['forceRelay'],
           connToken: args['connToken'],
         ));
+      } else if (call.method == kWindowEventRestoreTerminalSessions) {
+        _restoreSessions(call.arguments);
       } else if (call.method == "onDestroy") {
         tabController.clear();
       } else if (call.method == kWindowActionRebuild) {
@@ -186,6 +188,32 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
   void dispose() {
     HardwareKeyboard.instance.removeHandler(_handleKeyEvent);
     super.dispose();
+  }
+
+  Future<void> _restoreSessions(String arguments) async {
+    Map<String, dynamic>? args;
+    try {
+      args = jsonDecode(arguments) as Map<String, dynamic>;
+    } catch (e) {
+      debugPrint("Error parsing JSON arguments in _restoreSessions: $e");
+      return;
+    }
+    final persistentSessions =
+        args['persistent_sessions'] as List<dynamic>? ?? [];
+    final sortedSessions = persistentSessions.whereType<int>().toList()..sort();
+    for (final terminalId in sortedSessions) {
+      _addNewTerminalForCurrentPeer(terminalId: terminalId);
+      // A delay is required to ensure the UI has sufficient time to update
+      // before adding the next terminal. Without this delay, `_TerminalPageState::dispose()`
+      // may be called prematurely while the tab widget is still in the tab controller.
+      // This behavior is likely due to a race condition between the UI rendering lifecycle
+      // and the addition of new tabs. Attempts to use `_TerminalPageState::addPostFrameCallback()`
+      // to wait for the previous page to be ready were unsuccessful, as the observed call sequence is:
+      // `initState() 2 -> dispose() 2 -> postFrameCallback() 2`, followed by `initState() 3`.
+      // The `Future.delayed` approach mitigates this issue by introducing a buffer period,
+      // allowing the UI to stabilize before proceeding.
+      await Future.delayed(const Duration(milliseconds: 300));
+    }
   }
 
   bool _handleKeyEvent(KeyEvent event) {
@@ -276,17 +304,20 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
     return false;
   }
 
-  void _addNewTerminal(String peerId) {
+  void _addNewTerminal(String peerId, {int? terminalId}) {
     // Find first tab for this peer to get connection parameters
     final firstTab = tabController.state.value.tabs.firstWhere(
       (tab) => tab.key.startsWith('$peerId\_'),
     );
     if (firstTab.page is TerminalPage) {
       final page = firstTab.page as TerminalPage;
-      final terminalId = _nextTerminalId++;
+      final newTerminalId = terminalId ?? _nextTerminalId++;
+      if (terminalId != null && terminalId >= _nextTerminalId) {
+        _nextTerminalId = terminalId + 1;
+      }
       tabController.add(_createTerminalTab(
         peerId: peerId,
-        terminalId: terminalId,
+        terminalId: newTerminalId,
         password: page.password,
         isSharedPassword: page.isSharedPassword,
         forceRelay: page.forceRelay,
@@ -295,12 +326,12 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
     }
   }
 
-  void _addNewTerminalForCurrentPeer() {
+  void _addNewTerminalForCurrentPeer({int? terminalId}) {
     final currentTab = tabController.state.value.selectedTabInfo;
     final parts = currentTab.key.split('_');
     if (parts.isNotEmpty) {
       final peerId = parts[0];
-      _addNewTerminal(peerId);
+      _addNewTerminal(peerId, terminalId: terminalId);
     }
   }
 

--- a/flutter/lib/models/terminal_model.dart
+++ b/flutter/lib/models/terminal_model.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hbb/consts.dart';
+import 'package:flutter_hbb/main.dart';
 import 'package:xterm/xterm.dart';
 
 import 'model.dart';
@@ -195,6 +198,17 @@ class TerminalModel with ChangeNotifier {
         debugPrint('[TerminalModel] Error processing buffered input: $e');
         notifyListeners();
       });
+
+      final persistentSessions =
+          evt['persistent_sessions'] as List<dynamic>? ?? [];
+      if (kWindowId != null && persistentSessions.isNotEmpty) {
+        DesktopMultiWindow.invokeMethod(
+            kWindowId!,
+            kWindowEventRestoreTerminalSessions,
+            jsonEncode({
+              'persistent_sessions': persistentSessions,
+            }));
+      }
     } else {
       terminal.write('Failed to open terminal: $message\r\n');
     }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1119,6 +1119,9 @@ impl InvokeUiSession for FlutterHandler {
                     ("pid", json!(opened.pid)),
                     ("service_id", json!(&opened.service_id)),
                 ];
+                if !opened.persistent_sessions.is_empty() {
+                    event_data.push(("persistent_sessions", json!(opened.persistent_sessions)));
+                }
                 self.push_event_("terminal_response", &event_data, &[], &[]);
             }
             Some(Union::Data(data)) => {


### PR DESCRIPTION
## Preview

https://github.com/user-attachments/assets/c31da200-ec30-4e66-bb83-daf05aaff0b1

### Restore without sleep

`await Future.delayed(const Duration(milliseconds: 300));` is added after `_addNewTerminalForCurrentPeer(terminalId: terminalId);`.

https://github.com/user-attachments/assets/ed9edbd0-ca73-4fc3-9d7b-e676fe77d43f

## Issue

Restore sessions should not work if previous connection is `Administrator` and current is not.
I'll fix it in the next PR.
