### PR TITLE
disable iconv on android

### DIFF
--- a/res/vcpkg/ffmpeg/portfile.cmake
+++ b/res/vcpkg/ffmpeg/portfile.cmake
@@ -177,6 +177,7 @@ elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Android")
     string(APPEND OPTIONS "\
 --target-os=android \
 --disable-asm \
+--disable-iconv \
 --enable-jni \
 --enable-mediacodec \
 --disable-hwaccels \
@@ -185,11 +186,6 @@ elseif(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "Android")
 --enable-decoder=h264_mediacodec \
 --enable-decoder=hevc_mediacodec \
 ")
-    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
-        string(APPEND OPTIONS "\
---disable-iconv \
-")
-    endif()
 endif()
 
 if(VCPKG_TARGET_IS_OSX)


### PR DESCRIPTION
Before upgrading the codec, iconv was not referenced on AArch64 Android either.


# before codec updating

<img width="919" height="62" alt="aarch64_before" src="https://github.com/user-attachments/assets/398f0a24-a496-4f65-87ae-ad7c3d13f2c0" />

# after pr

<img width="926" height="99" alt="after_pr" src="https://github.com/user-attachments/assets/9bab37a4-41c1-4ef6-b275-d639abda5568" />
