### PR TITLE
ios: Allow transfered files to be managed by Files and iTunes

### DIFF
--- a/flutter/ios/Runner/Info.plist
+++ b/flutter/ios/Runner/Info.plist
@@ -43,6 +43,8 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -60,6 +62,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UISupportsDocumentBrowser</key>
+	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
For discussion: https://github.com/rustdesk/rustdesk/discussions/13205

This PR will enable `Files` app on iOS device and `iTunes` on pc/mac to manage files under `Documents` folder. 

I tested and these will work on real device, no compiled from source though. I took version from app store and modified `Info.plist` in the ipa. 

![DAA216DF473E5A1B1A737BD4DA9CBE4F](https://github.com/user-attachments/assets/f75f9270-6d7f-4dbe-a019-e8688ec5d0f3)
<img width="1305" height="913" alt="PS{4IP6PSMB {JGSHLQ(G1X" src="https://github.com/user-attachments/assets/7d0eb377-6186-4118-b60b-7f5de149c022" />


Relavent documentations: 
* [UIFileSharingEnabled](https://developer.apple.com/documentation/bundleresources/information-property-list/uifilesharingenabled?language=objc) - (Enables iTunes access)
* [UISupportsDocumentBrowser](https://developer.apple.com/documentation/bundleresources/information-property-list/uisupportsdocumentbrowser?language=objc) - (Enables Files access)
