### PR TITLE
fix issue: #13911 'Double Click' bug on iPad with Magic Mouse

### DIFF
--- a/flutter/lib/common/widgets/gestures.dart
+++ b/flutter/lib/common/widgets/gestures.dart
@@ -161,6 +161,8 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
     }
   }
 
+  GestureDragCancelCallback? onOneFingerPanCancel;
+
   DragUpdateDetails _getDragUpdateDetails(ScaleUpdateDetails d) =>
       DragUpdateDetails(
           globalPosition: d.focalPoint,
@@ -169,6 +171,17 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
 
   DragEndDetails _getDragEndDetails(ScaleEndDetails d) =>
       DragEndDetails(velocity: d.velocity);
+
+  @override
+  void rejectGesture(int pointer) {
+    super.rejectGesture(pointer);
+    if (_currentState == GestureState.oneFingerPan) {
+      if (onOneFingerPanCancel != null) {
+        onOneFingerPanCancel!();
+      }
+      _currentState = GestureState.none;
+    }
+  }
 }
 
 class HoldTapMoveGestureRecognizer extends GestureRecognizer {
@@ -717,6 +730,7 @@ RawGestureDetector getMixinGestureDetector({
   GestureDragStartCallback? onOneFingerPanStart,
   GestureDragUpdateCallback? onOneFingerPanUpdate,
   GestureDragEndCallback? onOneFingerPanEnd,
+  GestureDragCancelCallback? onOneFingerPanCancel,
   GestureScaleUpdateCallback? onTwoFingerScaleUpdate,
   GestureScaleEndCallback? onTwoFingerScaleEnd,
   GestureDragUpdateCallback? onThreeFingerVerticalDragUpdate,
@@ -765,6 +779,7 @@ RawGestureDetector getMixinGestureDetector({
             ..onOneFingerPanStart = onOneFingerPanStart
             ..onOneFingerPanUpdate = onOneFingerPanUpdate
             ..onOneFingerPanEnd = onOneFingerPanEnd
+            ..onOneFingerPanCancel = onOneFingerPanCancel
             ..onTwoFingerScaleUpdate = onTwoFingerScaleUpdate
             ..onTwoFingerScaleEnd = onTwoFingerScaleEnd
             ..onThreeFingerVerticalDragUpdate = onThreeFingerVerticalDragUpdate;

--- a/flutter/lib/common/widgets/gestures.dart
+++ b/flutter/lib/common/widgets/gestures.dart
@@ -25,6 +25,7 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
   GestureDragStartCallback? onOneFingerPanStart;
   GestureDragUpdateCallback? onOneFingerPanUpdate;
   GestureDragEndCallback? onOneFingerPanEnd;
+  GestureDragCancelCallback? onOneFingerPanCancel;
 
   // twoFingerScale : scale + pan event
   GestureScaleStartCallback? onTwoFingerScaleStart;
@@ -161,8 +162,6 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
     }
   }
 
-  GestureDragCancelCallback? onOneFingerPanCancel;
-
   DragUpdateDetails _getDragUpdateDetails(ScaleUpdateDetails d) =>
       DragUpdateDetails(
           globalPosition: d.focalPoint,
@@ -175,12 +174,22 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
   @override
   void rejectGesture(int pointer) {
     super.rejectGesture(pointer);
-    if (_currentState == GestureState.oneFingerPan) {
-      if (onOneFingerPanCancel != null) {
-        onOneFingerPanCancel!();
-      }
-      _currentState = GestureState.none;
+    switch (_currentState) {
+      case GestureState.oneFingerPan:
+        if (onOneFingerPanCancel != null) {
+          onOneFingerPanCancel!();
+        }
+        break;
+      case GestureState.twoFingerScale:
+        // Reset scale state if needed, currently self-contained
+        break;
+      case GestureState.threeFingerVerticalDrag:
+        // Reset drag state if needed, currently self-contained
+        break;
+      default:
+        break;
     }
+    _currentState = GestureState.none;
   }
 }
 

--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -158,7 +158,8 @@ class _RawTouchGestureDetectorRegionState
       final isMoved =
           await ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy);
       if (isMoved) {
-        if (lastTapDownDetails != null) {
+        // If pan already handled 'down', don't send it again.
+        if (lastTapDownDetails != null && !_touchModePanStarted) {
           await inputModel.tapDown(MouseButtons.left);
         }
         await inputModel.tapUp(MouseButtons.left);
@@ -424,6 +425,10 @@ class _RawTouchGestureDetectorRegionState
     }
   }
 
+  onOneFingerPanCancel() {
+    _touchModePanStarted = false;
+  }
+
   // scale + pan event
   onTwoFingerScaleStart(ScaleStartDetails d) {
     _lastTapDownDetails = null;
@@ -557,6 +562,7 @@ class _RawTouchGestureDetectorRegionState
         instance
           ..onOneFingerPanUpdate = onOneFingerPanUpdate
           ..onOneFingerPanEnd = onOneFingerPanEnd
+          ..onOneFingerPanCancel = onOneFingerPanCancel
           ..onTwoFingerScaleStart = onTwoFingerScaleStart
           ..onTwoFingerScaleUpdate = onTwoFingerScaleUpdate
           ..onTwoFingerScaleEnd = onTwoFingerScaleEnd

--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -425,6 +425,10 @@ class _RawTouchGestureDetectorRegionState
     }
   }
 
+  // Reset `_touchModePanStarted` if the one-finger pan gesture is cancelled
+  // or rejected by the gesture arena. Without this, the flag can remain
+  // stuck in the "started" state and cause issues such as the Magic Mouse
+  // double-click problem on iPad with magic mouse.
   onOneFingerPanCancel() {
     _touchModePanStarted = false;
   }


### PR DESCRIPTION
Issue #13911
This fix solve  problems caused by gesture conflicts in flutter and prevent input state from getting stuck during rapid interactions with magic mouse.  The fix prevent duplicate clicks by ignoring Tap when Pan has already started, add a reset path to hangle gesturecancellation or rejection to _touchModePanStarted not getting stuck

Cause:
iPad identifies magic mouse as a touch device and single physical click trigger two gesture recongnizers (Pansends first Mouse Down and Tap sends a second Mouse Down).

Changes:
remote_input.dart - Anti-duplication check in onTapUp and reset via onOneFingerPanCancel
gestures.dart - Detect gesture rejection (rejectGesture)

debug
test and simulate:
debugPrint statements in remote_input.dart, during touch gestures with magic mouse was possible to observe the sequence registered  ['Pan Down', 'Tap Down' (problem), 'Tap Up']. After the fix touch gestures consistently produced ['Pan Down', 'Tap Up']
The same can be reproduced using a MockInputModel to record the commands sent