### PR TITLE
README: add Related community projects section (mcp-rustdesk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,7 @@ Please ensure that you run these commands from the root of the RustDesk reposito
 
 ![TCP Tunneling](https://github.com/rustdesk/rustdesk/assets/28412477/78e8708f-e87e-4570-8373-1360033ea6c5)
 
+
+## Related community projects
+
+- [mcp-rustdesk](https://github.com/meumeu-dev/mcp-rustdesk) — An MCP (Model Context Protocol) server that lets an LLM (Claude, etc.) see and control a remote machine through the RustDesk protocol, reusing this project's codec pipeline and `Interface` trait. E2EE, NAT hole-punch via self-hosted hbbs, optional Gemini Live continuous watcher.


### PR DESCRIPTION
Minimal addition: a **Related community projects** section at the bottom of the README pointing to [mcp-rustdesk](https://github.com/meumeu-dev/mcp-rustdesk), a community MCP server that wraps RustDesk so LLMs (Claude, etc.) can see and control remote machines using your protocol — reusing the `InvokeUiSession` trait and the existing codec pipeline.

Happy to drop or adjust wording if you prefer. A show-and-tell discussion (#14792) was removed earlier, so trying a lighter README mention instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Related community projects" section to the documentation, featuring compatible community-built tools and extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->