### PR TITLE
Fix/linux shortcuts inhibit

### DIFF
--- a/flatpak/rustdesk.json
+++ b/flatpak/rustdesk.json
@@ -55,6 +55,7 @@
   ],
   "finish-args": [
     "--share=ipc",
+    "--socket=wayland",
     "--socket=x11",
     "--share=network",
     "--filesystem=home",

--- a/flutter/linux/CMakeLists.txt
+++ b/flutter/linux/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.10)
-project(runner LANGUAGES CXX)
+project(runner LANGUAGES C CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
@@ -54,6 +54,55 @@ add_subdirectory(${FLUTTER_MANAGED_DIR})
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
 
+# Wayland protocol for keyboard shortcuts inhibit
+pkg_check_modules(WAYLAND_CLIENT IMPORTED_TARGET wayland-client)
+pkg_check_modules(WAYLAND_PROTOCOLS_PKG QUIET wayland-protocols)
+pkg_check_modules(WAYLAND_SCANNER_PKG QUIET wayland-scanner)
+
+if(WAYLAND_PROTOCOLS_PKG_FOUND)
+  pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
+endif()
+if(WAYLAND_SCANNER_PKG_FOUND)
+  pkg_get_variable(WAYLAND_SCANNER wayland-scanner wayland_scanner)
+endif()
+
+if(WAYLAND_CLIENT_FOUND AND WAYLAND_PROTOCOLS_DIR AND WAYLAND_SCANNER)
+  set(KEYBOARD_SHORTCUTS_INHIBIT_PROTOCOL
+    "${WAYLAND_PROTOCOLS_DIR}/unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml")
+
+  if(EXISTS ${KEYBOARD_SHORTCUTS_INHIBIT_PROTOCOL})
+    set(WAYLAND_GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/wayland-protocols")
+    file(MAKE_DIRECTORY ${WAYLAND_GENERATED_DIR})
+
+    # Generate client header
+    add_custom_command(
+      OUTPUT "${WAYLAND_GENERATED_DIR}/keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
+      COMMAND ${WAYLAND_SCANNER} client-header
+        ${KEYBOARD_SHORTCUTS_INHIBIT_PROTOCOL}
+        "${WAYLAND_GENERATED_DIR}/keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
+      DEPENDS ${KEYBOARD_SHORTCUTS_INHIBIT_PROTOCOL}
+      VERBATIM
+    )
+
+    # Generate protocol code
+    add_custom_command(
+      OUTPUT "${WAYLAND_GENERATED_DIR}/keyboard-shortcuts-inhibit-unstable-v1-protocol.c"
+      COMMAND ${WAYLAND_SCANNER} private-code
+        ${KEYBOARD_SHORTCUTS_INHIBIT_PROTOCOL}
+        "${WAYLAND_GENERATED_DIR}/keyboard-shortcuts-inhibit-unstable-v1-protocol.c"
+      DEPENDS ${KEYBOARD_SHORTCUTS_INHIBIT_PROTOCOL}
+      VERBATIM
+    )
+
+    set(WAYLAND_PROTOCOL_SOURCES
+      "${WAYLAND_GENERATED_DIR}/keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
+      "${WAYLAND_GENERATED_DIR}/keyboard-shortcuts-inhibit-unstable-v1-protocol.c"
+    )
+
+    set(HAS_KEYBOARD_SHORTCUTS_INHIBIT TRUE)
+  endif()
+endif()
+
 add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
 
 # Define the application target. To change its name, change BINARY_NAME above,
@@ -63,9 +112,11 @@ add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
 add_executable(${BINARY_NAME}
   "main.cc"
   "my_application.cc"
+  "wayland_shortcuts_inhibit.cc"
   "bump_mouse.cc"
   "bump_mouse_x11.cc"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+  ${WAYLAND_PROTOCOL_SOURCES}
 )
 
 # Apply the standard set of build settings. This can be removed for applications
@@ -77,6 +128,13 @@ target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
 target_link_libraries(${BINARY_NAME} PRIVATE ${CMAKE_DL_LIBS})
 # target_link_libraries(${BINARY_NAME} PRIVATE librustdesk)
+
+# Wayland support for keyboard shortcuts inhibit
+if(HAS_KEYBOARD_SHORTCUTS_INHIBIT)
+  target_compile_definitions(${BINARY_NAME} PRIVATE HAS_KEYBOARD_SHORTCUTS_INHIBIT)
+  target_include_directories(${BINARY_NAME} PRIVATE ${WAYLAND_GENERATED_DIR})
+  target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::WAYLAND_CLIENT)
+endif()
 
 # Run the Flutter tool portions of the build. This must not be removed.
 add_dependencies(${BINARY_NAME} flutter_assemble)

--- a/flutter/linux/my_application.cc
+++ b/flutter/linux/my_application.cc
@@ -70,6 +70,13 @@ static void my_application_activate(GApplication* application) {
     gtk_window_set_title(window, "rustdesk");
   }
 
+  // Ask the window manager to disable any configured shortcuts so we can capture all input events.
+  GtkNative* native = gtk_widget_get_native(GTK_WIDGET(window));
+  if (native != NULL) {
+    GdkSurface* surface = gtk_native_get_surface(native);
+    gdk_toplevel_inhibit_system_shortcuts(GDK_TOPLEVEL(surface), NULL);
+  }
+
   // auto bdw = bitsdojo_window_from(window); // <--- add this line
   // bdw->setCustomFrame(true);               // <-- add this line
   int width = 800, height = 600;

--- a/flutter/linux/wayland_shortcuts_inhibit.cc
+++ b/flutter/linux/wayland_shortcuts_inhibit.cc
@@ -1,0 +1,244 @@
+// Wayland keyboard shortcuts inhibit implementation
+// Uses the zwp_keyboard_shortcuts_inhibit_manager_v1 protocol to request
+// the compositor to disable system shortcuts for specific windows.
+
+#include "wayland_shortcuts_inhibit.h"
+
+#if defined(GDK_WINDOWING_WAYLAND) && defined(HAS_KEYBOARD_SHORTCUTS_INHIBIT)
+
+#include <cstring>
+#include <gdk/gdkwayland.h>
+#include <wayland-client.h>
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
+
+// Data structure to hold inhibitor state for each window
+typedef struct {
+  struct zwp_keyboard_shortcuts_inhibit_manager_v1* manager;
+  struct zwp_keyboard_shortcuts_inhibitor_v1* inhibitor;
+} ShortcutsInhibitData;
+
+// Cleanup function for ShortcutsInhibitData
+static void shortcuts_inhibit_data_free(gpointer data) {
+  ShortcutsInhibitData* inhibit_data = static_cast<ShortcutsInhibitData*>(data);
+  if (inhibit_data->inhibitor != NULL) {
+    zwp_keyboard_shortcuts_inhibitor_v1_destroy(inhibit_data->inhibitor);
+  }
+  if (inhibit_data->manager != NULL) {
+    zwp_keyboard_shortcuts_inhibit_manager_v1_destroy(inhibit_data->manager);
+  }
+  g_free(inhibit_data);
+}
+
+// Wayland registry handler to find the shortcuts inhibit manager
+static void registry_handle_global(void* data, struct wl_registry* registry,
+                                   uint32_t name, const char* interface,
+                                   uint32_t /*version*/) {
+  ShortcutsInhibitData* inhibit_data = static_cast<ShortcutsInhibitData*>(data);
+  if (strcmp(interface,
+             zwp_keyboard_shortcuts_inhibit_manager_v1_interface.name) == 0) {
+    inhibit_data->manager =
+        static_cast<zwp_keyboard_shortcuts_inhibit_manager_v1*>(wl_registry_bind(
+            registry, name, &zwp_keyboard_shortcuts_inhibit_manager_v1_interface,
+            1));
+  }
+}
+
+static void registry_handle_global_remove(void* /*data*/, struct wl_registry* /*registry*/,
+                                          uint32_t /*name*/) {
+  // Not needed for this use case
+}
+
+static const struct wl_registry_listener registry_listener = {
+    registry_handle_global,
+    registry_handle_global_remove,
+};
+
+// Inhibitor event handlers
+static void inhibitor_active(void* /*data*/,
+                             struct zwp_keyboard_shortcuts_inhibitor_v1* /*inhibitor*/) {
+  // Inhibitor is now active, shortcuts are being captured
+}
+
+static void inhibitor_inactive(void* /*data*/,
+                               struct zwp_keyboard_shortcuts_inhibitor_v1* /*inhibitor*/) {
+  // Inhibitor is now inactive, shortcuts restored to compositor
+}
+
+static const struct zwp_keyboard_shortcuts_inhibitor_v1_listener inhibitor_listener = {
+    inhibitor_active,
+    inhibitor_inactive,
+};
+
+// Forward declaration
+static void uninhibit_keyboard_shortcuts(GtkWindow* window);
+
+// Inhibit keyboard shortcuts on Wayland for a specific window
+static void inhibit_keyboard_shortcuts(GtkWindow* window) {
+  GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(window));
+  if (!GDK_IS_WAYLAND_DISPLAY(display)) {
+    return;
+  }
+
+  // Check if already inhibited for this window
+  if (g_object_get_data(G_OBJECT(window), "shortcuts-inhibit-data") != NULL) {
+    return;
+  }
+
+  ShortcutsInhibitData* inhibit_data = g_new0(ShortcutsInhibitData, 1);
+
+  struct wl_display* wl_display = gdk_wayland_display_get_wl_display(display);
+  if (wl_display == NULL) {
+    shortcuts_inhibit_data_free(inhibit_data);
+    return;
+  }
+
+  struct wl_registry* registry = wl_display_get_registry(wl_display);
+  if (registry == NULL) {
+    shortcuts_inhibit_data_free(inhibit_data);
+    return;
+  }
+
+  wl_registry_add_listener(registry, &registry_listener, inhibit_data);
+  wl_display_roundtrip(wl_display);
+
+  if (inhibit_data->manager == NULL) {
+    wl_registry_destroy(registry);
+    shortcuts_inhibit_data_free(inhibit_data);
+    return;
+  }
+
+  GdkWindow* gdk_window = gtk_widget_get_window(GTK_WIDGET(window));
+  if (gdk_window == NULL) {
+    wl_registry_destroy(registry);
+    shortcuts_inhibit_data_free(inhibit_data);
+    return;
+  }
+
+  struct wl_surface* surface = gdk_wayland_window_get_wl_surface(gdk_window);
+  if (surface == NULL) {
+    wl_registry_destroy(registry);
+    shortcuts_inhibit_data_free(inhibit_data);
+    return;
+  }
+
+  GdkSeat* gdk_seat = gdk_display_get_default_seat(display);
+  if (gdk_seat == NULL) {
+    wl_registry_destroy(registry);
+    shortcuts_inhibit_data_free(inhibit_data);
+    return;
+  }
+
+  struct wl_seat* seat = gdk_wayland_seat_get_wl_seat(gdk_seat);
+  if (seat == NULL) {
+    wl_registry_destroy(registry);
+    shortcuts_inhibit_data_free(inhibit_data);
+    return;
+  }
+
+  inhibit_data->inhibitor =
+      zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
+          inhibit_data->manager, surface, seat);
+
+  if (inhibit_data->inhibitor == NULL) {
+    wl_registry_destroy(registry);
+    shortcuts_inhibit_data_free(inhibit_data);
+    return;
+  }
+
+  // Add listener to monitor active/inactive state
+  zwp_keyboard_shortcuts_inhibitor_v1_add_listener(
+      inhibit_data->inhibitor, &inhibitor_listener, window);
+
+  wl_display_roundtrip(wl_display);
+  wl_registry_destroy(registry);
+
+  // Associate the inhibit data with the window for cleanup on destroy
+  g_object_set_data_full(G_OBJECT(window), "shortcuts-inhibit-data",
+                         inhibit_data, shortcuts_inhibit_data_free);
+}
+
+// Remove keyboard shortcuts inhibitor from a window
+static void uninhibit_keyboard_shortcuts(GtkWindow* window) {
+  ShortcutsInhibitData* inhibit_data = static_cast<ShortcutsInhibitData*>(
+      g_object_get_data(G_OBJECT(window), "shortcuts-inhibit-data"));
+
+  if (inhibit_data == NULL) {
+    return;
+  }
+
+  // This will trigger shortcuts_inhibit_data_free via g_object_set_data
+  g_object_set_data(G_OBJECT(window), "shortcuts-inhibit-data", NULL);
+}
+
+// Focus event handlers for dynamic inhibitor management
+static gboolean on_window_focus_in(GtkWidget* widget, GdkEventFocus* /*event*/, gpointer /*user_data*/) {
+  if (GTK_IS_WINDOW(widget)) {
+    inhibit_keyboard_shortcuts(GTK_WINDOW(widget));
+  }
+  return FALSE;  // Continue event propagation
+}
+
+static gboolean on_window_focus_out(GtkWidget* widget, GdkEventFocus* /*event*/, gpointer /*user_data*/) {
+  if (GTK_IS_WINDOW(widget)) {
+    uninhibit_keyboard_shortcuts(GTK_WINDOW(widget));
+  }
+  return FALSE;  // Continue event propagation
+}
+
+// Key for marking window as having focus handlers connected
+static const char* const kFocusHandlersConnectedKey = "shortcuts-inhibit-focus-handlers-connected";
+// Key for marking window as having a pending realize handler
+static const char* const kRealizeHandlerConnectedKey = "shortcuts-inhibit-realize-handler-connected";
+
+// Callback when window is realized (mapped to screen)
+// Sets up focus-based inhibitor management
+static void on_window_realize(GtkWidget* widget, gpointer /*user_data*/) {
+  if (GTK_IS_WINDOW(widget)) {
+    // Check if focus handlers are already connected to avoid duplicates
+    if (g_object_get_data(G_OBJECT(widget), kFocusHandlersConnectedKey) != NULL) {
+      return;
+    }
+
+    // Connect focus events for dynamic inhibitor management
+    g_signal_connect(widget, "focus-in-event",
+                     G_CALLBACK(on_window_focus_in), NULL);
+    g_signal_connect(widget, "focus-out-event",
+                     G_CALLBACK(on_window_focus_out), NULL);
+
+    // Mark as connected to prevent duplicate connections
+    g_object_set_data(G_OBJECT(widget), kFocusHandlersConnectedKey, GINT_TO_POINTER(1));
+
+    // If window already has focus, create inhibitor now
+    if (gtk_window_has_toplevel_focus(GTK_WINDOW(widget))) {
+      inhibit_keyboard_shortcuts(GTK_WINDOW(widget));
+    }
+  }
+}
+
+// Public API: Initialize shortcuts inhibit for a sub-window
+void wayland_shortcuts_inhibit_init_for_subwindow(void* view) {
+  GtkWidget* widget = GTK_WIDGET(view);
+  GtkWidget* toplevel = gtk_widget_get_toplevel(widget);
+
+  if (toplevel != NULL && GTK_IS_WINDOW(toplevel)) {
+    // Check if already initialized to avoid duplicate realize handlers
+    if (g_object_get_data(G_OBJECT(toplevel), kFocusHandlersConnectedKey) != NULL ||
+        g_object_get_data(G_OBJECT(toplevel), kRealizeHandlerConnectedKey) != NULL) {
+      return;
+    }
+
+    if (gtk_widget_get_realized(toplevel)) {
+      // Window is already realized, set up focus handlers now
+      on_window_realize(toplevel, NULL);
+    } else {
+      // Mark realize handler as connected to prevent duplicate connections
+      // if called again before window is realized
+      g_object_set_data(G_OBJECT(toplevel), kRealizeHandlerConnectedKey, GINT_TO_POINTER(1));
+      // Wait for window to be realized
+      g_signal_connect(toplevel, "realize",
+                       G_CALLBACK(on_window_realize), NULL);
+    }
+  }
+}
+
+#endif  // defined(GDK_WINDOWING_WAYLAND) && defined(HAS_KEYBOARD_SHORTCUTS_INHIBIT)

--- a/flutter/linux/wayland_shortcuts_inhibit.h
+++ b/flutter/linux/wayland_shortcuts_inhibit.h
@@ -1,0 +1,22 @@
+// Wayland keyboard shortcuts inhibit support
+// This module provides functionality to inhibit system keyboard shortcuts
+// on Wayland compositors, allowing remote desktop windows to capture all
+// key events including Super, Alt+Tab, etc.
+
+#ifndef WAYLAND_SHORTCUTS_INHIBIT_H_
+#define WAYLAND_SHORTCUTS_INHIBIT_H_
+
+#include <gtk/gtk.h>
+
+#if defined(GDK_WINDOWING_WAYLAND) && defined(HAS_KEYBOARD_SHORTCUTS_INHIBIT)
+
+// Initialize shortcuts inhibit for a sub-window created by desktop_multi_window plugin.
+// This sets up focus-based inhibitor management: inhibitor is created when
+// the window gains focus and destroyed when it loses focus.
+//
+// @param view The FlView of the sub-window
+void wayland_shortcuts_inhibit_init_for_subwindow(void* view);
+
+#endif  // defined(GDK_WINDOWING_WAYLAND) && defined(HAS_KEYBOARD_SHORTCUTS_INHIBIT)
+
+#endif  // WAYLAND_SHORTCUTS_INHIBIT_H_

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -220,7 +220,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("default_proxy_tip", "Default protocol and port are Socks5 and 1080"),
         ("no_audio_input_device_tip", "No audio input device found."),
         ("clear_Wayland_screen_selection_tip", "After clearing the screen selection, you can reselect the screen to share."),
-        ("confirm_clear_Wayland_screen_selection_tip", "Are you sure to clear the Wayland screen selection?"),
+        ("confirm_clear_Wayland_screen_selection_tip", "Are you sure you want to clear the Wayland screen selection?"),
         ("android_new_voice_call_tip", "A new voice call request was received. If you accept, the audio will switch to voice communication."),
         ("texture_render_tip", "Use texture rendering to make the pictures smoother. You could try disabling this option if you encounter rendering issues."),
         ("floating_window_tip", "It helps to keep RustDesk background service"),


### PR DESCRIPTION
#4237

#5117

https://github.com/rustdesk/rustdesk/pull/14238

https://github.com/rustdesk/rustdesk/issues/13013

https://github.com/rustdesk/rustdesk/issues/14192

## Desc

1. **X11** input is working correctly; `Alt+Tab` and `Super/Win` keys are successfully forwarded to the remote session.

2. The permission prompt window behaves differently across desktops: it **appears in GNOME** but **does not appear in KDE Plasma or Hyprland**.

3. **Limitation**: The AppImage version currently does not support system shortcut inhibition (keyboard grabbing).

## Preview


https://github.com/user-attachments/assets/644094ed-655d-46d5-8b84-00b1ceb5dd15



## Tests

Both the installation version and the Flatpak version are tested.

- [x] GNOME. Ubuntu 22.04, Ubuntu 24.04, ArchLinux latest
- [x] KDE Plasma.  KUbuntu 22.04, Fedora 42, ArchLinux latest, openSUSE Leap 15.6
- [x] Hyprland. ArchLinux latest