### PR TITLE
refact: flatpak, socket x11, better compatibility

### DIFF
--- a/flatpak/rustdesk.json
+++ b/flatpak/rustdesk.json
@@ -56,7 +56,6 @@
   "finish-args": [
     "--share=ipc",
     "--socket=x11",
-    "--socket=wayland",
     "--share=network",
     "--filesystem=home",
     "--device=dri",


### PR DESCRIPTION
The cursor image cannot be captured when using `--socket=wayland`.
With `--socket=x11` alone, it works correctly on various distributions and desktop environments, including:
- Ubuntu 24.04 GNOME
- Archlinux KDE Plasma
- Archlinux GNOME  
- Fedora 42 KDE Plasma
- Fedora 42 GNOME
- openSUSE KDE Plasma
- openSUSE GNOME

## Preview

### Socket with `fallback-x11` and `wayland`

https://github.com/user-attachments/assets/e82285fa-b5e4-4aa2-be89-9164a503f258


### Socket `x11`

https://github.com/user-attachments/assets/ec5e1f83-3530-477c-bd56-056bc184f1a7

