### PR TITLE
fix: port forward, invalid msg

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -649,6 +649,9 @@ impl Connection {
                         }
                         #[cfg(target_os = "windows")]
                         ipc::Data::ClipboardFile(clip) => {
+                            if !conn.is_remote() {
+                                continue;
+                            }
                             match clip {
                                 clipboard::ClipboardFile::Files { files } => {
                                     let files = files.into_iter().map(|(f, s)| {


### PR DESCRIPTION
 https://github.com/rustdesk/rustdesk/discussions/12047

## Desc

Only send clipboard file messages if is Remote connection on Windows. A Clipboard Ready message is sent when cm is ready.

Linux and macOS do not need this check, because the clipboard file messages are handled only when the `file-clipboard` service is subscribed.

This issue is introduced since `1.2.3-2` when 
```rust
        let mut test_delay_timer =
            time::interval_at(Instant::now() + TEST_DELAY_TIMEOUT, TEST_DELAY_TIMEOUT);
```

is changed to 
```rust
        let mut test_delay_timer =
            crate::rustdesk_interval(time::interval_at(Instant::now(), TEST_DELAY_TIMEOUT));
```


