### PR TITLE
more assign from cli and devices.py

### DIFF
--- a/res/devices.py
+++ b/res/devices.py
@@ -95,8 +95,17 @@ def delete(url, token, guid, id):
 
 def assign(url, token, guid, id, type, value):
     print("assign", id, type, value)
-    if type != "ab" and type != "strategy_name" and type != "user_name":
-        print("Invalid type, it must be 'ab', 'strategy_name' or 'user_name'")
+    valid_types = [
+        "ab",
+        "strategy_name",
+        "user_name",
+        "device_group_name",
+        "note",
+        "device_username",
+        "device_name",
+    ]
+    if type not in valid_types:
+        print(f"Invalid type, it must be one of: {', '.join(valid_types)}")
         return
     data = {"type": type, "value": value}
     headers = {"Authorization": f"Bearer {token}"}
@@ -124,7 +133,7 @@ def main():
     parser.add_argument("--device_group_name", help="Device group name")
     parser.add_argument(
         "--assign_to",
-        help="<type>=<value>, e.g. user_name=mike, strategy_name=test, ab=ab1, ab=ab1,tag1",
+        help="<type>=<value>, e.g. user_name=mike, strategy_name=test, device_group_name=group1, note=note1, device_username=username1, device_name=name1, ab=ab1, ab=ab1,tag1,alias1,password1,note1"
     )
     parser.add_argument(
         "--offline_days", type=int, help="Offline duration in days, e.g., 7"
@@ -148,28 +157,37 @@ def main():
     if args.command == "view":
         for device in devices:
             print(device)
-    elif args.command == "disable":
-        for device in devices:
-            response = disable(args.url, args.token, device["guid"], device["id"])
-            print(response)
-    elif args.command == "enable":
-        for device in devices:
-            response = enable(args.url, args.token, device["guid"], device["id"])
-            print(response)
-    elif args.command == "delete":
-        for device in devices:
-            response = delete(args.url, args.token, device["guid"], device["id"])
-            print(response)
-    elif args.command == "assign":
-        if "=" not in args.assign_to:
-            print("Invalid assign_to format, it must be <type>=<value>")
-            return
-        type, value = args.assign_to.split("=", 1)
-        for device in devices:
-            response = assign(
-                args.url, args.token, device["guid"], device["id"], type, value
-            )
-            print(response)
+    elif args.command in ["disable", "enable", "delete", "assign"]:
+        # Check if we need user confirmation for multiple devices
+        if len(devices) > 1:
+            print(f"Found {len(devices)} devices. Do you want to proceed with {args.command} operation on the devices? (Y/N)")
+            confirmation = input("Type 'Y' to confirm: ").strip()
+            if confirmation.upper() != 'Y':
+                print("Operation cancelled.")
+                return
+        
+        if args.command == "disable":
+            for device in devices:
+                response = disable(args.url, args.token, device["guid"], device["id"])
+                print(response)
+        elif args.command == "enable":
+            for device in devices:
+                response = enable(args.url, args.token, device["guid"], device["id"])
+                print(response)
+        elif args.command == "delete":
+            for device in devices:
+                response = delete(args.url, args.token, device["guid"], device["id"])
+                print(response)
+        elif args.command == "assign":
+            if "=" not in args.assign_to:
+                print("Invalid assign_to format, it must be <type>=<value>")
+                return
+            type, value = args.assign_to.split("=", 1)
+            for device in devices:
+                response = assign(
+                    args.url, args.token, device["guid"], device["id"], type, value
+                )
+                print(response)
 
 
 if __name__ == "__main__":

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -462,51 +462,25 @@ pub fn core_main() -> Option<Vec<String>> {
                     let token = args[pos + 1].to_owned();
                     let id = crate::ipc::get_id();
                     let uuid = crate::encode64(hbb_common::get_uuid());
-                    let mut user_name = None;
-                    let pos = args.iter().position(|x| x == "--user_name").unwrap_or(max);
-                    if pos < max {
-                        user_name = Some(args[pos + 1].to_owned());
-                    }
-                    let mut strategy_name = None;
-                    let pos = args
-                        .iter()
-                        .position(|x| x == "--strategy_name")
-                        .unwrap_or(max);
-                    if pos < max {
-                        strategy_name = Some(args[pos + 1].to_owned());
-                    }
-                    let mut address_book_name = None;
-                    let pos = args
-                        .iter()
-                        .position(|x| x == "--address_book_name")
-                        .unwrap_or(max);
-                    if pos < max {
-                        address_book_name = Some(args[pos + 1].to_owned());
-                    }
-                    let mut address_book_tag = None;
-                    let pos = args
-                        .iter()
-                        .position(|x| x == "--address_book_tag")
-                        .unwrap_or(max);
-                    if pos < max {
-                        address_book_tag = Some(args[pos + 1].to_owned());
-                    }
-                    let mut address_book_alias = None;
-                    let pos = args
-                        .iter()
-                        .position(|x| x == "--address_book_alias")
-                        .unwrap_or(max);
-                    if pos < max {
-                        address_book_alias = Some(args[pos + 1].to_owned());
-                    }
-                    let mut device_group_name = None;
-                    let pos = args
-                        .iter()
-                        .position(|x| x == "--device_group_name")
-                        .unwrap_or(max);
-                    if pos < max {
-                        device_group_name = Some(args[pos + 1].to_owned());
-                    }
+                    let get_value = |c: &str| {
+                        let pos = args.iter().position(|x| x == c).unwrap_or(max);
+                        if pos < max {
+                            Some(args[pos + 1].to_owned())
+                        } else {
+                            None
+                        }
+                    };
+                    let user_name = get_value("--user_name");
+                    let strategy_name = get_value("--strategy_name");
+                    let address_book_name = get_value("--address_book_name");
+                    let address_book_tag = get_value("--address_book_tag");
+                    let address_book_alias = get_value("--address_book_alias");
+                    let address_book_password = get_value("--address_book_password");
+                    let address_book_note = get_value("--address_book_note");
+                    let device_group_name = get_value("--device_group_name");
+                    let note = get_value("--note");
+                    let device_username = get_value("--device_username");
+                    let device_name = get_value("--device_name");
                     let mut body = serde_json::json!({
                         "id": id,
                         "uuid": uuid,
@@ -516,9 +490,19 @@ pub fn core_main() -> Option<Vec<String>> {
                         && strategy_name.is_none()
                         && address_book_name.is_none()
                         && device_group_name.is_none()
+                        && note.is_none()
+                        && device_username.is_none()
+                        && device_name.is_none()
                     {
                         println!(
-                            "--user_name or --strategy_name or --address_book_name or --device_group_name is required!"
+                            r#"At least one of the following options is required:
+  --user_name
+  --strategy_name
+  --address_book_name
+  --device_group_name
+  --note
+  --device_username
+  --device_name"#
                         );
                     } else {
                         if let Some(name) = user_name {
@@ -535,9 +519,24 @@ pub fn core_main() -> Option<Vec<String>> {
                             if let Some(name) = address_book_alias {
                                 body["address_book_alias"] = serde_json::json!(name);
                             }
+                            if let Some(name) = address_book_password {
+                                body["address_book_password"] = serde_json::json!(name);
+                            }
+                            if let Some(name) = address_book_note {
+                                body["address_book_note"] = serde_json::json!(name);
+                            }
                         }
                         if let Some(name) = device_group_name {
                             body["device_group_name"] = serde_json::json!(name);
+                        }
+                        if let Some(name) = note {
+                            body["note"] = serde_json::json!(name);
+                        }
+                        if let Some(name) = device_username {
+                            body["device_username"] = serde_json::json!(name);
+                        }
+                        if let Some(name) = device_name {
+                            body["device_name"] = serde_json::json!(name);
                         }
                         let url = crate::ui_interface::get_api_server() + "/api/devices/cli";
                         match crate::post_request_sync(url, body.to_string(), &header) {

--- a/src/hbbs_http/sync.rs
+++ b/src/hbbs_http/sync.rs
@@ -140,6 +140,18 @@ async fn start_hbbs_sync_async() {
                     if !ab_tag.is_empty() {
                         v[keys::OPTION_PRESET_ADDRESS_BOOK_TAG] = json!(ab_tag);
                     }
+                    let ab_alias = Config::get_option(keys::OPTION_PRESET_ADDRESS_BOOK_ALIAS);
+                    if !ab_alias.is_empty() {
+                        v[keys::OPTION_PRESET_ADDRESS_BOOK_ALIAS] = json!(ab_alias);
+                    }
+                    let ab_password = Config::get_option(keys::OPTION_PRESET_ADDRESS_BOOK_PASSWORD);
+                    if !ab_password.is_empty() {
+                        v[keys::OPTION_PRESET_ADDRESS_BOOK_PASSWORD] = json!(ab_password);
+                    }
+                    let ab_note = Config::get_option(keys::OPTION_PRESET_ADDRESS_BOOK_NOTE);
+                    if !ab_note.is_empty() {
+                        v[keys::OPTION_PRESET_ADDRESS_BOOK_NOTE] = json!(ab_note);
+                    }
                     let username = get_builtin_option(keys::OPTION_PRESET_USERNAME);
                     if !username.is_empty() {
                         v[keys::OPTION_PRESET_USERNAME] = json!(username);
@@ -151,6 +163,18 @@ async fn start_hbbs_sync_async() {
                     let device_group_name = get_builtin_option(keys::OPTION_PRESET_DEVICE_GROUP_NAME);
                     if !device_group_name.is_empty() {
                         v[keys::OPTION_PRESET_DEVICE_GROUP_NAME] = json!(device_group_name);
+                    }
+                    let device_username = Config::get_option(keys::OPTION_PRESET_DEVICE_USERNAME);
+                    if !device_username.is_empty() {
+                        v["username"] = json!(device_username);
+                    }
+                    let device_name = Config::get_option(keys::OPTION_PRESET_DEVICE_NAME);
+                    if !device_name.is_empty() {
+                        v["hostname"] = json!(device_name);
+                    }
+                    let note = Config::get_option(keys::OPTION_PRESET_NOTE);
+                    if !note.is_empty() {
+                        v[keys::OPTION_PRESET_NOTE] = json!(note);
                     }
                     let v = v.to_string();
                     let mut hash = "".to_owned();


### PR DESCRIPTION
# Description

 Complete the command line, Python script, and preset advanced option to set the address book alias, password, note, as well as the peer’s device_username, device_name, and note.

# Preview

## command line

<img width="1919" height="1006" alt="cmd" src="https://github.com/user-attachments/assets/abb46f9a-9927-4ef6-9782-8bc5a089e938" />

<img width="1919" height="888" alt="cmd2" src="https://github.com/user-attachments/assets/743b37e1-2a02-44e6-b531-85bcf735f8d9" />

## devices.py

<img width="1919" height="1015" alt="py1" src="https://github.com/user-attachments/assets/765fdcc9-75af-4b4a-8dc9-d56cb3975cbc" />

