### PR TITLE
add brute-force protection for one-time password

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2032,8 +2032,10 @@ impl Connection {
             minute: i32,
             failures: i32,
         }
-        static TEMPORARY_PASSWORD_FAILURES: std::sync::LazyLock<Mutex<State>> =
-            std::sync::LazyLock::new(|| Mutex::new(State::default()));
+        lazy_static::lazy_static! {
+            static ref TEMPORARY_PASSWORD_FAILURES: Mutex<State> =
+                Mutex::new(State::default());
+        }
 
         if !password::temporary_enabled() {
             return;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2020,9 +2020,11 @@ impl Connection {
         self.validate_password_plain(storage)
     }
 
-    // This is coarse brute-force protection for the temporary password.
-    // We track consecutive full login failures against the current temporary password budget
-    // across all sources. Only a temporary-password success clears this state.
+    // This is coarse brute-force protection for the current temporary password value.
+    // We only care whether the active temporary password itself was presented correctly,
+    // not whether later authorization steps succeed. A successful temporary-password
+    // match clears this state immediately, and the counter also resets whenever the
+    // temporary password changes or is rotated.
     fn check_update_temporary_password(&self, temporary_password_success: bool) {
         const MAX_CONSECUTIVE_FAILURES: i32 = 10;
         #[derive(Default)]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2041,13 +2041,12 @@ impl Connection {
             return;
         }
 
+        let minute = (get_time() / 60_000) as i32;
+        let mut state = TEMPORARY_PASSWORD_FAILURES.lock().unwrap();
         let current_password = password::temporary_password();
         if current_password.is_empty() {
             return;
         }
-
-        let minute = (get_time() / 60_000) as i32;
-        let mut state = TEMPORARY_PASSWORD_FAILURES.lock().unwrap();
         if state.password != current_password {
             state.password = current_password;
             state.minute = minute;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1993,11 +1993,6 @@ impl Connection {
         constant_time_eq(&hasher2.finalize()[..], &self.lr.password[..])
     }
 
-    #[inline]
-    fn validate_one_password(&self, password: &str) -> bool {
-        self.validate_password_plain(password)
-    }
-
     fn validate_password_plain(&self, password: &str) -> bool {
         if password.is_empty() {
             return false;
@@ -2025,10 +2020,71 @@ impl Connection {
         self.validate_password_plain(storage)
     }
 
+    // This is coarse brute-force protection for the temporary password.
+    // We intentionally clear the failure window after any successful password authentication,
+    // including permanent-password success in mixed/fallback modes. The goal is to break up
+    // sustained wrong-attempt bursts, not to precisely attribute which password type was tried.
+    fn check_update_temporary_password(&self, validate_password_success: bool) {
+        const MAX_FAILURES_PER_MINUTE: i32 = 8;
+        #[derive(Default)]
+        struct State {
+            password: String,
+            minute: i32,
+            failures: i32,
+        }
+        static TEMPORARY_PASSWORD_FAILURES: std::sync::LazyLock<Mutex<State>> =
+            std::sync::LazyLock::new(|| Mutex::new(State::default()));
+
+        if !password::temporary_enabled() {
+            return;
+        }
+
+        let current_password = password::temporary_password();
+        if current_password.is_empty() {
+            return;
+        }
+
+        let minute = (get_time() / 60_000) as i32;
+        let mut state = TEMPORARY_PASSWORD_FAILURES.lock().unwrap();
+        if state.password != current_password {
+            state.password = current_password;
+            state.minute = minute;
+            state.failures = 0;
+        }
+
+        if validate_password_success {
+            state.minute = minute;
+            state.failures = 0;
+            return;
+        }
+
+        if state.minute == minute {
+            state.failures += 1;
+        } else {
+            state.minute = minute;
+            state.failures = 1;
+        }
+
+        if state.failures < MAX_FAILURES_PER_MINUTE {
+            return;
+        }
+
+        password::update_temporary_password();
+        let new_password = password::temporary_password();
+        log::warn!(
+            "Temporary password rotated after too many wrong attempts in one minute: failures={}, ip={}",
+            state.failures,
+            self.ip,
+        );
+        state.password = new_password;
+        state.minute = minute;
+        state.failures = 0;
+    }
+
     fn validate_password(&mut self, allow_permanent_password: bool) -> bool {
         if password::temporary_enabled() {
             let password = password::temporary_password();
-            if self.validate_one_password(&password) {
+            if self.validate_password_plain(&password) {
                 raii::AuthedConnID::update_or_insert_session(
                     self.session_key(),
                     Some(password),
@@ -2406,6 +2462,7 @@ impl Connection {
                 }
                 if !self.validate_password(allow_logon_screen_password) {
                     self.update_failure(failure, false, 0);
+                    self.check_update_temporary_password(false);
                     if err_msg.is_empty() {
                         self.send_login_error(crate::client::LOGIN_MSG_PASSWORD_WRONG)
                             .await;
@@ -2418,6 +2475,7 @@ impl Connection {
                     }
                 } else {
                     self.update_failure(failure, true, 0);
+                    self.check_update_temporary_password(true);
                     if err_msg.is_empty() {
                         #[cfg(target_os = "linux")]
                         self.linux_headless_handle.wait_desktop_cm_ready().await;
@@ -5668,4 +5726,5 @@ mod test {
         assert!(Ipv6Addr::from_str("127.0.0.1").is_err());
         assert!(Ipv6Addr::from_str("0").is_err());
     }
+
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2021,15 +2021,13 @@ impl Connection {
     }
 
     // This is coarse brute-force protection for the temporary password.
-    // We intentionally clear the failure window after any successful password authentication,
-    // including permanent-password success in mixed/fallback modes. The goal is to break up
-    // sustained wrong-attempt bursts, not to precisely attribute which password type was tried.
-    fn check_update_temporary_password(&self, validate_password_success: bool) {
-        const MAX_FAILURES_PER_MINUTE: i32 = 8;
+    // We track consecutive full login failures against the current temporary password budget
+    // across all sources. Only a temporary-password success clears this state.
+    fn check_update_temporary_password(&self, temporary_password_success: bool) {
+        const MAX_CONSECUTIVE_FAILURES: i32 = 10;
         #[derive(Default)]
         struct State {
             password: String,
-            minute: i32,
             failures: i32,
         }
         lazy_static::lazy_static! {
@@ -2041,7 +2039,6 @@ impl Connection {
             return;
         }
 
-        let minute = (get_time() / 60_000) as i32;
         let mut state = TEMPORARY_PASSWORD_FAILURES.lock().unwrap();
         let current_password = password::temporary_password();
         if current_password.is_empty() {
@@ -2049,36 +2046,27 @@ impl Connection {
         }
         if state.password != current_password {
             state.password = current_password;
-            state.minute = minute;
             state.failures = 0;
         }
 
-        if validate_password_success {
-            state.minute = minute;
+        if temporary_password_success {
             state.failures = 0;
             return;
         }
+        state.failures += 1;
 
-        if state.minute == minute {
-            state.failures += 1;
-        } else {
-            state.minute = minute;
-            state.failures = 1;
-        }
-
-        if state.failures < MAX_FAILURES_PER_MINUTE {
+        if state.failures < MAX_CONSECUTIVE_FAILURES {
             return;
         }
 
         password::update_temporary_password();
         let new_password = password::temporary_password();
         log::warn!(
-            "Temporary password rotated after too many wrong attempts in one minute: failures={}, ip={}",
+            "Temporary password rotated after too many consecutive wrong attempts: failures={}, ip={}",
             state.failures,
             self.ip,
         );
         state.password = new_password;
-        state.minute = minute;
         state.failures = 0;
     }
 
@@ -2091,6 +2079,7 @@ impl Connection {
                     Some(password),
                     Some(false),
                 );
+                self.check_update_temporary_password(true);
                 return true;
             }
         }
@@ -2476,7 +2465,6 @@ impl Connection {
                     }
                 } else {
                     self.update_failure(failure, true, 0);
-                    self.check_update_temporary_password(true);
                     if err_msg.is_empty() {
                         #[cfg(target_os = "linux")]
                         self.linux_headless_handle.wait_desktop_cm_ready().await;
@@ -5727,5 +5715,4 @@ mod test {
         assert!(Ipv6Addr::from_str("127.0.0.1").is_err());
         assert!(Ipv6Addr::from_str("0").is_err());
     }
-
 }


### PR DESCRIPTION
# Summary

  Harden brute-force protection for the one-time password by tracking consecutive failed login attempts against the current password, rotating it on the 10th failure, and resetting the counter only after a successful one-time-password authentication.

  # Tested

  - Verified the one-time password does not rotate after 9 consecutive failed login attempts
  - Verified the one-time password rotates on the 10th consecutive failed login attempt
  - Verified a successful one-time-password authentication resets the failure counter
  - Verified a successful permanent-password authentication does not reset the one-time-password failure counter
  - Verified rotating the one-time password resets the tracked state

# Related

- https://www.teamviewer.com/en/global/support/knowledge-base/teamviewer-classic/security/security-features/brute-force-protection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary passwords now auto-rotate after 10 consecutive failed validations for the same temporary password.
  * Failure tracking is scoped to the current temporary password and resets when the temporary password changes or after any successful authentication.
  * A warning is logged when rotation occurs, including the failure count and connection IP.
  * Brute-force protection is now integrated into the login flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->