### PR TITLE
Fix Windows session-based logon and lock-screen detection

### DIFF
--- a/src/platform/windows.cc
+++ b/src/platform/windows.cc
@@ -580,9 +580,8 @@ extern "C"
         return rdp_or_console;
     }
 
-    BOOL is_session_locked(BOOL include_rdp)
+    BOOL is_session_locked(DWORD session_id)
     {
-        DWORD session_id = get_current_session(include_rdp);
         if (session_id == 0xFFFFFFFF) {
             return FALSE;
         }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -523,7 +523,7 @@ const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
 extern "C" {
     fn get_current_session(rdp: BOOL) -> DWORD;
-    fn is_session_locked(include_rdp: BOOL) -> BOOL;
+    fn is_session_locked(session_id: DWORD) -> BOOL;
     fn LaunchProcessWin(
         cmd: *const u16,
         session_id: DWORD,
@@ -1149,20 +1149,21 @@ pub fn is_prelogin() -> bool {
 }
 
 pub fn is_locked() -> bool {
-    unsafe { is_session_locked(share_rdp()) == TRUE }
+    let Some(session_id) = get_current_process_session_id() else {
+        return false;
+    };
+    unsafe { is_session_locked(session_id) == TRUE }
 }
 
-// `is_logon_ui()` is regardless of multiple sessions now.
-// It only check if "LogonUI.exe" exists.
-//
-// If there're mulitple sessions (logged in users),
-// some are in the login screen, while the others are not.
-// Then this function may not work fine if the session we want to handle(connect) is not in the login screen.
-// But it's a rare case and cannot be simply handled, so it will not be dealt with for the time being.
 #[inline]
 pub fn is_logon_ui() -> ResultType<bool> {
+    let Some(current_sid) = get_current_process_session_id() else {
+        return Ok(false);
+    };
     let pids = get_pids("LogonUI.exe")?;
-    Ok(!pids.is_empty())
+    Ok(pids
+        .into_iter()
+        .any(|pid| get_session_id_of_process(pid) == Some(current_sid)))
 }
 
 pub fn is_root() -> bool {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2025,7 +2025,7 @@ impl Connection {
         self.validate_password_plain(storage)
     }
 
-    fn validate_password(&mut self) -> bool {
+    fn validate_password(&mut self, allow_permanent_password: bool) -> bool {
         if password::temporary_enabled() {
             let password = password::temporary_password();
             if self.validate_one_password(&password) {
@@ -2037,7 +2037,7 @@ impl Connection {
                 return true;
             }
         }
-        if password::permanent_enabled() {
+        if password::permanent_enabled() || allow_permanent_password {
             // Since hashed storage uses a prefix-based encoding, a hard plaintext that
             // happens to look like hashed storage could be mis-detected. Validate local storage
             // and hard/preset plaintext via separate paths to avoid that ambiguity.
@@ -2349,6 +2349,10 @@ impl Connection {
             #[cfg(any(target_os = "android", target_os = "ios"))]
             let is_logon = || crate::platform::is_prelogin();
 
+            let allow_logon_screen_password =
+                crate::get_builtin_option(keys::OPTION_ALLOW_LOGON_SCREEN_PASSWORD) == "Y"
+                    && is_logon();
+
             if !hbb_common::is_ip_str(&lr.username)
                 && !hbb_common::is_domain_port_str(&lr.username)
                 && lr.username != Config::get_id()
@@ -2357,8 +2361,7 @@ impl Connection {
                     .await;
                 return false;
             } else if (password::approve_mode() == ApproveMode::Click
-                && !(crate::get_builtin_option(keys::OPTION_ALLOW_LOGON_SCREEN_PASSWORD) == "Y"
-                    && is_logon()))
+                && !allow_logon_screen_password)
                 || password::approve_mode() == ApproveMode::Both && !password::has_valid_password()
             {
                 self.try_start_cm(lr.my_id, lr.my_name, false);
@@ -2394,7 +2397,7 @@ impl Connection {
                 if !res {
                     return true;
                 }
-                if !self.validate_password() {
+                if !self.validate_password(allow_logon_screen_password) {
                     self.update_failure(failure, false, 0);
                     if err_msg.is_empty() {
                         self.send_login_error(crate::client::LOGIN_MSG_PASSWORD_WRONG)

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2038,12 +2038,18 @@ impl Connection {
             }
         }
         if password::permanent_enabled() || allow_permanent_password {
+            let print_fallback = || {
+                if allow_permanent_password && !password::permanent_enabled() {
+                    log::info!("Permanent password accepted via logon-screen fallback");
+                }
+            };
             // Since hashed storage uses a prefix-based encoding, a hard plaintext that
             // happens to look like hashed storage could be mis-detected. Validate local storage
             // and hard/preset plaintext via separate paths to avoid that ambiguity.
             let (local_storage, _) = Config::get_local_permanent_password_storage_and_salt();
             if !local_storage.is_empty() {
                 if self.validate_password_storage(&local_storage) {
+                    print_fallback();
                     return true;
                 }
             } else {
@@ -2054,6 +2060,7 @@ impl Connection {
                     .cloned()
                     .unwrap_or_default();
                 if !hard.is_empty() && self.validate_password_plain(&hard) {
+                    print_fallback();
                     return true;
                 }
             }


### PR DESCRIPTION
## Summary
                                                                                                                                                                                              
  Fix Windows logon / lock-screen detection to use the current Windows session instead of a console-preferred session.                                                                        
                                                                                                                                                                                              
  Also allow permanent password fallback for logon / lock-screen access when `allow-logon-screen-password=Y`, even if the verification method is set to `Use one-time password`.              
                                                                                                                                                                                              
  ## Changes                                                                                                                                                                                  
                                                                                                                                                                                              
  - scope `is_locked()` to the current process session                                                                                                                                        
  - scope `is_logon_ui()` to `LogonUI.exe` in the current process session                                                                                                                     
  - allow permanent password fallback for logon / lock-screen access                                                                                                                          
                                                                                                                                                                                              
  ## Test                                                                                                                                                                                
            
 #### Setup                                                                                                                                                                                  
  - console user and RDP user are different Windows users                                                                                                                                     
  - permanent password is configured on the incoming client                                                                                                                                   
  - verification method is set to `Use one-time password`                                                                                                                                     
  - approve mode is set to `Accept sessions via click`                                                                                                                                        
                                                                                                                                                                                              
  #### Cases                                                                                                                                                                               
                                                                                                                                                                                              
  1. Console desktop, no RDP                                                                                                                                                                  
     Click confirmation is required.                                                                                                                                                          
                                                                                                                                                                                              
  2. Console locked or signed out, no RDP                                                                                                                                                     
     Password entry is allowed.                                                                                                                                                               
     a. Without switching user: connection succeeds.                                                                                                                                          
     b. After switching user: connection is disconnected, the desktop is shown, and click confirmation is required.                                                                           
                                                                                                                                                                                              
  3. Console desktop, RDP locked                                                                                                                                                              
     Current session is console: console click confirmation is required first, then session selection is shown.                                                                               
     a. Select console: connection succeeds directly.                                                                                                                                         
     b. Select RDP: password entry is allowed.
     Current session is RDP: password entry is allowed first, then session selection is shown.                                                                                                
     a. Select RDP: connection succeeds directly.                                                                                                                                             
     b. Select console: click confirmation is required.                                                                                                                                       
                                                                                                                                                                                              
  4. Console desktop, RDP desktop                                                                                                                                                             
     Current session is console: console click confirmation is required first, then session selection is shown.                                                                               
     a. Select console: connection succeeds directly.                                                                                                                                         
     b. Select RDP: RDP user click confirmation is required.                                                                                                                                  
     Current session is RDP: RDP user click confirmation is required first, then session selection is shown.                                                                                  
     a. Select RDP: connection succeeds directly.                                                                                                                                             
     b. Select console: console click confirmation is required.                                                                                                                               
                                                                                                                                                                                              
  5. Console signed out or locked, RDP desktop                                                                                                                                                
     Current session is console: password entry is allowed first, then session selection is shown.                                                                                            
     a. Select console: connection succeeds directly.                                                                                                                                         
     b. Select RDP: click confirmation is required.                                                                                                                                           
     Current session is RDP: click confirmation in the RDP window is required first, then session selection is shown.                                                                         
     a. Select RDP: connection succeeds directly.                                                                                                                                             
     b. Select console: password entry is allowed.                                                                                                                                            
                                                                                                                                                                                              
  6. Console signed out or locked, RDP locked                                                                                                                                                 
     Current session is console: password entry is allowed first, then session selection is shown.                                                                                            
     a. Select console: connection succeeds directly.                                                                                                                                         
     b. Select RDP: the previously entered password is reused.                                                                                                                                
     Current session is RDP: password entry is allowed first, then session selection is shown.                                                                                                
     a. Select RDP: connection succeeds directly.                                                                                                                                             
     b. Select console: the previously entered password is reused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session-lock and login-screen detection now use the actual session ID, improving accuracy across multi-session and remote-desktop scenarios.

* **Improvements**
  * Login flow refined to support an explicit logon-screen password fallback; when that fallback succeeds it now emits an informational log entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->