### PR TITLE
fix: file transfer, jobs lost if conn is not established

### DIFF
--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1054,7 +1054,9 @@ impl<T: InvokeUiSession> Remote<T> {
     }
 
     pub async fn sync_jobs_status_to_local(&mut self) -> bool {
-        log::info!("sync transfer job status");
+        if !self.is_connected {
+            return false;
+        }
         let mut config: PeerConfig = self.handler.load_config();
         let mut transfer_metas = TransferSerde::default();
         for job in self.read_jobs.iter() {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -2009,7 +2009,7 @@ pub async fn io_loop<T: InvokeUiSession>(handler: Session<T>, round: u32) {
     }
     let mut remote = Remote::new(handler, receiver, sender);
     remote.io_loop(&key, &token, round).await;
-    remote.sync_jobs_status_to_local().await;
+    let _ = remote.sync_jobs_status_to_local().await;
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/13302#discussioncomment-14790866

Jobs should be synced only after they have been loaded. `is_connected` is `true` if the last jobs are loaded.

Otherwise, syncing empty (default) jobs will cause the existing jobs to be lost.

