### PR TITLE
update hwcodec, support H265 encoding on Intel chip Macs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,7 +2011,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.4",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -3320,6 +3320,7 @@ name = "hbb_common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-recursion",
  "backtrace",
  "base64 0.22.1",
  "bytes",
@@ -3508,7 +3509,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "hwcodec"
 version = "0.7.1"
-source = "git+https://github.com/rustdesk-org/hwcodec#17c1dbb38450fe4a64aeba78fb50bec32f364a16"
+source = "git+https://github.com/rustdesk-org/hwcodec#398e5a8938dd8768ade0fcdc27ea80e8b4b38738"
 dependencies = [
  "bindgen 0.59.2",
  "cc",


### PR DESCRIPTION
https://github.com/rustdesk-org/hwcodec/pull/39