### PR TITLE
Fix audio delay (Linux): added pulse audio and pipewire configuration RustDesk service

### DIFF
--- a/res/rustdesk.service
+++ b/res/rustdesk.service
@@ -16,6 +16,7 @@ KillMode=mixed
 TimeoutStopSec=30
 User=root
 LimitNOFILE=100000
+Environment="PULSE_LATENCY_MSEC=60" "PIPEWIRE_LATENCY=1024/48000"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As per discussion in this issue: https://github.com/rustdesk/rustdesk/issues/534 it appears the RuskDesk service on Linux does not configure the environment to suitably reduce audio delay.

Without these environment variable configurations, I was able to reproduce ~2-3s on audio delay on Ubuntu 24.04 using RustDesk 1.4.

According to the thread the following variables need to configured: 

`PULSE_LATENCY_MSEC`
`PIPEWIRE_LATENCY`

I chose values that seemed acceptable from brief testing and these values worked well for my case.

It is unclear to me how/if these variables should be somehow configured for RustDesk usage that is not started as a service and as such this PR does not address that topic.