### PR TITLE
Feature/swap option command key

### DIFF
--- a/docs/superpowers/specs/2026-04-02-swap-option-command-key-design.md
+++ b/docs/superpowers/specs/2026-04-02-swap-option-command-key-design.md
@@ -1,0 +1,170 @@
+# Swap Option-Command Key Design
+
+## Summary
+
+Add a new session-level toggle for RustDesk remote desktop sessions that swaps `Option` and `Command` key behavior when the local client is macOS and the remote peer is not macOS.
+
+This new toggle must coexist with the existing `Swap control-command key` feature, but the two toggles are mutually exclusive. Enabling one must automatically disable the other.
+
+## Context
+
+RustDesk already supports a session toggle named `allow_swap_key`, exposed as `Swap control-command key`, for cross-platform keyboard adaptation involving macOS `Command` and non-macOS `Control`.
+
+The current code paths already support:
+
+- Session-scoped toggle persistence through `LoginConfigHandler` and `PeerConfig`
+- Flutter toolbar toggles in `flutter/lib/common/widgets/toolbar.dart`
+- Sciter toolbar toggles in `src/ui/header.tis`
+- Input rewriting for keyboard and mouse modifiers in `src/ui_session_interface.rs`
+
+The new feature should follow the same architecture and remain session-scoped.
+
+## Goals
+
+- Add a separate user-configurable toggle for swapping `Option` and `Command`
+- Only show and enable the new toggle when the local client is macOS and the remote peer is not macOS
+- Keep the existing `Swap control-command key` behavior unchanged unless the new toggle is explicitly enabled
+- Enforce mutual exclusivity between the two swap toggles
+- Apply the swap consistently to keyboard events and mouse modifier state
+
+## Non-Goals
+
+- No changes to system keyboard settings on the local machine
+- No changes to remote host input processing outside the normal RustDesk input pipeline
+- No change to the existing `Swap control-command key` label, storage key, or semantics
+- No generalized remapping UI for arbitrary modifier combinations
+
+## User Experience
+
+### Visibility Rules
+
+Show `Swap option-command key` only when all of the following are true:
+
+- The local client is macOS
+- The remote peer platform is not macOS
+- Keyboard input is enabled for the current session
+
+This differs from the existing `Swap control-command key` toggle, which remains governed by its current visibility rules.
+
+### Interaction Rules
+
+- The new toggle is session-scoped, like the existing swap toggle
+- Turning on `Swap option-command key` automatically turns off `Swap control-command key`
+- Turning on `Swap control-command key` automatically turns off `Swap option-command key`
+- Turning either toggle off leaves the other off unless the user explicitly enables it
+
+## Data Model
+
+Add a new boolean session config field:
+
+- Internal key: `allow_swap_option_command_key`
+
+This field should be stored and queried using the same `PeerConfig` and `LoginConfigHandler` mechanisms currently used by `allow_swap_key`.
+
+## Input Mapping Behavior
+
+### Keyboard Events
+
+When `allow_swap_option_command_key` is enabled:
+
+- `Alt` maps to `Meta`
+- `Meta` maps to `Alt`
+- `RAlt` maps to `Meta`
+- `RWin` maps to `Alt`
+
+The mapping must be applied in all keyboard event forms currently handled by `swap_modifier_key`:
+
+- `control_key` values
+- `modifiers` arrays
+- Platform-specific `chr` or scan/key code values derived from `rdev`
+
+The existing `allow_swap_key` path continues to swap `Control` and `Meta`.
+
+### Mouse Events
+
+When `allow_swap_option_command_key` is enabled, mouse modifier arrays must also swap:
+
+- `Alt` with `Meta`
+- `RAlt` with `Meta`
+- `RWin` with `Alt`
+
+This keeps click, drag, and wheel gestures consistent with keyboard state.
+
+## Architecture
+
+### UI
+
+Add a new toggle entry in both UI stacks:
+
+- Flutter: `flutter/lib/common/widgets/toolbar.dart`
+- Sciter: `src/ui/header.tis`
+
+Use a new translation string:
+
+- `Swap option-command key`
+
+### Session Config
+
+Extend `LoginConfigHandler` so the new key participates in:
+
+- Toggle writes
+- Toggle reads
+- Session persistence
+- Mutual exclusion enforcement
+
+Mutual exclusion must be enforced in Rust, not only in the UI, so persisted state remains coherent even if toggles are changed through other call sites.
+
+### Input Rewrite Layer
+
+Refactor the current swap logic in `src/ui_session_interface.rs` into explicit helper paths so the two behaviors are clear and isolated:
+
+- Existing `Control <-> Command` swap path
+- New `Option <-> Command` swap path
+
+The caller should choose at most one active swap behavior per event based on the mutually exclusive session state.
+
+## Error Handling
+
+- If both toggles are somehow true in stored config, toggling either option should normalize state so only the chosen option remains enabled
+- If neither toggle is enabled, input behavior remains unchanged
+- Unsupported platforms must never see the new toggle in the UI
+
+## Testing Strategy
+
+### Rust Logic
+
+Add targeted tests for:
+
+- `toggle_option()` mutual exclusion behavior
+- `get_toggle_option()` reads for the new field
+- Modifier swap helper behavior for `Alt/Meta` and right-side variants
+
+### UI
+
+Validate that:
+
+- Flutter shows the new toggle only for local macOS and remote non-macOS
+- Sciter shows the new toggle under the same condition
+- The existing `Swap control-command key` toggle remains available under its current condition
+
+### Regression Checks
+
+Verify that:
+
+- Existing `allow_swap_key` behavior still swaps `Control` and `Command`
+- Existing sessions without the new field continue to load without migration issues
+- Keyboard and mouse input both respect the selected swap mode
+
+## Risks
+
+- Left/right modifier normalization is asymmetric in the existing code paths, so the new mapping must follow current conventions instead of inventing a more invasive left/right model
+- UI-only mutual exclusion would be fragile, so Rust-side enforcement is required
+- `chr` remapping must remain platform-aware to avoid breaking shortcut delivery on Windows, Linux, or macOS peers
+
+## Implementation Outline
+
+1. Add the new config/toggle key and Rust-side mutual exclusion logic
+2. Add the new toolbar toggle in Flutter and Sciter with the macOS-local visibility condition
+3. Split modifier swap logic into separate `Control-Command` and `Option-Command` helper paths
+4. Apply the new swap mode to keyboard and mouse events
+5. Add tests for toggle state and swap behavior

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -853,6 +853,22 @@ List<TToggleMenu> toolbarKeyboardToggles(FFI ffi) {
         child: Text(translate('Swap control-command key'))));
   }
 
+  if (ffiModel.keyboard && isMacOS && pi.platform != kPeerPlatformMacOS) {
+    final option = 'allow_swap_option_command_key';
+    final value =
+        bind.sessionGetToggleOptionSync(sessionId: sessionId, arg: option);
+    onChanged(bool? value) {
+      if (value == null) return;
+      bind.sessionToggleOption(sessionId: sessionId, value: option);
+    }
+
+    final enabled = !ffi.ffiModel.viewOnly;
+    v.add(TToggleMenu(
+        value: value,
+        onChanged: enabled ? onChanged : null,
+        child: Text(translate('Swap option-command key'))));
+  }
+
   // Relative mouse mode (gaming mode).
   // Only show when server supports MOUSE_TYPE_MOVE_RELATIVE (version >= 1.4.5)
   // Note: This feature is only available in Flutter client. Sciter client does not support this.

--- a/src/client.rs
+++ b/src/client.rs
@@ -121,11 +121,9 @@ pub const LOGIN_SCREEN_WAYLAND: &str = "Wayland login screen is not supported";
 #[cfg(target_os = "linux")]
 pub const SCRAP_UBUNTU_HIGHER_REQUIRED: &str = "ubuntu-21-04-required";
 #[cfg(target_os = "linux")]
-pub const SCRAP_OTHER_VERSION_OR_X11_REQUIRED: &str =
-    "wayland-requires-higher-linux-version";
+pub const SCRAP_OTHER_VERSION_OR_X11_REQUIRED: &str = "wayland-requires-higher-linux-version";
 #[cfg(target_os = "linux")]
-pub const SCRAP_XDP_PORTAL_UNAVAILABLE: &str =
-    "xdp-portal-unavailable";
+pub const SCRAP_XDP_PORTAL_UNAVAILABLE: &str = "xdp-portal-unavailable";
 pub const SCRAP_X11_REQUIRED: &str = "x11 expected";
 pub const SCRAP_X11_REF_URL: &str = "https://rustdesk.com/docs/en/manual/linux/#x11-required";
 
@@ -1760,6 +1758,20 @@ pub struct LoginConfigHandler {
     pub record_permission: bool,
 }
 
+fn set_control_command_swap_enabled(config: &mut PeerConfig, enabled: bool) {
+    config.allow_swap_key.v = enabled;
+    if enabled {
+        config.allow_swap_option_command_key.v = false;
+    }
+}
+
+fn set_option_command_swap_enabled(config: &mut PeerConfig, enabled: bool) {
+    config.allow_swap_option_command_key.v = enabled;
+    if enabled {
+        config.allow_swap_key.v = false;
+    }
+}
+
 impl Deref for LoginConfigHandler {
     type Target = PeerConfig;
 
@@ -2124,7 +2136,11 @@ impl LoginConfigHandler {
         } else if name == "show-quality-monitor" {
             config.show_quality_monitor.v = !config.show_quality_monitor.v;
         } else if name == "allow_swap_key" {
-            config.allow_swap_key.v = !config.allow_swap_key.v;
+            let enabled = !config.allow_swap_key.v;
+            set_control_command_swap_enabled(&mut config, enabled);
+        } else if name == "allow_swap_option_command_key" {
+            let enabled = !config.allow_swap_option_command_key.v;
+            set_option_command_swap_enabled(&mut config, enabled);
         } else if name == "view-only" {
             config.view_only.v = !config.view_only.v;
             let f = |b: bool| {
@@ -2336,6 +2352,8 @@ impl LoginConfigHandler {
             self.config.show_quality_monitor.v
         } else if name == "allow_swap_key" {
             self.config.allow_swap_key.v
+        } else if name == "allow_swap_option_command_key" {
+            self.config.allow_swap_option_command_key.v
         } else if name == "view-only" {
             self.config.view_only.v
         } else if name == "show-my-cursor" {
@@ -2630,16 +2648,15 @@ impl LoginConfigHandler {
         };
         let mut avatar = get_builtin_option(keys::OPTION_AVATAR);
         if avatar.is_empty() {
-            avatar = serde_json::from_str::<serde_json::Value>(&LocalConfig::get_option(
-                "user_info",
-            ))
-            .ok()
-            .and_then(|x| {
-                x.get("avatar")
-                    .and_then(|x| x.as_str())
-                    .map(|x| x.trim().to_owned())
-            })
-            .unwrap_or_default();
+            avatar =
+                serde_json::from_str::<serde_json::Value>(&LocalConfig::get_option("user_info"))
+                    .ok()
+                    .and_then(|x| {
+                        x.get("avatar")
+                            .and_then(|x| x.as_str())
+                            .map(|x| x.trim().to_owned())
+                    })
+                    .unwrap_or_default();
         }
         avatar = resolve_avatar_url(avatar);
         let mut display_name = get_builtin_option(keys::OPTION_DISPLAY_NAME);
@@ -4054,7 +4071,36 @@ pub mod peer_online {
 
     #[cfg(test)]
     mod tests {
+        use super::*;
         use hbb_common::tokio;
+
+        #[test]
+        fn enable_option_command_swap_disables_control_command_swap() {
+            let mut config = PeerConfig {
+                allow_swap_key: hbb_common::config::AllowSwapKey { v: true },
+                ..Default::default()
+            };
+
+            set_option_command_swap_enabled(&mut config, true);
+
+            assert!(config.allow_swap_option_command_key.v);
+            assert!(!config.allow_swap_key.v);
+        }
+
+        #[test]
+        fn enable_control_command_swap_disables_option_command_swap() {
+            let mut config = PeerConfig {
+                allow_swap_option_command_key: hbb_common::config::AllowSwapOptionCommandKey {
+                    v: true,
+                },
+                ..Default::default()
+            };
+
+            set_control_command_swap_enabled(&mut config, true);
+
+            assert!(config.allow_swap_key.v);
+            assert!(!config.allow_swap_option_command_key.v);
+        }
 
         #[tokio::test]
         async fn test_query_onlines() {

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -568,6 +568,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("input_source_1_tip", "输入源 1"),
         ("input_source_2_tip", "输入源 2"),
         ("Swap control-command key", "交换 Control 键和 Command 键"),
+        ("Swap option-command key", "交换 Option 键和 Command 键"),
         ("swap-left-right-mouse", "交换鼠标左右键"),
         ("2FA code", "双重认证代码"),
         ("More", "更多"),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -568,6 +568,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("input_source_1_tip", ""),
         ("input_source_2_tip", ""),
         ("Swap control-command key", ""),
+        ("Swap option-command key", ""),
         ("swap-left-right-mouse", ""),
         ("2FA code", ""),
         ("More", ""),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -568,6 +568,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("input_source_1_tip", "輸入源 1"),
         ("input_source_2_tip", "輸入源 2"),
         ("Swap control-command key", "交換 Control 和 Command 按鍵"),
+        ("Swap option-command key", "交換 Option 和 Command 按鍵"),
         ("swap-left-right-mouse", "交換滑鼠左右鍵"),
         ("2FA code", "二步驟驗證碼"),
         ("More", "更多"),

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -220,6 +220,7 @@ class Header: Reactor.Component {
                 {keyboard_enabled ? <li #lock-after-session-end .toggle-option><span>{svg_checkmark}</span>{translate('Lock after session end')}</li> : ""} 
                 {keyboard_enabled && pi.platform == "Windows" ? <li #privacy-mode><span>{svg_checkmark}</span>{translate('Privacy mode')}</li> : ""}
                 {keyboard_enabled && ((is_osx && pi.platform != "Mac OS") || (!is_osx && pi.platform == "Mac OS")) ? <li #allow_swap_key  .toggle-option><span>{svg_checkmark}</span>{translate('Swap control-command key')}</li> : ""}
+                {keyboard_enabled && is_osx && pi.platform != "Mac OS" ? <li #allow_swap_option_command_key .toggle-option><span>{svg_checkmark}</span>{translate('Swap option-command key')}</li> : ""}
                 {handler.version_cmp(pi.version, '1.2.4') >= 0 ? <li #i444><span>{svg_checkmark}</span>{translate('True color (4:4:4)')}</li> : ""}
             </menu>
         </popup>;
@@ -489,7 +490,7 @@ function toggleMenuState() {
     for (var el in $$(menu#keyboard-options>li)) {
         el.attributes.toggleClass("selected", values.indexOf(el.id) >= 0);
     }
-    for (var id in ["show-remote-cursor", "follow-remote-cursor", "follow-remote-window", "show-quality-monitor", "disable-audio", "enable-file-copy-paste", "disable-clipboard", "lock-after-session-end", "allow_swap_key", "i444"]) {
+    for (var id in ["show-remote-cursor", "follow-remote-cursor", "follow-remote-window", "show-quality-monitor", "disable-audio", "enable-file-copy-paste", "disable-clipboard", "lock-after-session-end", "allow_swap_key", "allow_swap_option_command_key", "i444"]) {
         var el = self.select('#' + id);
         if (el) {
             var value = handler.get_toggle_option(id);

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -169,6 +169,82 @@ impl ChangeDisplayRecord {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ModifierSwapMode {
+    None,
+    ControlCommand,
+    OptionCommand,
+}
+
+fn modifier_swap_mode(
+    control_command_enabled: bool,
+    option_command_enabled: bool,
+) -> ModifierSwapMode {
+    if option_command_enabled {
+        ModifierSwapMode::OptionCommand
+    } else if control_command_enabled {
+        ModifierSwapMode::ControlCommand
+    } else {
+        ModifierSwapMode::None
+    }
+}
+
+fn swap_control_command_control_key(ck: ControlKey) -> ControlKey {
+    match ck {
+        ControlKey::Control => ControlKey::Meta,
+        ControlKey::Meta => ControlKey::Control,
+        ControlKey::RControl => ControlKey::Meta,
+        ControlKey::RWin => ControlKey::Control,
+        _ => ck,
+    }
+}
+
+fn swap_option_command_control_key(ck: ControlKey) -> ControlKey {
+    match ck {
+        ControlKey::Alt => ControlKey::Meta,
+        ControlKey::Meta => ControlKey::Alt,
+        ControlKey::RAlt => ControlKey::Meta,
+        ControlKey::RWin => ControlKey::Alt,
+        _ => ck,
+    }
+}
+
+fn remap_control_key_for_mode(mode: ModifierSwapMode, ck: ControlKey) -> ControlKey {
+    match mode {
+        ModifierSwapMode::None => ck,
+        ModifierSwapMode::ControlCommand => swap_control_command_control_key(ck),
+        ModifierSwapMode::OptionCommand => swap_option_command_control_key(ck),
+    }
+}
+
+fn swap_control_command_rdev_key(key: rdev::Key) -> rdev::Key {
+    match key {
+        rdev::Key::ControlLeft => rdev::Key::MetaLeft,
+        rdev::Key::MetaLeft => rdev::Key::ControlLeft,
+        rdev::Key::ControlRight => rdev::Key::MetaLeft,
+        rdev::Key::MetaRight => rdev::Key::ControlLeft,
+        _ => key,
+    }
+}
+
+fn swap_option_command_rdev_key(key: rdev::Key) -> rdev::Key {
+    match key {
+        rdev::Key::Alt => rdev::Key::MetaLeft,
+        rdev::Key::MetaLeft => rdev::Key::Alt,
+        rdev::Key::AltGr => rdev::Key::MetaLeft,
+        rdev::Key::MetaRight => rdev::Key::Alt,
+        _ => key,
+    }
+}
+
+fn remap_rdev_key_for_mode(mode: ModifierSwapMode, key: rdev::Key) -> rdev::Key {
+    match mode {
+        ModifierSwapMode::None => key,
+        ModifierSwapMode::ControlCommand => swap_control_command_rdev_key(key),
+        ModifierSwapMode::OptionCommand => swap_option_command_rdev_key(key),
+    }
+}
+
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 impl SessionPermissionConfig {
     pub fn is_text_clipboard_required(&self) -> bool {
@@ -186,6 +262,13 @@ impl SessionPermissionConfig {
 }
 
 impl<T: InvokeUiSession> Session<T> {
+    fn modifier_swap_mode(&self) -> ModifierSwapMode {
+        modifier_swap_mode(
+            self.get_toggle_option("allow_swap_key".to_string()),
+            self.get_toggle_option("allow_swap_option_command_key".to_string()),
+        )
+    }
+
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn get_permission_config(&self) -> SessionPermissionConfig {
         SessionPermissionConfig {
@@ -688,32 +771,20 @@ impl<T: InvokeUiSession> Session<T> {
     }
 
     pub fn swap_modifier_key(&self, msg: &mut KeyEvent) {
-        let allow_swap_key = self.get_toggle_option("allow_swap_key".to_string());
-        if allow_swap_key {
+        let mode = self.modifier_swap_mode();
+        if mode != ModifierSwapMode::None {
             if let Some(key_event::Union::ControlKey(ck)) = msg.union {
-                let ck = ck.enum_value_or_default();
-                let ck = match ck {
-                    ControlKey::Control => ControlKey::Meta,
-                    ControlKey::Meta => ControlKey::Control,
-                    ControlKey::RControl => ControlKey::Meta,
-                    ControlKey::RWin => ControlKey::Control,
-                    _ => ck,
-                };
+                let ck = remap_control_key_for_mode(mode, ck.enum_value_or_default());
                 msg.set_control_key(ck);
             }
             msg.modifiers = msg
                 .modifiers
                 .iter()
                 .map(|ck| {
-                    let ck = ck.enum_value_or_default();
-                    let ck = match ck {
-                        ControlKey::Control => ControlKey::Meta,
-                        ControlKey::Meta => ControlKey::Control,
-                        ControlKey::RControl => ControlKey::Meta,
-                        ControlKey::RWin => ControlKey::Control,
-                        _ => ck,
-                    };
-                    hbb_common::protobuf::EnumOrUnknown::new(ck)
+                    hbb_common::protobuf::EnumOrUnknown::new(remap_control_key_for_mode(
+                        mode,
+                        ck.enum_value_or_default(),
+                    ))
                 })
                 .collect();
 
@@ -723,39 +794,21 @@ impl<T: InvokeUiSession> Session<T> {
                 peer.retain(|c| !c.is_whitespace());
 
                 let key = match peer.as_str() {
-                    "windows" => {
-                        let key = rdev::win_key_from_scancode(code);
-                        let key = match key {
-                            rdev::Key::ControlLeft => rdev::Key::MetaLeft,
-                            rdev::Key::MetaLeft => rdev::Key::ControlLeft,
-                            rdev::Key::ControlRight => rdev::Key::MetaLeft,
-                            rdev::Key::MetaRight => rdev::Key::ControlLeft,
-                            _ => key,
-                        };
-                        rdev::win_scancode_from_key(key).unwrap_or_default()
-                    }
-                    "macos" => {
-                        let key = rdev::macos_key_from_code(code as _);
-                        let key = match key {
-                            rdev::Key::ControlLeft => rdev::Key::MetaLeft,
-                            rdev::Key::MetaLeft => rdev::Key::ControlLeft,
-                            rdev::Key::ControlRight => rdev::Key::MetaLeft,
-                            rdev::Key::MetaRight => rdev::Key::ControlLeft,
-                            _ => key,
-                        };
-                        rdev::macos_keycode_from_key(key).unwrap_or_default() as _
-                    }
-                    _ => {
-                        let key = rdev::linux_key_from_code(code);
-                        let key = match key {
-                            rdev::Key::ControlLeft => rdev::Key::MetaLeft,
-                            rdev::Key::MetaLeft => rdev::Key::ControlLeft,
-                            rdev::Key::ControlRight => rdev::Key::MetaLeft,
-                            rdev::Key::MetaRight => rdev::Key::ControlLeft,
-                            _ => key,
-                        };
-                        rdev::linux_keycode_from_key(key).unwrap_or_default()
-                    }
+                    "windows" => rdev::win_scancode_from_key(remap_rdev_key_for_mode(
+                        mode,
+                        rdev::win_key_from_scancode(code),
+                    ))
+                    .unwrap_or_default(),
+                    "macos" => rdev::macos_keycode_from_key(remap_rdev_key_for_mode(
+                        mode,
+                        rdev::macos_key_from_code(code as _),
+                    ))
+                    .unwrap_or_default() as _,
+                    _ => rdev::linux_keycode_from_key(remap_rdev_key_for_mode(
+                        mode,
+                        rdev::linux_key_from_code(code),
+                    ))
+                    .unwrap_or_default(),
                 };
                 msg.set_chr(key);
             }
@@ -1889,21 +1942,16 @@ impl<T: InvokeUiSession> Interface for Session<T> {
     }
 
     fn swap_modifier_mouse(&self, msg: &mut hbb_common::protos::message::MouseEvent) {
-        let allow_swap_key = self.get_toggle_option("allow_swap_key".to_string());
-        if allow_swap_key {
+        let mode = self.modifier_swap_mode();
+        if mode != ModifierSwapMode::None {
             msg.modifiers = msg
                 .modifiers
                 .iter()
                 .map(|ck| {
-                    let ck = ck.enum_value_or_default();
-                    let ck = match ck {
-                        ControlKey::Control => ControlKey::Meta,
-                        ControlKey::Meta => ControlKey::Control,
-                        ControlKey::RControl => ControlKey::Meta,
-                        ControlKey::RWin => ControlKey::Control,
-                        _ => ck,
-                    };
-                    hbb_common::protobuf::EnumOrUnknown::new(ck)
+                    hbb_common::protobuf::EnumOrUnknown::new(remap_control_key_for_mode(
+                        mode,
+                        ck.enum_value_or_default(),
+                    ))
                 })
                 .collect();
         };
@@ -2052,4 +2100,65 @@ async fn start_one_port_forward<T: InvokeUiSession>(
 async fn send_note(url: String, id: String, sid: u64, note: String) {
     let body = serde_json::json!({ "id": id, "session_id": sid, "note": note });
     allow_err!(crate::post_request(url, body.to_string(), "").await);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modifier_swap_mode_prefers_option_command_when_both_enabled() {
+        assert_eq!(
+            modifier_swap_mode(true, true),
+            ModifierSwapMode::OptionCommand
+        );
+    }
+
+    #[test]
+    fn swap_option_command_maps_alt_to_meta() {
+        assert_eq!(
+            swap_option_command_control_key(ControlKey::Alt),
+            ControlKey::Meta
+        );
+    }
+
+    #[test]
+    fn swap_option_command_maps_meta_to_alt() {
+        assert_eq!(
+            swap_option_command_control_key(ControlKey::Meta),
+            ControlKey::Alt
+        );
+    }
+
+    #[test]
+    fn swap_option_command_maps_ralt_to_meta() {
+        assert_eq!(
+            swap_option_command_control_key(ControlKey::RAlt),
+            ControlKey::Meta
+        );
+    }
+
+    #[test]
+    fn swap_option_command_maps_rwin_to_alt() {
+        assert_eq!(
+            swap_option_command_control_key(ControlKey::RWin),
+            ControlKey::Alt
+        );
+    }
+
+    #[test]
+    fn swap_option_command_maps_alt_rdev_to_meta_left() {
+        assert_eq!(
+            swap_option_command_rdev_key(rdev::Key::Alt),
+            rdev::Key::MetaLeft
+        );
+    }
+
+    #[test]
+    fn swap_option_command_maps_meta_right_rdev_to_alt() {
+        assert_eq!(
+            swap_option_command_rdev_key(rdev::Key::MetaRight),
+            rdev::Key::Alt
+        );
+    }
 }


### PR DESCRIPTION
#14670 

Add a new session-level Swap option-command key toggle for macOS clients controlling non-macOS peers.

  This is implemented as a separate option from the existing Swap control-command key, and the two toggles are mutually exclusive.

  ## What changed

  - Added a new persisted session config field: allow_swap_option_command_key
  - Added Rust-side mutual exclusion between:
      - Swap control-command key
      - Swap option-command key
  - Added a new modifier swap mode for Option <-> Command
  - Applied the new remapping to:
      - keyboard control keys
      - keyboard modifier arrays
      - platform-specific key codes / scan codes
      - mouse modifier arrays
  - Added the new toggle to:
      - Flutter toolbar
      - Sciter toolbar
  - Added translation entries for:
      - Swap option-command key

  ## Behavior

  The new toggle is shown only when:

  - the local client is macOS
  - the remote peer is not macOS
  - keyboard input is enabled for the session

  Mutual exclusion behavior:

  - enabling Swap option-command key disables Swap control-command key
  - enabling Swap control-command key disables Swap option-command key

  ## Verification

  Verified locally:

  - cargo test --manifest-path libs/hbb_common/Cargo.toml peer_config_swap_option_command_flag_defaults_to_false

  Notes:

  - full root-level Rust test/build verification was partially blocked by local environment issues:
      - missing native build/runtime dependencies during setup (libyuv, Sciter)
      - Sciter on macOS required using the repo-compatible Rust toolchain for local run testing
  - cargo test --manifest-path libs/hbb_common/Cargo.toml also showed one unrelated pre-existing failure in
    socket_client::tests::test_test_if_valid_server

  ## Files touched

  - libs/hbb_common/src/config.rs
  - src/client.rs
  - src/ui_session_interface.rs
  - flutter/lib/common/widgets/toolbar.dart
  - src/ui/header.tis
  - src/lang/template.rs
  - src/lang/cn.rs
  - src/lang/tw.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Swap option-command key" toggle for macOS clients connecting to non-macOS remote devices. The new option automatically disables the existing "Swap control-command key" toggle when enabled, ensuring only one keyboard swap mode is active at a time. Requires keyboard input to be enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->