### PR TITLE
fix: terminal, persistent

### DIFF
--- a/flutter/lib/desktop/pages/terminal_tab_page.dart
+++ b/flutter/lib/desktop/pages/terminal_tab_page.dart
@@ -124,7 +124,7 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
       },
       setter: (bool v) async {
         final ffi = Get.find<FFI>(tag: 'terminal_$peerId');
-        bind.sessionToggleOption(
+        await bind.sessionToggleOption(
           sessionId: ffi.sessionId,
           value: kOptionTerminalPersistent,
         );

--- a/src/server/terminal_service.rs
+++ b/src/server/terminal_service.rs
@@ -696,10 +696,7 @@ impl TerminalServiceProxy {
             opened.success = true;
             opened.message = "Reconnected to existing terminal".to_string();
             opened.pid = session.pid;
-            // Return service_id for persistent sessions
-            if self.is_persistent {
-                opened.service_id = self.service_id.clone();
-            }
+            opened.service_id = self.service_id.clone();
             if service.needs_session_sync {
                 if service.sessions.len() > 1 {
                     // No need to include the current terminal in the list.
@@ -869,10 +866,7 @@ impl TerminalServiceProxy {
         opened.success = true;
         opened.message = "Terminal opened".to_string();
         opened.pid = session.pid;
-        // Return service_id for persistent sessions
-        if self.is_persistent {
-            opened.service_id = service.service_id.clone();
-        }
+        opened.service_id = service.service_id.clone();
         if service.needs_session_sync {
             if !service.sessions.is_empty() {
                 opened.persistent_sessions = service.sessions.keys().cloned().collect();


### PR DESCRIPTION
Always return the `service_id` in `TerminalResponse`.

The terminal can't be restored if connecting to a new peer.
    a. Open a new terminal. `service_id A` is created. No `service_id` is returned because `is_persistent` is `false`.
    b. Check the persistent option.
    c. Close the terminal window.  `service_id A` is kept.
    d. Open the terminal again. There's no `terminal-service-id` in the peer configuration file. Then a new `service_id B` with persistent service is created on the controlled side. `service_id A` is not restored.

We can:
1. Sync the service id when toggling the persistent option.
2. Generating the service id on the controlling side.
3. Always return the `service_id`.

Method `3` requires the least changes.




