### PR TITLE
fix: bootstrap install LaunchAgent in user session

### DIFF
--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -319,6 +319,7 @@ mod tests {
             .and_then(|file| file.contents_utf8())
             .map(correct_app_name)
             .expect("install.scpt should be embedded");
+        let app_name = crate::get_app_name();
 
         assert!(
             install.contains("launchctl bootstrap gui/$uid")
@@ -335,9 +336,13 @@ mod tests {
             "install script must quote username-derived paths",
         );
         assert!(
-            install.contains("test ! -f \"$user_preferences_dir/RustDesk.toml\" || cp -rf")
-                && install
-                    .contains("test ! -f \"$user_preferences_dir/RustDesk2.toml\" || cp -rf"),
+            install.contains(&format!(
+                "test ! -f \"$user_preferences_dir/{}.toml\" || cp -rf",
+                app_name
+            )) && install.contains(&format!(
+                "test ! -f \"$user_preferences_dir/{}2.toml\" || cp -rf",
+                app_name
+            )),
             "install script must treat missing preference files as optional",
         );
     }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -312,6 +312,31 @@ fn correct_app_name(s: &str) -> String {
     s
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{correct_app_name, PRIVILEGES_SCRIPTS_DIR};
+
+    #[test]
+    fn install_script_bootstraps_agent_into_user_domain() {
+        let install = PRIVILEGES_SCRIPTS_DIR
+            .get_file("install.scpt")
+            .and_then(|file| file.contents_utf8())
+            .map(correct_app_name)
+            .expect("install.scpt should be embedded");
+
+        assert!(
+            install.contains("launchctl bootstrap gui/$uid")
+                || install.contains("launchctl bootstrap user/$uid"),
+            "install script must bootstrap the agent into a user launchd domain",
+        );
+        assert!(
+            install.contains("launchctl kickstart -k gui/$uid/$agent_label")
+                || install.contains("launchctl kickstart -k user/$uid/$agent_label"),
+            "install script must kickstart the agent after bootstrapping it",
+        );
+    }
+}
+
 pub fn uninstall_service(show_new_window: bool, sync: bool) -> bool {
     // to-do: do together with win/linux about refactory start/stop service
     if !is_installed_daemon(false) {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -234,16 +234,12 @@ pub fn is_installed_daemon(prompt: bool) -> bool {
             Err(e) => {
                 log::error!("run osascript failed: {}", e);
             }
-            _ => {
+            Ok(status) if !status.success() => {
+                log::warn!("run osascript failed with status: {}", status);
+            }
+            Ok(_) => {
                 let installed = std::path::Path::new(&agent_plist_file).exists();
                 log::info!("Agent file {} installed: {}", agent_plist_file, installed);
-                if installed {
-                    log::info!("launch server");
-                    std::process::Command::new("launchctl")
-                        .args(&["load", "-w", &agent_plist_file])
-                        .status()
-                        .ok();
-                }
             }
         }
     });
@@ -333,6 +329,16 @@ mod tests {
             install.contains("launchctl kickstart -k gui/$uid/$agent_label")
                 || install.contains("launchctl kickstart -k user/$uid/$agent_label"),
             "install script must kickstart the agent after bootstrapping it",
+        );
+        assert!(
+            install.contains("quoted form of user"),
+            "install script must quote username-derived paths",
+        );
+        assert!(
+            install.contains("test ! -f \"$user_preferences_dir/RustDesk.toml\" || cp -rf")
+                && install
+                    .contains("test ! -f \"$user_preferences_dir/RustDesk2.toml\" || cp -rf"),
+            "install script must treat missing preference files as optional",
         );
     }
 }

--- a/src/platform/privileges_scripts/install.scpt
+++ b/src/platform/privileges_scripts/install.scpt
@@ -6,17 +6,17 @@ on run {daemon_file, agent_file, user}
 
   set sh2 to "echo " & quoted form of agent_file & " > " & agent_plist & " && chown root:wheel " & agent_plist & ";"
 
-  set sh3 to "cp -rf /Users/" & user & "/Library/Preferences/com.carriez.RustDesk/RustDesk.toml /var/root/Library/Preferences/com.carriez.RustDesk/;"
+  set sh3 to "user_preferences_dir=/Users/" & quoted form of user & "/Library/Preferences/com.carriez.RustDesk; root_preferences_dir=/var/root/Library/Preferences/com.carriez.RustDesk; mkdir -p \"$root_preferences_dir\";"
+  set sh4 to "test ! -f \"$user_preferences_dir/RustDesk.toml\" || cp -rf \"$user_preferences_dir/RustDesk.toml\" \"$root_preferences_dir\";"
+  set sh5 to "test ! -f \"$user_preferences_dir/RustDesk2.toml\" || cp -rf \"$user_preferences_dir/RustDesk2.toml\" \"$root_preferences_dir\";"
 
-  set sh4 to "cp -rf /Users/" & user & "/Library/Preferences/com.carriez.RustDesk/RustDesk2.toml /var/root/Library/Preferences/com.carriez.RustDesk/;"
+  set sh6 to "uid=$(id -u " & quoted form of user & " 2>/dev/null || true);"
+  set sh7 to "launchctl load -w " & daemon_plist & ";"
+  set sh8 to "agent_label=$(basename " & quoted form of agent_plist & " .plist);"
+  set sh9 to "if [ -n \"$uid\" ]; then launchctl bootstrap gui/$uid " & quoted form of agent_plist & " 2>/dev/null || launchctl bootstrap user/$uid " & quoted form of agent_plist & " 2>/dev/null || launchctl load -w " & quoted form of agent_plist & " || true; else launchctl load -w " & quoted form of agent_plist & " || true; fi;"
+  set sh10 to "if [ -n \"$uid\" ]; then launchctl kickstart -k gui/$uid/$agent_label 2>/dev/null || launchctl kickstart -k user/$uid/$agent_label 2>/dev/null || true; fi;"
 
-  set sh5 to "uid=$(id -u " & quoted form of user & " 2>/dev/null || true);"
-  set sh6 to "launchctl load -w " & daemon_plist & ";"
-  set sh7 to "agent_label=$(basename " & quoted form of agent_plist & " .plist);"
-  set sh8 to "if [ -n \"$uid\" ]; then launchctl bootstrap gui/$uid " & quoted form of agent_plist & " 2>/dev/null || launchctl bootstrap user/$uid " & quoted form of agent_plist & " 2>/dev/null || launchctl load -w " & quoted form of agent_plist & " || true; else launchctl load -w " & quoted form of agent_plist & " || true; fi;"
-  set sh9 to "if [ -n \"$uid\" ]; then launchctl kickstart -k gui/$uid/$agent_label 2>/dev/null || launchctl kickstart -k user/$uid/$agent_label 2>/dev/null || true; fi;"
-
-  set sh to "set -e;" & sh1 & sh2 & sh3 & sh4 & sh5 & sh6 & sh7 & sh8 & sh9
+  set sh to "set -e;" & sh1 & sh2 & sh3 & sh4 & sh5 & sh6 & sh7 & sh8 & sh9 & sh10
 
   do shell script sh with prompt "RustDesk wants to install daemon and agent" with administrator privileges
 end run

--- a/src/platform/privileges_scripts/install.scpt
+++ b/src/platform/privileges_scripts/install.scpt
@@ -1,16 +1,22 @@
 on run {daemon_file, agent_file, user}
+  set daemon_plist to "/Library/LaunchDaemons/com.carriez.RustDesk_service.plist"
+  set agent_plist to "/Library/LaunchAgents/com.carriez.RustDesk_server.plist"
 
-  set sh1 to "echo " & quoted form of daemon_file & " > /Library/LaunchDaemons/com.carriez.RustDesk_service.plist && chown root:wheel /Library/LaunchDaemons/com.carriez.RustDesk_service.plist;"
+  set sh1 to "echo " & quoted form of daemon_file & " > " & daemon_plist & " && chown root:wheel " & daemon_plist & ";"
 
-  set sh2 to "echo " & quoted form of agent_file & " > /Library/LaunchAgents/com.carriez.RustDesk_server.plist && chown root:wheel /Library/LaunchAgents/com.carriez.RustDesk_server.plist;"
+  set sh2 to "echo " & quoted form of agent_file & " > " & agent_plist & " && chown root:wheel " & agent_plist & ";"
 
   set sh3 to "cp -rf /Users/" & user & "/Library/Preferences/com.carriez.RustDesk/RustDesk.toml /var/root/Library/Preferences/com.carriez.RustDesk/;"
 
   set sh4 to "cp -rf /Users/" & user & "/Library/Preferences/com.carriez.RustDesk/RustDesk2.toml /var/root/Library/Preferences/com.carriez.RustDesk/;"
 
-  set sh5 to "launchctl load -w /Library/LaunchDaemons/com.carriez.RustDesk_service.plist;"
+  set sh5 to "uid=$(id -u " & quoted form of user & " 2>/dev/null || true);"
+  set sh6 to "launchctl load -w " & daemon_plist & ";"
+  set sh7 to "agent_label=$(basename " & quoted form of agent_plist & " .plist);"
+  set sh8 to "if [ -n \"$uid\" ]; then launchctl bootstrap gui/$uid " & quoted form of agent_plist & " 2>/dev/null || launchctl bootstrap user/$uid " & quoted form of agent_plist & " 2>/dev/null || launchctl load -w " & quoted form of agent_plist & " || true; else launchctl load -w " & quoted form of agent_plist & " || true; fi;"
+  set sh9 to "if [ -n \"$uid\" ]; then launchctl kickstart -k gui/$uid/$agent_label 2>/dev/null || launchctl kickstart -k user/$uid/$agent_label 2>/dev/null || true; fi;"
 
-  set sh to sh1 & sh2 & sh3 & sh4 & sh5
+  set sh to "set -e;" & sh1 & sh2 & sh3 & sh4 & sh5 & sh6 & sh7 & sh8 & sh9
 
   do shell script sh with prompt "RustDesk wants to install daemon and agent" with administrator privileges
 end run


### PR DESCRIPTION
Fixes #10709 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added macOS installation script tests to validate service bootstrap/restart behavior and user-specific installation handling.

* **Bug Fixes**
  * Improved macOS installer: more robust user-domain service enablement with conditional agent loading, tolerant handling of missing preference files, and clearer logging for service load outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->