### PR TITLE
Fix: restore keyboard/mouse input on iPadOS after returning from background

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -154,7 +154,27 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       trySyncClipboard();
+      _restoreInputOnResume();
     }
+  }
+
+  // Fix: restore keyboard/mouse input after returning from background on iPadOS.
+  // Bug: switching apps on iPadOS loses all input (keyboard, trackpad, touch).
+  // Root cause: iOS drops the focus node when app goes to background; nobody re-requests it.
+  // Fix: on resume, restart mouse listener and re-request physical focus with a small
+  // delay (same pattern already used in onSoftKeyboardChanged for iOS keyboard workaround).
+  void _restoreInputOnResume() {
+    if (!isIOS) return;
+    gFFI.inputModel.listenToMouse(true);
+    _iosKeyboardWorkaroundTimer?.cancel();
+    _iosKeyboardWorkaroundTimer = Timer(Duration(milliseconds: 100), () {
+      if (!mounted) return;
+      _physicalFocusNode.unfocus();
+      _iosKeyboardWorkaroundTimer = Timer(Duration(milliseconds: 50), () {
+        if (!mounted) return;
+        _physicalFocusNode.requestFocus();
+      });
+    });
   }
 
   // For client side


### PR DESCRIPTION
## Problem

When the user switches to another app and returns to RustDesk on iPadOS, **all input stops working** (keyboard, trackpad, touch) until the app is restarted.

Related issues: #4570, #8768

## Root cause

iOS silently drops the Flutter focus node when the app goes to background. On resume, nobody re-requests it, so input events never reach the session.

## Fix

Call `_restoreInputOnResume()` from `didChangeAppLifecycleState` when `state == resumed`. This:
1. Restarts the mouse listener (`listenToMouse(true)`)
2. Re-requests physical keyboard focus with a short delay

This uses the exact same pattern already present in `onSoftKeyboardChanged` for the iOS virtual keyboard workaround.

## Tested on

- iPad Pro with Magic Keyboard Folio
- iPadOS 26.3.1 (beta)
- Self-hosted RustDesk server over Tailscale → macOS

## Steps to reproduce (before fix)

1. Open RustDesk on iPad and connect to a remote Mac
2. Press the Home button or switch to another app
3. Return to RustDesk
4. Try typing or using the trackpad → **no input works**

After this fix, input is restored automatically within ~150ms of returning to the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse input handling on iOS when the remote control app resumes.
  * Fixed keyboard focus recovery on iOS to ensure proper input responsiveness after app suspension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->