### PR TITLE
fix(mobile): account for safe area padding in canvas size calculation

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2216,23 +2216,20 @@ class CanvasModel with ChangeNotifier {
     double h = size.height - topToEdge - bottomToEdge;
     if (isMobile) {
       // Account for safe area insets
+      w = w - mediaData.padding.left - mediaData.padding.right;
+      h = h -
+          mediaData.viewInsets.bottom -
+          (parent.target?.cursorModel.keyHelpToolsRectToAdjustCanvas?.bottom ??
+              0);
       // Portrait: handle all four directions (top, bottom, left, right)
       // Landscape: only handle left/right (notch on sides), bottom home indicator auto-hides
       final isPortrait = size.height > size.width;
       if (isPortrait) {
-        w = w - mediaData.padding.left - mediaData.padding.right;
-        h = h -
-            mediaData.padding.top -
-            mediaData.padding.bottom -
-            mediaData.viewInsets.bottom -
-            (parent.target?.cursorModel.keyHelpToolsRectToAdjustCanvas?.bottom ??
-                0);
-      } else {
-        w = w - mediaData.padding.left - mediaData.padding.right;
-        h = h -
-            mediaData.viewInsets.bottom -
-            (parent.target?.cursorModel.keyHelpToolsRectToAdjustCanvas?.bottom ??
-                0);
+        // We need to subtract top/bottom padding in portrait mode to avoid
+        // the image being truncated.
+        // With this adjustment https://github.com/user-attachments/assets/30ed4559-c27e-432b-847f-8fec23c9f998
+        // Without this adjustment, the image will be truncated in both portrait and landscape modes when the device has non-zero top/bottom padding (e.g. Samsung devices with hole-punch cameras).
+        h = h - mediaData.padding.top - mediaData.padding.bottom;
       }
     }
     return Size(w < 0 ? 0 : w, h < 0 ? 0 : h);

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2215,14 +2215,25 @@ class CanvasModel with ChangeNotifier {
     double w = size.width - leftToEdge - rightToEdge;
     double h = size.height - topToEdge - bottomToEdge;
     if (isMobile) {
-      // Account for safe area (notch, home indicator)
-      w = w - mediaData.padding.left - mediaData.padding.right;
-      h = h -
-          mediaData.padding.top -
-          mediaData.padding.bottom -
-          mediaData.viewInsets.bottom -
-          (parent.target?.cursorModel.keyHelpToolsRectToAdjustCanvas?.bottom ??
-              0);
+      // Account for safe area insets
+      // Portrait: handle all four directions (top, bottom, left, right)
+      // Landscape: only handle left/right (notch on sides), bottom home indicator auto-hides
+      final isPortrait = size.height > size.width;
+      if (isPortrait) {
+        w = w - mediaData.padding.left - mediaData.padding.right;
+        h = h -
+            mediaData.padding.top -
+            mediaData.padding.bottom -
+            mediaData.viewInsets.bottom -
+            (parent.target?.cursorModel.keyHelpToolsRectToAdjustCanvas?.bottom ??
+                0);
+      } else {
+        w = w - mediaData.padding.left - mediaData.padding.right;
+        h = h -
+            mediaData.viewInsets.bottom -
+            (parent.target?.cursorModel.keyHelpToolsRectToAdjustCanvas?.bottom ??
+                0);
+      }
     }
     return Size(w < 0 ? 0 : w, h < 0 ? 0 : h);
   }

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2215,7 +2215,11 @@ class CanvasModel with ChangeNotifier {
     double w = size.width - leftToEdge - rightToEdge;
     double h = size.height - topToEdge - bottomToEdge;
     if (isMobile) {
+      // Account for safe area (notch, home indicator)
+      w = w - mediaData.padding.left - mediaData.padding.right;
       h = h -
+          mediaData.padding.top -
+          mediaData.padding.bottom -
           mediaData.viewInsets.bottom -
           (parent.target?.cursorModel.keyHelpToolsRectToAdjustCanvas?.bottom ??
               0);

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2215,23 +2215,30 @@ class CanvasModel with ChangeNotifier {
     double w = size.width - leftToEdge - rightToEdge;
     double h = size.height - topToEdge - bottomToEdge;
     if (isMobile) {
-      // Account for safe area insets
+      // Account for horizontal safe area insets on both orientations.
       w = w - mediaData.padding.left - mediaData.padding.right;
+      // Vertically, subtract the bottom keyboard inset (viewInsets.bottom) and any
+      // bottom overlay (e.g. key-help tools) so the canvas is not covered.
       h = h -
           mediaData.viewInsets.bottom -
           (parent.target?.cursorModel.keyHelpToolsRectToAdjustCanvas?.bottom ??
               0);
-      // Portrait: handle all four directions (top, bottom, left, right)
-      // Landscape: only handle left/right (notch on sides), bottom home indicator auto-hides
+      // Orientation-specific handling:
+      //  - Portrait: additionally subtract top padding (e.g. status bar / notch)
+      //  - Landscape: does not subtract mediaData.padding.top/bottom (home indicator auto-hides)
       final isPortrait = size.height > size.width;
       if (isPortrait) {
-        // We need to subtract top/bottom padding in portrait mode to avoid the image being truncated.
-        // top - 59.0, bottom - 34.0 on iOS 15
+        // In portrait mode, subtract the top safe-area padding (e.g. status bar / notch)
+        // so the remote image is not truncated, while keeping the bottom inset to avoid
+        // introducing unnecessary blank space around the canvas.
         //
-        // iOS -> Android, potrait, adjust mode.
-        // h = h https://github.com/user-attachments/assets/30ed4559-c27e-432b-847f-8fec23c9f998 top and bottom are truncated
-        // h = h - top - bottom https://github.com/user-attachments/assets/12a98817-3b4e-43aa-be0f-4b03cf364b7e there are extra blank spaces
-        // h = h - top - https://github.com/user-attachments/assets/95f047f2-7f47-4a36-8113-5023989a0c81 works fine
+        // iOS -> Android, portrait, adjust mode:
+        // h = h (no padding subtracted): top and bottom are truncated
+        //   https://github.com/user-attachments/assets/30ed4559-c27e-432b-847f-8fec23c9f998
+        // h = h - top - bottom: extra blank spaces appear
+        //   https://github.com/user-attachments/assets/12a98817-3b4e-43aa-be0f-4b03cf364b7e
+        // h = h - top (current): works fine
+        //   https://github.com/user-attachments/assets/95f047f2-7f47-4a36-8113-5023989a0c81
         h = h - mediaData.padding.top;
       }
     }

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2225,11 +2225,14 @@ class CanvasModel with ChangeNotifier {
       // Landscape: only handle left/right (notch on sides), bottom home indicator auto-hides
       final isPortrait = size.height > size.width;
       if (isPortrait) {
-        // We need to subtract top/bottom padding in portrait mode to avoid
-        // the image being truncated.
-        // With this adjustment https://github.com/user-attachments/assets/30ed4559-c27e-432b-847f-8fec23c9f998
-        // Without this adjustment, the image will be truncated in both portrait and landscape modes when the device has non-zero top/bottom padding (e.g. Samsung devices with hole-punch cameras).
-        h = h - mediaData.padding.top - mediaData.padding.bottom;
+        // We need to subtract top/bottom padding in portrait mode to avoid the image being truncated.
+        // top - 59.0, bottom - 34.0 on iOS 15
+        //
+        // iOS -> Android, potrait, adjust mode.
+        // h = h https://github.com/user-attachments/assets/30ed4559-c27e-432b-847f-8fec23c9f998 top and bottom are truncated
+        // h = h - top - bottom https://github.com/user-attachments/assets/12a98817-3b4e-43aa-be0f-4b03cf364b7e there are extra blank spaces
+        // h = h - top - https://github.com/user-attachments/assets/95f047f2-7f47-4a36-8113-5023989a0c81 works fine
+        h = h - mediaData.padding.top;
       }
     }
     return Size(w < 0 ? 0 : w, h < 0 ? 0 : h);


### PR DESCRIPTION
On iPhone devices, due to the SafeArea and the notch, the display is not centered in landscape mode but is shifted to the right(bottom).


## Preview 

Before 

<img width="2556" height="1179" alt="image" src="https://github.com/user-attachments/assets/b523aed5-6cb8-41ce-b7f5-3edc3b6ad0fa" />


After

<img width="2556" height="1179" alt="image" src="https://github.com/user-attachments/assets/780f9846-6cee-4020-af52-546ccd2cff94" />


### Adaptive mode - subtract top/bottom padding in portrait mode

Without `h = h - mediaData.padding.top - mediaData.padding.bottom;`

<img width="320" alt="image" src="https://github.com/user-attachments/assets/30ed4559-c27e-432b-847f-8fec23c9f998" />

With `h = h - mediaData.padding.top - mediaData.padding.bottom;`

<img width="320" alt="image" src="https://github.com/user-attachments/assets/12a98817-3b4e-43aa-be0f-4b03cf364b7e" />

With `h =  - mediaData.padding.top`

<img width="320" alt="image" src="https://github.com/user-attachments/assets/95f047f2-7f47-4a36-8113-5023989a0c81" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile canvas sizing corrected to respect device safe areas: left/right insets and top inset in portrait are now applied while prior bottom inset behavior is retained. Clamping prevents negative dimensions and ensures consistent layout across portrait and landscape orientations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->