### PR TITLE
fix is_public

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1051,7 +1051,7 @@ fn get_api_server_(api: String, custom: String) -> String {
 
 #[inline]
 pub fn is_public(url: &str) -> bool {
-    url.contains("rustdesk.com")
+    url.contains("rustdesk.com/") || url.ends_with("rustdesk.com")
 }
 
 pub fn get_udp_punch_enabled() -> bool {
@@ -2404,5 +2404,28 @@ mod tests {
             Duration::from_secs_f64(dur.as_secs_f64() * 0.499 * 1e-9),
             Duration::from_nanos(0)
         );
+    }
+
+    #[test]
+    fn test_is_public() {
+        // Test URLs containing "rustdesk.com/"
+        assert!(is_public("https://rustdesk.com/"));
+        assert!(is_public("https://www.rustdesk.com/"));
+        assert!(is_public("https://api.rustdesk.com/v1"));
+        assert!(is_public("https://rustdesk.com/path"));
+
+        // Test URLs ending with "rustdesk.com"
+        assert!(is_public("rustdesk.com"));
+        assert!(is_public("https://rustdesk.com"));
+        assert!(is_public("http://www.rustdesk.com"));
+        assert!(is_public("https://api.rustdesk.com"));
+
+        // Test non-public URLs
+        assert!(!is_public("https://example.com"));
+        assert!(!is_public("https://custom-server.com"));
+        assert!(!is_public("http://192.168.1.1"));
+        assert!(!is_public("localhost"));
+        assert!(!is_public("https://rustdesk.computer.com"));
+        assert!(!is_public("rustdesk.comhello.com"));
     }
 }

--- a/src/hbbs_http/sync.rs
+++ b/src/hbbs_http/sync.rs
@@ -278,7 +278,7 @@ fn heartbeat_url() -> String {
         Config::get_option("api-server"),
         Config::get_option("custom-rendezvous-server"),
     );
-    if url.is_empty() || url.contains("rustdesk.com") {
+    if url.is_empty() || crate::is_public(&url) {
         return "".to_owned();
     }
     format!("{}/api/heartbeat", url)


### PR DESCRIPTION
This issue was triggered by an API server from one of our Pro users.

<img width="721" height="113" alt="is_public" src="https://github.com/user-attachments/assets/044e02d7-efd0-4499-be2b-4802ccd6c44b" />


## Note

The logic need to be adjusted  in the future.

https://github.com/rustdesk/rustdesk/blob/23754630e8dfac8ee8f0f8ee17cda5c4f1897336/src/hbbs_http/sync.rs#L281

https://github.com/rustdesk/rustdesk/blob/23754630e8dfac8ee8f0f8ee17cda5c4f1897336/src/hbbs_http/sync.rs#L99

https://github.com/rustdesk/rustdesk/blob/23754630e8dfac8ee8f0f8ee17cda5c4f1897336/src/hbbs_http/sync.rs#L181

