### PR TITLE
fix(terminal): fix new tab auto-focus and NaN error on data before layout

### DIFF
--- a/flutter/lib/desktop/pages/terminal_tab_page.dart
+++ b/flutter/lib/desktop/pages/terminal_tab_page.dart
@@ -92,6 +92,7 @@ class _TerminalTabPageState extends State<TerminalTabPage> {
         key: ValueKey(tabKey),
         id: peerId,
         terminalId: terminalId,
+        tabKey: tabKey,
         password: password,
         isSharedPassword: isSharedPassword,
         tabController: tabController,


### PR DESCRIPTION
1. Opening a new terminal tab does not auto-focus the input — users must click the terminal area before typing.
2. When terminal data arrives before the TerminalView has completed layout, `setEditableSizeAndTransform` receives NaN dimensions, causing: `Unhandled Exception: Converting object to an encodable object failed: NaN`

## Root Cause

1. `TerminalView(autofocus: true)` only works on initial widget insertion. When a new tab is added, the terminal view may not yet have valid dimensions in the focus tree, so the autofocus request silently fails.
2. Terminal output data (`terminal.write()`) triggers `RenderTerminal._notifyEditableRect`, which calls `setEditableSizeAndTransform` with the current render size. Before the first layout pass, these values are `NaN`, and JSON serialization fails.

## Fix

### Auto-focus (terminal_page.dart)

  - Replace `autofocus: true` with a manually managed `FocusNode` (initially `canRequestFocus: false`).
  - Listen to `tabController.state` changes; when this tab is selected, request focus via `addPostFrameCallback` to ensure the widget is fully laid out.
  - Only enable `canRequestFocus` after the first valid resize callback (`w > 0 && h > 0`).

### NaN error (terminal_model.dart)
  - Buffer output data in `_pendingOutputChunks` when `_terminalViewReady` is false.
  - On the first valid `onResize` callback, mark the view as ready and flush the buffer.
  - Buffer has an 8KB cap with FIFO eviction (drop oldest chunks) to bound memory usage.
  - `onResizeExternal` is called before `_markViewReady()` to ensure the view layer has valid dimensions before flushing.

### Minor fixes (terminal_tab_page.dart)
  - Pass `tabKey` to `TerminalPage` for focus management.
  - Fix string interpolation: `'$peerId\_'` → `'${peerId}_'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better focus handling: tabs restore focus on resize and when switched.
  * Pre-layout output buffering: terminal output is preserved and displayed once the view is ready.

* **Bug Fixes**
  * Fixed focus subscription and tab selection issues to prevent focus leaks and ensure the correct tab receives focus.

* **Stability**
  * Improved cleanup on close to free buffers and reduce resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->