### PR TITLE
refact: show my cursor

### DIFF
--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1763,18 +1763,25 @@ class _KeyboardMenu extends StatelessWidget {
     final ffiModel = ffi.ffiModel;
     return CkbMenuButton(
             value: ffiModel.showMyCursor,
-            onChanged: ffiModel.viewOnly
-                ? (value) async {
-                    if (value == null) return;
-                    await bind.sessionToggleOption(
-                        sessionId: ffi.sessionId,
-                        value: kOptionToggleShowMyCursor);
-                    final showMyCursor = await bind.sessionGetToggleOption(
-                        sessionId: ffi.sessionId,
-                        arg: kOptionToggleShowMyCursor);
-                    ffiModel.setShowMyCursor(showMyCursor ?? value);
-                  }
-                : null,
+            onChanged: (value) async {
+              if (value == null) return;
+              await bind.sessionToggleOption(
+                  sessionId: ffi.sessionId, value: kOptionToggleShowMyCursor);
+              final showMyCursor = await bind.sessionGetToggleOption(
+                      sessionId: ffi.sessionId,
+                      arg: kOptionToggleShowMyCursor) ??
+                  value;
+              ffiModel.setShowMyCursor(showMyCursor);
+
+              // Also set view only if showMyCursor is enabled and viewOnly is not enabled.
+              if (showMyCursor && !ffiModel.viewOnly) {
+                await bind.sessionToggleOption(
+                    sessionId: ffi.sessionId, value: kOptionToggleViewOnly);
+                final viewOnly = await bind.sessionGetToggleOption(
+                    sessionId: ffi.sessionId, arg: kOptionToggleViewOnly);
+                ffiModel.setViewOnly(id, viewOnly ?? value);
+              }
+            },
             ffi: ffi,
             child: Text(translate('Show my cursor')))
         .paddingOnly(left: 26.0);

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3703,9 +3703,26 @@ impl Connection {
                 use crate::whiteboard;
                 self.show_my_cursor = q == BoolOption::Yes;
                 if q == BoolOption::Yes {
-                    whiteboard::register_whiteboard(whiteboard::get_key_cursor(self.inner.id));
+                    if crate::platform::windows::is_win_10_or_greater() {
+                        whiteboard::register_whiteboard(whiteboard::get_key_cursor(self.inner.id));
+                    } else {
+                        let mut msg_out = Message::new();
+                        let res = MessageBox {
+                            msgtype: "nook-nocancel-hasclose".to_owned(),
+                            title: "Show my cursor".to_owned(),
+                            text: "Windows 10 or greater is required.".to_owned(),
+                            link: "".to_owned(),
+                            ..Default::default()
+                        };
+                        msg_out.set_message_box(res);
+                        self.send(msg_out).await;
+                    }
                 } else {
-                    whiteboard::unregister_whiteboard(whiteboard::get_key_cursor(self.inner.id));
+                    if crate::platform::windows::is_win_10_or_greater() {
+                        whiteboard::unregister_whiteboard(whiteboard::get_key_cursor(
+                            self.inner.id,
+                        ));
+                    }
                 }
             }
         }


### PR DESCRIPTION
1. Show not supported on Win7. A temporary solution for now. AnyDesk whiteboard works fine on Win7. Current tranparent does not draw cursor on Win7.  https://github.com/rustdesk/rustdesk/compare/d0e9c6dc576a42a955cc2a9893ff5d4fb094bee2...fufesou:rustdesk:fix/win7_whiteboard

2. Enabling "Show my cursor" automatically enables "View mode".
