### PR TITLE
refact: active terminal on conn the same remote

### DIFF
--- a/flutter/lib/desktop/pages/terminal_tab_page.dart
+++ b/flutter/lib/desktop/pages/terminal_tab_page.dart
@@ -177,6 +177,18 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
         tabController.clear();
       } else if (call.method == kWindowActionRebuild) {
         reloadCurrentWindow();
+      } else if (call.method == kWindowEventActiveSession) {
+        if (tabController.state.value.tabs.isEmpty) {
+          return false;
+        }
+        final currentTab = tabController.state.value.selectedTabInfo;
+        assert(call.arguments is String,
+            "Expected String arguments for kWindowEventActiveSession, got ${call.arguments.runtimeType}");
+        if (currentTab.key.startsWith(call.arguments)) {
+          windowOnTop(windowId());
+          return true;
+        }
+        return false;
       }
     });
     Future.delayed(Duration.zero, () {


### PR DESCRIPTION
If connecting to an existing peer id's terminal, activate the existing terminal window.


## Preview


https://github.com/user-attachments/assets/93416ab9-a9a5-4e85-95d7-e5a4c367a12b

