### PR TITLE
Fix clipboard race condition with speech-to-text paste

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2,7 +2,7 @@ use super::{input_service::*, *};
 #[cfg(feature = "unix-file-copy-paste")]
 use crate::clipboard::try_empty_clipboard_files;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-use crate::clipboard::{update_clipboard, ClipboardSide};
+use crate::clipboard::{update_clipboard_blocking, ClipboardSide};
 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
 use crate::clipboard_file::*;
 #[cfg(target_os = "android")]
@@ -2597,7 +2597,7 @@ impl Connection {
                 Some(message::Union::Clipboard(cb)) => {
                     if self.clipboard {
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                        update_clipboard(vec![cb], ClipboardSide::Host);
+                        update_clipboard_blocking(vec![cb], ClipboardSide::Host).await;
                         // ios as the controlled side is actually not supported for now.
                         // The following code is only used to preserve the logic of handling text clipboard on mobile.
                         #[cfg(target_os = "ios")]
@@ -2625,7 +2625,7 @@ impl Connection {
                 Some(message::Union::MultiClipboards(_mcb)) => {
                     #[cfg(not(any(target_os = "android", target_os = "ios")))]
                     if self.clipboard {
-                        update_clipboard(_mcb.clipboards, ClipboardSide::Host);
+                        update_clipboard_blocking(_mcb.clipboards, ClipboardSide::Host).await;
                     }
                     #[cfg(target_os = "android")]
                     crate::clipboard::handle_msg_multi_clipboards(_mcb);


### PR DESCRIPTION
## Summary

- When a speech-to-text tool (e.g. MacWhisper) updates the clipboard and immediately triggers Cmd+V / Ctrl+V, the paste keystroke can arrive at the server before the clipboard content has been written — pasting stale/empty content
- Root cause: `update_clipboard()` spawns a fire-and-forget background thread, so the server processes the next message (the paste keystroke) before the clipboard write completes
- Fix: add an awaitable `update_clipboard_blocking()` variant using `tokio::task::spawn_blocking`, and use it on the server side so the clipboard write completes before the next message is processed

## Details

The race condition flow:
1. Client clipboard changes → `MultiClipboards` message sent to server
2. Client keystroke (Cmd+V) → `KeyEvent` message sent to server
3. Server receives `MultiClipboards` → spawns background thread to write clipboard → **immediately moves on**
4. Server receives `KeyEvent` (paste) → injects keystroke → OS pastes from clipboard that hasn't been written yet

The fix ensures step 3 completes before step 4 begins, by awaiting the clipboard write on the server's async message loop. The client side remains unchanged (fire-and-forget) since the race only affects the controlled machine.

This is a minimal, ~10-line change touching only two files with no protocol or behavioral changes for normal usage.

## Test plan

- [ ] Verify normal clipboard copy-paste between client and server works unchanged
- [ ] Test with a speech-to-text tool that uses clipboard + paste (e.g. MacWhisper) — text should now arrive correctly on the remote machine
- [ ] Confirm no noticeable latency increase during regular remote desktop usage
- [ ] Test on macOS, Windows, and Linux server targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)