### PR TITLE
add options: disable-change-permanent-password, disable-change-id, disable-unlock-pin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libs/hbb_common"]
 	path = libs/hbb_common
-	url = https://github.com/rustdesk/hbb_common
+	url = https://github.com/21pages/hbb_common
+	branch = disable-change-permanent-password

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3782,6 +3782,16 @@ setResizable(bool resizable) {
 
 isOptionFixed(String key) => bind.mainIsOptionFixed(key: key);
 
+bool isChangePermanentPasswordDisabled() =>
+    bind.mainGetBuildinOption(key: kOptionDisableChangePermanentPassword) ==
+    'Y';
+
+bool isChangeIdDisabled() =>
+    bind.mainGetBuildinOption(key: kOptionDisableChangeId) == 'Y';
+
+bool isUnlockPinDisabled() =>
+    bind.mainGetBuildinOption(key: kOptionDisableUnlockPin) == 'Y';
+
 bool? _isCustomClient;
 bool get isCustomClient {
   _isCustomClient ??= bind.isCustomClient();

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -180,6 +180,10 @@ const String kOptionHideSecuritySetting = "hide-security-settings";
 const String kOptionHideNetworkSetting = "hide-network-settings";
 const String kOptionRemovePresetPasswordWarning =
     "remove-preset-password-warning";
+const String kOptionDisableChangePermanentPassword =
+    "disable-change-permanent-password";
+const String kOptionDisableChangeId = "disable-change-id";
+const String kOptionDisableUnlockPin = "disable-unlock-pin";
 const kHideUsernameOnCard = "hide-username-on-card";
 const String kOptionHideHelpCards = "hide-help-cards";
 

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -825,7 +825,8 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
                 permissions(context),
                 password(context),
                 _Card(title: '2FA', children: [tfa()]),
-                _Card(title: 'ID', children: [changeId()]),
+                if (!isChangeIdDisabled())
+                  _Card(title: 'ID', children: [changeId()]),
                 more(context),
               ]),
             ),
@@ -1091,6 +1092,10 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
                                         .indexOf(kUsePermanentPassword)] &&
                                 (await bind.mainGetPermanentPassword())
                                     .isEmpty) {
+                              if (isChangePermanentPasswordDisabled()) {
+                                await callback();
+                                return;
+                              }
                               setPasswordDialog(notEmptyCallback: callback);
                             } else {
                               await callback();
@@ -1195,7 +1200,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
                   enabled: tmpEnabled && !locked),
             if (usePassword) numericOneTimePassword,
             if (usePassword) radios[1],
-            if (usePassword)
+            if (usePassword && !isChangePermanentPasswordDisabled())
               _SubButton('Set permanent password', setPasswordDialog,
                   permEnabled && !locked),
             // if (usePassword)
@@ -1218,7 +1223,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
         _OptionCheckBox(context, 'allow-only-conn-window-open-tip',
             'allow-only-conn-window-open',
             reverse: false, enabled: enabled),
-      if (bind.mainIsInstalled()) unlockPin()
+      if (bind.mainIsInstalled() && !isUnlockPinDisabled()) unlockPin()
     ]);
   }
 
@@ -2654,7 +2659,7 @@ Widget _lock(
                           ]).marginSymmetric(vertical: 2)),
                   onPressed: () async {
                     final unlockPin = bind.mainGetUnlockPin();
-                    if (unlockPin.isEmpty) {
+                    if (unlockPin.isEmpty || isUnlockPinDisabled()) {
                       bool checked = await callMainCheckSuperUserPermission();
                       if (checked) {
                         onUnlock();

--- a/flutter/lib/mobile/pages/server_page.dart
+++ b/flutter/lib/mobile/pages/server_page.dart
@@ -61,12 +61,13 @@ class _DropDownAction extends StatelessWidget {
           final isAllowNumericOneTimePassword =
               gFFI.serverModel.allowNumericOneTimePassword;
           return [
-            PopupMenuItem(
-              enabled: gFFI.serverModel.connectStatus > 0,
-              value: "changeID",
-              child: Text(translate("Change ID")),
-            ),
-            const PopupMenuDivider(),
+            if (!isChangeIdDisabled())
+              PopupMenuItem(
+                enabled: gFFI.serverModel.connectStatus > 0,
+                value: "changeID",
+                child: Text(translate("Change ID")),
+              ),
+            if (!isChangeIdDisabled()) const PopupMenuDivider(),
             PopupMenuItem(
               value: 'AcceptSessionsViaPassword',
               child: listTile(
@@ -87,7 +88,8 @@ class _DropDownAction extends StatelessWidget {
             ),
             if (showPasswordOption) const PopupMenuDivider(),
             if (showPasswordOption &&
-                verificationMethod != kUseTemporaryPassword)
+                verificationMethod != kUseTemporaryPassword &&
+                !isChangePermanentPasswordDisabled())
               PopupMenuItem(
                 value: "setPermanentPassword",
                 child: Text(translate("Set permanent password")),
@@ -149,6 +151,10 @@ class _DropDownAction extends StatelessWidget {
 
             if (value == kUsePermanentPassword &&
                 (await bind.mainGetPermanentPassword()).isEmpty) {
+              if (isChangePermanentPasswordDisabled()) {
+                callback();
+                return;
+              }
               setPasswordDialog(notEmptyCallback: callback);
             } else {
               callback();
@@ -648,9 +654,8 @@ class ConnectionManager extends StatelessWidget {
     return Column(
         children: serverModel.clients
             .map((client) => PaddingCard(
-                title: translate(client.isFileTransfer
-                    ? "Transfer file"
-                    : "Share screen"),
+                title: translate(
+                    client.isFileTransfer ? "Transfer file" : "Share screen"),
                 titleIcon: client.isFileTransfer
                     ? Icon(Icons.folder_outlined)
                     : Icon(Icons.mobile_screen_share),

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -406,6 +406,10 @@ pub fn core_main() -> Option<Vec<String>> {
                 println!("Settings are disabled!");
                 return None;
             }
+            if config::Config::is_disable_change_permanent_password() {
+                println!("Changing permanent password is disabled!");
+                return None;
+            }
             if args.len() == 2 {
                 if crate::platform::is_installed() && is_root() {
                     if let Err(err) = crate::ipc::set_permanent_password(args[1].to_owned()) {
@@ -419,6 +423,10 @@ pub fn core_main() -> Option<Vec<String>> {
             }
             return None;
         } else if args[0] == "--set-unlock-pin" {
+            if config::Config::is_disable_unlock_pin() {
+                println!("Unlock PIN is disabled!");
+                return None;
+            }
             #[cfg(feature = "flutter")]
             if args.len() == 2 {
                 if crate::platform::is_installed() && is_root() {
@@ -438,6 +446,10 @@ pub fn core_main() -> Option<Vec<String>> {
         } else if args[0] == "--set-id" {
             if config::is_disable_settings() {
                 println!("Settings are disabled!");
+                return None;
+            }
+            if config::Config::is_disable_change_id() {
+                println!("Changing ID is disabled!");
                 return None;
             }
             if args.len() == 2 {

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -16,6 +16,8 @@ const disable_ab = handler.is_disable_ab();
 const hide_server_settings = handler.get_builtin_option("hide-server-settings") == "Y";
 const hide_proxy_settings = handler.get_builtin_option("hide-proxy-settings") == "Y";
 const hide_websocket_settings = handler.get_builtin_option("hide-websocket-settings") == "Y";
+const disable_change_permanent_password = handler.get_builtin_option("disable-change-permanent-password") == "Y";
+const disable_change_id = handler.get_builtin_option("disable-change-id") == "Y";
 
 // html min-width, min-height not working on mac, below works for all
 if (incoming_only) {
@@ -508,11 +510,11 @@ class MyIdMenu: Reactor.Component {
                 {!disable_settings && is_win && handler.is_installed() ? <ShareRdp /> : ""}
                 {!disable_settings && <DirectServer />}
                 {!disable_settings && false && handler.using_public_server() && <li #allow-always-relay><span>{svg_checkmark}</span>{translate('Always connect via relay')}</li>}
-                {handler.is_ok_change_id() ? <div .separator /> : ""}
-                {!disable_account && (username ? 
+                {!disable_change_id && handler.is_ok_change_id() ? <div .separator /> : ""}
+                {!disable_account && (username ?
                 <li #logout>{translate('Logout')} ({username})</li> :
                 <li #login>{translate('Login')}</li>)}
-                {!disable_settings && handler.is_ok_change_id() && key_confirmed && connect_status > 0 ? <li #change-id>{translate('Change ID')}</li> : ""}
+                {!disable_change_id && !disable_settings && handler.is_ok_change_id() && key_confirmed && connect_status > 0 ? <li #change-id>{translate('Change ID')}</li> : ""}
                 <div .separator />
                 <li #allow-darktheme><span>{svg_checkmark}</span>{translate('Dark Theme')}</li>
                 <Languages />
@@ -1050,7 +1052,7 @@ class PasswordArea: Reactor.Component {
             { !show_password ? '' : <li #use-permanent-password><span>{svg_checkmark}</span>{translate('Use permanent password')}</li> }
             { !show_password ? '' : <li #use-both-passwords><span>{svg_checkmark}</span>{translate('Use both passwords')}</li> }
             { !show_password ? '' : <div .separator /> }
-            { !show_password ? '' : <li #set-password  disabled={ method == 'use-temporary-password' ? "true" : "false" }>{translate('Set permanent password')}</li> }
+            { !show_password || disable_change_permanent_password ? '' : <li #set-password  disabled={ method == 'use-temporary-password' ? "true" : "false" }>{translate('Set permanent password')}</li> }
             { !show_password ? '' : <TemporaryPasswordLengthMenu /> }
             <div .separator />
             <li #tfa><span>{svg_checkmark}</span>{translate('enable-2fa-title')}</li>


### PR DESCRIPTION
https://github.com/rustdesk/hbb_common/pull/473

## Summary

  This PR adds three new builtin advanced options as requested in rustdesk/rustdesk-server-pro#848:

  - **`disable-change-permanent-password`**: Hides the UI for changing permanent password and blocks command-line modification via `--password`
  - **`disable-change-id`**: Hides the UI for changing ID and blocks command-line modification via `--set-id`
  - **`disable-unlock-pin`**: Hides the UI for changing unlock PIN, blocks command-line modification via `--set-unlock-pin`, and use admin permission verification even if a PIN was previously set

## Test

* standard version
* flutter desktop

<img width="793" height="468" alt="desktop-disable-change-password" src="https://github.com/user-attachments/assets/fcd3d46b-44b4-4246-90a6-f2fc7c3c4c82" />

<img width="745" height="589" alt="desktop-disable-change-id" src="https://github.com/user-attachments/assets/9df1d412-0e12-47c5-944d-30eea3934779" />

<img width="674" height="481" alt="disable-unlock-pin" src="https://github.com/user-attachments/assets/b5140f3b-0316-4396-8bb8-b42e55ee4535" />

https://github.com/user-attachments/assets/08a1f43a-45a8-498b-a57a-87ea9c904bf7

https://github.com/user-attachments/assets/2f8dbc76-44fb-4634-9a4e-678cd4b774b6

* sciter

<img width="288" height="687" alt="sciter-disable-change-id" src="https://github.com/user-attachments/assets/ebdce6f9-caae-4c4b-b9c8-3a38e652b332" />

<img width="264" height="291" alt="sciter-disable-change-permanent-password" src="https://github.com/user-attachments/assets/6efba0c7-bad4-4a79-b004-383d722416e1" />

* mobile

<img width="1080" height="2400" alt="mobile" src="https://github.com/user-attachments/assets/c8183f08-dfbe-485d-b4e7-cac1c22a0f1f" />

