### PR TITLE
feat(terminal): add two-row floating keyboard buttons for common commands (mobile only)

### DIFF
--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -161,6 +161,7 @@ const String kOptionShowVirtualMouse = "show-virtual-mouse";
 const String kOptionVirtualMouseScale = "virtual-mouse-scale";
 const String kOptionShowVirtualJoystick = "show-virtual-joystick";
 const String kOptionAllowAskForNoteAtEndOfConnection = "allow-ask-for-note";
+const String kOptionAllowShowTerminalControlButton = "allow-show-terminal-control-button";
 
 // network options
 const String kOptionAllowWebSocket = "allow-websocket";

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -71,6 +71,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
   var _ignoreBatteryOpt = false;
   var _enableStartOnBoot = false;
   var _checkUpdateOnStartup = false;
+  var _showTerminalControlButton = false;
   var _floatingWindowDisabled = false;
   var _keepScreenOn = KeepScreenOn.duringControlled; // relay on floating window
   var _enableAbr = false;
@@ -139,6 +140,8 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
     _enableIpv6Punch = mainGetLocalBoolOptionSync(kOptionEnableIpv6Punch);
     _allowAskForNoteAtEndOfConnection =
         mainGetLocalBoolOptionSync(kOptionAllowAskForNoteAtEndOfConnection);
+    _showTerminalControlButton =
+        mainGetLocalBoolOptionSync(kOptionAllowShowTerminalControlButton);
   }
 
   @override
@@ -601,6 +604,23 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
         ),
       );
     }
+
+    enhancementsTiles.add(
+      SettingsTile.switchTile(
+        initialValue: _showTerminalControlButton,
+        title: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+          Text(translate('Show terminal control button')),
+        ]),
+        onToggle: (bool v) async {
+          await mainSetLocalBoolOption(kOptionAllowShowTerminalControlButton, v);
+          final newValue =
+            mainGetLocalBoolOptionSync(kOptionAllowShowTerminalControlButton);
+          setState(() {
+            _showTerminalControlButton = newValue;
+          });
+        },
+      ),
+    );
 
     onFloatingWindowChanged(bool toValue) async {
       if (toValue) {

--- a/flutter/lib/models/terminal_model.dart
+++ b/flutter/lib/models/terminal_model.dart
@@ -146,6 +146,10 @@ class TerminalModel with ChangeNotifier {
     }
   }
 
+  Future<void> sendVirtualKey(String data) async {
+    return _handleInput(data);
+  }
+
   Future<void> closeTerminal() async {
     if (_terminalOpened) {
       try {

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", "注意：RustDesk 开源服务器 (OSS server) 不包含此功能。"),
         ("input note here", "输入备注"),
         ("note-at-conn-end-tip", "在连接结束时请求备注"),
+        ("Show terminal control button", "显示终端控制按钮"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", "HINWEIS: RustDesk Server OSS enthält diese Funktion nicht."),
         ("input note here", "Hier eine Notiz eingeben"),
         ("note-at-conn-end-tip", "Am Ende der Verbindung um eine Notiz bitten."),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", "Note : Cette fonctionnalité n’est pas disponible sous la version open-source du serveur RustDesk."),
         ("input note here", "saisir la note ici"),
         ("note-at-conn-end-tip", "Proposer d’écrire une note une fois la connexion terminée"),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", "MEGJEGYZÉS: Az OSS RustDesk kiszolgáló nem támogatja ezt a funkciót."),
         ("input note here", "Megjegyzés bevitele"),
         ("note-at-conn-end-tip", "Megjegyzés a kapcsolat végén"),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", "NOTA: il sistema operativo del server RustDesk non include questa funzionalità."),
         ("input note here", "Inserisci nota qui"),
         ("note-at-conn-end-tip", "Visualizza nota alla fine della connessione"),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", "참고: RustDesk 서버 OSS에는 이 기능이 포함되어 있지 않습니다."),
         ("input note here", "여기에 노트 입력"),
         ("note-at-conn-end-tip", "연결이 끝날 때 메모 요청"),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", "Opmerking: Deze functie is niet beschikbaar in de open-sourceversie van de RustDesk-server."),
         ("input note here", "voeg hier een opmerking toe"),
         ("note-at-conn-end-tip", "Vraag om een opmerking aan het einde van de verbinding"),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", "ПРИМЕЧАНИЕ: в OSS-сервере RustDesk эта функция отсутствует."),
         ("input note here", "введите заметку"),
         ("note-at-conn-end-tip", "Запрашивать заметку в конце соединения"),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", "NOT: RustDesk sunucu OSS'si bu özelliği içermemektedir."),
         ("input note here", "Notu buraya girin"),
         ("note-at-conn-end-tip", "Bağlantı bittiğinde not sorulsun"),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", "注意：RustDesk 開源伺服器 (OSS server) 不包含此功能。"),
         ("input note here", "輸入備註"),
         ("note-at-conn-end-tip", "在連接結束時請求備註"),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -729,5 +729,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("server-oss-not-support-tip", ""),
         ("input note here", ""),
         ("note-at-conn-end-tip", ""),
+        ("Show terminal control button", ""),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
On mobile devices, using TerminalView with frequently used command keys (such as Esc, Ctrl+C, arrow keys, etc.) is inconvenient.  
This PR adds a floating keyboard to enable quick input of common commands.

<img width="1440" height="3200" alt="image" src="https://github.com/user-attachments/assets/bb403000-2299-46ff-a6db-2c93e0dd5fdf" />
<img width="1440" height="3200" alt="image" src="https://github.com/user-attachments/assets/1059cc72-2547-463a-a8e2-86fd921ad3a9" />
<img width="1440" height="3200" alt="image" src="https://github.com/user-attachments/assets/c1115e42-3d32-48c4-ac5f-fefddbaeba37" />
<img width="1440" height="3200" alt="image" src="https://github.com/user-attachments/assets/5906f56a-9fb7-4880-99f8-4c30deb3d555" />
