### PR TITLE
Fix terminal clear command to remove residual output

### DIFF
--- a/flutter/lib/models/terminal_model.dart
+++ b/flutter/lib/models/terminal_model.dart
@@ -317,6 +317,15 @@ class TerminalModel with ChangeNotifier {
           return;
         }
 
+        // Check for any clear screen sequences in the terminal output
+        // This ensures a complete clear and provides a better terminal experience
+        if (text.contains('\x1b[2J') ||  // Clear entire screen, if env TERM = xterm-256color, for consistent behavior
+            text.contains('\x1b[J') ||   // Clear from cursor to end of screen, if env TERM = vt220
+            text.contains('\x1b[25l\x1b[H\x1b[?25h') || // Hide cursor, move home, show cursor, ssh through windows powershell
+            text.contains('\x1b[25l\x1b[?2004l\x1b[H\x1b[?25h')) { // Hide cursor, disable bracketed paste, move home, show cursor, ssh through windows powershell
+          terminal.buffer.clear(); // Clear the terminal buffer
+        }
+
         terminal.write(text);
       } catch (e) {
         debugPrint('[TerminalModel] Failed to process terminal data: $e');


### PR DESCRIPTION
Ensure clear commands fully clear terminal output.After clearing, executing other commands displays output correctly without mixing or misalignment.
<img width="841" height="212" alt="bb6bf3e85a3946ccb18012a69fb4344d" src="https://github.com/user-attachments/assets/39e4ae58-9f4b-476a-8efd-a2af15b132fe" />
<img width="847" height="211" alt="0d4b9477807b4b2a98f40a8034b66f35" src="https://github.com/user-attachments/assets/366e821f-b826-4441-86a2-12ba4703b80a" />
