### PR TITLE
Faster IPv6 GUA punching && IPv6 NAT support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -97,6 +97,7 @@ pub mod screenshot;
 pub const MILLI1: Duration = Duration::from_millis(1);
 pub const SEC30: Duration = Duration::from_secs(30);
 pub const VIDEO_QUEUE_SIZE: usize = 120;
+const RELAY_RACE_DELAY: Duration = Duration::from_millis(90);
 const MAX_DECODE_FAIL_COUNTER: usize = 3;
 
 #[cfg(target_os = "linux")]
@@ -302,10 +303,6 @@ impl Client {
                 (check_port(other_server, RENDEZVOUS_PORT), Vec::new(), true)
             }
         };
-
-        if crate::get_ipv6_punch_enabled() {
-            crate::test_ipv6().await;
-        }
 
         let (stop_udp_tx, stop_udp_rx) = oneshot::channel::<()>();
         let udp =
@@ -515,12 +512,26 @@ impl Client {
                                 }
                             }
                             let s = ipv6.0.take();
+                            if ph.socket_addr_v6.is_empty() {
+                                log::debug!(
+                                    "PunchHoleResponse socket_addr_v6 is empty from hbbs/peer"
+                                );
+                            } else {
+                                log::info!(
+                                    "PunchHoleResponse socket_addr_v6={}",
+                                    AddrMangle::decode(&ph.socket_addr_v6)
+                                );
+                            }
                             if !ph.socket_addr_v6.is_empty() && s.is_some() {
                                 let addr = AddrMangle::decode(&ph.socket_addr_v6);
                                 if addr.port() > 0 {
                                     if let Some(s) = s {
                                         allow_err!(s.connect(addr).await);
                                         ipv6.0 = Some(s);
+                                        log::info!(
+                                            "IPv6 UDP socket connected to peer addr {} from PunchHoleResponse",
+                                            addr
+                                        );
                                     }
                                 }
                             }
@@ -535,36 +546,47 @@ impl Client {
                             rr.relay_server
                         );
                         start = Instant::now();
+                        signed_id_pk = rr.pk().into();
                         let mut connect_futures = Vec::new();
-                        if let Some(s) = ipv6.0 {
+                        if let Some(s) = ipv6.0.take() {
                             let addr = AddrMangle::decode(&rr.socket_addr_v6);
-                            if addr.port() > 0 {
-                                if s.connect(addr).await.is_ok() {
-                                    connect_futures
-                                        .push(udp_nat_connect(s, "IPv6", CONNECT_TIMEOUT).boxed());
-                                }
+                            log::info!("RelayResponse socket_addr_v6={}", addr);
+                            if addr.port() > 0 && s.connect(addr).await.is_ok() {
+                                connect_futures
+                                    .push(udp_nat_connect(s, "IPv6", CONNECT_TIMEOUT).boxed());
+                                log::info!(
+                                    "IPv6 UDP socket connected to peer addr {} from RelayResponse",
+                                    addr
+                                );
                             }
                         }
-                        signed_id_pk = rr.pk().into();
-                        let fut = Self::create_relay(
-                            &peer,
-                            rr.uuid,
-                            rr.relay_server,
-                            &key,
-                            conn_type,
-                            my_addr.is_ipv4(),
-                        );
+
+                        let relay_uuid = rr.uuid.clone();
+                        let relay_server = rr.relay_server.clone();
+                        let key_for_relay = key.clone();
+                        let peer_for_relay = peer.clone();
+                        let force_relay = interface.is_force_relay();
                         connect_futures.push(
                             async move {
-                                let conn = fut.await?;
+                                if !force_relay {
+                                    tokio::time::sleep(RELAY_RACE_DELAY).await;
+                                }
+                                let conn = Self::create_relay(
+                                    &peer_for_relay,
+                                    relay_uuid,
+                                    relay_server,
+                                    &key_for_relay,
+                                    conn_type,
+                                    my_addr.is_ipv4(),
+                                )
+                                .await?;
                                 Ok((conn, None, if use_ws() { "WebSocket" } else { "Relay" }))
                             }
                             .boxed(),
                         );
-                        // Run all connection attempts concurrently, return the first successful one
+
                         let (conn, kcp, typ) = match select_ok(connect_futures).await {
                             Ok(conn) => (Ok(conn.0 .0), conn.0 .1, conn.0 .2),
-
                             Err(e) => (Err(e), None, ""),
                         };
                         let mut conn = conn?;
@@ -653,6 +675,7 @@ impl Client {
         &'static str,
     )> {
         let direct_failures = interface.get_lch().read().unwrap().direct_failures;
+        let has_ipv6_punch = udp_socket_v6.is_some();
         let mut connect_timeout = 0;
         const MIN: u64 = 1000;
         if is_local || peer_nat_type == NatType::SYMMETRIC {
@@ -684,6 +707,15 @@ impl Client {
                 connect_timeout = MIN;
             }
         }
+        if has_ipv6_punch && !interface.is_force_relay() {
+            let mut ipv6_timeout = CONNECT_TIMEOUT;
+            if direct_failures > 0 {
+                ipv6_timeout = std::cmp::max(ipv6_timeout, punch_time_used * 6);
+            }
+            if connect_timeout < ipv6_timeout {
+                connect_timeout = ipv6_timeout;
+            }
+        }
         log::info!("peer address: {}, timeout: {}", peer, connect_timeout);
         let start = std::time::Instant::now();
 
@@ -702,25 +734,52 @@ impl Client {
         if let Some(udp_socket_v6) = udp_socket_v6 {
             connect_futures.push(udp_nat_connect(udp_socket_v6, "IPv6", connect_timeout).boxed());
         }
+        if !interface.is_force_relay() && !relay_server.is_empty() {
+            let peer_id = peer_id.to_owned();
+            let relay_server = relay_server.to_owned();
+            let rendezvous_server = rendezvous_server.to_owned();
+            let key = key.to_owned();
+            let token = token.to_owned();
+            let relay_secure = !signed_id_pk.is_empty();
+            connect_futures.push(
+                async move {
+                    tokio::time::sleep(RELAY_RACE_DELAY).await;
+                    let conn = Self::request_relay(
+                        &peer_id,
+                        relay_server,
+                        &rendezvous_server,
+                        relay_secure,
+                        &key,
+                        &token,
+                        conn_type,
+                    )
+                    .await?;
+                    Ok((conn, None, "Relay"))
+                }
+                .boxed(),
+            );
+        }
         // Run all connection attempts concurrently, return the first successful one
         let (mut conn, kcp, mut typ) = match select_ok(connect_futures).await {
             Ok(conn) => (Ok(conn.0 .0), conn.0 .1, conn.0 .2),
             Err(e) => (Err(e), None, ""),
         };
 
-        let mut direct = !conn.is_err();
+        let mut direct = !conn.is_err() && typ != "Relay" && typ != "WebSocket";
         if interface.is_force_relay() || conn.is_err() {
             if !relay_server.is_empty() {
-                conn = Self::request_relay(
-                    peer_id,
-                    relay_server.to_owned(),
-                    rendezvous_server,
-                    !signed_id_pk.is_empty(),
-                    key,
-                    token,
-                    conn_type,
-                )
-                .await;
+                if interface.is_force_relay() || typ != "Relay" {
+                    conn = Self::request_relay(
+                        peer_id,
+                        relay_server.to_owned(),
+                        rendezvous_server,
+                        !signed_id_pk.is_empty(),
+                        key,
+                        token,
+                        conn_type,
+                    )
+                    .await;
+                }
                 if let Err(e) = conn {
                     // this direct is mainly used by on_establish_connection_error, so we update it here before bail
                     interface.update_direct(Some(false));

--- a/src/common.rs
+++ b/src/common.rs
@@ -2172,8 +2172,8 @@ async fn stun_probe_on_socket(socket: &UdpSocket) -> Vec<SocketAddr> {
         }
         let per_server = std::cmp::min(remaining, std::time::Duration::from_millis(1500));
 
-        let stun_addr = match stun_server
-            .to_socket_addrs()
+        let stun_addr = match tokio::net::lookup_host(stun_server)
+            .await
             .ok()
             .and_then(|mut it| it.find(|x| x.is_ipv6()))
         {
@@ -2224,15 +2224,15 @@ pub async fn get_ipv6_socket() -> Option<(Arc<UdpSocket>, bytes::Bytes)> {
         socket.local_addr().ok().map(|a| a.ip())
     }
 
-    let socket = match UdpSocket::bind(SocketAddr::from(([0u16; 8], 0))).await {
+    let local_addr_ip = route_probe_ipv6()?;
+
+    let socket = match UdpSocket::bind(SocketAddr::from((local_addr_ip, 0))).await {
         Ok(s) => s,
         Err(err) => {
             log::warn!("Failed to create UDP socket for IPv6: {err}");
             return None;
         }
     };
-
-    let local_addr_ip = route_probe_ipv6()?;
 
     if is_usable_global_ipv6(local_addr_ip) {
         let socket_port = socket.local_addr().ok()?.port();

--- a/src/common.rs
+++ b/src/common.rs
@@ -96,7 +96,7 @@ lazy_static::lazy_static! {
     pub static ref SOFTWARE_UPDATE_URL: Arc<Mutex<String>> = Default::default();
     pub static ref DEVICE_ID: Arc<Mutex<String>> = Default::default();
     pub static ref DEVICE_NAME: Arc<Mutex<String>> = Default::default();
-    static ref PUBLIC_IPV6_ADDR: Arc<Mutex<(Option<SocketAddr>, Option<Instant>)>> = Default::default();
+
 }
 
 lazy_static::lazy_static! {
@@ -581,7 +581,6 @@ impl Drop for CheckTestNatType {
 }
 
 pub fn test_nat_type() {
-    test_ipv6_sync();
     use std::sync::atomic::{AtomicBool, Ordering};
     std::thread::spawn(move || {
         static IS_RUNNING: AtomicBool = AtomicBool::new(false);
@@ -2067,8 +2066,9 @@ async fn stun_ipv4_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
     })
 }
 
-static STUNS_V4: [&str; 3] = [
+static STUNS_V4: [&str; 4] = [
     "stun.l.google.com:19302",
+    "stun.qq.com:3478",
     "stun.cloudflare.com:3478",
     "stun.nextcloud.com:3478",
 ];
@@ -2097,108 +2097,6 @@ pub async fn test_nat_ipv4() -> ResultType<(SocketAddr, String)> {
             );
         }
     };
-}
-
-async fn test_bind_ipv6() -> ResultType<SocketAddr> {
-    let local_addr = SocketAddr::from(([0u16; 8], 0)); // [::]:0
-    let socket = UdpSocket::bind(local_addr).await?;
-    let addr = STUNS_V6[0]
-        .to_socket_addrs()?
-        .filter(|x| x.is_ipv6())
-        .next()
-        .ok_or_else(|| {
-            anyhow!(
-                "Failed to resolve STUN ipv6 server address: {}",
-                STUNS_V6[0]
-            )
-        })?;
-    socket.connect(addr).await?;
-    Ok(socket.local_addr()?)
-}
-
-pub async fn test_ipv6() -> Option<tokio::task::JoinHandle<()>> {
-    if PUBLIC_IPV6_ADDR
-        .lock()
-        .unwrap()
-        .1
-        .map(|x| x.elapsed().as_secs() < 60)
-        .unwrap_or(false)
-    {
-        return None;
-    }
-    PUBLIC_IPV6_ADDR.lock().unwrap().1 = Some(Instant::now());
-
-    match test_bind_ipv6().await {
-        Ok(mut addr) => {
-            if let std::net::IpAddr::V6(ip) = addr.ip() {
-                if !ip.is_loopback()
-                    && !ip.is_unspecified()
-                    && !ip.is_multicast()
-                    && (ip.segments()[0] & 0xe000) == 0x2000
-                {
-                    addr.set_port(0);
-                    PUBLIC_IPV6_ADDR.lock().unwrap().0 = Some(addr);
-                    log::debug!("Found public IPv6 address locally: {}", addr);
-                }
-            }
-        }
-        Err(e) => {
-            log::warn!("Failed to bind IPv6 socket: {}", e);
-        }
-    }
-    // Interestingly, on my macOS, sometimes my ipv6 works, sometimes not (test with ping6 or https://test-ipv6.com/).
-    // I checked ifconfig, could not see any difference. Both secure ipv6 and temporary ipv6 are there.
-    // So we can not rely on the local ipv6 address queries with if_addrs.
-    // above test_bind_ipv6 is safer, because it can fail in this case.
-    /*
-    std::thread::spawn(|| {
-        if let Ok(ifaces) = if_addrs::get_if_addrs() {
-            for iface in ifaces {
-                if let if_addrs::IfAddr::V6(v6) = iface.addr {
-                    let ip = v6.ip;
-                    if !ip.is_loopback()
-                        && !ip.is_unspecified()
-                        && !ip.is_multicast()
-                        && !ip.is_unique_local()
-                        && !ip.is_unicast_link_local()
-                        && (ip.segments()[0] & 0xe000) == 0x2000
-                    {
-                        // only use the first one, on mac, the first one is the stable
-                        // one, the last one is the temporary one. The middle ones are deperecated.
-                        *PUBLIC_IPV6_ADDR.lock().unwrap() =
-                            Some((SocketAddr::from((ip, 0)), Instant::now()));
-                        log::debug!("Found public IPv6 address locally: {}", ip);
-                        break;
-                    }
-                }
-            }
-        }
-    });
-    */
-
-    Some(tokio::spawn(async {
-        use hbb_common::futures::future::{select_ok, FutureExt};
-        let tests = STUNS_V6
-            .iter()
-            .map(|&stun| stun_ipv6_test(stun).boxed())
-            .collect::<Vec<_>>();
-
-        match select_ok(tests).await {
-            Ok(res) => {
-                let mut addr = res.0 .0;
-                addr.set_port(0); // Set port to 0 to avoid conflicts
-                PUBLIC_IPV6_ADDR.lock().unwrap().0 = Some(addr);
-                log::debug!(
-                    "Found public IPv6 address via STUN server {}: {}",
-                    res.0 .1,
-                    addr
-                );
-            }
-            Err(e) => {
-                log::error!("Failed to get public IPv6 address: {}", e);
-            }
-        };
-    }))
 }
 
 pub async fn punch_udp(
@@ -2252,35 +2150,152 @@ pub async fn punch_udp(
     }
 }
 
-fn test_ipv6_sync() {
-    #[tokio::main(flavor = "current_thread")]
-    async fn func() {
-        if let Some(job) = test_ipv6().await {
-            job.await.ok();
-        }
-    }
-    std::thread::spawn(func);
-}
+/// STUN query on the actual hole-punching socket.
+/// Tries up to 2 STUN servers sequentially within a global deadline.
+/// Returns the mapped (external) addresses from each successful response.
+/// All queries use the SAME socket .
+async fn stun_probe_on_socket(socket: &UdpSocket) -> Vec<SocketAddr> {
+    use std::net::ToSocketAddrs;
+    use stunclient::StunClient;
 
-pub async fn get_ipv6_socket() -> Option<(Arc<UdpSocket>, bytes::Bytes)> {
-    let Some(addr) = PUBLIC_IPV6_ADDR.lock().unwrap().0 else {
-        return None;
-    };
+    let mut mapped_addrs: Vec<SocketAddr> = Vec::new();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
 
-    match UdpSocket::bind(addr).await {
-        Err(err) => {
-            log::warn!("Failed to create UDP socket for IPv6: {err}");
+    for stun_server in STUNS_V6.iter() {
+        if mapped_addrs.len() >= 2 {
+            //enough for decision, no need to wait for more
+            break;
         }
-        Ok(socket) => {
-            if let Ok(local_addr_v6) = socket.local_addr() {
-                return Some((
-                    Arc::new(socket),
-                    hbb_common::AddrMangle::encode(local_addr_v6).into(),
-                ));
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let per_server = std::cmp::min(remaining, std::time::Duration::from_millis(1500));
+
+        let stun_addr = match stun_server
+            .to_socket_addrs()
+            .ok()
+            .and_then(|mut it| it.find(|x| x.is_ipv6()))
+        {
+            Some(a) => a,
+            None => continue,
+        };
+
+        let client = StunClient::new(stun_addr);
+        match tokio::time::timeout(per_server, client.query_external_address_async(socket)).await {
+            Ok(Ok(addr)) => {
+                log::debug!("IPv6 STUN {} → mapped {}", stun_server, addr);
+                mapped_addrs.push(addr);
+            }
+
+            Ok(Err(e)) => {
+                log::debug!("IPv6 STUN {} failed: {}", stun_server, e);
+            }
+            Err(_) => {
+                log::debug!("IPv6 STUN {} timed out", stun_server);
             }
         }
     }
-    None
+    mapped_addrs
+}
+
+/// Returns `(socket, encoded_mapped_addr)` where:
+/// - `socket` is bound to a local GUA address (used for sending/receiving),
+/// - `encoded_mapped_addr` is the STUN-discovered external address (reported to hbbs).
+/// Under NAT, the local and external addresses/ports may differ.
+pub async fn get_ipv6_socket() -> Option<(Arc<UdpSocket>, bytes::Bytes)> {
+    fn is_usable_global_ipv6(addr: std::net::IpAddr) -> bool {
+        if let std::net::IpAddr::V6(ip) = addr {
+            !ip.is_loopback()
+                && !ip.is_unspecified()
+                && !ip.is_multicast()
+                && (ip.segments()[0] & 0xe000) == 0x2000
+        } else {
+            false
+        }
+    }
+    fn route_probe_ipv6() -> Option<std::net::IpAddr> {
+        let addr: SocketAddr = "[2606:4700:49::]:3478".parse().ok()?;
+        let socket = std::net::UdpSocket::bind(SocketAddr::from(([0u16; 8], 0))).ok()?;
+        socket
+            .connect(addr)
+            .map_err(|e| log::debug!("route probe fail"))
+            .ok()?;
+        socket.local_addr().ok().map(|a| a.ip())
+    }
+
+    let socket = match UdpSocket::bind(SocketAddr::from(([0u16; 8], 0))).await {
+        Ok(s) => s,
+        Err(err) => {
+            log::warn!("Failed to create UDP socket for IPv6: {err}");
+            return None;
+        }
+    };
+
+    let local_addr_ip = route_probe_ipv6()?;
+
+    if is_usable_global_ipv6(local_addr_ip) {
+        let socket_port = socket.local_addr().ok()?.port();
+        let external_addr = SocketAddr::new(local_addr_ip, socket_port);
+        log::debug!(
+            "IPv6 socket: local={} (usable global IPv6, skipping STUN), external={}",
+            local_addr_ip,
+            external_addr
+        );
+        return Some((
+            Arc::new(socket),
+            hbb_common::AddrMangle::encode(external_addr).into(),
+        ));
+    }
+
+    log::debug!("IPv6 socket: local={} (not gua)", local_addr_ip);
+    // Single STUN flow on the actual hole-punching socket.
+    // Same source port for STUN and hole punching — correct under any NAT type.
+    // Pass local_addr so STUN can short-circuit when no NAT is detected.
+    let mapped_addrs = stun_probe_on_socket(&socket).await;
+
+    if mapped_addrs.is_empty() {
+        log::warn!("Failed to get IPv6 mapping from STUN");
+        return None;
+    }
+
+    let external_addr = if mapped_addrs.len() >= 2 {
+        let all_same = mapped_addrs
+            .iter()
+            .all(|a| a.ip() == mapped_addrs[0].ip() && a.port() == mapped_addrs[0].port());
+        if all_same {
+            // Cone NAT or no NAT — use mapped address (includes correct port).
+            log::info!(
+                "IPv6 STUN: consistent mapping {} (cone/no NAT)",
+                mapped_addrs[0]
+            );
+            mapped_addrs[0]
+        } else {
+            // Symmetric/unstable mapping — different servers see different mappings.
+            // Keep best-effort IPv6 punching by advertising the first mapped address
+            // instead of disabling IPv6 entirely.
+            log::warn!(
+                "IPv6 STUN mapping differs across servers: {:?}, using first mapped address {} for best-effort punching",
+                mapped_addrs,
+                mapped_addrs[0]
+            );
+            mapped_addrs[0]
+        }
+    } else {
+        // Single STUN response
+        log::info!("IPv6 STUN: single response, mapped {}", mapped_addrs[0]);
+        mapped_addrs[0]
+    };
+
+    log::debug!(
+        "IPv6 socket: local={}, external={} (reported to hbbs)",
+        local_addr_ip,
+        external_addr
+    );
+    Some((
+        Arc::new(socket),
+        hbb_common::AddrMangle::encode(external_addr).into(),
+    ))
 }
 
 // The color is the same to `str2color()` in flutter.

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -32,10 +32,15 @@ use crate::{
 };
 
 type Message = RendezvousMessage;
+const DEDUP_WINDOW_MS: u128 = 100;
 
 lazy_static::lazy_static! {
     static ref SOLVING_PK_MISMATCH: Mutex<String> = Default::default();
-    static ref LAST_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
+    static ref LAST_MSG: Mutex<(SocketAddr, SocketAddr, Instant)> = Mutex::new((
+        SocketAddr::new([0; 4].into(), 0),
+        SocketAddr::new(std::net::Ipv6Addr::UNSPECIFIED.into(), 0),
+        Instant::now()
+    ));
     static ref LAST_RELAY_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
 }
 static SHOULD_EXIT: AtomicBool = AtomicBool::new(false);
@@ -416,7 +421,7 @@ impl RendezvousMediator {
         let last = *LAST_RELAY_MSG.lock().await;
         *LAST_RELAY_MSG.lock().await = (addr, Instant::now());
         // skip duplicate relay request messages
-        if last.0 == addr && last.1.elapsed().as_millis() < 100 {
+        if last.0 == addr && last.1.elapsed().as_millis() < DEDUP_WINDOW_MS {
             return Ok(());
         }
 
@@ -484,13 +489,17 @@ impl RendezvousMediator {
 
     async fn handle_intranet(&self, fla: FetchLocalAddr, server: ServerPtr) -> ResultType<()> {
         let addr = AddrMangle::decode(&fla.socket_addr);
+        let peer_addr_v6 = hbb_common::AddrMangle::decode(&fla.socket_addr_v6);
         let last = *LAST_MSG.lock().await;
-        *LAST_MSG.lock().await = (addr, Instant::now());
-        // skip duplicate punch hole messages
-        if last.0 == addr && last.1.elapsed().as_millis() < 100 {
+        *LAST_MSG.lock().await = (addr, peer_addr_v6, Instant::now());
+        // skip duplicate punch hole messages (match by IP pair, ignore short-lived port jitter)
+        if last.2.elapsed().as_millis() < DEDUP_WINDOW_MS
+            && last.0.ip() == addr.ip()
+            && ((last.1.port() == 0 && peer_addr_v6.port() == 0)
+                || last.1.ip() == peer_addr_v6.ip())
+        {
             return Ok(());
         }
-        let peer_addr_v6 = hbb_common::AddrMangle::decode(&fla.socket_addr_v6);
         let relay_server = self.get_relay_server(fla.relay_server.clone());
         let relay = use_ws() || Config::is_proxy();
         let mut socket_addr_v6 = Default::default();
@@ -571,13 +580,18 @@ impl RendezvousMediator {
 
     async fn handle_punch_hole(&self, ph: PunchHole, server: ServerPtr) -> ResultType<()> {
         let mut peer_addr = AddrMangle::decode(&ph.socket_addr);
+        let peer_addr_v6 = hbb_common::AddrMangle::decode(&ph.socket_addr_v6);
         let last = *LAST_MSG.lock().await;
-        *LAST_MSG.lock().await = (peer_addr, Instant::now());
-        // skip duplicate punch hole messages
-        if last.0 == peer_addr && last.1.elapsed().as_millis() < 100 {
+        *LAST_MSG.lock().await = (peer_addr, peer_addr_v6, Instant::now());
+        // skip duplicate punch hole messages (match by IP pair, ignore short-lived port jitter)
+        if last.2.elapsed().as_millis() < DEDUP_WINDOW_MS
+            && last.0.ip() == peer_addr.ip()
+            && ((last.1.port() == 0 && peer_addr_v6.port() == 0)
+                || last.1.ip() == peer_addr_v6.ip())
+        {
             return Ok(());
         }
-        let peer_addr_v6 = hbb_common::AddrMangle::decode(&ph.socket_addr_v6);
+
         let relay = use_ws() || Config::is_proxy() || ph.force_relay;
         let mut socket_addr_v6 = Default::default();
         let control_permissions = ph.control_permissions.into_option();
@@ -590,10 +604,11 @@ impl RendezvousMediator {
             )
             .await;
         }
+        let has_ipv6_punch = !socket_addr_v6.is_empty();
         let relay_server = self.get_relay_server(ph.relay_server);
         // for ensure, websocket go relay directly
         if ph.nat_type.enum_value() == Ok(NatType::SYMMETRIC)
-            || Config::get_nat_type() == NatType::SYMMETRIC as i32
+            || (Config::get_nat_type() == NatType::SYMMETRIC as i32 && !has_ipv6_punch)
             || relay
             || (config::is_disable_tcp_listen() && ph.udp_port <= 0)
         {
@@ -849,8 +864,8 @@ async fn start_ipv6(
     server: ServerPtr,
     control_permissions: Option<ControlPermissions>,
 ) -> bytes::Bytes {
-    crate::test_ipv6().await;
-    if let Some((socket, local_addr_v6)) = crate::get_ipv6_socket().await {
+    // get v6 socket and mapped v6 addr.
+    if let Some((socket, mapped_addr_v6)) = crate::get_ipv6_socket().await {
         let server = server.clone();
         tokio::spawn(async move {
             allow_err!(
@@ -864,7 +879,7 @@ async fn start_ipv6(
                 .await
             );
         });
-        return local_addr_v6;
+        return mapped_addr_v6;
     }
     Default::default()
 }


### PR DESCRIPTION
If an IPv6 GUA exists, skip the STUN test to speed up IPv6 hole punching.

If it is a ULA, perform a STUN test.

If a relay connection is not forced, delay it by 90 ms and prioritize hole punching.
(We need to factor in the latency introduced by DNS resolution and STUN server responses. In certain regions, this delay can be significant, but it doesn't necessarily mean the direct connection quality is poor.)

`test_ipv6` is no longer needed and has been removed.

Tested in the following network configurations

> | Controller (local) | Controlled device (remote) |
> |--------------------|---------------------------|
> | IPv6 GUA | IPv6 GUA |
> | IPv6 GUA | IPv6 NAT |
> | IPv6 NAT | IPv6 GUA |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Broader IPv6 support: route-probe first with STUN fallback, now returning a bound IPv6 socket and external address when available.
  * Refined relay behavior: delayed/raced relay attempts, conditional relay fallback, and clearer relay-state handling.
  * Enhanced connection logic: concurrent relay attempts and adjusted timeouts for IPv6 punch attempts.
  * Improved duplicate-message filtering: IP-pair deduplication with a short dedup window and better logging/state tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->