### PR TITLE
fix: restart video service when first frame stalls

### DIFF
--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -68,6 +68,7 @@ pub struct Remote<T: InvokeUiSession> {
     last_update_jobs_status: (Instant, HashMap<i32, u64>),
     is_connected: bool,
     first_frame: bool,
+    watchdog: ClientFirstFrameWatchdog,
     #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]
     client_conn_id: i32, // used for file clipboard
     data_count: Arc<AtomicUsize>,
@@ -115,6 +116,7 @@ impl<T: InvokeUiSession> Remote<T> {
             last_update_jobs_status: (Instant::now(), Default::default()),
             is_connected: false,
             first_frame: false,
+            watchdog: ClientFirstFrameWatchdog::new(Duration::from_secs(3)),
             #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]
             client_conn_id: 0,
             data_count: Arc::new(AtomicUsize::new(0)),
@@ -279,6 +281,15 @@ impl<T: InvokeUiSession> Remote<T> {
                             }
                         }
                         _ = status_timer.tick() => {
+                            if self.watchdog.check(self.is_connected, self.first_frame, self.handler.is_default(), Instant::now()) {
+                                log::warn!("No first video frame received, sending refresh");
+                                let mut misc = Misc::new();
+                                misc.set_refresh_video(true);
+                                let mut msg = Message::new();
+                                msg.set_misc(misc);
+                                allow_err!(peer.send(&msg).await);
+                            }
+
                             let elapsed = fps_instant.elapsed().as_millis();
                             if elapsed < 1000 {
                                 continue;
@@ -2439,3 +2450,72 @@ impl Drop for VideoThread {
         *self.discard_queue.write().unwrap() = true;
     }
 }
+
+struct ClientFirstFrameWatchdog {
+    deadline: Option<Instant>,
+    timeout: Duration,
+}
+
+impl ClientFirstFrameWatchdog {
+    fn new(timeout: Duration) -> Self {
+        Self { deadline: None, timeout }
+    }
+
+    // Returns true if refresh should be triggered
+    fn check(&mut self, is_connected: bool, first_frame_received: bool, is_default: bool, now: Instant) -> bool {
+        if is_connected && !first_frame_received && is_default {
+            if let Some(d) = self.deadline {
+                if now > d {
+                    self.deadline = Some(now + self.timeout);
+                    return true;
+                }
+            } else {
+                self.deadline = Some(now + self.timeout);
+            }
+        } else {
+            self.deadline = None;
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_client_first_frame_watchdog() {
+        let timeout = Duration::from_secs(3);
+        let mut watchdog = ClientFirstFrameWatchdog::new(timeout);
+        let start = Instant::now();
+
+        // Not connected: no trigger, no deadline set
+        assert!(!watchdog.check(false, false, true, start));
+        assert!(watchdog.deadline.is_none());
+
+        // Connected, default, no frame: deadline set to start + 3s
+        assert!(!watchdog.check(true, false, true, start));
+        assert!(watchdog.deadline.is_some());
+        assert_eq!(watchdog.deadline.unwrap(), start + timeout);
+
+        // Advance 2s: no trigger
+        assert!(!watchdog.check(true, false, true, start + Duration::from_secs(2)));
+
+        // Advance 4s: trigger!
+        assert!(watchdog.check(true, false, true, start + Duration::from_secs(4)));
+        // Deadline reset to +3s from now (start+4s) -> start+7s
+        assert_eq!(watchdog.deadline.unwrap(), start + Duration::from_secs(4) + timeout);
+
+        // Frame received: reset
+        assert!(!watchdog.check(true, true, true, start + Duration::from_secs(5)));
+        assert!(watchdog.deadline.is_none());
+
+        // Not default: reset
+        watchdog.check(true, false, true, start); // set deadline
+        assert!(watchdog.deadline.is_some());
+        watchdog.check(true, false, false, start); // reset
+        assert!(watchdog.deadline.is_none());
+    }
+}
+

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -283,11 +283,8 @@ impl<T: InvokeUiSession> Remote<T> {
                         _ = status_timer.tick() => {
                             if self.watchdog.check(self.is_connected, self.first_frame, self.handler.is_default(), Instant::now()) {
                                 log::warn!("No first video frame received, sending refresh");
-                                let mut misc = Misc::new();
-                                misc.set_refresh_video(true);
-                                let mut msg = Message::new();
-                                msg.set_misc(misc);
-                                allow_err!(peer.send(&msg).await);
+                                let display = self.handler.lc.read().unwrap().peer_info.as_ref().map(|p| p.current_display).unwrap_or(0);
+                                self.handler.refresh_video(display as _);
                             }
 
                             let elapsed = fps_instant.elapsed().as_millis();

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3406,6 +3406,12 @@ impl Connection {
     }
 
     fn refresh_video_display(&self, display: Option<usize>) {
+        log::debug!(
+            "refresh_video_display: conn_id={}, display={:?}, source={:?}",
+            self.inner.id,
+            display,
+            self.video_source()
+        );
         video_service::refresh();
         self.server.upgrade().map(|s| {
             s.read().unwrap().set_video_service_opt(

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -655,7 +655,6 @@ fn run(vs: VideoService) -> ResultType<()> {
     let (mut second_instant, mut send_counter) = (Instant::now(), 0);
 
     while sp.ok() {
-        let mut produced_frame = false;
         #[cfg(windows)]
         check_uac_switch(c.privacy_mode_id, c._capturer_privacy_mode_id)?;
         check_qos(
@@ -783,9 +782,6 @@ fn run(vs: VideoService) -> ResultType<()> {
                         capture_width,
                         capture_height,
                     )?;
-                    if !send_conn_ids.is_empty() {
-                        produced_frame = true;
-                    }
                     frame_controller.set_send(now, send_conn_ids);
                     send_counter += 1;
 
@@ -847,9 +843,6 @@ fn run(vs: VideoService) -> ResultType<()> {
                             capture_width,
                             capture_height,
                         )?;
-                        if !send_conn_ids.is_empty() {
-                            produced_frame = true;
-                        }
                         frame_controller.set_send(now, send_conn_ids);
                         send_counter += 1;
                     }


### PR DESCRIPTION
### Problem
In some cases the capturer can return `Ok(frame)` while the frame is invalid (`!frame.valid()`). Previously this was treated as a successful capture, so the normal `WouldBlock` ("no image yet") handling didn't run and peers could remain stuck waiting for the first image.

### Approach
- Treat invalid frames as `WouldBlock` so existing retry/fallback paths run (including Windows `try_gdi`).
- Add a first-frame watchdog: if no frame is actually sent to any subscriber within ~3s, restart the video service via the existing `SWITCH` mechanism.

### Tests
- `cargo test`
