### PR TITLE
fix: uninstall, idd

### DIFF
--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -446,6 +446,8 @@ pub mod amyuni_idd {
             if crate::platform::windows::is_x64() {
                 log::info!("Uninstalling driver by deviceinstaller64.exe");
                 install_if_x86_on_x64(&work_dir, "remove usbmmidd")?;
+                // Sleep some time to wait for the driver to be uninstalled.
+                std::thread::sleep(Duration::from_secs(2));
                 return Ok(());
             }
         }


### PR DESCRIPTION
<img width="1287" height="357" alt="f74e7fc1-7359-43a0-a0f0-af027b0bb37c" src="https://github.com/user-attachments/assets/573bc97a-9e09-4bde-91d6-07c9d869ae72" />


Fix the bug where this file remains after uninstallation.
When installing an x86 program on an x64 computer, the uninstaller needs to call `deviceinstaller64.exe remove usbmmidd`, but this command is executed asynchronously.
It is necessary to wait for a short period to ensure the command completes execution.
One second should be sufficient (on my machine), but a two-second wait is more reliable.
