### PR TITLE
opt ui of Windows session dialog

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -2121,15 +2121,20 @@ void showWindowsSessionsDialog(
 
     return CustomAlertDialog(
       title: null,
-      content: msgboxContent(type, title, text),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          msgboxContent(type, title, text).marginOnly(bottom: 12),
+          ComboBox(
+              keys: sids,
+              values: names,
+              initialKey: selectedUserValue,
+              onChanged: (value) {
+                selectedUserValue = value;
+              }),
+        ],
+      ),
       actions: [
-        ComboBox(
-            keys: sids,
-            values: names,
-            initialKey: selectedUserValue,
-            onChanged: (value) {
-              selectedUserValue = value;
-            }),
         dialogButton('Connect', onPressed: submit, isOutline: false),
       ],
     );


### PR DESCRIPTION
| before | after |
| --- | --- |
| <img width="380" height="227" alt="before" src="https://github.com/user-attachments/assets/e2abb5fe-8f55-40d9-a155-162dcd6c0b09" /> | <img width="379" height="236" alt="after" src="https://github.com/user-attachments/assets/f3d21ae6-7c51-4777-9902-11170f0e2f18" />  |

overflow test

<img width="562" height="322" alt="overlow_test" src="https://github.com/user-attachments/assets/d722baba-6cd9-4c1f-9d8f-f6baa9b346e7" />


