### PR TITLE
fix(ios): workaround physical keyboard after virtual keyboard hidden

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -68,6 +68,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   double _viewInsetsBottom = 0;
   final _uniqueKey = UniqueKey();
   Timer? _timerDidChangeMetrics;
+  Timer? _iosKeyboardWorkaroundTimer;
 
   final _blockableOverlayState = BlockableOverlayState();
 
@@ -140,6 +141,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     await gFFI.close();
     _timer?.cancel();
     _timerDidChangeMetrics?.cancel();
+    _iosKeyboardWorkaroundTimer?.cancel();
     gFFI.dialogManager.dismissAll();
     await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
         overlays: SystemUiOverlay.values);
@@ -205,6 +207,21 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
       if (gFFI.chatModel.chatWindowOverlayEntry == null &&
           gFFI.ffiModel.pi.version.isNotEmpty) {
         gFFI.invokeMethod("enable_soft_keyboard", false);
+      }
+
+      // Workaround for iOS: physical keyboard input fails after virtual keyboard is hidden
+      // https://github.com/flutter/flutter/issues/39900
+      // https://github.com/rustdesk/rustdesk/discussions/11843#discussioncomment-13499698 - Virtual keyboard issue
+      if (isIOS) {
+        _iosKeyboardWorkaroundTimer?.cancel();
+        _iosKeyboardWorkaroundTimer = Timer(Duration(milliseconds: 100), () {
+          if (!mounted) return;
+          _physicalFocusNode.unfocus();
+          _iosKeyboardWorkaroundTimer = Timer(Duration(milliseconds: 50), () {
+            if (!mounted) return;
+            _physicalFocusNode.requestFocus();
+          });
+        });
       }
     } else {
       _timer?.cancel();


### PR DESCRIPTION
> Virtual keyboard issue:
Activate the RustDesk’s virtual keyboard or mouse control, to use floating shortcut bar for example, then the physical keyboard no longer responds correctly. It no longer writes characters and performs curious actions: for example, pressing the H key brings up the iMac desktop.
Restarting the RustDesk session doesn't change anything, you have to restart the remote iMac directly.

From https://github.com/rustdesk/rustdesk/discussions/11843#discussioncomment-13499698

https://github.com/flutter/flutter/issues/39900

