### PR TITLE
flutter: shift after one shot IME capitalization

### DIFF
--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
+import 'package:flutter/foundation.dart';
 import 'dart:ui' as ui;
 
 import 'package:desktop_multi_window/desktop_multi_window.dart';
@@ -718,6 +719,13 @@ class InputModel {
           hasTrackedShiftKeyDown: toReleaseRawKeys.lastLShiftKeyEvent != null ||
               toReleaseRawKeys.lastRShiftKeyEvent != null,
         )) {
+      if (kDebugMode) {
+        debugPrint(
+          'input: releasing stale mobile Shift before replaying tracked raw '
+          'key-up (logicalKey=${e.logicalKey.keyLabel}, '
+          'actualShiftPressed=${e.isShiftPressed}, cachedShiftPressed=$shift)',
+        );
+      }
       _releaseTrackedRawShiftKeyEventIfNeeded();
     }
 

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -621,6 +621,8 @@ class InputModel {
     }
   }
 
+  // Safe: this only re-dispatches synthesized Shift key-up events.
+  // The key-up path clears the tracked Shift state so this does not loop.
   void _releaseTrackedShiftKeyEventIfNeeded() {
     final leftShift = toReleaseKeys.lastLShiftKeyEvent;
     final rightShift = toReleaseKeys.lastRShiftKeyEvent;
@@ -632,6 +634,8 @@ class InputModel {
     }
   }
 
+  // Safe: this only re-dispatches synthesized Shift key-up events.
+  // The raw key-up path clears the tracked Shift state so this does not loop.
   void _releaseTrackedRawShiftKeyEventIfNeeded() {
     final leftShift = toReleaseRawKeys.lastLShiftKeyEvent;
     final rightShift = toReleaseRawKeys.lastRShiftKeyEvent;
@@ -710,6 +714,8 @@ class InputModel {
       legacyKeyboardModeRaw(e);
     }
 
+    // On some mobile soft-keyboard paths, Flutter may leave cached Shift state
+    // set even though the current raw key event is not shifted anymore.
     if (e is RawKeyDownEvent &&
         shouldReleaseStaleMobileShift(
           isMobile: isMobile,
@@ -759,6 +765,8 @@ class InputModel {
       iosCapsLock = _getIosCapsFromCharacter(e);
     }
 
+    // Update cached modifier state before sending the event. The stale mobile
+    // Shift release check below relies on this cached state.
     if (e is KeyUpEvent) {
       handleKeyUpEventModifiers(e);
     } else if (e is KeyDownEvent) {
@@ -796,6 +804,9 @@ class InputModel {
         }
       }
     }
+
+    // On some mobile soft-keyboard paths, Flutter may leave cached Shift state
+    // set even though the current key event is not shifted anymore.
     if (e is KeyDownEvent &&
         shouldReleaseStaleMobileShift(
           isMobile: isMobile,

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -722,7 +722,6 @@ class InputModel {
           cachedShiftPressed: shift,
           actualShiftPressed: e.isShiftPressed,
           logicalKey: e.logicalKey,
-          character: e.character,
           hasTrackedShiftKeyDown: toReleaseRawKeys.lastLShiftKeyEvent != null ||
               toReleaseRawKeys.lastRShiftKeyEvent != null,
         )) {
@@ -813,10 +812,8 @@ class InputModel {
           cachedShiftPressed: shift,
           actualShiftPressed: HardwareKeyboard.instance.isShiftPressed,
           logicalKey: e.logicalKey,
-          character: e.character,
-          hasTrackedShiftKeyDown:
-              toReleaseKeys.lastLShiftKeyEvent != null ||
-                  toReleaseKeys.lastRShiftKeyEvent != null,
+          hasTrackedShiftKeyDown: toReleaseKeys.lastLShiftKeyEvent != null ||
+              toReleaseKeys.lastRShiftKeyEvent != null,
         )) {
       _releaseTrackedShiftKeyEventIfNeeded();
     }

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -15,6 +15,7 @@ import 'package:get/get.dart';
 import '../../models/model.dart';
 import '../../models/platform_model.dart';
 import '../../models/state_model.dart';
+import 'input_modifier_utils.dart';
 import 'relative_mouse_model.dart';
 import '../common.dart';
 import '../consts.dart';
@@ -620,6 +621,34 @@ class InputModel {
     }
   }
 
+  void _releaseTrackedShiftKeyEventIfNeeded() {
+    final leftShift = toReleaseKeys.lastLShiftKeyEvent;
+    final rightShift = toReleaseKeys.lastRShiftKeyEvent;
+    if (leftShift != null) {
+      handleKeyEvent(leftShift);
+    }
+    if (rightShift != null) {
+      handleKeyEvent(rightShift);
+    }
+  }
+
+  void _releaseTrackedRawShiftKeyEventIfNeeded() {
+    final leftShift = toReleaseRawKeys.lastLShiftKeyEvent;
+    final rightShift = toReleaseRawKeys.lastRShiftKeyEvent;
+    if (leftShift != null) {
+      handleRawKeyEvent(RawKeyUpEvent(
+        data: leftShift.data,
+        character: leftShift.character,
+      ));
+    }
+    if (rightShift != null) {
+      handleRawKeyEvent(RawKeyUpEvent(
+        data: rightShift.data,
+        character: rightShift.character,
+      ));
+    }
+  }
+
   KeyEventResult handleRawKeyEvent(RawKeyEvent e) {
     if (isViewOnly) return KeyEventResult.handled;
     if (isViewCamera) return KeyEventResult.handled;
@@ -679,6 +708,19 @@ class InputModel {
       mapKeyboardModeRaw(e, iosCapsLock);
     } else {
       legacyKeyboardModeRaw(e);
+    }
+
+    if (e is RawKeyDownEvent &&
+        shouldReleaseStaleMobileShift(
+          isMobile: isMobile,
+          cachedShiftPressed: shift,
+          actualShiftPressed: e.isShiftPressed,
+          logicalKey: e.logicalKey,
+          character: e.character,
+          hasTrackedShiftKeyDown: toReleaseRawKeys.lastLShiftKeyEvent != null ||
+              toReleaseRawKeys.lastRShiftKeyEvent != null,
+        )) {
+      _releaseTrackedRawShiftKeyEventIfNeeded();
     }
 
     return KeyEventResult.handled;
@@ -754,6 +796,20 @@ class InputModel {
         }
       }
     }
+    if (e is KeyDownEvent &&
+        shouldReleaseStaleMobileShift(
+          isMobile: isMobile,
+          cachedShiftPressed: shift,
+          actualShiftPressed: HardwareKeyboard.instance.isShiftPressed,
+          logicalKey: e.logicalKey,
+          character: e.character,
+          hasTrackedShiftKeyDown:
+              toReleaseKeys.lastLShiftKeyEvent != null ||
+                  toReleaseKeys.lastRShiftKeyEvent != null,
+        )) {
+      _releaseTrackedShiftKeyEventIfNeeded();
+    }
+
     final isDesktopAndMapMode =
         isDesktop || (isWebDesktop && keyboardMode == kKeyMapMode);
     if (isMobileAndMapMode || isDesktopAndMapMode) {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -707,13 +707,6 @@ class InputModel {
       toReleaseRawKeys.updateKeyUp(key, e);
     }
 
-    // * Currently mobile does not enable map mode
-    if ((isDesktop || isWebDesktop) && keyboardMode == kKeyMapMode) {
-      mapKeyboardModeRaw(e, iosCapsLock);
-    } else {
-      legacyKeyboardModeRaw(e);
-    }
-
     // On some mobile soft-keyboard paths, Flutter may leave cached Shift state
     // set even though the current raw key event is not shifted anymore.
     if (e is RawKeyDownEvent &&
@@ -726,6 +719,13 @@ class InputModel {
               toReleaseRawKeys.lastRShiftKeyEvent != null,
         )) {
       _releaseTrackedRawShiftKeyEventIfNeeded();
+    }
+
+    // * Currently mobile does not enable map mode
+    if ((isDesktop || isWebDesktop) && keyboardMode == kKeyMapMode) {
+      mapKeyboardModeRaw(e, iosCapsLock);
+    } else {
+      legacyKeyboardModeRaw(e);
     }
 
     return KeyEventResult.handled;

--- a/flutter/lib/models/input_modifier_utils.dart
+++ b/flutter/lib/models/input_modifier_utils.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/services.dart';
+
+bool shouldReleaseStaleMobileShift({
+  required bool isMobile,
+  required bool cachedShiftPressed,
+  required bool actualShiftPressed,
+  required LogicalKeyboardKey logicalKey,
+  required String? character,
+  required bool hasTrackedShiftKeyDown,
+}) {
+  if (!isMobile || !cachedShiftPressed || actualShiftPressed) {
+    return false;
+  }
+  if (!hasTrackedShiftKeyDown) {
+    return false;
+  }
+  if (logicalKey == LogicalKeyboardKey.shiftLeft ||
+      logicalKey == LogicalKeyboardKey.shiftRight) {
+    return false;
+  }
+  return character?.isNotEmpty == true;
+}

--- a/flutter/lib/models/input_modifier_utils.dart
+++ b/flutter/lib/models/input_modifier_utils.dart
@@ -5,7 +5,6 @@ bool shouldReleaseStaleMobileShift({
   required bool cachedShiftPressed,
   required bool actualShiftPressed,
   required LogicalKeyboardKey logicalKey,
-  required String? character,
   required bool hasTrackedShiftKeyDown,
 }) {
   if (!isMobile || !cachedShiftPressed || actualShiftPressed) {

--- a/flutter/lib/models/input_modifier_utils.dart
+++ b/flutter/lib/models/input_modifier_utils.dart
@@ -1,5 +1,22 @@
 import 'package:flutter/services.dart';
 
+/// Returns true when a stale mobile one-shot Shift state should be released
+/// by replaying a tracked Shift key-down as a synthesized key-up.
+///
+/// This is only valid on mobile when Flutter's cached Shift state is still on
+/// (`cachedShiftPressed == true`) but the current hardware/raw event reports
+/// Shift as off (`actualShiftPressed == false`).
+///
+/// A tracked Shift key-down is required so the caller can safely synthesize the
+/// matching key-up. Both `shiftLeft` and `shiftRight` are excluded because the
+/// Shift key event itself must be processed first; otherwise we could release
+/// the tracked key while still handling the original Shift press/release.
+/// Callers should evaluate this only after their cached modifier state has been
+/// updated for the current event.
+///
+/// When this returns true, the caller logs a line like:
+/// `input: releasing stale mobile Shift before replaying tracked raw key-up`
+/// immediately before calling `_releaseTrackedRawShiftKeyEventIfNeeded()`.
 bool shouldReleaseStaleMobileShift({
   required bool isMobile,
   required bool cachedShiftPressed,

--- a/flutter/lib/models/input_modifier_utils.dart
+++ b/flutter/lib/models/input_modifier_utils.dart
@@ -18,5 +18,5 @@ bool shouldReleaseStaleMobileShift({
       logicalKey == LogicalKeyboardKey.shiftRight) {
     return false;
   }
-  return character?.isNotEmpty == true;
+  return true;
 }

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -113,8 +113,8 @@ dependencies:
 
 dev_dependencies:
   icons_launcher: ^2.0.4
-  #flutter_test:
-  #sdk: flutter
+  flutter_test:
+    sdk: flutter
   build_runner: ^2.4.6
   freezed: ^2.4.2
   flutter_lints: ^2.0.2

--- a/flutter/test/input_modifier_utils_test.dart
+++ b/flutter/test/input_modifier_utils_test.dart
@@ -11,7 +11,6 @@ void main() {
           cachedShiftPressed: false,
           actualShiftPressed: false,
           logicalKey: LogicalKeyboardKey.keyD,
-          character: 'D',
           hasTrackedShiftKeyDown: true,
         ),
         isFalse,
@@ -25,21 +24,20 @@ void main() {
           cachedShiftPressed: true,
           actualShiftPressed: false,
           logicalKey: LogicalKeyboardKey.keyD,
-          character: 'D',
           hasTrackedShiftKeyDown: true,
         ),
         isTrue,
       );
     });
 
-    test('does not release manually toggled shift without tracked key down', () {
+    test('does not release manually toggled shift without tracked key down',
+        () {
       expect(
         shouldReleaseStaleMobileShift(
           isMobile: true,
           cachedShiftPressed: true,
           actualShiftPressed: false,
           logicalKey: LogicalKeyboardKey.keyD,
-          character: 'D',
           hasTrackedShiftKeyDown: false,
         ),
         isFalse,
@@ -53,7 +51,6 @@ void main() {
           cachedShiftPressed: true,
           actualShiftPressed: true,
           logicalKey: LogicalKeyboardKey.keyD,
-          character: 'D',
           hasTrackedShiftKeyDown: true,
         ),
         isFalse,
@@ -67,35 +64,32 @@ void main() {
           cachedShiftPressed: true,
           actualShiftPressed: false,
           logicalKey: LogicalKeyboardKey.keyD,
-          character: 'D',
           hasTrackedShiftKeyDown: true,
         ),
         isFalse,
       );
     });
 
-    test('releases on non-text keys with empty character', () {
+    test('releases on enter key', () {
       expect(
         shouldReleaseStaleMobileShift(
           isMobile: true,
           cachedShiftPressed: true,
           actualShiftPressed: false,
-          logicalKey: LogicalKeyboardKey.keyD,
-          character: '',
+          logicalKey: LogicalKeyboardKey.enter,
           hasTrackedShiftKeyDown: true,
         ),
         isTrue,
       );
     });
 
-    test('releases on non-text keys with null character', () {
+    test('releases on arrow key', () {
       expect(
         shouldReleaseStaleMobileShift(
           isMobile: true,
           cachedShiftPressed: true,
           actualShiftPressed: false,
-          logicalKey: LogicalKeyboardKey.keyD,
-          character: null,
+          logicalKey: LogicalKeyboardKey.arrowLeft,
           hasTrackedShiftKeyDown: true,
         ),
         isTrue,
@@ -109,7 +103,6 @@ void main() {
           cachedShiftPressed: true,
           actualShiftPressed: false,
           logicalKey: LogicalKeyboardKey.shiftLeft,
-          character: null,
           hasTrackedShiftKeyDown: true,
         ),
         isFalse,
@@ -123,7 +116,6 @@ void main() {
           cachedShiftPressed: true,
           actualShiftPressed: false,
           logicalKey: LogicalKeyboardKey.shiftRight,
-          character: null,
           hasTrackedShiftKeyDown: true,
         ),
         isFalse,

--- a/flutter/test/input_modifier_utils_test.dart
+++ b/flutter/test/input_modifier_utils_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_hbb/models/input_modifier_utils.dart';
+
+void main() {
+  group('shouldReleaseStaleMobileShift', () {
+    test('does not release when cached shift is already false', () {
+      expect(
+        shouldReleaseStaleMobileShift(
+          isMobile: true,
+          cachedShiftPressed: false,
+          actualShiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyD,
+          character: 'D',
+          hasTrackedShiftKeyDown: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('releases one-shot mobile shift after a text key', () {
+      expect(
+        shouldReleaseStaleMobileShift(
+          isMobile: true,
+          cachedShiftPressed: true,
+          actualShiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyD,
+          character: 'D',
+          hasTrackedShiftKeyDown: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not release manually toggled shift without tracked key down', () {
+      expect(
+        shouldReleaseStaleMobileShift(
+          isMobile: true,
+          cachedShiftPressed: true,
+          actualShiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyD,
+          character: 'D',
+          hasTrackedShiftKeyDown: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not release when shift is still physically pressed', () {
+      expect(
+        shouldReleaseStaleMobileShift(
+          isMobile: true,
+          cachedShiftPressed: true,
+          actualShiftPressed: true,
+          logicalKey: LogicalKeyboardKey.keyD,
+          character: 'D',
+          hasTrackedShiftKeyDown: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not release on non-mobile platforms', () {
+      expect(
+        shouldReleaseStaleMobileShift(
+          isMobile: false,
+          cachedShiftPressed: true,
+          actualShiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyD,
+          character: 'D',
+          hasTrackedShiftKeyDown: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not release with empty character', () {
+      expect(
+        shouldReleaseStaleMobileShift(
+          isMobile: true,
+          cachedShiftPressed: true,
+          actualShiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyD,
+          character: '',
+          hasTrackedShiftKeyDown: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not release with null character on non-modifier keys', () {
+      expect(
+        shouldReleaseStaleMobileShift(
+          isMobile: true,
+          cachedShiftPressed: true,
+          actualShiftPressed: false,
+          logicalKey: LogicalKeyboardKey.keyD,
+          character: null,
+          hasTrackedShiftKeyDown: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not release on modifier events', () {
+      expect(
+        shouldReleaseStaleMobileShift(
+          isMobile: true,
+          cachedShiftPressed: true,
+          actualShiftPressed: false,
+          logicalKey: LogicalKeyboardKey.shiftLeft,
+          character: null,
+          hasTrackedShiftKeyDown: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not release on shiftRight modifier events', () {
+      expect(
+        shouldReleaseStaleMobileShift(
+          isMobile: true,
+          cachedShiftPressed: true,
+          actualShiftPressed: false,
+          logicalKey: LogicalKeyboardKey.shiftRight,
+          character: null,
+          hasTrackedShiftKeyDown: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/flutter/test/input_modifier_utils_test.dart
+++ b/flutter/test/input_modifier_utils_test.dart
@@ -74,7 +74,7 @@ void main() {
       );
     });
 
-    test('does not release with empty character', () {
+    test('releases on non-text keys with empty character', () {
       expect(
         shouldReleaseStaleMobileShift(
           isMobile: true,
@@ -84,11 +84,11 @@ void main() {
           character: '',
           hasTrackedShiftKeyDown: true,
         ),
-        isFalse,
+        isTrue,
       );
     });
 
-    test('does not release with null character on non-modifier keys', () {
+    test('releases on non-text keys with null character', () {
       expect(
         shouldReleaseStaleMobileShift(
           isMobile: true,
@@ -98,7 +98,7 @@ void main() {
           character: null,
           hasTrackedShiftKeyDown: true,
         ),
-        isFalse,
+        isTrue,
       );
     });
 


### PR DESCRIPTION
## Summary
Fix soft keyboard Shift in Android getting stuck after typing single uppercase letter in remote sessions.
Rustdesk can keep its local mobile Shift state enabled after Gboard uses Shift for single uppercase character so the next characters are still sent as shifted.
Fixes #14673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects and clears stale mobile Shift states during key input, preventing a stuck Shift modifier from affecting typing across input paths.

* **Tests**
  * Added unit tests covering stale-Shift detection and release across mobile vs non-mobile and modifier vs non-modifier scenarios.

* **Chores**
  * Enabled Flutter test tooling in dev dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->