### PR TITLE
fix(keyboard): legacy mode

### DIFF
--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -269,7 +269,7 @@ impl KeyboardControllable for Enigo {
                     for pos in 0..mod_len {
                         let rpos = mod_len - 1 - pos;
                         if flag & (0x0001 << rpos) != 0 {
-                            self.key_up(modifiers[pos]);
+                            self.key_up(modifiers[rpos]);
                         }
                     }
 
@@ -298,7 +298,18 @@ impl KeyboardControllable for Enigo {
     }
 
     fn key_up(&mut self, key: Key) {
-        keybd_event(KEYEVENTF_KEYUP, self.key_to_keycode(key), 0);
+        match key {
+            Key::Layout(c) => {
+                let code = self.get_layoutdependent_keycode(c);
+                if code as u16 != 0xFFFF {
+                    let vk = code & 0x00FF;
+                    keybd_event(KEYEVENTF_KEYUP, vk, 0);
+                }
+            }
+            _ => {
+                keybd_event(KEYEVENTF_KEYUP, self.key_to_keycode(key), 0);
+            }
+        }
     }
 
     fn get_key_state(&mut self, key: Key) -> bool {

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -809,7 +809,7 @@ fn record_key_is_control_key(record_key: u64) -> bool {
 
 #[inline]
 fn record_key_is_chr(record_key: u64) -> bool {
-    record_key < KEY_CHAR_START
+    record_key >= KEY_CHAR_START
 }
 
 #[inline]
@@ -1513,6 +1513,27 @@ fn get_control_key_value(key_event: &KeyEvent) -> i32 {
     }
 }
 
+#[inline]
+fn has_hotkey_modifiers(key_event: &KeyEvent) -> bool {
+    key_event.modifiers.iter().any(|ck| {
+        let v = ck.value();
+        v == ControlKey::Control.value()
+            || v == ControlKey::RControl.value()
+            || v == ControlKey::Meta.value()
+            || v == ControlKey::RWin.value()
+            || {
+                #[cfg(any(target_os = "windows", target_os = "linux"))]
+                {
+                    v == ControlKey::Alt.value() || v == ControlKey::RAlt.value()
+                }
+                #[cfg(target_os = "macos")]
+                {
+                    false
+                }
+            }
+    })
+}
+
 fn release_unpressed_modifiers(en: &mut Enigo, key_event: &KeyEvent) {
     let ck_value = get_control_key_value(key_event);
     fix_modifiers(&key_event.modifiers[..], en, ck_value);
@@ -1572,7 +1593,9 @@ fn need_to_uppercase(en: &mut Enigo) -> bool {
     get_modifier_state(Key::Shift, en) || get_modifier_state(Key::CapsLock, en)
 }
 
-fn process_chr(en: &mut Enigo, chr: u32, down: bool) {
+fn process_chr(en: &mut Enigo, chr: u32, down: bool, hotkey: bool) {
+    let _ = hotkey;
+
     // On Wayland with uinput mode, use clipboard for character input
     #[cfg(target_os = "linux")]
     if !crate::platform::linux::is_x11() && wayland_use_uinput() {
@@ -1585,6 +1608,20 @@ fn process_chr(en: &mut Enigo, chr: u32, down: bool) {
             }
             return;
         }
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    if !hotkey {
+        if down {
+            if let Ok(chr) = char::try_from(chr) {
+                let mut s = chr.to_string();
+                if need_to_uppercase(en) {
+                    s = s.to_uppercase();
+                }
+                en.key_sequence(&s);
+            }
+        }
+        return;
     }
 
     let key = char_value_to_key(chr);
@@ -1856,7 +1893,7 @@ fn legacy_keyboard_mode(evt: &KeyEvent) {
 
             let record_key = chr as u64 + KEY_CHAR_START;
             record_pressed_key(KeysDown::EnigoKey(record_key), down);
-            process_chr(&mut en, chr, down)
+            process_chr(&mut en, chr, down, has_hotkey_modifiers(evt))
         }
         Some(key_event::Union::Unicode(chr)) => {
             // Same as Chr: release Shift for Unicode input

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1609,9 +1609,11 @@ fn process_chr(en: &mut Enigo, chr: u32, down: bool, _hotkey: bool) {
     }
 
     #[cfg(any(target_os = "macos", target_os = "windows"))]
-    if !_hotkey && down {
-        if let Ok(chr) = char::try_from(chr) {
-            en.key_sequence(&chr.to_string());
+    if !_hotkey {
+        if down {
+            if let Ok(chr) = char::try_from(chr) {
+                en.key_sequence(&chr.to_string());
+            }
         }
         return;
     }

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1609,11 +1609,9 @@ fn process_chr(en: &mut Enigo, chr: u32, down: bool, _hotkey: bool) {
     }
 
     #[cfg(any(target_os = "macos", target_os = "windows"))]
-    if !_hotkey {
-        if down {
-            if let Ok(chr) = char::try_from(chr) {
-                en.key_sequence(&chr.to_string());
-            }
+    if !_hotkey && down {
+        if let Ok(chr) = char::try_from(chr) {
+            en.key_sequence(&chr.to_string());
         }
         return;
     }

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1593,9 +1593,7 @@ fn need_to_uppercase(en: &mut Enigo) -> bool {
     get_modifier_state(Key::Shift, en) || get_modifier_state(Key::CapsLock, en)
 }
 
-fn process_chr(en: &mut Enigo, chr: u32, down: bool, hotkey: bool) {
-    let _ = hotkey;
-
+fn process_chr(en: &mut Enigo, chr: u32, down: bool, _hotkey: bool) {
     // On Wayland with uinput mode, use clipboard for character input
     #[cfg(target_os = "linux")]
     if !crate::platform::linux::is_x11() && wayland_use_uinput() {
@@ -1611,7 +1609,7 @@ fn process_chr(en: &mut Enigo, chr: u32, down: bool, hotkey: bool) {
     }
 
     #[cfg(any(target_os = "macos", target_os = "windows"))]
-    if !hotkey {
+    if !_hotkey {
         if down {
             if let Ok(chr) = char::try_from(chr) {
                 let mut s = chr.to_string();

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1612,11 +1612,7 @@ fn process_chr(en: &mut Enigo, chr: u32, down: bool, _hotkey: bool) {
     if !_hotkey {
         if down {
             if let Ok(chr) = char::try_from(chr) {
-                let mut s = chr.to_string();
-                if need_to_uppercase(en) {
-                    s = s.to_uppercase();
-                }
-                en.key_sequence(&s);
+                en.key_sequence(&chr.to_string());
             }
         }
         return;


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/14104

1. Use `en.key_sequence(&s);` to handle `process_chr()` -> `legacy_keyboard_mode()`.
2. Fix `record_key_is_chr()`
3. Fix `key_down()` and `key_up()` in `libs\enigo\src\win\win_impl.rs`.

## Tests

- [x] mobile -> linux/win/macOS (Czech - cz, French - fr)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed modifier release ordering for more reliable modifier key behavior.
  * Improved handling of layout-dependent keys so layout-mapped keys are recognized and released correctly.

* **Enhancements**
  * Detects common hotkey modifiers and refines cross-platform input routing to avoid unintended clipboard pastes or incorrect sequence input when modifiers are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->