### PR TITLE
fix(idd): installation

### DIFF
--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -29,7 +29,7 @@
 		<CustomAction Id="SetPropertyServiceStop.SetParam.ConfigKey" Return="check" Property="ConfigKey" Value="stop-service" />
 		<CustomAction Id="SetPropertyServiceStop.SetParam.PropertyName" Return="check" Property="PropertyName" Value="STOP_SERVICE" />
 		<CustomAction Id="TryDeleteStartupShortcut.SetParam" Return="check" Property="ShortcutName" Value="$(var.Product) Tray" />
-		<CustomAction Id="RemoveAmyuniIdd.SetParam" Return="check" Property="RemoveAmyuniIdd" Value="[INSTALLFOLDER_INNER]" />
+		<CustomAction Id="RemoveAmyuniIdd.SetParam" Return="check" Property="RemoveAmyuniIdd" Value="$(var.Product)" />
 		<CustomAction Id="InstallPrinter.SetParam" Return="check" Property="InstallPrinter" Value="[INSTALLFOLDER_INNER]" />
 		<InstallExecuteSequence>
 
@@ -91,8 +91,9 @@
 			<Custom Action="TerminateProcesses.SetParam" Before="TerminateProcesses"/>
 			<Custom Action="TerminateBrokers" Before="RemoveInstallFolder"/>
 			<Custom Action="TerminateBrokers.SetParam" Before="TerminateBrokers"/>
-			<Custom Action="RemoveAmyuniIdd" Before="RemoveInstallFolder"/>
-			<Custom Action="RemoveAmyuniIdd.SetParam" Before="RemoveAmyuniIdd"/>
+			<!-- Only run during uninstall: (Installed AND REMOVE AND NOT UPGRADINGPRODUCTCODE) -->
+			<Custom Action="RemoveAmyuniIdd" Before="RemoveRegistryValues" Condition="Installed AND REMOVE AND NOT UPGRADINGPRODUCTCODE"/>
+			<Custom Action="RemoveAmyuniIdd.SetParam" Before="RemoveAmyuniIdd" Condition="Installed AND REMOVE AND NOT UPGRADINGPRODUCTCODE"/>
 		</InstallExecuteSequence>
 
 		<!-- Shortcuts -->

--- a/src/virtual_display_manager.rs
+++ b/src/virtual_display_manager.rs
@@ -500,6 +500,7 @@ pub mod amyuni_idd {
             if crate::platform::windows::is_x64() {
                 log::info!("Installing driver by deviceinstaller64.exe");
                 install_if_x86_on_x64(&work_dir, "install usbmmidd.inf usbmmidd")?;
+                crate::platform::windows::set_amyuni_idd_installed();
                 *is_async = true;
                 return Ok(());
             }
@@ -519,6 +520,7 @@ pub mod amyuni_idd {
         let mut reboot_required = false;
         let _ =
             unsafe { win_device::install_driver(&inf_path, HARDWARE_ID, &mut reboot_required)? };
+        crate::platform::windows::set_amyuni_idd_installed();
         *is_async = false;
         Ok(())
     }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/14034

## Desc

1. Do not uninstall the idd on install.
2. Set the reg value `AmyuniIddInstalled` to `1` when the idd is installed by RustDesk.
3. Uninstall the idd if the reg value `AmyuniIddInstalled`  is `1` when removing RustDesk.

## Tests

The flutter, sicter and msi version are all tested.

- [x] Pre-install the idd, install and uninstall RustDesk.
- [x] No pre installed idd, install RustDesk, toggle the virtual display, then uninstall RustDesk

## Issues

It may leave the idd if directly upgraded from the old version to the current version. (EXE)
Because the previous version installed the idd without setting the reg value.

