### PR TITLE
fix: save frame, LateInitializationError

### DIFF
--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -405,10 +405,15 @@ class _DesktopTabState extends State<DesktopTab>
   }
 
   _saveFrame({bool? flush}) async {
-    if (tabType == DesktopTabType.main) {
-      await saveWindowPosition(WindowType.Main, flush: flush);
-    } else if (kWindowType != null && kWindowId != null) {
-      await saveWindowPosition(kWindowType!, windowId: kWindowId, flush: flush);
+    try {
+      if (tabType == DesktopTabType.main) {
+        await saveWindowPosition(WindowType.Main, flush: flush);
+      } else if (kWindowType != null && kWindowId != null) {
+        await saveWindowPosition(kWindowType!,
+            windowId: kWindowId, flush: flush);
+      }
+    } catch (e) {
+      debugPrint('Error saving window position: $e');
     }
   }
 

--- a/flutter/lib/utils/multi_window_manager.dart
+++ b/flutter/lib/utils/multi_window_manager.dart
@@ -475,7 +475,11 @@ class RustDeskMultiWindowManager {
       final shouldSavePos = type != WindowType.Terminal || i == windows.length - 1;
       if (shouldSavePos) {
         debugPrint("closing multi window, type: ${type.toString()} id: $wId");
-        await saveWindowPosition(type, windowId: wId);
+        try {
+          await saveWindowPosition(type, windowId: wId);
+        } catch (e) {
+          debugPrint('Failed to save window position of $wId, $e');
+        }
       }
       try {
         await WindowController.fromWindowId(wId).setPreventClose(false);


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/13260

Fix `Unhandled Exception: LateInitializationError: Local 'position' has not been initialized.`.
`position` and `sz` are not initialized if the window is maximized or fullscreen.
Then the following code throws exception.

```dart
    position = Offset(
        lpos?.offsetWidth ?? position.dx, lpos?.offsetHeight ?? position.dy);
    sz = Size(lpos?.width ?? sz.width, lpos?.height ?? sz.height);
```

This issue occurs on Linux when new peer is connected.
Because new remote windows on Windows and macOS are not maximized or fullscreen.
New remote windows on Linux may be maximized on a new machine.

1.4.2 also has this issue.

But `saveWindowPosition()` is not called in `close()` callback in `1.4.2`. Closing window is not affected then.

## Tests

- [x] Maximize, close, open. Maximized.
- [x] Fullscreen, close, open. Fullscreen.
- [x] Minimize, close, open. State before minimized.
