### PR TITLE
fix macos low fps after installation

### DIFF
--- a/src/platform/privileges_scripts/agent.plist
+++ b/src/platform/privileges_scripts/agent.plist
@@ -31,5 +31,7 @@
         </array>
         <key>WorkingDirectory</key>
         <string>/Applications/RustDesk.app/Contents/MacOS/</string>
+        <key>ProcessType</key>
+        <string>Interactive</string>
     </dict>
 </plist>


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/11152

After installation, `std::thread::sleep` on macOS actually sleeps for a long time. Adding `ProcessType` to `Interactive` to `agent.plist` improves this situation.

* code
![code](https://github.com/user-attachments/assets/f441b36e-2a14-4d24-b608-7e53e23b6ec6)

* before
![before](https://github.com/user-attachments/assets/cb1a67a1-1a80-47cb-b0f5-c969bbe95776)

* after
![ProcessType](https://github.com/user-attachments/assets/764d1c45-6a8f-454a-aeab-903d9d44343b)
