### PR TITLE
android mediacodec encode align 64

### DIFF
--- a/res/vcpkg/ffmpeg/patch/0011-android-mediacodec-encode-align-64.patch
+++ b/res/vcpkg/ffmpeg/patch/0011-android-mediacodec-encode-align-64.patch
@@ -1,0 +1,42 @@
+From a609e1666c79ccce4faf7aa61d509bf202df9149 Mon Sep 17 00:00:00 2001
+From: 21pages <sunboeasy@gmail.com>
+Date: Fri, 5 Sep 2025 21:35:37 +0800
+Subject: [PATCH] android mediacodec encode align 64
+
+Signed-off-by: 21pages <sunboeasy@gmail.com>
+---
+ libavcodec/mediacodecenc.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/libavcodec/mediacodecenc.c b/libavcodec/mediacodecenc.c
+index 221f7360f4..768c8151df 100644
+--- a/libavcodec/mediacodecenc.c
++++ b/libavcodec/mediacodecenc.c
+@@ -242,18 +242,19 @@ static av_cold int mediacodec_init(AVCodecContext *avctx)
+     ff_AMediaFormat_setString(format, "mime", codec_mime);
+     // Workaround the alignment requirement of mediacodec. We can't do it
+     // silently for AV_PIX_FMT_MEDIACODEC.
++    const int align = 64;
+     if (avctx->pix_fmt != AV_PIX_FMT_MEDIACODEC &&
+         (avctx->codec_id == AV_CODEC_ID_H264 ||
+          avctx->codec_id == AV_CODEC_ID_HEVC)) {
+-        s->width = FFALIGN(avctx->width, 16);
+-        s->height = FFALIGN(avctx->height, 16);
++        s->width = FFALIGN(avctx->width, align);
++        s->height = FFALIGN(avctx->height, align);
+     } else {
+         s->width = avctx->width;
+         s->height = avctx->height;
+-        if (s->width % 16 || s->height % 16)
++        if (s->width % align || s->height % align)
+             av_log(avctx, AV_LOG_WARNING,
+-                    "Video size %dx%d isn't align to 16, it may have device compatibility issue\n",
+-                    s->width, s->height);
++                    "Video size %dx%d isn't align to %d, it may have device compatibility issue\n",
++                    s->width, s->height, align);
+     }
+     ff_AMediaFormat_setInt32(format, "width", s->width);
+     ff_AMediaFormat_setInt32(format, "height", s->height);
+-- 
+2.43.0.windows.1
+

--- a/res/vcpkg/ffmpeg/portfile.cmake
+++ b/res/vcpkg/ffmpeg/portfile.cmake
@@ -26,6 +26,7 @@ vcpkg_from_github(
     patch/0008-remove-amf-loop-query.patch
     patch/0009-fix-nvenc-reconfigure-blur.patch
     patch/0010.disable-loading-DLLs-from-app-dir.patch
+    patch/0011-android-mediacodec-encode-align-64.patch
 )
 
 if(SOURCE_PATH MATCHES " ")


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/12719#discussioncomment-14321509

This patch was removed in https://github.com/rustdesk/rustdesk/pull/9266/files#diff-1317054a17d86eaa1fa222a0408a30ee7bd1bba3a9ce5f3f6a78fb0004dda6da
 because https://patchwork.ffmpeg.org/project/ffmpeg/patch/tencent_6819C159B46C6A8A01A168167EA6AD02390A@qq.com/
 was merged into FFmpeg: https://github.com/FFmpeg/FFmpeg/blob/b08d7969c550a804a59511c7b83f2dd8cc0499b8/libavcodec/mediacodecenc.c#L157.

In the original issue https://github.com/rustdesk/rustdesk/issues/8101, only H.265 had a green bottom problem while H.264 was fine. After the merge, my testing showed no issues and the new ffmepg fix that problem. However, in the new issue, both H.264 and H.265 are scrambled , and align 64 works for the new issue.

