### PR TITLE
fix: terminal, restore, cross users

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2551,7 +2551,7 @@ impl LoginConfigHandler {
             }),
             ConnType::TERMINAL => {
                 let mut terminal = Terminal::new();
-                terminal.service_id = self.get_option("terminal-service-id");
+                terminal.service_id = self.get_option(self.get_key_terminal_service_id());
                 lr.set_terminal(terminal);
             }
             _ => {}
@@ -2601,6 +2601,14 @@ impl LoginConfigHandler {
 
     pub fn get_id(&self) -> &str {
         &self.id
+    }
+
+    pub fn get_key_terminal_service_id(&self) -> &'static str {
+        if self.is_terminal_admin {
+            "terminal-admin-service-id"
+        } else {
+            "terminal-service-id"
+        }
     }
 }
 

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1944,10 +1944,9 @@ impl<T: InvokeUiSession> Remote<T> {
                     use hbb_common::message_proto::terminal_response::Union;
                     if let Some(Union::Opened(opened)) = &response.union {
                         if opened.success && !opened.service_id.is_empty() {
-                            self.handler.lc.write().unwrap().set_option(
-                                "terminal-service-id".to_owned(),
-                                opened.service_id.clone(),
-                            );
+                            let mut lc = self.handler.lc.write().unwrap();
+                            let key = lc.get_key_terminal_service_id().to_owned();
+                            lc.set_option(key, opened.service_id.clone());
                         }
                     }
                     self.handler.handle_terminal_response(response);


### PR DESCRIPTION
Use `terminal-admin-service-id` and `terminal-service-id` to store different terminal connection types.

Fix the issue methoned in PR https://github.com/rustdesk/rustdesk/pull/12334 .