### PR TITLE
feat(terminal): add reconnection buffer support for persistent sessions

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3063,6 +3063,9 @@ Future<void> start_service(bool is_start) async {
 }
 
 Future<bool> canBeBlocked() async {
+  if (isWeb) {
+    return true;
+  }
   // First check control permission
   final controlPermission = await bind.mainGetCommon(
       key: "is-remote-modify-enabled-by-control-permissions");

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3064,7 +3064,9 @@ Future<void> start_service(bool is_start) async {
 
 Future<bool> canBeBlocked() async {
   if (isWeb) {
-    return true;
+    // Web can only act as a controller, never as a controlled side,
+    // so it should never be blocked by a remote session.
+    return false;
   }
   // First check control permission
   final controlPermission = await bind.mainGetCommon(

--- a/flutter/lib/mobile/pages/terminal_page.dart
+++ b/flutter/lib/mobile/pages/terminal_page.dart
@@ -83,7 +83,8 @@ class _TerminalPageState extends State<TerminalPage>
     // Register this terminal model with FFI for event routing
     _ffi.registerTerminalModel(widget.terminalId, _terminalModel);
 
-    _showTerminalExtraKeys = mainGetLocalBoolOptionSync(kOptionEnableShowTerminalExtraKeys);
+    _showTerminalExtraKeys = !isWebDesktop &&
+        mainGetLocalBoolOptionSync(kOptionEnableShowTerminalExtraKeys);
     // Initialize terminal connection
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _ffi.dialogManager

--- a/flutter/lib/mobile/pages/terminal_page.dart
+++ b/flutter/lib/mobile/pages/terminal_page.dart
@@ -83,6 +83,8 @@ class _TerminalPageState extends State<TerminalPage>
     // Register this terminal model with FFI for event routing
     _ffi.registerTerminalModel(widget.terminalId, _terminalModel);
 
+    // Web desktop users have full hardware keyboard access, so the on-screen
+    // terminal extra keys bar is unnecessary and disabled.
     _showTerminalExtraKeys = !isWebDesktop &&
         mainGetLocalBoolOptionSync(kOptionEnableShowTerminalExtraKeys);
     // Initialize terminal connection

--- a/flutter/lib/models/terminal_model.dart
+++ b/flutter/lib/models/terminal_model.dart
@@ -26,20 +26,11 @@ class TerminalModel with ChangeNotifier {
   final _inputBuffer = <String>[];
   // Buffer for output data received before terminal view has valid dimensions.
   // This prevents NaN errors when writing to terminal before layout is complete.
-  // Uses List<String> chunks to avoid truncating ANSI escape sequences mid-stream.
   final _pendingOutputChunks = <String>[];
-  int _pendingOutputSize = 0;  // in characters (UTF-16 code units)
-  // Local buffer limit (characters) - roughly matches server's DEFAULT_REQUEST_BUFFER_BYTES (8KB).
-  // Server counts UTF-8 bytes while this counts UTF-16 code units; for CJK-heavy output the
-  // effective size may differ (1 CJK char = 3 UTF-8 bytes vs 1 UTF-16 code unit), but this is
-  // acceptable as an approximate cap to prevent unbounded memory growth.
+  int _pendingOutputSize = 0;
   static const int _kMaxOutputBufferChars = 8 * 1024;
   // View ready state: true when terminal has valid dimensions, safe to write
   bool _terminalViewReady = false;
-  // When true, flush will send RIS (Reset to Initial State) before buffered output.
-  // This avoids putting RIS into _pendingOutputChunks where it could be evicted
-  // by the FIFO capacity control when large replay data arrives before view is ready.
-  bool _needsClearOnFlush = false;
 
   bool get isPeerWindows => parent.ffiModel.pi.platform == kPeerPlatformWindows;
 
@@ -225,15 +216,25 @@ class TerminalModel with ChangeNotifier {
     }
   }
 
-  /// Parse a boolean value from event map, handling both bool and String types (for web compatibility).
-  static bool getBoolFromEvt(Map<String, dynamic> evt, String key, {bool defaultValue = false}) {
-    final v = evt[key];
-    if (v is bool) return v;
-    if (v is String) return v.toLowerCase() == 'true';
-    if (v != null) {
-      debugPrint('[TerminalModel] Unexpected type for "$key": ${v.runtimeType}, value: $v');
+  static bool getSuccessFromEvt(Map<String, dynamic> evt) {
+    if (evt.containsKey('success')) {
+      final v = evt['success'];
+      if (v is bool) {
+        // Desktop and mobile
+        return v;
+      } else if (v is String) {
+        // Web
+        return v.toLowerCase() == 'true';
+      } else {
+        // Unexpected type, log and handle gracefully
+        debugPrint(
+            '[TerminalModel] Unexpected success type: ${v.runtimeType}, value: $v. Expected bool or String.');
+        return false;
+      }
+    } else {
+      debugPrint('[TerminalModel] Event does not contain success');
+      return false;
     }
-    return defaultValue;
   }
 
   void handleTerminalResponse(Map<String, dynamic> evt) {
@@ -264,44 +265,26 @@ class TerminalModel with ChangeNotifier {
   }
 
   void _handleTerminalOpened(Map<String, dynamic> evt) {
-    final bool success = getBoolFromEvt(evt, 'success');
-    final String message = evt['message'] ?? '';
-    final String? serviceId = evt['service_id'];
-    final bool reconnected = getBoolFromEvt(evt, 'reconnected');
+    final bool success = getSuccessFromEvt(evt);
+    final String message = evt['message']?.toString() ?? '';
+    final String? serviceId = evt['service_id']?.toString();
 
     debugPrint(
-        '[TerminalModel] Terminal opened response: success=$success, message=$message, service_id=$serviceId, reconnected=$reconnected');
+        '[TerminalModel] Terminal opened response: success=$success, message=$message, service_id=$serviceId');
 
     if (success) {
       _terminalOpened = true;
 
-      // Service ID is now saved on the Rust side in handle_terminal_response
-      // Note: buffer for reconnection is automatically pushed by the server
-      // via pending_buffer in handle_open, no client request needed.
-
-      if (reconnected) {
-        // Clear terminal to avoid duplicate output: the server will replay
-        // recent history via pending_buffer, so discard local state first.
-        _pendingOutputChunks.clear();
-        _pendingOutputSize = 0;
-
-        if (_terminalViewReady) {
-          // View is already ready — clear screen immediately, subsequent
-          // pending_buffer data will be written directly via _writeToTerminal.
-          terminal.write('\x1bc'); // RIS: Reset to Initial State
-          debugPrint('[TerminalModel] Reconnection detected, cleared terminal immediately');
-        } else {
-          // View not ready yet — defer the clear to flush time so it cannot
-          // be evicted by FIFO capacity control in the pending buffer.
-          _needsClearOnFlush = true;
-          debugPrint('[TerminalModel] Reconnection detected, will clear terminal on flush');
-        }
-      }
+      // On reconnect ("Reconnected to existing terminal"), server may replay recent output.
+      // If this TerminalView instance is reused (not rebuilt), duplicate lines can appear.
+      // We intentionally accept this tradeoff for now to keep logic simple.
 
       // Fallback: if terminal view is not yet ready but already has valid
       // dimensions (e.g. layout completed before open response arrived),
       // mark view ready now to avoid output stuck in buffer indefinitely.
-      if (!_terminalViewReady && terminal.viewWidth > 0 && terminal.viewHeight > 0) {
+      if (!_terminalViewReady &&
+          terminal.viewWidth > 0 &&
+          terminal.viewHeight > 0) {
         _markViewReady();
       }
 
@@ -386,8 +369,7 @@ class TerminalModel with ChangeNotifier {
       // because it only affects the pre-layout buffering window and the
       // terminal will self-correct on subsequent output.
       if (text.length >= _kMaxOutputBufferChars) {
-        final truncated =
-            text.substring(text.length - _kMaxOutputBufferChars);
+        final truncated = text.substring(text.length - _kMaxOutputBufferChars);
         _pendingOutputChunks
           ..clear()
           ..add(truncated);
@@ -408,13 +390,6 @@ class TerminalModel with ChangeNotifier {
   }
 
   void _flushOutputBuffer() {
-    // Send RIS before buffered output if reconnection requested a clear.
-    // This is done here (not in _writeToTerminal) to guarantee the clear
-    // cannot be evicted by FIFO capacity control in the pending buffer.
-    if (_needsClearOnFlush) {
-      _needsClearOnFlush = false;
-      terminal.write('\x1bc'); // RIS: Reset to Initial State (clears screen + scrollback)
-    }
     if (_pendingOutputChunks.isEmpty) return;
     debugPrint(
         '[TerminalModel] Flushing $_pendingOutputSize buffered chars (${_pendingOutputChunks.length} chunks)');
@@ -452,7 +427,6 @@ class TerminalModel with ChangeNotifier {
     _inputBuffer.clear();
     _pendingOutputChunks.clear();
     _pendingOutputSize = 0;
-    _needsClearOnFlush = false;
     // Terminal cleanup is handled server-side when service closes
     super.dispose();
   }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1135,6 +1135,7 @@ impl InvokeUiSession for FlutterHandler {
                     ("message", json!(&opened.message)),
                     ("pid", json!(opened.pid)),
                     ("service_id", json!(&opened.service_id)),
+                    ("reconnected", json!(opened.reconnected)),
                 ];
                 if !opened.persistent_sessions.is_empty() {
                     event_data.push(("persistent_sessions", json!(opened.persistent_sessions)));

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1135,7 +1135,6 @@ impl InvokeUiSession for FlutterHandler {
                     ("message", json!(&opened.message)),
                     ("pid", json!(opened.pid)),
                     ("service_id", json!(&opened.service_id)),
-                    ("reconnected", json!(opened.reconnected)),
                 ];
                 if !opened.persistent_sessions.is_empty() {
                     event_data.push(("persistent_sessions", json!(opened.persistent_sessions)));

--- a/src/server/terminal_service.rs
+++ b/src/server/terminal_service.rs
@@ -30,10 +30,40 @@ const MAX_OUTPUT_BUFFER_SIZE: usize = 1024 * 1024; // 1MB per terminal
 const MAX_BUFFER_LINES: usize = 10000;
 const MAX_SERVICES: usize = 100; // Maximum number of persistent terminal services
 const SERVICE_IDLE_TIMEOUT: Duration = Duration::from_secs(3600); // 1 hour idle timeout
-const CHANNEL_BUFFER_SIZE: usize = 500; // Number of messages to buffer in channel (increased to reduce data loss)
+const CHANNEL_BUFFER_SIZE: usize = 500; // Channel buffer size. Max per-message size ~4KB (reader buffer), so worst case ~500*4KB ≈ 2MB/terminal. Increased from 100 to reduce data loss during disconnects.
 const COMPRESS_THRESHOLD: usize = 512; // Compress terminal data larger than this
-                                       // Default max bytes for buffer request.
-const DEFAULT_REQUEST_BUFFER_BYTES: usize = 8 * 1024;
+                                       // Default max bytes for reconnection buffer replay.
+const DEFAULT_RECONNECT_BUFFER_BYTES: usize = 8 * 1024;
+const MAX_SIGWINCH_PHASE_ATTEMPTS: u8 = 3; // Max attempts per SIGWINCH phase before giving up
+
+/// Two-phase SIGWINCH trigger for TUI app redraw on reconnection.
+///
+/// Why two phases? A single resize-then-restore done back-to-back is too fast:
+/// by the time the TUI app handles the asynchronous SIGWINCH signal and calls
+/// `ioctl(TIOCGWINSZ)`, the PTY size has already been restored to the original.
+/// ncurses sees no size change and skips the full redraw.
+///
+/// Splitting across two `read_outputs()` calls (~30ms apart) ensures the app
+/// sees a real size change on each SIGWINCH, forcing a complete redraw.
+#[derive(Debug, Clone)]
+enum SigwinchPhase {
+    /// No SIGWINCH needed.
+    Idle,
+    /// Phase 1: Resize PTY to temp dimensions (rows±1). The app handles SIGWINCH
+    /// and redraws at the temporary size.
+    TempResize { retries: u8 },
+    /// Phase 2: Restore PTY to correct dimensions. The app handles SIGWINCH,
+    /// detects the size change, and performs a full redraw at the correct size.
+    Restore { retries: u8 },
+}
+
+/// Which resize to perform in the two-phase SIGWINCH sequence.
+enum SigwinchAction {
+    /// Phase 1: resize to temp dimensions (rows±1) to trigger SIGWINCH with a visible size change.
+    TempResize,
+    /// Phase 2: restore to correct dimensions to trigger SIGWINCH and force full redraw.
+    Restore,
+}
 
 /// Session state machine for terminal streaming.
 #[derive(Debug)]
@@ -42,7 +72,11 @@ enum SessionState {
     Closed,
     /// Session is active, streaming data to client.
     /// pending_buffer: historical buffer to send before real-time data (set on reconnection).
-    Active { pending_buffer: Option<Vec<u8>> },
+    /// sigwinch: two-phase SIGWINCH trigger state for TUI app redraw.
+    Active {
+        pending_buffer: Option<Vec<u8>>,
+        sigwinch: SigwinchPhase,
+    },
 }
 
 lazy_static::lazy_static! {
@@ -458,14 +492,23 @@ impl OutputBuffer {
             if size + line.len() > max_bytes {
                 if size == 0 && line.len() > max_bytes {
                     // Single oversized chunk: take the tail to preserve the most recent content.
-                    // Align offset forward to a UTF-8 char boundary to avoid producing
-                    // invalid UTF-8 (which could cause issues in protobuf or Dart decoding).
+                    // Align offset forward to a UTF-8 char boundary so that downstream
+                    // clients (e.g. Dart) that decode the payload as UTF-8 text don't
+                    // encounter split code points. The protobuf bytes field itself allows
+                    // arbitrary bytes; this is a best-effort mitigation for client-side decoding.
                     let mut offset = line.len() - max_bytes;
-                    while offset < line.len() && (line[offset] & 0b1100_0000) == 0b1000_0000 {
-                        offset += 1; // skip UTF-8 continuation bytes
+                    // Skip at most 3 continuation bytes (UTF-8 max 4-byte sequence).
+                    // Prevents runaway skipping on non-UTF-8 binary data.
+                    let mut skipped = 0u8;
+                    while skipped < 3
+                        && offset < line.len()
+                        && (line[offset] & 0b1100_0000) == 0b1000_0000
+                    {
+                        offset += 1;
+                        skipped += 1;
                     }
                     // If we skipped past all remaining bytes (degenerate data), drop the
-                    // chunk entirely rather than producing invalid UTF-8.
+                    // chunk entirely rather than emitting a slice that decodes poorly on the client.
                     if offset < line.len() {
                         chunks.push(&line[offset..]);
                         size = line.len() - offset;
@@ -485,6 +528,51 @@ impl OutputBuffer {
         }
 
         result
+    }
+}
+
+/// Try to send data through the output channel with rate-limited drop logging.
+/// Returns `true` if the caller should break out of the read loop (channel disconnected).
+fn try_send_output(
+    output_tx: &mpsc::SyncSender<Vec<u8>>,
+    data: Vec<u8>,
+    terminal_id: i32,
+    label: &str,
+    drop_count: &mut u64,
+    last_drop_warn: &mut Instant,
+) -> bool {
+    match output_tx.try_send(data) {
+        Ok(_) => {
+            if *drop_count > 0 {
+                log::trace!(
+                    "Terminal {}{} output channel recovered, dropped {} chunks since last report",
+                    terminal_id,
+                    label,
+                    *drop_count
+                );
+                *drop_count = 0;
+            }
+            false
+        }
+        Err(mpsc::TrySendError::Full(_)) => {
+            *drop_count += 1;
+            if last_drop_warn.elapsed() >= Duration::from_secs(5) {
+                log::trace!(
+                    "Terminal {}{} output channel full, dropped {} chunks in last {:?}",
+                    terminal_id,
+                    label,
+                    *drop_count,
+                    last_drop_warn.elapsed()
+                );
+                *drop_count = 0;
+                *last_drop_warn = Instant::now();
+            }
+            false
+        }
+        Err(mpsc::TrySendError::Disconnected(_)) => {
+            log::debug!("Terminal {}{} output channel disconnected", terminal_id, label);
+            true
+        }
     }
 }
 
@@ -708,7 +796,9 @@ impl PersistentTerminalService {
             (
                 session.rows,
                 session.cols,
-                session.output_buffer.get_recent(DEFAULT_REQUEST_BUFFER_BYTES),
+                session
+                    .output_buffer
+                    .get_recent(DEFAULT_RECONNECT_BUFFER_BYTES),
             )
         })
     }
@@ -851,22 +941,25 @@ impl TerminalServiceProxy {
             // Historical buffer is sent first by read_outputs(), then real-time data follows.
             // No overlap: pending_buffer comes from output_buffer (pre-disconnect history),
             // while received_data in read_outputs() comes from the channel (post-reconnect).
-            // During disconnect, read_outputs() is not called so output_buffer is not updated.
+            // During disconnect, the run loop (sp.ok()) exits so read_outputs() stops being
+            // called; output_buffer is not updated, and channel data may be lost if it fills up.
             let buffer = session
                 .output_buffer
-                .get_recent(DEFAULT_REQUEST_BUFFER_BYTES);
+                .get_recent(DEFAULT_RECONNECT_BUFFER_BYTES);
+            let has_pending = !buffer.is_empty();
             session.state = SessionState::Active {
-                pending_buffer: if buffer.is_empty() {
-                    None
-                } else {
-                    Some(buffer)
+                pending_buffer: if has_pending { Some(buffer) } else { None },
+                // Always trigger two-phase SIGWINCH on reconnect to force TUI app redraw,
+                // regardless of whether there's pending buffer data. This avoids edge cases
+                // where buffer is empty but a TUI app (top/htop) still needs a full redraw.
+                sigwinch: SigwinchPhase::TempResize {
+                    retries: MAX_SIGWINCH_PHASE_ATTEMPTS,
                 },
             };
             let mut opened = TerminalOpened::new();
             opened.terminal_id = open.terminal_id;
             opened.success = true;
             opened.message = "Reconnected to existing terminal".to_string();
-            opened.reconnected = true;
             opened.pid = session.pid;
             opened.service_id = self.service_id.clone();
             if service.needs_session_sync {
@@ -994,7 +1087,8 @@ impl TerminalServiceProxy {
             let mut reader = reader;
             let mut buf = vec![0u8; 4096];
             let mut drop_count: u64 = 0;
-            let mut last_drop_warn = Instant::now();
+            // Initialize to > 5s ago so the first drop triggers a warning immediately.
+            let mut last_drop_warn = Instant::now() - Duration::from_secs(6);
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => {
@@ -1015,33 +1109,15 @@ impl TerminalServiceProxy {
                         // Note: data produced during disconnect may be lost if channel fills up,
                         // since output_buffer is only updated in read_outputs(). The buffer will
                         // contain history from before the disconnect, not data produced after it.
-                        match output_tx.try_send(data) {
-                            Ok(_) => {
-                                // Flush accumulated drop warning if any
-                                if drop_count > 0 {
-                                    log::warn!(
-                                        "Terminal {} output channel full, dropped {} chunks (reconnection buffer may have gaps)",
-                                        terminal_id, drop_count
-                                    );
-                                    drop_count = 0;
-                                }
-                            }
-                            Err(mpsc::TrySendError::Full(_)) => {
-                                drop_count += 1;
-                                // Rate-limit warnings: at most once per 5 seconds
-                                if last_drop_warn.elapsed() >= Duration::from_secs(5) {
-                                    log::warn!(
-                                        "Terminal {} output channel full, dropped {} chunks (reconnection buffer may have gaps)",
-                                        terminal_id, drop_count
-                                    );
-                                    drop_count = 0;
-                                    last_drop_warn = Instant::now();
-                                }
-                            }
-                            Err(mpsc::TrySendError::Disconnected(_)) => {
-                                log::debug!("Terminal {} output channel disconnected", terminal_id);
-                                break;
-                            }
+                        if try_send_output(
+                            &output_tx,
+                            data,
+                            terminal_id,
+                            "",
+                            &mut drop_count,
+                            &mut last_drop_warn,
+                        ) {
+                            break;
                         }
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -1069,6 +1145,7 @@ impl TerminalServiceProxy {
         session.writer_thread = Some(writer_thread);
         session.state = SessionState::Active {
             pending_buffer: None,
+            sigwinch: SigwinchPhase::Idle,
         };
 
         let mut opened = TerminalOpened::new();
@@ -1232,7 +1309,8 @@ impl TerminalServiceProxy {
         let reader_thread = thread::spawn(move || {
             let mut buf = vec![0u8; 4096];
             let mut drop_count: u64 = 0;
-            let mut last_drop_warn = Instant::now();
+            // Initialize to > 5s ago so the first drop triggers a warning immediately.
+            let mut last_drop_warn = Instant::now() - Duration::from_secs(6);
             loop {
                 match output_pipe.read(&mut buf) {
                     Ok(0) => {
@@ -1246,31 +1324,15 @@ impl TerminalServiceProxy {
                         }
                         let data = buf[..n].to_vec();
                         // Use try_send to avoid blocking the reader thread (same as direct PTY mode)
-                        match output_tx.try_send(data) {
-                            Ok(_) => {
-                                if drop_count > 0 {
-                                    log::warn!(
-                                        "Terminal {} (helper) output channel full, dropped {} chunks (reconnection buffer may have gaps)",
-                                        terminal_id, drop_count
-                                    );
-                                    drop_count = 0;
-                                }
-                            }
-                            Err(mpsc::TrySendError::Full(_)) => {
-                                drop_count += 1;
-                                if last_drop_warn.elapsed() >= Duration::from_secs(5) {
-                                    log::warn!(
-                                        "Terminal {} (helper) output channel full, dropped {} chunks (reconnection buffer may have gaps)",
-                                        terminal_id, drop_count
-                                    );
-                                    drop_count = 0;
-                                    last_drop_warn = Instant::now();
-                                }
-                            }
-                            Err(mpsc::TrySendError::Disconnected(_)) => {
-                                log::debug!("Terminal {} output channel disconnected", terminal_id);
-                                break;
-                            }
+                        if try_send_output(
+                            &output_tx,
+                            data,
+                            terminal_id,
+                            " (helper)",
+                            &mut drop_count,
+                            &mut last_drop_warn,
+                        ) {
+                            break;
                         }
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -1302,6 +1364,7 @@ impl TerminalServiceProxy {
         session.writer_thread = Some(writer_thread);
         session.state = SessionState::Active {
             pending_buffer: None,
+            sigwinch: SigwinchPhase::Idle,
         };
         session.is_helper_mode = true;
         session.helper_process_handle = Some(SendableHandle::new(helper_raw_handle));
@@ -1343,6 +1406,11 @@ impl TerminalServiceProxy {
             session.update_activity();
             session.rows = resize.rows as u16;
             session.cols = resize.cols as u16;
+
+            // Note: we do NOT clear the sigwinch phase here. The server-side two-phase
+            // SIGWINCH mechanism in read_outputs() is self-contained (temp resize → restore
+            // across two polling cycles), so client resize is purely a dimension sync and
+            // doesn't affect it.
 
             // Windows: handle helper mode vs direct PTY mode
             #[cfg(target_os = "windows")]
@@ -1449,6 +1517,94 @@ impl TerminalServiceProxy {
         }
     }
 
+    /// Perform a single PTY resize as part of the two-phase SIGWINCH sequence.
+    /// Returns true if the resize succeeded.
+    ///
+    /// Takes individual field references to avoid borrowing the entire TerminalSession,
+    /// which would conflict with the mutable borrow of session.state in read_outputs().
+    fn do_sigwinch_resize(
+        terminal_id: i32,
+        rows: u16,
+        cols: u16,
+        pty_pair: &Option<portable_pty::PtyPair>,
+        input_tx: &Option<SyncSender<Vec<u8>>>,
+        _is_helper_mode: bool,
+        action: &SigwinchAction,
+    ) -> bool {
+        // Skip if dimensions are not initialized (shouldn't happen on reconnect,
+        // but guard against it to avoid resizing to nonsensical values).
+        if rows == 0 || cols == 0 {
+            return false;
+        }
+
+        let target_rows = match action {
+            SigwinchAction::TempResize => {
+                // For very small terminals (≤2 rows), subtracting 1 would result in an unusable
+                // size (0 or 1 row), so we add 1 instead. Either direction triggers SIGWINCH.
+                if rows > 2 {
+                    rows.saturating_sub(1)
+                } else {
+                    rows.saturating_add(1)
+                }
+            }
+            SigwinchAction::Restore => rows,
+        };
+
+        let phase_name = match action {
+            SigwinchAction::TempResize => "temp resize",
+            SigwinchAction::Restore => "restore",
+        };
+
+        #[cfg(target_os = "windows")]
+        let use_helper = _is_helper_mode;
+        #[cfg(not(target_os = "windows"))]
+        let use_helper = false;
+
+        if use_helper {
+            #[cfg(target_os = "windows")]
+            {
+                let input_tx = match input_tx {
+                    Some(tx) => tx,
+                    None => return false,
+                };
+                let msg = encode_resize_message(target_rows, cols);
+                if let Err(e) = input_tx.try_send(msg) {
+                    log::warn!(
+                        "Terminal {} SIGWINCH {} via helper failed: {}",
+                        terminal_id,
+                        phase_name,
+                        e
+                    );
+                    return false;
+                }
+                true
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                let _ = (input_tx, phase_name);
+                false
+            }
+        } else if let Some(pty_pair) = pty_pair {
+            if let Err(e) = pty_pair.master.resize(PtySize {
+                rows: target_rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            }) {
+                log::warn!(
+                    "Terminal {} SIGWINCH {} failed: {}",
+                    terminal_id,
+                    phase_name,
+                    e
+                );
+                return false;
+            }
+            true
+        } else {
+            false
+        }
+    }
+
     /// Helper to create a TerminalResponse with optional compression.
     fn create_terminal_data_response(terminal_id: i32, data: Vec<u8>) -> TerminalResponse {
         let mut response = TerminalResponse::new();
@@ -1512,8 +1668,11 @@ impl TerminalServiceProxy {
                     closed_terminals.push(terminal_id);
                 }
 
-                // Read from output channel (always read to prevent channel overflow,
-                // even when session is not opened - data will be buffered for reconnection)
+                // Always drain the output channel regardless of session state.
+                // When Active: data is sent to client. When Closed (within the same
+                // connection): data is buffered in output_buffer for reconnection replay.
+                // Note: during actual disconnect, the run loop exits and read_outputs()
+                // is not called, so channel data produced after disconnect may be lost.
                 let mut has_activity = false;
                 let mut received_data = Vec::new();
                 if let Some(output_rx) = &session.output_rx {
@@ -1535,16 +1694,94 @@ impl TerminalServiceProxy {
 
                 // Skip sending responses if session is not Active.
                 // Data is already buffered above and will be sent on next reconnection.
-                let pending_buffer = match &mut session.state {
-                    SessionState::Active { pending_buffer } => pending_buffer,
-                    _ => continue,
+                // Use a scoped block to limit the mutable borrow of session.state,
+                // so we can immutably borrow other session fields afterwards.
+                let sigwinch_action = {
+                    let (pending_buffer, sigwinch) = match &mut session.state {
+                        SessionState::Active {
+                            pending_buffer,
+                            sigwinch,
+                        } => (pending_buffer, sigwinch),
+                        _ => continue,
+                    };
+
+                    // Send pending buffer response first (set on reconnection in handle_open).
+                    // This ensures historical buffer is sent before any real-time data.
+                    if let Some(buffer) = pending_buffer.take() {
+                        if !buffer.is_empty() {
+                            responses
+                                .push(Self::create_terminal_data_response(terminal_id, buffer));
+                        }
+                    }
+
+                    // Two-phase SIGWINCH: see SigwinchPhase doc comments for rationale.
+                    // Each phase is a single PTY resize, spaced ~30ms apart by the polling
+                    // interval, ensuring the TUI app sees a real size change on each signal.
+                    match sigwinch {
+                        SigwinchPhase::TempResize { retries } => {
+                            if *retries == 0 {
+                                log::warn!(
+                                    "Terminal {} SIGWINCH phase 1 (temp resize) failed after {} attempts, giving up",
+                                    terminal_id, MAX_SIGWINCH_PHASE_ATTEMPTS
+                                );
+                                *sigwinch = SigwinchPhase::Idle;
+                                None
+                            } else {
+                                *retries -= 1;
+                                Some(SigwinchAction::TempResize)
+                            }
+                        }
+                        SigwinchPhase::Restore { retries } => {
+                            if *retries == 0 {
+                                log::warn!(
+                                    "Terminal {} SIGWINCH phase 2 (restore) failed after {} attempts, giving up",
+                                    terminal_id, MAX_SIGWINCH_PHASE_ATTEMPTS
+                                );
+                                *sigwinch = SigwinchPhase::Idle;
+                                None
+                            } else {
+                                *retries -= 1;
+                                Some(SigwinchAction::Restore)
+                            }
+                        }
+                        SigwinchPhase::Idle => None,
+                    }
                 };
 
-                // Send pending buffer response first (set on reconnection in handle_open).
-                // This ensures historical buffer is sent before any real-time data.
-                if let Some(buffer) = pending_buffer.take() {
-                    if !buffer.is_empty() {
-                        responses.push(Self::create_terminal_data_response(terminal_id, buffer));
+                // Execute SIGWINCH resize outside the mutable borrow scope of session.state.
+                if let Some(action) = sigwinch_action {
+                    #[cfg(target_os = "windows")]
+                    let is_helper = session.is_helper_mode;
+                    #[cfg(not(target_os = "windows"))]
+                    let is_helper = false;
+                    let resize_ok = Self::do_sigwinch_resize(
+                        terminal_id,
+                        session.rows,
+                        session.cols,
+                        &session.pty_pair,
+                        &session.input_tx,
+                        is_helper,
+                        &action,
+                    );
+                    if let SessionState::Active { sigwinch, .. } = &mut session.state {
+                        match action {
+                            SigwinchAction::TempResize => {
+                                if resize_ok {
+                                    // Phase 1 succeeded — advance to phase 2 (restore).
+                                    *sigwinch = SigwinchPhase::Restore {
+                                        retries: MAX_SIGWINCH_PHASE_ATTEMPTS,
+                                    };
+                                }
+                                // If failed, retries already decremented; will retry phase 1.
+                            }
+                            SigwinchAction::Restore => {
+                                if resize_ok {
+                                    // Phase 2 succeeded — SIGWINCH sequence complete.
+                                    *sigwinch = SigwinchPhase::Idle;
+                                }
+                                // If failed, retries already decremented; will retry phase 2.
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fix two related issues:
  1. Reconnecting to persistent sessions shows a blank screen — the server now automatically sends the historical buffer on reconnection via the SessionState machine with pending_buffer, eliminating the need for client-initiated buffer requests.
  2. TUI apps (`top`, `htop`) fail to redraw after reconnection — a two-phase SIGWINCH mechanism (temp resize → restore, spaced across two polling cycles) forces ncurses-based apps to perform a full redraw.

Rust side:
  - Introduce SessionState enum (Closed/Active), replacing bool `is_opened`
  - Auto-attach pending buffer on reconnection in handle_open()
  - Add two-phase SIGWINCH state machine (TempResize → Restore → Idle) with retry logic for TUI app redraw on reconnection
  - Add session remap logic for non-contiguous terminal_id reconnection
  - Always drain the output channel in read_outputs() to prevent overflow
  - Increase channel buffer from 100 to 500
  - Optimize get_recent() to collect whole chunks (avoids ANSI truncation) with UTF-8 boundary alignment and continuation byte skip limit
  - Extract create_terminal_data_response() and try_send_output() helpers (DRY)

Flutter side:
  - Buffer output chunks until the terminal view has valid dimensions
  - Flush buffered output on first valid resize via _markViewReady()
  - Fix max_bytes type (u32) to match protobuf definition
  - Fix _showTerminalExtraKeys for web desktop
  - Add web guard in canBeBlocked()


## Tests

- [x] reconnect, auto refresh the view
- [x] reconnect, `top` `htop`
- [x] web as the controlling side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal reconnection and two-phase redraws to reduce data loss and visual glitches during reconnect/resize.
  * Ensured sessions are persisted on window-close to avoid lost state.

* **Improvements**
  * Stronger terminal output replay so recent output is preserved on reconnect and buffered input is processed reliably (with error handling).
  * Terminal view readiness now flushes pre-layout output when dimensions are available.

* **New Features**
  * Web builds: terminals are no longer considered blockable; on-screen extra-keys bar suppressed on web desktop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->