### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -23,7 +23,7 @@ env:
   MAC_RUST_VERSION: "1.81" # 1.81 is requred for macos, because of https://github.com/yury/cidre requires 1.81
   CARGO_NDK_VERSION: "3.1.2"
   SCITER_ARMV7_CMAKE_VERSION: "3.29.7"
-  SCITER_NASM_DEBVERSION: "2.14-1"
+  SCITER_NASM_DEBVERSION: "2.15.05-1"
   LLVM_VERSION: "15.0.6"
   FLUTTER_VERSION: "3.24.5"
   ANDROID_FLUTTER_VERSION: "3.24.5"
@@ -1978,11 +1978,8 @@ jobs:
           # https://github.com/AppImage/AppImageKit/wiki/FUSE
           sudo apt-get install -y libarchive-tools libfuse2
           # set-up appimage-builder
-          pushd /tmp
-          wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage
-          chmod +x appimage-builder-x86_64.AppImage
-          sudo mv appimage-builder-x86_64.AppImage /usr/local/bin/appimage-builder
-          popd
+          # https://github.com/AppImage/AppImageKit/issues/1395
+          sudo pip3 install git+https://github.com/rustdesk-org/appimage-builder.git
           # run appimage-builder
           pushd appimage
           sudo appimage-builder --skip-tests --recipe ./AppImageBuilder-${{ matrix.job.arch }}.yml
@@ -2009,14 +2006,15 @@ jobs:
         job:
           - {
               target: x86_64-unknown-linux-gnu,
-              distro: ubuntu18.04,
+              # https://github.com/ostreedev/ostree/commit/4bac96a8c817beda37448f9b8c662162bb619981
+              distro: ubuntu22.04,
               on: ubuntu-22.04,
               arch: x86_64,
               suffix: "",
             }
           - {
               target: x86_64-unknown-linux-gnu,
-              distro: ubuntu18.04,
+              distro: ubuntu22.04,
               on: ubuntu-22.04,
               arch: x86_64,
               suffix: "-sciter",

--- a/appimage/AppImageBuilder-aarch64.yml
+++ b/appimage/AppImageBuilder-aarch64.yml
@@ -99,3 +99,4 @@ AppDir:
 AppImage:
   arch: aarch64
   update-information: guess
+  comp: gzip

--- a/appimage/AppImageBuilder-x86_64.yml
+++ b/appimage/AppImageBuilder-x86_64.yml
@@ -102,3 +102,4 @@ AppDir:
 AppImage:
   arch: x86_64
   update-information: guess
+  comp: gzip


### PR DESCRIPTION
https://github.com/21pages/rustdesk/actions/runs/16464892435

1. Linux sciter: update nasm the current version 2.14-1 is not supported.  http://ftp.us.debian.org/debian/pool/main/n/nasm/ 

<img width="971" height="108" alt="Screenshot from 2025-07-23 16-40-41" src="https://github.com/user-attachments/assets/110e06d3-359e-439f-89f0-c7ab0a98f84b" />


2. AppImage: The runtime link for the official AppImage Builder has changed, and the new runtime does not support xz compression. https://github.com/AppImage/AppImageKit/issues/1395, https://github.com/AppImage/type2-runtime/issues/118

<img width="1415" height="565" alt="Screenshot from 2025-07-23 16-42-13" src="https://github.com/user-attachments/assets/4c943ca3-5e25-4c2e-81f1-35bd27be8a2b" />

<img width="682" height="160" alt="5f62bdcf169a845a4ddc62e72e174959" src="https://github.com/user-attachments/assets/197f100d-5684-4372-b6e7-2f7b2d09f46f" />

3. Flatpak: Requires a higher version of the distribution. Flatpak are no longer supported after merged for Ubuntu 18.04 and 20.04. https://github.com/ostreedev/ostree/commit/4bac96a8c817beda37448f9b8c662162bb619981

<img width="1218" height="121" alt="Screenshot from 2025-07-23 16-44-03" src="https://github.com/user-attachments/assets/42cb2603-fff8-4502-b85e-ed03ff142d4a" />

## run
<img width="918" height="644" alt="sciter-deb" src="https://github.com/user-attachments/assets/a68dfc5f-43a0-426d-b75d-f8211103e9bc" />

<img width="801" height="652" alt="appimage" src="https://github.com/user-attachments/assets/37d867a2-ffa2-4480-83d5-a85e6f2121a6" />

<img width="841" height="674" alt="flatpak" src="https://github.com/user-attachments/assets/04b1bc02-0ee8-4b6e-b021-ee7f0627c3d1" />
