### PR TITLE
Fix window positioning on Windows when the taskbar is on the top or left

### DIFF
--- a/flutter/windows/runner/CMakeLists.txt
+++ b/flutter/windows/runner/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(${BINARY_NAME} WIN32
   "flutter_window.cpp"
   "main.cpp"
   "utils.cpp"
+  "win32_desktop.cpp"
   "win32_window.cpp"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
   "Runner.rc"

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -126,20 +126,22 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   command_line_arguments.insert(command_line_arguments.end(), rust_args.begin(), rust_args.end());
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
+  FlutterWindow window(project);
+
+  // Get primary monitor's work area.
   Win32Window::Point workarea_origin(0, 0);
   Win32Window::Size workarea_size(0, 0);
 
   Win32Desktop::GetWorkArea(workarea_origin, workarea_size);
 
-  FlutterWindow window(project);
-
-  // NB: If, in the future, this is persisted across runs, make sure that the saved
-  //     origin is relative to the work area, and that it is translated back into
-  //     the work area on load.
+  // Compute window bounds for default main window position: (10, 10) x(800, 600)
   Win32Window::Point relative_origin(10, 10);
 
   Win32Window::Point origin(workarea_origin.x + relative_origin.x, workarea_origin.y + relative_origin.y);
-  Win32Window::Size size(std::min(800u, workarea_size.width - relative_origin.x), std::min(600u, workarea_size.height - relative_origin.y));
+  Win32Window::Size size(800u, 600u);
+
+  // Fit the window to the monitor's work area.
+  Win32Desktop::FitToWorkArea(origin, size);
 
   std::wstring window_title;
   if (is_cm_page) {

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -139,7 +139,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   Win32Window::Point relative_origin(10, 10);
 
   Win32Window::Point origin(workarea_origin.x + relative_origin.x, workarea_origin.y + relative_origin.y);
-  Win32Window::Size size(min(800u, workarea_size.width - relative_origin.x), min(600u, workarea_size.height - relative_origin.y));
+  Win32Window::Size size(std::min(800u, workarea_size.width - relative_origin.x), std::min(600u, workarea_size.height - relative_origin.y));
 
   std::wstring window_title;
   if (is_cm_page) {

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <iostream>
 
+#include "win32_desktop.h"
 #include "flutter_window.h"
 #include "utils.h"
 
@@ -125,9 +126,19 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   command_line_arguments.insert(command_line_arguments.end(), rust_args.begin(), rust_args.end());
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
+  Win32Window::Point workarea_origin(0, 0);
+  Win32Window::Size workarea_size(0, 0);
+
+  Win32Desktop::GetWorkArea(workarea_origin, workarea_size);
+
   FlutterWindow window(project);
-  Win32Window::Point origin(10, 10);
-  Win32Window::Size size(800, 600);
+
+  // NB: If, in the future, this is persisted across runs, make sure that the saved
+  //     origin is relative to the work area, and that it is translated back into
+  //     the work area on load.
+  Win32Window::Point origin(workarea_origin.x + 10, workarea_origin.y + 10);
+  Win32Window::Size size(min(800u, workarea_size.width - origin.x), min(600u, workarea_size.height - origin.y));
+
   std::wstring window_title;
   if (is_cm_page) {
     window_title = app_name + L" - Connection Manager";

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -136,8 +136,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // NB: If, in the future, this is persisted across runs, make sure that the saved
   //     origin is relative to the work area, and that it is translated back into
   //     the work area on load.
-  Win32Window::Point origin(workarea_origin.x + 10, workarea_origin.y + 10);
-  Win32Window::Size size(min(800u, workarea_size.width - origin.x), min(600u, workarea_size.height - origin.y));
+  Win32Window::Point relative_origin(10, 10);
+
+  Win32Window::Point origin(workarea_origin.x + relative_origin.x, workarea_origin.y + relative_origin.y);
+  Win32Window::Size size(min(800u, workarea_size.width - relative_origin.x), min(600u, workarea_size.height - relative_origin.y));
 
   std::wstring window_title;
   if (is_cm_page) {

--- a/flutter/windows/runner/win32_desktop.cpp
+++ b/flutter/windows/runner/win32_desktop.cpp
@@ -2,15 +2,43 @@
 
 #include <windows.h>
 
+#include <algorithm>
+
 namespace Win32Desktop
 {
   void GetWorkArea(Win32Window::Point& origin, Win32Window::Size& size)
   {
-    RECT workAreaRect;
+    RECT windowRect;
 
-    if (!SystemParametersInfoA(SPI_GETWORKAREA, 0, &workAreaRect, 0))
+    windowRect.left = origin.x;
+    windowRect.top = origin.y;
+    windowRect.right = origin.x + size.width;
+    windowRect.bottom = origin.y + size.height;
+
+    HMONITOR hMonitor = MonitorFromRect(&windowRect, MONITOR_DEFAULTTONEAREST);
+
+    if (hMonitor == NULL)
+      hMonitor = MonitorFromWindow(NULL, MONITOR_DEFAULTTOPRIMARY);
+
+    RECT workAreaRect;
+    bool haveWorkAreaRect = false;
+
+    if (hMonitor != NULL)
     {
-      // I don't think this function can fail, but just in case, some
+      MONITORINFO monitorInfo = {0};
+
+      monitorInfo.cbSize = sizeof(monitorInfo);
+
+      if (GetMonitorInfoW(hMonitor, &monitorInfo))
+      {
+        workAreaRect = monitorInfo.rcWork;
+        haveWorkAreaRect = true;
+      }
+    }
+
+    if (!haveWorkAreaRect)
+    {
+      // I don't think this is possible, but just in case, some
       // reasonably sane fallbacks.
       workAreaRect.left = 0;
       workAreaRect.top = 0;
@@ -23,5 +51,27 @@ namespace Win32Desktop
 
     size.width = workAreaRect.right - workAreaRect.left;
     size.height = workAreaRect.bottom - workAreaRect.top;
+  }
+
+  void FitToWorkArea(Win32Window::Point& origin, Win32Window::Size& size)
+  {
+    // Retrieve the work area of the monitor that contains or
+    // is closed to the supplied window bounds.
+    Win32Window::Point workarea_origin = origin;
+    Win32Window::Size workarea_size = size;
+
+    GetWorkArea(workarea_origin, workarea_size);
+
+    // Translate the window so that its top/left is inside the work area.
+    origin.x = std::max(origin.x, workarea_origin.x);
+    origin.y = std::max(origin.y, workarea_origin.y);
+
+    // Crop the window if it extends past the bottom/right of the work area.
+    Win32Window::Point workarea_bottom_right(
+      workarea_origin.x + workarea_size.width,
+      workarea_origin.y + workarea_size.height);
+
+    size.width = std::min(size.width, workarea_bottom_right.x - origin.x);
+    size.height = std::min(size.height, workarea_bottom_right.y - origin.y);
   }
 }

--- a/flutter/windows/runner/win32_desktop.cpp
+++ b/flutter/windows/runner/win32_desktop.cpp
@@ -1,0 +1,27 @@
+#include "win32_desktop.h"
+
+#include <windows.h>
+
+namespace Win32Desktop
+{
+  void GetWorkArea(Win32Window::Point& origin, Win32Window::Size& size)
+  {
+    RECT workAreaRect;
+
+    if (!SystemParametersInfoA(SPI_GETWORKAREA, 0, &workAreaRect, 0))
+    {
+      // I don't think this function can fail, but just in case, some
+      // reasonably sane fallbacks.
+      workAreaRect.left = 0;
+      workAreaRect.top = 0;
+      workAreaRect.right = 1280;
+      workAreaRect.bottom = 1024 - 40; // default Windows 10 task bar height
+    }
+
+    origin.x = workAreaRect.left;
+    origin.y = workAreaRect.top;
+
+    size.width = workAreaRect.right - workAreaRect.left;
+    size.height = workAreaRect.bottom - workAreaRect.top;
+  }
+}

--- a/flutter/windows/runner/win32_desktop.h
+++ b/flutter/windows/runner/win32_desktop.h
@@ -1,0 +1,11 @@
+#ifndef RUNNER_WIN32_DESKTOP_H_
+#define RUNNER_WIN32_DESKTOP_H_
+
+#include "win32_window.h"
+
+namespace Win32Desktop
+{
+  void GetWorkArea(Win32Window::Point& origin, Win32Window::Size& size);
+}
+
+#endif  // RUNNER_WIN32_DESKTOP_H_

--- a/flutter/windows/runner/win32_desktop.h
+++ b/flutter/windows/runner/win32_desktop.h
@@ -6,6 +6,7 @@
 namespace Win32Desktop
 {
   void GetWorkArea(Win32Window::Point& origin, Win32Window::Size& size);
+  void FitToWorkArea(Win32Window::Point& origin, Win32Window::Size& size);
 }
 
 #endif  // RUNNER_WIN32_DESKTOP_H_


### PR DESCRIPTION
In Windows versions prior to Windows 11, the Task Bar can be docked to any edge of the screen. Even with Windows 11, this can still be done with third-party tools such as "StartAllBack". 

When RustDesk creates its main window, it (currently) supplies a hardcoded window position of (10, 10):

https://github.com/rustdesk/rustdesk/blob/317639169359936f7f9f85ef445ec9774218772d/flutter/windows/runner/main.cpp#L129

If the Task Bar is on the top or left edge of the screen, the pixel offset (10, 10) might be covered by the task bar. Part of the RustDesk window is thus not visible and inaccessible:

<img width="1275" height="477" alt="image" src="https://github.com/user-attachments/assets/b55745f8-7a81-4ee7-8754-8fb4a151c9e1" />

With no visible title bar, the window cannot be dragged to reposition it, and window control widgets located in the title bar are inaccessible. (There is a non-obvious workaround; when a window resize operation completes, Windows automatically crops the resulting rectangle to the active work area, so using any of the visible edges to resize the window causes the top edge of the window to be moved down making the title bar visible.)

This PR addresses this by querying the _work area_. This indicates the exact coordinate range that is _not_ covered by permanent fixtures such as the Task Bar. The `origin` and `size` are then computed based on this.

The work area is in _virtual_ pixels. If the system desktop scale is not 100%, then the work area is correspondingly scaled. For instance, I'm presently using a 50" TV as my display, native resolution 1920x1080, and if I run it at the standard assumed 96 dpi, the text is difficult to read. So, my desktop scale ("Make everything bigger" in Display settings) is set to 150%. As a result, the work area is returned as (0, 40)-(1280, 720), instead of the actual literal pixel area of (0, 60)-(1920, 1080).

But, this is okay, because the `Win32Window` abstraction being used has, in its `CreateAndShow` method, code to find the monitor's DPI and scale the coordinates correspondingly. So, the coordinate system for `origin` is the same as the scaled frame of reference used for the work area (*as long as `origin` is on the primary monitor -- if not, they might be the same but they might not, but in any case the current hardcoded (10, 10) will always be on the primary monitor).

I wasn't able to get a build environment set up. The `rustup_init.exe` tool created a `bin` folder with all the requisite `.exe` files, except they're all 0-byte files. Not sure why. So, I tested this code piecemeal, by copy/pasting it into a smaller project that I can build. It worked there. But, it might require tweaks in situ. I know that's a pain in the butt, and if I figure out why Rust didn't install properly, I'll see if I can't build it locally. In the meantime, I'm hoping someone with a working build environment will take pity on me and do a local build and push any fixes. :-)