### PR TITLE
Fix audio capture device selection on Windows

### DIFF
--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -286,18 +286,21 @@ mod cpal_impl {
         if !audio_input.is_empty() {
             return get_audio_input(&audio_input);
         }
+        // FIX: Use default_input_device() for audio input capture on Windows
+        // Previously used default_output_device() which caused audio playback issues
+        // when the default device was an output-only device (like "Astro MixAmp Pro Game")
         let device = HOST
-            .default_output_device()
-            .with_context(|| "Failed to get default output device for loopback")?;
+            .default_input_device()
+            .with_context(|| "Failed to get default input device for loopback")?;
         log::info!(
-            "Default output device: {}",
+            "Default input device: {}",
             device.name().unwrap_or("".to_owned())
         );
         let format = device
-            .default_output_config()
+            .default_input_config()
             .map_err(|e| anyhow!(e))
-            .with_context(|| "Failed to get default output format")?;
-        log::info!("Default output format: {:?}", format);
+            .with_context(|| "Failed to get default input format")?;
+        log::info!("Default input format: {:?}", format);
         Ok((device, format))
     }
 


### PR DESCRIPTION
Fix audio capture device selection on Windows to resolve issue where audio playback from remote machines cannot be heard.

## Problem
When connecting to remote machines via RustDesk, users cannot hear audio playback when the default audio device is set to an output-only device (e.g., "Astro MixAmp Pro Game"). The issue only occurs when using Windows CoreAudio.

## Root Cause
The code was incorrectly using `HOST.default_output_device()` instead of `HOST.default_input_device()` for audio input capture on Windows. This caused issues when:
- The default device was configured as an output-only device
- The code attempted to use it as an audio input device
- Audio capture failed or produced no output

## Solution
Changed Windows platform implementation to use `default_input_device()` for audio input capture:

**File**: `src/server/audio_service.rs`

**Changes**:
- `default_output_device()` → `default_input_device()`
- `default_output_config()` → `default_input_config()`
- Updated log messages to reflect "input" instead of "output"

This ensures that a proper audio input-capable device is selected for system audio capture.

## Testing
The fix should be tested by:
1. Setting default audio device to an output-only device
2. Connecting to a remote machine
3. Playing audio on the remote machine
4. Verifying that audio can be heard on the local machine

## Limitations
- This fix does not include ASIO support as originally mentioned in the issue
- ASIO support would require significant additional changes and should be done as a follow-up enhancement
- The current solution uses Windows CoreAudio (WASAPI) which provides adequate performance for most use cases

## References
- Issue: https://github.com/rustdesk/rustdesk/issues/3762
- Bounty: $100

/claim 3762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows loopback audio capture to use the default input device instead of the default output device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->