### PR TITLE
fix(xdo): deb, libxdo3 | libxdo4

### DIFF
--- a/build.py
+++ b/build.py
@@ -299,7 +299,7 @@ Version: %s
 Architecture: %s
 Maintainer: rustdesk <info@rustdesk.com>
 Homepage: https://rustdesk.com
-Depends: libgtk-3-0, libxcb-randr0, libxdo3, libxfixes3, libxcb-shape0, libxcb-xfixes0, libasound2, libsystemd0, curl, libva2, libva-drm2, libva-x11-2, libgstreamer-plugins-base1.0-0, libpam0g, gstreamer1.0-pipewire%s
+Depends: libgtk-3-0, libxcb-randr0, libxdo3 | libxdo4, libxfixes3, libxcb-shape0, libxcb-xfixes0, libasound2, libsystemd0, curl, libva2, libva-drm2, libva-x11-2, libgstreamer-plugins-base1.0-0, libpam0g, gstreamer1.0-pipewire%s
 Recommends: libayatana-appindicator3-1
 Description: A remote control software.
 


### PR DESCRIPTION
Updated the `DEB` package to accept either `libxdo3` or `libxdo4`, while the Arch package (which uses `xdotool`) remains unchanged.

Even though `libxdo4` doesn’t exist yet, it doesn’t hurt to add it now. We’re just putting a placeholder in place and can update it down the road when the time comes.

https://pkgs.org/search/?q=xdotool