### PR TITLE
Fix regaining control after a remote cursor movement

### DIFF
--- a/flutter/lib/common/mouse_speed_analyzer.dart
+++ b/flutter/lib/common/mouse_speed_analyzer.dart
@@ -1,0 +1,58 @@
+import 'dart:collection';
+import 'dart:math';
+
+final class MouseSpeedAnalyzer {
+  final Queue<MousePosition> _events = Queue<MousePosition>();
+  final Duration _window;
+  final double _threshold;
+
+  double _currentSum = 0.0;
+
+  MouseSpeedAnalyzer({int windowMilliseconds = 250, double threshold = 60})
+    : _window = Duration(milliseconds: windowMilliseconds),
+      _threshold = threshold;
+
+  void addEvent(double x, double y) {
+    pruneEvents();
+
+    var newEvent = MousePosition(x, y);
+
+    if (_events.isNotEmpty) {
+      _currentSum += newEvent - _events.last;
+    }
+
+    _events.add(newEvent);
+  }
+
+  void pruneEvents() {
+    while (_events.isNotEmpty && (_events.first.age > _window)) {
+      if (_events.length > 1) {
+        _currentSum -= _events.elementAt(1) - _events.first;
+      }
+      _events.removeFirst();
+    }
+
+    if (_events.isEmpty) {
+      // Reset sum to prevent any possibility of error accumulation
+      _currentSum = 0.0;
+    }
+  }
+
+  bool get hasExceededThreshold => _currentSum >= _threshold;
+}
+
+final class MousePosition {
+  final DateTime timestamp = DateTime.now();
+  final double x, y;
+
+  MousePosition(this.x, this.y);
+
+  Duration get age => DateTime.now().difference(timestamp);
+
+  double operator -(MousePosition other) {
+    double dx = other.x - x;
+    double dy = other.y - y;
+
+    return sqrt(dx * dx + dy * dy);
+  }
+}

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -1219,7 +1219,6 @@ class InputModel {
       if (selfGetControl) {
         cursorModel.gotMouseControl = true;
       } else {
-        lastMousePos = ui.Offset(x, y);
         return true;
       }
     }

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -1213,9 +1213,15 @@ class InputModel {
     }
 
     if (!cursorModel.gotMouseControl) {
-      bool selfGetControl =
-          (x - lastMousePos.dx).abs() > kMouseControlDistance ||
-              (y - lastMousePos.dy).abs() > kMouseControlDistance;
+      final dx = x - lastMousePos.dx;
+      final dy = y - lastMousePos.dy;
+
+      // Use the distance squared to avoid sqrt()
+      final d2 = dx * dx + dy + dy;
+      final threshold2 = kMouseControlDistance * kMouseControlDistance;
+
+      final bool selfGetControl = d2 > threshold2;
+
       if (selfGetControl) {
         cursorModel.gotMouseControl = true;
       } else {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -14,6 +14,7 @@ import 'package:get/get.dart';
 
 import '../../models/model.dart';
 import '../../models/platform_model.dart';
+import '../../common/mouse_speed_analyzer.dart';
 import '../common.dart';
 import '../consts.dart';
 
@@ -360,6 +361,7 @@ class InputModel {
   final isPhysicalMouse = false.obs;
   int _lastButtons = 0;
   Offset lastMousePos = Offset.zero;
+  MouseSpeedAnalyzer _mouseSpeedAnalyzer = MouseSpeedAnalyzer();
 
   bool _queryOtherWindowCoords = false;
   Rect? _windowRect;
@@ -1213,16 +1215,9 @@ class InputModel {
     }
 
     if (!cursorModel.gotMouseControl) {
-      final dx = x - lastMousePos.dx;
-      final dy = y - lastMousePos.dy;
+      _mouseSpeedAnalyzer.addEvent(x, y);
 
-      // Use the distance squared to avoid sqrt()
-      final d2 = dx * dx + dy + dy;
-      final threshold2 = kMouseControlDistance * kMouseControlDistance;
-
-      final bool selfGetControl = d2 > threshold2;
-
-      if (selfGetControl) {
+      if (_mouseSpeedAnalyzer.hasExceededThreshold) {
         cursorModel.gotMouseControl = true;
       } else {
         return true;


### PR DESCRIPTION
I have encountered a bug related to remote cursor movement. When a remote cursor movement is detected, the `cursorModel` is updated so that `gotMouseControl` is `false`. The `_checkPeerControlProtected` method in input_model.dart includes logic to allow you to regain control if the cursor moves more than a certain distance. However, this logic doesn't work as expected because after each check, it latches the new mouse position. As a result, the mouse movement isn't cumulative. The cursor must move `kMouseControlDistance` pixels _in a single event_ in order to regain control. It turns out, at least on my Windows 10 machine, that it takes considerable effort to move the mouse fast enough to trigger this. So what ends up happening is that input is just locked until the cursor leaves the RustDesk remote view window. Then, later, when the mouse cursor re-enters the view, it's usually more than `kMouseControlDistance` pixels away from where it left the window so the `selfGetControl` logic finally triggers.

This PR fixes the bug by removing the line that latches each new mouse event location every time the `selfGetControl` test fails. As a result, now once the mouse has moved a _cumulative_ `kMouseControlDistance` pixels, control is regained.

In addition, the `selfGetControl` calculation uses an imprecise model that checks the distance moved on the X and Y axes separately. As such, it is possible to move the mouse up to 1.414 (sqrt(2)) times `kMouseControlDistance` before `selfGetControl` activates, if the movement is diagonal. This PR updates the calculation to compute the actual distance travelled, so that it triggers after `kMouseControlDistance` in any direction, not just orthogonal directions. (The comparison is done between the square of the distance and the square of the threshold, to avoid performing a square root computation. On any computer less than 30 years old I'm fairly certain this optimization is beyond unnecessary, but it's the principle of the matter. 😛 In another PR, Copilot actually told me to use this exact optimization in another context earlier today, for what it's worth.)