### PR TITLE
refact: show proxy settings on ios

### DIFF
--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -685,7 +685,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
                     setState(callback);
                   });
                 }),
-          if (!isIOS && !_hideNetwork && !_hideProxy)
+          if (!_hideNetwork && !_hideProxy)
             SettingsTile(
                 title: Text(translate('Socks5/Http(s) Proxy')),
                 leading: Icon(Icons.network_ping),

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -452,10 +452,8 @@ pub fn install_options() -> String {
 pub fn get_socks() -> Vec<String> {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     let s = ipc::get_socks();
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "android", target_os = "ios"))]
     let s = Config::get_socks();
-    #[cfg(target_os = "ios")]
-    let s: Option<config::Socks5Server> = None;
     match s {
         None => Vec::new(),
         Some(s) => {
@@ -477,7 +475,7 @@ pub fn set_socks(proxy: String, username: String, password: String) {
     };
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     ipc::set_socks(socks).ok();
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "android", target_os = "ios"))]
     {
         let _nat = crate::CheckTestNatType::new();
         if socks.proxy.is_empty() {
@@ -485,8 +483,11 @@ pub fn set_socks(proxy: String, username: String, password: String) {
         } else {
             Config::set_socks(Some(socks));
         }
-        crate::RendezvousMediator::restart();
         log::info!("socks updated");
+    }
+    #[cfg(target_os = "android")]
+    {
+        crate::RendezvousMediator::restart();
     }
 }
 


### PR DESCRIPTION
Proxy can be used:
1. Establish a connection.
2. Query peers online status.