### PR TITLE
Fix mouse hover issue on menu bar when controlling Mac from iPad

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -810,6 +810,10 @@ class InputModel {
   }
 
   Future<void> tapDown(MouseButtons button) async {
+    if (!_pointerMovedAfterEnter) {
+      refreshMousePos();
+      await Future.delayed(Duration(milliseconds: 10));
+    }
     await sendMouse('down', button);
   }
 


### PR DESCRIPTION
Fixes #8789

The issue was that when using the virtual/floating mouse on mobile devices to control a Mac, mouse clicks would occur at the wrong position, particularly noticeable in the menu bar where hover menus would disappear immediately.

Root cause: The tapDown() method was sending mouse button events without ensuring the cursor position was updated on the server side first. This caused clicks to register at stale cursor positions.

Solution: Before sending a mouse down event, check if the pointer has moved since entering the session. If not, send a mouse move event first to update the cursor position, then wait briefly before sending the click event.

This ensures the remote cursor is at the correct position before any mouse button action is performed.