### PR TITLE
fix crash on android armv7

### DIFF
--- a/res/vcpkg/ffmpeg/portfile.cmake
+++ b/res/vcpkg/ffmpeg/portfile.cmake
@@ -185,6 +185,11 @@ elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Android")
 --enable-decoder=h264_mediacodec \
 --enable-decoder=hevc_mediacodec \
 ")
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+        string(APPEND OPTIONS "\
+--disable-iconv \
+")
+    endif()
 endif()
 
 if(VCPKG_TARGET_IS_OSX)


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/12980 https://github.com/rustdesk/rustdesk/issues/12998

It's introduced by https://github.com/rustdesk/rustdesk/pull/12795, FFmpeg is not updated but the env is changed.

<img width="927" height="164" alt="env" src="https://github.com/user-attachments/assets/9cfa1dc6-1792-4f36-b068-2743e10cdd37" />

Testd armv7/aarch64/universal after fix.

<img width="927" height="164" alt="fix_armv7" src="https://github.com/user-attachments/assets/d79d0f84-ed42-45fa-9d23-eb83be3708db" />
