### PR TITLE
auto retry on offline when controlled peer's account changes

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -120,6 +120,7 @@ class FfiModel with ChangeNotifier {
   late VirtualMouseMode virtualMouseMode;
   Timer? _timer;
   var _reconnects = 1;
+  DateTime? _offlineReconnectStartTime;
   bool _viewOnly = false;
   bool _showMyCursor = false;
   WeakReference<FFI> parent;
@@ -783,7 +784,8 @@ class FfiModel with ChangeNotifier {
     }
   }
 
-  Future<void> updateCurDisplay(SessionID sessionId, {updateCursorPos = false}) async {
+  Future<void> updateCurDisplay(SessionID sessionId,
+      {updateCursorPos = false}) async {
     final newRect = displaysRect();
     if (newRect == null) {
       return;
@@ -939,9 +941,44 @@ class FfiModel with ChangeNotifier {
       showPrivacyFailedDialog(
           sessionId, type, title, text, link, hasRetry, dialogManager);
     } else {
-      final hasRetry = evt['hasRetry'] == 'true';
+      var hasRetry = evt['hasRetry'] == 'true';
+      if (!hasRetry) {
+        hasRetry = shouldAutoRetryOnOffline(type, title, text);
+      }
       showMsgBox(sessionId, type, title, text, link, hasRetry, dialogManager);
     }
+  }
+
+  /// Auto-retry check for "Remote desktop is offline" error.
+  /// returns true to auto-retry, false otherwise.
+  bool shouldAutoRetryOnOffline(
+    String type,
+    String title,
+    String text,
+  ) {
+    if (type == 'error' &&
+        title == 'Connection Error' &&
+        text == 'Remote desktop is offline' &&
+        _pi.isSet.isTrue) {
+      // Auto retry for ~30s (server's peer offline threshold) when controlled peer's account changes
+      // (e.g., signout, switch user, login into OS) causes temporary offline via websocket/tcp connection.
+      // The actual wait may exceed 30s (e.g., 20s elapsed + 16s next retry = 36s), which is acceptable
+      // since the controlled side reconnects quickly after account changes.
+      // Uses time-based check instead of _reconnects count because user can manually retry.
+      // https://github.com/rustdesk/rustdesk/discussions/14048
+      if (_offlineReconnectStartTime == null) {
+        // First offline, record time and start retry
+        _offlineReconnectStartTime = DateTime.now();
+        return true;
+      } else {
+        final elapsed =
+            DateTime.now().difference(_offlineReconnectStartTime!).inSeconds;
+        if (elapsed < 30) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   handleToast(Map<String, dynamic> evt, SessionID sessionId, String peerId) {
@@ -1001,6 +1038,7 @@ class FfiModel with ChangeNotifier {
       _reconnects *= 2;
     } else {
       _reconnects = 1;
+      _offlineReconnectStartTime = null;
     }
   }
 
@@ -1323,6 +1361,7 @@ class FfiModel with ChangeNotifier {
       }
       if (displays.isNotEmpty) {
         _reconnects = 1;
+        _offlineReconnectStartTime = null;
         waitForFirstImage.value = true;
         isRefreshing = false;
       }


### PR DESCRIPTION
Fix https://github.com/rustdesk/rustdesk/discussions/14048

When the controlled peer connects to the server via websocket/tcp, account changes (signout, switch user, login into OS) cause temporary disconnection, resulting in "Remote desktop is offline" error on the controller side.

This PR adds auto retry for ~30s (matches server's peer offline threshold) when the peer was previously connected, instead of immediately showing the error dialog.

# Test

- Controlled peer is offline from the start: shows offline error immediately (no retry)
- During a single connection, each account change—after the previous one succeeds—calculates its own retry time.
- Added different delays for the controlled peer when connecting to the server and tested with tcp/ws/udp connections: results as expected.

# Video

https://github.com/user-attachments/assets/7bb44b26-cd0e-4d1d-a2ee-4bbcdb56eaf8


https://github.com/user-attachments/assets/82bf8014-be35-4361-8036-3e77e849af46

https://github.com/user-attachments/assets/420eb25d-8e58-4eb5-8134-3a61acc0e9c4


https://github.com/user-attachments/assets/7bcfa214-a9b9-4631-a11c-3873486babf8


