### PR TITLE
fix: debounce trackpad scroll to prevent stutter and reversal

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1050,6 +1050,7 @@ impl Connection {
         }
         #[cfg(target_os = "linux")]
         clear_remapped_keycode();
+        reset_scroll_state();
         log::debug!("Input thread exited");
     }
 

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -474,7 +474,7 @@ impl ScrollState {
                     && dir_y == -self.last_direction_y
                     && y.abs() == 1;
 
-                is_micro_reversal_x || is_micro_reversal_y
+                is_micro_reversal_x && is_micro_reversal_y
             } else {
                 false
             }
@@ -501,6 +501,11 @@ impl ScrollState {
         self.last_direction_y = 0;
         self.last_scroll_time = None;
     }
+}
+
+/// Reset scroll state on disconnect to prevent stale state affecting next session
+pub fn reset_scroll_state() {
+    SCROLL_STATE.lock().unwrap().reset();
 }
 
 lazy_static::lazy_static! {


### PR DESCRIPTION
## Summary

- Add scroll debouncing logic to filter micro-reversals from trackpad gesture streams
- Drop single-unit opposite-direction scroll events within 40ms window

## Problem

Trackpad scrolling stutters and goes backwards during normal-speed two-finger scrolling gestures. The issue primarily affects:
- Mac-to-Mac connections
- Mac-to-Windows connections (especially in Adobe Acrobat)
- Horizontal scrolling with two-finger gestures

**Root cause**: Trackpad hardware generates occasional micro-reversal events (tiny opposite-direction scroll steps) as artifacts of the gesture recognition, not intentional user input.

## Solution

Implemented a `ScrollState` struct that tracks:
- Last scroll direction (x and y)
- Timestamp of last scroll event

The debouncing logic filters out scroll events that:
1. Are single-unit movements (`abs(delta) == 1`)
2. Are in the opposite direction of the previous scroll
3. Occur within 40ms of the previous scroll event

This approach is conservative - it only drops obvious micro-reversals while preserving intentional direction changes and larger scroll movements.

## Test plan

- [ ] Mac → Mac: Test two-finger horizontal scrolling
- [ ] Mac → Windows: Test scrolling in various applications
- [ ] Verify fast scrolling still works normally
- [ ] Verify intentional direction changes are not blocked
- [ ] Verify scrollbar dragging is unaffected

Fixes #13403