### PR TITLE
update: rust-webm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9652,16 +9652,18 @@ dependencies = [
 
 [[package]]
 name = "webm"
-version = "1.1.0"
-source = "git+https://github.com/rustdesk-org/rust-webm#d2c4d3ac133c7b0e4c0f656da710b48391981e64"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bc0bbde92953f4853a977388180c1fe19c018cdb54dea1152e8d7fdbb10c52"
 dependencies = [
  "webm-sys",
 ]
 
 [[package]]
 name = "webm-sys"
-version = "1.0.4"
-source = "git+https://github.com/rustdesk-org/rust-webm#d2c4d3ac133c7b0e4c0f656da710b48391981e64"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2638f978256596fe3eef55c8587549d01744682eea7ef1c68e0fd966b93fab3"
 dependencies = [
  "cc",
 ]

--- a/libs/scrap/Cargo.toml
+++ b/libs/scrap/Cargo.toml
@@ -21,7 +21,7 @@ cfg-if = "1.0"
 num_cpus = "1.15"
 lazy_static = "1.4"
 hbb_common = { path = "../hbb_common" }
-webm = { git = "https://github.com/rustdesk-org/rust-webm" }
+webm = "2.2"
 serde = {version="1.0", features=["derive"]}
 
 [dependencies.winapi]


### PR DESCRIPTION
Required as per :

- https://github.com/rustdesk/rustdesk/issues/13100
- https://github.com/DiamondLovesYou/rust-webm/issues/26
- https://github.com/4JX/L5P-Keyboard-RGB/issues/249

## Alternative

Sync https://github.com/rustdesk-org/rust-webm from upstream and run `cargo update -p webm`