### PR TITLE
Fix config sync reconnection retry loop

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -704,8 +704,7 @@ async fn sync_and_watch_config_dir() {
                                 match crate::ipc::connect(1000, "_service").await {
                                     Ok(mut _conn) => {
                                         conn = _conn;
-                                        log::info!("reconnected to ipc_service");
-                                        break;
+                                        log::info!("reconnected to ipc_service, looping to retry");
                                     }
                                     _ => {}
                                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -704,7 +704,7 @@ async fn sync_and_watch_config_dir() {
                                 match crate::ipc::connect(1000, "_service").await {
                                     Ok(mut _conn) => {
                                         conn = _conn;
-                                        log::info!("reconnected to ipc_service, looping to retry");
+                                        log::info!("reconnected to ipc_service");
                                     }
                                     _ => {}
                                 }


### PR DESCRIPTION
Remove erroneous `break` from the retry loop in `sync_and_watch_config_dir` in `server.rs`.