### PR TITLE
fix: Use upstream webm-sys, update toolchains

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -6,10 +6,11 @@ on:
   workflow_call:
 
 env:
-  CARGO_EXPAND_VERSION: "1.0.95"
-  FLUTTER_VERSION: "3.22.3"
-  FLUTTER_RUST_BRIDGE_VERSION: "1.80.1"
-  RUST_VERSION: "1.75" # https://github.com/rustdesk/rustdesk/discussions/7503
+  CARGO_EXPAND_VERSION: '1.0.95'
+  FLUTTER_VERSION: '3.22.3'
+  FLUTTER_RUST_BRIDGE_VERSION: '1.80.1'
+  # webm 2.2.0 uses 2024-edition let-chains; keep bridge generation on current stable
+  RUST_VERSION: '1.94.0'
 
 jobs:
   generate_bridge:
@@ -21,7 +22,7 @@ jobs:
           - {
               target: x86_64-unknown-linux-gnu,
               os: ubuntu-22.04,
-              extra-build-args: "",
+              extra-build-args: '',
             }
     steps:
       - name: Checkout source code
@@ -53,7 +54,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: ${{ matrix.job.target }}
-          components: "rustfmt"
+          components: 'rustfmt'
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -69,7 +70,7 @@ jobs:
       - name: Install flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: "stable"
+          channel: 'stable'
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -18,9 +18,10 @@ on:
 # in this file!
 
 env:
-  SCITER_RUST_VERSION: "1.75" # https://github.com/rustdesk/rustdesk/discussions/7503, also 1.78 has ABI change which causes our sciter version not working, https://blog.rust-lang.org/2024/03/30/i128-layout-update.html
-  RUST_VERSION: "1.75" # sciter failed on m1 with 1.78 because of https://blog.rust-lang.org/2024/03/30/i128-layout-update.html
-  MAC_RUST_VERSION: "1.81" # 1.81 is requred for macos, because of https://github.com/yury/cidre requires 1.81
+  SCITER_RUST_VERSION: "1.94.0" # use current stable; webm 2.2.0 relies on 2024-edition let-chains stabilized after 1.85
+  SCITER_X86_NIGHTLY_RUST_VERSION: "nightly" # dyn_x86 still has a stale #![feature(abi_thiscall)] attribute, so this one job must stay on nightly until upstream removes it
+  RUST_VERSION: "1.94.0" # use current stable; webm 2.2.0 relies on 2024-edition let-chains stabilized after 1.85
+  MAC_RUST_VERSION: "1.94.0" # keep >=1.81 for cidre; current stable also satisfies the newer webm floor
   CARGO_NDK_VERSION: "3.1.2"
   SCITER_ARMV7_CMAKE_VERSION: "3.29.7"
   SCITER_NASM_DEBVERSION: "2.15.05-1"
@@ -321,7 +322,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly-2023-10-13-${{ matrix.job.target }} # must use nightly here, because of abi_thiscall feature required
+          toolchain: ${{ env.SCITER_X86_NIGHTLY_RUST_VERSION }}-${{ matrix.job.target }} # dyn_x86 still declares #![feature(abi_thiscall)] even though thiscall itself is stable
           targets: ${{ matrix.job.target }}
           components: "rustfmt"
 

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_VERSION: "1.75" # https://github.com/rustdesk/rustdesk/discussions/7503
+  RUST_VERSION: "1.94.0" # use current stable; webm 2.2.0 relies on 2024-edition let-chains stabilized after 1.85
   CARGO_NDK_VERSION: "3.1.2"
   LLVM_VERSION: "15.0.6"
   FLUTTER_VERSION: "3.22.2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9652,16 +9652,18 @@ dependencies = [
 
 [[package]]
 name = "webm"
-version = "1.1.0"
-source = "git+https://github.com/rustdesk-org/rust-webm#d2c4d3ac133c7b0e4c0f656da710b48391981e64"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bc0bbde92953f4853a977388180c1fe19c018cdb54dea1152e8d7fdbb10c52"
 dependencies = [
  "webm-sys",
 ]
 
 [[package]]
 name = "webm-sys"
-version = "1.0.4"
-source = "git+https://github.com/rustdesk-org/rust-webm#d2c4d3ac133c7b0e4c0f656da710b48391981e64"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2638f978256596fe3eef55c8587549d01744682eea7ef1c68e0fd966b93fab3"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 build= "build.rs"
 description = "RustDesk Remote Desktop"
 default-run = "rustdesk"
-rust-version = "1.75"
+rust-version = "1.88"
 
 [lib]
 name = "librustdesk"

--- a/libs/scrap/Cargo.toml
+++ b/libs/scrap/Cargo.toml
@@ -21,7 +21,7 @@ cfg-if = "1.0"
 num_cpus = "1.15"
 lazy_static = "1.4"
 hbb_common = { path = "../hbb_common" }
-webm = { git = "https://github.com/rustdesk-org/rust-webm" }
+webm = "2.2.0"
 serde = {version="1.0", features=["derive"]}
 
 [dependencies.winapi]

--- a/libs/scrap/examples/record-screen.rs
+++ b/libs/scrap/examples/record-screen.rs
@@ -86,15 +86,18 @@ fn main() -> io::Result<()> {
         Err(e) => return Err(e.into()),
     };
 
-    let mut webm =
-        mux::Segment::new(mux::Writer::new(out)).expect("Could not initialize the multiplexer.");
+    let builder = mux::SegmentBuilder::new(mux::Writer::new(out))
+        .expect("Could not initialize the multiplexer.");
 
     let (vpx_codec, mux_codec) = match args.flag_codec {
         Codec::Vp8 => (vpx_encode::VpxVideoCodecId::VP8, mux::VideoCodecId::VP8),
         Codec::Vp9 => (vpx_encode::VpxVideoCodecId::VP9, mux::VideoCodecId::VP9),
     };
 
-    let mut vt = webm.add_video_track(width, height, None, mux_codec);
+    let (builder, vt) = builder
+        .add_video_track(width, height, mux_codec, None)
+        .expect("Could not add video track.");
+    let mut webm = builder.build();
 
     // Setup the encoder.
     let quality = args.flag_quality;
@@ -142,7 +145,8 @@ fn main() -> io::Result<()> {
             let ms = time.as_secs() * 1000 + time.subsec_millis() as u64;
             frame.to(vpx.yuvfmt(), &mut yuv, &mut mid_data).unwrap();
             for frame in vpx.encode(ms as i64, &yuv, STRIDE_ALIGN).unwrap() {
-                vt.add_frame(frame.data, frame.pts as u64 * 1_000_000, frame.key);
+                webm.add_frame(vt, frame.data, frame.pts as u64 * 1_000_000, frame.key)
+                    .expect("Could not add frame.");
             }
         }
 

--- a/libs/scrap/src/common/record.rs
+++ b/libs/scrap/src/common/record.rs
@@ -16,7 +16,7 @@ use std::{
     sync::mpsc::Sender,
     time::Instant,
 };
-use webm::mux::{self, Segment, Track, VideoTrack, Writer};
+use webm::mux::{self, Segment, SegmentBuilder, VideoTrack};
 
 const MIN_SECS: u64 = 1;
 
@@ -272,7 +272,7 @@ impl Recorder {
 
 struct WebmRecorder {
     vt: VideoTrack,
-    webm: Option<Segment<Writer<File>>>,
+    webm: Option<Segment<File>>,
     ctx: RecorderContext,
     ctx2: RecorderContext2,
     key: bool,
@@ -292,29 +292,30 @@ impl RecorderApi for WebmRecorder {
             Err(ref e) if e.kind() == io::ErrorKind::AlreadyExists => File::create(&ctx2.filename)?,
             Err(e) => return Err(e.into()),
         };
-        let mut webm = match mux::Segment::new(mux::Writer::new(out)) {
-            Some(v) => v,
-            None => bail!("Failed to create webm mux"),
-        };
-        let vt = webm.add_video_track(
-            ctx2.width as _,
-            ctx2.height as _,
-            None,
-            if ctx2.format == CodecFormat::VP9 {
-                mux::VideoCodecId::VP9
-            } else if ctx2.format == CodecFormat::VP8 {
-                mux::VideoCodecId::VP8
-            } else {
-                mux::VideoCodecId::AV1
-            },
-        );
+        let builder = SegmentBuilder::new(mux::Writer::new(out))
+            .map_err(|e| io::Error::other(format!("Failed to create webm mux builder: {e}")))?;
+        let (mut builder, vt) = builder
+            .add_video_track(
+                ctx2.width as _,
+                ctx2.height as _,
+                if ctx2.format == CodecFormat::VP9 {
+                    mux::VideoCodecId::VP9
+                } else if ctx2.format == CodecFormat::VP8 {
+                    mux::VideoCodecId::VP8
+                } else {
+                    mux::VideoCodecId::AV1
+                },
+                None,
+            )
+            .map_err(|e| io::Error::other(format!("Failed to add webm video track: {e}")))?;
         if ctx2.format == CodecFormat::AV1 {
             // [129, 8, 12, 0] in 3.6.0, but zero works
             let codec_private = vec![0, 0, 0, 0];
-            if !webm.set_codec_private(vt.track_number(), &codec_private) {
-                bail!("Failed to set codec private");
-            }
+            builder = builder
+                .set_codec_private(vt, &codec_private)
+                .map_err(|e| io::Error::other(format!("Failed to set webm codec private: {e}")))?;
         }
+        let webm = builder.build();
         Ok(WebmRecorder {
             vt,
             webm: Some(webm),
@@ -331,9 +332,11 @@ impl RecorderApi for WebmRecorder {
             self.key = true;
         }
         if self.key {
-            let ok = self
-                .vt
-                .add_frame(&frame.data, frame.pts as u64 * 1_000_000, frame.key);
+            let vt = self.vt;
+            let ok = self.webm.as_mut().map_or(false, |webm| {
+                webm.add_frame(vt, &frame.data, frame.pts as u64 * 1_000_000, frame.key)
+                    .is_ok()
+            });
             if ok {
                 self.written = true;
             }
@@ -346,7 +349,7 @@ impl RecorderApi for WebmRecorder {
 
 impl Drop for WebmRecorder {
     fn drop(&mut self) {
-        let _ = std::mem::replace(&mut self.webm, None).map_or(false, |webm| webm.finalize(None));
+        let _ = std::mem::replace(&mut self.webm, None).map(|webm| webm.finalize(None));
         let mut state = RecordState::WriteTail;
         if !self.written || self.start.elapsed().as_secs() < MIN_SECS {
             std::fs::remove_file(&self.ctx2.filename).ok();


### PR DESCRIPTION
Mostly here for now to be able to verify this works with upstream's CI as it's still a bit funky on my fork and to open discussion about how to go about this

A [distro wide update to use `GCC 15` on NixOS](https://github.com/NixOS/nixpkgs/issues/475479) as the default compiler makes rustdesk not able to compile on NixOS without the help of [some patching to its `webm-sys` dependency](https://github.com/NixOS/nixpkgs/issues/475479?issue=NixOS%7Cnixpkgs%7C475861) due to less implicit headers being included.

This was fixed [two years ago](https://github.com/webmproject/libwebm/commit/3b630045052e1e4d563207ab9e3be8d137c26067) on the upstream `libwebm` which rustdesk hasn't updated to due to the use of a forked `webm-sys` crate.

_This PR:_
- Updates `webm-sys` to follow upstream again
- Optimistically updates all the toolchains to the latest rust version, pending validation of what compromise can be reached between using the newest rust version and supporting older hardware/software.

Related issues for this rust version bump include:
- The main catch 22 is https://github.com/rustdesk/rustdesk/discussions/7503 where newer rust versions simply don't seem to support Windows 7 and 8. This is an issue because from my POV it's either "mantain your own updated `libwebm` fork with older compiler support" "do that, but at the `webm-sys` level" or "think about forgoing older windows versions".
- The sciter `thiscall` is still present due to that being a fork as well, but there's no reason to use a really old nightly. It's not pinned either right now which is not great, but it should allow it to pass.

###### _This implementation is currently completely untested, I just want to make CI pass first_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain versions across CI workflows to 1.94.0 and project manifest to 1.88.
  * Updated webm dependency to version 2.2.0 for enhanced video recording support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->