### PR TITLE
refact: flatpak, socket, fallback x11

### DIFF
--- a/flatpak/rustdesk.json
+++ b/flatpak/rustdesk.json
@@ -55,8 +55,7 @@
   ],
   "finish-args": [
     "--share=ipc",
-    "--socket=x11",
-    "--socket=wayland",
+    "--socket=fallback-x11",
     "--share=network",
     "--filesystem=home",
     "--device=dri",


### PR DESCRIPTION
Using both `--socket=x11` and `--socket=wayland` causes the following error.

```
+ flatpak-builder-lint --gha-format --exceptions --debug manifest com.rustdesk.RustDesk.json
DEBUG: flatpak-builder-lint version: 3.0.0.post465.dev0+f6f57fa
DEBUG: GitHub namespace for remote https://github.com/flathub/com.rustdesk.RustDesk is flathub
DEBUG: Git repo tree size for /work: 23095 bytes
Error: 'finish-args-contains-both-x11-and-wayland' error found in linter manifest check. 
Notice: 💡 See https://docs.flathub.org/linter for details and exceptions
error: Recipe `validate-manifest` failed with exit code 1
Error: Process completed with exit code 1.
```

https://github.com/flathub-infra/vorarbeiter/actions/runs/19457048373/job/55672904088#step:10:33

