### PR TITLE
  - UI display: display_name first

### DIFF
--- a/flutter/lib/common/hbbs/hbbs.dart
+++ b/flutter/lib/common/hbbs/hbbs.dart
@@ -25,6 +25,7 @@ enum UserStatus { kDisabled, kNormal, kUnverified }
 // Is all the fields of the user needed?
 class UserPayload {
   String name = '';
+  String displayName = '';
   String email = '';
   String note = '';
   String? verifier;
@@ -33,6 +34,7 @@ class UserPayload {
 
   UserPayload.fromJson(Map<String, dynamic> json)
       : name = json['name'] ?? '',
+        displayName = json['display_name'] ?? '',
         email = json['email'] ?? '',
         note = json['note'] ?? '',
         verifier = json['verifier'],
@@ -46,6 +48,7 @@ class UserPayload {
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> map = {
       'name': name,
+      'display_name': displayName,
       'status': status == UserStatus.kDisabled
           ? 0
           : status == UserStatus.kUnverified
@@ -58,8 +61,13 @@ class UserPayload {
   Map<String, dynamic> toGroupCacheJson() {
     final Map<String, dynamic> map = {
       'name': name,
+      'display_name': displayName,
     };
     return map;
+  }
+
+  String get displayNameOrName {
+    return displayName.trim().isEmpty ? name : displayName;
   }
 }
 

--- a/flutter/lib/common/widgets/my_group.dart
+++ b/flutter/lib/common/widgets/my_group.dart
@@ -158,9 +158,9 @@ class _MyGroupState extends State<MyGroup> {
     return Obx(() {
       final userItems = gFFI.groupModel.users.where((p0) {
         if (searchAccessibleItemNameText.isNotEmpty) {
-          return p0.name
-              .toLowerCase()
-              .contains(searchAccessibleItemNameText.value.toLowerCase());
+          final search = searchAccessibleItemNameText.value.toLowerCase();
+          return p0.name.toLowerCase().contains(search) ||
+              p0.displayNameOrName.toLowerCase().contains(search);
         }
         return true;
       }).toList();
@@ -187,6 +187,7 @@ class _MyGroupState extends State<MyGroup> {
 
   Widget _buildUserItem(UserPayload user) {
     final username = user.name;
+    final displayName = user.displayNameOrName;
     return InkWell(onTap: () {
       isSelectedDeviceGroup.value = false;
       if (selectedAccessibleItemName.value != username) {
@@ -229,7 +230,7 @@ class _MyGroupState extends State<MyGroup> {
                     ),
                   ),
                 ).marginOnly(right: 4),
-                if (isMe) Flexible(child: Text(username)),
+                if (isMe) Flexible(child: Text(displayName)),
                 if (isMe)
                   Flexible(
                     child: Container(
@@ -246,7 +247,7 @@ class _MyGroupState extends State<MyGroup> {
                       ),
                     ),
                   ),
-                if (!isMe) Expanded(child: Text(username)),
+                if (!isMe) Expanded(child: Text(displayName)),
               ],
             ).paddingSymmetric(vertical: 4),
           ),

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -571,8 +571,10 @@ class MyGroupPeerView extends BasePeersView {
     final model = gFFI.groupModel;
     if (model.searchAccessibleItemNameText.isNotEmpty) {
       final text = model.searchAccessibleItemNameText.value;
-      final searchPeersOfUser = peer.loginName.contains(text) &&
-          model.users.any((user) => user.name == peer.loginName);
+      final searchPeersOfUser = model.users.any((user) =>
+          user.name == peer.loginName &&
+          (user.name.contains(text) ||
+              user.displayNameOrName.contains(text)));
       final searchPeersOfDeviceGroup = peer.device_group_name.contains(text) &&
           model.deviceGroups.any((g) => g.name == peer.device_group_name);
       if (!searchPeersOfUser && !searchPeersOfDeviceGroup) {

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -570,13 +570,14 @@ class MyGroupPeerView extends BasePeersView {
   static bool filter(Peer peer) {
     final model = gFFI.groupModel;
     if (model.searchAccessibleItemNameText.isNotEmpty) {
-      final text = model.searchAccessibleItemNameText.value;
+      final text = model.searchAccessibleItemNameText.value.toLowerCase();
       final searchPeersOfUser = model.users.any((user) =>
           user.name == peer.loginName &&
-          (user.name.contains(text) ||
-              user.displayNameOrName.contains(text)));
-      final searchPeersOfDeviceGroup = peer.device_group_name.contains(text) &&
-          model.deviceGroups.any((g) => g.name == peer.device_group_name);
+          (user.name.toLowerCase().contains(text) ||
+              user.displayNameOrName.toLowerCase().contains(text)));
+      final searchPeersOfDeviceGroup =
+          peer.device_group_name.toLowerCase().contains(text) &&
+              model.deviceGroups.any((g) => g.name == peer.device_group_name);
       if (!searchPeersOfUser && !searchPeersOfDeviceGroup) {
         return false;
       }

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -2016,7 +2016,9 @@ class _AccountState extends State<_Account> {
 
   Widget accountAction() {
     return Obx(() => _Button(
-        gFFI.userModel.userName.value.isEmpty ? 'Login' : 'Logout',
+        gFFI.userModel.userName.value.isEmpty
+            ? 'Login'
+            : 'Logout (${gFFI.userModel.accountLabelWithHandle})',
         () => {
               gFFI.userModel.userName.value.isEmpty
                   ? loginDialog()
@@ -2037,6 +2039,9 @@ class _AccountState extends State<_Account> {
           offstage: gFFI.userModel.userName.value.isEmpty,
           child: Column(
             children: [
+              if (gFFI.userModel.displayName.value.trim().isNotEmpty &&
+                  gFFI.userModel.displayName.value != gFFI.userModel.userName.value)
+                text('Display Name', gFFI.userModel.displayName.value),
               text('Username', gFFI.userModel.userName.value),
               // text('Group', gFFI.groupModel.groupName.value),
             ],
@@ -2130,7 +2135,9 @@ class _PluginState extends State<_Plugin> {
 
   Widget accountAction() {
     return Obx(() => _Button(
-        gFFI.userModel.userName.value.isEmpty ? 'Login' : 'Logout',
+        gFFI.userModel.userName.value.isEmpty
+            ? 'Login'
+            : 'Logout (${gFFI.userModel.accountLabelWithHandle})',
         () => {
               gFFI.userModel.userName.value.isEmpty
                   ? loginDialog()

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -2018,7 +2018,7 @@ class _AccountState extends State<_Account> {
     return Obx(() => _Button(
         gFFI.userModel.userName.value.isEmpty
             ? 'Login'
-            : 'Logout (${gFFI.userModel.accountLabelWithHandle})',
+            : '${translate('Logout')} (${gFFI.userModel.accountLabelWithHandle})',
         () => {
               gFFI.userModel.userName.value.isEmpty
                   ? loginDialog()
@@ -2040,8 +2040,9 @@ class _AccountState extends State<_Account> {
           child: Column(
             children: [
               if (gFFI.userModel.displayName.value.trim().isNotEmpty &&
-                  gFFI.userModel.displayName.value != gFFI.userModel.userName.value)
-                text('Display Name', gFFI.userModel.displayName.value),
+                  gFFI.userModel.displayName.value.trim() !=
+                      gFFI.userModel.userName.value.trim())
+                text('Display Name', gFFI.userModel.displayName.value.trim()),
               text('Username', gFFI.userModel.userName.value),
               // text('Group', gFFI.groupModel.groupName.value),
             ],
@@ -2137,7 +2138,7 @@ class _PluginState extends State<_Plugin> {
     return Obx(() => _Button(
         gFFI.userModel.userName.value.isEmpty
             ? 'Login'
-            : 'Logout (${gFFI.userModel.accountLabelWithHandle})',
+            : '${translate('Logout')} (${gFFI.userModel.accountLabelWithHandle})',
         () => {
               gFFI.userModel.userName.value.isEmpty
                   ? loginDialog()

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -688,7 +688,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
               SettingsTile(
                 title: Obx(() => Text(gFFI.userModel.userName.value.isEmpty
                     ? translate('Login')
-                    : '${translate('Logout')} (${gFFI.userModel.userName.value})')),
+                    : '${translate('Logout')} (${gFFI.userModel.accountLabelWithHandle})')),
                 leading: Icon(Icons.person),
                 onPressed: (context) {
                   if (gFFI.userModel.userName.value.isEmpty) {

--- a/res/msi/preprocess.py
+++ b/res/msi/preprocess.py
@@ -336,7 +336,9 @@ def gen_custom_ARPSYSTEMCOMPONENT_True(args, dist_dir):
             f'{indent}<RegistryValue Type="integer" Name="Language" Value="[ProductLanguage]" />\n'
         )
 
-        estimated_size = get_folder_size(dist_dir)
+        # EstimatedSize in uninstall registry must be in KB.
+        estimated_size_bytes = get_folder_size(dist_dir)
+        estimated_size = max(1, (estimated_size_bytes + 1023) // 1024)
         lines_new.append(
             f'{indent}<RegistryValue Type="integer" Name="EstimatedSize" Value="{estimated_size}" />\n'
         )

--- a/src/client.rs
+++ b/src/client.rs
@@ -2630,10 +2630,12 @@ impl LoginConfigHandler {
             display_name =
                 serde_json::from_str::<serde_json::Value>(&LocalConfig::get_option("user_info"))
                     .map(|x| {
-                        x.get("name")
-                            .map(|x| x.as_str().unwrap_or_default())
+                        x.get("display_name")
+                            .and_then(|x| x.as_str())
+                            .filter(|x| !x.is_empty())
+                            .or_else(|| x.get("name").and_then(|x| x.as_str()))
+                            .map(|x| x.to_owned())
                             .unwrap_or_default()
-                            .to_owned()
                     })
                     .unwrap_or_default();
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2632,6 +2632,7 @@ impl LoginConfigHandler {
                     .map(|x| {
                         x.get("display_name")
                             .and_then(|x| x.as_str())
+                            .map(|x| x.trim())
                             .filter(|x| !x.is_empty())
                             .or_else(|| x.get("name").and_then(|x| x.as_str()))
                             .map(|x| x.to_owned())

--- a/src/hbbs_http/account.rs
+++ b/src/hbbs_http/account.rs
@@ -80,6 +80,8 @@ pub enum UserStatus {
 pub struct UserPayload {
     pub name: String,
     #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
     pub email: Option<String>,
     #[serde(default)]
     pub note: Option<String>,
@@ -268,7 +270,12 @@ impl OidcSession {
                             );
                             LocalConfig::set_option(
                                 "user_info".to_owned(),
-                                serde_json::json!({ "name": auth_body.user.name, "status": auth_body.user.status }).to_string(),
+                                serde_json::json!({
+                                    "name": auth_body.user.name,
+                                    "display_name": auth_body.user.display_name,
+                                    "status": auth_body.user.status
+                                })
+                                .to_string(),
                             );
                         }
                     }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "متابعة مع {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Працягнуць з {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Продължи с {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Continua amb {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "使用 {} 登录"),
+        ("Display Name", "显示名称"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Pokračovat s {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Fortsæt med {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "Bildschirm während ausgehender Sitzungen aktiv halten"),
         ("keep-awake-during-incoming-sessions-label", "Bildschirm während eingehender Sitzungen aktiv halten"),
         ("Continue with {}", "Fortfahren mit {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Συνέχεια με {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", ""),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Continuar con {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Jätka koos {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "{} honekin jarraitu"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "ادامه با {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Jatka käyttäen {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "Maintenir l’écran allumé lors des sessions sortantes"),
         ("keep-awake-during-incoming-sessions-label", "Maintenir l’écran allumé lors des sessions entrantes"),
         ("Continue with {}", "Continuer avec {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "{}-ით გაგრძელება"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "המשך עם {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Nastavi sa {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "Képernyő aktív állapotban tartása a kimenő munkamenetek során"),
         ("keep-awake-during-incoming-sessions-label", "Képernyő aktív állapotban tartása a bejövő munkamenetek során"),
         ("Continue with {}", "Folytatás a következővel: {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Lanjutkan dengan {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "Mantieni lo schermo attivo durante le sessioni in uscita"),
         ("keep-awake-during-incoming-sessions-label", "Mantieni lo schermo attivo durante le sessioni in ingresso"),
         ("Continue with {}", "Continua con {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "{} で続行"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "발신 세션 중 화면 켜짐 유지"),
         ("keep-awake-during-incoming-sessions-label", "수신 세션 중 화면 켜짐 유지"),
         ("Continue with {}", "{}(으)로 계속"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", ""),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Tęsti su {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Turpināt ar {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Fortsett med {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "Houd het scherm open tijdens de uitgaande sessies."),
         ("keep-awake-during-incoming-sessions-label", "Houd het scherm open tijdens de inkomende sessies."),
         ("Continue with {}", "Ga verder met {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "Utrzymuj urządzenie w stanie aktywnym podczas sesji wychodzących"),
         ("keep-awake-during-incoming-sessions-label", "Utrzymuj urządzenie w stanie aktywnym podczas sesji przychodzących"),
         ("Continue with {}", "Kontynuuj z {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", ""),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "Manter tela ativa durante sessões de saída"),
         ("keep-awake-during-incoming-sessions-label", "Manter tela ativa durante sessões de entrada"),
         ("Continue with {}", "Continuar com {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Continuă cu {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "Не отключать экран во время исходящих сеансов"),
         ("keep-awake-during-incoming-sessions-label", "Не отключать экран во время входящих сеансов"),
         ("Continue with {}", "Продолжить с {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Sighi cun {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Pokračovať s {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Nadaljuj z {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Vazhdo me {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Nastavi sa {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Fortsätt med {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "{} உடன் தொடர்"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", ""),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "ทำต่อด้วย {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "Giden oturumlar süresince ekranı açık tutun"),
         ("keep-awake-during-incoming-sessions-label", "Gelen oturumlar süresince ekranı açık tutun"),
         ("Continue with {}", "{} ile devam et"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "在連出工作階段期間保持螢幕喚醒"),
         ("keep-awake-during-incoming-sessions-label", "在連入工作階段期間保持螢幕喚醒"),
         ("Continue with {}", "使用 {} 登入"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Продовжити з {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -739,5 +739,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", ""),
         ("keep-awake-during-incoming-sessions-label", ""),
         ("Continue with {}", "Tiếp tục với {}"),
+        ("Display Name", ""),
     ].iter().cloned().collect();
 }

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -358,6 +358,22 @@ function getUserName() {
     return '';
 }
 
+function getAccountLabelWithHandle() {
+    try {
+        var user = JSON.parse(handler.get_local_option("user_info"));
+        var username = (user.name || '').trim();
+        if (!username) {
+            return '';
+        }
+        var displayName = (user.display_name || '').trim();
+        if (!displayName || displayName == username) {
+            return username;
+        }
+        return displayName + " (@" + username + ")";
+    } catch(e) {}
+    return '';
+}
+
 // Shared dialog functions
 function open_custom_server_dialog() {
     var configOptions = handler.get_options();
@@ -493,7 +509,7 @@ class MyIdMenu: Reactor.Component {
     }
 
     function renderPop() {
-        var username = handler.get_local_option("access_token") ? getUserName() : '';
+        var accountLabel = handler.get_local_option("access_token") ? getAccountLabelWithHandle() : '';
         return <popup>
             <menu.context #config-options>
                 {!disable_settings && <li #enable-keyboard><span>{svg_checkmark}</span>{translate('Enable keyboard/mouse')}</li>}
@@ -521,8 +537,8 @@ class MyIdMenu: Reactor.Component {
                 {!disable_settings && <DirectServer />}
                 {!disable_settings && false && handler.using_public_server() && <li #allow-always-relay><span>{svg_checkmark}</span>{translate('Always connect via relay')}</li>}
                 {!disable_change_id && handler.is_ok_change_id() ? <div .separator /> : ""}
-                {!disable_account && (username ?
-                <li #logout>{translate('Logout')} ({username})</li> :
+                {!disable_account && (accountLabel ?
+                <li #logout>{translate('Logout')} ({accountLabel})</li> :
                 <li #login>{translate('Login')}</li>)}
                 {!disable_change_id && !disable_settings && handler.is_ok_change_id() && key_confirmed && connect_status > 0 ? <li #change-id>{translate('Change ID')}</li> : ""}
                 <div .separator />
@@ -1430,6 +1446,9 @@ checkConnectStatus();
 
 function set_local_user_info(user) {
     var user_info = {name: user.name};
+    if (user.display_name) {
+        user_info.display_name = user.display_name;
+    }
     if (user.status) {
         user_info.status = user.status;
     }


### PR DESCRIPTION
  - Fallback: name
  - Technical identity: still name

  ### What changed

  - Added account display helpers and display_name state in user model:
      - flutter/lib/models/user_model.dart:16
  - Account/logout label now uses display_name (@name) when both exist: - flutter/lib/mobile/pages/settings_page.dart:689 - flutter/lib/desktop/pages/desktop_setting_page.dart:2016 - flutter/lib/desktop/pages/desktop_setting_page.dart:2135
  - Desktop Account info now shows both when applicable:
      - Display Name: ...
      - Username: ... - flutter/lib/desktop/pages/desktop_setting_page.dart:2039
  - Previously done group-list behavior remains: - group user list displays display_name with name fallback - flutter/lib/common/widgets/my_group.dart:187
  - Persistence path for display_name remains enabled (including group cache/submodule field):
      - libs/hbb_common/src/config.rs:2347
  - src/client.rs:2630
  - LoginRequest.my_name now resolves as:
      1. OPTION_DISPLAY_NAME (manual override)
      2. user_info.display_name 3. user_info.name 4. OS username fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display Name support: users can set a preferred display name shown across lists, user rows, initials, and the "Me" badge; search and filtering match display name or username.
  * Account labels and logout text now show a combined label when a display name exists; settings show a Display Name field.

* **Localization**
  * Added "Display Name" key to many language packs for translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->