### PR TITLE
fix(install): linux xdo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2517,6 +2517,7 @@ version = "0.0.14"
 dependencies = [
  "core-graphics 0.22.3",
  "hbb_common",
+ "libxdo-sys",
  "log",
  "objc",
  "pkg-config",
@@ -3720,6 +3721,7 @@ dependencies = [
  "httparse",
  "lazy_static",
  "libc",
+ "libloading 0.8.4",
  "log",
  "mac_address",
  "machine-uid",
@@ -3755,6 +3757,7 @@ dependencies = [
  "webrtc",
  "whoami",
  "winapi 0.3.9",
+ "x11 2.21.0",
  "zstd 0.13.1",
 ]
 
@@ -4546,11 +4549,8 @@ dependencies = [
 [[package]]
 name = "libxdo-sys"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
 dependencies = [
- "libc",
- "x11 2.21.0",
+ "hbb_common",
 ]
 
 [[package]]
@@ -7181,9 +7181,9 @@ dependencies = [
  "kcp-sys",
  "keepawake",
  "lazy_static",
- "libloading 0.8.4",
  "libpulse-binding",
  "libpulse-simple-binding",
+ "libxdo-sys",
  "mac_address",
  "magnum-opus",
  "nix 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ crossbeam-queue = "0.3"
 hex = "0.4"
 chrono = "0.4"
 cidr-utils = "0.5"
-libloading = "0.8"
 fon = "0.6"
 zip = "0.6"
 shutdown_hooks = "0.1"
@@ -177,6 +176,7 @@ bytemuck = "1.23"
 ttf-parser = "0.25"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+libxdo-sys = "0.11"
 psimple = { package = "libpulse-simple-binding", version = "2.27" }
 pulse = { package = "libpulse-binding", version = "2.27" }
 rust-pulsectl = { git = "https://github.com/rustdesk-org/pulsectl" }
@@ -206,6 +206,11 @@ android-wakelock = { git = "https://github.com/rustdesk-org/android-wakelock" }
 [workspace]
 members = ["libs/scrap", "libs/hbb_common", "libs/enigo", "libs/clipboard", "libs/virtual_display", "libs/virtual_display/dylib", "libs/portable", "libs/remote_printer"]
 exclude = ["vdi/host", "examples/custom_plugin"]
+
+# Patch libxdo-sys to use a stub implementation that doesn't require libxdo
+# This allows building and running on systems without libxdo installed (e.g., Wayland-only)
+[patch.crates-io]
+libxdo-sys = { path = "libs/libxdo-sys-stub" }
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2025 Purslane Ltd. All rights reserved."

--- a/libs/enigo/Cargo.toml
+++ b/libs/enigo/Cargo.toml
@@ -37,5 +37,8 @@ core-graphics = "0.22"
 objc = "0.2"
 unicode-segmentation = "1.10"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libxdo-sys = "0.11"
+
 [build-dependencies]
 pkg-config = "0.3"

--- a/libs/libxdo-sys-stub/Cargo.toml
+++ b/libs/libxdo-sys-stub/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "libxdo-sys"
+version = "0.11.0"
+edition = "2021"
+publish = false
+description = "Dynamic loading wrapper for libxdo-sys that doesn't require libxdo at compile/link time"
+
+[dependencies]
+hbb_common = { path = "../hbb_common" }

--- a/libs/libxdo-sys-stub/src/lib.rs
+++ b/libs/libxdo-sys-stub/src/lib.rs
@@ -1,0 +1,505 @@
+//! Dynamic loading wrapper for libxdo.
+//!
+//! Provides the same API as libxdo-sys but loads libxdo at runtime,
+//! allowing the program to run on systems without libxdo installed
+//! (e.g., Wayland-only environments).
+
+use hbb_common::{
+    libc::{c_char, c_int, c_uint},
+    libloading::{Library, Symbol},
+    log,
+};
+use std::sync::OnceLock;
+
+pub use hbb_common::x11::xlib::{Display, Screen, Window};
+
+#[repr(C)]
+pub struct xdo_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct charcodemap_t {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub struct xdo_search_t {
+    _private: [u8; 0],
+}
+
+pub type useconds_t = c_uint;
+
+pub const CURRENTWINDOW: Window = 0;
+
+type FnXdoNew = unsafe extern "C" fn(*const c_char) -> *mut xdo_t;
+type FnXdoNewWithOpenedDisplay =
+    unsafe extern "C" fn(*mut Display, *const c_char, c_int) -> *mut xdo_t;
+type FnXdoFree = unsafe extern "C" fn(*mut xdo_t);
+type FnXdoSendKeysequenceWindow =
+    unsafe extern "C" fn(*const xdo_t, Window, *const c_char, useconds_t) -> c_int;
+type FnXdoSendKeysequenceWindowDown =
+    unsafe extern "C" fn(*const xdo_t, Window, *const c_char, useconds_t) -> c_int;
+type FnXdoSendKeysequenceWindowUp =
+    unsafe extern "C" fn(*const xdo_t, Window, *const c_char, useconds_t) -> c_int;
+type FnXdoEnterTextWindow =
+    unsafe extern "C" fn(*const xdo_t, Window, *const c_char, useconds_t) -> c_int;
+type FnXdoClickWindow = unsafe extern "C" fn(*const xdo_t, Window, c_int) -> c_int;
+type FnXdoMouseDown = unsafe extern "C" fn(*const xdo_t, Window, c_int) -> c_int;
+type FnXdoMouseUp = unsafe extern "C" fn(*const xdo_t, Window, c_int) -> c_int;
+type FnXdoMoveMouse = unsafe extern "C" fn(*const xdo_t, c_int, c_int, c_int) -> c_int;
+type FnXdoMoveMouseRelative = unsafe extern "C" fn(*const xdo_t, c_int, c_int) -> c_int;
+type FnXdoMoveMouseRelativeToWindow =
+    unsafe extern "C" fn(*const xdo_t, Window, c_int, c_int) -> c_int;
+type FnXdoGetMouseLocation =
+    unsafe extern "C" fn(*const xdo_t, *mut c_int, *mut c_int, *mut c_int) -> c_int;
+type FnXdoGetMouseLocation2 =
+    unsafe extern "C" fn(*const xdo_t, *mut c_int, *mut c_int, *mut c_int, *mut Window) -> c_int;
+type FnXdoGetActiveWindow = unsafe extern "C" fn(*const xdo_t, *mut Window) -> c_int;
+type FnXdoGetFocusedWindow = unsafe extern "C" fn(*const xdo_t, *mut Window) -> c_int;
+type FnXdoGetFocusedWindowSane = unsafe extern "C" fn(*const xdo_t, *mut Window) -> c_int;
+type FnXdoGetWindowLocation =
+    unsafe extern "C" fn(*const xdo_t, Window, *mut c_int, *mut c_int, *mut *mut Screen) -> c_int;
+type FnXdoGetWindowSize =
+    unsafe extern "C" fn(*const xdo_t, Window, *mut c_uint, *mut c_uint) -> c_int;
+type FnXdoGetInputState = unsafe extern "C" fn(*const xdo_t) -> c_uint;
+type FnXdoActivateWindow = unsafe extern "C" fn(*const xdo_t, Window) -> c_int;
+type FnXdoWaitForMouseMoveFrom = unsafe extern "C" fn(*const xdo_t, c_int, c_int) -> c_int;
+type FnXdoWaitForMouseMoveTo = unsafe extern "C" fn(*const xdo_t, c_int, c_int) -> c_int;
+type FnXdoSetWindowClass =
+    unsafe extern "C" fn(*const xdo_t, Window, *const c_char, *const c_char) -> c_int;
+type FnXdoSearchWindows =
+    unsafe extern "C" fn(*const xdo_t, *const xdo_search_t, *mut *mut Window, *mut c_uint) -> c_int;
+
+struct XdoLib {
+    _lib: Library,
+    xdo_new: FnXdoNew,
+    xdo_new_with_opened_display: Option<FnXdoNewWithOpenedDisplay>,
+    xdo_free: FnXdoFree,
+    xdo_send_keysequence_window: FnXdoSendKeysequenceWindow,
+    xdo_send_keysequence_window_down: Option<FnXdoSendKeysequenceWindowDown>,
+    xdo_send_keysequence_window_up: Option<FnXdoSendKeysequenceWindowUp>,
+    xdo_enter_text_window: Option<FnXdoEnterTextWindow>,
+    xdo_click_window: Option<FnXdoClickWindow>,
+    xdo_mouse_down: Option<FnXdoMouseDown>,
+    xdo_mouse_up: Option<FnXdoMouseUp>,
+    xdo_move_mouse: Option<FnXdoMoveMouse>,
+    xdo_move_mouse_relative: Option<FnXdoMoveMouseRelative>,
+    xdo_move_mouse_relative_to_window: Option<FnXdoMoveMouseRelativeToWindow>,
+    xdo_get_mouse_location: Option<FnXdoGetMouseLocation>,
+    xdo_get_mouse_location2: Option<FnXdoGetMouseLocation2>,
+    xdo_get_active_window: Option<FnXdoGetActiveWindow>,
+    xdo_get_focused_window: Option<FnXdoGetFocusedWindow>,
+    xdo_get_focused_window_sane: Option<FnXdoGetFocusedWindowSane>,
+    xdo_get_window_location: Option<FnXdoGetWindowLocation>,
+    xdo_get_window_size: Option<FnXdoGetWindowSize>,
+    xdo_get_input_state: Option<FnXdoGetInputState>,
+    xdo_activate_window: Option<FnXdoActivateWindow>,
+    xdo_wait_for_mouse_move_from: Option<FnXdoWaitForMouseMoveFrom>,
+    xdo_wait_for_mouse_move_to: Option<FnXdoWaitForMouseMoveTo>,
+    xdo_set_window_class: Option<FnXdoSetWindowClass>,
+    xdo_search_windows: Option<FnXdoSearchWindows>,
+}
+
+impl XdoLib {
+    fn load() -> Option<Self> {
+        // https://github.com/rustdesk/rustdesk/issues/13711
+        const LIB_NAMES: [&str; 3] = ["libxdo.so.4", "libxdo.so.3", "libxdo.so"];
+
+        unsafe {
+            let (lib, lib_name) = LIB_NAMES
+                .iter()
+                .find_map(|name| Library::new(name).ok().map(|lib| (lib, *name)))?;
+
+            log::info!("libxdo-sys Loaded {}", lib_name);
+
+            let xdo_new: FnXdoNew = *lib.get(b"xdo_new").ok()?;
+            let xdo_free: FnXdoFree = *lib.get(b"xdo_free").ok()?;
+            let xdo_send_keysequence_window: FnXdoSendKeysequenceWindow =
+                *lib.get(b"xdo_send_keysequence_window").ok()?;
+
+            let xdo_new_with_opened_display = lib
+                .get(b"xdo_new_with_opened_display")
+                .ok()
+                .map(|s: Symbol<FnXdoNewWithOpenedDisplay>| *s);
+            let xdo_send_keysequence_window_down = lib
+                .get(b"xdo_send_keysequence_window_down")
+                .ok()
+                .map(|s: Symbol<FnXdoSendKeysequenceWindowDown>| *s);
+            let xdo_send_keysequence_window_up = lib
+                .get(b"xdo_send_keysequence_window_up")
+                .ok()
+                .map(|s: Symbol<FnXdoSendKeysequenceWindowUp>| *s);
+            let xdo_enter_text_window = lib
+                .get(b"xdo_enter_text_window")
+                .ok()
+                .map(|s: Symbol<FnXdoEnterTextWindow>| *s);
+            let xdo_click_window = lib
+                .get(b"xdo_click_window")
+                .ok()
+                .map(|s: Symbol<FnXdoClickWindow>| *s);
+            let xdo_mouse_down = lib
+                .get(b"xdo_mouse_down")
+                .ok()
+                .map(|s: Symbol<FnXdoMouseDown>| *s);
+            let xdo_mouse_up = lib
+                .get(b"xdo_mouse_up")
+                .ok()
+                .map(|s: Symbol<FnXdoMouseUp>| *s);
+            let xdo_move_mouse = lib
+                .get(b"xdo_move_mouse")
+                .ok()
+                .map(|s: Symbol<FnXdoMoveMouse>| *s);
+            let xdo_move_mouse_relative = lib
+                .get(b"xdo_move_mouse_relative")
+                .ok()
+                .map(|s: Symbol<FnXdoMoveMouseRelative>| *s);
+            let xdo_move_mouse_relative_to_window = lib
+                .get(b"xdo_move_mouse_relative_to_window")
+                .ok()
+                .map(|s: Symbol<FnXdoMoveMouseRelativeToWindow>| *s);
+            let xdo_get_mouse_location = lib
+                .get(b"xdo_get_mouse_location")
+                .ok()
+                .map(|s: Symbol<FnXdoGetMouseLocation>| *s);
+            let xdo_get_mouse_location2 = lib
+                .get(b"xdo_get_mouse_location2")
+                .ok()
+                .map(|s: Symbol<FnXdoGetMouseLocation2>| *s);
+            let xdo_get_active_window = lib
+                .get(b"xdo_get_active_window")
+                .ok()
+                .map(|s: Symbol<FnXdoGetActiveWindow>| *s);
+            let xdo_get_focused_window = lib
+                .get(b"xdo_get_focused_window")
+                .ok()
+                .map(|s: Symbol<FnXdoGetFocusedWindow>| *s);
+            let xdo_get_focused_window_sane = lib
+                .get(b"xdo_get_focused_window_sane")
+                .ok()
+                .map(|s: Symbol<FnXdoGetFocusedWindowSane>| *s);
+            let xdo_get_window_location = lib
+                .get(b"xdo_get_window_location")
+                .ok()
+                .map(|s: Symbol<FnXdoGetWindowLocation>| *s);
+            let xdo_get_window_size = lib
+                .get(b"xdo_get_window_size")
+                .ok()
+                .map(|s: Symbol<FnXdoGetWindowSize>| *s);
+            let xdo_get_input_state = lib
+                .get(b"xdo_get_input_state")
+                .ok()
+                .map(|s: Symbol<FnXdoGetInputState>| *s);
+            let xdo_activate_window = lib
+                .get(b"xdo_activate_window")
+                .ok()
+                .map(|s: Symbol<FnXdoActivateWindow>| *s);
+            let xdo_wait_for_mouse_move_from = lib
+                .get(b"xdo_wait_for_mouse_move_from")
+                .ok()
+                .map(|s: Symbol<FnXdoWaitForMouseMoveFrom>| *s);
+            let xdo_wait_for_mouse_move_to = lib
+                .get(b"xdo_wait_for_mouse_move_to")
+                .ok()
+                .map(|s: Symbol<FnXdoWaitForMouseMoveTo>| *s);
+            let xdo_set_window_class = lib
+                .get(b"xdo_set_window_class")
+                .ok()
+                .map(|s: Symbol<FnXdoSetWindowClass>| *s);
+            let xdo_search_windows = lib
+                .get(b"xdo_search_windows")
+                .ok()
+                .map(|s: Symbol<FnXdoSearchWindows>| *s);
+
+            Some(Self {
+                _lib: lib,
+                xdo_new,
+                xdo_new_with_opened_display,
+                xdo_free,
+                xdo_send_keysequence_window,
+                xdo_send_keysequence_window_down,
+                xdo_send_keysequence_window_up,
+                xdo_enter_text_window,
+                xdo_click_window,
+                xdo_mouse_down,
+                xdo_mouse_up,
+                xdo_move_mouse,
+                xdo_move_mouse_relative,
+                xdo_move_mouse_relative_to_window,
+                xdo_get_mouse_location,
+                xdo_get_mouse_location2,
+                xdo_get_active_window,
+                xdo_get_focused_window,
+                xdo_get_focused_window_sane,
+                xdo_get_window_location,
+                xdo_get_window_size,
+                xdo_get_input_state,
+                xdo_activate_window,
+                xdo_wait_for_mouse_move_from,
+                xdo_wait_for_mouse_move_to,
+                xdo_set_window_class,
+                xdo_search_windows,
+            })
+        }
+    }
+}
+
+static XDO_LIB: OnceLock<Option<XdoLib>> = OnceLock::new();
+
+fn get_lib() -> Option<&'static XdoLib> {
+    XDO_LIB
+        .get_or_init(|| {
+            let lib = XdoLib::load();
+            if lib.is_none() {
+                log::info!("libxdo-sys libxdo not found, xdo functions will be disabled");
+            }
+            lib
+        })
+        .as_ref()
+}
+
+pub unsafe extern "C" fn xdo_new(display: *const c_char) -> *mut xdo_t {
+    get_lib().map_or(std::ptr::null_mut(), |lib| (lib.xdo_new)(display))
+}
+
+pub unsafe extern "C" fn xdo_new_with_opened_display(
+    xdpy: *mut Display,
+    display: *const c_char,
+    close_display_when_freed: c_int,
+) -> *mut xdo_t {
+    get_lib()
+        .and_then(|lib| lib.xdo_new_with_opened_display)
+        .map_or(std::ptr::null_mut(), |f| {
+            f(xdpy, display, close_display_when_freed)
+        })
+}
+
+pub unsafe extern "C" fn xdo_free(xdo: *mut xdo_t) {
+    if xdo.is_null() {
+        return;
+    }
+    if let Some(lib) = get_lib() {
+        (lib.xdo_free)(xdo);
+    }
+}
+
+pub unsafe extern "C" fn xdo_send_keysequence_window(
+    xdo: *const xdo_t,
+    window: Window,
+    keysequence: *const c_char,
+    delay: useconds_t,
+) -> c_int {
+    get_lib().map_or(1, |lib| {
+        (lib.xdo_send_keysequence_window)(xdo, window, keysequence, delay)
+    })
+}
+
+pub unsafe extern "C" fn xdo_send_keysequence_window_down(
+    xdo: *const xdo_t,
+    window: Window,
+    keysequence: *const c_char,
+    delay: useconds_t,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_send_keysequence_window_down)
+        .map_or(1, |f| f(xdo, window, keysequence, delay))
+}
+
+pub unsafe extern "C" fn xdo_send_keysequence_window_up(
+    xdo: *const xdo_t,
+    window: Window,
+    keysequence: *const c_char,
+    delay: useconds_t,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_send_keysequence_window_up)
+        .map_or(1, |f| f(xdo, window, keysequence, delay))
+}
+
+pub unsafe extern "C" fn xdo_enter_text_window(
+    xdo: *const xdo_t,
+    window: Window,
+    string: *const c_char,
+    delay: useconds_t,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_enter_text_window)
+        .map_or(1, |f| f(xdo, window, string, delay))
+}
+
+pub unsafe extern "C" fn xdo_click_window(
+    xdo: *const xdo_t,
+    window: Window,
+    button: c_int,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_click_window)
+        .map_or(1, |f| f(xdo, window, button))
+}
+
+pub unsafe extern "C" fn xdo_mouse_down(xdo: *const xdo_t, window: Window, button: c_int) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_mouse_down)
+        .map_or(1, |f| f(xdo, window, button))
+}
+
+pub unsafe extern "C" fn xdo_mouse_up(xdo: *const xdo_t, window: Window, button: c_int) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_mouse_up)
+        .map_or(1, |f| f(xdo, window, button))
+}
+
+pub unsafe extern "C" fn xdo_move_mouse(
+    xdo: *const xdo_t,
+    x: c_int,
+    y: c_int,
+    screen: c_int,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_move_mouse)
+        .map_or(1, |f| f(xdo, x, y, screen))
+}
+
+pub unsafe extern "C" fn xdo_move_mouse_relative(xdo: *const xdo_t, x: c_int, y: c_int) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_move_mouse_relative)
+        .map_or(1, |f| f(xdo, x, y))
+}
+
+pub unsafe extern "C" fn xdo_move_mouse_relative_to_window(
+    xdo: *const xdo_t,
+    window: Window,
+    x: c_int,
+    y: c_int,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_move_mouse_relative_to_window)
+        .map_or(1, |f| f(xdo, window, x, y))
+}
+
+pub unsafe extern "C" fn xdo_get_mouse_location(
+    xdo: *const xdo_t,
+    x: *mut c_int,
+    y: *mut c_int,
+    screen_num: *mut c_int,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_get_mouse_location)
+        .map_or(1, |f| f(xdo, x, y, screen_num))
+}
+
+pub unsafe extern "C" fn xdo_get_mouse_location2(
+    xdo: *const xdo_t,
+    x: *mut c_int,
+    y: *mut c_int,
+    screen_num: *mut c_int,
+    window: *mut Window,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_get_mouse_location2)
+        .map_or(1, |f| f(xdo, x, y, screen_num, window))
+}
+
+pub unsafe extern "C" fn xdo_get_active_window(
+    xdo: *const xdo_t,
+    window_ret: *mut Window,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_get_active_window)
+        .map_or(1, |f| f(xdo, window_ret))
+}
+
+pub unsafe extern "C" fn xdo_get_focused_window(
+    xdo: *const xdo_t,
+    window_ret: *mut Window,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_get_focused_window)
+        .map_or(1, |f| f(xdo, window_ret))
+}
+
+pub unsafe extern "C" fn xdo_get_focused_window_sane(
+    xdo: *const xdo_t,
+    window_ret: *mut Window,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_get_focused_window_sane)
+        .map_or(1, |f| f(xdo, window_ret))
+}
+
+pub unsafe extern "C" fn xdo_get_window_location(
+    xdo: *const xdo_t,
+    window: Window,
+    x: *mut c_int,
+    y: *mut c_int,
+    screen_ret: *mut *mut Screen,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_get_window_location)
+        .map_or(1, |f| f(xdo, window, x, y, screen_ret))
+}
+
+pub unsafe extern "C" fn xdo_get_window_size(
+    xdo: *const xdo_t,
+    window: Window,
+    width: *mut c_uint,
+    height: *mut c_uint,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_get_window_size)
+        .map_or(1, |f| f(xdo, window, width, height))
+}
+
+pub unsafe extern "C" fn xdo_get_input_state(xdo: *const xdo_t) -> c_uint {
+    get_lib()
+        .and_then(|lib| lib.xdo_get_input_state)
+        .map_or(0, |f| f(xdo))
+}
+
+pub unsafe extern "C" fn xdo_activate_window(xdo: *const xdo_t, wid: Window) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_activate_window)
+        .map_or(1, |f| f(xdo, wid))
+}
+
+pub unsafe extern "C" fn xdo_wait_for_mouse_move_from(
+    xdo: *const xdo_t,
+    origin_x: c_int,
+    origin_y: c_int,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_wait_for_mouse_move_from)
+        .map_or(1, |f| f(xdo, origin_x, origin_y))
+}
+
+pub unsafe extern "C" fn xdo_wait_for_mouse_move_to(
+    xdo: *const xdo_t,
+    dest_x: c_int,
+    dest_y: c_int,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_wait_for_mouse_move_to)
+        .map_or(1, |f| f(xdo, dest_x, dest_y))
+}
+
+pub unsafe extern "C" fn xdo_set_window_class(
+    xdo: *const xdo_t,
+    wid: Window,
+    name: *const c_char,
+    class: *const c_char,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_set_window_class)
+        .map_or(1, |f| f(xdo, wid, name, class))
+}
+
+pub unsafe extern "C" fn xdo_search_windows(
+    xdo: *const xdo_t,
+    search: *const xdo_search_t,
+    windowlist_ret: *mut *mut Window,
+    nwindows_ret: *mut c_uint,
+) -> c_int {
+    get_lib()
+        .and_then(|lib| lib.xdo_search_windows)
+        .map_or(1, |f| f(xdo, search, windowlist_ret, nwindows_ret))
+}

--- a/res/rpm-flutter-suse.spec
+++ b/res/rpm-flutter-suse.spec
@@ -5,8 +5,8 @@ Summary:    RPM package
 License:    GPL-3.0
 URL:        https://rustdesk.com
 Vendor:     rustdesk <info@rustdesk.com>
-Requires:   gtk3 libxcb1 xdotool libXfixes3 alsa-utils libXtst6 libva2 pam gstreamer-plugins-base gstreamer-plugin-pipewire
-Recommends: libayatana-appindicator3-1
+Requires:   gtk3 libxcb1 libXfixes3 alsa-utils libXtst6 libva2 pam gstreamer-plugins-base gstreamer-plugin-pipewire
+Recommends: libayatana-appindicator3-1 xdotool
 Provides:   libdesktop_drop_plugin.so()(64bit), libdesktop_multi_window_plugin.so()(64bit), libfile_selector_linux_plugin.so()(64bit), libflutter_custom_cursor_plugin.so()(64bit), libflutter_linux_gtk.so()(64bit), libscreen_retriever_plugin.so()(64bit), libtray_manager_plugin.so()(64bit), liburl_launcher_linux_plugin.so()(64bit), libwindow_manager_plugin.so()(64bit), libwindow_size_plugin.so()(64bit), libtexture_rgba_renderer_plugin.so()(64bit)
 
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/

--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -5,8 +5,8 @@ Summary:    RPM package
 License:    GPL-3.0
 URL:        https://rustdesk.com
 Vendor:     rustdesk <info@rustdesk.com>
-Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libva pam gstreamer1-plugins-base
-Recommends: libayatana-appindicator-gtk3
+Requires:   gtk3 libxcb libXfixes alsa-lib libva pam gstreamer1-plugins-base
+Recommends: libayatana-appindicator-gtk3 libxdo
 Provides:   libdesktop_drop_plugin.so()(64bit), libdesktop_multi_window_plugin.so()(64bit), libfile_selector_linux_plugin.so()(64bit), libflutter_custom_cursor_plugin.so()(64bit), libflutter_linux_gtk.so()(64bit), libscreen_retriever_plugin.so()(64bit), libtray_manager_plugin.so()(64bit), liburl_launcher_linux_plugin.so()(64bit), libwindow_manager_plugin.so()(64bit), libwindow_size_plugin.so()(64bit), libtexture_rgba_renderer_plugin.so()(64bit)
 
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/

--- a/res/rpm-suse.spec
+++ b/res/rpm-suse.spec
@@ -3,8 +3,8 @@ Version:    1.1.9
 Release:    0
 Summary:    RPM package
 License:    GPL-3.0
-Requires:   gtk3 libxcb1 xdotool libXfixes3 alsa-utils libXtst6 libva2 pam gstreamer-plugins-base gstreamer-plugin-pipewire
-Recommends: libayatana-appindicator3-1
+Requires:   gtk3 libxcb1 libXfixes3 alsa-utils libXtst6 libva2 pam gstreamer-plugins-base gstreamer-plugin-pipewire
+Recommends: libayatana-appindicator3-1 xdotool
 
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/
 

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -5,8 +5,8 @@ Summary:    RPM package
 License:    GPL-3.0
 URL:        https://rustdesk.com
 Vendor:     rustdesk <info@rustdesk.com>
-Requires:   gtk3 libxcb libxdo libXfixes alsa-lib libva2 pam gstreamer1-plugins-base
-Recommends: libayatana-appindicator-gtk3
+Requires:   gtk3 libxcb libXfixes alsa-lib libva2 pam gstreamer1-plugins-base
+Recommends: libayatana-appindicator-gtk3 libxdo
 
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/
 


### PR DESCRIPTION
Try to fix 

https://github.com/rustdesk/rustdesk/issues/13711
https://github.com/rustdesk/rustdesk/issues/13859
https://github.com/rustdesk/rustdesk/issues/13873

# REAYD for test in nightly build https://github.com/rustdesk/rustdesk/releases/tag/nightly


https://github.com/rustdesk/hbb_common/pull/483 needs to be merged first.


## Desc

### Issues

`openSUSE Tumbleweed` provides `libxdo.so.4`.
`Rocky Linux 10.1` does not provide `xdotools` anymore.

`libxdo` is required by `libs/enigo` and `tray-icon` -> `muda` -> `libxdo-sys`.

### Fix

1. Replace `libxdo` and `libxdo-sys`

We have to create a `[patch.crates-io]` (`libxdo-sys`) to replace the `libxdo`.

`libxdo-sys` dynamically loads the so files.

`libxdo-sys` provides an empty implementation for the OS that does not provide `libxdo`.

2. Only `rpm*.spec` files are changed. `xdotool` is moved from `Requires` to `Recommends`.

The `.deb` and `.pkg.tar.zst` are not changed.

`zypper` and `dnf` will install the `Recommends` by default.

`pacman` does not install the `optdepends`, so `PKGBUILD` is not changed.

`dpkg -i` + `apt install -f` does not install the `Recommends`, so `build.py` is not changed.
Thought `apt install rustdesk.deb` installs the `Recommends`, it also throws a notice as follows.
> N: Download is performed unsandboxed as root as file '/home/username/rustdesk-1.4.5-x86_64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)

## Tests

- [x] Fedora 42, KDE
- [x] openSUSE Leap 15.6, openSUSE  Tumbleweed 260113
- [x] Ubuntu 24.04 (with and without `libxdo3`)
- [x] Archlinux 
- [ ] Rocky Linux 10.1. This OS requires a newer CPU

<img width="1200" alt="db8a63882eb35ef6de3a2d72d5c0d066" src="https://github.com/user-attachments/assets/47e81f87-140f-41ed-a033-86991533d0f6" />



