### PR TITLE
fix(update): macos, test before update

### DIFF
--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -859,9 +859,10 @@ on run {app_name, cur_pid, app_dir, user_name}
     set app_dir_q to quoted form of app_dir
     set user_name_q to quoted form of user_name
 
+    set check_source to "test -d " & app_dir_q & " || exit 1;"
     set kill_others to "pids=$(pgrep -x '" & app_name & "' | grep -vx " & cur_pid & " || true); if [ -n \"$pids\" ]; then echo \"$pids\" | xargs kill -9 || true; fi;"
     set copy_files to "rm -rf " & app_bundle_q & " && ditto " & app_dir_q & " " & app_bundle_q & " && chown -R " & user_name_q & ":staff " & app_bundle_q & " && (xattr -r -d com.apple.quarantine " & app_bundle_q & " || true);"
-    set sh to "set -e;" & kill_others & copy_files
+    set sh to "set -e;" & check_source & kill_others & copy_files
 
     do shell script sh with prompt app_name & " wants to update itself" with administrator privileges
 end run

--- a/src/platform/privileges_scripts/update.scpt
+++ b/src/platform/privileges_scripts/update.scpt
@@ -4,6 +4,7 @@ on run {daemon_file, agent_file, user, cur_pid, source_dir}
   set daemon_plist to "/Library/LaunchDaemons/com.carriez.RustDesk_service.plist"
   set app_bundle to "/Applications/RustDesk.app"
 
+  set check_source to "test -d " & quoted form of source_dir & " || exit 1;"
   set resolve_uid to "uid=$(id -u " & quoted form of user & " 2>/dev/null || true);"
   set unload_agent to "if [ -n \"$uid\" ]; then launchctl bootout gui/$uid " & quoted form of agent_plist & " 2>/dev/null || launchctl bootout user/$uid " & quoted form of agent_plist & " 2>/dev/null || launchctl unload -w " & quoted form of agent_plist & " || true; else launchctl unload -w " & quoted form of agent_plist & " || true; fi;"
   set unload_service to "launchctl unload -w " & daemon_plist & " || true;"
@@ -19,7 +20,7 @@ on run {daemon_file, agent_file, user, cur_pid, source_dir}
   set kickstart_agent to "if [ -n \"$uid\" ]; then launchctl kickstart -k gui/$uid/$agent_label 2>/dev/null || launchctl kickstart -k user/$uid/$agent_label 2>/dev/null || true; fi;"
   set load_agent to agent_label_cmd & bootstrap_agent & kickstart_agent
 
-  set sh to "set -e;" & resolve_uid & unload_agent & unload_service & kill_others & copy_files & write_daemon_plist & write_agent_plist & load_service & load_agent
+  set sh to "set -e;" & check_source & resolve_uid & unload_agent & unload_service & kill_others & copy_files & write_daemon_plist & write_agent_plist & load_service & load_agent
 
   do shell script sh with prompt "RustDesk wants to update itself" with administrator privileges
 end run


### PR DESCRIPTION
Fix the issue:
1. Click "Update"
2. Show the password dialog
3. Close the client
4. Restart the client (remove `/tmp/.rustdeskupdate-505`)
5. Input the password
6. `rm -rf /Application/RustDesk.app && ditto ...`

Then the app is removed. While the `ditto` command fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved macOS app update reliability by adding a verification step that checks the app directory exists before proceeding with the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->