### PR TITLE
fix reqwest proxy auth

### DIFF
--- a/src/hbbs_http/http_client.rs
+++ b/src/hbbs_http/http_client.rs
@@ -36,19 +36,13 @@ macro_rules! configure_http_client {
                     };
 
                     match proxy_setup {
-                        Ok(p) => {
-                            builder = builder.proxy(p);
+                        Ok(mut p) => {
                             if let Some(auth) = proxy.intercept.maybe_auth() {
-                                let basic_auth =
-                                    format!("Basic {}", auth.get_basic_authorization());
-                                if let Ok(auth) = basic_auth.parse() {
-                                    builder = builder.default_headers(
-                                        vec![(reqwest::header::PROXY_AUTHORIZATION, auth)]
-                                            .into_iter()
-                                            .collect(),
-                                    );
+                                if !auth.username().is_empty() && !auth.password().is_empty() {
+                                    p = p.basic_auth(auth.username(), auth.password());
                                 }
                             }
+                            builder = builder.proxy(p);
                             builder.build().unwrap_or_else(|e| {
                                 info!("Failed to create a proxied client: {}", e);
                                 <$Client>::new()


### PR DESCRIPTION
# Description

When using my own setup of `tinyproxy` (HTTP proxy) and `apache2` (HTTPS proxy), reqwest version 1.4.3 fails to work properly when authentication with a username and password is required. Changing `PROXY_AUTHORIZATION` to [Proxy::basic_auth ](https://docs.rs/reqwest/latest/reqwest/struct.Proxy.html#method.basic_auth) works as expected. The possible reason is that reqwest internally handles the username and password information in its own way, as seen in this code:
https://github.com/seanmonstar/reqwest/blob/b126ca49da7897e5d676639cdbf67a0f6838b586/src/async_impl/client.rs#L2562
https://github.com/seanmonstar/reqwest/blob/b126ca49da7897e5d676639cdbf67a0f6838b586/src/proxy.rs#L288


# Test

| software | proxy | auth required | 1.4.3 | pr |
|  - | - | - | - | - |
| tinyproxy | http | Y | N | Y |
| tinyproxy | http | N | | Y |
| apache2 | https | Y | N | Y |
| apache2 | https | N |  | Y|

# Videos

## 1.4.3 tinyproxy auth required

[1.4.3_release_tinyproxy_http_proxy_with_auth_required_reqwest_not_work.webm](https://github.com/user-attachments/assets/23a6a55c-50e8-4dd1-b501-25f0e8b1615a)

<img width="1003" height="67" alt="1 4 3_release_tinyproxy_http_proxy_with_auth_required_reqwest_error_info" src="https://github.com/user-attachments/assets/93eb7aac-19bb-4703-88f9-158566f43621" />

## 1.4.3 apache2 auth required

[1.4.3_release_apache2_https_proxy_with_auth_required_reqwest_not_work.webm](https://github.com/user-attachments/assets/87ed914c-baf6-437c-9da4-aff7d022e645)

<img width="1010" height="65" alt="1 4 3_release_apache2_https_proxy_with_auth_required_reqwest_error_info" src="https://github.com/user-attachments/assets/bf4623d9-0392-4123-ba77-9a2384477753" />

## pr tinyproxy

### auth required 

[pr_tinyproxy_http_proxy_with_auth_required_reqwest_works.webm](https://github.com/user-attachments/assets/4a6d75e5-a487-4c84-9222-d3eb3100cacf)

### without auth required

[pr_tinyproxy_http_porxy_without_auth_required_reqwest_works.webm](https://github.com/user-attachments/assets/a47723f2-bc3e-439a-83ec-a6fe780dd070)

## pr apache2

### auth required

[pr_apache2_https_proxy_with_auth_required_reqwest_works.webm](https://github.com/user-attachments/assets/5ad54080-2767-4e48-b065-aa317e47eaa2)

### without auth required

[pr_apache2_https_proxy_without_auth_required_reqwest_works.webm](https://github.com/user-attachments/assets/ea563646-9ee3-44e9-98e0-72e77b3170c4)
