### PR TITLE
feat(ui): show alias instead of peerId in terminal tab label

### DIFF
--- a/flutter/lib/desktop/pages/terminal_tab_page.dart
+++ b/flutter/lib/desktop/pages/terminal_tab_page.dart
@@ -61,9 +61,11 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
     String? connToken,
   }) {
     final tabKey = '${peerId}_$terminalId';
+    final alias = bind.mainGetPeerOptionSync(id: peerId, key: 'alias');
+    final tabLabel = alias.isNotEmpty ? '$alias #$terminalId' : '$peerId #$terminalId';
     return TabInfo(
       key: tabKey,
-      label: '$peerId #$terminalId',
+      label: tabLabel,
       selectedIcon: selectedIcon,
       unselectedIcon: unselectedIcon,
       onTabCloseButton: () async {


### PR DESCRIPTION
Display peer alias instead of peerId in the terminal tab label for better readability.
<img width="1036" height="365" alt="08c9c69fc5d14771b80dabaa19f17d31" src="https://github.com/user-attachments/assets/37aaa6bf-b760-48f9-bb7e-2c40b7502bf9" />