### PR TITLE
fix camera capture large error log

### DIFF
--- a/libs/scrap/src/common/camera.rs
+++ b/libs/scrap/src/common/camera.rs
@@ -268,12 +268,12 @@ impl TraitCapturer for CameraCapturer {
 
     #[cfg(windows)]
     fn is_gdi(&self) -> bool {
-        false
+        true
     }
 
     #[cfg(windows)]
     fn set_gdi(&mut self) -> bool {
-        false
+        true
     }
 
     #[cfg(feature = "vram")]


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/13220

# Description

When the camera capture fails, `set_gdi` does not make any changes and capture continues, resulting in continuous error log printing. Now, the camera capture is treated as GDI; if a capture fails, it will immediately return, exit the loop, and the service will sleep.

https://github.com/rustdesk/rustdesk/blob/c90d72d720973027e7a924615810c56357e2c0a9/src/server/video_service.rs#L787

https://github.com/rustdesk/rustdesk/blob/c90d72d720973027e7a924615810c56357e2c0a9/src/server/service.rs#L317

# Screenshots

## before

<img width="1863" height="373" alt="before" src="https://github.com/user-attachments/assets/acb0bfb6-d863-49a2-88de-4f829ef832b2" />


## after

<img width="1678" height="592" alt="after" src="https://github.com/user-attachments/assets/99185c93-cde5-4524-ac3a-37ce29e6b7de" />
