### PR TITLE
fix: set TERM env variable for terminal to fix Delete key not working

### DIFF
--- a/src/server/terminal_service.rs
+++ b/src/server/terminal_service.rs
@@ -774,6 +774,11 @@ impl TerminalServiceProxy {
         #[allow(unused_mut)]
         let mut cmd = CommandBuilder::new(&shell);
 
+        // Set TERM environment variable to ensure proper handling of control sequences
+        // This fixes issues with Delete/Backspace keys not working correctly
+        // See: https://github.com/rustdesk/rustdesk/issues/13621
+        cmd.env("TERM", "xterm-256color");
+
         #[cfg(target_os = "windows")]
         if let Some(token) = &self.user_token {
             cmd.set_user_token(*token as _);


### PR DESCRIPTION
## Summary

- Set `TERM=xterm-256color` environment variable when spawning PTY shell
- This ensures proper handling of terminal control sequences

## Problem

Delete/Backspace keys were not working in terminal connections, particularly when connecting from iPad to Linux.

**Root cause**: The PTY was spawning shell without setting the `TERM` environment variable, causing the shell to not properly interpret certain control character sequences.

## Solution

Added `cmd.env("TERM", "xterm-256color")` in `terminal_service.rs` before spawning the shell process. This tells the shell it's running in an xterm-compatible terminal, enabling proper handling of:
- Delete key (`\x7f`)
- Backspace key
- Arrow keys and other special keys

## Test plan

- [ ] Connect from iPad to Linux via terminal
- [ ] Type text and press Delete/Backspace
- [ ] Verify characters are correctly deleted
- [ ] Run `echo $TERM` and verify output is `xterm-256color`

Fixes #13621