### PR TITLE
fix(ios): preserve capslock state across key events

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -15,6 +15,7 @@ import 'package:get/get.dart';
 import '../../models/model.dart';
 import '../../models/platform_model.dart';
 import '../../models/state_model.dart';
+import 'ios_caps_lock_state_tracker.dart';
 import 'relative_mouse_model.dart';
 import '../common.dart';
 import '../consts.dart';
@@ -335,7 +336,7 @@ class InputModel {
   var ctrl = false;
   var alt = false;
   var command = false;
-  bool _iosCapsLock = false;
+  final _iosCapsLockTracker = IosCapsLockStateTracker();
 
   final ToReleaseRawKeys toReleaseRawKeys = ToReleaseRawKeys();
   final ToReleaseKeys toReleaseKeys = ToReleaseKeys();
@@ -472,38 +473,12 @@ class InputModel {
     // value and update it from explicit CapsLock presses or inferable
     // character output, then reuse that cached state for key-up and
     // non-character events.
-    if (isKeyDown && logicalKey == LogicalKeyboardKey.capsLock) {
-      _iosCapsLock = !_iosCapsLock;
-      return _iosCapsLock;
-    }
-    final inferred = _getIosCapsFromCharacterImpl(character, shiftPressed);
-    if (inferred != null) {
-      _iosCapsLock = inferred;
-    }
-    return _iosCapsLock;
-  }
-
-  // Shared implementation for inferring CapsLock state from character.
-  // Uses Unicode-aware case detection to support non-ASCII letters (e.g., ü/Ü, é/É).
-  //
-  // Limitations:
-  // 1. This inference assumes the client and server use the same keyboard layout.
-  //    If layouts differ (e.g., client uses EN, server uses DE), the character output
-  //    may not match expectations. For example, ';' on EN layout maps to 'ö' on DE
-  //    layout, making it impossible to correctly infer CapsLock state from the
-  //    character alone.
-  // 2. On iOS, CapsLock+Shift produces uppercase letters (unlike desktop where it
-  //    produces lowercase). This method cannot handle that case correctly.
-  bool? _getIosCapsFromCharacterImpl(String? ch, bool shiftPressed) {
-    if (ch == null || ch.length != 1) return null;
-    // Use Dart's built-in Unicode-aware case detection
-    final upper = ch.toUpperCase();
-    final lower = ch.toLowerCase();
-    final isUpper = upper == ch && lower != ch;
-    final isLower = lower == ch && upper != ch;
-    // Skip non-letter characters (e.g., numbers, symbols, CJK characters without case)
-    if (!isUpper && !isLower) return null;
-    return isUpper != shiftPressed;
+    return _iosCapsLockTracker.update(
+      character: character,
+      shiftPressed: shiftPressed,
+      logicalKey: logicalKey,
+      isKeyDown: isKeyDown,
+    );
   }
 
   int _buildLockModes(bool iosCapsLock) {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -957,9 +957,12 @@ class InputModel {
             .encode(modify({'id': id, 'type': 'wheel', 'y': y.toString()})));
   }
 
-  /// Reset key modifiers to false, including [shift], [ctrl], [alt] and [command].
+  /// Reset local key state, including modifiers and cached iOS lock state.
   void resetModifiers() {
     shift = ctrl = alt = command = false;
+    if (isIOS) {
+      _iosCapsLockTracker.reset();
+    }
   }
 
   /// Modify the given modifier map [evt] based on current modifier key status.

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -335,6 +335,7 @@ class InputModel {
   var ctrl = false;
   var alt = false;
   var command = false;
+  bool _iosCapsLock = false;
 
   final ToReleaseRawKeys toReleaseRawKeys = ToReleaseRawKeys();
   final ToReleaseKeys toReleaseKeys = ToReleaseKeys();
@@ -441,16 +442,45 @@ class InputModel {
   // incorrect CapsLock state on iOS.
   bool _getIosCapsFromCharacter(KeyEvent e) {
     if (!isIOS) return false;
-    final ch = e.character;
-    return _getIosCapsFromCharacterImpl(
-        ch, HardwareKeyboard.instance.isShiftPressed);
+    return _getIosCapsLockState(
+      character: e.character,
+      shiftPressed: HardwareKeyboard.instance.isShiftPressed,
+      logicalKey: e.logicalKey,
+      isKeyDown: e is KeyDownEvent || e is KeyRepeatEvent,
+    );
   }
 
   // RawKeyEvent version of _getIosCapsFromCharacter.
   bool _getIosCapsFromRawCharacter(RawKeyEvent e) {
     if (!isIOS) return false;
-    final ch = e.character;
-    return _getIosCapsFromCharacterImpl(ch, e.isShiftPressed);
+    return _getIosCapsLockState(
+      character: e.character,
+      shiftPressed: e.isShiftPressed,
+      logicalKey: e.logicalKey,
+      isKeyDown: e is RawKeyDownEvent,
+    );
+  }
+
+  bool _getIosCapsLockState({
+    required String? character,
+    required bool shiftPressed,
+    required LogicalKeyboardKey logicalKey,
+    required bool isKeyDown,
+  }) {
+    if (!isIOS) return false;
+    // Flutter's reported lock state is unreliable on iOS. Keep a cached
+    // value and update it from explicit CapsLock presses or inferable
+    // character output, then reuse that cached state for key-up and
+    // non-character events.
+    if (isKeyDown && logicalKey == LogicalKeyboardKey.capsLock) {
+      _iosCapsLock = !_iosCapsLock;
+      return _iosCapsLock;
+    }
+    final inferred = _getIosCapsFromCharacterImpl(character, shiftPressed);
+    if (inferred != null) {
+      _iosCapsLock = inferred;
+    }
+    return _iosCapsLock;
   }
 
   // Shared implementation for inferring CapsLock state from character.
@@ -464,15 +494,15 @@ class InputModel {
   //    character alone.
   // 2. On iOS, CapsLock+Shift produces uppercase letters (unlike desktop where it
   //    produces lowercase). This method cannot handle that case correctly.
-  bool _getIosCapsFromCharacterImpl(String? ch, bool shiftPressed) {
-    if (ch == null || ch.length != 1) return false;
+  bool? _getIosCapsFromCharacterImpl(String? ch, bool shiftPressed) {
+    if (ch == null || ch.length != 1) return null;
     // Use Dart's built-in Unicode-aware case detection
     final upper = ch.toUpperCase();
     final lower = ch.toLowerCase();
     final isUpper = upper == ch && lower != ch;
     final isLower = lower == ch && upper != ch;
     // Skip non-letter characters (e.g., numbers, symbols, CJK characters without case)
-    if (!isUpper && !isLower) return false;
+    if (!isUpper && !isLower) return null;
     return isUpper != shiftPressed;
   }
 
@@ -636,7 +666,7 @@ class InputModel {
     }
 
     bool iosCapsLock = false;
-    if (isIOS && e is RawKeyDownEvent) {
+    if (isIOS) {
       iosCapsLock = _getIosCapsFromRawCharacter(e);
     }
 
@@ -713,7 +743,7 @@ class InputModel {
     }
 
     bool iosCapsLock = false;
-    if (isIOS && (e is KeyDownEvent || e is KeyRepeatEvent)) {
+    if (isIOS) {
       iosCapsLock = _getIosCapsFromCharacter(e);
     }
 

--- a/flutter/lib/models/ios_caps_lock_state_tracker.dart
+++ b/flutter/lib/models/ios_caps_lock_state_tracker.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/services.dart';
+
+class IosCapsLockStateTracker {
+  bool _capsLock = false;
+
+  bool get value => _capsLock;
+
+  bool update({
+    required String? character,
+    required bool shiftPressed,
+    required LogicalKeyboardKey logicalKey,
+    required bool isKeyDown,
+  }) {
+    if (isKeyDown && logicalKey == LogicalKeyboardKey.capsLock) {
+      _capsLock = !_capsLock;
+      return _capsLock;
+    }
+    final inferred = inferFromCharacter(character, shiftPressed);
+    if (inferred != null) {
+      _capsLock = inferred;
+    }
+    return _capsLock;
+  }
+
+  static bool? inferFromCharacter(String? character, bool shiftPressed) {
+    if (shiftPressed) return null;
+    if (character == null || character.length != 1) return null;
+    final upper = character.toUpperCase();
+    final lower = character.toLowerCase();
+    final isUpper = upper == character && lower != character;
+    final isLower = lower == character && upper != character;
+    if (!isUpper && !isLower) return null;
+    return isUpper;
+  }
+}

--- a/flutter/lib/models/ios_caps_lock_state_tracker.dart
+++ b/flutter/lib/models/ios_caps_lock_state_tracker.dart
@@ -5,6 +5,10 @@ class IosCapsLockStateTracker {
 
   bool get value => _capsLock;
 
+  void reset() {
+    _capsLock = false;
+  }
+
   bool update({
     required String? character,
     required bool shiftPressed,

--- a/flutter/lib/models/ios_caps_lock_state_tracker.dart
+++ b/flutter/lib/models/ios_caps_lock_state_tracker.dart
@@ -15,6 +15,9 @@ class IosCapsLockStateTracker {
       _capsLock = !_capsLock;
       return _capsLock;
     }
+    if (!isKeyDown) {
+      return _capsLock;
+    }
     final inferred = inferFromCharacter(character, shiftPressed);
     if (inferred != null) {
       _capsLock = inferred;

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -113,8 +113,8 @@ dependencies:
 
 dev_dependencies:
   icons_launcher: ^2.0.4
-  #flutter_test:
-  #sdk: flutter
+  flutter_test:
+    sdk: flutter
   build_runner: ^2.4.6
   freezed: ^2.4.2
   flutter_lints: ^2.0.2

--- a/flutter/test/models/input_model_ios_capslock_test.dart
+++ b/flutter/test/models/input_model_ios_capslock_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_hbb/models/ios_caps_lock_state_tracker.dart';
+
+void main() {
+  group('IosCapsLockStateTracker', () {
+    test('preserves cached caps lock state for non-character events', () {
+      final tracker = IosCapsLockStateTracker();
+
+      expect(
+        tracker.update(
+          character: null,
+          shiftPressed: false,
+          logicalKey: LogicalKeyboardKey.capsLock,
+          isKeyDown: true,
+        ),
+        isTrue,
+      );
+
+      expect(
+        tracker.update(
+          character: 'A',
+          shiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyA,
+          isKeyDown: true,
+        ),
+        isTrue,
+      );
+
+      expect(
+        tracker.update(
+          character: null,
+          shiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyA,
+          isKeyDown: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not clear cached caps lock state when shift is pressed', () {
+      final tracker = IosCapsLockStateTracker();
+
+      tracker.update(
+        character: null,
+        shiftPressed: false,
+        logicalKey: LogicalKeyboardKey.capsLock,
+        isKeyDown: true,
+      );
+
+      expect(
+        tracker.update(
+          character: 'A',
+          shiftPressed: true,
+          logicalKey: LogicalKeyboardKey.keyA,
+          isKeyDown: true,
+        ),
+        isTrue,
+      );
+
+      expect(
+        tracker.update(
+          character: null,
+          shiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyA,
+          isKeyDown: false,
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/flutter/test/models/input_model_ios_capslock_test.dart
+++ b/flutter/test/models/input_model_ios_capslock_test.dart
@@ -38,6 +38,30 @@ void main() {
       );
     });
 
+    test('does not change cached caps lock state on key up', () {
+      final tracker = IosCapsLockStateTracker();
+
+      expect(
+        tracker.update(
+          character: null,
+          shiftPressed: false,
+          logicalKey: LogicalKeyboardKey.capsLock,
+          isKeyDown: true,
+        ),
+        isTrue,
+      );
+
+      expect(
+        tracker.update(
+          character: 'a',
+          shiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyA,
+          isKeyDown: false,
+        ),
+        isTrue,
+      );
+    });
+
     test('does not clear cached caps lock state when shift is pressed', () {
       final tracker = IosCapsLockStateTracker();
 

--- a/flutter/test/models/input_model_ios_capslock_test.dart
+++ b/flutter/test/models/input_model_ios_capslock_test.dart
@@ -92,5 +92,32 @@ void main() {
         isTrue,
       );
     });
+
+    test('reset clears cached caps lock state', () {
+      final tracker = IosCapsLockStateTracker();
+
+      expect(
+        tracker.update(
+          character: null,
+          shiftPressed: false,
+          logicalKey: LogicalKeyboardKey.capsLock,
+          isKeyDown: true,
+        ),
+        isTrue,
+      );
+
+      tracker.reset();
+
+      expect(tracker.value, isFalse);
+      expect(
+        tracker.update(
+          character: null,
+          shiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyA,
+          isKeyDown: false,
+        ),
+        isFalse,
+      );
+    });
   });
 }


### PR DESCRIPTION
Fixes #12111.

## Problem

RustDesk already contains an iOS-specific Caps Lock workaround, but the current implementation only derives `iosCapsLock` from the current event's character output.

That leaves a stale-state gap on iOS:

- key-up events fall back to `false` when they do not carry a usable character
- non-letter events also fall back to `false`
- explicit Caps Lock key presses do not maintain a cached logical state across subsequent events

This matches the still-open iPad Magic Keyboard issue and the stale lock-mode concerns raised during review of the earlier workaround PR.

## Root cause

The iOS workaround is stateless per event. It infers Caps Lock from letter output, but it does not cache the result and reuse it for key-up / repeat / non-character paths.

## Fix

- add a cached `_iosCapsLock` state in `InputModel`
- toggle it on explicit Caps Lock key-down events
- update it when character output is inferable
- reuse the cached state for key-up and non-character events instead of resetting to `false`

This keeps the patch inside the existing workaround design instead of changing the broader keyboard pipeline.

## Verification

- `git diff --check`
- `cd flutter && flutter analyze lib/models/input_model.dart`

Verification result in this environment:
- no new errors from this patch
- existing info-level deprecation warnings remain in `input_model.dart`

## Notes

The issue thread is locked, so I could not post a claim comment there.

## Residual Risk

I do not have a live iPad Magic Keyboard -> macOS repro setup in this environment for end-to-end input smoke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable iOS Caps Lock detection via a cached lock-state tracker and broader event handling to avoid incorrect inferences across non-character and shifted inputs, and to ensure resets clear cached state.
* **Tests**
  * Added tests validating Caps Lock caching and behavior across key down/up, shift, and reset scenarios.
* **Chores**
  * Enabled test tooling dependency for development testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->