### PR TITLE
Allow configuring remote control permissions for different users

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3039,10 +3039,21 @@ Future<void> start_service(bool is_start) async {
 }
 
 Future<bool> canBeBlocked() async {
-  var access_mode = await bind.mainGetOption(key: kOptionAccessMode);
+  // First check control permission
+  final controlPermission = await bind.mainGetCommon(
+      key: "is-remote-modify-enabled-by-control-permissions");
+  if (controlPermission == "true") {
+    return false;
+  } else if (controlPermission == "false") {
+    return true;
+  }
+
+  // Check local settings
+  var accessMode = await bind.mainGetOption(key: kOptionAccessMode);
+  var isCustomAccessMode = accessMode != 'full' && accessMode != 'view';
   var option = option2bool(kOptionAllowRemoteConfigModification,
       await bind.mainGetOption(key: kOptionAllowRemoteConfigModification));
-  return access_mode == 'view' || (access_mode.isEmpty && !option);
+  return accessMode == 'view' || (isCustomAccessMode && !option);
 }
 
 // to-do: web not implemented

--- a/src/common.rs
+++ b/src/common.rs
@@ -2277,6 +2277,28 @@ pub fn str2color(s: &str, alpha: u8) -> u32 {
     (alpha as u32) << 24 | rgb
 }
 
+/// Check control permission state from a u64 bitmap.
+/// Each permission uses 2 bits: 0 = not set, 1 = disable, 2 = enable, 3 = invalid (treated as not set)
+/// Returns: Some(true) = enabled, Some(false) = disabled, None = not set or invalid
+pub fn get_control_permission(
+    permissions: u64,
+    permission: hbb_common::rendezvous_proto::control_permissions::Permission,
+) -> Option<bool> {
+    use hbb_common::protobuf::Enum;
+    let index = permission.value();
+    if index >= 0 && index < 32 {
+        let shift = index * 2;
+        let value = (permissions >> shift) & 0b11;
+        match value {
+            1 => Some(false), // disable
+            2 => Some(true),  // enable
+            _ => None,        // 0 = not set, 3 = invalid
+        }
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2600,6 +2600,13 @@ pub fn main_get_common(key: String) -> String {
         return false.to_string();
     } else if key == "transfer-job-id" {
         return hbb_common::fs::get_next_job_id().to_string();
+    } else if key == "is-remote-modify-enabled-by-control-permissions" {
+        return match is_remote_modify_enabled_by_control_permissions() {
+            Some(true) => "true",
+            Some(false) => "false",
+            None => "",
+        }
+        .to_string();
     } else {
         if key.starts_with("download-data-") {
             let id = key.replace("download-data-", "");

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -427,6 +427,7 @@ impl RendezvousMediator {
             rr.secure,
             false,
             Default::default(),
+            rr.control_permissions.clone().into_option(),
         )
         .await
     }
@@ -440,6 +441,7 @@ impl RendezvousMediator {
         secure: bool,
         initiate: bool,
         socket_addr_v6: bytes::Bytes,
+        control_permissions: Option<ControlPermissions>,
     ) -> ResultType<()> {
         let peer_addr = AddrMangle::decode(&socket_addr);
         log::info!(
@@ -473,6 +475,7 @@ impl RendezvousMediator {
             peer_addr,
             secure,
             is_ipv4(&self.addr),
+            control_permissions,
         )
         .await;
         Ok(())
@@ -491,7 +494,13 @@ impl RendezvousMediator {
         let relay = use_ws() || Config::is_proxy();
         let mut socket_addr_v6 = Default::default();
         if peer_addr_v6.port() > 0 && !relay {
-            socket_addr_v6 = start_ipv6(peer_addr_v6, addr, server.clone()).await;
+            socket_addr_v6 = start_ipv6(
+                peer_addr_v6,
+                addr,
+                server.clone(),
+                fla.control_permissions.clone().into_option(),
+            )
+            .await;
         }
         if is_ipv4(&self.addr) && !relay && !config::is_disable_tcp_listen() {
             if let Err(err) = self
@@ -517,6 +526,7 @@ impl RendezvousMediator {
             true,
             true,
             socket_addr_v6,
+            fla.control_permissions.into_option(),
         )
         .await
     }
@@ -547,7 +557,14 @@ impl RendezvousMediator {
         });
         let bytes = msg_out.write_to_bytes()?;
         socket.send_raw(bytes).await?;
-        crate::accept_connection(server.clone(), socket, peer_addr, true).await;
+        crate::accept_connection(
+            server.clone(),
+            socket,
+            peer_addr,
+            true,
+            fla.control_permissions.into_option(),
+        )
+        .await;
         Ok(())
     }
 
@@ -562,8 +579,15 @@ impl RendezvousMediator {
         let peer_addr_v6 = hbb_common::AddrMangle::decode(&ph.socket_addr_v6);
         let relay = use_ws() || Config::is_proxy() || ph.force_relay;
         let mut socket_addr_v6 = Default::default();
+        let control_permissions = ph.control_permissions.into_option();
         if peer_addr_v6.port() > 0 && !relay {
-            socket_addr_v6 = start_ipv6(peer_addr_v6, peer_addr, server.clone()).await;
+            socket_addr_v6 = start_ipv6(
+                peer_addr_v6,
+                peer_addr,
+                server.clone(),
+                control_permissions.clone(),
+            )
+            .await;
         }
         let relay_server = self.get_relay_server(ph.relay_server);
         // for ensure, websocket go relay directly
@@ -582,6 +606,7 @@ impl RendezvousMediator {
                     true,
                     true,
                     socket_addr_v6.clone(),
+                    control_permissions,
                 )
                 .await;
         }
@@ -598,7 +623,8 @@ impl RendezvousMediator {
         };
         if ph.udp_port > 0 {
             peer_addr.set_port(ph.udp_port as u16);
-            self.punch_udp_hole(peer_addr, server, msg_punch).await?;
+            self.punch_udp_hole(peer_addr, server, msg_punch, control_permissions)
+                .await?;
             return Ok(());
         }
         log::debug!("Punch tcp hole to {:?}", peer_addr);
@@ -614,7 +640,8 @@ impl RendezvousMediator {
         msg_out.set_punch_hole_sent(msg_punch);
         let bytes = msg_out.write_to_bytes()?;
         socket.send_raw(bytes).await?;
-        crate::accept_connection(server.clone(), socket, peer_addr, true).await;
+        crate::accept_connection(server.clone(), socket, peer_addr, true, control_permissions)
+            .await;
         Ok(())
     }
 
@@ -623,6 +650,7 @@ impl RendezvousMediator {
         peer_addr: SocketAddr,
         server: ServerPtr,
         msg_punch: PunchHoleSent,
+        control_permissions: Option<ControlPermissions>,
     ) -> ResultType<()> {
         let mut msg_out = Message::new();
         msg_out.set_punch_hole_sent(msg_punch);
@@ -637,7 +665,14 @@ impl RendezvousMediator {
                 socket.send_to(&data, addr).await.ok();
             }
         });
-        udp_nat_listen(socket_cloned.clone(), peer_addr, peer_addr, server).await?;
+        udp_nat_listen(
+            socket_cloned.clone(),
+            peer_addr,
+            peer_addr,
+            server,
+            control_permissions,
+        )
+        .await?;
         Ok(())
     }
 
@@ -778,6 +813,7 @@ async fn direct_server(server: ServerPtr) {
                             hbb_common::Stream::from(stream, local_addr),
                             addr,
                             false,
+                            None, // Direct connections don't have control_permissions
                         )
                         .await
                     );
@@ -809,12 +845,22 @@ async fn start_ipv6(
     peer_addr_v6: SocketAddr,
     peer_addr_v4: SocketAddr,
     server: ServerPtr,
+    control_permissions: Option<ControlPermissions>,
 ) -> bytes::Bytes {
     crate::test_ipv6().await;
     if let Some((socket, local_addr_v6)) = crate::get_ipv6_socket().await {
         let server = server.clone();
         tokio::spawn(async move {
-            allow_err!(udp_nat_listen(socket.clone(), peer_addr_v6, peer_addr_v4, server).await);
+            allow_err!(
+                udp_nat_listen(
+                    socket.clone(),
+                    peer_addr_v6,
+                    peer_addr_v4,
+                    server,
+                    control_permissions
+                )
+                .await
+            );
         });
         return local_addr_v6;
     }
@@ -826,6 +872,7 @@ async fn udp_nat_listen(
     peer_addr: SocketAddr,
     peer_addr_v4: SocketAddr,
     server: ServerPtr,
+    control_permissions: Option<ControlPermissions>,
 ) -> ResultType<()> {
     let tm = Instant::now();
     let socket_cloned = socket.clone();
@@ -838,7 +885,14 @@ async fn udp_nat_listen(
             res,
         )
         .await?;
-        crate::server::create_tcp_connection(server, stream.1, peer_addr_v4, true).await?;
+        crate::server::create_tcp_connection(
+            server,
+            stream.1,
+            peer_addr_v4,
+            true,
+            control_permissions,
+        )
+        .await?;
         Ok(())
     };
     func.await.map_err(|e: anyhow::Error| {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -699,6 +699,15 @@ impl UI {
     fn get_builtin_option(&self, key: String) -> String {
         crate::ui_interface::get_builtin_option(&key)
     }
+
+    fn is_remote_modify_enabled_by_control_permissions(&self) -> String {
+        match crate::ui_interface::is_remote_modify_enabled_by_control_permissions() {
+            Some(true) => "true",
+            Some(false) => "false",
+            None => "",
+        }
+        .to_string()
+    }
 }
 
 impl sciter::EventHandler for UI {
@@ -801,6 +810,7 @@ impl sciter::EventHandler for UI {
         fn verify_login(String, String);
         fn is_option_fixed(String);
         fn get_builtin_option(String);
+        fn is_remote_modify_enabled_by_control_permissions();
     }
 }
 

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -1396,7 +1396,16 @@ function self.onMouse(evt) {
 }
 
 function check_if_overlay() {
-    if (handler.get_option('allow-remote-config-modification') != 'Y') {
+    var enabled;
+    var is_enabled_by_control_permissions = handler.is_remote_modify_enabled_by_control_permissions();
+    if (is_enabled_by_control_permissions == "true") {
+        enabled = true;
+    } else if (is_enabled_by_control_permissions == "false") {
+        enabled = false;
+    } else {
+        enabled = handler.get_option('allow-remote-config-modification') == 'Y';
+    }
+    if (!enabled) {
         var time0 = getTime();
         handler.check_mouse_time();
         self.timer(120ms, function() {

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -772,7 +772,14 @@ impl<T: InvokeUiCM> IpcTaskRunner<T> {
 #[tokio::main(flavor = "current_thread")]
 pub async fn start_ipc<T: InvokeUiCM>(cm: ConnectionManager<T>) {
     #[cfg(target_os = "windows")]
-    ContextSend::enable(crate::Connection::permission(OPTION_ENABLE_FILE_TRANSFER));
+    {
+        let enabled = crate::Connection::is_permission_enabled_locally(OPTION_ENABLE_FILE_TRANSFER);
+        let mut lock = crate::ui_interface::IS_FILE_TRANSFER_ENABLED
+            .lock()
+            .unwrap();
+        ContextSend::enable(enabled);
+        *lock = Some(enabled);
+    }
     match ipc::new_listener("_cm").await {
         Ok(mut incoming) => {
             while let Some(result) = incoming.next().await {


### PR DESCRIPTION
Related:
  - https://github.com/rustdesk/rustdesk-server-pro/discussions/718
  - https://github.com/rustdesk/hbb_common/pull/477

## Implementation Details

  1. Permission info is received via server's `PunchHole`, `FetchLocalAddr`, and `RequestRelay` responses, then passed directly to `Connection::start`. Direct IP access is not restricted.

  2. Control permissions now support both enable and disable states (tri-state: enable/disable/not set). Control permissions take priority over local settings.

  3. Permission calculation rules:
     - **Session-level permissions**: Control permission overrides local setting when set
     - **Remote configuration modification** (global): If any connection has it disabled → disabled; else if any has it enabled → enabled; else use local setting
  4. Only supported when the controlled side is a desktop; Android is not supported.

  ## Permission Calculation Table

  ### Session-level Permissions

  | Control Permission | Local Setting | Result |
  |---|---|---|
  | Enable | Enable | Enable |
  | Enable | Disable | **Enable** |
  | Disable | Enable | **Disable** |
  | Disable | Disable | Disable |
  | Not Set | Enable | Enable |
  | Not Set | Disable | Disable |

  ### Global: Remote configuration modification

  | All Connections' Control Permission | Result |
  |---|---|
  | Any Disable | **Disable** |
  | No Disable, Any Enable | **Enable** |
  | All Not Set | Use local setting |

  ## Known Permission Issue
  - The remote configuration modification of the control role is checked using a timer, so it cannot be guaranteed to take effect during the first second immediately after a connection is established.
  - Clipboard file transfer on Windows: Context::enable is not called when cm panel permission changes .