### PR TITLE
fix: add Content-Length header for empty body POST requests

### DIFF
--- a/flutter/lib/models/ab_model.dart
+++ b/flutter/lib/models/ab_model.dart
@@ -202,6 +202,7 @@ class AbModel {
       final api = "${await bind.mainGetApiServer()}/api/ab/settings";
       var headers = getHttpHeaders();
       headers['Content-Type'] = "application/json";
+      _setEmptyBody(headers);
       final resp = await http.post(Uri.parse(api), headers: headers);
       if (resp.statusCode == 404) {
         debugPrint("HTTP 404, api server doesn't support shared address book");
@@ -228,6 +229,7 @@ class AbModel {
       final api = "${await bind.mainGetApiServer()}/api/ab/personal";
       var headers = getHttpHeaders();
       headers['Content-Type'] = "application/json";
+      _setEmptyBody(headers);
       final resp = await http.post(Uri.parse(api), headers: headers);
       if (resp.statusCode == 404) {
         debugPrint("HTTP 404, current api server is legacy mode");
@@ -269,6 +271,7 @@ class AbModel {
             });
         var headers = getHttpHeaders();
         headers['Content-Type'] = "application/json";
+        _setEmptyBody(headers);
         final resp = await http.post(uri, headers: headers);
         Map<String, dynamic> json =
             _jsonDecodeRespMap(decode_http_response(resp), resp.statusCode);
@@ -1406,6 +1409,7 @@ class Ab extends BaseAb {
             });
         var headers = getHttpHeaders();
         headers['Content-Type'] = "application/json";
+        _setEmptyBody(headers);
         final resp = await http.post(uri, headers: headers);
         statusCode = resp.statusCode;
         Map<String, dynamic> json =
@@ -1463,6 +1467,7 @@ class Ab extends BaseAb {
       );
       var headers = getHttpHeaders();
       headers['Content-Type'] = "application/json";
+      _setEmptyBody(headers);
       final resp = await http.post(uri, headers: headers);
       statusCode = resp.statusCode;
       List<dynamic> json =
@@ -1976,4 +1981,9 @@ String _jsonDecodeActionResp(http.Response resp) {
     }
   }
   return errMsg;
+}
+
+// https://github.com/seanmonstar/reqwest/issues/838
+void _setEmptyBody(Map<String, String> headers) {
+  headers['Content-Length'] = '0';
 }


### PR DESCRIPTION
https://github.com/seanmonstar/reqwest/issues/838
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Length

Certain servers return HTTP 411 (Length Required) for POST requests with an empty body. This is fixed by adding a `Content-Length: 0 `header. Alternatively, setting the body to `'{}'` also works.