### PR TITLE
refact: rust backtrace logs

### DIFF
--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -29,6 +29,9 @@ macro_rules! my_println{
 /// If it returns [`Some`], then the process will continue, and flutter gui will be started.
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub fn core_main() -> Option<Vec<String>> {
+    if !crate::common::global_init() {
+        return None;
+    }
     crate::load_custom_client();
     #[cfg(windows)]
     if !crate::platform::windows::bootstrap() {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -70,6 +70,10 @@ fn initialize(app_dir: &str, custom_client_config: &str) {
         init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "debug"));
         crate::common::test_nat_type();
     }
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    {
+        let _ = crate::common::global_init();
+    }
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     {
         // core_main's init_log does not work for flutter since it is only applied to its load_library in main.c

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,6 @@ fn main() {
     feature = "flutter"
 )))]
 fn main() {
-    if !common::global_init() {
-        return;
-    }
     #[cfg(all(windows, not(feature = "inline")))]
     unsafe {
         winapi::um::shellscalingapi::SetProcessDpiAwareness(2);


### PR DESCRIPTION
Fix build.

## TODOs

`breakdown_signal_handler()` may not work well on `Windows`, `Linux` and `macOS`.

We may need a better solution.

### Tests

1. Add `panic!(" crash test --- IGNORE ---");` in `fn start()` -> `connection.rs`.
2. Set `RUST_BACKTRACE=1`.
3. Connect to the peer with `panic!()`.


<details open><summary>Logs on Windows</summary>

```
[2025-11-10 13:07:49.429373 +08:00] INFO [src\server.rs:600] server not started: The system cannot find the file specified. (os error 2)

Stack backtrace:
   0: hwcodec_log
   1: hwcodec_log
   2: hwcodec_log
   3: <unknown>
   4: privacy_mode_hook_mouse
   5: privacy_mode_hook_mouse
   6: <unknown>
   7: <unknown>
   8: hwcodec_log
   9: BaseThreadInitThunk
  10: RtlUserThreadStart, no_server: false

...

Stack backtrace:
   0: hwcodec_log
   1: hwcodec_log
   2: hwcodec_log
   3: <unknown>
   4: <unknown>
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: hwcodec_log
   9: hwcodec_log
  10: hwcodec_log
  11: hwcodec_log
  12: hwcodec_log
  13: hwcodec_log
  14: BaseThreadInitThunk
  15: RtlUserThreadStart, librustdesk::rendezvous_mediator:src\rendezvous_mediator.rs:610:13
```

</details>

<details open><summary>Logs on macOS</summary>

```
[2025-11-10 13:32:35.464806 +08:00] INFO [src/server.rs:600] server not started: No such file or directory (os error 2)

Stack backtrace:
   0: _cg_event_tap_callback_internal, no_server: false
```


</details>


No logs on Linux.
`journalctl -f` can get the output


<details open><summary>journalctl -f</summary>

```
Nov 10 01:24:12 xxx rustdesk[2064169]: thread 'tokio-runtime-worker' panicked at src/server/connection.rs:377:9:
Nov 10 01:24:12 xxx rustdesk[2064169]:  crash test --- IGNORE ---
Nov 10 01:24:12 xxx rustdesk[2064169]: stack backtrace:
Nov 10 01:24:12 xxx rustdesk[2064169]: note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
