### PR TITLE
change quick support filename detection

### DIFF
--- a/libs/portable/src/main.rs
+++ b/libs/portable/src/main.rs
@@ -187,7 +187,7 @@ fn main() {
         i += 1;
     }
     let click_setup = args.is_empty() && arg_exe.to_lowercase().ends_with("install.exe");
-    let quick_support = args.is_empty() && arg_exe.to_lowercase().ends_with("qs.exe");
+    let quick_support = args.is_empty() && win::is_quick_support_exe(&arg_exe);
 
     let mut ui = false;
     let reader = BinaryReader::default();
@@ -233,5 +233,13 @@ mod win {
             .creation_flags(winapi::um::winbase::CREATE_NO_WINDOW)
             .output();
         let _allow_err = std::fs::copy(src, &format!("{}\\{}", dir.to_string_lossy(), tgt));
+    }
+
+    /// Check if the executable is a Quick Support version.
+    /// Note: This function must be kept in sync with `src/core_main.rs`.
+    #[inline]
+    pub(super) fn is_quick_support_exe(exe: &str) -> bool {
+        let exe = exe.to_lowercase();
+        exe.contains("-qs-") || exe.contains("-qs.exe") || exe.contains("_qs.exe")
     }
 }

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -140,7 +140,7 @@ pub fn core_main() -> Option<Vec<String>> {
     {
         _is_quick_support |= !crate::platform::is_installed()
             && args.is_empty()
-            && (arg_exe.to_lowercase().contains("-qs-")
+            && (is_quick_support_exe(&arg_exe)
                 || config::LocalConfig::get_option("pre-elevate-service") == "Y"
                 || (!click_setup && crate::platform::is_elevated(None).unwrap_or(false)));
         crate::portable_service::client::set_quick_support(_is_quick_support);
@@ -828,4 +828,13 @@ fn is_root() -> bool {
     }
     #[allow(unreachable_code)]
     crate::platform::is_root()
+}
+
+/// Check if the executable is a Quick Support version.
+/// Note: This function must be kept in sync with `libs/portable/src/main.rs`.
+#[cfg(windows)]
+#[inline]
+fn is_quick_support_exe(exe: &str) -> bool {
+    let exe = exe.to_lowercase();
+    exe.contains("-qs-") || exe.contains("-qs.exe") || exe.contains("_qs.exe")
 }


### PR DESCRIPTION
Quick Support now supports filenames containing:

- `-qs-`
- `-qs.exe`
- `_qs.exe`

The previous detection using only `qs.exe` is no longer supported, to avoid triggering Quick Support for applications whose names simply end with `qs`.