### PR TITLE
fix empty strategy value cannot apply over default advanced options

### DIFF
--- a/src/hbbs_http/sync.rs
+++ b/src/hbbs_http/sync.rs
@@ -286,10 +286,14 @@ fn heartbeat_url() -> String {
 
 fn handle_config_options(config_options: HashMap<String, String>) {
     let mut options = Config::get_options();
+    let default_settings = config::DEFAULT_SETTINGS.read().unwrap().clone();
     config_options
         .iter()
         .map(|(k, v)| {
-            if v.is_empty() {
+            // Priority: user config > default advanced options.
+            // Only when default advanced options are also empty, remove user option (fallback to built-in default);
+            // otherwise insert an empty value so user config remains present.
+            if v.is_empty() && default_settings.get(k).map_or("", |v| v).is_empty() {
                 options.remove(k);
             } else {
                 options.insert(k.to_string(), v.to_string());


### PR DESCRIPTION
Tested different types of options in the strategy. Since the `get_or` function only checks whether the key exists, an empty value can effectively work as the default value.
https://github.com/rustdesk/hbb_common/blob/48c37de3e6c4e399af6f51ca20e8e3e1fd037976/src/config.rs#L2461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined configuration merge behavior: when a user option is empty, it is now preserved or removed depending on the corresponding default setting, preventing unintended removal of options and improving consistency of applied settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->