### PR TITLE
Eliminate build warnings from the Scrap crate

### DIFF
--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -233,21 +233,6 @@ fn main() {
     // there is problem with cfg(target_os) in build.rs, so use our workaround
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
 
-    // We check if is macos, because macos uses rust 1.8.1.
-    // `cargo::rustc-check-cfg` is new with Cargo 1.80.
-    // No need to run `cargo version` to get the version here, because:
-    // The following lines are used to suppress the lint warnings.
-    //          warning: unexpected `cfg` condition name: `quartz`
-    if cfg!(target_os = "macos") {
-        if target_os != "ios" {
-            println!("cargo::rustc-check-cfg=cfg(android)");
-            println!("cargo::rustc-check-cfg=cfg(dxgi)");
-            println!("cargo::rustc-check-cfg=cfg(quartz)");
-            println!("cargo::rustc-check-cfg=cfg(x11)");
-            //        ^^^^^^^^^^^^^^^^^^^^^^ new with Cargo 1.80
-        }
-    }
-
     // note: all link symbol names in x86 (32-bit) are prefixed wth "_".
     // run "rustup show" to show current default toolchain, if it is stable-x86-pc-windows-msvc,
     // please install x64 toolchain by "rustup toolchain install stable-x86_64-pc-windows-msvc",

--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -228,9 +228,7 @@ fn ffmpeg() {
 
 fn main() {
     // in this crate, these are also valid configurations
-    println!("cargo:rustc-check-cfg=cfg(dxgi)");
-    println!("cargo:rustc-check-cfg=cfg(quartz)");
-    println!("cargo:rustc-check-cfg=cfg(x11)");
+    println!("cargo:rustc-check-cfg=cfg(dxgi,quartz,x11)");
 
     // there is problem with cfg(target_os) in build.rs, so use our workaround
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -228,7 +228,7 @@ fn ffmpeg() {
 
 fn main() {
     // in this crate, these are also valid configurations
-    println!("cargo::rustc-check-cfg=cfg(dxgi,quartz,x11)");
+    println!("cargo:rustc-check-cfg=cfg(dxgi,quartz,x11)");
 
     // there is problem with cfg(target_os) in build.rs, so use our workaround
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -227,6 +227,9 @@ fn ffmpeg() {
 */
 
 fn main() {
+    // in this crate, these are also valid configurations
+    println!("cargo::rustc-check-cfg=cfg(dxgi,quartz,x11)");
+
     // there is problem with cfg(target_os) in build.rs, so use our workaround
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
 

--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -228,7 +228,9 @@ fn ffmpeg() {
 
 fn main() {
     // in this crate, these are also valid configurations
-    println!("cargo:rustc-check-cfg=cfg(dxgi,quartz,x11)");
+    println!("cargo:rustc-check-cfg=cfg(dxgi)");
+    println!("cargo:rustc-check-cfg=cfg(quartz)");
+    println!("cargo:rustc-check-cfg=cfg(x11)");
 
     // there is problem with cfg(target_os) in build.rs, so use our workaround
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/libs/scrap/src/common/aom.rs
+++ b/libs/scrap/src/common/aom.rs
@@ -287,7 +287,7 @@ impl EncoderApi for AomEncoder {
 }
 
 impl AomEncoder {
-    pub fn encode(&mut self, ms: i64, data: &[u8], stride_align: usize) -> Result<EncodeFrames> {
+    pub fn encode<'a>(&'a mut self, ms: i64, data: &[u8], stride_align: usize) -> Result<EncodeFrames<'a>> {
         let bpp = if self.i444 { 24 } else { 12 };
         if data.len() < self.width * self.height * bpp / 8 {
             return Err(Error::FailedCall("len not enough".to_string()));
@@ -461,7 +461,7 @@ impl AomDecoder {
         Ok(Self { ctx })
     }
 
-    pub fn decode(&mut self, data: &[u8]) -> Result<DecodeFrames> {
+    pub fn decode<'a>(&'a mut self, data: &[u8]) -> Result<DecodeFrames<'a>> {
         call_aom!(aom_codec_decode(
             &mut self.ctx,
             data.as_ptr(),
@@ -476,7 +476,7 @@ impl AomDecoder {
     }
 
     /// Notify the decoder to return any pending frame
-    pub fn flush(&mut self) -> Result<DecodeFrames> {
+    pub fn flush<'a>(&'a mut self) -> Result<DecodeFrames<'a>> {
         call_aom!(aom_codec_decode(
             &mut self.ctx,
             ptr::null(),

--- a/libs/scrap/src/common/hwcodec.rs
+++ b/libs/scrap/src/common/hwcodec.rs
@@ -364,7 +364,7 @@ impl HwRamDecoder {
             }
         }
     }
-    pub fn decode(&mut self, data: &[u8]) -> ResultType<Vec<HwRamDecoderImage>> {
+    pub fn decode<'a>(&'a mut self, data: &[u8]) -> ResultType<Vec<HwRamDecoderImage<'a>>> {
         match self.decoder.decode(data) {
             Ok(v) => Ok(v.iter().map(|f| HwRamDecoderImage { frame: f }).collect()),
             Err(e) => Err(anyhow!(e)),

--- a/libs/scrap/src/common/vpx.rs
+++ b/libs/scrap/src/common/vpx.rs
@@ -3,6 +3,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(improper_ctypes)]
 #![allow(dead_code)]
+#![allow(unused_imports)]
 
 impl Default for vpx_codec_enc_cfg {
     fn default() -> Self {

--- a/libs/scrap/src/common/vpxcodec.rs
+++ b/libs/scrap/src/common/vpxcodec.rs
@@ -231,7 +231,7 @@ impl EncoderApi for VpxEncoder {
 }
 
 impl VpxEncoder {
-    pub fn encode(&mut self, pts: i64, data: &[u8], stride_align: usize) -> Result<EncodeFrames> {
+    pub fn encode<'a>(&'a mut self, pts: i64, data: &[u8], stride_align: usize) -> Result<EncodeFrames<'a>> {
         let bpp = if self.i444 { 24 } else { 12 };
         if data.len() < self.width * self.height * bpp / 8 {
             return Err(Error::FailedCall("len not enough".to_string()));
@@ -268,7 +268,7 @@ impl VpxEncoder {
     }
 
     /// Notify the encoder to return any pending packets
-    pub fn flush(&mut self) -> Result<EncodeFrames> {
+    pub fn flush<'a>(&'a mut self) -> Result<EncodeFrames<'a>> {
         call_vpx!(vpx_codec_encode(
             &mut self.ctx,
             ptr::null(),
@@ -473,7 +473,7 @@ impl VpxDecoder {
     /// The `data` slice is sent to the decoder
     ///
     /// It matches a call to `vpx_codec_decode`.
-    pub fn decode(&mut self, data: &[u8]) -> Result<DecodeFrames> {
+    pub fn decode<'a>(&'a mut self, data: &[u8]) -> Result<DecodeFrames<'a>> {
         call_vpx!(vpx_codec_decode(
             &mut self.ctx,
             data.as_ptr(),
@@ -489,7 +489,7 @@ impl VpxDecoder {
     }
 
     /// Notify the decoder to return any pending frame
-    pub fn flush(&mut self) -> Result<DecodeFrames> {
+    pub fn flush<'a>(&'a mut self) -> Result<DecodeFrames<'a>> {
         call_vpx!(vpx_codec_decode(
             &mut self.ctx,
             ptr::null(),

--- a/libs/scrap/src/common/vram.rs
+++ b/libs/scrap/src/common/vram.rs
@@ -367,7 +367,7 @@ impl VRamDecoder {
             }
         }
     }
-    pub fn decode(&mut self, data: &[u8]) -> ResultType<Vec<VRamDecoderImage>> {
+    pub fn decode<'a>(&'a mut self, data: &[u8]) -> ResultType<Vec<VRamDecoderImage<'a>>> {
         match self.decoder.decode(data) {
             Ok(v) => Ok(v.iter().map(|f| VRamDecoderImage { frame: f }).collect()),
             Err(e) => Err(anyhow!(e)),

--- a/libs/scrap/src/dxgi/mag.rs
+++ b/libs/scrap/src/dxgi/mag.rs
@@ -1,4 +1,6 @@
 // logic from webrtc -- https://github.com/shiguredo/libwebrtc/blob/main/modules/desktop_capture/win/screen_capturer_win_magnifier.cc
+#![allow(non_snake_case)]
+
 use lazy_static;
 use std::{
     ffi::CString,


### PR DESCRIPTION
If I'm understanding correctly, RustDesk embeds its own copy of the source code of the Scrap crate that has been considerably extended to provide additional necessary functionality. During builds, a number of warnings are emitted from this part of the code:

- It uses configurations other than the standard ones, and RustC by default emits warnings about references to configurations `dxgi`, `quartz` and `x11`.
- A number of methods elide lifetime in the `self` parameter and return an unannotated value that borrows references, hiding the lifetime.
- Generated bindings include unused imports.
- The `dxgi` code has some interop code that uses the Windows naming convention for identifiers and thus intentionally has `non_snake_case` identifiers.

This PR eliminates these build warnings.

I'm very new to Rust, so please check my changes to ensure that I haven't done things incorrectly or introduced unintended side-effects.

Before:

```
C:\code\rustdesk\libs\scrap>cargo build -p scrap 2>&1 | find "warning"
warning: unexpected `cfg` condition name: `quartz`
warning: unexpected `cfg` condition name: `dxgi`
warning: unexpected `cfg` condition name: `quartz`
warning: unexpected `cfg` condition name: `x11`
warning: unexpected `cfg` condition name: `x11`
warning: unexpected `cfg` condition name: `dxgi`
warning: unexpected `cfg` condition name: `x11`
warning: unexpected `cfg` condition name: `x11`
warning: unexpected `cfg` condition name: `x11`
warning: unexpected `cfg` condition name: `quartz`
warning: unexpected `cfg` condition name: `x11`
warning: unexpected `cfg` condition name: `dxgi`
warning: unused import: `self::vp9e_temporal_layering_mode as VP9E_TEMPORAL_LAYERING_MODE`
warning: variable `dwFilterMode` should have a snake case name
warning: variable `pHWND` should have a snake case name
warning: hiding a lifetime that's elided elsewhere is confusing
warning: hiding a lifetime that's elided elsewhere is confusing
warning: hiding a lifetime that's elided elsewhere is confusing
warning: hiding a lifetime that's elided elsewhere is confusing
warning: hiding a lifetime that's elided elsewhere is confusing
warning: hiding a lifetime that's elided elsewhere is confusing
warning: hiding a lifetime that's elided elsewhere is confusing
warning: `scrap` (lib) generated 22 warnings (run `cargo fix --lib -p scrap` to apply 1 suggestion)

C:\code\rustdesk\libs\scrap>
```

After:

```
C:\code\rustdesk\libs\scrap>cargo clean -p scrap
     Removed 202 files, 293.3MiB total

C:\code\rustdesk\libs\scrap>cargo build -p scrap
   Compiling scrap v0.5.0 (C:\code\rustdesk\libs\scrap)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.38s

C:\code\rustdesk\libs\scrap>
```