### PR TITLE
feat: macos, update dmg

### DIFF
--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -38,6 +38,8 @@ static PRIVILEGES_SCRIPTS_DIR: Dir =
     include_dir!("$CARGO_MANIFEST_DIR/src/platform/privileges_scripts");
 static mut LATEST_SEED: i32 = 0;
 
+// Using a fixed temporary directory for updates is preferable to
+// using one that includes the custom client name.
 const UPDATE_TEMP_DIR: &str = "/tmp/.rustdeskupdate";
 
 extern "C" {
@@ -714,6 +716,14 @@ pub fn quit_gui() {
     };
 }
 
+#[inline]
+pub fn try_remove_temp_update_dir(dir: Option<&str>) {
+    let target_path = Path::new(dir.unwrap_or(UPDATE_TEMP_DIR));
+    if target_path.exists() {
+        std::fs::remove_dir_all(target_path).ok();
+    }
+}
+
 pub fn update_me() -> ResultType<()> {
     let is_installed_daemon = is_installed_daemon(false);
     let option_stop_service = "stop-service";
@@ -733,6 +743,7 @@ pub fn update_me() -> ResultType<()> {
         bail!("Unknown app directory of current exe file: {:?}", cmd);
     };
 
+    let app_name = crate::get_app_name();
     if is_installed_daemon && !is_service_stopped {
         let agent = format!("{}_server.plist", crate::get_full_name());
         let agent_plist_file = format!("/Library/LaunchAgents/{}", agent);
@@ -749,12 +760,13 @@ pub fn update_me() -> ResultType<()> {
         let update_body = format!(
             r#"
 do shell script "
-pgrep -x 'RustDesk' | grep -v {} | xargs kill -9 && rm -rf /Applications/RustDesk.app && ditto '{}' /Applications/RustDesk.app && chown -R {}:staff /Applications/RustDesk.app && xattr -r -d com.apple.quarantine /Applications/RustDesk.app
-" with prompt "RustDesk wants to update itself" with administrator privileges
+pgrep -x '{app_name}' | grep -v {pid} | xargs kill -9 && rm -rf '/Applications/{app_name}.app' && ditto '{app_dir}' '/Applications/{app_name}.app' && chown -R {user}:staff '/Applications/{app_name}.app' && xattr -r -d com.apple.quarantine '/Applications/{app_name}.app'
+" with prompt "{app_name} wants to update itself" with administrator privileges
     "#,
-            std::process::id(),
-            app_dir,
-            get_active_username()
+            app_name = app_name,
+            pid = std::process::id(),
+            app_dir = app_dir,
+            user = get_active_username()
         );
         match Command::new("osascript")
             .arg("-e")
@@ -772,11 +784,20 @@ pgrep -x 'RustDesk' | grep -v {} | xargs kill -9 && rm -rf /Applications/RustDes
     }
     std::process::Command::new("open")
         .arg("-n")
-        .arg(&format!("/Applications/{}.app", crate::get_app_name()))
+        .arg(&format!("/Applications/{}.app", app_name))
         .spawn()
         .ok();
     // leave open a little time
     std::thread::sleep(std::time::Duration::from_millis(300));
+    Ok(())
+}
+
+pub fn update_from_dmg(dmg_path: &str) -> ResultType<()> {
+    println!("Starting update from DMG: {}", dmg_path);
+    extract_dmg(dmg_path, UPDATE_TEMP_DIR)?;
+    println!("DMG extracted");
+    update_extracted(UPDATE_TEMP_DIR)?;
+    println!("Update process started");
     Ok(())
 }
 
@@ -811,9 +832,13 @@ fn extract_dmg(dmg_path: &str, target_dir: &str) -> ResultType<()> {
     }
     std::fs::create_dir_all(target_path)?;
 
-    Command::new("hdiutil")
+    let status = Command::new("hdiutil")
         .args(&["attach", "-nobrowse", "-mountpoint", mount_point, dmg_path])
         .status()?;
+
+    if !status.success() {
+        bail!("Failed to attach DMG image at {}: {:?}", dmg_path, status);
+    }
 
     struct DmgGuard(&'static str);
     impl Drop for DmgGuard {
@@ -825,7 +850,7 @@ fn extract_dmg(dmg_path: &str, target_dir: &str) -> ResultType<()> {
     }
     let _guard = DmgGuard(mount_point);
 
-    let app_name = "RustDesk.app";
+    let app_name = format!("{}.app", crate::get_app_name());
     let src_path = format!("{}/{}", mount_point, app_name);
     let dest_path = format!("{}/{}", target_dir, app_name);
 
@@ -834,7 +859,12 @@ fn extract_dmg(dmg_path: &str, target_dir: &str) -> ResultType<()> {
         .status()?;
 
     if !copy_status.success() {
-        bail!("Failed to copy application {:?}", copy_status);
+        bail!(
+            "Failed to copy application from {} to {}: {:?}",
+            src_path,
+            dest_path,
+            copy_status
+        );
     }
 
     if !Path::new(&dest_path).exists() {
@@ -848,9 +878,13 @@ fn extract_dmg(dmg_path: &str, target_dir: &str) -> ResultType<()> {
 }
 
 fn update_extracted(target_dir: &str) -> ResultType<()> {
-    let exe_path = format!("{}/RustDesk.app/Contents/MacOS/RustDesk", target_dir);
+    let app_name = crate::get_app_name();
+    let exe_path = format!(
+        "{}/{}.app/Contents/MacOS/{}",
+        target_dir, app_name, app_name
+    );
     let _child = unsafe {
-        Command::new(&exe_path)
+        if let Err(e) = Command::new(&exe_path)
             .arg("--update")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
@@ -859,7 +893,11 @@ fn update_extracted(target_dir: &str) -> ResultType<()> {
                 hbb_common::libc::setsid();
                 Ok(())
             })
-            .spawn()?
+            .spawn()
+        {
+            try_remove_temp_update_dir(Some(target_dir));
+            bail!(e);
+        }
     };
     Ok(())
 }


### PR DESCRIPTION
This PR https://github.com/rustdesk/rustdesk/pull/13539 removes `/tmp/.rustdeskupdate` before the update process is finished.

https://github.com/rustdesk/rustdesk/compare/3787b45b49b405fd9e4d6e044eaa6de9474e5baa...fufesou:rustdesk:feat/macos_update_dmg?expand=1...fufesou:rustdesk:feat/macos_update_dmg?expand=1
