### PR TITLE
Updated Persian translations in fa.rs

### DIFF
--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -708,6 +708,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Failed to check if the user is an administrator.", "بررسی وضعیت مدیر سیستم برای کاربر ناموفق بود."),
         ("Supported only in the installed version.", "فقط در نسخه نصب‌شده پشتیبانی می‌شود."),
         ("elevation_username_tip", "لطفاً نام کاربری مدیریتی را برای ارتقاء دسترسی وارد کنید."),
-        ("Preparing for installation ...", ""),
+        ("Preparing for installation ...", "در حال آماده‌سازی برای نصب..."),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
### Summary

This PR updates the Persian (`fa.rs`) translations by completing the missing entry for installation preparation.

### Changes

- Added translation for:
  - `"Preparing for installation ..."`
