### PR TITLE
Feat: file transfer, resume

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -26,7 +26,9 @@ use hbb_common::{
     config::{self, keys::OPTION_ALLOW_WEBSOCKET, Config, Config2},
     futures::StreamExt as _,
     futures_util::sink::SinkExt,
-    log, password_security as password, timeout,
+    log,
+    message_proto::FileTransferSendConfirmRequest,
+    password_security as password, timeout,
     tokio::{
         self,
         io::{AsyncRead, AsyncWrite},
@@ -105,6 +107,7 @@ pub enum FS {
         last_modified: u64,
         is_upload: bool,
     },
+    SendConfirm(Vec<u8>),
     Rename {
         id: i32,
         path: String,

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2703,7 +2703,11 @@ impl Connection {
                             }
                             Some(file_action::Union::SendConfirm(r)) => {
                                 if let Some(job) = fs::get_job(r.id, &mut self.read_jobs) {
-                                    job.confirm(&r);
+                                    job.confirm(&r).await;
+                                } else {
+                                    if let Ok(sc) = r.write_to_bytes() {
+                                        self.send_fs(ipc::FS::SendConfirm(sc));
+                                    }
                                 }
                             }
                             Some(file_action::Union::Rename(r)) => {

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -880,6 +880,7 @@ async fn handle_fs(
                         let path = get_string(&fs::TransferJob::join(p, &file.name));
                         match is_write_need_confirmation(&path, &digest) {
                             Ok(digest_result) => {
+                                job.set_digest(file_size, last_modified);
                                 match digest_result {
                                     DigestCheckResult::IsSame => {
                                         req.set_skip(true);
@@ -906,6 +907,13 @@ async fn handle_fs(
                             }
                         }
                     }
+                }
+            }
+        }
+        ipc::FS::SendConfirm(bytes) => {
+            if let Ok(r) = FileTransferSendConfirmRequest::parse_from_bytes(&bytes) {
+                if let Some(job) = fs::get_job(r.id, write_jobs) {
+                    job.confirm(&r).await;
                 }
             }
         }


### PR DESCRIPTION

1. Feat. File transfer resume. Reset the `overwrite` value if the digest is identical and current job is resume.

<img width="1216" height="541" alt="image" src="https://github.com/user-attachments/assets/a7755c66-9b25-4c36-aa01-b2f1e7cd5de9" />


2. Fix. `new_receive()` should send the remote path, but it send the local path `p`.

<img width="1194" height="404" alt="image" src="https://github.com/user-attachments/assets/df1e39e5-08e7-4719-8e7c-55e714c64ff3" />

## Tests

- [x] Windows <-> MacOS. New <-> Old, New <-> New.
- [x] Windows <-> Android. New <-> Old, New <-> New.

## TODOs

1. Web.
2. Load last file transfer jobs sometimes does not work fine on reconnection.
