### PR TITLE
remove gzip encoding in Legacy AB pushes

### DIFF
--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -1012,16 +1012,8 @@ class LegacyAb extends BaseAb {
       var authHeaders = getHttpHeaders();
       authHeaders['Content-Type'] = "application/json";
       final body = jsonEncode({"data": jsonEncode(_serialize())});
-      http.Response resp;
-      // support compression
-      if (licensedDevices > 0 && body.length > 1024) {
-        authHeaders['Content-Encoding'] = "gzip";
-        resp = await http.post(Uri.parse(api),
-            headers: authHeaders, body: GZipCodec().encode(utf8.encode(body)));
-      } else {
-        resp =
-            await http.post(Uri.parse(api), headers: authHeaders, body: body);
-      }
+      http.Response resp =
+          await http.post(Uri.parse(api), headers: authHeaders, body: body);
       if (resp.statusCode == 200 &&
           (resp.body.isEmpty || resp.body.toLowerCase() == 'null')) {
         ret = true;


### PR DESCRIPTION
Since the current HTTP request only supports string type body, remove the gzip header when sending Legacy Ab to the server, as very few people are using Legacy AB now.

# before

https://github.com/user-attachments/assets/9801c376-9f42-4460-8864-a08465e7a059

# after

https://github.com/user-attachments/assets/4ce442e7-fff2-430f-832b-f164339f7101

