### PR TITLE
fix(linux): prevent X11 BadWindow crash in get_focused_display

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -6,7 +6,7 @@ use hbb_common::{
     anyhow::anyhow,
     bail,
     config::{keys::OPTION_ALLOW_LINUX_HEADLESS, Config},
-    libc::{c_char, c_int, c_long, c_uint, c_void},
+    libc::{c_char, c_int, c_long, c_uint, c_ulong, c_void},
     log,
     message_proto::{DisplayInfo, Resolution},
     regex::{Captures, Regex},
@@ -97,10 +97,53 @@ thread_local! {
     static DISPLAY: RefCell<*mut c_void> = RefCell::new(unsafe { XOpenDisplay(std::ptr::null())});
 }
 
+// X11 error event structure for the custom error handler.
+// See: https://www.x.org/releases/current/doc/libX11/libX11/libX11.html#Using-the-Default-Error-Handlers
+#[repr(C)]
+#[allow(non_snake_case)]
+struct XErrorEvent {
+    type_: c_int,
+    display: *mut c_void,   // Display*
+    resourceid: c_ulong,    // XID
+    serial: c_ulong,
+    error_code: u8,
+    request_code: u8,
+    minor_code: u8,
+}
+
+type XErrorHandler = unsafe extern "C" fn(*mut c_void, *mut XErrorEvent) -> c_int;
+
+/// Atomic flag set by the custom X error handler when a BadWindow error occurs.
+static X_BAD_WINDOW_DETECTED: AtomicBool = AtomicBool::new(false);
+
+/// Custom X error handler that catches BadWindow errors (error_code == 3) instead of
+/// letting the default handler terminate the process.
+/// See issue: https://github.com/rustdesk/rustdesk/issues/9003
+unsafe extern "C" fn handle_x_error(_display: *mut c_void, event: *mut XErrorEvent) -> c_int {
+    const BAD_WINDOW: u8 = 3; // X11 BadWindow error code
+    if !event.is_null() && (*event).error_code == BAD_WINDOW {
+        X_BAD_WINDOW_DETECTED.store(true, Ordering::SeqCst);
+        log::debug!("Caught X11 BadWindow error (suppressed), window was likely destroyed");
+        return 0;
+    }
+    // For non-BadWindow errors, just log and return (don't crash).
+    if !event.is_null() {
+        log::warn!(
+            "X11 error: error_code={}, request_code={}, minor_code={}",
+            (*event).error_code,
+            (*event).request_code,
+            (*event).minor_code,
+        );
+    }
+    0
+}
+
 #[link(name = "X11")]
 extern "C" {
     fn XOpenDisplay(display_name: *const c_char) -> *mut c_void;
     // fn XCloseDisplay(d: *mut c_void) -> c_int;
+    fn XSetErrorHandler(handler: Option<XErrorHandler>) -> Option<XErrorHandler>;
+    fn XSync(display: *mut c_void, discard: c_int) -> c_int;
 }
 
 #[link(name = "Xfixes")]
@@ -231,25 +274,50 @@ pub fn get_focused_display(displays: Vec<DisplayInfo>) -> Option<usize> {
                 if libxdo_sys::xdo_get_active_window(*xdo as *const _, &mut window) != 0 {
                     return;
                 }
-                if libxdo_sys::xdo_get_window_location(
+
+                // Install a custom X error handler to catch BadWindow errors.
+                // Between xdo_get_active_window and the subsequent calls, the
+                // window can be destroyed (e.g. user closes it), causing a
+                // BadWindow X error that would crash the process with the
+                // default handler. See: https://github.com/rustdesk/rustdesk/issues/9003
+                X_BAD_WINDOW_DETECTED.store(false, Ordering::SeqCst);
+                let prev_handler = XSetErrorHandler(Some(handle_x_error));
+
+                let loc_ret = libxdo_sys::xdo_get_window_location(
                     *xdo as *const _,
                     window,
                     &mut x as _,
                     &mut y as _,
                     std::ptr::null_mut(),
-                ) != 0
-                {
+                );
+
+                let size_ret = if loc_ret == 0 {
+                    libxdo_sys::xdo_get_window_size(
+                        *xdo as *const _,
+                        window,
+                        &mut width,
+                        &mut height,
+                    )
+                } else {
+                    1 // skip if location failed
+                };
+
+                // Flush to ensure any deferred X errors are delivered to our handler.
+                DISPLAY.with(|disp| {
+                    let d = *disp.borrow();
+                    if !d.is_null() {
+                        XSync(d, 0);
+                    }
+                });
+
+                // Restore the previous error handler.
+                XSetErrorHandler(prev_handler);
+
+                // If a BadWindow error was caught, or either call failed, bail out.
+                if X_BAD_WINDOW_DETECTED.load(Ordering::SeqCst) || loc_ret != 0 || size_ret != 0 {
                     return;
                 }
-                if libxdo_sys::xdo_get_window_size(
-                    *xdo as *const _,
-                    window,
-                    &mut width,
-                    &mut height,
-                ) != 0
-                {
-                    return;
-                }
+
                 let center_x = x + (width / 2) as c_int;
                 let center_y = y + (height / 2) as c_int;
                 res = displays.iter().position(|d| {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -100,11 +100,10 @@ thread_local! {
 // X11 error event structure for the custom error handler.
 // See: https://www.x.org/releases/current/doc/libX11/libX11/libX11.html#Using-the-Default-Error-Handlers
 #[repr(C)]
-#[allow(non_snake_case)]
 struct XErrorEvent {
     type_: c_int,
-    display: *mut c_void,   // Display*
-    resourceid: c_ulong,    // XID
+    display: *mut c_void, // Display*
+    resourceid: c_ulong,  // XID
     serial: c_ulong,
     error_code: u8,
     request_code: u8,
@@ -113,20 +112,24 @@ struct XErrorEvent {
 
 type XErrorHandler = unsafe extern "C" fn(*mut c_void, *mut XErrorEvent) -> c_int;
 
+const X11_BAD_WINDOW: u8 = 3;
+const XDO_SUCCESS: c_int = 0;
+const XDO_ERROR: c_int = 1;
+
 /// Atomic flag set by the custom X error handler when a BadWindow error occurs.
 static X_BAD_WINDOW_DETECTED: AtomicBool = AtomicBool::new(false);
+static X_UNEXPECTED_ERROR_DETECTED: AtomicBool = AtomicBool::new(false);
 
 /// Custom X error handler that catches BadWindow errors (error_code == 3) instead of
 /// letting the default handler terminate the process.
 /// See issue: https://github.com/rustdesk/rustdesk/issues/9003
 unsafe extern "C" fn handle_x_error(_display: *mut c_void, event: *mut XErrorEvent) -> c_int {
-    const BAD_WINDOW: u8 = 3; // X11 BadWindow error code
-    if !event.is_null() && (*event).error_code == BAD_WINDOW {
+    if !event.is_null() && (*event).error_code == X11_BAD_WINDOW {
         X_BAD_WINDOW_DETECTED.store(true, Ordering::SeqCst);
         log::debug!("Caught X11 BadWindow error (suppressed), window was likely destroyed");
         return 0;
     }
-    // For non-BadWindow errors, just log and return (don't crash).
+    X_UNEXPECTED_ERROR_DETECTED.store(true, Ordering::SeqCst);
     if !event.is_null() {
         log::warn!(
             "X11 error: error_code={}, request_code={}, minor_code={}",
@@ -143,7 +146,6 @@ extern "C" {
     fn XOpenDisplay(display_name: *const c_char) -> *mut c_void;
     // fn XCloseDisplay(d: *mut c_void) -> c_int;
     fn XSetErrorHandler(handler: Option<XErrorHandler>) -> Option<XErrorHandler>;
-    fn XSync(display: *mut c_void, discard: c_int) -> c_int;
 }
 
 #[link(name = "Xfixes")]
@@ -275,12 +277,12 @@ pub fn get_focused_display(displays: Vec<DisplayInfo>) -> Option<usize> {
                     return;
                 }
 
-                // Install a custom X error handler to catch BadWindow errors.
-                // Between xdo_get_active_window and the subsequent calls, the
-                // window can be destroyed (e.g. user closes it), causing a
-                // BadWindow X error that would crash the process with the
-                // default handler. See: https://github.com/rustdesk/rustdesk/issues/9003
+                // XSetErrorHandler is process-global, not scoped to this Display/thread.
+                // This path is currently called by the single window_focus service thread.
+                // While installed, this handler can still observe unrelated X11 errors from
+                // other threads; unexpected errors make this geometry query fail.
                 X_BAD_WINDOW_DETECTED.store(false, Ordering::SeqCst);
+                X_UNEXPECTED_ERROR_DETECTED.store(false, Ordering::SeqCst);
                 let prev_handler = XSetErrorHandler(Some(handle_x_error));
 
                 let loc_ret = libxdo_sys::xdo_get_window_location(
@@ -290,8 +292,7 @@ pub fn get_focused_display(displays: Vec<DisplayInfo>) -> Option<usize> {
                     &mut y as _,
                     std::ptr::null_mut(),
                 );
-
-                let size_ret = if loc_ret == 0 {
+                let size_ret = if loc_ret == XDO_SUCCESS {
                     libxdo_sys::xdo_get_window_size(
                         *xdo as *const _,
                         window,
@@ -299,22 +300,20 @@ pub fn get_focused_display(displays: Vec<DisplayInfo>) -> Option<usize> {
                         &mut height,
                     )
                 } else {
-                    1 // skip if location failed
+                    XDO_ERROR
                 };
 
-                // Flush to ensure any deferred X errors are delivered to our handler.
-                DISPLAY.with(|disp| {
-                    let d = *disp.borrow();
-                    if !d.is_null() {
-                        XSync(d, 0);
-                    }
-                });
-
-                // Restore the previous error handler.
+                // Do not call XSync(DISPLAY) here: DISPLAY is a separate
+                // XOpenDisplay() connection, while libxdo owns the Display*
+                // used by these geometry queries. These libxdo calls are
+                // synchronous XGetWindowAttributes-based queries, so the target
+                // BadWindow is expected to be delivered before the calls return.
                 XSetErrorHandler(prev_handler);
-
-                // If a BadWindow error was caught, or either call failed, bail out.
-                if X_BAD_WINDOW_DETECTED.load(Ordering::SeqCst) || loc_ret != 0 || size_ret != 0 {
+                if X_BAD_WINDOW_DETECTED.load(Ordering::SeqCst)
+                    || X_UNEXPECTED_ERROR_DETECTED.load(Ordering::SeqCst)
+                    || loc_ret != XDO_SUCCESS
+                    || size_ret != XDO_SUCCESS
+                {
                     return;
                 }
 
@@ -2218,7 +2217,10 @@ pub fn clear_gnome_shortcuts_inhibitor_permission() -> ResultType<()> {
                 || err_name == "org.freedesktop.DBus.Error.UnknownObject"
                 || err_name == "org.freedesktop.DBus.Error.ServiceUnknown"
             {
-                log::info!("GNOME shortcuts inhibitor permission was not set ({})", err_name);
+                log::info!(
+                    "GNOME shortcuts inhibitor permission was not set ({})",
+                    err_name
+                );
                 Ok(())
             } else {
                 bail!("Failed to clear permission: {}", e)


### PR DESCRIPTION
## Summary

Fixes #9003

When a user closes a window on a remote-controlled Linux (X11) machine while RustDesk is running the `window_focus` service, the `rustdesk --server` process crashes and the session disconnects/reconnects.

### Reproduce steps

It may not be easy to reproduce the crash.
We should modify the code to make it easier to reproduce.

1. `git apply src.patch`

<details open><summary>src.patch</summary>

```
index 9493e1cae..e31ee1d84 100644
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -231,6 +231,10 @@ pub fn get_focused_display(displays: Vec<DisplayInfo>) -> Option<usize> {
                 if libxdo_sys::xdo_get_active_window(*xdo as *const _, &mut window) != 0 {
                     return;
                 }
+
+  std::thread::sleep(std::time::Duration::from_millis(3000));
+
+  log::info!("===================================== active window 111: {}", window);
                 if libxdo_sys::xdo_get_window_location(
                     *xdo as *const _,
                     window,
@@ -239,8 +243,10 @@ pub fn get_focused_display(displays: Vec<DisplayInfo>) -> Option<usize> {
                     std::ptr::null_mut(),
                 ) != 0
                 {
+                    log::info!("===================================== xdo_get_window_location failed for window {}", window);
                     return;
                 }
+                log::info!("================================= ==== active window: {}, location: ({}, {})", window, x, y);
                 if libxdo_sys::xdo_get_window_size(
                     *xdo as *const _,
                     window,
@@ -248,8 +254,10 @@ pub fn get_focused_display(displays: Vec<DisplayInfo>) -> Option<usize> {
                     &mut height,
                 ) != 0
                 {
+                    log::info!("===================================== xdo_get_window_size failed for window {}", window);
                     return;
                 }
+                log::info!("===================================== active window: {}, size: ({}x{})", window, width, height);
                 let center_x = x + (width / 2) as c_int;
                 let center_y = y + (height / 2) as c_int;
                 res = displays.iter().position(|d| {
```

</details>

2. Connect to an X11 peer with 2 or more displays
3. Enable "Follow remote window focus"

<img width="200" alt="image" src="https://github.com/user-attachments/assets/7cd333a9-896f-4b17-ae66-1f210063be31" />

4. Run the script
```bash
#/bin/bash

  for i in $(seq 1 2000); do
    xterm -title "rd-badwindow-$i" &
    pid=$!
    sleep 0.03
    xdotool windowfocus "$(xdotool search --name "rd-badwindow-$i" | tail -1)" 2>/dev/null || true
    sleep 0.01
    kill "$pid" 2>/dev/null || true
  done
```


### Root cause

`get_focused_display()` calls `xdo_get_active_window` to get the currently focused window, then calls `xdo_get_window_location` and `xdo_get_window_size` on that window. If the window is destroyed between these calls (e.g. user clicks X to close it), `xdo_get_window_location` internally calls `XGetWindowAttributes` on the now-invalid window ID. This triggers an X11 `BadWindow` error, and the **default Xlib error handler terminates the process**, crashing the server.

From the issue logs:
```
X Error of failed request: BadWindow (invalid Window parameter)
Major opcode of failed request: 3 (X_GetWindowAttributes)
```

### Fix

Install a custom X error handler (`XSetErrorHandler`) around the `xdo_get_window_location` / `xdo_get_window_size` calls that catches `BadWindow` errors (error code 3) and sets an atomic flag instead of crashing.

~~After the calls, `XSync` is used to flush any deferred errors, then the previous error handler is restored.~~

If a `BadWindow` error was caught, the function returns `None` gracefully.

This approach is consistent with how other X11 applications handle race conditions with destroyed windows.

### Testing

- Verified the fix is consistent with existing code patterns in the file
- The change only affects the Linux X11 code path (`src/platform/linux.rs`)
- No functional change when windows are not being destroyed during the call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux stability by intercepting and handling X11 errors to avoid crashes when windows are destroyed or unavailable.
  * Made window detection and geometry queries more robust, returning safely on unexpected X errors or failed queries.

* **Style**
  * Minor logging formatting cleaned up for GNOME shortcuts inhibitor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->