### PR TITLE
fix: alarm audit number, ipv6 prefix attempts

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -4478,7 +4478,10 @@ pub enum AlarmAuditType {
     IpWhitelist = 0,
     ExceedThirtyAttempts = 1,
     SixAttemptsWithinOneMinute = 2,
-    ExceedIPv6PrefixAttempts = 3,
+    // ExceedThirtyLoginAttempts = 3,
+    // MultipleLoginsAttemptsWithinOneMinute = 4,
+    // MultipleLoginsAttemptsWithinOneHour = 5,
+    ExceedIPv6PrefixAttempts = 6,
 }
 
 pub enum FileAuditType {


### PR DESCRIPTION
Correct the number of new alarm audit type.
