### PR TITLE
fix: iPad mouse down detection for physical mouse input

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -1332,6 +1332,17 @@ class InputModel {
     return false;
   }
 
+  /// iOS may emit a synthesized touch event after a real mouse click.
+  /// This helper ignores touch-down events that arrive shortly after a mouse down,
+  /// even when the position is far (e.g., near the top edge).
+  bool shouldIgnoreTouchAfterMouse(ui.Offset pos, int nowMs) {
+    if (!isIOS) return false;
+    if (shouldIgnoreTouchTap(pos)) return true;
+    const int kTouchAfterMouseWindowMs = 700;
+    final dt = nowMs - _lastMouseDownTimeMs;
+    return dt >= 0 && dt < kTouchAfterMouseWindowMs;
+  }
+
   void onPointDownImage(PointerDownEvent e) {
     debugPrint("onPointDownImage ${e.kind}");
     _stopFling = true;
@@ -1344,6 +1355,9 @@ class InputModel {
     // Track mouse down events for duplicate detection on iOS.
     final nowMs = DateTime.now().millisecondsSinceEpoch;
     if (e.kind == ui.PointerDeviceKind.mouse) {
+      if (!isPhysicalMouse.value) {
+        isPhysicalMouse.value = true;
+      }
       _lastMouseDownTimeMs = nowMs;
       _lastMouseDownPos = e.position;
     }
@@ -1353,6 +1367,10 @@ class InputModel {
     }
 
     if (e.kind != ui.PointerDeviceKind.mouse) {
+      // Ignore duplicate touch events that follow a recent mouse click (iOS Magic Mouse issue).
+      if (isPhysicalMouse.value && shouldIgnoreTouchAfterMouse(e.position, nowMs)) {
+        return;
+      }
       if (isPhysicalMouse.value) {
         isPhysicalMouse.value = false;
       }

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -1335,7 +1335,7 @@ class InputModel {
   /// iOS may emit a synthesized touch event after a real mouse click.
   /// This helper ignores touch-down events that arrive shortly after a mouse down,
   /// even when the position is far (e.g., near the top edge).
-  bool shouldIgnoreTouchAfterMouse(ui.Offset pos, int nowMs) {
+  bool _shouldIgnoreTouchAfterMouse(int nowMs) {
     if (!isIOS) return false;
     const int kTouchAfterMouseWindowMs = 700;
     final dt = nowMs - _lastMouseDownTimeMs;
@@ -1367,7 +1367,7 @@ class InputModel {
 
     if (e.kind != ui.PointerDeviceKind.mouse) {
       // Ignore duplicate touch events that follow a recent mouse click (iOS Magic Mouse issue).
-      if (isPhysicalMouse.value && shouldIgnoreTouchAfterMouse(e.position, nowMs)) {
+      if (isPhysicalMouse.value && _shouldIgnoreTouchAfterMouse(nowMs)) {
         return;
       }
       if (isPhysicalMouse.value) {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -1337,7 +1337,6 @@ class InputModel {
   /// even when the position is far (e.g., near the top edge).
   bool shouldIgnoreTouchAfterMouse(ui.Offset pos, int nowMs) {
     if (!isIOS) return false;
-    if (shouldIgnoreTouchTap(pos)) return true;
     const int kTouchAfterMouseWindowMs = 700;
     final dt = nowMs - _lastMouseDownTimeMs;
     return dt >= 0 && dt < kTouchAfterMouseWindowMs;


### PR DESCRIPTION
On iPadOS `PointerDownEvent` from a real mouse can arrive before any hover events.`isPhysicalMouse` was only set on hover. so mouse down or up messages were skipped and menus closed immediately.
This change marks `isPhysicalMouse` as true on mouse down and allowing click events to be sent consistently.

~~Fixes #10424~~

Fixes https://github.com/rustdesk/rustdesk/pull/14515#issuecomment-4039181532 

https://github.com/rustdesk/rustdesk/issues/8789

## Root cause

`inputModel.isPhysicalMouse.value` is initially `false`. At this point, `RawTouchGestureDetectorRegion` is built.

When clicking near the top edge, the following events are triggered:
  - `onPointDownImage()` twice, `onPointDownImage PointerDeviceKind.mouse` and `onPointDownImage PointerDeviceKind.touch`
  - `tap()` once

https://github.com/rustdesk/rustdesk/blob/b3f43f55c1c00f287b8baf22152f3d1b88b51fb6/flutter/lib/models/input_model.dart#L1335 

https://github.com/rustdesk/rustdesk/blob/b3f43f55c1c00f287b8baf22152f3d1b88b51fb6/flutter/lib/models/input_model.dart#L933

As a result, on the first connection -- while `inputModel.isPhysicalMouse.value` is still false -- clicking near the top edge causes two mouse click events to be sent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input handling on iOS to prevent duplicate pointer events when switching between mouse and touch inputs on compatible devices, reducing unintended interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->