### PR TITLE
fix: Android soft keyboard input corruption - every key becomes space or 1

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -201,6 +201,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
       );
 
   void onSoftKeyboardChanged(bool visible) {
+    inputModel.androidSoftKeyboardActive = visible;
     if (!visible) {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: []);
       // [pi.version.isNotEmpty] -> check ready or not, avoid login without soft-keyboard
@@ -300,8 +301,11 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     if (newValue.length == oldValue.length) {
       // ?
     } else if (newValue.length < oldValue.length) {
-      final char = 'VK_BACK';
-      inputModel.inputKey(char);
+      // Send exactly one VK_BACK per onChanged callback regardless of how many
+      // characters the IME removed (Samsung accelerates held-delete).  The
+      // IME's own callback frequency provides a steady, controllable repeat
+      // rate instead of runaway exponential deletion.
+      inputModel.inputKey('VK_BACK');
     } else {
       final content = newValue.substring(oldValue.length);
       if (content.length > 1) {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -367,6 +367,12 @@ class InputModel {
   bool _pointerMovedAfterEnter = false;
   bool _pointerInsideImage = false;
 
+  /// True while the Android soft keyboard editor is active.
+  /// When set, key events are ignored so they flow through to the
+  /// hidden TextFormField's onChanged handler instead of being
+  /// processed here with potentially incorrect physicalKey data.
+  bool androidSoftKeyboardActive = false;
+
   // mouse
   final isPhysicalMouse = false.obs;
   int _lastButtons = 0;
@@ -687,6 +693,29 @@ class InputModel {
   KeyEventResult handleKeyEvent(KeyEvent e) {
     if (isViewOnly) return KeyEventResult.handled;
     if (isViewCamera) return KeyEventResult.handled;
+    // When the Android soft keyboard is active, avoid processing key events
+    // through the normal input pipeline because physicalKey data from the
+    // soft keyboard is unreliable (Flutter issue #157771) and can corrupt
+    // subsequent input, causing every keypress to repeat a single character.
+    //
+    // Return `handled` (not `ignored`) so Android keeps sending key-repeat
+    // events for held keys and the TextFormField does not consume sentinel
+    // buffer characters.
+    //
+    // For Backspace and Enter, send them directly using the reliable logical
+    // key data. This is required because for some IMEs (ko/zh/ja) returning
+    // `handled` prevents the IME from processing the key through onChanged.
+    if (isAndroid && androidSoftKeyboardActive) {
+      if (e is KeyDownEvent || e is KeyRepeatEvent) {
+        if (e.logicalKey == LogicalKeyboardKey.backspace) {
+          inputKey('VK_BACK', press: true);
+        } else if (e.logicalKey == LogicalKeyboardKey.enter ||
+            e.logicalKey == LogicalKeyboardKey.numpadEnter) {
+          inputKey('VK_RETURN', press: true);
+        }
+      }
+      return KeyEventResult.handled;
+    }
     if (!isInputSourceFlutter) {
       if (isDesktop) {
         return KeyEventResult.handled;


### PR DESCRIPTION
## Bug Description

When connecting from Android to any remote host (Windows, Linux, etc.), the Android soft keyboard can enter a broken state where **every keypress sends the same character** — typically space or the number `1`, regardless of which key is actually pressed.

### Reliable reproduction (from issue #13737)
1. Connect from Android to a remote PC
2. Open the soft keyboard  
3. Press **Backspace/Delete immediately** before typing anything
4. Every subsequent keypress now produces a single repeated character

The workaround is to close and reopen the keyboard, but the bug returns easily.

### Affected versions
Reported since v1.3.2 (worked in v1.3.1). Still present in v1.4.5.

### Related issues
- #13737 — exact reproduction steps and video evidence
- #9789 — "bunch of 1's on the keyboard" regression in v1.3.2  
- #11073 — "only 1 character keeps being repeated for every key press"

## Root Cause

On Android, the soft keyboard's `physicalKey.usbHidUsage` data is unreliable for certain IME-generated key events (see [Flutter issue #157771](https://github.com/flutter/flutter/issues/157771)). The existing code comments in `input_model.dart` already document this for Backspace and Enter specifically.

The problem: `RawKeyFocusScope` wraps the entire remote page, so `InputModel.handleKeyEvent()` processes **all** key events — including ones from the soft keyboard with garbled physical key data. When the soft keyboard is active, this corrupts the hidden `TextFormField`'s text buffer state, causing the diff logic in `handleSoftKeyboardInput()` to desynchronise. Once desynced, every subsequent keypress repeats whatever stale scancode was last processed.

## Fix

Two changes in `InputModel.handleKeyEvent()` and `remote_page.dart`:

**1. `InputModel` — skip normal key processing when Android soft keyboard is active**

Added an `androidSoftKeyboardActive` flag. When set, `handleKeyEvent()` returns `KeyEventResult.handled` but skips the normal input pipeline (no garbled scancodes sent). Backspace and Enter are sent directly using the reliable `logicalKey` data, since some IMEs (ko/zh/ja) require this.

Returns `handled` (not `ignored`) so Android keeps sending key-repeat events for held keys.

**2. `remote_page.dart` — wire up the flag**

`onSoftKeyboardChanged()` sets/clears `inputModel.androidSoftKeyboardActive` when the keyboard opens/closes.

### What this preserves
- Physical keyboard input still works normally (flag is only set when soft keyboard is visible)
- The existing `TextFormField` text-diff approach for soft keyboard input (`handleSoftKeyboardInput`) continues to handle all character input
- The `initText` sentinel buffer trick still works
- Korean/Chinese/Japanese IME composing behavior is unaffected
- iOS behavior is completely untouched

### Tested on
- Samsung Galaxy (One UI, Samsung Keyboard + Gboard)
- Android → Windows remote connection
- Verified: original bug no longer reproduces, normal typing works, held-delete works at controlled rate

## Files changed
- `flutter/lib/models/input_model.dart` — `androidSoftKeyboardActive` flag + early return in `handleKeyEvent()`
- `flutter/lib/mobile/pages/remote_page.dart` — set/clear flag in `onSoftKeyboardChanged()`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android soft keyboard input reliability, ensuring backspace and enter keys are processed consistently without duplicate inputs
  * Enhanced soft keyboard visibility tracking on Android devices for more accurate input state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->