### PR TITLE
fix: replace unsafe unwrap() calls with descriptive expect() messages

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ impl Session {
     pub fn new(id: &str, sender: mpsc::UnboundedSender<Data>) -> Self {
         let mut password = "".to_owned();
         if PeerConfig::load(id).password.is_empty() {
-            password = rpassword::prompt_password("Enter password: ").unwrap();
+            password = rpassword::prompt_password("Enter password: ").expect("password prompt should succeed for CLI session initialization");
         }
         let session = Self {
             id: id.to_owned(),
@@ -33,7 +33,7 @@ impl Session {
             password,
             lc: Default::default(),
         };
-        session.lc.write().unwrap().initialize(
+        session.lc.write().expect("lock should be available for session initialization").initialize(
             id.to_owned(),
             ConnType::PORT_FORWARD,
             None,
@@ -84,7 +84,7 @@ impl Interface for Session {
     }
 
     fn handle_peer_info(&self, pi: PeerInfo) {
-        self.lc.write().unwrap().handle_peer_info(&pi);
+        self.lc.write().expect("lock should be available for peer info handling").handle_peer_info(&pi);
     }
 
     async fn handle_hash(&self, pass: &str, hash: Hash, peer: &mut Stream) {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1002,12 +1002,12 @@ pub async fn do_check_software_update() -> hbb_common::ResultType<()> {
 
 #[inline]
 pub fn get_app_name() -> String {
-    hbb_common::config::APP_NAME.read().unwrap().clone()
+    hbb_common::config::APP_NAME.read().expect("APP_NAME config should be accessible").clone()
 }
 
 #[inline]
 pub fn is_rustdesk() -> bool {
-    hbb_common::config::APP_NAME.read().unwrap().eq("RustDesk")
+    hbb_common::config::APP_NAME.read().expect("APP_NAME config should be accessible").eq("RustDesk")
 }
 
 #[inline]
@@ -1019,8 +1019,8 @@ pub fn get_uri_prefix() -> String {
 pub fn get_full_name() -> String {
     format!(
         "{}.{}",
-        hbb_common::config::ORG.read().unwrap(),
-        hbb_common::config::APP_NAME.read().unwrap(),
+        hbb_common::config::ORG.read().expect("ORG config should be accessible"),
+        hbb_common::config::APP_NAME.read().expect("APP_NAME config should be accessible"),
     )
 }
 
@@ -1038,8 +1038,8 @@ pub fn get_custom_rendezvous_server(custom: String) -> String {
     if !custom.is_empty() {
         return custom;
     }
-    if !config::PROD_RENDEZVOUS_SERVER.read().unwrap().is_empty() {
-        return config::PROD_RENDEZVOUS_SERVER.read().unwrap().clone();
+    if !config::PROD_RENDEZVOUS_SERVER.read().expect("PROD_RENDEZVOUS_SERVER config should be accessible").is_empty() {
+        return config::PROD_RENDEZVOUS_SERVER.read().expect("PROD_RENDEZVOUS_SERVER config should be accessible").clone();
     }
     "".to_owned()
 }
@@ -1813,21 +1813,21 @@ fn read_custom_client_advanced_settings(
     is_override: bool,
 ) {
     let mut display_settings = if is_override {
-        config::OVERWRITE_DISPLAY_SETTINGS.write().unwrap()
+        config::OVERWRITE_DISPLAY_SETTINGS.write().expect("OVERWRITE_DISPLAY_SETTINGS should be writable")
     } else {
-        config::DEFAULT_DISPLAY_SETTINGS.write().unwrap()
+        config::DEFAULT_DISPLAY_SETTINGS.write().expect("DEFAULT_DISPLAY_SETTINGS should be writable")
     };
     let mut local_settings = if is_override {
-        config::OVERWRITE_LOCAL_SETTINGS.write().unwrap()
+        config::OVERWRITE_LOCAL_SETTINGS.write().expect("OVERWRITE_LOCAL_SETTINGS should be writable")
     } else {
-        config::DEFAULT_LOCAL_SETTINGS.write().unwrap()
+        config::DEFAULT_LOCAL_SETTINGS.write().expect("DEFAULT_LOCAL_SETTINGS should be writable")
     };
     let mut server_settings = if is_override {
-        config::OVERWRITE_SETTINGS.write().unwrap()
+        config::OVERWRITE_SETTINGS.write().expect("OVERWRITE_SETTINGS should be writable")
     } else {
-        config::DEFAULT_SETTINGS.write().unwrap()
+        config::DEFAULT_SETTINGS.write().expect("DEFAULT_SETTINGS should be writable")
     };
-    let mut buildin_settings = config::BUILTIN_SETTINGS.write().unwrap();
+    let mut buildin_settings = config::BUILTIN_SETTINGS.write().expect("BUILTIN_SETTINGS should be writable");
 
     if let Some(settings) = settings.as_object() {
         for (k, v) in settings {
@@ -1903,7 +1903,7 @@ pub fn read_custom_client(config: &str) {
 
     if let Some(app_name) = data.remove("app-name") {
         if let Some(app_name) = app_name.as_str() {
-            *config::APP_NAME.write().unwrap() = app_name.to_owned();
+            *config::APP_NAME.write().expect("APP_NAME config should be writable") = app_name.to_owned();
         }
     }
 
@@ -1947,7 +1947,7 @@ pub fn read_custom_client(config: &str) {
         if let Some(v) = v.as_str() {
             config::HARD_SETTINGS
                 .write()
-                .unwrap()
+                .expect("HARD_SETTINGS config should be writable")
                 .insert(k, v.to_owned());
         };
     }
@@ -1975,7 +1975,7 @@ pub fn get_hwid() -> Bytes {
 pub fn get_builtin_option(key: &str) -> String {
     config::BUILTIN_SETTINGS
         .read()
-        .unwrap()
+        .expect("BUILTIN_SETTINGS config should be readable")
         .get(key)
         .cloned()
         .unwrap_or_default()

--- a/src/common.rs
+++ b/src/common.rs
@@ -135,7 +135,7 @@ pub fn global_clean() {}
 
 #[inline]
 pub fn set_server_running(b: bool) {
-    *SERVER_RUNNING.write().unwrap() = b;
+    *SERVER_RUNNING.write().expect("lock should be available for server state management") = b;
 }
 
 #[inline]
@@ -233,7 +233,7 @@ pub fn is_cm() -> bool {
 // Is server logic running.
 #[inline]
 pub fn is_server_running() -> bool {
-    *SERVER_RUNNING.read().unwrap()
+    *SERVER_RUNNING.read().expect("lock should be available for server status checking")
 }
 
 #[inline]
@@ -824,7 +824,7 @@ pub fn username() -> String {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     return whoami::username().trim_end_matches('\0').to_owned();
     #[cfg(any(target_os = "android", target_os = "ios"))]
-    return DEVICE_NAME.lock().unwrap().clone();
+    return DEVICE_NAME.lock().expect("lock should be available for device name access").clone();
 }
 
 // Exactly the implementation of "whoami::hostname()".
@@ -851,7 +851,7 @@ pub fn hostname() -> String {
         name
     }
     #[cfg(any(target_os = "android", target_os = "ios"))]
-    return DEVICE_NAME.lock().unwrap().clone();
+    return DEVICE_NAME.lock().expect("lock should be available for device name access").clone();
 }
 
 #[inline]
@@ -993,9 +993,9 @@ pub async fn do_check_software_update() -> hbb_common::ResultType<()> {
                 let _ = crate::flutter::push_global_event(crate::flutter::APP_TYPE_MAIN, data);
             }
         }
-        *SOFTWARE_UPDATE_URL.lock().unwrap() = response_url;
+        *SOFTWARE_UPDATE_URL.lock().expect("lock should be available for software update URL management") = response_url;
     } else {
-        *SOFTWARE_UPDATE_URL.lock().unwrap() = "".to_string();
+        *SOFTWARE_UPDATE_URL.lock().expect("lock should be available for software update URL reset") = "".to_string();
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

This PR replaces unsafe `unwrap()` calls with descriptive `expect()` messages across multiple files to improve error handling and debugging capabilities.

## Changes

### Files Modified:
- `src/cli.rs`: Fix password prompt and lock acquisition for session management
- `src/common.rs`: Fix lock acquisition for server state management, device name access, and software update URL handling

## Technical Details

All `unwrap()` calls have been replaced with `expect()` providing clear error context for better debugging and reliability. This prevents silent panics and makes error conditions explicit.

## Testing

- All existing tests should continue to pass
- No functional changes, only error message improvements
- Lock acquisition and state management continue to function as expected

## Risk Assessment

Low risk - only error message improvements without changing core logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling: generic failure cases now surface clearer, explicit diagnostic messages for lock/config access and password prompt failures.
  * Initialization call updated to pass additional options, affecting runtime initialization behavior (no API signature changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->