### PR TITLE
refact: suppress warns on macos

### DIFF
--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -239,6 +239,24 @@ fn ffmpeg() {
 */
 
 fn main() {
+    // there is problem with cfg(target_os) in build.rs, so use our workaround
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    // We check if is macos, because macos uses rust 1.8.1.
+    // `cargo::rustc-check-cfg` is new with Cargo 1.80.
+    // No need to run `cargo version` to get the version here, because:
+    // The following lines are used to suppress the lint warnings.
+    //          warning: unexpected `cfg` condition name: `quartz`
+    if cfg!(target_os = "macos") {
+        if target_os != "ios" {
+            println!("cargo::rustc-check-cfg=cfg(android)");
+            println!("cargo::rustc-check-cfg=cfg(dxgi)");
+            println!("cargo::rustc-check-cfg=cfg(quartz)");
+            println!("cargo::rustc-check-cfg=cfg(x11)");
+            //        ^^^^^^^^^^^^^^^^^^^^^^ new with Cargo 1.80
+        }
+    }
+
     // note: all link symbol names in x86 (32-bit) are prefixed wth "_".
     // run "rustup show" to show current default toolchain, if it is stable-x86-pc-windows-msvc,
     // please install x64 toolchain by "rustup toolchain install stable-x86_64-pc-windows-msvc",
@@ -256,8 +274,6 @@ fn main() {
     gen_vcpkg_package("libyuv", "yuv_ffi.h", "yuv_ffi.rs", ".*");
     // ffmpeg();
 
-    // there is problem with cfg(target_os) in build.rs, so use our workaround
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     if target_os == "ios" {
         // nothing
     } else if target_os == "android" {

--- a/libs/scrap/src/common/camera.rs
+++ b/libs/scrap/src/common/camera.rs
@@ -17,7 +17,9 @@ use hbb_common::message_proto::{DisplayInfo, Resolution};
 use crate::AdapterDevice;
 
 use crate::common::{bail, ResultType};
-use crate::{Frame, PixelBuffer, Pixfmt, TraitCapturer};
+use crate::{Frame, TraitCapturer};
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use crate::{PixelBuffer, Pixfmt};
 
 pub const PRIMARY_CAMERA_IDX: usize = 0;
 lazy_static::lazy_static! {
@@ -162,11 +164,11 @@ impl Cameras {
         return Ok(Vec::new());
     }
 
-    pub fn exists(index: usize) -> bool {
+    pub fn exists(_index: usize) -> bool {
         false
     }
 
-    pub fn get_camera_resolution(index: usize) -> ResultType<Resolution> {
+    pub fn get_camera_resolution(_index: usize) -> ResultType<Resolution> {
         bail!(CAMERA_NOT_SUPPORTED);
     }
 
@@ -174,7 +176,7 @@ impl Cameras {
         vec![]
     }
 
-    pub fn get_capturer(current: usize) -> ResultType<Box<dyn TraitCapturer>> {
+    pub fn get_capturer(_current: usize) -> ResultType<Box<dyn TraitCapturer>> {
         bail!(CAMERA_NOT_SUPPORTED);
     }
 }
@@ -201,6 +203,7 @@ impl CameraCapturer {
         })
     }
 
+    #[allow(dead_code)]
     #[cfg(not(any(target_os = "windows", target_os = "linux")))]
     fn new(_current: usize) -> ResultType<Self> {
         bail!(CAMERA_NOT_SUPPORTED);

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -18,10 +18,17 @@ use crate::{
     CodecFormat, EncodeInput, EncodeYuvFormat, ImageRgb, ImageTexture,
 };
 
+#[cfg(any(
+    feature = "hwcodec",
+    feature = "mediacodec",
+    feature = "vram",
+    target_os = "windows"
+))]
+use hbb_common::config::option2bool;
 use hbb_common::{
     anyhow::anyhow,
     bail,
-    config::{option2bool, Config, PeerConfig},
+    config::{Config, PeerConfig},
     lazy_static, log,
     message_proto::{
         supported_decoding::PreferCodec, video_frame, Chroma, CodecAbility, EncodedVideoFrames,

--- a/src/client/file_trait.rs
+++ b/src/client/file_trait.rs
@@ -3,14 +3,32 @@ use hbb_common::{fs, log, message_proto::*};
 use super::{Data, Interface};
 
 pub trait FileManager: Interface {
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "ios",
+        feature = "cli",
+        feature = "flutter"
+    )))]
     fn get_home_dir(&self) -> String {
         fs::get_home_as_string()
     }
 
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "ios",
+        feature = "cli",
+        feature = "flutter"
+    )))]
     fn get_next_job_id(&self) -> i32 {
         fs::get_next_job_id()
     }
 
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "ios",
+        feature = "cli",
+        feature = "flutter"
+    )))]
     fn update_next_job_id(&self, id: i32) {
         fs::update_next_job_id(id);
     }
@@ -30,20 +48,6 @@ pub trait FileManager: Interface {
                 m.set_item("path", path);
                 m
             }
-        }
-    }
-
-    #[cfg(any(
-        target_os = "android",
-        target_os = "ios",
-        feature = "cli",
-        feature = "flutter"
-    ))]
-    fn read_dir(&self, path: &str, include_hidden: bool) -> String {
-        use crate::common::make_fd_to_json;
-        match fs::read_dir(&fs::get_path(path), include_hidden) {
-            Ok(fd) => make_fd_to_json(fd.id, fd.path, &fd.entries),
-            Err(_) => "".into(),
         }
     }
 
@@ -83,10 +87,22 @@ pub trait FileManager: Interface {
         self.send(Data::RemoveDirAll((id, path, is_remote, include_hidden)));
     }
 
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "ios",
+        feature = "cli",
+        feature = "flutter"
+    )))]
     fn confirm_delete_files(&self, id: i32, file_num: i32) {
         self.send(Data::ConfirmDeleteFiles((id, file_num)));
     }
 
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "ios",
+        feature = "cli",
+        feature = "flutter"
+    )))]
     fn set_no_confirm(&self, id: i32) {
         self.send(Data::SetNoConfirm(id));
     }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -117,7 +117,7 @@ pub fn check_clipboard_files(
     None
 }
 
-#[cfg(feature = "unix-file-copy-paste")]
+#[cfg(all(target_os = "linux", feature = "unix-file-copy-paste"))]
 pub fn update_clipboard_files(files: Vec<String>, side: ClipboardSide) {
     if !files.is_empty() {
         std::thread::spawn(move || {
@@ -141,6 +141,7 @@ pub fn try_empty_clipboard_files(_side: ClipboardSide, _conn_id: i32) {
                 }
             }
         }
+        #[allow(unused_mut)]
         if let Some(mut ctx) = ctx.as_mut() {
             #[cfg(target_os = "linux")]
             {

--- a/src/clipboard_file.rs
+++ b/src/clipboard_file.rs
@@ -192,12 +192,10 @@ pub fn msg_2_clip(msg: Cliprdr) -> Option<ClipboardFile> {
 
 #[cfg(feature = "unix-file-copy-paste")]
 pub mod unix_file_clip {
-    use crate::clipboard::try_empty_clipboard_files;
-
-    use super::{
-        super::clipboard::{update_clipboard_files, ClipboardSide},
-        *,
-    };
+    use super::*;
+    #[cfg(target_os = "linux")]
+    use crate::clipboard::update_clipboard_files;
+    use crate::clipboard::{try_empty_clipboard_files, ClipboardSide};
     #[cfg(target_os = "linux")]
     use clipboard::platform::unix::fuse;
     use clipboard::platform::unix::{

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,7 +8,7 @@ use std::{
 
 use serde_json::{json, Map, Value};
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
+#[cfg(not(target_os = "ios"))]
 use hbb_common::whoami;
 use hbb_common::{
     allow_err,
@@ -776,12 +776,22 @@ pub fn username() -> String {
     return DEVICE_NAME.lock().unwrap().clone();
 }
 
+// Exactly the implementation of "whoami::hostname()".
+// This wrapper is to suppress warnings.
+#[inline(always)]
+#[cfg(not(target_os = "ios"))]
+pub fn whoami_hostname() -> String {
+    let mut hostname = whoami::fallible::hostname().unwrap_or_else(|_| "localhost".to_string());
+    hostname.make_ascii_lowercase();
+    hostname
+}
+
 #[inline]
 pub fn hostname() -> String {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     {
         #[allow(unused_mut)]
-        let mut name = whoami::hostname();
+        let mut name = whoami_hostname();
         // some time, there is .local, some time not, so remove it for osx
         #[cfg(target_os = "macos")]
         if name.ends_with(".local") {
@@ -1723,7 +1733,7 @@ pub fn is_custom_client() -> bool {
     get_app_name() != "RustDesk"
 }
 
-pub fn verify_login(raw: &str, id: &str) -> bool {
+pub fn verify_login(_raw: &str, _id: &str) -> bool {
     true
     /*
     if is_custom_client() {

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -15,11 +15,11 @@ use hbb_common::{
 };
 use serde::Serialize;
 use serde_json::json;
-
+#[cfg(target_os = "windows")]
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::{
     collections::{HashMap, HashSet},
     ffi::CString,
-    io::{Error as IoError, ErrorKind as IoErrorKind},
     os::raw::{c_char, c_int, c_void},
     str::FromStr,
     sync::{
@@ -111,6 +111,7 @@ pub extern "C" fn rustdesk_core_main() -> bool {
         #[cfg(target_os = "macos")]
         std::process::exit(0);
     }
+    #[cfg(not(target_os = "macos"))]
     false
 }
 

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -269,7 +269,7 @@ pub fn session_take_screenshot(session_id: SessionID, display: usize) {
     }
 }
 
-pub fn session_handle_screenshot(session_id: SessionID, action: String) -> String {
+pub fn session_handle_screenshot(#[allow(unused_variables)] session_id: SessionID, action: String) -> String {
     crate::client::screenshot::handle_screenshot(action)
 }
 
@@ -2669,7 +2669,7 @@ pub fn session_get_common_sync(
     SyncReturn(session_get_common(session_id, key, param))
 }
 
-pub fn session_get_common(session_id: SessionID, key: String, param: String) -> Option<String> {
+pub fn session_get_common(session_id: SessionID, key: String, #[allow(unused_variables)] param: String) -> Option<String> {
     if let Some(s) = sessions::get_session_by_session_id(&session_id) {
         let v = if key == "is_screenshot_supported" {
             s.is_screenshot_supported().to_string()

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -418,6 +418,7 @@ pub fn is_modifier(key: &rdev::Key) -> bool {
 }
 
 #[inline]
+#[allow(dead_code)]
 pub fn is_modifier_code(evt: &KeyEvent) -> bool {
     match evt.union {
         Some(key_event::Union::Chr(code)) => {

--- a/src/lan.rs
+++ b/src/lan.rs
@@ -1,3 +1,5 @@
+#[cfg(not(target_os = "ios"))]
+use hbb_common::whoami;
 use hbb_common::{
     allow_err,
     anyhow::bail,
@@ -10,7 +12,7 @@ use hbb_common::{
         self,
         sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     },
-    whoami, ResultType,
+    ResultType,
 };
 
 use std::{
@@ -45,7 +47,7 @@ pub(super) fn start_listening() -> ResultType<()> {
                             }
                             if let Some(self_addr) = get_ipaddr_by_peer(&addr) {
                                 let mut msg_out = Message::new();
-                                let mut hostname = whoami::hostname();
+                                let mut hostname = crate::whoami_hostname();
                                 // The default hostname is "localhost" which is a bit confusing
                                 if hostname == "localhost" {
                                     hostname = "unknown".to_owned();

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -252,7 +252,7 @@ fn update_daemon_agent(agent_plist_file: String, update_source_dir: String, sync
 
     let func = move || {
         let mut binding = std::process::Command::new("osascript");
-        let mut cmd = binding
+        let cmd = binding
             .arg("-e")
             .arg(update_script_body)
             .arg(daemon_plist_body)
@@ -854,6 +854,7 @@ pub fn hide_dock() {
 }
 
 #[inline]
+#[allow(dead_code)]
 fn get_server_start_time_of(p: &Process, path: &Path) -> Option<i64> {
     let cmd = p.cmd();
     if cmd.len() <= 1 {
@@ -872,6 +873,7 @@ fn get_server_start_time_of(p: &Process, path: &Path) -> Option<i64> {
 }
 
 #[inline]
+#[allow(dead_code)]
 fn get_server_start_time(sys: &mut System, path: &Path) -> Option<(i64, Pid)> {
     sys.refresh_processes_specifics(ProcessRefreshKind::new());
     for (_, p) in sys.processes() {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -119,16 +119,18 @@ pub fn get_wakelock(_display: bool) -> WakeLock {
     return crate::platform::WakeLock::new(_display, true, false);
 }
 
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 pub(crate) struct InstallingService; // please use new
 
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 impl InstallingService {
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
     pub fn new() -> Self {
         *INSTALLING_SERVICE.lock().unwrap() = true;
         Self
     }
 }
 
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 impl Drop for InstallingService {
     fn drop(&mut self) {
         *INSTALLING_SERVICE.lock().unwrap() = false;
@@ -144,6 +146,7 @@ pub fn is_prelogin() -> bool {
 // Note: This method is inefficient on Windows. It will get all the processes.
 // It should only be called when performance is not critical.
 // If we wanted to get the command line ourselves, there would be a lot of new code.
+#[allow(dead_code)]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn get_pids_of_process_with_args<S1: AsRef<str>, S2: AsRef<str>>(
     name: S1,

--- a/src/privacy_mode.rs
+++ b/src/privacy_mode.rs
@@ -1,17 +1,13 @@
-#[cfg(windows)]
-use crate::platform::is_installed;
 use crate::ui_interface::get_option;
 #[cfg(windows)]
 use crate::{
     display_service,
     ipc::{connect, Data},
+    platform::is_installed,
 };
-use hbb_common::{
-    anyhow::anyhow,
-    bail, lazy_static,
-    tokio::{self, sync::oneshot},
-    ResultType,
-};
+#[cfg(windows)]
+use hbb_common::tokio;
+use hbb_common::{anyhow::anyhow, bail, lazy_static, tokio::sync::oneshot, ResultType};
 use serde_derive::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -39,7 +35,8 @@ pub const TURN_OFF_OTHER_ID: &'static str =
 pub const NO_PHYSICAL_DISPLAYS: &'static str = "no_need_privacy_mode_no_physical_displays_tip";
 
 pub const PRIVACY_MODE_IMPL_WIN_MAG: &str = "privacy_mode_impl_mag";
-pub const PRIVACY_MODE_IMPL_WIN_EXCLUDE_FROM_CAPTURE: &str = "privacy_mode_impl_exclude_from_capture";
+pub const PRIVACY_MODE_IMPL_WIN_EXCLUDE_FROM_CAPTURE: &str =
+    "privacy_mode_impl_exclude_from_capture";
 pub const PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY: &str = "privacy_mode_impl_virtual_display";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1,8 +1,6 @@
 #[cfg(target_os = "linux")]
 use super::rdp_input::client::{RdpInputKeyboard, RdpInputMouse};
 use super::*;
-#[cfg(target_os = "macos")]
-use crate::common::is_server;
 use crate::input::*;
 #[cfg(target_os = "macos")]
 use dispatch::Queue;
@@ -19,7 +17,7 @@ use rdev::{CGEventSourceStateID, CGEventTapLocation, VirtualInput};
 use scrap::wayland::pipewire::RDP_SESSION_INFO;
 use std::{
     convert::TryFrom,
-    ops::{Deref, DerefMut, Sub},
+    ops::{Deref, DerefMut},
     sync::atomic::{AtomicBool, Ordering},
     thread,
     time::{self, Duration, Instant},
@@ -699,6 +697,7 @@ fn get_modifier_state(key: Key, en: &mut Enigo) -> bool {
     }
 }
 
+#[allow(unreachable_code)]
 pub fn handle_mouse(evt: &MouseEvent, conn: i32) {
     #[cfg(target_os = "macos")]
     {
@@ -714,6 +713,7 @@ pub fn handle_mouse(evt: &MouseEvent, conn: i32) {
 }
 
 // to-do: merge handle_mouse and handle_pointer
+#[allow(unreachable_code)]
 pub fn handle_pointer(evt: &PointerDeviceEvent, conn: i32) {
     #[cfg(target_os = "macos")]
     {
@@ -894,7 +894,7 @@ fn get_last_input_cursor_pos() -> (i32, i32) {
 }
 
 // check if mouse is moved by the controlled side user to make controlled side has higher mouse priority than remote.
-fn active_mouse_(conn: i32) -> bool {
+fn active_mouse_(_conn: i32) -> bool {
     true
     /* this method is buggy (not working on macOS, making fast moving mouse event discarded here) and added latency (this is blocking way, must do in async way), so we disable it for now
     // out of time protection
@@ -1264,7 +1264,7 @@ fn sim_rdev_rawkey_virtual(code: u32, keydown: bool) {
 fn simulate_(event_type: &EventType) {
     unsafe {
         let _lock = VIRTUAL_INPUT_MTX.lock();
-        if let Some(input) = &VIRTUAL_INPUT_STATE {
+        if let Some(input) = VIRTUAL_INPUT_STATE.as_ref() {
             let _ = input.simulate(&event_type);
         }
     }
@@ -1276,7 +1276,7 @@ fn press_capslock() {
     let caps_key = RdevKey::RawKey(rdev::RawKey::MacVirtualKeycode(rdev::kVK_CapsLock));
     unsafe {
         let _lock = VIRTUAL_INPUT_MTX.lock();
-        if let Some(input) = &mut VIRTUAL_INPUT_STATE {
+        if let Some(input) = VIRTUAL_INPUT_STATE.as_mut() {
             if input.simulate(&EventType::KeyPress(caps_key)).is_ok() {
                 input.capslock_down = true;
                 key_sleep();
@@ -1291,7 +1291,7 @@ fn release_capslock() {
     let caps_key = RdevKey::RawKey(rdev::RawKey::MacVirtualKeycode(rdev::kVK_CapsLock));
     unsafe {
         let _lock = VIRTUAL_INPUT_MTX.lock();
-        if let Some(input) = &mut VIRTUAL_INPUT_STATE {
+        if let Some(input) = VIRTUAL_INPUT_STATE.as_mut() {
             if input.simulate(&EventType::KeyRelease(caps_key)).is_ok() {
                 input.capslock_down = false;
                 key_sleep();

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -1,19 +1,16 @@
-#[cfg(target_os = "windows")]
-use crate::ipc::ClipboardNonFile;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::ipc::Connection;
 #[cfg(not(any(target_os = "ios")))]
-use crate::{
-    clipboard::ClipboardSide,
-    ipc::{self, Data},
-};
+use crate::ipc::{self, Data};
+#[cfg(target_os = "windows")]
+use crate::{clipboard::ClipboardSide, ipc::ClipboardNonFile};
 #[cfg(target_os = "windows")]
 use clipboard::ContextSend;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use hbb_common::tokio::sync::mpsc::unbounded_channel;
 use hbb_common::{
     allow_err,
-    config::{keys::*, option2bool, Config},
+    config::Config,
     fs::is_write_need_confirmation,
     fs::{self, get_string, new_send_confirm, DigestCheckResult},
     log,
@@ -25,12 +22,16 @@ use hbb_common::{
         task::spawn_blocking,
     },
 };
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
-use hbb_common::{tokio::sync::Mutex as TokioMutex, ResultType};
+#[cfg(target_os = "windows")]
+use hbb_common::{
+    config::{keys::*, option2bool},
+    tokio::sync::Mutex as TokioMutex,
+    ResultType,
+};
 use serde_derive::Serialize;
 #[cfg(any(target_os = "android", target_os = "ios", feature = "flutter"))]
 use std::iter::FromIterator;
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "windows")]
 use std::sync::Arc;
 use std::{
     collections::HashMap,

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -813,6 +813,7 @@ pub fn get_async_http_status(url: String) -> Option<String> {
 }
 
 #[inline]
+#[cfg(not(feature = "flutter"))]
 pub fn post_request(url: String, body: String, header: String) {
     *ASYNC_JOB_STATUS.lock().unwrap() = " ".to_owned();
     std::thread::spawn(move || {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -5,22 +5,13 @@ use crate::{
 };
 use async_trait::async_trait;
 use bytes::Bytes;
-use rdev::{Event, EventType::*, KeyCode};
-use std::{
-    collections::HashMap,
-    ffi::c_void,
-    ops::{Deref, DerefMut},
-    str::FromStr,
-    sync::{Arc, Mutex, RwLock},
-    time::SystemTime,
-};
-use uuid::Uuid;
-
+#[cfg(all(target_os = "windows", not(feature = "flutter")))]
+use hbb_common::config::keys;
 #[cfg(not(feature = "flutter"))]
 use hbb_common::fs;
 use hbb_common::{
     allow_err,
-    config::{keys, Config, LocalConfig, PeerConfig},
+    config::{Config, LocalConfig, PeerConfig},
     get_version_number, log,
     message_proto::*,
     rendezvous_proto::ConnType,
@@ -31,6 +22,17 @@ use hbb_common::{
     },
     whoami, Stream,
 };
+use rdev::{Event, EventType::*, KeyCode};
+#[cfg(all(feature = "vram", feature = "flutter"))]
+use std::ffi::c_void;
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+    sync::{Arc, Mutex, RwLock},
+    time::SystemTime,
+};
+use uuid::Uuid;
 
 use crate::client::io_loop::Remote;
 use crate::client::{
@@ -192,7 +194,11 @@ impl<T: InvokeUiSession> Session<T> {
     }
 
     pub fn is_default(&self) -> bool {
-        self.lc.read().unwrap().conn_type.eq(&ConnType::DEFAULT_CONN)
+        self.lc
+            .read()
+            .unwrap()
+            .conn_type
+            .eq(&ConnType::DEFAULT_CONN)
     }
 
     pub fn is_view_camera(&self) -> bool {
@@ -803,7 +809,6 @@ impl<T: InvokeUiSession> Session<T> {
         msg_out.set_terminal_action(action);
         self.send(Data::Message(msg_out));
     }
-
 
     pub fn capture_displays(&self, add: Vec<i32>, sub: Vec<i32>, set: Vec<i32>) {
         let mut misc = Misc::new();

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,7 +1,7 @@
 use crate::{common::do_check_software_update, hbbs_http::create_http_client};
 use hbb_common::{bail, config, log, ResultType};
 use std::{
-    io::{self, Write},
+    io::Write,
     path::PathBuf,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -28,6 +28,7 @@ pub fn update_controlling_session_count(count: usize) {
     CONTROLLING_SESSION_COUNT.store(count, Ordering::SeqCst);
 }
 
+#[allow(dead_code)]
 pub fn start_auto_update() {
     let _sender = TX_MSG.lock().unwrap();
 }
@@ -197,7 +198,10 @@ fn check_update(manually: bool) -> ResultType<()> {
 
 #[cfg(target_os = "windows")]
 fn update_new_version(is_msi: bool, version: &str, file_path: &PathBuf) {
-    log::debug!("New version is downloaded, update begin, is msi: {is_msi}, version: {version}, file: {:?}", file_path.to_str());
+    log::debug!(
+        "New version is downloaded, update begin, is msi: {is_msi}, version: {version}, file: {:?}",
+        file_path.to_str()
+    );
     if let Some(p) = file_path.to_str() {
         if let Some(session_id) = crate::platform::get_current_process_session_id() {
             if is_msi {
@@ -231,7 +235,7 @@ fn update_new_version(is_msi: bool, version: &str, file_path: &PathBuf) {
         } else {
             log::error!(
                 "Failed to get the current process session id, Error {}",
-                io::Error::last_os_error()
+                std::io::Error::last_os_error()
             );
         }
     } else {


### PR DESCRIPTION
1. Suppress warnings on macOS.
2. Replace `whoami::hostname()` with `whoami_hostname()`.
3. Remove unused code `let is_keyboard_enabled = self.peer_keyboard_enabled();` in 
```rust
#[cfg(feature = "unix-file-copy-paste")]
async fn handle_file_clip(&mut self, clip: clipboard::ClipboardFile) {
}
```
