### PR TITLE
fix mac hwcodec check

### DIFF
--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -687,7 +687,7 @@ pub fn check_available_hwcodec() -> String {
         height: 720,
         pixfmt: DEFAULT_PIXFMT,
         align: HW_STRIDE_ALIGN as _,
-        kbs: 0,
+        kbs: 1000,
         fps: DEFAULT_FPS,
         gop: DEFAULT_GOP,
         quality: DEFAULT_HW_QUALITY,


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/12792#discussioncomment-14800751

After pr, still only H265 is available, H264 will be available after adjusting some parameters.

