### PR TITLE
fix https://github.com/rustdesk/rustdesk/issues/609#issuecomment-3931…

### DIFF
--- a/src/ui/chatbox.html
+++ b/src/ui/chatbox.html
@@ -12,7 +12,11 @@
             include "common.tis";
             var p = view.parameters;
             view.refresh = function() {
+                var draft_input = $(input);
+                var draft = draft_input ? (draft_input.value || "") : "";
                 $(body).content(<ChatBox msgs={p.msgs} callback={p.callback} />);
+                var next_input = $(input);
+                if (next_input) next_input.value = draft;
                 view.focus = $(input);
             }
             function self.closing() {


### PR DESCRIPTION
  What it does:

  - Before refresh(), it reads current input text.
  - After re-rendering ChatBox, it restores that text to the new input.

  So incoming message refresh no longer wipes unsent draft in that chat window path.

For fix https://github.com/rustdesk/rustdesk/issues/609#issuecomment-3931613118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chat input preservation: Your draft messages in the chat box are now automatically saved and restored when the interface refreshes, preventing data loss and improving the user experience during continuous conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->