### PR TITLE
fix(update): macos, input password

### DIFF
--- a/src/platform/privileges_scripts/update.scpt
+++ b/src/platform/privileges_scripts/update.scpt
@@ -1,18 +1,21 @@
 on run {daemon_file, agent_file, user, cur_pid, source_dir}
 
-  set unload_service to "launchctl unload -w /Library/LaunchDaemons/com.carriez.RustDesk_service.plist || true;"
+  set agent_plist to "/Library/LaunchAgents/com.carriez.RustDesk_server.plist"
+  set daemon_plist to "/Library/LaunchDaemons/com.carriez.RustDesk_service.plist"
+  set app_bundle to "/Applications/RustDesk.app"
 
-  set kill_others to "pgrep -x 'RustDesk' | grep -v " & cur_pid & " | xargs kill -9;"
+  set resolve_uid to "uid=$(id -u " & quoted form of user & " 2>/dev/null || true);"
+  set unload_agent to "if [ -n \"$uid\" ]; then launchctl bootout gui/$uid " & quoted form of agent_plist & " 2>/dev/null || launchctl bootout user/$uid " & quoted form of agent_plist & " 2>/dev/null || launchctl unload -w " & quoted form of agent_plist & " || true; else launchctl unload -w " & quoted form of agent_plist & " || true; fi;"
+  set unload_service to "launchctl unload -w " & daemon_plist & " || true;"
+  set kill_others to "pids=$(pgrep -x 'RustDesk' | grep -vx " & cur_pid & " || true); if [ -n \"$pids\" ]; then echo \"$pids\" | xargs kill -9 || true; fi;"
 
-  set copy_files to "rm -rf /Applications/RustDesk.app && ditto " & source_dir & " /Applications/RustDesk.app && chown -R " & quoted form of user & ":staff /Applications/RustDesk.app && xattr -r -d com.apple.quarantine /Applications/RustDesk.app;"
+  set copy_files to "(rm -rf " & quoted form of app_bundle & " && ditto " & quoted form of source_dir & " " & quoted form of app_bundle & " && chown -R " & quoted form of user & ":staff " & quoted form of app_bundle & " && (xattr -r -d com.apple.quarantine " & quoted form of app_bundle & " || true)) || exit 1;"
 
-  set sh1 to "echo " & quoted form of daemon_file & " > /Library/LaunchDaemons/com.carriez.RustDesk_service.plist && chown root:wheel /Library/LaunchDaemons/com.carriez.RustDesk_service.plist;"
+  set write_daemon_plist to "echo " & quoted form of daemon_file & " > " & daemon_plist & " && chown root:wheel " & daemon_plist & ";"
+  set write_agent_plist to "echo " & quoted form of agent_file & " > " & agent_plist & " && chown root:wheel " & agent_plist & ";"
+  set load_service to "launchctl load -w " & daemon_plist & ";"
 
-  set sh2 to "echo " & quoted form of agent_file & " > /Library/LaunchAgents/com.carriez.RustDesk_server.plist && chown root:wheel /Library/LaunchAgents/com.carriez.RustDesk_server.plist;"
-
-  set sh3 to "launchctl load -w /Library/LaunchDaemons/com.carriez.RustDesk_service.plist;"
-
-  set sh to unload_service & kill_others & copy_files & sh1 & sh2 & sh3
+  set sh to "set -e;" & resolve_uid & unload_agent & unload_service & kill_others & copy_files & write_daemon_plist & write_agent_plist & load_service
 
   do shell script sh with prompt "RustDesk wants to update itself" with administrator privileges
 end run


### PR DESCRIPTION
When updating RustDesk on macOS:
1. Install → Connect → Click "Update" → Disconnect
2. osascript prompt appears after disconnection
3. Password cannot be input (connection closed)
4. Update process gets stuck

## Fixes

1. Show osascript prompt before disconnecting (add `launchctl unload agent` to `update.scpt`)
2. Add `quoted form of` to variables

## Tests

1. Standard RustDesk update
2. Custom client update (`--update test.dmg`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling and status logging during application updates for clearer feedback on operation success.
  * Improved daemon process management during updates to ensure more reliable system behavior and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->