### PR TITLE
impl(cm): implement change_theme and change_language callbacks

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -31,7 +31,7 @@ class RawKeyFocusScope extends StatelessWidget {
     // https://github.com/flutter/flutter/issues/154053
     final useRawKeyEvents = isLinux && !isWeb;
     // FIXME: On Windows, `AltGr` will generate `Alt` and `Control` key events,
-    // while `Alt` and `Control` are seperated key events for en-US input method.
+    // while `Alt` and `Control` are separated key events for en-US input method.
     return FocusScope(
         autofocus: true,
         child: Focus(

--- a/libs/clipboard/src/platform/unix/fuse/cs.rs
+++ b/libs/clipboard/src/platform/unix/fuse/cs.rs
@@ -12,7 +12,7 @@
 //!
 //! For now, we transfer all file names with windows separators, UTF-16 encoded.
 //! *Need a way to transfer file names with '\' safely*.
-//! Maybe we can use URL encoded file names and '/' seperators as a new standard, while keep the support to old schemes.
+//! Maybe we can use URL encoded file names and '/' separators as a new standard, while keep the support to old schemes.
 //!
 //! # Note
 //! - all files on FS should be read only, and mark the owner to be the current user

--- a/libs/virtual_display/dylib/README.md
+++ b/libs/virtual_display/dylib/README.md
@@ -29,4 +29,4 @@ TODO
 
 ## X11
 
-## OSX
+## macOS

--- a/src/ui/cm.rs
+++ b/src/ui/cm.rs
@@ -52,12 +52,12 @@ impl InvokeUiCM for SciterHandler {
         self.call("newMessage", &make_args!(id, text));
     }
 
-    fn change_theme(&self, _dark: String) {
-        // TODO
+    fn change_theme(&self, dark: String) {
+        self.call("changeTheme", &make_args!(dark));
     }
 
     fn change_language(&self) {
-        // TODO
+        self.call("changeLanguage", &make_args!());
     }
 
     fn show_elevation(&self, show: bool) {


### PR DESCRIPTION
## Summary

Implements the `change_theme` and `change_language` callbacks in the Connection Manager's SciterHandler which were previously empty TODO stubs.

## Changes

- `src/ui/cm.rs`: Added implementation for `change_theme(dark: String)` and `change_language()` to properly invoke Sciter UI handlers when theme or language changes occur.

## Testing

- Code compiles without errors
- Follows existing patterns in the codebase (matches `flutter.rs` implementation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented theme and language switching functionality that was previously unavailable.
* **Documentation**
  * Fixed spelling errors in code comments and documentation files. Updated platform documentation naming to current standards for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->