### PR TITLE
Eliminate build warnings from the remote_printer crate

### DIFF
--- a/libs/remote_printer/src/setup/mod.rs
+++ b/libs/remote_printer/src/setup/mod.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use hbb_common::{bail, ResultType};
 use std::{io, ptr::null_mut};
 use winapi::{


### PR DESCRIPTION
During a build, the remote_printer crate emits warnings about non_snake_case identifiers:

```
C:\code\rustdesk>cargo build 2>&1 | find "warning"
warning: variable `Level` should have a snake case name
warning: variable `pDriverInfo` should have a snake case name
warning: variable `cbBuf` should have a snake case name
warning: variable `pcbNeeded` should have a snake case name
warning: variable `pcReturned` should have a snake case name
warning: `remote_printer` (lib) generated 5 warnings
^C
C:\code\rustdesk>
```

This PR adds an attribute allowing these explicitly.