### PR TITLE
Remove unused option_env!(...)

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1045,10 +1045,6 @@ fn get_api_server_(api: String, custom: String) -> String {
     if !api.is_empty() {
         return api.to_owned();
     }
-    let api = option_env!("API_SERVER").unwrap_or_default();
-    if !api.is_empty() {
-        return api.into();
-    }
     let s0 = get_custom_rendezvous_server(custom);
     if !s0.is_empty() {
         let s = crate::increase_port(&s0, -2);
@@ -1710,8 +1706,7 @@ pub fn create_symmetric_key_msg(their_pk_b: [u8; 32]) -> (Bytes, Bytes, secretbo
 
 #[inline]
 pub fn using_public_server() -> bool {
-    option_env!("RENDEZVOUS_SERVER").unwrap_or("").is_empty()
-        && crate::get_custom_rendezvous_server(get_option("custom-rendezvous-server")).is_empty()
+    crate::get_custom_rendezvous_server(get_option("custom-rendezvous-server")).is_empty()
 }
 
 pub struct ThrottledInterval {


### PR DESCRIPTION
In commit 33d90c7 , the options `option_env!("RENDEZVOUS_SERVER")` and `option_env!("RS_PUB_KEY")` have been disabled due to security reasons.

In src/common.rs , two instances have been forgotten, which are removed by this PR.

I am not sure if this fix can be considered just a code-cleanup, or if this fixes a security threat, since the removal of these environment variables was done as security measure.

( Fixes https://github.com/rustdesk/rustdesk/discussions/13850 )
