### PR TITLE
fix websocket reconnect

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3829,7 +3829,11 @@ pub fn check_if_retry(msgtype: &str, title: &str, text: &str, retry_for_relay: b
         && ((text.contains("10054") || text.contains("104")) && retry_for_relay
             || (!text.to_lowercase().contains("offline")
                 && !text.to_lowercase().contains("not exist")
-                && !text.to_lowercase().contains("handshake")
+                && (!text.to_lowercase().contains("handshake")
+                    // https://github.com/snapview/tungstenite-rs/blob/e7e060a89a72cb08e31c25a6c7284dc1bd982e23/src/error.rs#L248
+                    || text
+                        .to_lowercase()
+                        .contains("connection reset without closing handshake") && use_ws())
                 && !text.to_lowercase().contains("failed")
                 && !text.to_lowercase().contains("resolve")
                 && !text.to_lowercase().contains("mismatch")


### PR DESCRIPTION
# Description

Fix the issue where the WebSocket cannot automatically reconnect when it disconnects (for example, when switching the controlled user).

<img width="583" height="204" alt="daa0a06c3ab765344039cdec15b7db03" src="https://github.com/user-attachments/assets/a34134de-57a4-4678-9e53-aebf5142da6e" />

# Test

* Errors like “ID not exist” will not trigger a reconnect.

* Handshake errors in a secure connection will not trigger a reconnect.

* When the controlled side actively closes the connection, it will not reconnect.

* Windows / Linux / Mac platforms.

https://github.com/user-attachments/assets/f3d872c5-44fa-4465-a33a-02b0773c8e0f

https://github.com/user-attachments/assets/9de690d0-73cb-4046-9377-7148132d4c94

https://github.com/user-attachments/assets/80f860f4-fa0f-4cc2-9e0b-a12f97cc1897




