### PR TITLE
Fix: Window positioning out of bounds on multi-monitors setup #13828

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1932,44 +1932,41 @@ Future<Offset?> _adjustRestoreMainWindowOffset(
     return null;
   }
 
-  double? frameLeft;
-  double? frameTop;
-  double? frameRight;
-  double? frameBottom;
-
   if (isDesktop || isWebDesktop) {
-    for (final screen in await window_size.getScreenList()) {
-      frameLeft = frameLeft == null
-          ? screen.visibleFrame.left
-          : min(screen.visibleFrame.left, frameLeft);
-      frameTop = frameTop == null
-          ? screen.visibleFrame.top
-          : min(screen.visibleFrame.top, frameTop);
-      frameRight = frameRight == null
-          ? screen.visibleFrame.right
-          : max(screen.visibleFrame.right, frameRight);
-      frameBottom = frameBottom == null
-          ? screen.visibleFrame.bottom
-          : max(screen.visibleFrame.bottom, frameBottom);
+    final screens = await window_size.getScreenList();
+    if (screens.isNotEmpty) {
+      final windowRect = Rect.fromLTWH(left, top, width, height);
+      bool isVisible = false;
+      for (final screen in screens) {
+        final intersection = windowRect.intersect(screen.visibleFrame);
+        if (intersection.width >= 10.0 && intersection.height >= 10.0) {
+          isVisible = true;
+          break;
+        }
+      }
+      if (!isVisible) {
+        return null;
+      }
+      return Offset(left, top);
     }
   }
-  if (frameLeft == null) {
-    frameLeft = 0.0;
-    frameTop = 0.0;
-    frameRight = ((isDesktop || isWebDesktop)
-            ? kDesktopMaxDisplaySize
-            : kMobileMaxDisplaySize)
-        .toDouble();
-    frameBottom = ((isDesktop || isWebDesktop)
-            ? kDesktopMaxDisplaySize
-            : kMobileMaxDisplaySize)
-        .toDouble();
-  }
+
+  double frameLeft = 0.0;
+  double frameTop = 0.0;
+  double frameRight = ((isDesktop || isWebDesktop)
+          ? kDesktopMaxDisplaySize
+          : kMobileMaxDisplaySize)
+      .toDouble();
+  double frameBottom = ((isDesktop || isWebDesktop)
+          ? kDesktopMaxDisplaySize
+          : kMobileMaxDisplaySize)
+      .toDouble();
+
   final minWidth = 10.0;
-  if ((left + minWidth) > frameRight! ||
-      (top + minWidth) > frameBottom! ||
+  if ((left + minWidth) > frameRight ||
+      (top + minWidth) > frameBottom ||
       (left + width - minWidth) < frameLeft ||
-      top < frameTop!) {
+      top < frameTop) {
     return null;
   } else {
     return Offset(left, top);


### PR DESCRIPTION
Bug Description:
The previous window positioning logic relied on a global bounding box that encompassed all connected monitors. In non-rectangular multi-monitor layouts (for example, L-shaped arrangements or displays with gaps), this allowed the application window to be restored to coordinates that were technically inside the bounding box but visually located in a “void” area where no physical monitor exists. As a result, the window could appear missing or inaccessible.

Changes:
Updated the window restore logic in flutter/lib/common.dart to validate window positions against actual screen geometries rather than a global bounding box.

Replaced global min/max coordinate validation with a strict screen-intersection check.

The saved window position is now validated by iterating through window_size.getScreenList().

A position is considered valid only if the window rectangle intersects with at least one screen’s visibleFrame by a minimum of 10×10 pixels.

If the saved position is invalid (off-screen or within a gap between monitors), the window safely defaults to being centered on the primary display.

Result:
This ensures restored windows always appear on a visible monitor, even in complex or non-rectangular multi-monitor configurations.