### PR TITLE
Allow flipping sort order in mobile app's file transfer

### DIFF
--- a/flutter/lib/mobile/pages/file_manager_page.dart
+++ b/flutter/lib/mobile/pages/file_manager_page.dart
@@ -424,6 +424,7 @@ class FileManagerView extends StatefulWidget {
 class _FileManagerViewState extends State<FileManagerView> {
   final _listScrollController = ScrollController();
   final _breadCrumbScroller = ScrollController();
+  final ascending = Rx<bool?>(null);
 
   bool get isLocal => widget.controller.isLocal;
   FileController get controller => widget.controller;
@@ -589,57 +590,67 @@ class _FileManagerViewState extends State<FileManagerView> {
 
   Widget headTools() => Container(
           child: Row(
-        children: [
-          Expanded(child: Obx(() {
-            final home = controller.options.value.home;
-            final isWindows = controller.options.value.isWindows;
-            return BreadCrumb(
-              items: getPathBreadCrumbItems(controller.shortPath, isWindows,
-                  () => controller.goToHomeDirectory(), (list) {
-                var path = "";
-                if (home.startsWith(list[0])) {
-                  // absolute path
-                  for (var item in list) {
-                    path = PathUtil.join(path, item, isWindows);
-                  }
-                } else {
-                  path += home;
-                  for (var item in list) {
-                    path = PathUtil.join(path, item, isWindows);
-                  }
-                }
-                controller.openDirectory(path);
-              }),
-              divider: Icon(Icons.chevron_right),
-              overflow: ScrollableOverflow(controller: _breadCrumbScroller),
-            );
-          })),
-          Row(
             children: [
-              IconButton(
-                icon: Icon(Icons.arrow_back),
-                onPressed: controller.goBack,
-              ),
-              IconButton(
-                icon: Icon(Icons.arrow_upward),
-                onPressed: controller.goToParentDirectory,
-              ),
-              PopupMenuButton<SortBy>(
-                  tooltip: "",
-                  icon: Icon(Icons.sort),
-                  itemBuilder: (context) {
-                    return SortBy.values
-                        .map((e) => PopupMenuItem(
-                              child: Text(translate(e.toString())),
-                              value: e,
-                            ))
-                        .toList();
-                  },
-                  onSelected: controller.changeSortStyle),
+              Expanded(child: Obx(() {
+                final home = controller.options.value.home;
+                final isWindows = controller.options.value.isWindows;
+                return BreadCrumb(
+                  items: getPathBreadCrumbItems(controller.shortPath, isWindows,
+                      () => controller.goToHomeDirectory(), (list) {
+                    var path = "";
+                    if (home.startsWith(list[0])) {
+                      // absolute path
+                      for (var item in list) {
+                        path = PathUtil.join(path, item, isWindows);
+                      }
+                    } else {
+                      path += home;
+                      for (var item in list) {
+                        path = PathUtil.join(path, item, isWindows);
+                      }
+                    }
+                    controller.openDirectory(path);
+                  }),
+                  divider: Icon(Icons.chevron_right),
+                  overflow: ScrollableOverflow(controller: _breadCrumbScroller),
+                );
+              })),
+              Row(
+                children: [
+                  IconButton(
+                    icon: Icon(Icons.arrow_back),
+                    onPressed: controller.goBack,
+                  ),
+                  IconButton(
+                    icon: Icon(Icons.arrow_upward),
+                    onPressed: controller.goToParentDirectory,
+                  ),
+                  PopupMenuButton<SortBy>(
+                      tooltip: "",
+                      icon: Icon(Icons.sort),
+                      itemBuilder: (context) {
+                        return SortBy.values
+                            .map((e) => PopupMenuItem(
+                                  child: Text(translate(e.toString())),
+                                  value: e,
+                                ))
+                            .toList();
+                      },
+                      onSelected: (sortBy) {
+                        // If selecting the same sort option, flip the order
+                        // If selecting a different sort option, use ascending order
+                        if (controller.sortBy.value == sortBy) {
+                          ascending.value = !controller.sortAscending;
+                        } else {
+                          ascending.value = true;
+                        }
+                        controller.changeSortStyle(sortBy, ascending: ascending.value!);
+                      }
+                  ),
+                ],
+              )
             ],
-          )
-        ],
-      ));
+          ));
 
   Widget listTail() => Obx(() => Container(
         height: 100,

--- a/flutter/lib/mobile/pages/file_manager_page.dart
+++ b/flutter/lib/mobile/pages/file_manager_page.dart
@@ -424,7 +424,7 @@ class FileManagerView extends StatefulWidget {
 class _FileManagerViewState extends State<FileManagerView> {
   final _listScrollController = ScrollController();
   final _breadCrumbScroller = ScrollController();
-  final ascending = Rx<bool?>(null);
+  late final ascending = Rx<bool>(controller.sortAscending);
 
   bool get isLocal => widget.controller.isLocal;
   FileController get controller => widget.controller;
@@ -644,7 +644,7 @@ class _FileManagerViewState extends State<FileManagerView> {
                         } else {
                           ascending.value = true;
                         }
-                        controller.changeSortStyle(sortBy, ascending: ascending.value!);
+                        controller.changeSortStyle(sortBy, ascending: ascending.value);
                       }
                   ),
                 ],

--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -428,7 +428,7 @@ class FileController {
     }
     try {
       final fd = await fileFetcher.fetchDirectory(path, isLocal, showHidden);
-      fd.format(isWindows, sort: sortBy.value);
+      fd.format(isWindows, sort: sortBy.value, ascending: sortAscending);
       directory.value = fd;
     } catch (e) {
       debugPrint("Failed to openDirectory $path: $e");
@@ -1314,12 +1314,12 @@ class FileDirectory {
   }
 
   // generate full path for every entry , init sort style if need.
-  format(bool isWindows, {SortBy? sort}) {
+  format(bool isWindows, {SortBy? sort, bool ascending = true}) {
     for (var entry in entries) {
       entry.path = PathUtil.join(path, entry.name, isWindows);
     }
     if (sort != null) {
-      changeSortStyle(sort);
+      changeSortStyle(sort, ascending: ascending);
     }
   }
 

--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -428,7 +428,7 @@ class FileController {
     }
     try {
       final fd = await fileFetcher.fetchDirectory(path, isLocal, showHidden);
-      fd.format(isWindows, sort: sortBy.value, ascending: sortAscending);
+      fd.format(isWindows, sort: sortBy.value);
       directory.value = fd;
     } catch (e) {
       debugPrint("Failed to openDirectory $path: $e");
@@ -1314,12 +1314,12 @@ class FileDirectory {
   }
 
   // generate full path for every entry , init sort style if need.
-  format(bool isWindows, {SortBy? sort, bool ascending = true}) {
+  format(bool isWindows, {SortBy? sort}) {
     for (var entry in entries) {
       entry.path = PathUtil.join(path, entry.name, isWindows);
     }
     if (sort != null) {
-      changeSortStyle(sort, ascending: ascending);
+      changeSortStyle(sort);
     }
   }
 


### PR DESCRIPTION
Right now I can't find any way in the mobile app to change sort order from ascending to descending when doing file transfer. 

A common pattern that I am trying to add in this PR is to flip the order when the same sort type is selected. I think the same behavior is already implemented for the Desktop client.

https://github.com/user-attachments/assets/4b1913a2-405a-4c7f-b40e-7ddc61bf0e1c

I have created a test build in my fork: https://github.com/nguyenquyhy/rustdesk/releases/tag/sort