### PR TITLE
Move port mapping afterwards

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -560,6 +560,9 @@ impl Connection {
                     match data {
                         ipc::Data::Authorize => {
                             conn.require_2fa.take();
+                            if !conn.connect_port_forward_if_needed().await {
+                                break;
+                            }
                             conn.send_logon_response().await;
                             if conn.port_forward_socket.is_some() {
                                 break;
@@ -1336,6 +1339,47 @@ impl Connection {
     #[inline]
     async fn post_audit_async(url: String, v: Value) -> ResultType<String> {
         crate::post_request(url, v.to_string(), "").await
+    }
+
+    fn normalize_port_forward_target(pf: &mut PortForward) -> (String, bool) {
+        let mut is_rdp = false;
+        if pf.host == "RDP" && pf.port == 0 {
+            pf.host = "localhost".to_owned();
+            pf.port = 3389;
+            is_rdp = true;
+        }
+        if pf.host.is_empty() {
+            pf.host = "localhost".to_owned();
+        }
+        (format!("{}:{}", pf.host, pf.port), is_rdp)
+    }
+
+    async fn connect_port_forward_if_needed(&mut self) -> bool {
+        if self.port_forward_socket.is_some() {
+            return true;
+        }
+        let Some(login_request::Union::PortForward(mut pf)) = self.lr.union.clone() else {
+            return true;
+        };
+        let (mut addr, is_rdp) = Self::normalize_port_forward_target(&mut pf);
+        self.port_forward_address = addr.clone();
+        match timeout(3000, TcpStream::connect(&addr)).await {
+            Ok(Ok(sock)) => {
+                self.port_forward_socket = Some(Framed::new(sock, BytesCodec::new()));
+                true
+            }
+            _ => {
+                if is_rdp {
+                    addr = "RDP".to_owned();
+                }
+                self.send_login_error(format!(
+                    "Failed to access remote {}, please make sure if it is open",
+                    addr
+                ))
+                .await;
+                false
+            }
+        }
     }
 
     async fn send_logon_response(&mut self) {
@@ -2178,33 +2222,8 @@ impl Connection {
                         sleep(1.).await;
                         return false;
                     }
-                    let mut is_rdp = false;
-                    if pf.host == "RDP" && pf.port == 0 {
-                        pf.host = "localhost".to_owned();
-                        pf.port = 3389;
-                        is_rdp = true;
-                    }
-                    if pf.host.is_empty() {
-                        pf.host = "localhost".to_owned();
-                    }
-                    let mut addr = format!("{}:{}", pf.host, pf.port);
-                    self.port_forward_address = addr.clone();
-                    match timeout(3000, TcpStream::connect(&addr)).await {
-                        Ok(Ok(sock)) => {
-                            self.port_forward_socket = Some(Framed::new(sock, BytesCodec::new()));
-                        }
-                        _ => {
-                            if is_rdp {
-                                addr = "RDP".to_owned();
-                            }
-                            self.send_login_error(format!(
-                                "Failed to access remote {}, please make sure if it is open",
-                                addr
-                            ))
-                            .await;
-                            return false;
-                        }
-                    }
+                    let (addr, _is_rdp) = Self::normalize_port_forward_target(&mut pf);
+                    self.port_forward_address = addr;
                 }
                 _ => {
                     if !self.check_privacy_mode_on().await {
@@ -2276,6 +2295,9 @@ impl Connection {
                 if err_msg.is_empty() {
                     #[cfg(target_os = "linux")]
                     self.linux_headless_handle.wait_desktop_cm_ready().await;
+                    if !self.connect_port_forward_if_needed().await {
+                        return false;
+                    }
                     self.send_logon_response().await;
                     self.try_start_cm(lr.my_id.clone(), lr.my_name.clone(), self.authorized);
                 } else {
@@ -2312,6 +2334,9 @@ impl Connection {
                     if err_msg.is_empty() {
                         #[cfg(target_os = "linux")]
                         self.linux_headless_handle.wait_desktop_cm_ready().await;
+                        if !self.connect_port_forward_if_needed().await {
+                            return false;
+                        }
                         self.send_logon_response().await;
                         self.try_start_cm(lr.my_id, lr.my_name, self.authorized);
                     } else {
@@ -2330,6 +2355,9 @@ impl Connection {
                         self.update_failure(failure, true, 1);
                         self.require_2fa.take();
                         raii::AuthedConnID::set_session_2fa(self.session_key());
+                        if !self.connect_port_forward_if_needed().await {
+                            return false;
+                        }
                         self.send_logon_response().await;
                         self.try_start_cm(
                             self.lr.my_id.to_owned(),
@@ -2381,6 +2409,9 @@ impl Connection {
                     if let Some((_instant, uuid_old)) = uuid_old {
                         if uuid == uuid_old {
                             self.from_switch = true;
+                            if !self.connect_port_forward_if_needed().await {
+                                return false;
+                            }
                             self.send_logon_response().await;
                             self.try_start_cm(
                                 lr.my_id.clone(),

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -560,10 +560,9 @@ impl Connection {
                     match data {
                         ipc::Data::Authorize => {
                             conn.require_2fa.take();
-                            if !conn.connect_port_forward_if_needed().await {
+                            if !conn.send_logon_response().await {
                                 break;
                             }
-                            conn.send_logon_response().await;
                             if conn.port_forward_socket.is_some() {
                                 break;
                             }
@@ -1382,9 +1381,9 @@ impl Connection {
         }
     }
 
-    async fn send_logon_response(&mut self) {
+    async fn send_logon_response(&mut self) -> bool {
         if self.authorized {
-            return;
+            return true;
         }
         if self.require_2fa.is_some() && !self.is_recent_session(true) && !self.from_switch {
             self.require_2fa.as_ref().map(|totp| {
@@ -1415,7 +1414,10 @@ impl Connection {
                 }
             });
             self.send_login_error(crate::client::REQUIRE_2FA).await;
-            return;
+            return true;
+        }
+        if !self.connect_port_forward_if_needed().await {
+            return false;
         }
         self.authorized = true;
         let (conn_type, auth_conn_type) = if self.file_transfer.is_some() {
@@ -1538,7 +1540,7 @@ impl Connection {
             res.set_peer_info(pi);
             msg_out.set_login_response(res);
             self.send(msg_out).await;
-            return;
+            return true;
         }
         #[cfg(target_os = "linux")]
         if self.is_remote() {
@@ -1561,7 +1563,7 @@ impl Connection {
                 let mut msg_out = Message::new();
                 msg_out.set_login_response(res);
                 self.send(msg_out).await;
-                return;
+                return true;
             }
         }
         #[allow(unused_mut)]
@@ -1715,6 +1717,7 @@ impl Connection {
                 self.try_sub_monitor_services();
             }
         }
+        true
     }
 
     fn try_sub_camera_displays(&mut self) {
@@ -2295,10 +2298,9 @@ impl Connection {
                 if err_msg.is_empty() {
                     #[cfg(target_os = "linux")]
                     self.linux_headless_handle.wait_desktop_cm_ready().await;
-                    if !self.connect_port_forward_if_needed().await {
+                    if !self.send_logon_response().await {
                         return false;
                     }
-                    self.send_logon_response().await;
                     self.try_start_cm(lr.my_id.clone(), lr.my_name.clone(), self.authorized);
                 } else {
                     self.send_login_error(err_msg).await;
@@ -2334,10 +2336,9 @@ impl Connection {
                     if err_msg.is_empty() {
                         #[cfg(target_os = "linux")]
                         self.linux_headless_handle.wait_desktop_cm_ready().await;
-                        if !self.connect_port_forward_if_needed().await {
+                        if !self.send_logon_response().await {
                             return false;
                         }
-                        self.send_logon_response().await;
                         self.try_start_cm(lr.my_id, lr.my_name, self.authorized);
                     } else {
                         self.send_login_error(err_msg).await;
@@ -2355,10 +2356,9 @@ impl Connection {
                         self.update_failure(failure, true, 1);
                         self.require_2fa.take();
                         raii::AuthedConnID::set_session_2fa(self.session_key());
-                        if !self.connect_port_forward_if_needed().await {
+                        if !self.send_logon_response().await {
                             return false;
                         }
-                        self.send_logon_response().await;
                         self.try_start_cm(
                             self.lr.my_id.to_owned(),
                             self.lr.my_name.to_owned(),
@@ -2409,10 +2409,9 @@ impl Connection {
                     if let Some((_instant, uuid_old)) = uuid_old {
                         if uuid == uuid_old {
                             self.from_switch = true;
-                            if !self.connect_port_forward_if_needed().await {
+                            if !self.send_logon_response().await {
                                 return false;
                             }
-                            self.send_logon_response().await;
                             self.try_start_cm(
                                 lr.my_id.clone(),
                                 lr.my_name.clone(),

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1368,7 +1368,20 @@ impl Connection {
                 self.port_forward_socket = Some(Framed::new(sock, BytesCodec::new()));
                 true
             }
-            _ => {
+            Ok(Err(e)) => {
+                log::warn!("Port forward connect failed for {}: {}", addr, e);
+                if is_rdp {
+                    addr = "RDP".to_owned();
+                }
+                self.send_login_error(format!(
+                    "Failed to access remote {}. Please make sure it is reachable/open.",
+                    addr
+                ))
+                .await;
+                false
+            }
+            Err(e) => {
+                log::warn!("Port forward connect timed out for {}: {}", addr, e);
                 if is_rdp {
                     addr = "RDP".to_owned();
                 }
@@ -1382,6 +1395,8 @@ impl Connection {
         }
     }
 
+    // Returns whether this connection should be kept alive.
+    // `true` does not necessarily mean authorization succeeded (e.g. REQUIRE_2FA case).
     async fn send_logon_response_and_keep_alive(&mut self) -> bool {
         if self.authorized {
             return true;
@@ -1415,6 +1430,7 @@ impl Connection {
                 }
             });
             self.send_login_error(crate::client::REQUIRE_2FA).await;
+            // Keep the connection alive so the client can continue with 2FA.
             return true;
         }
         if !self.connect_port_forward_if_needed().await {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -560,7 +560,7 @@ impl Connection {
                     match data {
                         ipc::Data::Authorize => {
                             conn.require_2fa.take();
-                            if !conn.send_logon_response().await {
+                            if !conn.send_logon_response_and_keep_alive().await {
                                 break;
                             }
                             if conn.port_forward_socket.is_some() {
@@ -1357,9 +1357,10 @@ impl Connection {
         if self.port_forward_socket.is_some() {
             return true;
         }
-        let Some(login_request::Union::PortForward(mut pf)) = self.lr.union.clone() else {
+        let Some(login_request::Union::PortForward(pf)) = self.lr.union.as_ref() else {
             return true;
         };
+        let mut pf = pf.clone();
         let (mut addr, is_rdp) = Self::normalize_port_forward_target(&mut pf);
         self.port_forward_address = addr.clone();
         match timeout(3000, TcpStream::connect(&addr)).await {
@@ -1372,7 +1373,7 @@ impl Connection {
                     addr = "RDP".to_owned();
                 }
                 self.send_login_error(format!(
-                    "Failed to access remote {}, please make sure if it is open",
+                    "Failed to access remote {}. Please make sure it is reachable/open.",
                     addr
                 ))
                 .await;
@@ -1381,7 +1382,7 @@ impl Connection {
         }
     }
 
-    async fn send_logon_response(&mut self) -> bool {
+    async fn send_logon_response_and_keep_alive(&mut self) -> bool {
         if self.authorized {
             return true;
         }
@@ -2257,9 +2258,7 @@ impl Connection {
             // `is_logon_ui()` is a fallback for logon UI detection on Windows.
             #[cfg(target_os = "windows")]
             let is_logon = || {
-                crate::platform::is_prelogin()
-                    || crate::platform::is_locked()
-                    || {
+                crate::platform::is_prelogin() || crate::platform::is_locked() || {
                     match crate::platform::is_logon_ui() {
                         Ok(result) => result,
                         Err(e) => {
@@ -2298,7 +2297,7 @@ impl Connection {
                 if err_msg.is_empty() {
                     #[cfg(target_os = "linux")]
                     self.linux_headless_handle.wait_desktop_cm_ready().await;
-                    if !self.send_logon_response().await {
+                    if !self.send_logon_response_and_keep_alive().await {
                         return false;
                     }
                     self.try_start_cm(lr.my_id.clone(), lr.my_name.clone(), self.authorized);
@@ -2336,7 +2335,7 @@ impl Connection {
                     if err_msg.is_empty() {
                         #[cfg(target_os = "linux")]
                         self.linux_headless_handle.wait_desktop_cm_ready().await;
-                        if !self.send_logon_response().await {
+                        if !self.send_logon_response_and_keep_alive().await {
                             return false;
                         }
                         self.try_start_cm(lr.my_id, lr.my_name, self.authorized);
@@ -2356,7 +2355,7 @@ impl Connection {
                         self.update_failure(failure, true, 1);
                         self.require_2fa.take();
                         raii::AuthedConnID::set_session_2fa(self.session_key());
-                        if !self.send_logon_response().await {
+                        if !self.send_logon_response_and_keep_alive().await {
                             return false;
                         }
                         self.try_start_cm(
@@ -2409,7 +2408,7 @@ impl Connection {
                     if let Some((_instant, uuid_old)) = uuid_old {
                         if uuid == uuid_old {
                             self.from_switch = true;
-                            if !self.send_logon_response().await {
+                            if !self.send_logon_response_and_keep_alive().await {
                                 return false;
                             }
                             self.try_start_cm(
@@ -5377,9 +5376,8 @@ mod raii {
         }
 
         pub fn check_wake_lock_on_setting_changed() {
-            let current = config::Config::get_bool_option(
-                keys::OPTION_KEEP_AWAKE_DURING_INCOMING_SESSIONS,
-            );
+            let current =
+                config::Config::get_bool_option(keys::OPTION_KEEP_AWAKE_DURING_INCOMING_SESSIONS);
             let cached = *WAKELOCK_KEEP_AWAKE_OPTION.lock().unwrap();
             if cached != Some(current) {
                 Self::check_wake_lock();


### PR DESCRIPTION

  TcpStream::connect() was previously executed in the LoginRequest::PortForward branch before password validation, which allowed unauthenticated users to trigger outbound TCP probes.

  ### What changed

  1. Removed pre-auth outbound connect from the PortForward branch.
  2. Kept only target normalization/address preparation in pre-auth handling.
  3. Added connect_port_forward_if_needed() and invoked it only on auth-success paths (right before login success handling).

  ### Why this is minimal

  - No auth model redesign.
  - No protocol changes.
  - Existing flow is preserved; only the connection timing moved from pre-auth to post-auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and standardized remote-access port-forward handling across authentication and post-login flows for more consistent and reliable connection behavior.

* **Bug Fixes**
  * Improved and unified error reporting for remote-access failures, now consistently showing the normalized target (or "RDP") to make connection errors clearer to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->