### PR TITLE
fix(packaging): add support for time64 packages

### DIFF
--- a/build.py
+++ b/build.py
@@ -299,7 +299,7 @@ Version: %s
 Architecture: %s
 Maintainer: rustdesk <info@rustdesk.com>
 Homepage: https://rustdesk.com
-Depends: libgtk-3-0, libxcb-randr0, libxdo3 | libxdo4, libxfixes3, libxcb-shape0, libxcb-xfixes0, libasound2, libsystemd0, curl, libva2, libva-drm2, libva-x11-2, libgstreamer-plugins-base1.0-0, libpam0g, gstreamer1.0-pipewire%s
+Depends: libgtk-3-0t64 | libgtk-3-0, libxcb-randr0, libxdo3 | libxdo4, libxfixes3, libxcb-shape0, libxcb-xfixes0, libasound2t64 | libasound2, libsystemd0, curl, libva2, libva-drm2, libva-x11-2, libgstreamer-plugins-base1.0-0, libpam0g, gstreamer1.0-pipewire%s
 Recommends: libayatana-appindicator3-1
 Description: A remote control software.
 


### PR DESCRIPTION
Debian 13 Trixie and Ubuntu 24.04 Noble come with time64 transitioned packages: https://wiki.debian.org/ReleaseGoals/64bit-time

This means, all packages which use the time_t syscall on 32-bit do now use the time64 syscall instead, to get 64-bit year 2038 prove UNIX time values. Those packages get a "t64" suffix for their name, also for 64-bit architectures for consistency. Since time_t values on 64-bit are 64-bit already, no actual change happened there, and a package dependency without the t64 suffix is still satisfied by the packages with t64 suffix, via "Provides" attribute. This however is not the case for 32-bit.

The rustdesk package currently depends on libgtk-3-0 and libasound2, while Debian Trixie and Ubuntu Noble serve `libgtk-3-0t64` and `libasound2t64`. On 64-bit architectures (amd64 and arm64), the available packages satisfy the dependency, but on 32-bit (armhf) this is not the case. In turn the rustdesk `armv7-sciter.deb` package cannot be installed on recent distro versions.

This commit solves the issue by adding the respective t64 packages are alternative dependency. If available, the t64 package is installed, else (on older distro versions), the one without t64 suffix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system library dependencies for improved compatibility across different system configurations and architecture variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->