### PR TITLE
packaging: deb: remove obsolete Python version check

### DIFF
--- a/res/DEBIAN/postinst
+++ b/res/DEBIAN/postinst
@@ -6,15 +6,13 @@ if [ "$1" = configure ]; then
 
 	INITSYS=$(ls -al /proc/1/exe | awk -F' ' '{print $NF}' | awk -F'/' '{print $NF}')
 	ln -f -s /usr/share/rustdesk/rustdesk /usr/bin/rustdesk
-	
+
 	if [ "systemd" == "$INITSYS" ]; then
 
 		if [ -e /etc/systemd/system/rustdesk.service ]; then
 			rm /etc/systemd/system/rustdesk.service /usr/lib/systemd/system/rustdesk.service /usr/lib/systemd/user/rustdesk.service >/dev/null  2>&1
 		fi
-		version=$(python3 -V 2>&1 | grep -Po '(?<=Python )(.+)')
-		parsedVersion=$(echo "${version//./}")
-        mkdir -p /usr/lib/systemd/system/
+		mkdir -p /usr/lib/systemd/system/
 		cp /usr/share/rustdesk/files/systemd/rustdesk.service /usr/lib/systemd/system/rustdesk.service
 		# try fix error in Ubuntu 18.04
 		# Failed to reload rustdesk.service: Unit rustdesk.service is not loaded properly: Exec format error.


### PR DESCRIPTION
It was used to conditionally install a Python module in the past. But that is not the case anymore since https://github.com/rustdesk/rustdesk/commit/37dbfcc. Now the check is obsolete.

Due to `set -e`, the check leads to a package configuration failure if Python is not installed, which however otherwise is not needed for RustDesk.

The commit includes an indentation fix and trailing space removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Debian package post-installation script to adjust systemd service setup configuration during package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->