### PR TITLE
Add Wayland multi-monitor screen capture functionality

### DIFF
--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -661,7 +661,9 @@ fn on_create_session_response(
                 Variant(Box::new("u3".to_string())),
             );
             // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html
-            args.insert("multiple".into(), Variant(Box::new(true)));
+            if is_server_running() {
+                args.insert("multiple".into(), Variant(Box::new(true)));
+            }
             args.insert("types".into(), Variant(Box::new(1u32))); //| 2u32)));
 
             let path = portal.select_sources(ses.clone(), args)?;
@@ -725,7 +727,9 @@ fn on_select_devices_response(
             Variant(Box::new("u3".to_string())),
         );
         // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html
-        args.insert("multiple".into(), Variant(Box::new(true)));
+        if is_server_running() {
+            args.insert("multiple".into(), Variant(Box::new(true)));
+        }
         args.insert("types".into(), Variant(Box::new(1u32))); //| 2u32)));
 
         let session = session.clone();

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -661,7 +661,7 @@ fn on_create_session_response(
                 Variant(Box::new("u3".to_string())),
             );
             // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html
-            // args.insert("multiple".into(), Variant(Box::new(true)));
+            args.insert("multiple".into(), Variant(Box::new(true)));
             args.insert("types".into(), Variant(Box::new(1u32))); //| 2u32)));
 
             let path = portal.select_sources(ses.clone(), args)?;
@@ -725,7 +725,7 @@ fn on_select_devices_response(
             Variant(Box::new("u3".to_string())),
         );
         // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html
-        // args.insert("multiple".into(), Variant(Box::new(true)));
+        args.insert("multiple".into(), Variant(Box::new(true)));
         args.insert("types".into(), Variant(Box::new(1u32))); //| 2u32)));
 
         let session = session.clone();

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -147,7 +147,7 @@ fn calculate_max_resolution_from_displays(displays: &[Display]) -> (i32, i32) {
     // TODO: this doesn't work in most situations other than sharing all displays
     //  this is because the function only gets called with the displays being shared with pipewire
     //  the xrandr method does work otherwise we could get this correctly using xdg-output-unstable-v1 when xrandr isn't available
-    log::warn!("using incorrect max resolution calculation uinput may not work correctly");
+    // log::warn!("using incorrect max resolution calculation uinput may not work correctly");
     let (mut max_x, mut max_y) = (0, 0);
     for d in displays {
         let (x, y) = d.origin();


### PR DESCRIPTION
* Refactored Wayland display management to support per-display capturer instances instead of single shared capturer
* Added reference counting for active display sessions to properly manage resource cleanup
* Replaced single capturer pointer to `HashMap<usize, Arc<CapDisplayInfo>>` to allow for tracking info about all the shared displays