### PR TITLE
fix(shell): restrict kv in `update_install_option`

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2029,6 +2029,9 @@ pub fn update_install_option(k: &str, v: &str) -> ResultType<()> {
     if !is_installed() || !crate::is_server() {
         return Ok(());
     }
+    if ![REG_NAME_INSTALL_PRINTER].contains(&k) || !["0", "1"].contains(&v) {
+        return Ok(());
+    }
     let app_name = crate::get_app_name();
     let ext = app_name.to_lowercase();
     let cmds =


### PR DESCRIPTION
Fix `update_install_option()`, check `k & v` before updating the registry value.

`update_install_option()` is only used to update the registry value of `PRINTER` for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for installation configuration updates to prevent unintended changes by restricting to supported options only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->