### PR TITLE
Fix super call in onWindowResized handler

### DIFF
--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -422,7 +422,7 @@ class _DesktopTabState extends State<DesktopTab>
   @override
   void onWindowResized() {
     _saveFrameDebounce.call(_saveFrame);
-    super.onWindowMoved();
+    super.onWindowResized();
   }
 
   @override


### PR DESCRIPTION
Highlighted by Copilot in automated review on an unrelated PR, this override looks wrong in that it calls a different method in the superclass. Maybe this is intentional, in which case this PR can be summarily closed. :-) (Though if it is intentional, it should probably be explained with a comment.)