### PR TITLE
Fix logon-screen password for click approval on Windows

### DIFF
--- a/src/platform/windows.cc
+++ b/src/platform/windows.cc
@@ -580,6 +580,31 @@ extern "C"
         return rdp_or_console;
     }
 
+    BOOL is_session_locked(BOOL include_rdp)
+    {
+        DWORD session_id = get_current_session(include_rdp);
+        if (session_id == 0xFFFFFFFF) {
+            return FALSE;
+        }
+        PWTSINFOEXW pInfo = NULL;
+        DWORD bytes = 0;
+        BOOL locked = FALSE;
+        if (WTSQuerySessionInformationW(
+                WTS_CURRENT_SERVER_HANDLE,
+                session_id,
+                WTSSessionInfoEx,
+                (LPWSTR *)&pInfo,
+                &bytes)) {
+            if (pInfo && pInfo->Level == 1) {
+                locked = (pInfo->Data.WTSInfoExLevel1.SessionFlags == WTS_SESSIONSTATE_LOCK);
+            }
+            if (pInfo) {
+                WTSFreeMemory(pInfo);
+            }
+        }
+        return locked;
+    }
+
     uint32_t get_active_user(PWSTR bufin, uint32_t nin, BOOL rdp)
     {
         uint32_t nout = 0;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -527,6 +527,7 @@ const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
 extern "C" {
     fn get_current_session(rdp: BOOL) -> DWORD;
+    fn is_session_locked(include_rdp: BOOL) -> BOOL;
     fn LaunchProcessWin(
         cmd: *const u16,
         session_id: DWORD,
@@ -1127,6 +1128,10 @@ pub fn is_prelogin() -> bool {
         return false;
     };
     username.is_empty() || username == "SYSTEM"
+}
+
+pub fn is_locked() -> bool {
+    unsafe { is_session_locked(share_rdp()) == TRUE }
 }
 
 // `is_logon_ui()` is regardless of multiple sessions now.

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2232,11 +2232,12 @@ impl Connection {
 
             // https://github.com/rustdesk/rustdesk-server-pro/discussions/646
             // `is_logon` is used to check login with `OPTION_ALLOW_LOGON_SCREEN_PASSWORD` == "Y".
-            // `is_logon_ui()` is used on Windows, because there's no good way to detect `is_locked()`.
-            // Detecting `is_logon_ui()` (if `LogonUI.exe` running) is a workaround.
+            // `is_logon_ui()` is a fallback for logon UI detection on Windows.
             #[cfg(target_os = "windows")]
             let is_logon = || {
-                crate::platform::is_prelogin() || {
+                crate::platform::is_prelogin()
+                    || crate::platform::is_locked()
+                    || {
                     match crate::platform::is_logon_ui() {
                         Ok(result) => result,
                         Err(e) => {


### PR DESCRIPTION
## Summary
- Add Windows session lock detection using WTS session info.
- Treat locked/logon state as eligible for password auth when `approve-mode=click` and `allow-logon-screen-password=Y`.
- Keep LogonUI.exe detection as a fallback.

## Motivation
When a controlled Windows session is locked or at the logon screen, click-based approval cannot happen. With `allow-logon-screen-password=Y`, users should be able to authenticate via the permanent password. This change ensures the lock/logon state is detected reliably and allows password auth in that scenario.

## Changes
- `src/platform/windows.cc`: add `is_session_locked()` using `WTSSessionInfoEx`.
- `src/platform/windows.rs`: expose `is_locked()` binding.
- `src/server/connection.rs`: include `is_locked()` in Windows logon detection gate.

Fixes #13728


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to detect session lock state on Windows, including support for remote desktop sessions.

* **Bug Fixes**
  * Improved Windows login screen detection by incorporating session lock status into the login validation process. Enhanced error logging to provide better diagnostics when login detection encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->