### PR TITLE
Fix typo in update message

### DIFF
--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -195,7 +195,7 @@ pub fn core_main() -> Option<Vec<String>> {
                 }
                 let res = platform::update_me(false);
                 let text = match res {
-                    Ok(_) => translate("Update successfully!".to_string()),
+                    Ok(_) => translate("Update successful!".to_string()),
                     Err(err) => {
                         log::error!("Failed with error: {err}");
                         translate("Update failed!".to_string())
@@ -298,7 +298,7 @@ pub fn core_main() -> Option<Vec<String>> {
             if args[0] == "--update" {
                 let _text = match platform::update_me() {
                     Ok(_) => {
-                        log::info!("{}", translate("Update successfully!".to_string()));
+                        log::info!("{}", translate("Update successful!".to_string()));
                     }
                     Err(err) => {
                         log::error!("Update failed with error: {err}");

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2650,7 +2650,7 @@ pub fn main_set_common(_key: String, _value: String) {
                     #[cfg(target_os = "macos")]
                     match crate::platform::update_to(f) {
                         Ok(_) => {
-                            log::info!("Update successfully!");
+                            log::info!("Update successful!");
                         }
                         Err(e) => {
                             log::error!("Failed to update to new version, {}", e);


### PR DESCRIPTION
When RustDesk updates, the message reads "Update successfully!", which is incorrect. Changed to "Update sucessful!".