### PR TITLE
fix(flutter): reduce accidental horizontal trackpad scrolling during vertical pan

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -348,6 +348,12 @@ class InputModel {
   final _trackpadAdjustPeerLinux = 0.06;
   // This is an experience value.
   final _trackpadAdjustMacToWin = 2.50;
+  // Ignore directional locking for very small mixed-axis deltas to avoid
+  // over-filtering subtle movements near zero.
+  static const double _trackpadAxisNoiseThreshold = 0.2;
+  // Lock to dominant axis only when one axis is clearly stronger.
+  // 1.6 means the dominant axis must be >= 60% larger than the other.
+  static const double _trackpadAxisLockRatio = 1.6;
   int _trackpadSpeed = kDefaultTrackpadSpeed;
   double _trackpadSpeedInner = kDefaultTrackpadSpeed / 100.0;
   var _trackpadScrollUnsent = Offset.zero;
@@ -1172,6 +1178,7 @@ class InputModel {
     if (isMacOS && peerPlatform == kPeerPlatformWindows) {
       delta *= _trackpadAdjustMacToWin;
     }
+    delta = _filterTrackpadDeltaAxis(delta);
     _trackpadLastDelta = delta;
 
     var x = delta.dx.toInt();
@@ -1202,6 +1209,24 @@ class InputModel {
             msg: '{"type": "trackpad", "x": "$x", "y": "$y"}');
       }
     }
+  }
+
+  Offset _filterTrackpadDeltaAxis(Offset delta) {
+    final absDx = delta.dx.abs();
+    final absDy = delta.dy.abs();
+    // Keep diagonal intent when movement is tiny on both axes.
+    if (absDx < _trackpadAxisNoiseThreshold &&
+        absDy < _trackpadAxisNoiseThreshold) {
+      return delta;
+    }
+    // Dominant-axis lock to reduce accidental cross-axis scrolling noise.
+    if (absDy >= absDx * _trackpadAxisLockRatio) {
+      return Offset(0, delta.dy);
+    }
+    if (absDx >= absDy * _trackpadAxisLockRatio) {
+      return Offset(delta.dx, 0);
+    }
+    return delta;
   }
 
   void _scheduleFling(double x, double y, int delay) {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -348,8 +348,8 @@ class InputModel {
   final _trackpadAdjustPeerLinux = 0.06;
   // This is an experience value.
   final _trackpadAdjustMacToWin = 2.50;
-  // Ignore directional locking for very small mixed-axis deltas to avoid
-  // over-filtering subtle movements near zero.
+  // Ignore directional locking for very small deltas on both axes (including
+  // tiny single-axis movement) to avoid over-filtering near zero.
   static const double _trackpadAxisNoiseThreshold = 0.2;
   // Lock to dominant axis only when one axis is clearly stronger.
   // 1.6 means the dominant axis must be >= 60% larger than the other.


### PR DESCRIPTION

This PR reduces accidental horizontal scrolling when using a trackpad to pan vertically in cross-platform remote sessions.

## Issue

`onPointerPanZoomUpdate` forwarded both `dx` and `dy` for trackpad input without dominant-axis filtering.

Small cross-axis noise could be quantized into non-zero horizontal scroll, especially in `macOS -> Windows` due to delta scaling.

## Tests

- [x] Trackpad, Windows -> macOS, macOS -> Windows, Windows -> Linux(X11), macOS -> Linux(X11), Linux(X11) -> Windows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trackpad input filtering to reduce small mixed-axis noise and accidental diagonal drift.
  * Movement now more consistently follows the dominant direction when one axis is clearly stronger, yielding smoother, more precise pan/scroll gestures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->