### PR TITLE
Fix some single device multiple ids scenarios on MacOS

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -82,6 +82,10 @@ type ConnMap = HashMap<i32, ConnInner>;
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 const CONFIG_SYNC_INTERVAL_SECS: f32 = 0.3;
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+// 3s is enough for at least one initial sync attempt:
+// 0.3s backoff + up to 1s connect timeout + up to 1s response timeout.
+const CONFIG_SYNC_INITIAL_WAIT_SECS: u64 = 3;
 
 lazy_static::lazy_static! {
     pub static ref CHILD_PROCESS: Childs = Default::default();
@@ -600,7 +604,7 @@ pub async fn start_server(is_server: bool, no_server: bool) {
             allow_err!(input_service::setup_uinput(0, 1920, 0, 1080).await);
         }
         #[cfg(any(target_os = "macos", target_os = "linux"))]
-        tokio::spawn(async { sync_and_watch_config_dir().await });
+        wait_initial_config_sync().await;
         #[cfg(target_os = "windows")]
         crate::platform::try_kill_broker();
         #[cfg(feature = "hwcodec")]
@@ -685,14 +689,43 @@ pub async fn start_ipc_url_server() {
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-async fn sync_and_watch_config_dir() {
+async fn wait_initial_config_sync() {
     if crate::platform::is_root() {
         return;
     }
 
+    // Non-server process should not block startup, but still keeps background sync/watch alive.
+    if !crate::is_server() {
+        tokio::spawn(async move {
+            sync_and_watch_config_dir(None).await;
+        });
+        return;
+    }
+
+    let (sync_done_tx, mut sync_done_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        sync_and_watch_config_dir(Some(sync_done_tx)).await;
+    });
+
+    // Server process waits up to N seconds for initial root->local sync to reduce stale-start window.
+    tokio::select! {
+        _ = &mut sync_done_rx => {
+        }
+        _ = tokio::time::sleep(Duration::from_secs(CONFIG_SYNC_INITIAL_WAIT_SECS)) => {
+            log::warn!(
+                "timed out waiting {}s for initial config sync, continue startup and keep syncing in background",
+                CONFIG_SYNC_INITIAL_WAIT_SECS
+            );
+        }
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+async fn sync_and_watch_config_dir(sync_done_tx: Option<tokio::sync::oneshot::Sender<()>>) {
     let mut cfg0 = (Config::get(), Config2::get());
     let mut synced = false;
     let mut is_root_config_empty = false;
+    let mut sync_done_tx = sync_done_tx;
     let tries = if crate::is_server() { 30 } else { 3 };
     log::debug!("#tries of ipc service connection: {}", tries);
     use hbb_common::sleep;
@@ -707,6 +740,8 @@ async fn sync_and_watch_config_dir() {
                                 Data::SyncConfig(Some(configs)) => {
                                     let (config, config2) = *configs;
                                     let _chk = crate::ipc::CheckIfRestart::new();
+                                    #[cfg(target_os = "macos")]
+                                    let _chk_pk = crate::CheckIfResendPk::new();
                                     if !config.is_empty() {
                                         if cfg0.0 != config {
                                             cfg0.0 = config.clone();
@@ -728,6 +763,10 @@ async fn sync_and_watch_config_dir() {
                                         }
                                     }
                                     synced = true;
+                                    // Notify startup waiter once initial sync phase finishes successfully.
+                                    if let Some(tx) = sync_done_tx.take() {
+                                        let _ = tx.send(());
+                                    }
                                 }
                                 _ => {}
                             };
@@ -770,6 +809,10 @@ async fn sync_and_watch_config_dir() {
                 log::info!("#{} try: failed to connect to ipc_service", i);
             }
         }
+    }
+    // Notify startup waiter even when initial sync is skipped/failed, to avoid unnecessary waiting.
+    if let Some(tx) = sync_done_tx.take() {
+        let _ = tx.send(());
     }
     log::warn!("skipped config sync");
 }


### PR DESCRIPTION
https://github.com/rustdesk/hbb_common/pull/489

## Scenario 1: Config not synced to root user

#### Steps to reproduce (100% reproducible)
* First-time installation or all user configuration are removed.
* User A has a proxy enabled, installs the custom client, but does not change any client settings after installation(At this point, the configuration is not synced to the root user.) -> proxy ip, pk1
* User A logs out, under the root user, configuration is regenerated, proxy software is killed -> real ip, pk2 -> new ID

#### Fix
* When syncing configurations from the root directory, if the config is empty, sync the user configuration to the root directory.

## Scenario 2: Register Pk before config synced

#### Steps to reproduce (change code to reproduce)

* The code is modified to introduce an delay when syncing service configuration to the user directory to simulate cases where the service process starts slower than the server process.
* First-time installation or all user configuration are removed. 
* User A installs the custom client, changes a configuration option to avoiding Scenario 1. -> real ip, pk1
* User A logs out, root user -> real ip, pk1
* User B logs in, A new key pair (PK) is generated and registered before the configuration is synced from the root -> real ip, pk2
* When the root configuration is later synced, in the current version, `KEY_PAIR` is not updated.
* User B enables the proxy -> proxy ip, pk2
* Logout, root user -> real ip, pk1 -> new ID

#### Fix

Wait up to 3s for initial root->local config sync before starting server.

During config sync, we also update the KEY_PAIR. After the sync completes, we check whether the KEY_PAIR has changed; if it has, we re-register.

However, this approach isn’t very generic. Considering there is only a single rendezvous server, another option would be to **compare the current public key with the registered public key in the second timer** on the rendezvous server. I’m not sure whether we should refactor it this way.

<img width="893" height="112" alt="Screenshot 2026-02-14 at 16 41 27" src="https://github.com/user-attachments/assets/b17b9b77-a42f-4d2b-a7be-84e10d11d603" />

<img width="1006" height="86" alt="Screenshot 2026-02-14 at 17 05 14" src="https://github.com/user-attachments/assets/12180ced-0f08-4c5a-8e58-7bf51ce6b626" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout/backoff to initial configuration sync to avoid startup delays on macOS/Linux.
  * Improved detection of public-key changes so key confirmation is reset and re-registration is triggered when keys change.

* **New Features**
  * Coordinated initial sync flow so non-server processes start background syncing without blocking startup.
  * macOS: limited root-sync attempts, clearer logging, and startup signaling to avoid deadlocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->