### PR TITLE
fix: terminal, web, fonts

### DIFF
--- a/flutter/lib/mobile/pages/terminal_page.dart
+++ b/flutter/lib/mobile/pages/terminal_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_hbb/common.dart';
 import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/terminal_model.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:xterm/xterm.dart';
 import '../../desktop/pages/terminal_connection_manager.dart';
 
@@ -30,6 +31,12 @@ class _TerminalPageState extends State<TerminalPage>
     with AutomaticKeepAliveClientMixin {
   late FFI _ffi;
   late TerminalModel _terminalModel;
+
+  // For web only.
+  // 'monospace' does not work on web, use Google Fonts, `??` is only for null safety.
+  final String _robotoMonoFontFamily = isWeb
+      ? (GoogleFonts.robotoMono().fontFamily ?? 'monospace')
+      : 'monospace';
 
   @override
   void initState() {
@@ -81,6 +88,7 @@ class _TerminalPageState extends State<TerminalPage>
         _terminalModel.terminal,
         controller: _terminalModel.terminalController,
         autofocus: true,
+        textStyle: _getTerminalStyle(),
         backgroundOpacity: 0.7,
         padding: const EdgeInsets.symmetric(horizontal: 5.0, vertical: 2.0),
         onSecondaryTapDown: (details, offset) async {
@@ -99,6 +107,17 @@ class _TerminalPageState extends State<TerminalPage>
         },
       ),
     );
+  }
+
+  // https://github.com/TerminalStudio/xterm.dart/issues/42#issuecomment-877495472
+  // https://github.com/TerminalStudio/xterm.dart/issues/198#issuecomment-2526548458
+  TerminalStyle _getTerminalStyle() {
+    return isWeb
+        ? TerminalStyle(
+            fontFamily: _robotoMonoFontFamily,
+            fontSize: 14,
+          )
+        : const TerminalStyle();
   }
 
   @override

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -689,6 +689,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
   graphs:
     dependency: transitive
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -108,6 +108,7 @@ dependencies:
   extended_text: 14.0.0
   xterm: 4.0.0
   sqflite: 2.2.0
+  google_fonts: ^6.2.1
 
 dev_dependencies:
   icons_launcher: ^2.0.4


### PR DESCRIPTION
Web terminal (Windows, Linux, MacOS) has the fonts issue.

https://github.com/TerminalStudio/xterm.dart/issues/198#issuecomment-2526548458


https://github.com/TerminalStudio/xterm.dart/issues/42#issuecomment-877495472

## Preview

### Before

<img width="1036" height="284" alt="4e7458d3a97763641a052bfcc0d61fe5" src="https://github.com/user-attachments/assets/4444729f-688c-4c19-aff4-8805da38f6c2" />

### After

<img width="1033" height="244" alt="0cd7391c0f37f0680d800b3ed6dd9906" src="https://github.com/user-attachments/assets/5e6794ae-64e8-4113-b922-2a7a295d41df" />


