### PR TITLE
Improved Russian localization

### DIFF
--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -170,7 +170,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Local Port", "Локальный порт"),
         ("Local Address", "Локальный адрес"),
         ("Change Local Port", "Изменить локальный порт"),
-        ("setup_server_tip", "Для более быстрого подключения настройте собственный сервер."),
+        ("setup_server_tip", "Для более быстрого подключения настройте собственный сервер"),
         ("Too short, at least 6 characters.", "Слишком короткий, минимум 6 символов."),
         ("The confirmation is not identical.", "Подтверждение не совпадает"),
         ("Permissions", "Разрешения"),

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -46,7 +46,7 @@ class ConnectStatus: Reactor.Component {
             return translate('connecting_status');
         }
         if (!handler.using_public_server()) return translate('Ready');
-        return <span>{translate("Ready")}, <span .link #setup-server>{translate("setup_server_tip")}</span></span>;
+        return <span>{translate("Ready")}. <span .link #setup-server>{translate("setup_server_tip")}</span></span>;
     }
 
     event click $(#start-service) () {


### PR DESCRIPTION
Also, from my point of view, this is lexically incorrect to place a comma after "Ready" instead of a dot.