### PR TITLE
fix: msi, prevent black window

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1882,6 +1882,7 @@ oLink.Save
     .to_owned();
     std::process::Command::new("cscript")
         .arg(&shortcut)
+        .creation_flags(CREATE_NO_WINDOW)
         .output()?;
     allow_err!(std::fs::remove_file(shortcut));
     Ok(())


### PR DESCRIPTION
For msi version, the black window is shown when creating desktop shortcut for connection.

The exe version does not have this issue.

## Issue preview

https://github.com/user-attachments/assets/da6c508e-fa00-453c-baae-511ac351c736

## Tests

- [x] Administrator session. exe portable, exe installation, msi
- [x] Normal user session. exe portable, exe installation, msi

