### PR TITLE
add try catch on android setCodecInfo in case of unexpected crash

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -62,7 +62,13 @@ class MainActivity : FlutterActivity() {
             channelTag
         )
         initFlutterChannel(flutterMethodChannel!!)
-        thread { setCodecInfo() }
+        thread {
+            try {
+                setCodecInfo()
+            } catch (e: Exception) {
+                Log.e("MainActivity", "Failed to setCodecInfo: ${e.message}", e)
+            }
+        }
     }
 
     override fun onResume() {


### PR DESCRIPTION
# Description

A pro user's custom client will crash at here in cloud environment.

# Test
<img width="480" height="270" alt="Screenshot from 2025-10-24 20-36-47" src="https://github.com/user-attachments/assets/a578fa70-81c4-48b0-8b64-caac8bee005c" />
