### PR TITLE
feat: file transfer, resume

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -38,7 +38,7 @@ env:
   #  https://github.com/rustdesk/rustdesk/actions/runs/14414119794/job/40427970174
   # 2. Update the `VCPKG_COMMIT_ID` in `ci.yml` and `playground.yml`.
   VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
-  VERSION: "1.4.1"
+  VERSION: "1.4.2"
   NDK_VERSION: "r27c"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -17,7 +17,7 @@ env:
   TAG_NAME: "nightly"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
   VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836"
-  VERSION: "1.4.1"
+  VERSION: "1.4.2"
   NDK_VERSION: "r26d"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: RustDesk.RustDesk
-          version: "1.4.1"
-          release-tag: "1.4.1"
+          version: "1.4.2"
+          release-tag: "1.4.2"
           token: ${{ secrets.WINGET_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6110,7 +6110,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "android-wakelock",
  "android_logger",
@@ -6216,7 +6216,7 @@ dependencies = [
 
 [[package]]
 name = "rustdesk-portable-packer"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "brotli",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["rustdesk <info@rustdesk.com>"]
 edition = "2021"
 build= "build.rs"

--- a/appimage/AppImageBuilder-aarch64.yml
+++ b/appimage/AppImageBuilder-aarch64.yml
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.4.1
+    version: 1.4.2
     exec: usr/share/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/appimage/AppImageBuilder-x86_64.yml
+++ b/appimage/AppImageBuilder-x86_64.yml
@@ -18,7 +18,7 @@ AppDir:
     id: rustdesk
     name: rustdesk
     icon: rustdesk
-    version: 1.4.1
+    version: 1.4.2
     exec: usr/share/rustdesk/rustdesk
     exec_args: $@
   apt:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # 1.1.9-1 works for android, but for ios it becomes 1.1.91, need to set it to 1.1.9-a.1 for iOS, will get 1.1.9.1, but iOS store not allow 4 numbers
-version: 1.4.1+59
+version: 1.4.2+60
 
 environment:
   sdk: '^3.1.0'

--- a/libs/portable/Cargo.toml
+++ b/libs/portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustdesk-portable-packer"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 description = "RustDesk Remote Desktop"
 

--- a/res/PKGBUILD
+++ b/res/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=rustdesk
-pkgver=1.4.1
+pkgver=1.4.2
 pkgrel=0
 epoch=
 pkgdesc=""

--- a/res/rpm-flutter-suse.spec
+++ b/res/rpm-flutter-suse.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.4.1
+Version:    1.4.2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.4.1
+Version:    1.4.2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -1,5 +1,5 @@
 Name:       rustdesk
-Version:    1.4.1
+Version:    1.4.2
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0

--- a/src/common.rs
+++ b/src/common.rs
@@ -163,6 +163,16 @@ pub fn is_support_screenshot_num(ver: i64) -> bool {
     ver >= hbb_common::get_version_number("1.4.0")
 }
 
+#[inline]
+pub fn is_support_file_transfer_resume(ver: &str) -> bool {
+    is_support_file_transfer_resume_num(hbb_common::get_version_number(ver))
+}
+
+#[inline]
+pub fn is_support_file_transfer_resume_num(ver: i64) -> bool {
+    ver >= hbb_common::get_version_number("1.4.2")
+}
+
 // is server process, with "--server" args
 #[inline]
 pub fn is_server() -> bool {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -104,7 +104,9 @@ pub enum FS {
         file_size: u64,
         last_modified: u64,
         is_upload: bool,
+        is_resume: bool,
     },
+    SendConfirm(Vec<u8>),
     Rename {
         id: i32,
         path: String,

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2703,7 +2703,11 @@ impl Connection {
                             }
                             Some(file_action::Union::SendConfirm(r)) => {
                                 if let Some(job) = fs::get_job(r.id, &mut self.read_jobs) {
-                                    job.confirm(&r);
+                                    job.confirm(&r).await;
+                                } else {
+                                    if let Ok(sc) = r.write_to_bytes() {
+                                        self.send_fs(ipc::FS::SendConfirm(sc));
+                                    }
                                 }
                             }
                             Some(file_action::Union::Rename(r)) => {
@@ -2747,6 +2751,7 @@ impl Connection {
                         file_size: d.file_size,
                         last_modified: d.last_modified,
                         is_upload: true,
+                        is_resume: d.is_resume,
                     }),
                     Some(file_response::Union::Error(e)) => {
                         self.send_fs(ipc::FS::WriteError {

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -860,6 +860,7 @@ async fn handle_fs(
             file_size,
             last_modified,
             is_upload,
+            is_resume,
         } => {
             if let Some(job) = fs::get_job(id, write_jobs) {
                 let mut req = FileTransferSendConfirmRequest {
@@ -878,8 +879,9 @@ async fn handle_fs(
                 if let Some(file) = job.files().get(file_num as usize) {
                     if let fs::DataSource::FilePath(p) = &job.data_source {
                         let path = get_string(&fs::TransferJob::join(p, &file.name));
-                        match is_write_need_confirmation(&path, &digest) {
+                        match is_write_need_confirmation(is_resume, &path, &digest) {
                             Ok(digest_result) => {
+                                job.set_digest(file_size, last_modified);
                                 match digest_result {
                                     DigestCheckResult::IsSame => {
                                         req.set_skip(true);
@@ -906,6 +908,13 @@ async fn handle_fs(
                             }
                         }
                     }
+                }
+            }
+        }
+        ipc::FS::SendConfirm(bytes) => {
+            if let Ok(r) = FileTransferSendConfirmRequest::parse_from_bytes(&bytes) {
+                if let Some(job) = fs::get_job(r.id, write_jobs) {
+                    job.confirm(&r).await;
                 }
             }
         }


### PR DESCRIPTION
1. Feat. File transfer resume. Reset the `overwrite` value if the digest is identical and current job is resume, and some bytes have been transferred.

<img width="1578" height="429" alt="image" src="https://github.com/user-attachments/assets/633987a3-98ac-4a76-8fd6-07af7e6906a8" />


2. Bump to `1.4.2`. `1.4.2` is used to check if file transfer resumability is supported.

3. Add `is_resume` in `is_write_need_confirmation()` for compability. Only check the `.digest` file is both side support resume and current is resume.

4. Fix. `new_receive()` should send the remote path, but it send the local path `p`.

<img width="1194" height="404" alt="image" src="https://github.com/user-attachments/assets/df1e39e5-08e7-4719-8e7c-55e714c64ff3" />


## Resume Tests

|  Connection       |  File Transfer  |  Ok |  Remark           |
|------------------|-------|---------------------|-------------------|
| New (Desktop) -> New (Desktop)    |  Controlling -> Controlled    |   ✅    |  Resume from the last offset   |
| New (Desktop) -> New (Desktop)     |  Controlled  -> Controlling   |   ✅    |  Resume from the last offset   |
| New (Desktop) -> Old (Desktop)      |  Controlling -> Controlled   |   ✅    |  Resume from 0   |
| New (Desktop) -> Old (Desktop)     |  Controlled  -> Controlling   |  ✅    |  Resume from 0   |
| Old (Desktop) -> New (Desktop)     |  Controlling -> Controlled   |   ❌    |  The path is wrong (historical issue) </br> Error or 100% but wrong path  |
| Old (Desktop) -> New (Desktop)     |  Controlled  -> Controlling   |   ✅    |  Resume from 0   |
| New (Desktop) -> New (Android)     |  Controlling -> Controlled    |   ✅    |  Resume from the last offset   |
| New (Desktop) -> New (Android)     |  Controlled  -> Controlling   |   ✅    |  Resume from the last offset   |
| New (Desktop) -> Old (Android)      |  Controlling -> Controlled   |   ✅    |  Resume from 0   |
| New (Desktop) -> Old (Android)     |  Controlled  -> Controlling   |  ✅    |  Resume from 0   |
| Old (Desktop) -> New (Android)     |  Controlling -> Controlled   |   ❌    |  The path is wrong (historical issue) </br> Error or 100% but wrong path  |
| Old (Desktop) -> New (Android)     |  Controlled  -> Controlling   |   ✅    |  Resume from 0   |
| Android -> Desktop     |    |      |  UI does not support  |



