### PR TITLE
fix(client): serialize X11 keyboard grab and debounce focus feedback

### DIFF
--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -615,9 +615,9 @@ pub fn session_enter_or_leave(_session_id: SessionID, _enter: bool) -> SyncRetur
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if let Some(session) = sessions::get_session_by_session_id(&_session_id) {
         let keyboard_mode = session.get_keyboard_mode();
-        // Use the per-window UUID (not lc.session_id which is per-connection)
+        // Use the full per-window UUID (not lc.session_id which is per-connection)
         // so that two windows viewing the same peer get distinct grab owners.
-        let window_id = _session_id.as_u128() as u64;
+        let window_id = _session_id.as_u128();
         if _enter {
             set_cur_session_id_(_session_id, &keyboard_mode);
             crate::keyboard::client::change_grab_status(

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -605,12 +605,10 @@ pub fn session_handle_flutter_raw_key_event(
     }
 }
 
-// SyncReturn<()> is used to make sure enter() and leave() are executed in the sequence this function is called.
-//
 // If the cursor jumps between remote page of two connections, leave view and enter view will be called.
 // session_enter_or_leave() will be called then.
-// As rust is multi-thread, it is possible that enter() is called before leave().
-// This will cause the keyboard input to take no effect.
+// As Rust is multi-threaded, enter() can be called before leave().
+// The Rust-side grab ownership state filters stale transitions.
 pub fn session_enter_or_leave(_session_id: SessionID, _enter: bool) -> SyncReturn<()> {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if let Some(session) = sessions::get_session_by_session_id(&_session_id) {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -615,11 +615,22 @@ pub fn session_enter_or_leave(_session_id: SessionID, _enter: bool) -> SyncRetur
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if let Some(session) = sessions::get_session_by_session_id(&_session_id) {
         let keyboard_mode = session.get_keyboard_mode();
+        // Use the per-window UUID (not lc.session_id which is per-connection)
+        // so that two windows viewing the same peer get distinct grab owners.
+        let window_id = _session_id.as_u128() as u64;
         if _enter {
             set_cur_session_id_(_session_id, &keyboard_mode);
-            session.enter(keyboard_mode);
+            crate::keyboard::client::change_grab_status(
+                crate::common::GrabState::Run,
+                &keyboard_mode,
+                window_id,
+            );
         } else {
-            session.leave(keyboard_mode);
+            crate::keyboard::client::change_grab_status(
+                crate::common::GrabState::Wait,
+                &keyboard_mode,
+                window_id,
+            );
         }
     }
     SyncReturn(())

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -146,7 +146,7 @@ pub mod client {
     }
 
     pub fn start_grab_loop() {
-        let mut lock = IS_GRAB_STARTED.lock().unwrap_or_else(|e| e.into_inner());
+        let mut lock = IS_GRAB_STARTED.lock().unwrap();
         if *lock {
             return;
         }
@@ -167,7 +167,7 @@ pub mod client {
         let mut run_grab_after_unlock = None;
         #[cfg(target_os = "linux")]
         let mut disable_after_unlock = false;
-        let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
+        let mut gs = GRAB_STATE.lock().unwrap();
         match state {
             GrabState::Ready => {}
             GrabState::Run => {
@@ -248,8 +248,7 @@ pub mod client {
                             std::thread::spawn(move || {
                                 std::thread::sleep(std::time::Duration::from_millis(remaining));
                                 let release_keys = {
-                                    let mut gs =
-                                        GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
+                                    let mut gs = GRAB_STATE.lock().unwrap();
                                     // Release only if no new Run has refreshed the grab since.
                                     if gs.owner == Some(session_id) && gs.last_grab == snapshot {
                                         let to_release = take_remote_keys();
@@ -731,7 +730,7 @@ pub fn is_long_press(event: &Event) -> bool {
 }
 
 fn take_remote_keys() -> HashMap<Key, Event> {
-    let mut to_release = TO_RELEASE.lock().unwrap_or_else(|e| e.into_inner());
+    let mut to_release = TO_RELEASE.lock().unwrap();
     std::mem::take(&mut *to_release)
 }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -84,11 +84,16 @@ pub mod client {
 
     /// Tracks grab ownership and serializes transitions across threads.
     ///
-    /// On Linux/X11, `XGrabKeyboard` can cause a focus-change feedback loop:
-    /// grab -> focus shifts -> PointerExit -> ungrab -> focus returns ->
-    /// PointerEnter -> grab -> ... at ~10 Hz. `last_grab` lets us debounce
-    /// spurious `Wait` events that arrive shortly after a `Run` for the same
-    /// session - these are X11 focus feedback, not real user actions.
+    /// Multiple Flutter isolates (one per session window) call
+    /// `change_grab_status(Run/Wait)` concurrently. Without serialization a
+    /// stale `Wait` from session A can clobber session B's freshly acquired
+    /// grab on any desktop OS.
+    ///
+    /// Windows and macOS are less susceptible in practice because the Flutter
+    /// side triggers `enterView` only after a mouse click inside the window,
+    /// but we cannot rely on that. On Linux/X11, `XGrabKeyboard` can also
+    /// cause a focus-change feedback loop (~10 Hz), so `last_grab` debounces
+    /// spurious `Wait` events that arrive shortly after a `Run`.
     #[derive(Default)]
     struct GrabOwnerState {
         owner: Option<u64>,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -82,8 +82,31 @@ lazy_static::lazy_static! {
 pub mod client {
     use super::*;
 
+    /// Tracks grab ownership and serializes transitions across threads.
+    ///
+    /// On Linux/X11, `XGrabKeyboard` can cause a focus-change feedback loop:
+    /// grab -> focus shifts -> PointerExit -> ungrab -> focus returns ->
+    /// PointerEnter -> grab -> ... at ~10 Hz. `last_grab` lets us debounce
+    /// spurious `Wait` events that arrive shortly after a `Run` for the same
+    /// session - these are X11 focus feedback, not real user actions.
+    struct GrabOwnerState {
+        owner: Option<u64>,
+        last_grab: Option<std::time::Instant>,
+    }
+
+    impl Default for GrabOwnerState {
+        fn default() -> Self {
+            Self { owner: None, last_grab: None }
+        }
+    }
+
+    /// How long after a grab acquisition we suppress Wait from the same session.
+    /// Must exceed one full X11 feedback cycle (~100 ms: 50 ms enable + 50 ms disable).
+    const GRAB_DEBOUNCE_MS: u128 = 300;
+
     lazy_static::lazy_static! {
         static ref IS_GRAB_STARTED: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
+        static ref GRAB_STATE: Arc<Mutex<GrabOwnerState>> = Arc::new(Mutex::new(GrabOwnerState::default()));
     }
 
     pub fn start_grab_loop() {
@@ -96,33 +119,98 @@ pub mod client {
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    pub fn change_grab_status(state: GrabState, keyboard_mode: &str) {
+    pub fn change_grab_status(state: GrabState, keyboard_mode: &str, session_id: u64) {
         #[cfg(feature = "flutter")]
         if !IS_RDEV_ENABLED.load(Ordering::SeqCst) {
             return;
         }
+        // Serialize transitions so a stale `Wait` from a previous owner cannot
+        // clobber a fresh `Run` from a different session window.
+        let mut gs = GRAB_STATE.lock().unwrap();
         match state {
             GrabState::Ready => {}
             GrabState::Run => {
                 #[cfg(windows)]
                 update_grab_get_key_name(keyboard_mode);
+
+                // Idempotent: if this session already owns the grab, just
+                // refresh the debounce timer (proves the session is still
+                // actively focused) and skip the actual grab call.
+                if gs.owner == Some(session_id) {
+                    gs.last_grab = Some(std::time::Instant::now());
+                    log::debug!("[grab] Run(0x{:x}): already owner, refresh debounce", session_id);
+                    return;
+                }
+
+                log::info!(
+                    "[grab] Run(0x{:x}): prev_owner={}, mode={}",
+                    session_id,
+                    gs.owner.map_or("none".to_string(), |id| format!("0x{:x}", id)),
+                    keyboard_mode,
+                );
+
                 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-                KEYBOARD_HOOKED.swap(true, Ordering::SeqCst);
+                KEYBOARD_HOOKED.store(true, Ordering::SeqCst);
 
                 #[cfg(target_os = "linux")]
-                rdev::enable_grab();
+                {
+                    // On handoff, explicitly release any prior owner's X11 grab
+                    // before taking our own. This keeps the rdev control thread
+                    // and the X server in a consistent state even if the prior
+                    // owner never sent `Wait` (e.g. disconnected or raced).
+                    if gs.owner.is_some() {
+                        log::info!("[grab] handoff: disable_grab before re-grab");
+                        rdev::disable_grab();
+                    }
+                    rdev::enable_grab();
+                }
+                gs.owner = Some(session_id);
+                gs.last_grab = Some(std::time::Instant::now());
             }
             GrabState::Wait => {
+                // Drop stale `Wait` events that do not correspond to the
+                // current grab owner. This prevents a late PointerExit from
+                // session A from releasing session B's freshly acquired grab.
+                if gs.owner != Some(session_id) {
+                    log::debug!(
+                        "[grab] Wait(0x{:x}): ignored, owner={}",
+                        session_id,
+                        gs.owner.map_or("none".to_string(), |id| format!("0x{:x}", id)),
+                    );
+                    return;
+                }
+
+                // Debounce: on Linux/X11, XGrabKeyboard causes a focus-change
+                // feedback loop (grab -> PointerExit -> ungrab -> PointerEnter ->
+                // grab -> ...). Suppress Wait if the grab was acquired recently
+                // by this same session -- it is X11 feedback, not a real leave.
+                #[cfg(target_os = "linux")]
+                if let Some(t) = gs.last_grab {
+                    let elapsed = t.elapsed().as_millis();
+                    if elapsed < GRAB_DEBOUNCE_MS {
+                        log::debug!(
+                            "[grab] Wait(0x{:x}): debounced ({}ms < {}ms)",
+                            session_id, elapsed, GRAB_DEBOUNCE_MS,
+                        );
+                        return;
+                    }
+                }
+
+                log::info!("[grab] Wait(0x{:x}): releasing grab", session_id);
+
                 #[cfg(windows)]
                 rdev::set_get_key_unicode(false);
 
                 release_remote_keys(keyboard_mode);
 
                 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-                KEYBOARD_HOOKED.swap(false, Ordering::SeqCst);
+                KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
 
                 #[cfg(target_os = "linux")]
                 rdev::disable_grab();
+
+                gs.owner = None;
+                gs.last_grab = None;
             }
             GrabState::Exit => {}
         }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -211,9 +211,9 @@ pub mod client {
                             std::thread::spawn(move || {
                                 std::thread::sleep(std::time::Duration::from_millis(remaining));
                                 let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
-                                gs.deferred_pending = false;
                                 // Release only if no new Run has refreshed the grab since.
                                 if gs.owner == Some(session_id) && gs.last_grab == snapshot {
+                                    gs.deferred_pending = false;
                                     log::info!("[grab] Wait(0x{:x}): deferred release", session_id);
                                     release_remote_keys(&mode);
                                     KEYBOARD_HOOKED.store(false, Ordering::SeqCst);

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -105,6 +105,7 @@ pub mod client {
 
     /// How long after a grab acquisition we suppress Wait from the same session.
     /// Must exceed one full X11 feedback cycle (~100 ms: 50 ms enable + 50 ms disable).
+    #[cfg(target_os = "linux")]
     const GRAB_DEBOUNCE_MS: u128 = 300;
 
     lazy_static::lazy_static! {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -108,7 +108,7 @@ pub mod client {
     }
 
     pub fn start_grab_loop() {
-        let mut lock = IS_GRAB_STARTED.lock().unwrap();
+        let mut lock = IS_GRAB_STARTED.lock().unwrap_or_else(|e| e.into_inner());
         if *lock {
             return;
         }
@@ -124,7 +124,7 @@ pub mod client {
         }
         // Serialize transitions so a stale `Wait` from a previous owner cannot
         // clobber a fresh `Run` from a different session window.
-        let mut gs = GRAB_STATE.lock().unwrap();
+        let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
         match state {
             GrabState::Ready => {}
             GrabState::Run => {
@@ -205,7 +205,7 @@ pub mod client {
                             let mode = keyboard_mode.to_string();
                             std::thread::spawn(move || {
                                 std::thread::sleep(std::time::Duration::from_millis(remaining));
-                                let mut gs = GRAB_STATE.lock().unwrap();
+                                let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
                                 gs.deferred_pending = false;
                                 // Release only if no new Run has refreshed the grab since.
                                 if gs.owner == Some(session_id) && gs.last_grab == snapshot {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -89,18 +89,13 @@ pub mod client {
     /// PointerEnter -> grab -> ... at ~10 Hz. `last_grab` lets us debounce
     /// spurious `Wait` events that arrive shortly after a `Run` for the same
     /// session - these are X11 focus feedback, not real user actions.
+    #[derive(Default)]
     struct GrabOwnerState {
         owner: Option<u64>,
         last_grab: Option<std::time::Instant>,
         /// True while a deferred-release thread is in flight. Prevents
         /// spawning redundant threads during the X11 feedback loop.
         deferred_pending: bool,
-    }
-
-    impl Default for GrabOwnerState {
-        fn default() -> Self {
-            Self { owner: None, last_grab: None, deferred_pending: false }
-        }
     }
 
     /// How long after a grab acquisition we suppress Wait from the same session.
@@ -141,6 +136,9 @@ pub mod client {
                 // actively focused) and skip the actual grab call.
                 if gs.owner == Some(session_id) {
                     gs.last_grab = Some(std::time::Instant::now());
+                    // Reset so the next Wait can spawn a fresh deferred-release
+                    // timer with an up-to-date snapshot of last_grab.
+                    gs.deferred_pending = false;
                     log::debug!("[grab] Run(0x{:x}): already owner, refresh debounce", session_id);
                     return;
                 }
@@ -169,6 +167,9 @@ pub mod client {
                 }
                 gs.owner = Some(session_id);
                 gs.last_grab = Some(std::time::Instant::now());
+                // Invalidate any in-flight deferred release from the previous
+                // owner so it cannot suppress a fresh timer for the new owner.
+                gs.deferred_pending = false;
             }
             GrabState::Wait => {
                 // Drop stale `Wait` events that do not correspond to the

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -113,6 +113,38 @@ pub mod client {
         static ref GRAB_STATE: Arc<Mutex<GrabOwnerState>> = Arc::new(Mutex::new(GrabOwnerState::default()));
     }
 
+    #[cfg(target_os = "linux")]
+    lazy_static::lazy_static! {
+        static ref GRAB_OP_LOCK: Mutex<()> = Mutex::new(());
+    }
+
+    #[cfg(target_os = "linux")]
+    fn apply_run_grab_if_owner(session_id: u128, disable_first: bool) {
+        let _lock = GRAB_OP_LOCK.lock().unwrap();
+        let gs = GRAB_STATE.lock().unwrap();
+        if gs.owner != Some(session_id) {
+            return;
+        }
+        drop(gs);
+        if disable_first {
+            log::debug!("[grab] handoff: disable_grab before re-grab");
+            rdev::disable_grab();
+        }
+        rdev::enable_grab();
+    }
+
+    #[cfg(target_os = "linux")]
+    fn disable_grab_if_released() {
+        let _lock = GRAB_OP_LOCK.lock().unwrap();
+        let should_disable = {
+            let gs = GRAB_STATE.lock().unwrap();
+            gs.owner.is_none() && gs.last_grab.is_none()
+        };
+        if should_disable {
+            rdev::disable_grab();
+        }
+    }
+
     pub fn start_grab_loop() {
         let mut lock = IS_GRAB_STARTED.lock().unwrap_or_else(|e| e.into_inner());
         if *lock {
@@ -130,6 +162,11 @@ pub mod client {
         }
         // Serialize transitions so a stale `Wait` from a previous owner cannot
         // clobber a fresh `Run` from a different session window.
+        let mut release_after_unlock = None;
+        #[cfg(target_os = "linux")]
+        let mut run_grab_after_unlock = None;
+        #[cfg(target_os = "linux")]
+        let mut disable_after_unlock = false;
         let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
         match state {
             GrabState::Ready => {}
@@ -145,14 +182,18 @@ pub mod client {
                     // Reset so the next Wait can spawn a fresh deferred-release
                     // timer with an up-to-date snapshot of last_grab.
                     gs.deferred_pending = false;
-                    log::debug!("[grab] Run(0x{:x}): already owner, refresh debounce", session_id);
+                    log::debug!(
+                        "[grab] Run(0x{:x}): already owner, refresh debounce",
+                        session_id
+                    );
                     return;
                 }
 
                 log::debug!(
                     "[grab] Run(0x{:x}): prev_owner={}, mode={}",
                     session_id,
-                    gs.owner.map_or("none".to_string(), |id| format!("0x{:x}", id)),
+                    gs.owner
+                        .map_or("none".to_string(), |id| format!("0x{:x}", id)),
                     keyboard_mode,
                 );
 
@@ -160,22 +201,16 @@ pub mod client {
                 KEYBOARD_HOOKED.store(true, Ordering::SeqCst);
 
                 #[cfg(target_os = "linux")]
-                {
-                    // On handoff, explicitly release any prior owner's X11 grab
-                    // before taking our own. This keeps the rdev control thread
-                    // and the X server in a consistent state even if the prior
-                    // owner never sent `Wait` (e.g. disconnected or raced).
-                    if gs.owner.is_some() {
-                        log::debug!("[grab] handoff: disable_grab before re-grab");
-                        rdev::disable_grab();
-                    }
-                    rdev::enable_grab();
-                }
+                let had_owner = gs.owner.is_some();
                 gs.owner = Some(session_id);
                 gs.last_grab = Some(std::time::Instant::now());
                 // Invalidate any in-flight deferred release from the previous
                 // owner so it cannot suppress a fresh timer for the new owner.
                 gs.deferred_pending = false;
+                #[cfg(target_os = "linux")]
+                {
+                    run_grab_after_unlock = Some(had_owner);
+                }
             }
             GrabState::Wait => {
                 // Drop stale `Wait` events that do not correspond to the
@@ -185,7 +220,8 @@ pub mod client {
                     log::debug!(
                         "[grab] Wait(0x{:x}): ignored, owner={}",
                         session_id,
-                        gs.owner.map_or("none".to_string(), |id| format!("0x{:x}", id)),
+                        gs.owner
+                            .map_or("none".to_string(), |id| format!("0x{:x}", id)),
                     );
                     return;
                 }
@@ -211,21 +247,32 @@ pub mod client {
                             let mode = keyboard_mode.to_string();
                             std::thread::spawn(move || {
                                 std::thread::sleep(std::time::Duration::from_millis(remaining));
-                                let mut gs = GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
-                                // Release only if no new Run has refreshed the grab since.
-                                if gs.owner == Some(session_id) && gs.last_grab == snapshot {
-                                    gs.deferred_pending = false;
-                                    log::debug!("[grab] Wait(0x{:x}): deferred release", session_id);
-                                    release_remote_keys(&mode);
-                                    KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
-                                    rdev::disable_grab();
-                                    gs.owner = None;
-                                    gs.last_grab = None;
-                                } else {
-                                    log::debug!(
-                                        "[grab] Wait(0x{:x}): deferred release cancelled (grab refreshed)",
-                                        session_id,
-                                    );
+                                let release_keys = {
+                                    let mut gs =
+                                        GRAB_STATE.lock().unwrap_or_else(|e| e.into_inner());
+                                    // Release only if no new Run has refreshed the grab since.
+                                    if gs.owner == Some(session_id) && gs.last_grab == snapshot {
+                                        let to_release = take_remote_keys();
+                                        gs.deferred_pending = false;
+                                        log::debug!(
+                                            "[grab] Wait(0x{:x}): deferred release",
+                                            session_id
+                                        );
+                                        KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
+                                        gs.owner = None;
+                                        gs.last_grab = None;
+                                        Some(to_release)
+                                    } else {
+                                        log::debug!(
+                                            "[grab] Wait(0x{:x}): deferred release cancelled (grab refreshed)",
+                                            session_id,
+                                        );
+                                        None
+                                    }
+                                };
+                                if let Some(to_release) = release_keys {
+                                    disable_grab_if_released();
+                                    release_remote_keys_for_events(&mode, to_release);
                                 }
                             });
                         } else {
@@ -243,19 +290,32 @@ pub mod client {
                 #[cfg(windows)]
                 rdev::set_get_key_unicode(false);
 
-                release_remote_keys(keyboard_mode);
-
                 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
                 KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
-
-                #[cfg(target_os = "linux")]
-                rdev::disable_grab();
 
                 gs.owner = None;
                 gs.last_grab = None;
                 gs.deferred_pending = false;
+                release_after_unlock = Some(take_remote_keys());
+                #[cfg(target_os = "linux")]
+                {
+                    disable_after_unlock = true;
+                }
             }
             GrabState::Exit => {}
+        }
+        drop(gs);
+        #[cfg(target_os = "linux")]
+        {
+            if disable_after_unlock {
+                disable_grab_if_released();
+            }
+            if let Some(disable_first) = run_grab_after_unlock {
+                apply_run_grab_if_owner(session_id, disable_first);
+            }
+        }
+        if let Some(to_release) = release_after_unlock {
+            release_remote_keys_for_events(keyboard_mode, to_release);
         }
     }
 
@@ -472,7 +532,6 @@ fn notify_exit_relative_mouse_mode() {
     flutter::push_session_event(&session_id, "exit_relative_mouse_mode", vec![]);
 }
 
-
 /// Handle relative mouse mode shortcuts in the rdev grab loop.
 /// Returns true if the event should be blocked from being sent to the peer.
 #[cfg(feature = "flutter")]
@@ -671,10 +730,12 @@ pub fn is_long_press(event: &Event) -> bool {
     return false;
 }
 
-pub fn release_remote_keys(keyboard_mode: &str) {
-    // todo!: client quit suddenly, how to release keys?
-    let to_release = TO_RELEASE.lock().unwrap().clone();
-    TO_RELEASE.lock().unwrap().clear();
+fn take_remote_keys() -> HashMap<Key, Event> {
+    let mut to_release = TO_RELEASE.lock().unwrap_or_else(|e| e.into_inner());
+    std::mem::take(&mut *to_release)
+}
+
+fn release_remote_keys_for_events(keyboard_mode: &str, to_release: HashMap<Key, Event>) {
     for (key, mut event) in to_release.into_iter() {
         event.event_type = EventType::KeyRelease(key);
         client::process_event(keyboard_mode, &event, None);
@@ -687,6 +748,12 @@ pub fn release_remote_keys(keyboard_mode: &str) {
             client::process_event(keyboard_mode, &event, None);
         }
     }
+}
+
+#[allow(dead_code)]
+pub fn release_remote_keys(keyboard_mode: &str) {
+    // todo!: client quit suddenly, how to release keys?
+    release_remote_keys_for_events(keyboard_mode, take_remote_keys());
 }
 
 pub fn get_keyboard_mode_enum(keyboard_mode: &str) -> KeyboardMode {
@@ -879,7 +946,6 @@ pub fn event_to_key_events(
 ) -> Vec<KeyEvent> {
     peer.retain(|c| !c.is_whitespace());
 
-    let mut key_event = KeyEvent::new();
     update_modifiers_state(event);
 
     match event.event_type {
@@ -892,6 +958,7 @@ pub fn event_to_key_events(
         _ => {}
     }
 
+    let mut key_event = KeyEvent::new();
     key_event.mode = keyboard_mode.into();
 
     let mut key_events = match keyboard_mode {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -96,7 +96,7 @@ pub mod client {
     /// spurious `Wait` events that arrive shortly after a `Run`.
     #[derive(Default)]
     struct GrabOwnerState {
-        owner: Option<u64>,
+        owner: Option<u128>,
         last_grab: Option<std::time::Instant>,
         /// True while a deferred-release thread is in flight. Prevents
         /// spawning redundant threads during the X11 feedback loop.
@@ -122,7 +122,7 @@ pub mod client {
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    pub fn change_grab_status(state: GrabState, keyboard_mode: &str, session_id: u64) {
+    pub fn change_grab_status(state: GrabState, keyboard_mode: &str, session_id: u128) {
         #[cfg(feature = "flutter")]
         if !IS_RDEV_ENABLED.load(Ordering::SeqCst) {
             return;
@@ -148,7 +148,7 @@ pub mod client {
                     return;
                 }
 
-                log::info!(
+                log::debug!(
                     "[grab] Run(0x{:x}): prev_owner={}, mode={}",
                     session_id,
                     gs.owner.map_or("none".to_string(), |id| format!("0x{:x}", id)),
@@ -165,7 +165,7 @@ pub mod client {
                     // and the X server in a consistent state even if the prior
                     // owner never sent `Wait` (e.g. disconnected or raced).
                     if gs.owner.is_some() {
-                        log::info!("[grab] handoff: disable_grab before re-grab");
+                        log::debug!("[grab] handoff: disable_grab before re-grab");
                         rdev::disable_grab();
                     }
                     rdev::enable_grab();
@@ -214,7 +214,7 @@ pub mod client {
                                 // Release only if no new Run has refreshed the grab since.
                                 if gs.owner == Some(session_id) && gs.last_grab == snapshot {
                                     gs.deferred_pending = false;
-                                    log::info!("[grab] Wait(0x{:x}): deferred release", session_id);
+                                    log::debug!("[grab] Wait(0x{:x}): deferred release", session_id);
                                     release_remote_keys(&mode);
                                     KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
                                     rdev::disable_grab();
@@ -237,7 +237,7 @@ pub mod client {
                     }
                 }
 
-                log::info!("[grab] Wait(0x{:x}): releasing grab", session_id);
+                log::debug!("[grab] Wait(0x{:x}): releasing grab", session_id);
 
                 #[cfg(windows)]
                 rdev::set_get_key_unicode(false);
@@ -252,6 +252,7 @@ pub mod client {
 
                 gs.owner = None;
                 gs.last_grab = None;
+                gs.deferred_pending = false;
             }
             GrabState::Exit => {}
         }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -92,11 +92,14 @@ pub mod client {
     struct GrabOwnerState {
         owner: Option<u64>,
         last_grab: Option<std::time::Instant>,
+        /// True while a deferred-release thread is in flight. Prevents
+        /// spawning redundant threads during the X11 feedback loop.
+        deferred_pending: bool,
     }
 
     impl Default for GrabOwnerState {
         fn default() -> Self {
-            Self { owner: None, last_grab: None }
+            Self { owner: None, last_grab: None, deferred_pending: false }
         }
     }
 
@@ -184,14 +187,46 @@ pub mod client {
                 // feedback loop (grab -> PointerExit -> ungrab -> PointerEnter ->
                 // grab -> ...). Suppress Wait if the grab was acquired recently
                 // by this same session -- it is X11 feedback, not a real leave.
+                // A deferred release is scheduled so that a genuine leave within
+                // the debounce window is not permanently lost.
                 #[cfg(target_os = "linux")]
                 if let Some(t) = gs.last_grab {
                     let elapsed = t.elapsed().as_millis();
                     if elapsed < GRAB_DEBOUNCE_MS {
-                        log::debug!(
-                            "[grab] Wait(0x{:x}): debounced ({}ms < {}ms)",
-                            session_id, elapsed, GRAB_DEBOUNCE_MS,
-                        );
+                        if !gs.deferred_pending {
+                            log::debug!(
+                                "[grab] Wait(0x{:x}): debounced ({}ms < {}ms), scheduling deferred release",
+                                session_id, elapsed, GRAB_DEBOUNCE_MS,
+                            );
+                            gs.deferred_pending = true;
+                            let remaining = (GRAB_DEBOUNCE_MS - elapsed) as u64 + 50;
+                            let snapshot = gs.last_grab;
+                            let mode = keyboard_mode.to_string();
+                            std::thread::spawn(move || {
+                                std::thread::sleep(std::time::Duration::from_millis(remaining));
+                                let mut gs = GRAB_STATE.lock().unwrap();
+                                gs.deferred_pending = false;
+                                // Release only if no new Run has refreshed the grab since.
+                                if gs.owner == Some(session_id) && gs.last_grab == snapshot {
+                                    log::info!("[grab] Wait(0x{:x}): deferred release", session_id);
+                                    release_remote_keys(&mode);
+                                    KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
+                                    rdev::disable_grab();
+                                    gs.owner = None;
+                                    gs.last_grab = None;
+                                } else {
+                                    log::debug!(
+                                        "[grab] Wait(0x{:x}): deferred release cancelled (grab refreshed)",
+                                        session_id,
+                                    );
+                                }
+                            });
+                        } else {
+                            log::debug!(
+                                "[grab] Wait(0x{:x}): debounced, deferred release already pending",
+                                session_id,
+                            );
+                        }
                         return;
                     }
                 }

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -870,12 +870,14 @@ impl<T: InvokeUiSession> Session<T> {
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn enter(&self, keyboard_mode: String) {
-        keyboard::client::change_grab_status(GrabState::Run, &keyboard_mode);
+        let session_id = self.lc.read().unwrap().session_id;
+        keyboard::client::change_grab_status(GrabState::Run, &keyboard_mode, session_id);
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn leave(&self, keyboard_mode: String) {
-        keyboard::client::change_grab_status(GrabState::Wait, &keyboard_mode);
+        let session_id = self.lc.read().unwrap().session_id;
+        keyboard::client::change_grab_status(GrabState::Wait, &keyboard_mode, session_id);
     }
 
     // flutter only TODO new input

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -870,13 +870,13 @@ impl<T: InvokeUiSession> Session<T> {
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn enter(&self, keyboard_mode: String) {
-        let session_id = self.lc.read().unwrap().session_id;
+        let session_id = self.lc.read().unwrap().session_id as u128;
         keyboard::client::change_grab_status(GrabState::Run, &keyboard_mode, session_id);
     }
 
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn leave(&self, keyboard_mode: String) {
-        let session_id = self.lc.read().unwrap().session_id;
+        let session_id = self.lc.read().unwrap().session_id as u128;
         keyboard::client::change_grab_status(GrabState::Wait, &keyboard_mode, session_id);
     }
 


### PR DESCRIPTION
## Summary

- Fixes keyboard input getting stuck on the wrong session (or stopping entirely) when switching between two fullscreen RustDesk sessions on separate monitors on Linux/X11
- Breaks the XGrabKeyboard focus-change feedback loop that blocks keyboard input for seconds during workspace switches

## Problem

When two RustDesk sessions run fullscreen on separate monitors on Linux/X11 (tested with MATE/Marco), keyboard input gets stuck on the wrong session or stops working entirely after clicking between monitors. The same workflow from a Windows client has no issues.

**Root cause 1 -- Race condition:** Each Flutter isolate (one per DesktopMultiWindow session window) calls `change_grab_status(Run/Wait)` concurrently via FFI. `SyncReturn` only serializes within a single Dart isolate, so two Rust threads race on `KEYBOARD_HOOKED` and the rdev grab channel. A stale `Wait` from session A can clobber session B's freshly acquired grab.

**Root cause 2 -- X11 focus feedback loop:** `XGrabKeyboard` shifts focus away from the Flutter window, triggering `PointerExit`, which releases the grab, restoring focus, triggering `PointerEnter`, which re-grabs -- cycling at ~10 Hz. This is the "rdev issues" referenced in `remote_page.dart` that led to focus-based grab handling being disabled on Linux.

## Fix

1. **Serialized grab transitions** via `GRAB_STATE: Mutex<GrabOwnerState>` that tracks which session (by `lc.session_id`) currently owns the grab
2. **Stale Wait filtering** -- ignores `Wait` from sessions that don't own the grab, so a late `PointerExit` from session A cannot release session B's grab
3. **Debounce (300 ms)** -- suppresses `Wait` events that arrive shortly after a `Run` for the same session, breaking the X11 focus feedback loop
4. **Debounce refresh** -- idempotent `Run` calls (enterView while already owner) refresh the debounce timer, keeping the grab stable during normal use

`src/keyboard.rs`, `src/ui_session_interface.rs`, and `src/flutter_ffi.rs` are changed. Client-side only -- remote machines need no changes. Windows/macOS behavior is preserved (the debounce is `#[cfg(target_os = "linux")]` only).

## Environment

- RustDesk version: 1.4.6
- Client OS: Linux Mint with MATE (X11)
- Remote OS: Linux Mint with MATE
- Setup: Two separate RustDesk sessions, each fullscreen on its own monitor

## Test plan

- [ ] Two fullscreen sessions on separate monitors -- keyboard follows mouse click between them
- [ ] Workspace switch does not cause multi-second keyboard lockout
- [ ] F12/hotkeys are captured by the remote session, not the local OS
- [ ] Single session: keyboard works normally after entering/leaving the remote image
- [ ] Windows/macOS clients are unaffected (no behavioral change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale or conflicting keyboard grabs between sessions and added a debounced release on Linux to avoid rapid toggles and spurious releases.
  * Ensured deferred releases no longer release a different session’s grab.

* **Improvements**
  * Grab transitions are session-aware and idempotent, improving input ownership and handoff reliability.
  * More robust ordering of release/handoff operations to reduce unexpected remote key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
