### PR TITLE
fix: flatpak, wayland, cursor image

### DIFF
--- a/flatpak/rustdesk.json
+++ b/flatpak/rustdesk.json
@@ -55,7 +55,7 @@
   ],
   "finish-args": [
     "--share=ipc",
-    "--socket=fallback-x11",
+    "--socket=x11",
     "--socket=wayland",
     "--share=network",
     "--filesystem=home",


### PR DESCRIPTION
Use `--socket=x11` instead of `--socket=fallback-x11` to capture the cursor images using XWayland.