### PR TITLE
Fix F-Droid 1.4.6 build

### DIFF
--- a/flutter/build_fdroid.sh
+++ b/flutter/build_fdroid.sh
@@ -184,13 +184,9 @@ prebuild)
 	fi
 
 	# Map NDK version to revision
-
-	NDK_VERSION="$(wget \
-		-qO- \
-		-H "Accept: application/vnd.github+json" \
-		-H "X-GitHub-Api-Version: 2022-11-28" \
-		'https://api.github.com/repos/android/ndk/releases' |
-		jq -r ".[] | select(.tag_name == \"${NDK_VERSION}\") | .body | match(\"ndkVersion \\\"(.*)\\\"\").captures[0].string")"
+	NDK_VERSION="$(curl https://gitlab.com/fdroid/android-sdk-transparency-log/-/raw/master/signed/checksums.json \
+	  | jq -r ".\"https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux.zip\"[0].\"source.properties\"" \
+	  | sed -n -E 's/.*Pkg.Revision = ([0-9.]+).*/\1/p')"
 
 	if [ -z "${NDK_VERSION}" ]; then
 		echo "ERROR: Can not map Android NDK codename to revision!" >&2
@@ -414,13 +410,9 @@ build)
 		.github/workflows/flutter-build.yml)"
 
 	# Map NDK version to revision
-
-	NDK_VERSION="$(wget \
-		-qO- \
-		-H "Accept: application/vnd.github+json" \
-		-H "X-GitHub-Api-Version: 2022-11-28" \
-		'https://api.github.com/repos/android/ndk/releases' |
-		jq -r ".[] | select(.tag_name == \"${NDK_VERSION}\") | .body | match(\"ndkVersion \\\"(.*)\\\"\").captures[0].string")"
+	NDK_VERSION="$(curl https://gitlab.com/fdroid/android-sdk-transparency-log/-/raw/master/signed/checksums.json \
+	  | jq -r ".\"https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux.zip\"[0].\"source.properties\"" \
+	  | sed -n -E 's/.*Pkg.Revision = ([0-9.]+).*/\1/p')"
 
 	if [ -z "${NDK_VERSION}" ]; then
 		echo "ERROR: Can not map Android NDK codename to revision!" >&2

--- a/flutter/build_fdroid.sh
+++ b/flutter/build_fdroid.sh
@@ -312,6 +312,18 @@ prebuild)
 	# `FLUTTER_BRIDGE_VERSION` an restore the pubspec later
 
 	if [ "${FLUTTER_VERSION}" != "${FLUTTER_BRIDGE_VERSION}" ]; then
+		# Find first libclang.so and set BRIDGE_LLVM_PATH
+
+		BRIDGE_LLVM_PATH="$(find /usr/lib/ -name libclang.so | head -n1)"
+
+		if [ -z "${BRIDGE_LLVM_PATH}" ]; then
+			echo 'ERROR: Can not find libclang.so for bridge generator!' >&2
+			exit 1
+		fi
+
+		BRIDGE_LLVM_PATH="$(dirname "${BRIDGE_LLVM_PATH}")"
+		BRIDGE_LLVM_PATH="$(dirname "${BRIDGE_LLVM_PATH}")"
+
 		# Install Flutter bridge version
 
 		prepare_flutter "${FLUTTER_BRIDGE_VERSION}" "${HOME}/flutter"
@@ -340,7 +352,8 @@ prebuild)
 
 		flutter_rust_bridge_codegen \
 			--rust-input ./src/flutter_ffi.rs \
-			--dart-output ./flutter/lib/generated_bridge.dart
+			--dart-output ./flutter/lib/generated_bridge.dart \
+			--llvm-path "${BRIDGE_LLVM_PATH}"
 
 		# Add bridge files to save-list
 
@@ -351,6 +364,8 @@ prebuild)
 		git checkout '*'
 		git clean -dffx
 		git reset
+
+		unset BRIDGE_LLVM_PATH
 	fi
 
 	# Install Flutter version for RustDesk library build

--- a/flutter/build_fdroid.sh
+++ b/flutter/build_fdroid.sh
@@ -7,7 +7,7 @@
 #               2024, Vasyl Gello <vasek.gello@gmail.com>
 #
 
-# The script is invoked by F-Droid builder system ste-by-step.
+# The script is invoked by F-Droid builder system step-by-step.
 #
 # It accepts the following arguments:
 #
@@ -16,7 +16,6 @@
 # - Android architecture to build APK for: armeabi-v7a arm64-v8av x86 x86_64
 # - The build step to execute:
 #
-#   + sudo-deps: as root, install needed Debian packages into builder VM
 #   + prebuild: patch sources and do other stuff before the build
 #   + build: perform actual build of APK file
 #
@@ -184,9 +183,9 @@ prebuild)
 	fi
 
 	# Map NDK version to revision
-	NDK_VERSION="$(curl https://gitlab.com/fdroid/android-sdk-transparency-log/-/raw/master/signed/checksums.json \
-	  | jq -r ".\"https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux.zip\"[0].\"source.properties\"" \
-	  | sed -n -E 's/.*Pkg.Revision = ([0-9.]+).*/\1/p')"
+	NDK_VERSION="$(curl https://gitlab.com/fdroid/android-sdk-transparency-log/-/raw/master/signed/checksums.json |
+		jq -r ".\"https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux.zip\"[0].\"source.properties\"" |
+		sed -n -E 's/.*Pkg.Revision = ([0-9.]+).*/\1/p')"
 
 	if [ -z "${NDK_VERSION}" ]; then
 		echo "ERROR: Can not map Android NDK codename to revision!" >&2
@@ -372,7 +371,7 @@ prebuild)
 
 	prepare_flutter "${FLUTTER_VERSION}" "${HOME}/flutter"
 
-	# gms is not in thoes files now, but we still keep the following line for future reference(maybe).
+	# gms is not in these files now, but we still keep the following line for future reference(maybe).
 
 	sed \
 		-i \
@@ -425,9 +424,9 @@ build)
 		.github/workflows/flutter-build.yml)"
 
 	# Map NDK version to revision
-	NDK_VERSION="$(curl https://gitlab.com/fdroid/android-sdk-transparency-log/-/raw/master/signed/checksums.json \
-	  | jq -r ".\"https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux.zip\"[0].\"source.properties\"" \
-	  | sed -n -E 's/.*Pkg.Revision = ([0-9.]+).*/\1/p')"
+	NDK_VERSION="$(curl https://gitlab.com/fdroid/android-sdk-transparency-log/-/raw/master/signed/checksums.json |
+		jq -r ".\"https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux.zip\"[0].\"source.properties\"" |
+		sed -n -E 's/.*Pkg.Revision = ([0-9.]+).*/\1/p')"
 
 	if [ -z "${NDK_VERSION}" ]; then
 		echo "ERROR: Can not map Android NDK codename to revision!" >&2


### PR DESCRIPTION
I guess https://monitor.f-droid.org/builds/log/com.carriez.flutter_hbb/104040003#site-footer is caused by github api rate limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script with improved Android NDK dependency resolution, now sourcing configuration from F-Droid repositories instead of GitHub APIs.
  * Enhanced error handling to detect missing build dependencies and provide early failure notifications.
  * Fixed minor documentation inconsistencies in the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->