### PR TITLE
Fix: release all modifier keys on focus loss to prevent stuck state

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -547,9 +547,17 @@ pub fn release_remote_keys(keyboard_mode: &str) {
     for (key, mut event) in to_release.into_iter() {
         event.event_type = EventType::KeyRelease(key);
         client::process_event(keyboard_mode, &event, None);
-        // If Alt or AltGr is pressed, we need to send another key stoke to release it.
-        // Because the controlled side may hold the alt state, if local window is switched by [Alt + Tab].
-        if key == Key::Alt || key == Key::AltGr {
+        // If a modifier key is pressed, we need to send another key stroke to release it.
+        // Because the controlled side may hold the modifier state, if local window is switched
+        // by [Alt + Tab] or by releasing the key during a focus change.
+        // This handles Alt, AltGr, Control, and Meta (Command/Win) keys.
+        if key == Key::Alt
+            || key == Key::AltGr
+            || key == Key::ControlLeft
+            || key == Key::ControlRight
+            || key == Key::MetaLeft
+            || key == Key::MetaRight
+        {
             event.event_type = EventType::KeyPress(key);
             client::process_event(keyboard_mode, &event, None);
             event.event_type = EventType::KeyRelease(key);


### PR DESCRIPTION
Issue: #14447

When local window focus is lost (e.g., Alt+Tab or releasing Ctrl during focus change), the remote machine may keep Ctrl pressed indefinitely. This happens because release_remote_keys() only force-releases Alt/AltGr but not Control or Meta keys.

Fixed by extending the force-release logic to include:
- ControlLeft
- ControlRight
- MetaLeft (Command/Win)
- MetaRight

This ensures all modifier keys are properly reset when focus changes, preventing unintended behaviors like multi-file selection or zooming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of modifier key releases to prevent stuck keys in certain scenarios. Now correctly processes Control, Meta, Alt, and AltGr keys when released, preventing potential input issues when switching windows or after specific key combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->