### PR TITLE
Store Permanent Password as Hashed Verifier

### DIFF
--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -908,12 +908,11 @@ class _DesktopHomePageState extends State<DesktopHomePage>
 }
 
 void setPasswordDialog({VoidCallback? notEmptyCallback}) async {
-  final pw = await bind.mainGetPermanentPassword();
-  final p0 = TextEditingController(text: pw);
-  final p1 = TextEditingController(text: pw);
+  final p0 = TextEditingController(text: "");
+  final p1 = TextEditingController(text: "");
   var errMsg0 = "";
   var errMsg1 = "";
-  final RxString rxPass = pw.trim().obs;
+  final RxString rxPass = "".obs;
   final rules = [
     DigitValidationRule(),
     UppercaseValidationRule(),

--- a/flutter/lib/mobile/widgets/dialog.dart
+++ b/flutter/lib/mobile/widgets/dialog.dart
@@ -17,12 +17,19 @@ void _showError() {
 }
 
 void setPermanentPasswordDialog(OverlayDialogManager dialogManager) async {
-  final pw = await bind.mainGetPermanentPassword();
-  final p0 = TextEditingController(text: pw);
-  final p1 = TextEditingController(text: pw);
-  var validateLength = false;
-  var validateSame = false;
+  final p0 = TextEditingController(text: "");
+  final p1 = TextEditingController(text: "");
   dialogManager.show((setState, close, context) {
+    bool canSubmit() {
+      final a = p0.text.trim();
+      final b = p1.text.trim();
+      if (a.isEmpty && b.isEmpty) {
+        // Allow clearing the permanent password.
+        return true;
+      }
+      return a.length > 5 && a == b;
+    }
+
     submit() async {
       close();
       dialogManager.showLoading(translate("Waiting"));
@@ -54,15 +61,15 @@ void setPermanentPasswordDialog(OverlayDialogManager dialogManager) async {
                 labelText: translate('Password'),
               ),
               controller: p0,
+              onChanged: (_) => setState(() {}),
               validator: (v) {
                 if (v == null) return null;
-                final val = v.trim().length > 5;
-                if (validateLength != val) {
-                  // use delay to make setState success
-                  Future.delayed(Duration(microseconds: 1),
-                      () => setState(() => validateLength = val));
+                final trimmed = v.trim();
+                if (trimmed.isEmpty) {
+                  return null;
                 }
-                return val
+                final ok = trimmed.length > 5;
+                return ok
                     ? null
                     : translate('Too short, at least 6 characters.');
               },
@@ -74,21 +81,18 @@ void setPermanentPasswordDialog(OverlayDialogManager dialogManager) async {
                 labelText: translate('Confirmation'),
               ),
               controller: p1,
+              onChanged: (_) => setState(() {}),
               validator: (v) {
                 if (v == null) return null;
-                final val = p0.text == v;
-                if (validateSame != val) {
-                  Future.delayed(Duration(microseconds: 1),
-                      () => setState(() => validateSame = val));
-                }
-                return val
+                final ok = p0.text.trim() == v.trim();
+                return ok
                     ? null
                     : translate('The confirmation is not identical.');
               },
             ).workaroundFreezeLinuxMint(),
           ])),
       onCancel: close,
-      onSubmit: (validateLength && validateSame) ? submit : null,
+      onSubmit: canSubmit() ? submit : null,
       actions: [
         dialogButton(
           'Cancel',
@@ -99,7 +103,7 @@ void setPermanentPasswordDialog(OverlayDialogManager dialogManager) async {
         dialogButton(
           'OK',
           icon: Icon(Icons.done_rounded),
-          onPressed: (validateLength && validateSame) ? submit : null,
+          onPressed: canSubmit() ? submit : null,
         ),
       ],
     );

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -475,11 +475,8 @@ class ServerModel with ChangeNotifier {
     await bind.mainSetPermanentPassword(password: newPW);
     await Future.delayed(Duration(milliseconds: 500));
     final pw = await bind.mainGetPermanentPassword();
-    if (newPW == pw) {
-      return true;
-    } else {
-      return false;
-    }
+    final hasPw = pw.trim().isNotEmpty;
+    return newPW.trim().isEmpty ? !hasPw : hasPw;
   }
 
   fetchID() async {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2423,16 +2423,37 @@ pub fn is_disable_installation() -> SyncReturn<bool> {
 }
 
 pub fn is_preset_password() -> bool {
-    config::HARD_SETTINGS
+    use hbb_common::{sha2::Digest, sha2::Sha256, sodiumoxide::base64};
+
+    let hard = config::HARD_SETTINGS
         .read()
         .unwrap()
         .get("password")
-        .map_or(false, |p| {
-            #[cfg(not(any(target_os = "android", target_os = "ios")))]
-            return p == &crate::ipc::get_permanent_password();
-            #[cfg(any(target_os = "android", target_os = "ios"))]
-            return p == &config::Config::get_permanent_password();
-        })
+        .cloned()
+        .unwrap_or_default();
+    if hard.is_empty() {
+        return false;
+    }
+
+    let stored = config::Config::get_permanent_password();
+    if stored == hard {
+        return true;
+    }
+
+    if let Some(encoded) = stored.strip_prefix("01$") {
+        if let Ok(h1_stored) = base64::decode(encoded.as_bytes(), base64::Variant::Original) {
+            if h1_stored.len() == 32 {
+                let salt = config::Config::get_salt();
+                let mut hasher = Sha256::new();
+                hasher.update(hard.as_bytes());
+                hasher.update(salt.as_bytes());
+                let h1_expected = hasher.finalize();
+                return h1_expected[..] == h1_stored[..];
+            }
+        }
+    }
+
+    false
 }
 
 // Don't call this function for desktop version.

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -633,7 +633,11 @@ async fn handle(data: Data, stream: &mut Connection) {
                 } else if name == "temporary-password" {
                     value = Some(password::temporary_password());
                 } else if name == "permanent-password" {
-                    value = Some(Config::get_permanent_password());
+                    value = Some(if Config::has_permanent_password() {
+                        "<set>".to_owned()
+                    } else {
+                        String::new()
+                    });
                 } else if name == "salt" {
                     value = Some(Config::get_salt());
                 } else if name == "rendezvous_server" {
@@ -1144,11 +1148,14 @@ pub fn update_temporary_password() -> ResultType<()> {
 }
 
 pub fn get_permanent_password() -> String {
+    // Desktop UI should query service side "is set" state without persisting any secret locally.
     if let Ok(Some(v)) = get_config("permanent-password") {
-        Config::set_permanent_password(&v);
-        v
+        return v;
+    }
+    if Config::has_permanent_password() {
+        "<set>".to_owned()
     } else {
-        Config::get_permanent_password()
+        String::new()
     }
 }
 
@@ -1159,7 +1166,6 @@ pub fn get_fingerprint() -> String {
 }
 
 pub fn set_permanent_password(v: String) -> ResultType<()> {
-    Config::set_permanent_password(&v);
     set_config("permanent-password", v)
 }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -35,6 +35,7 @@ use hbb_common::{
     password_security::{self as password, ApproveMode},
     sha2::{Digest, Sha256},
     sleep, timeout,
+    sodiumoxide::base64,
     tokio::{
         net::TcpStream,
         sync::mpsc,
@@ -1969,23 +1970,38 @@ impl Connection {
         self.tx_input.send(MessageInput::Key((msg, press))).ok();
     }
 
-    fn validate_one_password(&self, password: String) -> bool {
-        if password.len() == 0 {
+    fn validate_one_password(&self, password: &str) -> bool {
+        if password.is_empty() {
             return false;
         }
-        let mut hasher = Sha256::new();
-        hasher.update(password);
-        hasher.update(&self.hash.salt);
+        let h1: Vec<u8> = if let Some(encoded) = password.strip_prefix("01$") {
+            match base64::decode(encoded.as_bytes(), base64::Variant::Original) {
+                Ok(v) if v.len() == 32 => v,
+                _ => {
+                    log::error!("Invalid hashed permanent password storage; treating as plaintext");
+                    let mut hasher = Sha256::new();
+                    hasher.update(password.as_bytes());
+                    hasher.update(self.hash.salt.as_bytes());
+                    hasher.finalize()[..].to_vec()
+                }
+            }
+        } else {
+            let mut hasher = Sha256::new();
+            hasher.update(password.as_bytes());
+            hasher.update(self.hash.salt.as_bytes());
+            hasher.finalize()[..].to_vec()
+        };
+
         let mut hasher2 = Sha256::new();
-        hasher2.update(&hasher.finalize()[..]);
-        hasher2.update(&self.hash.challenge);
+        hasher2.update(&h1[..]);
+        hasher2.update(self.hash.challenge.as_bytes());
         hasher2.finalize()[..] == self.lr.password[..]
     }
 
     fn validate_password(&mut self) -> bool {
         if password::temporary_enabled() {
             let password = password::temporary_password();
-            if self.validate_one_password(password.clone()) {
+            if self.validate_one_password(&password) {
                 raii::AuthedConnID::update_or_insert_session(
                     self.session_key(),
                     Some(password),
@@ -1995,7 +2011,8 @@ impl Connection {
             }
         }
         if password::permanent_enabled() {
-            if self.validate_one_password(Config::get_permanent_password()) {
+            let stored = Config::get_permanent_password();
+            if self.validate_one_password(&stored) {
                 return true;
             }
         }

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -1128,11 +1128,9 @@ class PasswordArea: Reactor.Component {
 
     event click $(li#set-password) {
         var me = this;
-        var password = handler.permanent_password();
-        var value_field = password.length == 0 ? "" : "value=" + password;
         msgbox("custom-password", translate("Set Password"), "<div .form .set-password> \
-            <div><span>" + translate('Password') + ":</span><input|password(password) .outline-focus " + value_field + " /></div> \
-            <div><span>" + translate('Confirmation') + ":</span><input|password(confirmation) " + value_field + " /></div> \
+            <div><span>" + translate('Password') + ":</span><input|password(password) .outline-focus /></div> \
+            <div><span>" + translate('Confirmation') + ":</span><input|password(confirmation) /></div> \
         </div> \
         ", "", function(res=null) {
             if (!res) return;

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -611,7 +611,11 @@ pub fn update_temporary_password() {
 #[inline]
 pub fn permanent_password() -> String {
     #[cfg(any(target_os = "android", target_os = "ios"))]
-    return Config::get_permanent_password();
+    return if Config::has_permanent_password() {
+        "<set>".to_owned()
+    } else {
+        String::new()
+    };
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     return ipc::get_permanent_password();
 }


### PR DESCRIPTION
This change addresses a reported security issue where a permanent ("master") password could be recovered from local configuration due to reversible storage combined with service/user configuration synchronization. The permanent password is now stored as a non-reversible verifier, and UI/IPC no longer exposes or pre-fills the secret.

## Problem
- Permanent password was stored in a reversible form on disk.
- The application may sync configuration between service/root and user config locations.
- As a result, an unprivileged local attacker could retrieve the permanent password from synced configuration, making it impractical to deploy in hardened environments.

## Solution (High Level)
- Store permanent password as a hashed verifier instead of reversible ciphertext or plaintext.
- Keep backward compatibility by migrating existing stored values on load.
- Allow syncing the verifier to user-side config for non-installed usage, but never expose plaintext via UI/IPC.
- Freeze `salt` once the hashed storage format is in use to avoid breaking verification.

## Details
- New storage format: `01$<base64(H1)>`
- `H1 = SHA256(password || salt)` (32 bytes)
- During auth verification:
  - If stored value starts with `01$`, decode `H1` and compute `H2 = SHA256(H1 || challenge)`
  - Otherwise, fall back to legacy behavior (`H1 = SHA256(password || salt)`) for compatibility

## Changes
- `libs/hbb_common/src/config.rs`
  - Add `01$...` hashed permanent password storage.
  - Auto-migrate legacy stored passwords to `01$...` on load.
  - Prevent `salt` changes once permanent password is stored as `01$...`.
  - Guard `Config::set(cfg)` so sync paths cannot silently change `salt` (and keep `password`/`salt` consistent).
- `src/server/connection.rs`
  - Accept both hashed storage (`01$...`) and legacy plaintext-like input during password validation.
- `src/ipc.rs`, `src/ui_interface.rs`
  - IPC `get_config("permanent-password")` returns `"<set>"` or empty string (no secret material).
  - Desktop UI queries service-side "is set" state via IPC without persisting plaintext locally.
- `src/ui/index.tis` (Sciter)
  - "Set permanent password" dialog no longer pre-fills existing password.
- Flutter UI
  - Do not pre-fill permanent password fields.
  - Allow submitting empty fields to clear the permanent password.
  - Adjust success detection to work with "is set" semantics rather than secret readback.

## Backward Compatibility
- Existing configs with legacy permanent password storage are migrated to the new `01$...` format on first load (when possible).
- Service-side validation remains compatible with legacy inputs.

## Tests

  - [ ] Set permanent password, restart, verify remote auth works.
  - [ ] Confirm config does not contain plaintext or reversibly-encrypted permanent password.
  - [ ] Confirm UI does not display or pre-fill permanent password.
  - [ ] Confirm that clearing the permanent password works.

## Notes / Risk
- `salt` becomes a long-lived parameter once hashed storage is active. Sync paths are explicitly prevented from changing it to avoid breaking permanent password verification.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password validation logic to properly handle various password storage formats, including legacy hashed passwords.
  * Fixed password dialog behavior to open with empty fields instead of displaying existing passwords.

* **Improvements**
  * Enhanced password security handling by using presence indicators instead of exposing actual password values in certain contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->