### PR TITLE
fix: file transfer, resume

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -38,7 +38,7 @@ env:
   #  https://github.com/rustdesk/rustdesk/actions/runs/14414119794/job/40427970174
   # 2. Update the `VCPKG_COMMIT_ID` in `ci.yml` and `playground.yml`.
   VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
-  VERSION: "1.4.1"
+  VERSION: "1.4.2"
   NDK_VERSION: "r27c"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -17,7 +17,7 @@ env:
   TAG_NAME: "nightly"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
   VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
-  VERSION: "1.4.1"
+  VERSION: "1.4.2"
   NDK_VERSION: "r26d"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: RustDesk.RustDesk
-          version: "1.4.1"
-          release-tag: "1.4.1"
+          version: "1.4.2"
+          release-tag: "1.4.2"
           token: ${{ secrets.WINGET_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6110,7 +6110,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "android-wakelock",
  "android_logger",
@@ -6216,7 +6216,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk-portable-packer"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "brotli",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["rustdesk <info@rustdesk.com>"]
 edition = "2021"
 build= "build.rs"

--- a/appimage/AppImageBuilder-aarch64.yml
+++ b/appimage/AppImageBuilder-aarch64.yml
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.4.1
+    version: 1.4.2
     exec: usr/share/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/appimage/AppImageBuilder-x86_64.yml
+++ b/appimage/AppImageBuilder-x86_64.yml
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.4.1
+    version: 1.4.2
     exec: usr/share/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # 1.1.9-1 works for android, but for ios it becomes 1.1.91, need to set it to 1.1.9-a.1 for iOS, will get 1.1.9.1, but iOS store not allow 4 numbers
-version: 1.4.1+59
+version: 1.4.2+60
 
 environment:
   sdk: '^3.1.0'

--- a/libs/portable/Cargo.toml
+++ b/libs/portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk-portable-packer"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 description = "RustDesk Remote Desktop"
 

--- a/res/PKGBUILD
+++ b/res/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=rustdesk
-pkgver=1.4.1
+pkgver=1.4.2
 pkgrel=0
 epoch=
 pkgdesc=""

--- a/res/rpm-flutter-suse.spec
+++ b/res/rpm-flutter-suse.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.4.1
+Version:    1.4.2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.4.1
+Version:    1.4.2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.4.1
+Version:    1.4.2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1481,9 +1481,6 @@ impl<T: InvokeUiSession> Remote<T> {
                                                 if digest.transferred_size > 0 {
                                                     overwrite_strategy = Some(true);
                                                     offset = digest.transferred_size as _;
-                                                } else {
-                                                    // Force skip if the file is identical and the job is set to resume.
-                                                    overwrite_strategy = Some(false);
                                                 }
                                             }
                                             if let Some(overwrite) = overwrite_strategy {
@@ -1521,7 +1518,13 @@ impl<T: InvokeUiSession> Remote<T> {
                                             let write_path =
                                                 get_string(&fs::TransferJob::join(p, &file.name));
                                             job.set_digest(digest.file_size, digest.last_modified);
+                                            let peer_ver = self.handler.lc.read().unwrap().version;
+                                            let is_support_resume =
+                                                crate::is_support_file_transfer_resume_num(
+                                                    peer_ver,
+                                                );
                                             match fs::is_write_need_confirmation(
+                                                is_support_resume,
                                                 &write_path,
                                                 &digest,
                                             ) {
@@ -1546,9 +1549,6 @@ impl<T: InvokeUiSession> Remote<T> {
                                                                 overwrite_strategy = Some(true);
                                                                 offset =
                                                                     digest.transferred_size as _;
-                                                            } else {
-                                                                // Force skip if the file is identical and the job is set to resume.
-                                                                overwrite_strategy = Some(false);
                                                             }
                                                         }
                                                         if let Some(overwrite) = overwrite_strategy

--- a/src/common.rs
+++ b/src/common.rs
@@ -163,6 +163,16 @@ pub fn is_support_screenshot_num(ver: i64) -> bool {
     ver >= hbb_common::get_version_number("1.4.0")
 }
 
+#[inline]
+pub fn is_support_file_transfer_resume(ver: &str) -> bool {
+    is_support_file_transfer_resume_num(hbb_common::get_version_number(ver))
+}
+
+#[inline]
+pub fn is_support_file_transfer_resume_num(ver: i64) -> bool {
+    ver >= hbb_common::get_version_number("1.4.2")
+}
+
 // is server process, with "--server" args
 #[inline]
 pub fn is_server() -> bool {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -195,6 +195,7 @@ pub enum Data {
         is_view_camera: bool,
         is_terminal: bool,
         peer_id: String,
+        peer_version: String,
         name: String,
         authorized: bool,
         port_forward: String,

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -76,6 +76,7 @@ struct IpcTaskRunner<T: InvokeUiCM> {
     close: bool,
     running: bool,
     conn_id: i32,
+    peer_ver: String,
     #[cfg(target_os = "windows")]
     file_transfer_enabled: bool,
     #[cfg(target_os = "windows")]
@@ -408,10 +409,11 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                         }
                         Ok(Some(data)) => {
                             match data {
-                                Data::Login{id, is_file_transfer, is_view_camera, is_terminal, port_forward, peer_id, name, authorized, keyboard, clipboard, audio, file, file_transfer_enabled: _file_transfer_enabled, restart, recording, block_input, from_switch} => {
+                                Data::Login{id, is_file_transfer, is_view_camera, is_terminal, port_forward, peer_id, peer_version, name, authorized, keyboard, clipboard, audio, file, file_transfer_enabled: _file_transfer_enabled, restart, recording, block_input, from_switch} => {
                                     log::debug!("conn_id: {}", id);
                                     self.cm.add_connection(id, is_file_transfer, is_view_camera, is_terminal, port_forward, peer_id, name, authorized, keyboard, clipboard, audio, file, restart, recording, block_input, from_switch, self.tx.clone());
                                     self.conn_id = id;
+                                    self.peer_ver = peer_version;
                                     #[cfg(target_os = "windows")]
                                     {
                                         self.file_transfer_enabled = _file_transfer_enabled;
@@ -442,10 +444,10 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
                                     if let ipc::FS::WriteBlock { id, file_num, data: _, compressed } = fs {
                                         if let Ok(bytes) = self.stream.next_raw().await {
                                             fs = ipc::FS::WriteBlock{id, file_num, data:bytes.into(), compressed};
-                                            handle_fs(fs, &mut write_jobs, &self.tx, Some(&tx_log)).await;
+                                            handle_fs(fs, &mut write_jobs, &self.tx, Some(&tx_log), &self.peer_ver).await;
                                         }
                                     } else {
-                                        handle_fs(fs, &mut write_jobs, &self.tx, Some(&tx_log)).await;
+                                        handle_fs(fs, &mut write_jobs, &self.tx, Some(&tx_log), &self.peer_ver).await;
                                     }
                                     let log = fs::serialize_transfer_jobs(&write_jobs);
                                     self.cm.ui_handler.file_transfer_log("transfer", &log);
@@ -614,6 +616,7 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
             close: true,
             running: true,
             conn_id: 0,
+            peer_ver: String::new(),
             #[cfg(target_os = "windows")]
             file_transfer_enabled: false,
             #[cfg(target_os = "windows")]
@@ -672,6 +675,7 @@ pub async fn start_listen<T: InvokeUiCM>(
     tx: mpsc::UnboundedSender<Data>,
 ) {
     let mut current_id = 0;
+    let mut peer_ver = String::new();
     let mut write_jobs: Vec<fs::TransferJob> = Vec::new();
     loop {
         match rx.recv().await {
@@ -682,6 +686,7 @@ pub async fn start_listen<T: InvokeUiCM>(
                 is_terminal,
                 port_forward,
                 peer_id,
+                peer_version,
                 name,
                 authorized,
                 keyboard,
@@ -695,6 +700,7 @@ pub async fn start_listen<T: InvokeUiCM>(
                 ..
             }) => {
                 current_id = id;
+                peer_ver = peer_version;
                 cm.add_connection(
                     id,
                     is_file_transfer,
@@ -719,7 +725,7 @@ pub async fn start_listen<T: InvokeUiCM>(
                 cm.new_message(current_id, text);
             }
             Some(Data::FS(fs)) => {
-                handle_fs(fs, &mut write_jobs, &tx, None).await;
+                handle_fs(fs, &mut write_jobs, &tx, None, &peer_ver).await;
             }
             Some(Data::Close) => {
                 break;
@@ -748,6 +754,7 @@ async fn handle_fs(
     write_jobs: &mut Vec<fs::TransferJob>,
     tx: &UnboundedSender<Data>,
     tx_log: Option<&UnboundedSender<String>>,
+    peer_ver: &str,
 ) {
     use std::path::PathBuf;
 
@@ -878,7 +885,8 @@ async fn handle_fs(
                 if let Some(file) = job.files().get(file_num as usize) {
                     if let fs::DataSource::FilePath(p) = &job.data_source {
                         let path = get_string(&fs::TransferJob::join(p, &file.name));
-                        match is_write_need_confirmation(&path, &digest) {
+                        let is_support_resume = crate::is_support_file_transfer_resume(peer_ver);
+                        match is_write_need_confirmation(is_support_resume, &path, &digest) {
                             Ok(digest_result) => {
                                 job.set_digest(file_size, last_modified);
                                 match digest_result {


### PR DESCRIPTION
This PR can't be compiled util https://github.com/rustdesk/hbb_common/pull/321 is merged.

Fix the issue when `new` --> `old`, resuming file transfer from `old` to `new`, the files are wrong.

1. Bump to `1.4.2`. `1.4.2` is used to check if file transfer resumability is supported.
2. Add `is_support_resume` in `is_write_need_confirmation()` for compability. Add `peer_ver` in `ui_cm_interface.rs` to check if peer side support file transfer resumability .
3. Remove "Force skip if the file is identical and the job is set to resume." when resuming the file transfer and the files are identical. It should be decided by the original `overwrite_strategy`.


|  Connection       |  File Transfer  |  Ok |  Remark           |
|------------------|-------|---------------------|-------------------|
| New -> New     |  Controlling -> Controlled    |   ✅    |  Resume from the last offset   |
| New -> New     |  Controlled  -> Controlling   |   ✅    |  Resume from the last offset   |
| New -> Old      |  Controlling -> Controlled   |   ✅    |  Resume from 0   |
| New -> Old     |  Controlled  -> Controlling   |  ✅    |  Resume from 0   |
| Old -> New     |  Controlling -> Controlled   |   ❌    |  The path is wrong (historical issue)   |
| Old -> New     |  Controlled  -> Controlling   |   ✅    |  Resume from 0   |



