### PR TITLE
stop retrying on restricted mobile access errors

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3870,6 +3870,7 @@ pub fn check_if_retry(msgtype: &str, title: &str, text: &str, retry_for_relay: b
                 && !text.to_lowercase().contains("resolve")
                 && !text.to_lowercase().contains("mismatch")
                 && !text.to_lowercase().contains("manually")
+                && !text.to_lowercase().contains("restricted")
                 && !text.to_lowercase().contains("not allowed")))
 }
 


### PR DESCRIPTION
Treat "Access to mobile devices is restricted in your country" as a non-retriable connection error so the error dialog does not trigger reconnect attempts.

<img width="503" height="158" alt="retry" src="https://github.com/user-attachments/assets/3fdbbe31-afc7-4c73-b4ba-8bebb6747611" />

Other Testing

* When an **unauthenticated device** accesses a logged-in device, there is no retry.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error handling to correctly identify and skip retry attempts for restricted error conditions, reducing unnecessary network requests and improving overall system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->