### PR TITLE
fix(ios): Add defensive timer cancellation for keyboard visibility

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -224,6 +224,8 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
         });
       }
     } else {
+      _iosKeyboardWorkaroundTimer?.cancel();
+      _iosKeyboardWorkaroundTimer = null;
       _timer?.cancel();
       _timer = Timer(kMobileDelaySoftKeyboardFocus, () {
         SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/pull/14207#discussion_r2780333339

No actual race condition exists here, but we can still add defensive code.
