### PR TITLE
DBUS_SESSION_BUS_ADDRESS propagation (for Wayland, see https://github.com/rustdesk/rustdesk/discussions/13350)

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -349,6 +349,9 @@ fn try_start_server_(desktop: Option<&Desktop>) -> ResultType<Option<Child>> {
             if !desktop.home.is_empty() {
                 envs.push(("HOME", desktop.home.clone()));
             }
+            if !desktop.dbus.is_empty() {
+                envs.push(("DBUS_SESSION_BUS_ADDRESS", desktop.dbus.clone()));
+            }
             envs.push((
                 "TERM",
                 get_cur_term(&desktop.uid).unwrap_or_else(|| suggest_best_term()),
@@ -1111,6 +1114,7 @@ mod desktop {
         pub display: String,
         pub xauth: String,
         pub home: String,
+        pub dbus: String,
         pub is_rustdesk_subprocess: bool,
         pub wl_display: String,
     }
@@ -1145,6 +1149,7 @@ mod desktop {
                     self.display = get_env("DISPLAY", &self.uid, proc);
                     self.xauth = get_env("XAUTHORITY", &self.uid, proc);
                     self.wl_display = get_env("WAYLAND_DISPLAY", &self.uid, proc);
+                    self.dbus = get_env("DBUS_SESSION_BUS_ADDRESS", &self.uid, proc);
                     if !self.display.is_empty() && !self.xauth.is_empty() {
                         return;
                     }


### PR DESCRIPTION
This adds DBUS_SESSION_BUS_ADDRESS to the collection of "pilfered environment" variables on Linux. These are variables rustdesk grabs from running processes and inserts into the environments of spawned session processes like DISPLAY, WAYLAND_DISPLAY and a few others.

The net effect should be that a session's sub-processes launched by rustdesk --service (--server and --tray) get the right bus.

Presumably, this happens with systemd environment management, but on Void Linux & other non-systemd, this prevents a connection to a client from any controller with a message about a service not being available. (As the DBUS lookup fails).

On X11, this is not an issue as retrieval of Wayland capabilities via DBUS registry is not required.

In general, this is a more robust Wayland solution than just grabbing WAYLAND_DISPLAY, since Wayland is heavily dependent on DBUS for protocol registration.

A more generalized solution would be to allow the list to expand based on configuration, but this the list is probably not going to change often, so that general solution is not worth the effort.