### PR TITLE
feat: file transfer, resume

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -38,7 +38,7 @@ env:
   #  https://github.com/rustdesk/rustdesk/actions/runs/14414119794/job/40427970174
   # 2. Update the `VCPKG_COMMIT_ID` in `ci.yml` and `playground.yml`.
   VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
-  VERSION: "1.4.1"
+  VERSION: "1.4.2"
   NDK_VERSION: "r27c"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -17,7 +17,7 @@ env:
   TAG_NAME: "nightly"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
   VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
-  VERSION: "1.4.1"
+  VERSION: "1.4.2"
   NDK_VERSION: "r26d"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: RustDesk.RustDesk
-          version: "1.4.1"
-          release-tag: "1.4.1"
+          version: "1.4.2"
+          release-tag: "1.4.2"
           token: ${{ secrets.WINGET_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6110,7 +6110,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "android-wakelock",
  "android_logger",
@@ -6216,7 +6216,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk-portable-packer"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "brotli",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["rustdesk <info@rustdesk.com>"]
 edition = "2021"
 build= "build.rs"

--- a/appimage/AppImageBuilder-aarch64.yml
+++ b/appimage/AppImageBuilder-aarch64.yml
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.4.1
+    version: 1.4.2
     exec: usr/share/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/appimage/AppImageBuilder-x86_64.yml
+++ b/appimage/AppImageBuilder-x86_64.yml
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.4.1
+    version: 1.4.2
     exec: usr/share/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # 1.1.9-1 works for android, but for ios it becomes 1.1.91, need to set it to 1.1.9-a.1 for iOS, will get 1.1.9.1, but iOS store not allow 4 numbers
-version: 1.4.1+59
+version: 1.4.2+60
 
 environment:
   sdk: '^3.1.0'

--- a/libs/portable/Cargo.toml
+++ b/libs/portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk-portable-packer"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 description = "RustDesk Remote Desktop"
 

--- a/res/PKGBUILD
+++ b/res/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=rustdesk
-pkgver=1.4.1
+pkgver=1.4.2
 pkgrel=0
 epoch=
 pkgdesc=""

--- a/res/rpm-flutter-suse.spec
+++ b/res/rpm-flutter-suse.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.4.1
+Version:    1.4.2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.4.1
+Version:    1.4.2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.4.1
+Version:    1.4.2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -704,6 +704,7 @@ impl<T: InvokeUiSession> Remote<T> {
                 if is_remote {
                     if let Some(job) = get_job(id, &mut self.write_jobs) {
                         job.is_last_job = false;
+                        job.is_resume = true;
                         allow_err!(
                             peer.send(&fs::new_send(
                                 id,
@@ -718,12 +719,13 @@ impl<T: InvokeUiSession> Remote<T> {
                 } else {
                     if let Some(job) = get_job(id, &mut self.read_jobs) {
                         match &job.data_source {
-                            fs::DataSource::FilePath(p) => {
+                            fs::DataSource::FilePath(_p) => {
                                 job.is_last_job = false;
+                                job.is_resume = true;
                                 allow_err!(
                                     peer.send(&fs::new_receive(
                                         id,
-                                        p.to_string_lossy().to_string(),
+                                        job.remote.clone(),
                                         job.file_num,
                                         job.files.clone(),
                                         job.total_size(),
@@ -771,7 +773,8 @@ impl<T: InvokeUiSession> Remote<T> {
                                 Some(file_transfer_send_confirm_request::Union::Skip(true))
                             },
                             ..Default::default()
-                        });
+                        })
+                        .await;
                     }
                 } else {
                     if let Some(job) = fs::get_job(id, &mut self.write_jobs) {
@@ -790,7 +793,7 @@ impl<T: InvokeUiSession> Remote<T> {
                             },
                             ..Default::default()
                         };
-                        job.confirm(&req);
+                        job.confirm(&req).await;
                         file_action.set_send_confirm(req);
                         msg.set_file_action(file_action);
                         allow_err!(peer.send(&msg).await);
@@ -1471,14 +1474,21 @@ impl<T: InvokeUiSession> Remote<T> {
                                         if let fs::DataSource::FilePath(p) = &job.data_source {
                                             let read_path =
                                                 get_string(&fs::TransferJob::join(p, &file.name));
-                                            let overwrite_strategy =
+                                            let mut overwrite_strategy =
                                                 job.default_overwrite_strategy();
+                                            let mut offset = 0;
+                                            if digest.is_identical && job.is_resume {
+                                                if digest.transferred_size > 0 {
+                                                    overwrite_strategy = Some(true);
+                                                    offset = digest.transferred_size as _;
+                                                }
+                                            }
                                             if let Some(overwrite) = overwrite_strategy {
                                                 let req = FileTransferSendConfirmRequest {
                                                     id: digest.id,
                                                     file_num: digest.file_num,
                                                     union: Some(if overwrite {
-                                                        file_transfer_send_confirm_request::Union::OffsetBlk(0)
+                                                        file_transfer_send_confirm_request::Union::OffsetBlk(offset)
                                                     } else {
                                                         file_transfer_send_confirm_request::Union::Skip(
                                                             true,
@@ -1486,7 +1496,7 @@ impl<T: InvokeUiSession> Remote<T> {
                                                     }),
                                                     ..Default::default()
                                                 };
-                                                job.confirm(&req);
+                                                job.confirm(&req).await;
                                                 let msg = new_send_confirm(req);
                                                 allow_err!(peer.send(&msg).await);
                                             } else {
@@ -1507,25 +1517,40 @@ impl<T: InvokeUiSession> Remote<T> {
                                         if let fs::DataSource::FilePath(p) = &job.data_source {
                                             let write_path =
                                                 get_string(&fs::TransferJob::join(p, &file.name));
-                                            let overwrite_strategy =
-                                                job.default_overwrite_strategy();
+                                            job.set_digest(digest.file_size, digest.last_modified);
+                                            let peer_ver = self.handler.lc.read().unwrap().version;
+                                            let is_support_resume =
+                                                crate::is_support_file_transfer_resume_num(
+                                                    peer_ver,
+                                                );
                                             match fs::is_write_need_confirmation(
+                                                is_support_resume,
                                                 &write_path,
                                                 &digest,
                                             ) {
                                                 Ok(res) => match res {
                                                     DigestCheckResult::IsSame => {
                                                         let req = FileTransferSendConfirmRequest {
-                                                        id: digest.id,
-                                                        file_num: digest.file_num,
-                                                        union: Some(file_transfer_send_confirm_request::Union::Skip(true)),
-                                                        ..Default::default()
-                                                    };
-                                                        job.confirm(&req);
+                                                            id: digest.id,
+                                                            file_num: digest.file_num,
+                                                            union: Some(file_transfer_send_confirm_request::Union::Skip(true)),
+                                                            ..Default::default()
+                                                        };
+                                                        job.confirm(&req).await;
                                                         let msg = new_send_confirm(req);
                                                         allow_err!(peer.send(&msg).await);
                                                     }
                                                     DigestCheckResult::NeedConfirm(digest) => {
+                                                        let mut overwrite_strategy =
+                                                            job.default_overwrite_strategy();
+                                                        let mut offset = 0;
+                                                        if digest.is_identical && job.is_resume {
+                                                            if digest.transferred_size > 0 {
+                                                                overwrite_strategy = Some(true);
+                                                                offset =
+                                                                    digest.transferred_size as _;
+                                                            }
+                                                        }
                                                         if let Some(overwrite) = overwrite_strategy
                                                         {
                                                             let req =
@@ -1533,13 +1558,13 @@ impl<T: InvokeUiSession> Remote<T> {
                                                                     id: digest.id,
                                                                     file_num: digest.file_num,
                                                                     union: Some(if overwrite {
-                                                                        file_transfer_send_confirm_request::Union::OffsetBlk(0)
+                                                                        file_transfer_send_confirm_request::Union::OffsetBlk(offset)
                                                                     } else {
                                                                         file_transfer_send_confirm_request::Union::Skip(true)
                                                                     }),
                                                                     ..Default::default()
                                                                 };
-                                                            job.confirm(&req);
+                                                            job.confirm(&req).await;
                                                             let msg = new_send_confirm(req);
                                                             allow_err!(peer.send(&msg).await);
                                                         } else {
@@ -1559,7 +1584,7 @@ impl<T: InvokeUiSession> Remote<T> {
                                                         union: Some(file_transfer_send_confirm_request::Union::OffsetBlk(0)),
                                                         ..Default::default()
                                                     };
-                                                        job.confirm(&req);
+                                                        job.confirm(&req).await;
                                                         let msg = new_send_confirm(req);
                                                         allow_err!(peer.send(&msg).await);
                                                     }
@@ -1906,7 +1931,7 @@ impl<T: InvokeUiSession> Remote<T> {
                     },
                     Some(file_action::Union::SendConfirm(c)) => {
                         if let Some(job) = fs::get_job(c.id, &mut self.read_jobs) {
-                            job.confirm(&c);
+                            job.confirm(&c).await;
                         }
                     }
                     _ => {}

--- a/src/common.rs
+++ b/src/common.rs
@@ -163,6 +163,16 @@ pub fn is_support_screenshot_num(ver: i64) -> bool {
     ver >= hbb_common::get_version_number("1.4.0")
 }
 
+#[inline]
+pub fn is_support_file_transfer_resume(ver: &str) -> bool {
+    is_support_file_transfer_resume_num(hbb_common::get_version_number(ver))
+}
+
+#[inline]
+pub fn is_support_file_transfer_resume_num(ver: i64) -> bool {
+    ver >= hbb_common::get_version_number("1.4.2")
+}
+
 // is server process, with "--server" args
 #[inline]
 pub fn is_server() -> bool {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -105,6 +105,7 @@ pub enum FS {
         last_modified: u64,
         is_upload: bool,
     },
+    SendConfirm(Vec<u8>),
     Rename {
         id: i32,
         path: String,
@@ -192,6 +193,7 @@ pub enum Data {
         is_view_camera: bool,
         is_terminal: bool,
         peer_id: String,
+        peer_version: String,
         name: String,
         authorized: bool,
         port_forward: String,

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1704,7 +1704,13 @@ impl Connection {
             && crate::get_builtin_option(keys::OPTION_ONE_WAY_FILE_TRANSFER) != "Y"
     }
 
-    fn try_start_cm(&mut self, peer_id: String, name: String, authorized: bool) {
+    fn try_start_cm(
+        &mut self,
+        peer_id: String,
+        peer_version: String,
+        name: String,
+        authorized: bool,
+    ) {
         self.send_to_cm(ipc::Data::Login {
             id: self.inner.id(),
             is_file_transfer: self.file_transfer.is_some(),
@@ -1712,6 +1718,7 @@ impl Connection {
             is_terminal: self.terminal,
             port_forward: self.port_forward_address.clone(),
             peer_id,
+            peer_version,
             name,
             authorized,
             keyboard: self.keyboard,
@@ -2110,7 +2117,7 @@ impl Connection {
                     && is_logon()))
                 || password::approve_mode() == ApproveMode::Both && !password::has_valid_password()
             {
-                self.try_start_cm(lr.my_id, lr.my_name, false);
+                self.try_start_cm(lr.my_id, lr.version.clone(), lr.my_name, false);
                 if hbb_common::get_version_number(&lr.version)
                     >= hbb_common::get_version_number("1.2.0")
                 {
@@ -2123,13 +2130,18 @@ impl Connection {
                     #[cfg(target_os = "linux")]
                     self.linux_headless_handle.wait_desktop_cm_ready().await;
                     self.send_logon_response().await;
-                    self.try_start_cm(lr.my_id.clone(), lr.my_name.clone(), self.authorized);
+                    self.try_start_cm(
+                        lr.my_id.clone(),
+                        lr.version.clone(),
+                        lr.my_name.clone(),
+                        self.authorized,
+                    );
                 } else {
                     self.send_login_error(err_msg).await;
                 }
             } else if lr.password.is_empty() {
                 if err_msg.is_empty() {
-                    self.try_start_cm(lr.my_id, lr.my_name, false);
+                    self.try_start_cm(lr.my_id, lr.version, lr.my_name, false);
                 } else {
                     self.send_login_error(
                         crate::client::LOGIN_MSG_DESKTOP_SESSION_NOT_READY_PASSWORD_EMPTY,
@@ -2146,7 +2158,7 @@ impl Connection {
                     if err_msg.is_empty() {
                         self.send_login_error(crate::client::LOGIN_MSG_PASSWORD_WRONG)
                             .await;
-                        self.try_start_cm(lr.my_id, lr.my_name, false);
+                        self.try_start_cm(lr.my_id, lr.version, lr.my_name, false);
                     } else {
                         self.send_login_error(
                             crate::client::LOGIN_MSG_DESKTOP_SESSION_NOT_READY_PASSWORD_WRONG,
@@ -2159,7 +2171,7 @@ impl Connection {
                         #[cfg(target_os = "linux")]
                         self.linux_headless_handle.wait_desktop_cm_ready().await;
                         self.send_logon_response().await;
-                        self.try_start_cm(lr.my_id, lr.my_name, self.authorized);
+                        self.try_start_cm(lr.my_id, lr.version, lr.my_name, self.authorized);
                     } else {
                         self.send_login_error(err_msg).await;
                     }
@@ -2179,6 +2191,7 @@ impl Connection {
                         self.send_logon_response().await;
                         self.try_start_cm(
                             self.lr.my_id.to_owned(),
+                            self.lr.version.to_owned(),
                             self.lr.my_name.to_owned(),
                             self.authorized,
                         );
@@ -2230,6 +2243,7 @@ impl Connection {
                             self.send_logon_response().await;
                             self.try_start_cm(
                                 lr.my_id.clone(),
+                                lr.version.clone(),
                                 lr.my_name.clone(),
                                 self.authorized,
                             );
@@ -2703,7 +2717,11 @@ impl Connection {
                             }
                             Some(file_action::Union::SendConfirm(r)) => {
                                 if let Some(job) = fs::get_job(r.id, &mut self.read_jobs) {
-                                    job.confirm(&r);
+                                    job.confirm(&r).await;
+                                } else {
+                                    if let Ok(sc) = r.write_to_bytes() {
+                                        self.send_fs(ipc::FS::SendConfirm(sc));
+                                    }
                                 }
                             }
                             Some(file_action::Union::Rename(r)) => {


### PR DESCRIPTION
1. Feat. File transfer resume. Reset the `overwrite` value if the digest is identical and current job is resume.

<img width="1578" height="429" alt="image" src="https://github.com/user-attachments/assets/633987a3-98ac-4a76-8fd6-07af7e6906a8" />


2. Bump to `1.4.2`. `1.4.2` is used to check if file transfer resumability is supported.
3. Add `is_support_resume` in `is_write_need_confirmation()` for compability. Add `peer_ver` in `ui_cm_interface.rs` to check if peer side support file transfer resumability .

4. Fix. `new_receive()` should send the remote path, but it send the local path `p`.

<img width="1194" height="404" alt="image" src="https://github.com/user-attachments/assets/df1e39e5-08e7-4719-8e7c-55e714c64ff3" />

