### PR TITLE
Centre the main window (Windows)

### DIFF
--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -135,13 +135,11 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   Win32Desktop::GetWorkArea(workarea_origin, workarea_size);
 
   // Compute window bounds for default main window position: (10, 10) x(800, 600)
-  Win32Window::Point relative_origin(10, 10);
-
-  Win32Window::Point origin(workarea_origin.x + relative_origin.x, workarea_origin.y + relative_origin.y);
+  Win32Window::Point origin = workarea_origin;
   Win32Window::Size size(800u, 600u);
 
   // Fit the window to the monitor's work area.
-  Win32Desktop::FitToWorkArea(origin, size);
+  Win32Desktop::CentreInWorkArea(origin, size);
 
   std::wstring window_title;
   if (is_cm_page) {

--- a/flutter/windows/runner/win32_desktop.cpp
+++ b/flutter/windows/runner/win32_desktop.cpp
@@ -21,10 +21,7 @@ namespace Win32Desktop
       hMonitor = MonitorFromWindow(NULL, MONITOR_DEFAULTTOPRIMARY);
 
     RECT workAreaRect;
-    workAreaRect.left = 0;
-    workAreaRect.top = 0;
-    workAreaRect.right = 1280;
-    workAreaRect.bottom = 1024 - 40; // default Windows 10 task bar height
+    bool haveWorkAreaRect = false;
 
     if (hMonitor != NULL)
     {
@@ -35,7 +32,18 @@ namespace Win32Desktop
       if (GetMonitorInfoW(hMonitor, &monitorInfo))
       {
         workAreaRect = monitorInfo.rcWork;
+        haveWorkAreaRect = true;
       }
+    }
+
+    if (!haveWorkAreaRect)
+    {
+      // I don't think this is possible, but just in case, some
+      // reasonably sane fallbacks.
+      workAreaRect.left = 0;
+      workAreaRect.top = 0;
+      workAreaRect.right = 1280;
+      workAreaRect.bottom = 1024 - 40; // default Windows 10 task bar height
     }
 
     origin.x = workAreaRect.left;
@@ -45,25 +53,51 @@ namespace Win32Desktop
     size.height = workAreaRect.bottom - workAreaRect.top;
   }
 
+  namespace
+  {
+    void FitToWorkAreaImpl(Win32Window::Point& origin, Win32Window::Size& size, Win32Window::Point& workarea_origin, Win32Window::Size& workarea_size)
+    {
+      // Retrieve the work area of the monitor that contains or
+      // is closed to the supplied window bounds.
+      workarea_origin = origin;
+      workarea_size = size;
+
+      GetWorkArea(workarea_origin, workarea_size);
+
+      // Translate the window so that its top/left is inside the work area.
+      origin.x = std::max(origin.x, workarea_origin.x);
+      origin.y = std::max(origin.y, workarea_origin.y);
+
+      // Crop the window if it extends past the bottom/right of the work area.
+      Win32Window::Point workarea_bottom_right(
+        workarea_origin.x + workarea_size.width,
+        workarea_origin.y + workarea_size.height);
+
+      size.width = std::min(size.width, workarea_bottom_right.x - origin.x);
+      size.height = std::min(size.height, workarea_bottom_right.y - origin.y);
+    }
+  }
+
   void FitToWorkArea(Win32Window::Point& origin, Win32Window::Size& size)
   {
-    // Retrieve the work area of the monitor that contains or
-    // is closed to the supplied window bounds.
-    Win32Window::Point workarea_origin = origin;
-    Win32Window::Size workarea_size = size;
+    Win32Window::Point workarea_origin(0, 0);
+    Win32Window::Size workarea_size(0, 0);
 
-    GetWorkArea(workarea_origin, workarea_size);
+    FitToWorkAreaImpl(origin, size, workarea_origin, workarea_size);
+  }
 
-    // Translate the window so that its top/left is inside the work area.
-    origin.x = std::max(origin.x, workarea_origin.x);
-    origin.y = std::max(origin.y, workarea_origin.y);
+  void CentreInWorkArea(Win32Window::Point& origin, Win32Window::Size& size)
+  {
+    Win32Window::Point workarea_origin(0, 0);
+    Win32Window::Size workarea_size(0, 0);
 
-    // Crop the window if it extends past the bottom/right of the work area.
-    Win32Window::Point workarea_bottom_right(
-      workarea_origin.x + workarea_size.width,
-      workarea_origin.y + workarea_size.height);
+    FitToWorkAreaImpl(origin, size, workarea_origin, workarea_size);
 
-    size.width = std::min(size.width, workarea_bottom_right.x - origin.x);
-    size.height = std::min(size.height, workarea_bottom_right.y - origin.y);
+    Win32Window::Point relative_origin(
+      (workarea_size.width - size.width) / 2,
+      (workarea_size.height - size.height) / 2);
+
+    origin.x = workarea_origin.x + relative_origin.x;
+    origin.y = workarea_origin.y + relative_origin.y;
   }
 }

--- a/flutter/windows/runner/win32_desktop.cpp
+++ b/flutter/windows/runner/win32_desktop.cpp
@@ -20,7 +20,7 @@ namespace Win32Desktop
     if (hMonitor == NULL)
       hMonitor = MonitorFromWindow(NULL, MONITOR_DEFAULTTOPRIMARY);
 
-    RECT workAreaRect;
+    RECT workAreaRect = {0};
     bool haveWorkAreaRect = false;
 
     if (hMonitor != NULL)

--- a/flutter/windows/runner/win32_desktop.h
+++ b/flutter/windows/runner/win32_desktop.h
@@ -7,6 +7,7 @@ namespace Win32Desktop
 {
   void GetWorkArea(Win32Window::Point& origin, Win32Window::Size& size);
   void FitToWorkArea(Win32Window::Point& origin, Win32Window::Size& size);
+  void CentreInWorkArea(Win32Window::Point& origin, Win32Window::Size& size);
 }
 
 #endif  // RUNNER_WIN32_DESKTOP_H_


### PR DESCRIPTION
When the Windows app is starting, it places the window with a specific location and size. That location is currently hardcoded to be the pixel offset (10, 10). Most parts of the system, including all subsidiary windows, automatically centre themselves. This PR updates the top-level window to be centered as well.

This PR is built on top of #12933. If that PR gets merged first, I will rebase this one as needed. If this PR gets merged instead of that PR, the changes from that PR will be included via this PR. As of creation, the diff on this PR shows the combined effect of both PRs, but this PR properly only includes this commit:

https://github.com/rustdesk/rustdesk/commit/04cc078afe64387a94253a213332f57e56e5bf7d