### PR TITLE
fix connect timeout of udp_nat_connect and udp_nat_listen

### DIFF
--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -834,7 +834,7 @@ async fn udp_nat_listen(
         let res = crate::punch_udp(socket.clone(), true).await?;
         let stream = crate::kcp_stream::KcpStream::accept(
             socket,
-            Duration::from_secs(CONNECT_TIMEOUT as _),
+            Duration::from_millis(CONNECT_TIMEOUT as _),
             res,
         )
         .await?;


### PR DESCRIPTION
1. Change wrong seconds to milliseconds.
2. Use `connect_timeout` for `udp_nat_connect` like TCP.