### PR TITLE
fix: correct typos and improve code clarity

### DIFF
--- a/libs/scrap/src/x11/server.rs
+++ b/libs/scrap/src/x11/server.rs
@@ -98,7 +98,7 @@ unsafe fn check_x11_shm_available(c: *mut xcb_connection_t) -> Result<(), Error>
     let mut e: *mut xcb_generic_error_t = std::ptr::null_mut();
     let reply = xcb_shm_query_version_reply(c, cookie, &mut e as _);
     if reply.is_null() {
-        // TODO: Should seperate SHM disabled from SHM not supported?
+        // TODO: Should separate SHM disabled from SHM not supported?
         return Err(Error::UnsupportedExtension);
     } else {
         // https://github.com/FFmpeg/FFmpeg/blob/6229e4ac425b4566446edefb67d5c225eb397b58/libavdevice/xcbgrab.c#L229

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -197,7 +197,7 @@ pub fn check_clipboard_cm() -> ResultType<MultiClipboards> {
 
 #[cfg(not(target_os = "android"))]
 fn update_clipboard_(multi_clipboards: Vec<Clipboard>, side: ClipboardSide) {
-    let to_update_data = proto::from_multi_clipbards(multi_clipboards);
+    let to_update_data = proto::from_multi_clipboards(multi_clipboards);
     if to_update_data.is_empty() {
         return;
     }
@@ -432,7 +432,7 @@ impl ClipboardContext {
                 #[cfg(target_os = "macos")]
                 let is_kde_x11 = false;
                 let clear_holder_text = if is_kde_x11 {
-                    "RustDesk placeholder to clear the file clipbard"
+                    "RustDesk placeholder to clear the file clipboard"
                 } else {
                     ""
                 }
@@ -672,7 +672,7 @@ mod proto {
     }
 
     #[cfg(not(target_os = "android"))]
-    pub fn from_multi_clipbards(multi_clipboards: Vec<Clipboard>) -> Vec<ClipboardData> {
+    pub fn from_multi_clipboards(multi_clipboards: Vec<Clipboard>) -> Vec<ClipboardData> {
         multi_clipboards
             .into_iter()
             .filter_map(from_clipboard)
@@ -814,7 +814,7 @@ pub mod clipboard_listener {
                 subscribers: listener_lock.subscribers.clone(),
             };
             let (tx_start_res, rx_start_res) = channel();
-            let h = start_clipbard_master_thread(handler, tx_start_res);
+            let h = start_clipboard_master_thread(handler, tx_start_res);
             let shutdown = match rx_start_res.recv() {
                 Ok((Some(s), _)) => s,
                 Ok((None, err)) => {
@@ -854,7 +854,7 @@ pub mod clipboard_listener {
         log::info!("Clipboard listener unsubscribed: {}", name);
     }
 
-    fn start_clipbard_master_thread(
+    fn start_clipboard_master_thread(
         handler: impl ClipboardHandler + Send + 'static,
         tx_start_res: Sender<(Option<Shutdown>, String)>,
     ) -> JoinHandle<()> {

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -123,7 +123,7 @@ fn check_update(manually: bool) -> ResultType<()> {
     if !(manually || config::Config::get_bool_option(config::keys::OPTION_ALLOW_AUTO_UPDATE)) {
         return Ok(());
     }
-    if !do_check_software_update().is_ok() {
+    if do_check_software_update().is_err() {
         // ignore
         return Ok(());
     }
@@ -185,7 +185,7 @@ fn check_update(manually: bool) -> ResultType<()> {
             let mut file = std::fs::File::create(&file_path)?;
             file.write_all(&file_data)?;
         }
-        // We have checked if the `conns`` is empty before, but we need to check again.
+        // We have checked if the `conns` is empty before, but we need to check again.
         // No need to care about the downloaded file here, because it's rare case that the `conns` are empty
         // before the download, but not empty after the download.
         if has_no_active_conns() {


### PR DESCRIPTION
## Changes

### Typo fixes in `src/clipboard.rs`
- Renamed `from_multi_clipbards` → `from_multi_clipboards` (function name)
- Renamed `start_clipbard_master_thread` → `start_clipboard_master_thread` (function name)
- Fixed typo in user-facing string: "clear the file clipbard" → "clear the file clipboard"
- Fixed typo in call site referencing the renamed function

### Typo fix in `libs/scrap/src/x11/server.rs`
- Fixed "seperate" → "separate" in comment

### Code clarity in `src/updater.rs`
- Replaced `!do_check_software_update().is_ok()` with idiomatic `do_check_software_update().is_err()` (clippy: `unnecessary_negation`)
- Fixed double backtick typo in comment: `conns`` → `conns`

All changes are safe refactors with no behavioral impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected software update verification logic to properly handle check results.

* **Chores**
  * Fixed multiple spelling errors throughout codebase comments and internal references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->