### PR TITLE
feat: clipboard files, audit

### DIFF
--- a/libs/clipboard/src/cliprdr.h
+++ b/libs/clipboard/src/cliprdr.h
@@ -170,6 +170,8 @@ extern "C"
 
     typedef UINT (*pcNotifyClipboardMsg)(UINT32 connID, const NOTIFICATION_MESSAGE *msg);
 
+    typedef UINT (*pcHandleClipboardFiles)(UINT32 connID, size_t nFiles, WCHAR **fileNames);
+
     typedef UINT (*pcCliprdrClientFormatList)(CliprdrClientContext *context,
                                               const CLIPRDR_FORMAT_LIST *formatList);
     typedef UINT (*pcCliprdrServerFormatList)(CliprdrClientContext *context,
@@ -217,6 +219,7 @@ extern "C"
         pcCliprdrMonitorReady MonitorReady;
         pcCliprdrTempDirectory TempDirectory;
         pcNotifyClipboardMsg NotifyClipboardMsg;
+        pcHandleClipboardFiles HandleClipboardFiles;
         pcCliprdrClientFormatList ClientFormatList;
         pcCliprdrServerFormatList ServerFormatList;
         pcCliprdrClientFormatListResponse ClientFormatListResponse;

--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -132,6 +132,9 @@ pub enum ClipboardFile {
         requested_data: Vec<u8>,
     },
     TryEmpty,
+    Files {
+        files: Vec<(String, u64)>,
+    },
 }
 
 struct MsgChannel {

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -2257,7 +2257,7 @@ impl<T: InvokeUiSession> Remote<T> {
             }
             #[cfg(feature = "unix-file-copy-paste")]
             if crate::is_support_file_copy_paste_num(self.handler.lc.read().unwrap().version) {
-                let mut out_msg = None;
+                let mut out_msgs = vec![];
 
                 #[cfg(target_os = "macos")]
                 if clipboard::platform::unix::macos::should_handle_msg(&clip) {
@@ -2269,7 +2269,7 @@ impl<T: InvokeUiSession> Remote<T> {
                         log::error!("failed to handle cliprdr msg: {}", e);
                     }
                 } else {
-                    out_msg = unix_file_clip::serve_clip_messages(
+                    out_msgs = unix_file_clip::serve_clip_messages(
                         ClipboardSide::Client,
                         clip,
                         self.client_conn_id,
@@ -2278,14 +2278,14 @@ impl<T: InvokeUiSession> Remote<T> {
 
                 #[cfg(not(target_os = "macos"))]
                 {
-                    out_msg = unix_file_clip::serve_clip_messages(
+                    out_msgs = unix_file_clip::serve_clip_messages(
                         ClipboardSide::Client,
                         clip,
                         self.client_conn_id,
                     );
                 }
 
-                if let Some(msg) = out_msg {
+                for msg in out_msgs.into_iter() {
                     allow_err!(_peer.send(&msg).await);
                 }
             }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk-server-pro/issues/750

## Preview

The source files are recorded in the audit logs.
The target directory is difficult to detect and is currently empty.

https://github.com/user-attachments/assets/d87b5a0f-c6c9-4978-ba86-07a8d77e5231


## Desc

1. Use `first_file_index` to inidcate a new file transfer.
2. Windows. Call `HandleClipboardFiles()` to post file names in `wf_cliprdr.c`.
```C
			if (clipboard->nFiles > 0 &&
				fileContentsRequest->listIndex == (UINT32)clipboard->first_file_index &&
				fileContentsRequest->nPositionLow == 0 &&
				fileContentsRequest->nPositionHigh == 0) {
				clipboard->context->HandleClipboardFiles(fileContentsRequest->connID, clipboard->nFiles, clipboard->file_names);
			}
```
3. Linux and MacOS. Return `ClipboardFile::Files` to post audit logs.
```rust
    fn get_files_for_audit(&self, request: &FileContentsRequest) -> Option<ClipboardFile> {
        if let FileContentsRequest::Range {
            file_idx, offset, ..
        } = request
        {
            if *file_idx == self.first_file_index && *offset == 0 {
                let files: Vec<(String, u64)> = self
                    .file_list
                    .iter()
                    .filter_map(|f| {
                        if f.path.is_file() {
                            Some((f.path.to_string_lossy().to_string(), f.size))
                        } else {
                            None
                        }
                    })
                    .collect::<_>();
                if files.is_empty() {
                    return None;
                } else {
                    return Some(ClipboardFile::Files { files });
                }
            }
        }
        None
    }
```

## Tests

- [x] Windows <-> MacOS
- [x] Windows <-> Linux
- [x] MacOS <-> Linux