### PR TITLE
chore: report 10 resource leak findings from static analysis

### DIFF
--- a/.gnosis/scanner-findings.md
+++ b/.gnosis/scanner-findings.md
@@ -1,0 +1,16 @@
+# Gnosis Polyglot Scanner Findings
+
+## Resource Leak Detections (10 findings)
+
+| File | Line | Type | Priority |
+|------|------|------|----------|
+| libs/clipboard/src/windows/wf_cliprdr.c | 552 | Memory | High |
+| libs/clipboard/src/windows/wf_cliprdr.c | 558 | Memory | High |
+| libs/clipboard/src/windows/wf_cliprdr.c | 773 | Memory | High |
+| libs/clipboard/src/platform/unix/fuse/cs.rs | 115 | File | Medium |
+| libs/clipboard/src/platform/unix/fuse/cs.rs | 117 | File | Medium |
+| libs/clipboard/src/platform/unix/fuse/cs.rs | 385 | File | Medium |
+| libs/clipboard/src/platform/unix/local_file.rs | 171 | File | Medium |
+| libs/clipboard/src/platform/unix/macos/paste_task.rs | 569 | File | Medium |
+| build.py | 635 | File | Low |
+| examples/ipc.rs | 75 | Connection | Low |


### PR DESCRIPTION
## Summary

The Gnosis Polyglot Scanner detected 10 resource leak patterns across the rustdesk codebase:

### Clipboard (production code, highest priority)
- `libs/clipboard/src/platform/unix/fuse/cs.rs:115,117` -- File resources in FUSE handler
- `libs/clipboard/src/platform/unix/fuse/cs.rs:385` -- File resource
- `libs/clipboard/src/platform/unix/local_file.rs:171` -- File resource
- `libs/clipboard/src/platform/unix/macos/paste_task.rs:569` -- File resource
- `libs/clipboard/src/windows/wf_cliprdr.c:552,558,773` -- Memory resources (GlobalAlloc without GlobalFree on error)

### Build + Examples
- `build.py:635` -- File resource
- `examples/ipc.rs:75` -- Connection resource

Detected via topological analysis of control flow graphs: resource acquisition nodes without matching release nodes on all execution paths.

Found by [Gnosis Polyglot Scanner](https://gnosis.church)

Signed-off-by: Taylor Buley <taylor@forkjoin.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added scanner findings report documenting resource leak detections across the codebase, including file locations, line numbers, detection types (Memory, File, Connection), and priority levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->