### PR TITLE
fix(iPad): keep touch gestures with external mouse

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -532,7 +532,9 @@ class _RawTouchGestureDetectorRegionState
       // Official
       TapGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
-              () => TapGestureRecognizer(), (instance) {
+              () => TapGestureRecognizer(
+                    supportedDevices: kTouchBasedDeviceKinds,
+                  ), (instance) {
         instance
           ..onTapDown = onTapDown
           ..onTapUp = onTapUp
@@ -540,14 +542,18 @@ class _RawTouchGestureDetectorRegionState
       }),
       DoubleTapGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<DoubleTapGestureRecognizer>(
-              () => DoubleTapGestureRecognizer(), (instance) {
+              () => DoubleTapGestureRecognizer(
+                    supportedDevices: kTouchBasedDeviceKinds,
+                  ), (instance) {
         instance
           ..onDoubleTapDown = onDoubleTapDown
           ..onDoubleTap = onDoubleTap;
       }),
       LongPressGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
-              () => LongPressGestureRecognizer(), (instance) {
+              () => LongPressGestureRecognizer(
+                    supportedDevices: kTouchBasedDeviceKinds,
+                  ), (instance) {
         instance
           ..onLongPressDown = onLongPressDown
           ..onLongPressUp = onLongPressUp
@@ -557,7 +563,9 @@ class _RawTouchGestureDetectorRegionState
       // Customized
       HoldTapMoveGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<HoldTapMoveGestureRecognizer>(
-              () => HoldTapMoveGestureRecognizer(),
+              () => HoldTapMoveGestureRecognizer(
+                    supportedDevices: kTouchBasedDeviceKinds,
+                  ),
               (instance) => instance
                 ..onHoldDragStart = onHoldDragStart
                 ..onHoldDragUpdate = onHoldDragUpdate
@@ -565,14 +573,18 @@ class _RawTouchGestureDetectorRegionState
                 ..onHoldDragEnd = onHoldDragEnd),
       DoubleFinerTapGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<DoubleFinerTapGestureRecognizer>(
-              () => DoubleFinerTapGestureRecognizer(), (instance) {
+              () => DoubleFinerTapGestureRecognizer(
+                    supportedDevices: kTouchBasedDeviceKinds,
+                  ), (instance) {
         instance
           ..onDoubleFinerTap = onDoubleFinerTap
           ..onDoubleFinerTapDown = onDoubleFinerTapDown;
       }),
       CustomTouchGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<CustomTouchGestureRecognizer>(
-              () => CustomTouchGestureRecognizer(), (instance) {
+              () => CustomTouchGestureRecognizer(
+                    supportedDevices: kTouchBasedDeviceKinds,
+                  ), (instance) {
         instance.onOneFingerPanStart =
             (DragStartDetails d) => onOneFingerPanStart(context, d);
         instance

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -426,13 +426,10 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
                               }
                               return Container(
                                 color: MyTheme.canvasColor,
-                                child:
-                                    Obx(() => inputModel.isPhysicalMouse.value
-                                        ? getBodyForMobile()
-                                        : RawTouchGestureDetectorRegion(
-                                            child: getBodyForMobile(),
-                                            ffi: gFFI,
-                                          )),
+                                child: RawTouchGestureDetectorRegion(
+                                  child: getBodyForMobile(),
+                                  ffi: gFFI,
+                                ),
                               );
                             }),
                           ),

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -426,12 +426,15 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
                               }
                               return Container(
                                 color: MyTheme.canvasColor,
-                                child: inputModel.isPhysicalMouse.value
-                                    ? getBodyForMobile()
-                                    : RawTouchGestureDetectorRegion(
-                                        child: getBodyForMobile(),
-                                        ffi: gFFI,
-                                      ),
+                                child: RawTouchGestureDetectorRegion(
+                                  // Keep touch gestures available even after an
+                                  // external mouse or trackpad is detected on
+                                  // iPad. Pointer input still flows through the
+                                  // session body listener, while this wrapper
+                                  // preserves pinch / pan touch gestures.
+                                  child: getBodyForMobile(),
+                                  ffi: gFFI,
+                                ),
                               );
                             }),
                           ),

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -426,15 +426,13 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
                               }
                               return Container(
                                 color: MyTheme.canvasColor,
-                                child: RawTouchGestureDetectorRegion(
-                                  // Keep touch gestures available even after an
-                                  // external mouse or trackpad is detected on
-                                  // iPad. Pointer input still flows through the
-                                  // session body listener, while this wrapper
-                                  // preserves pinch / pan touch gestures.
-                                  child: getBodyForMobile(),
-                                  ffi: gFFI,
-                                ),
+                                child:
+                                    Obx(() => inputModel.isPhysicalMouse.value
+                                        ? getBodyForMobile()
+                                        : RawTouchGestureDetectorRegion(
+                                            child: getBodyForMobile(),
+                                            ffi: gFFI,
+                                          )),
                               );
                             }),
                           ),

--- a/flutter/lib/mobile/pages/view_camera_page.dart
+++ b/flutter/lib/mobile/pages/view_camera_page.dart
@@ -259,13 +259,11 @@ class _ViewCameraPageState extends State<ViewCameraPage>
                         }
                         return Container(
                           color: MyTheme.canvasColor,
-                          child: inputModel.isPhysicalMouse.value
-                              ? getBodyForMobile()
-                              : RawTouchGestureDetectorRegion(
-                                  child: getBodyForMobile(),
-                                  ffi: gFFI,
-                                  isCamera: true,
-                                ),
+                          child: RawTouchGestureDetectorRegion(
+                            child: getBodyForMobile(),
+                            ffi: gFFI,
+                            isCamera: true,
+                          ),
                         );
                       }),
                     ),


### PR DESCRIPTION
Fixes #13011.

## Problem

On iPad, once an external mouse / trackpad is detected, the mobile remote page stops wrapping the session body in `RawTouchGestureDetectorRegion`.

That disables touch gestures such as pinch-to-zoom and leaves the session in the mixed "mouse mode behaves like broken touch mode" state described in the issue.

## Root cause

`RemotePage` currently gates the touch gesture wrapper on `inputModel.isPhysicalMouse.value`:

- no physical mouse: wrap in `RawTouchGestureDetectorRegion`
- physical mouse detected: render `getBodyForMobile()` directly

Pointer input already continues to flow through the session body listener, so dropping the gesture wrapper is unnecessary and removes the touch-only gesture path.

## Fix

Always keep the mobile session body wrapped in `RawTouchGestureDetectorRegion`.

This preserves touch gestures even after an external mouse / trackpad is attached, while leaving the existing pointer event path intact.

## Verification

- `git diff --check`
- `cd flutter && flutter analyze lib/mobile/pages/remote_page.dart`

Verification result in this environment:
- no errors from this patch
- only pre-existing informational warnings in `remote_page.dart`

## Residual Risk

I do not have a live iPad -> macOS repro rig in this environment for end-to-end device smoke, so the remaining risk is behavioral rather than static.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Touch handling consistently uses the touch-aware UI wrapper so touch gestures remain active regardless of a connected physical mouse.
  * Gesture recognizers now accept only touch pointer types, preventing mouse/trackpad input from interfering with touch interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->