### PR TITLE
fix(mobile): restore canvas offset after hidding the soft keyboard

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -181,9 +181,6 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     _timerDidChangeMetrics = Timer(Duration(milliseconds: 100), () async {
       // We need this comparation because poping up the floating action will also trigger `didChangeMetrics()`.
       if (newBottom != _viewInsetsBottom) {
-        if (newBottom > _viewInsetsBottom) {
-          gFFI.canvasModel.mobileFocusCanvasCursor();
-        }
         _viewInsetsBottom = newBottom;
       }
     });

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -181,7 +181,9 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     _timerDidChangeMetrics = Timer(Duration(milliseconds: 100), () async {
       // We need this comparation because poping up the floating action will also trigger `didChangeMetrics()`.
       if (newBottom != _viewInsetsBottom) {
-        gFFI.canvasModel.mobileFocusCanvasCursor();
+        if (newBottom > _viewInsetsBottom) {
+          gFFI.canvasModel.mobileFocusCanvasCursor();
+        }
         _viewInsetsBottom = newBottom;
       }
     });

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -65,9 +64,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   bool _showGestureHelp = false;
   String _value = '';
   Orientation? _currentOrientation;
-  double _viewInsetsBottom = 0;
   final _uniqueKey = UniqueKey();
-  Timer? _timerDidChangeMetrics;
   Timer? _iosKeyboardWorkaroundTimer;
 
   final _blockableOverlayState = BlockableOverlayState();
@@ -140,7 +137,6 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     _physicalFocusNode.dispose();
     await gFFI.close();
     _timer?.cancel();
-    _timerDidChangeMetrics?.cancel();
     _iosKeyboardWorkaroundTimer?.cancel();
     gFFI.dialogManager.dismissAll();
     await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
@@ -165,25 +161,6 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   // When swithing from other app to this app, try to sync clipboard.
   void trySyncClipboard() {
     gFFI.invokeMethod("try_sync_clipboard");
-  }
-
-  @override
-  void didChangeMetrics() {
-    // If the soft keyboard is visible and the canvas has been changed(panned or scaled)
-    // Don't try reset the view style and focus the cursor.
-    if (gFFI.cursorModel.lastKeyboardIsVisible &&
-        gFFI.canvasModel.isMobileCanvasChanged) {
-      return;
-    }
-
-    final newBottom = MediaQueryData.fromView(ui.window).viewInsets.bottom;
-    _timerDidChangeMetrics?.cancel();
-    _timerDidChangeMetrics = Timer(Duration(milliseconds: 100), () async {
-      // We need this comparation because poping up the floating action will also trigger `didChangeMetrics()`.
-      if (newBottom != _viewInsetsBottom) {
-        _viewInsetsBottom = newBottom;
-      }
-    });
   }
 
   // to-do: It should be better to use transparent color instead of the bgColor.

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2681,6 +2681,7 @@ class CanvasModel with ChangeNotifier {
 
   void restoreMobileOffsetAfterSoftKeyboard() {
     _timerMobileRestoreCanvasOffset?.cancel();
+    _timerMobileFocusCanvasCursor?.cancel();
     final targetOffset = _offsetBeforeMobileSoftKeyboard;
     final targetScale = _scaleBeforeMobileSoftKeyboard;
     if (targetOffset == null || targetScale == null) {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2686,8 +2686,7 @@ class CanvasModel with ChangeNotifier {
     if (targetOffset == null || targetScale == null) {
       return;
     }
-    _timerMobileRestoreCanvasOffset =
-        Timer(Duration(milliseconds: 100), () async {
+    _timerMobileRestoreCanvasOffset = Timer(Duration(milliseconds: 100), () {
       updateSize();
       _x = targetOffset.dx;
       _y = targetOffset.dy;

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2152,6 +2152,9 @@ class CanvasModel with ChangeNotifier {
   ViewStyle _lastViewStyle = ViewStyle.defaultViewStyle();
 
   Timer? _timerMobileFocusCanvasCursor;
+  Timer? _timerMobileRestoreCanvasOffset;
+  Offset? _offsetBeforeMobileSoftKeyboard;
+  double? _scaleBeforeMobileSoftKeyboard;
 
   // `isMobileCanvasChanged` is used to avoid canvas reset when changing the input method
   // after showing the soft keyboard.
@@ -2639,6 +2642,9 @@ class CanvasModel with ChangeNotifier {
     _scale = 1.0;
     _lastViewStyle = ViewStyle.defaultViewStyle();
     _timerMobileFocusCanvasCursor?.cancel();
+    _timerMobileRestoreCanvasOffset?.cancel();
+    _offsetBeforeMobileSoftKeyboard = null;
+    _scaleBeforeMobileSoftKeyboard = null;
   }
 
   updateScrollPercent() {
@@ -2663,6 +2669,31 @@ class CanvasModel with ChangeNotifier {
         Timer(Duration(milliseconds: 100), () async {
       updateSize();
       _resetCanvasOffset(getDisplayWidth(), getDisplayHeight());
+      notifyListeners();
+    });
+  }
+
+  void saveMobileOffsetBeforeSoftKeyboard() {
+    _timerMobileRestoreCanvasOffset?.cancel();
+    _offsetBeforeMobileSoftKeyboard = Offset(_x, _y);
+    _scaleBeforeMobileSoftKeyboard = _scale;
+  }
+
+  void restoreMobileOffsetAfterSoftKeyboard() {
+    _timerMobileRestoreCanvasOffset?.cancel();
+    final targetOffset = _offsetBeforeMobileSoftKeyboard;
+    final targetScale = _scaleBeforeMobileSoftKeyboard;
+    if (targetOffset == null || targetScale == null) {
+      return;
+    }
+    _timerMobileRestoreCanvasOffset =
+        Timer(Duration(milliseconds: 100), () async {
+      updateSize();
+      _x = targetOffset.dx;
+      _y = targetOffset.dy;
+      _scale = targetScale;
+      _offsetBeforeMobileSoftKeyboard = null;
+      _scaleBeforeMobileSoftKeyboard = null;
       notifyListeners();
     });
   }
@@ -2919,8 +2950,13 @@ class CursorModel with ChangeNotifier {
       _lastIsBlocked = true;
     }
     if (isMobile && _lastKeyboardIsVisible != keyboardIsVisible) {
-      parent.target?.canvasModel.mobileFocusCanvasCursor();
-      parent.target?.canvasModel.isMobileCanvasChanged = false;
+      if (keyboardIsVisible) {
+        parent.target?.canvasModel.saveMobileOffsetBeforeSoftKeyboard();
+        parent.target?.canvasModel.mobileFocusCanvasCursor();
+        parent.target?.canvasModel.isMobileCanvasChanged = false;
+      } else {
+        parent.target?.canvasModel.restoreMobileOffsetAfterSoftKeyboard();
+      }
     }
     _lastKeyboardIsVisible = keyboardIsVisible;
   }


### PR DESCRIPTION

Fix mobile: restore canvas after showing/hiding the soft keyboard.

### Preview

https://github.com/user-attachments/assets/b36ae63e-1560-41d3-befd-57ed848b0647


https://github.com/user-attachments/assets/b829404b-3aa0-4c09-8bbb-3b665943cff6

### Tests

Android and iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves canvas position and zoom when the mobile soft keyboard appears and restores them after it hides to prevent unexpected jumps.
  * Stabilizes cursor behavior during mobile text input to avoid unintended resets or flicker.

* **Refactor**
  * Reworked mobile keyboard handling to a save/restore flow for canvas offset/scale, simplifying state management and timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->