### PR TITLE
ci: update macOS runner from unsupported macos-13 to macos-latest

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -444,7 +444,7 @@ jobs:
           - {
               arch: aarch64,
               target: aarch64-apple-ios,
-              os: macos-13,
+              os: macos-latest,
               vcpkg-triplet: arm64-ios,
             }
     steps:


### PR DESCRIPTION
- Replace deprecated `macos-13` with `macos-latest` runner
- Ensure CI compatibility with supported macOS versions
- Maintain build stability and future-proof workflows