### PR TITLE
Fix relay routing for devices after WebSocket is disabled

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2532,11 +2532,11 @@ impl LoginConfigHandler {
                     .insert("other-server-key".to_owned(), c.clone());
             }
         }
-        if self.force_relay {
-            config
-                .options
-                .insert("force-always-relay".to_owned(), "Y".to_owned());
-        }
+        //if self.force_relay {
+        //    config
+        //        .options
+        //        .insert("force-always-relay".to_owned(), "Y".to_owned());
+        //}
         #[cfg(feature = "flutter")]
         {
             // sync connected password to personal ab automatically if it is not shared password


### PR DESCRIPTION
Fix the bug where, after enabling WebSocket and then disabling it, devices that did not previously select 'force relay' still route through the relay.