### PR TITLE
refact: option, touch mode, move to local

### DIFF
--- a/flutter/lib/common/widgets/setting_widgets.dart
+++ b/flutter/lib/common/widgets/setting_widgets.dart
@@ -230,7 +230,6 @@ List<(String, String)> otherDefaultSettings() {
     ('Disable clipboard', kOptionDisableClipboard),
     ('Lock after session end', kOptionLockAfterSessionEnd),
     ('Privacy mode', kOptionPrivacyMode),
-    if (isMobile) ('Touch mode', kOptionTouchMode),
     ('True color (4:4:4)', kOptionI444),
     ('Reverse mouse wheel', kKeyReverseMouseWheel),
     ('swap-left-right-mouse', kOptionSwapLeftRightMouse),

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -803,9 +803,8 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
               touchMode: gFFI.ffiModel.touchMode,
               onTouchModeChange: (t) {
                 gFFI.ffiModel.toggleTouchMode();
-                final v = gFFI.ffiModel.touchMode ? 'Y' : '';
-                bind.sessionPeerOption(
-                    sessionId: sessionId, name: kOptionTouchMode, value: v);
+                final v = gFFI.ffiModel.touchMode ? 'Y' : 'N';
+                bind.mainSetLocalOption(key: kOptionTouchMode, value: v);
               },
               virtualMouseMode: gFFI.ffiModel.virtualMouseMode,
             )));

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1107,9 +1107,20 @@ class FfiModel with ChangeNotifier {
     if (isPeerAndroid) {
       _touchMode = true;
     } else {
-      _touchMode = await bind.sessionGetOption(
-              sessionId: sessionId, arg: kOptionTouchMode) !=
-          '';
+      // `kOptionTouchMode` is originally peer option, but it is moved to local option later.
+      // We check local option first, if not set, then check peer option.
+      // Because if local option is not empty:
+      // 1. User has set the touch mode explicitly.
+      // 2. The advanced option (custom client) is set.
+      //    Then we choose to use the local option.
+      final optLocal = bind.mainGetLocalOption(key: kOptionTouchMode);
+      if (optLocal != '') {
+        _touchMode = optLocal == 'Y';
+      } else {
+        final optSession = await bind.sessionGetOption(
+            sessionId: sessionId, arg: kOptionTouchMode);
+        _touchMode = optSession != '';
+      }
     }
     if (isMobile) {
       virtualMouseMode.loadOptions();


### PR DESCRIPTION
**Refactor**: Move the "Touch mode" option from peer configuration to local configuration.

**Implementation**:

**Reading**: Local configuration → Peer configuration. If local configuration is not set, use peer configuration.
**Writing**: Save to local configuration only .

