### PR TITLE
Eliminate build warnings from the main project

### DIFF
--- a/src/auth_2fa.rs
+++ b/src/auth_2fa.rs
@@ -119,6 +119,8 @@ pub struct TelegramBot {
     pub chat_id: String,
 }
 
+// RustC doesn't recognize call sites for some methods
+#[allow(dead_code)]
 impl TelegramBot {
     fn into_string(&self) -> ResultType<String> {
         let token = encrypt_vec_or_original(self.token_str.as_bytes(), "00", 1024);
@@ -162,6 +164,8 @@ pub async fn send_2fa_code_to_telegram(text: &str, bot: TelegramBot) -> ResultTy
     Ok(())
 }
 
+// RustC doesn't recognize some call sites
+#[allow(dead_code)]
 pub fn get_chatid_telegram(bot_token: &str) -> ResultType<Option<String>> {
     let url = format!("https://api.telegram.org/bot{}/getUpdates", bot_token);
     // because caller is in tokio runtime, so we must call post_request_sync in new thread.

--- a/src/client.rs
+++ b/src/client.rs
@@ -3924,6 +3924,8 @@ async fn hc_connection_(
     Ok(())
 }
 
+// RustC doesn't recognize call sites for some methods
+#[allow(dead_code)]
 pub mod peer_online {
     use hbb_common::{
         anyhow::bail,

--- a/src/client/file_trait.rs
+++ b/src/client/file_trait.rs
@@ -2,6 +2,8 @@ use hbb_common::{fs, log, message_proto::*};
 
 use super::{Data, Interface};
 
+// RustC doesn't recognize call sites in flutter_ffi.rs
+#[allow(dead_code)]
 pub trait FileManager: Interface {
     #[cfg(not(any(
         target_os = "android",

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -21,14 +21,15 @@ use hbb_common::{
     rendezvous_proto::ConnType,
     ResultType,
 };
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use std::path::PathBuf;
 use std::{
     collections::HashMap,
-    path::PathBuf,
     sync::{
         atomic::{AtomicI32, Ordering},
         Arc,
     },
-    time::{Duration, SystemTime},
+    time::SystemTime,
 };
 
 pub type SessionID = uuid::Uuid;

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -22,7 +22,10 @@ use hbb_common::{
     ResultType,
 };
 #[cfg(any(target_os = "windows", target_os = "macos"))]
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    time::Duration,
+};
 use std::{
     collections::HashMap,
     sync::{

--- a/src/hbbs_http.rs
+++ b/src/hbbs_http.rs
@@ -13,6 +13,8 @@ pub use http_client::{
     get_url_for_tls,
 };
 
+// RustC doesn't recognize sites where this is used
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum HbbHttpResponse<T> {
     ErrorFormat,

--- a/src/hbbs_http/downloader.rs
+++ b/src/hbbs_http/downloader.rs
@@ -1,3 +1,6 @@
+// RustC doesn't recognize call sites for some functions
+#![allow(dead_code)]
+
 use super::create_http_client_async_with_url;
 use hbb_common::{
     bail,

--- a/src/hbbs_http/sync.rs
+++ b/src/hbbs_http/sync.rs
@@ -184,10 +184,7 @@ async fn start_hbbs_sync_async() {
                         hasher.update(url.as_bytes());
                         hasher.update(&v.as_bytes());
                         let res = hasher.finalize();
-                        {
-                            #![allow(deprecated)]
-                            hash = hbb_common::base64::encode(&res[..]);
-                        }
+                        hash = crate::encode64(&res[..]);
                         let old_hash = config::Status::get("sysinfo_hash");
                         let ver = config::Status::get("sysinfo_ver"); // sysinfo_ver is the version of sysinfo on server's side
                         if hash == old_hash {

--- a/src/hbbs_http/sync.rs
+++ b/src/hbbs_http/sync.rs
@@ -184,7 +184,10 @@ async fn start_hbbs_sync_async() {
                         hasher.update(url.as_bytes());
                         hasher.update(&v.as_bytes());
                         let res = hasher.finalize();
-                        hash = hbb_common::base64::encode(&res[..]);
+                        {
+                            #![allow(deprecated)]
+                            hash = hbb_common::base64::encode(&res[..]);
+                        }
                         let old_hash = config::Status::get("sysinfo_hash");
                         let ver = config::Status::get("sysinfo_ver"); // sysinfo_ver is the version of sysinfo on server's side
                         if hash == old_hash {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -746,15 +746,6 @@ pub fn is_root() -> bool {
     crate::username() == "root"
 }
 
-fn is_opensuse() -> bool {
-    if let Ok(res) = run_cmds("cat /etc/os-release | grep opensuse") {
-        if !res.is_empty() {
-            return true;
-        }
-    }
-    false
-}
-
 pub fn run_as_user<I, K, V>(
     arg: Vec<&str>,
     user: Option<(String, String)>,
@@ -902,6 +893,15 @@ pub fn check_super_user_permission() -> ResultType<bool> {
 }
 
 /*
+fn is_opensuse() -> bool {
+    if let Ok(res) = run_cmds("cat /etc/os-release | grep opensuse") {
+        if !res.is_empty() {
+            return true;
+        }
+    }
+    false
+}
+
 pub fn elevate(args: Vec<&str>) -> ResultType<bool> {
     let cmd = std::env::current_exe()?;
     match cmd.to_str() {
@@ -1188,7 +1188,7 @@ mod desktop {
             }
             self.display = self
                 .display
-                .replace(&hbb_common::whoami::hostname(), "")
+                .replace(&hbb_common::whoami::fallible::hostname().unwrap_or_else(|_| "".to_string()), "")
                 .replace("localhost", "");
         }
 
@@ -1422,7 +1422,10 @@ mod desktop {
     }
 }
 
-pub struct WakeLock(Option<keepawake::AwakeHandle>);
+pub struct WakeLock(
+    #[allow(unused)]
+    Option<keepawake::AwakeHandle>
+);
 
 impl WakeLock {
     pub fn new(display: bool, idle: bool, sleep: bool) -> Self {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1188,7 +1188,7 @@ mod desktop {
             }
             self.display = self
                 .display
-                .replace(&hbb_common::whoami::fallible::hostname().unwrap_or_else(|_| "".to_string()), "")
+                .replace(&hbb_common::whoami::fallible::hostname().unwrap_or_default(), "")
                 .replace("localhost", "");
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -703,7 +703,6 @@ async fn sync_and_watch_config_dir() {
                                 log::error!("sync config to root failed: {}", e);
                                 match crate::ipc::connect(1000, "_service").await {
                                     Ok(mut _conn) => {
-                                        conn = _conn;
                                         log::info!("reconnected to ipc_service");
                                     }
                                     _ => {}

--- a/src/server.rs
+++ b/src/server.rs
@@ -703,6 +703,7 @@ async fn sync_and_watch_config_dir() {
                                 log::error!("sync config to root failed: {}", e);
                                 match crate::ipc::connect(1000, "_service").await {
                                     Ok(mut _conn) => {
+                                        conn = _conn;
                                         log::info!("reconnected to ipc_service");
                                     }
                                     _ => {}

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -85,8 +85,8 @@ mod pa_impl {
             return data;
         }
 
-        let mut buf = vec![];
-        buf = unsafe { hbb_common::mem::aligned_u8_vec(data.len(), 4) };
+        let mut buf =
+            unsafe { hbb_common::mem::aligned_u8_vec(data.len(), 4) };
         buf.extend_from_slice(data.as_ref());
         buf
     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3,10 +3,8 @@ use super::{input_service::*, *};
 use crate::clipboard::try_empty_clipboard_files;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::clipboard::{update_clipboard, ClipboardSide};
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", feature = "unix-file-copy-paste"))]
 use crate::clipboard_file::*;
-#[cfg(feature = "unix-file-copy-paste")]
-use crate::unix_file_clip;
 #[cfg(target_os = "android")]
 use crate::keyboard::client::map_key_to_control_key;
 #[cfg(target_os = "linux")]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -5,6 +5,8 @@ use crate::clipboard::try_empty_clipboard_files;
 use crate::clipboard::{update_clipboard, ClipboardSide};
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 use crate::clipboard_file::*;
+#[cfg(feature = "unix-file-copy-paste")]
+use crate::unix_file_clip;
 #[cfg(target_os = "android")]
 use crate::keyboard::client::map_key_to_control_key;
 #[cfg(target_os = "linux")]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3,7 +3,7 @@ use super::{input_service::*, *};
 use crate::clipboard::try_empty_clipboard_files;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::clipboard::{update_clipboard, ClipboardSide};
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use crate::clipboard_file::*;
 #[cfg(target_os = "android")]
 use crate::keyboard::client::map_key_to_control_key;
@@ -243,7 +243,7 @@ pub struct Connection {
     // by peer
     disable_audio: bool,
     // by peer
-    #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+    #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]
     enable_file_transfer: bool,
     // by peer
     audio_sender: Option<MediaSender>,
@@ -414,7 +414,7 @@ impl Connection {
             multi_ui_session: false,
             ip: "".to_owned(),
             disable_audio: false,
-            #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+            #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]
             enable_file_transfer: false,
             disable_clipboard: false,
             disable_keyboard: false,

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3,7 +3,7 @@ use super::{input_service::*, *};
 use crate::clipboard::try_empty_clipboard_files;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use crate::clipboard::{update_clipboard, ClipboardSide};
-#[cfg(any(target_os = "windows", target_os = "macos", feature = "unix-file-copy-paste"))]
+#[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]
 use crate::clipboard_file::*;
 #[cfg(target_os = "android")]
 use crate::keyboard::client::map_key_to_control_key;

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -22,8 +22,12 @@ struct ChangedResolution {
     changed: (i32, i32),
 }
 
+#[cfg(windows)]
 lazy_static::lazy_static! {
     static ref IS_CAPTURER_MAGNIFIER_SUPPORTED: bool = is_capturer_mag_supported();
+}
+
+lazy_static::lazy_static! {
     static ref CHANGED_RESOLUTIONS: Arc<RwLock<HashMap<String, ChangedResolution>>> = Default::default();
     // Initial primary display index.
     // It should not be updated when displays changed.
@@ -152,11 +156,9 @@ pub fn restore_resolutions() {
 }
 
 #[inline]
+#[cfg(windows)]
 fn is_capturer_mag_supported() -> bool {
-    #[cfg(windows)]
     return scrap::CapturerMag::is_supported();
-    #[cfg(not(windows))]
-    false
 }
 
 #[inline]

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -9,6 +9,7 @@ use hbb_common::get_version_number;
 use hbb_common::protobuf::MessageField;
 use scrap::Display;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::LazyLock;
 
 // https://github.com/rustdesk/rustdesk/discussions/6042, avoiding dbus call
 
@@ -23,9 +24,9 @@ struct ChangedResolution {
 }
 
 #[cfg(windows)]
-lazy_static::lazy_static! {
-    static ref IS_CAPTURER_MAGNIFIER_SUPPORTED: bool = is_capturer_mag_supported();
-}
+static IS_CAPTURER_MAGNIFIER_SUPPORTED: LazyLock<bool> = LazyLock::new(|| {
+    scrap::CapturerMag::is_supported()
+});
 
 lazy_static::lazy_static! {
     static ref CHANGED_RESOLUTIONS: Arc<RwLock<HashMap<String, ChangedResolution>>> = Default::default();
@@ -153,12 +154,6 @@ pub fn restore_resolutions() {
     }
     // Can be cleared because restore resolutions is called when there is no client connected.
     CHANGED_RESOLUTIONS.write().unwrap().clear();
-}
-
-#[inline]
-#[cfg(windows)]
-fn is_capturer_mag_supported() -> bool {
-    return scrap::CapturerMag::is_supported();
 }
 
 #[inline]

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 #[cfg(target_os = "linux")]
 use super::rdp_input::client::{RdpInputKeyboard, RdpInputMouse};
 use super::*;

--- a/src/server/rdp_input.rs
+++ b/src/server/rdp_input.rs
@@ -69,7 +69,6 @@ pub mod client {
         conn: Arc<SyncConnection>,
         session: Path<'static>,
         stream: PwStreamInfo,
-        resolution: (usize, usize),
         scale: Option<f64>,
         position: (f64, f64),
     }
@@ -104,7 +103,6 @@ pub mod client {
                 conn,
                 session,
                 stream,
-                resolution,
                 scale,
                 position: (pos.0 as f64, pos.1 as f64),
             })

--- a/src/server/uinput.rs
+++ b/src/server/uinput.rs
@@ -868,6 +868,7 @@ mod mouce {
     }
 
     #[derive(Debug, Copy, Clone)]
+    #[allow(unused)]
     pub enum MouseButton {
         Left,
         Middle,
@@ -880,6 +881,7 @@ mod mouce {
     }
 
     #[derive(Debug, Copy, Clone)]
+    #[allow(unused)]
     pub enum ScrollDirection {
         Up,
         Down,

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -1,5 +1,5 @@
 use super::*;
-use hbb_common::{allow_err, anyhow, platform::linux::DISTRO};
+use hbb_common::{allow_err, platform::linux::DISTRO};
 use scrap::{
     is_cursor_embedded, set_map_err,
     wayland::pipewire::{fill_displays, try_fix_logical_size},

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,5 +1,3 @@
-use librustdesk::*;
-
 #[cfg(not(target_os = "macos"))]
 fn main() {}
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -3,6 +3,7 @@ fn main() {}
 
 #[cfg(target_os = "macos")]
 fn main() {
+    use librustdesk::*;
     crate::common::load_custom_client();
     hbb_common::init_log(false, "service");
     crate::start_os_service();

--- a/src/service.rs
+++ b/src/service.rs
@@ -3,8 +3,8 @@ fn main() {}
 
 #[cfg(target_os = "macos")]
 fn main() {
-    use librustdesk::*;
-    crate::common::load_custom_client();
+    use librustdesk;
+    librustdesk::common::load_custom_client();
     hbb_common::init_log(false, "service");
-    crate::start_os_service();
+    librustdesk::start_os_service();
 }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -57,7 +57,7 @@ fn make_tray() -> hbb_common::ResultType<()> {
     let icon = tray_icon::Icon::from_rgba(icon_rgba, icon_width, icon_height)
         .context("Failed to open icon")?;
 
-    let mut event_loop = EventLoopBuilder::new().build();
+    let event_loop = EventLoopBuilder::new().build();
 
     let tray_menu = Menu::new();
     let quit_i = MenuItem::new(translate("Stop service".to_owned()), true, None);

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -57,6 +57,9 @@ fn make_tray() -> hbb_common::ResultType<()> {
     let icon = tray_icon::Icon::from_rgba(icon_rgba, icon_width, icon_height)
         .context("Failed to open icon")?;
 
+    #[cfg(target_os = "macos")]
+    let mut event_loop = EventLoopBuilder::new().build();
+    #[cfg(not(target_os = "macos"))]
     let event_loop = EventLoopBuilder::new().build();
 
     let tray_menu = Menu::new();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -602,6 +602,8 @@ impl UI {
         change_id_shared(id, old_id);
     }
 
+    // RustC doesn't recognize some call sites
+    #[allow(dead_code)]
     fn http_request(&self, url: String, method: String, body: Option<String>, header: String) {
         http_request(url, method, body, header)
     }
@@ -618,6 +620,8 @@ impl UI {
         get_async_job_status()
     }
 
+    // RustC doesn't recognize some call sites
+    #[allow(dead_code)]
     fn get_http_status(&self, url: String) -> Option<String> {
         get_async_http_status(url)
     }

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -1,3 +1,6 @@
+// RustC doesn't recognize some call sites for some functions
+#![allow(dead_code)]
+
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use hbb_common::password_security;
 use hbb_common::{

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use crate::{
     common::{get_supported_keyboard_modes, is_keyboard_mode_supported},
     input::{MOUSE_BUTTON_LEFT, MOUSE_TYPE_DOWN, MOUSE_TYPE_UP, MOUSE_TYPE_WHEEL},

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -20,10 +20,14 @@ lazy_static::lazy_static! {
     static ref TX_MSG : Mutex<Sender<UpdateMsg>> = Mutex::new(start_auto_update_check());
 }
 
+// RustC doesn't recognize sites where this is referenced
+#[allow(dead_code)]
 static CONTROLLING_SESSION_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 const DUR_ONE_DAY: Duration = Duration::from_secs(60 * 60 * 24);
 
+// RustC doesn't recognize some call sites
+#[allow(dead_code)]
 pub fn update_controlling_session_count(count: usize) {
     CONTROLLING_SESSION_COUNT.store(count, Ordering::SeqCst);
 }


### PR DESCRIPTION
This PR makes minor adjustments so that `rustdesk` builds without warnings.

Before:

```
C:\code\rustdesk>cargo build 2>&1 | find "warning"
warning: unused imports: `MOUSE_BUTTON_LEFT`, `MOUSE_TYPE_DOWN`, `MOUSE_TYPE_UP`, and `MOUSE_TYPE_WHEEL`
warning: use of deprecated function `hbb_common::base64::encode`: Use Engine::encode
warning: variable does not need to be mutable
warning: fields `x` and `y` are never read
warning: constant `MOUSE_MOVE_PROTECTION_TIMEOUT` is never used
warning: constant `MOUSE_ACTIVE_DISTANCE` is never used
warning: function `get_last_input_cursor_pos` is never used
warning: methods `read_empty_dirs`, `set_confirm_override_file`, and `rename_file` are never used
warning: function `query_online_states` is never used
warning: function `create_online_stream` is never used
warning: function `query_online_states_` is never used
warning: methods `http_request` and `get_http_status` are never used
warning: methods `into_string` and `save` are never used
warning: function `get_chatid_telegram` is never used
warning: static `CONTROLLING_SESSION_COUNT` is never used
warning: function `update_controlling_session_count` is never used
warning: function `http_request` is never used
warning: function `get_async_http_status` is never used
warning: function `has_valid_bot` is never used
warning: function `verify_bot` is never used
warning: enum `HbbHttpResponse` is never used
warning: struct `DownloadData` is never constructed
warning: struct `Downloader` is never constructed
warning: function `download_file` is never used
warning: function `do_download` is never used
warning: function `get_download_data` is never used
warning: function `cancel` is never used
warning: function `remove` is never used
warning: `rustdesk` (lib) generated 28 warnings (run `cargo fix --lib -p rustdesk` to apply 2 suggestions)
warning: unused import: `librustdesk::*`
warning: `rustdesk` (bin "service") generated 1 warning (run `cargo fix --bin "service"` to apply 1 suggestion)

C:\code\rustdesk>
```

After:

```
C:\code\rustdesk>cargo clean -p rustdesk
     Removed 401 files, 6.6GiB total

C:\code\rustdesk>cargo build
   Compiling rustdesk v1.4.3 (C:\code\rustdesk)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 40.47s

C:\code\rustdesk>
```

In this PR, each type of warning is addressed in a separate commit.