### PR TITLE
fix(iOS): Unexpected mouse movement to (0,0) on idle

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -1048,6 +1048,14 @@ class InputModel {
     if (isViewOnly && !showMyCursor) return;
     if (e.kind != ui.PointerDeviceKind.mouse) return;
 
+    // May fix https://github.com/rustdesk/rustdesk/issues/13009
+    if (isIOS && e.synthesized && e.position == Offset.zero && e.buttons == 0) {
+      // iOS may emit a synthesized hover event at (0,0) when the mouse is disconnected.
+      // Ignore this event to prevent cursor jumping.
+      debugPrint('Ignored synthesized hover at (0,0) on iOS');
+      return;
+    }
+
     // Only update pointer region when relative mouse mode is enabled.
     // This avoids unnecessary tracking when not in relative mode.
     if (_relativeMouse.enabled.value) {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/13009

## Desc

I can reproduce this issue by changing 

https://github.com/rustdesk/rustdesk/blob/c76d10a438f64fac521749690d520c5260e23b1b/flutter/lib/models/input_model.dart#L1707

to 

```dart
return Position(0, 0);
```

Though I can't reproduce this issue directly, I believe it's caused by Flutter synthesizing a mouse hover event.
