### PR TITLE
ui: accept --connection-manager in addition to --cm

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -113,7 +113,9 @@ pub fn start(args: &mut [String]) {
         frame.event_handler(UI {});
         frame.sciter_handler(UIHostHandler {});
         page = "install.html";
-    } else if args[0] == "--cm" {
+    } else if (args[0] == "--cm"
+        || args[0] == "--connection-manager")
+    {
         frame.register_behavior("connection-manager", move || {
             Box::new(cm::SciterConnectionManager::new())
         });


### PR DESCRIPTION
Arguably, connection manager is more visual than cm and makes it a bit easier to discover the functionality.