### PR TITLE
Fix retry button blocked by overly broad "exist" filter

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3693,7 +3693,7 @@ pub fn check_if_retry(msgtype: &str, title: &str, text: &str, retry_for_relay: b
         && title == "Connection Error"
         && ((text.contains("10054") || text.contains("104")) && retry_for_relay
             || (!text.to_lowercase().contains("offline")
-                && !text.to_lowercase().contains("exist")
+                && !text.to_lowercase().contains("not exist")
                 && !text.to_lowercase().contains("handshake")
                 && !text.to_lowercase().contains("failed")
                 && !text.to_lowercase().contains("resolve")


### PR DESCRIPTION
## Problem
Users reported that the `"Retry"` button was not appearing for legitimate network disconnection errors, specifically for the error message:

```
"Connection error: An existing connection was forcibly closed by the remote host"
```
<img height="186" alt="image" src="https://github.com/user-attachments/assets/42599f54-e58c-4242-867a-07f62f473e62" />
<img  height="186" alt="image" src="https://github.com/user-attachments/assets/d2a52497-a6a8-40f4-abb7-30aa3aaa212e" />


## Root Cause Analysis
After investigating the codebase, we found that the `check_if_retry()` function in `src/client.rs` uses substring matching to filter out errors that shouldn't show retry buttons:

```rust
&& !text.to_lowercase().contains("exist")
```

This filter was intended to block retry buttons for `"ID does not exist"` type errors, but it was too broad and also caught legitimate network errors containing the word `"existing"` (as in `"existing connection was forcibly closed"`).

## Solution
Changed the filter from `"exist"` to `"not exist"` to be more specific:

```rust
// Before
&& !text.to_lowercase().contains("exist")

// After
&& !text.to_lowercase().contains("not exist")
```

This change:
- Still blocks `"ID does not exist"`, `"Device does not exist"`, etc.
- Allows `"An existing connection was forcibly closed"` to show retry
- Maintains all other existing filter logic

## Testing
This fix specifically addresses network disconnection scenarios where the connection is forcibly closed by the remote host, which should be retryable.

## Related Discussion
Full analysis and discussion: https://github.com/rustdesk/rustdesk/discussions/12346

## Impact
- Fixes missing retry buttons for legitimate network disconnection errors
- No impact on existing functionality
- Single line change with minimal risk