### PR TITLE
fix(linux): enable mouse side buttons in remote sessions

### DIFF
--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -28,6 +28,7 @@ import 'consts.dart';
 import 'mobile/pages/home_page.dart';
 import 'mobile/pages/server_page.dart';
 import 'models/platform_model.dart';
+import 'models/input_model.dart';
 
 import 'package:flutter_hbb/plugin/handlers.dart'
     if (dart.library.html) 'package:flutter_hbb/web/plugin/handlers.dart';
@@ -130,6 +131,8 @@ Future<void> initEnv(String appType) async {
   _registerEventHandler();
   // Update the system theme.
   updateSystemWindowTheme();
+  // Initialize side mouse button channel (Linux only, no-op on other platforms).
+  InputModel.initSideButtonChannel();
 }
 
 void runMainApp(bool startService) async {

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -28,7 +28,6 @@ import 'consts.dart';
 import 'mobile/pages/home_page.dart';
 import 'mobile/pages/server_page.dart';
 import 'models/platform_model.dart';
-import 'models/input_model.dart';
 
 import 'package:flutter_hbb/plugin/handlers.dart'
     if (dart.library.html) 'package:flutter_hbb/web/plugin/handlers.dart';
@@ -131,8 +130,6 @@ Future<void> initEnv(String appType) async {
   _registerEventHandler();
   // Update the system theme.
   updateSystemWindowTheme();
-  // Initialize side mouse button channel (Linux only, no-op on other platforms).
-  InputModel.initSideButtonChannel();
 }
 
 void runMainApp(bool startService) async {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -339,6 +339,10 @@ class InputModel {
   static final Map<MouseButtons, InputModel> _sideButtonDownModels = {};
   static bool _sideButtonChannelInitialized = false;
 
+  /// Each Flutter engine (main window + sub-windows from desktop_multi_window)
+  /// runs its own Dart isolate with its own statics. Called from initEnv()
+  /// which runs per-engine, so each isolate registers its own handler tied
+  /// to its own set of InputModels.
   static void initSideButtonChannel() {
     if (!Platform.isLinux) return;
     if (_sideButtonChannelInitialized) return;

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -387,7 +387,10 @@ class InputModel {
         .toList();
     for (final mb in held) {
       _sideButtonDownModels.remove(mb);
-      unawaited(sendMouse('up', mb));
+      // Best-effort release; session may already be tearing down.
+      unawaited(sendMouse('up', mb).catchError((Object e) {
+        debugPrint('[InputModel] failed to release side button $mb: $e');
+      }));
     }
   }
 

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -488,6 +488,7 @@ class InputModel {
   bool get isRelativeMouseModeSupported => _relativeMouse.isSupported;
 
   InputModel(this.parent) {
+    initSideButtonChannel();
     sessionId = parent.target!.sessionId;
     _relativeMouse = RelativeMouseModel(
       sessionId: sessionId,

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -359,16 +359,20 @@ class InputModel {
         if (type == 'down') {
           final model = _activeSideButtonModel;
           if (model != null &&
-              !(model.isViewOnly && !model.showMyCursor)) {
+              !(model.isViewOnly && !model.showMyCursor) &&
+              model.keyboardPerm &&
+              !model.isViewCamera) {
             _sideButtonDownModels[mb] = model;
-            await model.sendMouse(type, mb);
+            await model._sendMouseUnchecked(type, mb);
           }
         } else {
           // Only route 'up' when we recorded the matching 'down';
           // dropping avoids sending unpaired 'up' to an unrelated session.
+          // Use _sendMouseUnchecked to bypass permission checks so the
+          // release always goes through even if permissions changed.
           final model = _sideButtonDownModels.remove(mb);
           if (model != null) {
-            await model.sendMouse(type, mb);
+            await model._sendMouseUnchecked(type, mb);
           }
         }
       }
@@ -388,7 +392,7 @@ class InputModel {
     for (final mb in held) {
       _sideButtonDownModels.remove(mb);
       // Best-effort release; session may already be tearing down.
-      unawaited(sendMouse('up', mb).catchError((Object e) {
+      unawaited(_sendMouseUnchecked('up', mb).catchError((Object e) {
         debugPrint('[InputModel] failed to release side button $mb: $e');
       }));
     }
@@ -1033,13 +1037,20 @@ class InputModel {
     return evt;
   }
 
+  /// Send mouse event unconditionally (no permission checks).
+  /// Used for side button releases that must go through even if permissions
+  /// changed after the matching down was sent.
+  Future<void> _sendMouseUnchecked(String type, MouseButtons button) async {
+    await bind.sessionSendMouse(
+        sessionId: sessionId,
+        msg: json.encode(modify({'type': type, 'buttons': button.value})));
+  }
+
   /// Send mouse press event.
   Future<void> sendMouse(String type, MouseButtons button) async {
     if (!keyboardPerm) return;
     if (isViewCamera) return;
-    await bind.sessionSendMouse(
-        sessionId: sessionId,
-        msg: json.encode(modify({'type': type, 'buttons': button.value})));
+    await _sendMouseUnchecked(type, button);
   }
 
   void enterOrLeave(bool enter) {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -333,9 +333,10 @@ class InputModel {
   // Flutter's Linux embedder drops X11 button 8/9 events, so we capture them
   // natively via GDK and forward through the platform channel.
   static InputModel? _activeSideButtonModel;
-  // Tracks the model that received a side button down event, so the matching
-  // up event is routed there even if the pointer has left the remote view.
-  static InputModel? _sideButtonDownModel;
+  // Tracks per-button which model received a side button down event, so the
+  // matching up event is routed there even if the pointer has left the view
+  // or a different button was pressed in between.
+  static final Map<MouseButtons, InputModel> _sideButtonDownModels = {};
   static bool _sideButtonChannelInitialized = false;
 
   static void initSideButtonChannel() {
@@ -354,14 +355,14 @@ class InputModel {
         if (type == 'down') {
           final model = _activeSideButtonModel;
           if (model != null) {
-            _sideButtonDownModel = model;
+            _sideButtonDownModels[mb] = model;
             await model.sendMouse(type, mb);
           }
         } else {
           // Route 'up' to the model that received the matching 'down',
           // even if the pointer has since left the remote view.
-          final model = _sideButtonDownModel ?? _activeSideButtonModel;
-          _sideButtonDownModel = null;
+          final model =
+              _sideButtonDownModels.remove(mb) ?? _activeSideButtonModel;
           if (model != null) {
             await model.sendMouse(type, mb);
           }
@@ -374,7 +375,7 @@ class InputModel {
   /// Clear any static references to this model (prevents stale routing).
   void disposeSideButtonTracking() {
     if (_activeSideButtonModel == this) _activeSideButtonModel = null;
-    if (_sideButtonDownModel == this) _sideButtonDownModel = null;
+    _sideButtonDownModels.removeWhere((_, model) => model == this);
   }
 
   final WeakReference<FFI> parent;

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -363,7 +363,10 @@ class InputModel {
               model.keyboardPerm &&
               !model.isViewCamera) {
             _sideButtonDownModels[mb] = model;
-            await model._sendMouseUnchecked(type, mb);
+            // Fire-and-forget to avoid blocking the platform channel handler.
+            unawaited(model._sendMouseUnchecked(type, mb).catchError((Object e) {
+              debugPrint('[InputModel] failed to send side button $type for $mb: $e');
+            }));
           }
         } else {
           // Only route 'up' when we recorded the matching 'down';
@@ -372,7 +375,9 @@ class InputModel {
           // release always goes through even if permissions changed.
           final model = _sideButtonDownModels.remove(mb);
           if (model != null) {
-            await model._sendMouseUnchecked(type, mb);
+            unawaited(model._sendMouseUnchecked(type, mb).catchError((Object e) {
+              debugPrint('[InputModel] failed to send side button $type for $mb: $e');
+            }));
           }
         }
       }

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -354,15 +354,15 @@ class InputModel {
 
         if (type == 'down') {
           final model = _activeSideButtonModel;
-          if (model != null) {
+          if (model != null &&
+              !(model.isViewOnly && !model.showMyCursor)) {
             _sideButtonDownModels[mb] = model;
             await model.sendMouse(type, mb);
           }
         } else {
-          // Route 'up' to the model that received the matching 'down',
-          // even if the pointer has since left the remote view.
-          final model =
-              _sideButtonDownModels.remove(mb) ?? _activeSideButtonModel;
+          // Only route 'up' when we recorded the matching 'down';
+          // dropping avoids sending unpaired 'up' to an unrelated session.
+          final model = _sideButtonDownModels.remove(mb);
           if (model != null) {
             await model.sendMouse(type, mb);
           }
@@ -373,9 +373,18 @@ class InputModel {
   }
 
   /// Clear any static references to this model (prevents stale routing).
+  /// Releases any held side buttons on the peer so closing a session
+  /// mid-press does not leave a stuck button.
   void disposeSideButtonTracking() {
     if (_activeSideButtonModel == this) _activeSideButtonModel = null;
-    _sideButtonDownModels.removeWhere((_, model) => model == this);
+    final held = _sideButtonDownModels.entries
+        .where((e) => e.value == this)
+        .map((e) => e.key)
+        .toList();
+    for (final mb in held) {
+      _sideButtonDownModels.remove(mb);
+      unawaited(sendMouse('up', mb));
+    }
   }
 
   final WeakReference<FFI> parent;

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -20,7 +20,7 @@ import '../common.dart';
 import '../consts.dart';
 
 /// Mouse button enum.
-enum MouseButtons { left, right, wheel, back }
+enum MouseButtons { left, right, wheel, back, forward }
 
 const _kMouseEventDown = 'mousedown';
 const _kMouseEventUp = 'mouseup';
@@ -157,6 +157,8 @@ extension ToString on MouseButtons {
         return 'wheel';
       case MouseButtons.back:
         return 'back';
+      case MouseButtons.forward:
+        return 'forward';
     }
   }
 }
@@ -327,6 +329,54 @@ class ToReleaseKeys {
 }
 
 class InputModel {
+  // Side mouse button support for Linux.
+  // Flutter's Linux embedder drops X11 button 8/9 events, so we capture them
+  // natively via GDK and forward through the platform channel.
+  static InputModel? _activeSideButtonModel;
+  // Tracks the model that received a side button down event, so the matching
+  // up event is routed there even if the pointer has left the remote view.
+  static InputModel? _sideButtonDownModel;
+  static bool _sideButtonChannelInitialized = false;
+
+  static void initSideButtonChannel() {
+    if (!Platform.isLinux) return;
+    if (_sideButtonChannelInitialized) return;
+    _sideButtonChannelInitialized = true;
+
+    const channel = MethodChannel('org.rustdesk.rustdesk/side_buttons');
+    channel.setMethodCallHandler((call) async {
+      if (call.method == 'onSideMouseButton') {
+        final args = call.arguments as Map<dynamic, dynamic>;
+        final button = args['button'] as String;
+        final type = args['type'] as String;
+        final mb = button == 'back' ? MouseButtons.back : MouseButtons.forward;
+
+        if (type == 'down') {
+          final model = _activeSideButtonModel;
+          if (model != null) {
+            _sideButtonDownModel = model;
+            await model.sendMouse(type, mb);
+          }
+        } else {
+          // Route 'up' to the model that received the matching 'down',
+          // even if the pointer has since left the remote view.
+          final model = _sideButtonDownModel ?? _activeSideButtonModel;
+          _sideButtonDownModel = null;
+          if (model != null) {
+            await model.sendMouse(type, mb);
+          }
+        }
+      }
+      return null;
+    });
+  }
+
+  /// Clear any static references to this model (prevents stale routing).
+  void disposeSideButtonTracking() {
+    if (_activeSideButtonModel == this) _activeSideButtonModel = null;
+    if (_sideButtonDownModel == this) _sideButtonDownModel = null;
+  }
+
   final WeakReference<FFI> parent;
   String keyboardMode = '';
 
@@ -981,6 +1031,13 @@ class InputModel {
     _pointerMovedAfterEnter = false;
     _pointerInsideImage = enter;
     _lastWheelTsUs = 0;
+
+    // Track active model for side button events (Linux).
+    if (enter) {
+      _activeSideButtonModel = this;
+    } else if (_activeSideButtonModel == this) {
+      _activeSideButtonModel = null;
+    }
 
     // Fix status
     if (!enter) {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -3932,6 +3932,7 @@ class FFI {
     inputModel.resetModifiers();
     // Dispose relative mouse mode resources to ensure cursor is restored
     inputModel.disposeRelativeMouseMode();
+    inputModel.disposeSideButtonTracking();
     if (closeSession) {
       await bind.sessionClose(sessionId: sessionId);
     }

--- a/flutter/linux/my_application.cc
+++ b/flutter/linux/my_application.cc
@@ -29,6 +29,78 @@ void try_set_transparent(GtkWindow* window, GdkScreen* screen, FlView* view);
 
 extern bool gIsConnectionManager;
 
+// --- Side mouse button support (back/forward) ---
+// Flutter's Linux embedder doesn't deliver X11 button 8/9 events to Dart.
+// We intercept them via GDK and forward through a dedicated platform channel.
+
+static const char* kSideButtonChannelName = "org.rustdesk.rustdesk/side_buttons";
+
+static gboolean on_side_button_event(GtkWidget* widget, GdkEventButton* event, gpointer user_data) {
+  if (event->button != 8 && event->button != 9) {
+    return FALSE;
+  }
+  // Ignore GDK_2BUTTON_PRESS / GDK_3BUTTON_PRESS (double/triple-click synthetic
+  // events) - only handle real press and release.
+  if (event->type != GDK_BUTTON_PRESS && event->type != GDK_BUTTON_RELEASE) {
+    return FALSE;
+  }
+
+  FlMethodChannel* channel = FL_METHOD_CHANNEL(user_data);
+  if (channel == NULL) return FALSE;
+
+  g_autoptr(FlValue) args = fl_value_new_map();
+  fl_value_set_string_take(args, "button",
+    fl_value_new_string(event->button == 8 ? "back" : "forward"));
+  fl_value_set_string_take(args, "type",
+    fl_value_new_string(event->type == GDK_BUTTON_PRESS ? "down" : "up"));
+
+  fl_method_channel_invoke_method(channel, "onSideMouseButton", args,
+    NULL, NULL, NULL);
+
+  return TRUE;
+}
+
+static FlMethodChannel* side_buttons_create_channel(FlEngine* engine) {
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  return fl_method_channel_new(
+    fl_engine_get_binary_messenger(engine),
+    kSideButtonChannelName,
+    FL_METHOD_CODEC(codec));
+}
+
+static void side_buttons_channel_destroy(gpointer data) {
+  g_object_unref(data);
+}
+
+static void side_buttons_init_for_window(GtkWindow* window, FlMethodChannel* channel) {
+  // Guard against double-initialization (would leave dangling signal user_data).
+  if (g_object_get_data(G_OBJECT(window), "side-buttons-channel") != NULL) return;
+
+  gtk_widget_add_events(GTK_WIDGET(window),
+    GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK);
+  // Store channel on the window so it stays alive and is freed with the window.
+  g_object_set_data_full(G_OBJECT(window), "side-buttons-channel",
+    g_object_ref(channel), side_buttons_channel_destroy);
+  g_signal_connect(window, "button-press-event",
+    G_CALLBACK(on_side_button_event), channel);
+  g_signal_connect(window, "button-release-event",
+    G_CALLBACK(on_side_button_event), channel);
+}
+
+static void on_subwindow_created(FlPluginRegistry* registry) {
+#if defined(GDK_WINDOWING_WAYLAND) && defined(HAS_KEYBOARD_SHORTCUTS_INHIBIT)
+  wayland_shortcuts_inhibit_init_for_subwindow(registry);
+#endif
+  // Set up side button forwarding for sub-windows.
+  FlView* view = FL_VIEW(registry);
+  GtkWidget* toplevel = gtk_widget_get_toplevel(GTK_WIDGET(view));
+  if (toplevel != NULL && GTK_IS_WINDOW(toplevel)) {
+    FlMethodChannel* channel = side_buttons_create_channel(fl_view_get_engine(view));
+    side_buttons_init_for_window(GTK_WINDOW(toplevel), channel);
+    g_object_unref(channel);  // window now owns a ref via g_object_set_data_full
+  }
+}
+
 GtkWidget *find_gl_area(GtkWidget *widget);
 
 // Implements GApplication::activate.
@@ -96,12 +168,10 @@ static void my_application_activate(GApplication* application) {
   gtk_widget_show(GTK_WIDGET(window));
   gtk_widget_show(GTK_WIDGET(view));
 
-#if defined(GDK_WINDOWING_WAYLAND) && defined(HAS_KEYBOARD_SHORTCUTS_INHIBIT)
-  // Register callback for sub-windows created by desktop_multi_window plugin
-  // Only sub-windows (remote windows) need keyboard shortcuts inhibition
+  // Register callback for sub-windows created by desktop_multi_window plugin.
+  // Handles both Wayland shortcuts inhibition and side button forwarding.
   desktop_multi_window_plugin_set_window_created_callback(
-      (WindowCreatedCallback)wayland_shortcuts_inhibit_init_for_subwindow);
-#endif
+      (WindowCreatedCallback)on_subwindow_created);
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
@@ -115,6 +185,11 @@ static void my_application_activate(GApplication* application) {
     host_channel_call_handler,
     self,
     nullptr);
+
+  // Forward side mouse button events (back/forward) to Dart on the main window.
+  FlMethodChannel* side_channel = side_buttons_create_channel(fl_view_get_engine(view));
+  side_buttons_init_for_window(window, side_channel);
+  g_object_unref(side_channel);
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }

--- a/flutter/linux/my_application.cc
+++ b/flutter/linux/my_application.cc
@@ -169,7 +169,9 @@ static void my_application_activate(GApplication* application) {
   gtk_widget_show(GTK_WIDGET(view));
 
   // Register callback for sub-windows created by desktop_multi_window plugin.
-  // Handles both Wayland shortcuts inhibition and side button forwarding.
+  // Handles both Wayland shortcuts inhibition (guarded inside) and side button
+  // forwarding. Safe to call on X11-only builds - the plugin just stores the
+  // callback pointer regardless of windowing system.
   desktop_multi_window_plugin_set_window_created_callback(
       (WindowCreatedCallback)on_subwindow_created);
 

--- a/flutter/linux/my_application.cc
+++ b/flutter/linux/my_application.cc
@@ -92,10 +92,12 @@ static void on_subwindow_created(FlPluginRegistry* registry) {
   wayland_shortcuts_inhibit_init_for_subwindow(registry);
 #endif
   // Set up side button forwarding for sub-windows.
+  if (registry == NULL || !FL_IS_VIEW(registry)) return;
   FlView* view = FL_VIEW(registry);
   GtkWidget* toplevel = gtk_widget_get_toplevel(GTK_WIDGET(view));
   if (toplevel != NULL && GTK_IS_WINDOW(toplevel)) {
     FlMethodChannel* channel = side_buttons_create_channel(fl_view_get_engine(view));
+    if (channel == NULL) return;
     side_buttons_init_for_window(GTK_WINDOW(toplevel), channel);
     g_object_unref(channel);  // window now owns a ref via g_object_set_data_full
   }

--- a/libs/enigo/src/linux/xdo.rs
+++ b/libs/enigo/src/linux/xdo.rs
@@ -8,6 +8,7 @@
 use crate::{Key, KeyboardControllable, MouseButton, MouseControllable};
 
 use hbb_common::libc::c_int;
+use hbb_common::x11::xlib::{Display, XGetPointerMapping, XSetPointerMapping};
 use libxdo_sys::{self, xdo_t, CURRENTWINDOW};
 use std::{borrow::Cow, ffi::CString};
 
@@ -32,6 +33,75 @@ fn mousebutton(button: MouseButton) -> c_int {
     }
 }
 
+/// Minimum number of buttons the X11 core pointer must support.
+/// Buttons 8 (Back) and 9 (Forward) are needed for mouse side buttons.
+const MIN_POINTER_BUTTONS: usize = 9;
+
+/// Ensure the X11 core pointer's button map includes at least 9 buttons so that
+/// `XTestFakeButtonEvent` can simulate Back (8) and Forward (9) side buttons.
+///
+/// On headless or remote machines the XTEST virtual pointer often only advertises
+/// buttons 1-3 (or 1-7). Without extending the map, libxdo's calls for buttons
+/// 8/9 are silently ignored by the X server.
+fn ensure_x11_button_map(xdo: *mut xdo_t) {
+    // The first field of libxdo's xdo_t struct is `Display *xdpy` (offset 0).
+    let display: *mut Display = unsafe { *(xdo as *const *mut Display) };
+    if display.is_null() {
+        log::warn!("xdo Display pointer is null, cannot extend button map");
+        return;
+    }
+
+    let mut current_map = [0u8; 32];
+    let nbuttons =
+        unsafe { XGetPointerMapping(display, current_map.as_mut_ptr(), current_map.len() as i32) };
+
+    if nbuttons < 0 {
+        log::warn!("XGetPointerMapping failed (returned {nbuttons})");
+        return;
+    }
+
+    let nbuttons = nbuttons as usize;
+    if nbuttons >= MIN_POINTER_BUTTONS {
+        log::info!("X11 pointer already has {nbuttons} buttons, no extension needed");
+        return;
+    }
+
+    // Preserve existing entries, append identity mapping for new ones.
+    let mut new_map = [0u8; MIN_POINTER_BUTTONS];
+    new_map[..nbuttons].copy_from_slice(&current_map[..nbuttons]);
+    for i in nbuttons..MIN_POINTER_BUTTONS {
+        new_map[i] = (i + 1) as u8;
+    }
+
+    // XSetPointerMapping returns:
+    //   MappingSuccess (0) - mapping was changed
+    //   MappingBusy    (1) - a button is currently held, try again later
+    //   MappingFailed  (2) - the server rejected the mapping
+    const MAPPING_SUCCESS: c_int = 0;
+    const MAPPING_BUSY: c_int = 1;
+    const MAX_RETRIES: usize = 5;
+    const RETRY_DELAY_MS: u64 = 100;
+
+    for attempt in 1..=MAX_RETRIES {
+        let result = unsafe {
+            XSetPointerMapping(display, new_map.as_ptr(), MIN_POINTER_BUTTONS as c_int)
+        };
+        if result == MAPPING_SUCCESS {
+            log::info!("Extended X11 pointer button map from {nbuttons} to {MIN_POINTER_BUTTONS} buttons");
+            return;
+        }
+        if result == MAPPING_BUSY {
+            log::info!("XSetPointerMapping returned MappingBusy (attempt {attempt}), retrying");
+            std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
+            continue;
+        }
+        // MappingFailed or unexpected code - no point retrying.
+        log::warn!("XSetPointerMapping failed with code {result} (tried {nbuttons} -> {MIN_POINTER_BUTTONS})");
+        return;
+    }
+    log::warn!("XSetPointerMapping failed after {MAX_RETRIES} retries (all MappingBusy)");
+}
+
 /// The main struct for handling the event emitting
 pub(super) struct EnigoXdo {
     xdo: *mut xdo_t,
@@ -52,6 +122,7 @@ impl Default for EnigoXdo {
             log::warn!("Failed to create xdo context, xdo functions will be disabled");
         } else {
             log::info!("xdo context created successfully");
+            ensure_x11_button_map(xdo);
         }
         Self {
             xdo,

--- a/libs/enigo/src/linux/xdo.rs
+++ b/libs/enigo/src/linux/xdo.rs
@@ -45,6 +45,12 @@ const MIN_POINTER_BUTTONS: usize = 9;
 /// diagnosable. `XSetPointerMapping` cannot extend the button count (its
 /// length must match `XGetPointerMapping`), so we only diagnose here.
 fn check_x11_button_map() {
+    // Skip on non-X11 sessions to avoid noisy "XOpenDisplay failed" warnings
+    // on pure Wayland or headless environments without $DISPLAY.
+    if std::env::var_os("DISPLAY").is_none() {
+        return;
+    }
+
     let display: *mut Display = unsafe { XOpenDisplay(std::ptr::null()) };
     if display.is_null() {
         log::warn!("XOpenDisplay failed, cannot check button map");

--- a/libs/enigo/src/linux/xdo.rs
+++ b/libs/enigo/src/linux/xdo.rs
@@ -8,7 +8,7 @@
 use crate::{Key, KeyboardControllable, MouseButton, MouseControllable};
 
 use hbb_common::libc::c_int;
-use hbb_common::x11::xlib::{Display, XGetPointerMapping, XSetPointerMapping};
+use hbb_common::x11::xlib::{Display, XCloseDisplay, XGetPointerMapping, XOpenDisplay, XSetPointerMapping};
 use libxdo_sys::{self, xdo_t, CURRENTWINDOW};
 use std::{borrow::Cow, ffi::CString};
 
@@ -43,11 +43,12 @@ const MIN_POINTER_BUTTONS: usize = 9;
 /// On headless or remote machines the XTEST virtual pointer often only advertises
 /// buttons 1-3 (or 1-7). Without extending the map, libxdo's calls for buttons
 /// 8/9 are silently ignored by the X server.
-fn ensure_x11_button_map(xdo: *mut xdo_t) {
-    // The first field of libxdo's xdo_t struct is `Display *xdpy` (offset 0).
-    let display: *mut Display = unsafe { *(xdo as *const *mut Display) };
+fn ensure_x11_button_map() {
+    // Open an independent display connection rather than extracting the pointer
+    // from xdo_t's private struct layout (which is an undocumented ABI detail).
+    let display: *mut Display = unsafe { XOpenDisplay(std::ptr::null()) };
     if display.is_null() {
-        log::warn!("xdo Display pointer is null, cannot extend button map");
+        log::warn!("XOpenDisplay failed, cannot extend button map");
         return;
     }
 
@@ -57,12 +58,14 @@ fn ensure_x11_button_map(xdo: *mut xdo_t) {
 
     if nbuttons < 0 {
         log::warn!("XGetPointerMapping failed (returned {nbuttons})");
+        unsafe { XCloseDisplay(display) };
         return;
     }
 
     let nbuttons = nbuttons as usize;
     if nbuttons >= MIN_POINTER_BUTTONS {
         log::info!("X11 pointer already has {nbuttons} buttons, no extension needed");
+        unsafe { XCloseDisplay(display) };
         return;
     }
 
@@ -88,7 +91,7 @@ fn ensure_x11_button_map(xdo: *mut xdo_t) {
         };
         if result == MAPPING_SUCCESS {
             log::info!("Extended X11 pointer button map from {nbuttons} to {MIN_POINTER_BUTTONS} buttons");
-            return;
+            break;
         }
         if result == MAPPING_BUSY {
             log::info!("XSetPointerMapping returned MappingBusy (attempt {attempt}), retrying");
@@ -97,9 +100,10 @@ fn ensure_x11_button_map(xdo: *mut xdo_t) {
         }
         // MappingFailed or unexpected code - no point retrying.
         log::warn!("XSetPointerMapping failed with code {result} (tried {nbuttons} -> {MIN_POINTER_BUTTONS})");
-        return;
+        break;
     }
-    log::warn!("XSetPointerMapping failed after {MAX_RETRIES} retries (all MappingBusy)");
+
+    unsafe { XCloseDisplay(display) };
 }
 
 /// The main struct for handling the event emitting
@@ -122,7 +126,7 @@ impl Default for EnigoXdo {
             log::warn!("Failed to create xdo context, xdo functions will be disabled");
         } else {
             log::info!("xdo context created successfully");
-            ensure_x11_button_map(xdo);
+            ensure_x11_button_map();
         }
         Self {
             xdo,

--- a/libs/enigo/src/linux/xdo.rs
+++ b/libs/enigo/src/linux/xdo.rs
@@ -8,7 +8,7 @@
 use crate::{Key, KeyboardControllable, MouseButton, MouseControllable};
 
 use hbb_common::libc::c_int;
-use hbb_common::x11::xlib::{Display, XCloseDisplay, XGetPointerMapping, XOpenDisplay, XSetPointerMapping};
+use hbb_common::x11::xlib::{Display, XCloseDisplay, XGetPointerMapping, XOpenDisplay};
 use libxdo_sys::{self, xdo_t, CURRENTWINDOW};
 use std::{borrow::Cow, ffi::CString};
 
@@ -37,78 +37,39 @@ fn mousebutton(button: MouseButton) -> c_int {
 /// Buttons 8 (Back) and 9 (Forward) are needed for mouse side buttons.
 const MIN_POINTER_BUTTONS: usize = 9;
 
-/// Ensure the X11 core pointer's button map includes at least 9 buttons so that
-/// `XTestFakeButtonEvent` can simulate Back (8) and Forward (9) side buttons.
+/// Check that the X11 core pointer's button map includes at least 9 buttons
+/// so that `XTestFakeButtonEvent` can simulate Back (8) and Forward (9).
 ///
-/// On headless or remote machines the XTEST virtual pointer often only advertises
-/// buttons 1-3 (or 1-7). Without extending the map, libxdo's calls for buttons
-/// 8/9 are silently ignored by the X server.
-///
-/// NOTE: `XSetPointerMapping` mutates the global X11 pointer map (not per-client).
-/// On typical desktops with >= 9 buttons this is a no-op. On minimal/headless
-/// servers it appends identity entries that persist for the X server's lifetime.
-/// Called once from `EnigoXdo::default()` which is a lazy_static singleton.
-fn ensure_x11_button_map() {
-    // Open an independent display connection rather than extracting the pointer
-    // from xdo_t's private struct layout (which is an undocumented ABI detail).
+/// RustDesk's uinput "Mouse passthrough" device normally provides enough
+/// buttons, but we log a warning if the map is too small so the issue is
+/// diagnosable. `XSetPointerMapping` cannot extend the button count (its
+/// length must match `XGetPointerMapping`), so we only diagnose here.
+fn check_x11_button_map() {
     let display: *mut Display = unsafe { XOpenDisplay(std::ptr::null()) };
     if display.is_null() {
-        log::warn!("XOpenDisplay failed, cannot extend button map");
+        log::warn!("XOpenDisplay failed, cannot check button map");
         return;
     }
 
     let mut current_map = [0u8; 32];
     let nbuttons =
         unsafe { XGetPointerMapping(display, current_map.as_mut_ptr(), current_map.len() as i32) };
+    unsafe { XCloseDisplay(display) };
 
     if nbuttons < 0 {
         log::warn!("XGetPointerMapping failed (returned {nbuttons})");
-        unsafe { XCloseDisplay(display) };
         return;
     }
 
     let nbuttons = nbuttons as usize;
     if nbuttons >= MIN_POINTER_BUTTONS {
-        log::info!("X11 pointer already has {nbuttons} buttons, no extension needed");
-        unsafe { XCloseDisplay(display) };
-        return;
+        log::info!("X11 pointer has {nbuttons} buttons, side buttons supported");
+    } else {
+        log::warn!(
+            "X11 pointer has only {nbuttons} buttons (need {MIN_POINTER_BUTTONS}); \
+             back/forward side buttons may not work until a device with more buttons is added"
+        );
     }
-
-    // Preserve existing entries, append identity mapping for new ones.
-    let mut new_map = [0u8; MIN_POINTER_BUTTONS];
-    new_map[..nbuttons].copy_from_slice(&current_map[..nbuttons]);
-    for i in nbuttons..MIN_POINTER_BUTTONS {
-        new_map[i] = (i + 1) as u8;
-    }
-
-    // XSetPointerMapping returns:
-    //   MappingSuccess (0) - mapping was changed
-    //   MappingBusy    (1) - a button is currently held, try again later
-    //   MappingFailed  (2) - the server rejected the mapping
-    const MAPPING_SUCCESS: c_int = 0;
-    const MAPPING_BUSY: c_int = 1;
-    const MAX_RETRIES: usize = 5;
-    const RETRY_DELAY_MS: u64 = 100;
-
-    for attempt in 1..=MAX_RETRIES {
-        let result = unsafe {
-            XSetPointerMapping(display, new_map.as_ptr(), MIN_POINTER_BUTTONS as c_int)
-        };
-        if result == MAPPING_SUCCESS {
-            log::info!("Extended X11 pointer button map from {nbuttons} to {MIN_POINTER_BUTTONS} buttons");
-            break;
-        }
-        if result == MAPPING_BUSY {
-            log::info!("XSetPointerMapping returned MappingBusy (attempt {attempt}), retrying");
-            std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
-            continue;
-        }
-        // MappingFailed or unexpected code - no point retrying.
-        log::warn!("XSetPointerMapping failed with code {result} (tried {nbuttons} -> {MIN_POINTER_BUTTONS})");
-        break;
-    }
-
-    unsafe { XCloseDisplay(display) };
 }
 
 /// The main struct for handling the event emitting
@@ -131,7 +92,7 @@ impl Default for EnigoXdo {
             log::warn!("Failed to create xdo context, xdo functions will be disabled");
         } else {
             log::info!("xdo context created successfully");
-            ensure_x11_button_map();
+            check_x11_button_map();
         }
         Self {
             xdo,

--- a/libs/enigo/src/linux/xdo.rs
+++ b/libs/enigo/src/linux/xdo.rs
@@ -43,6 +43,11 @@ const MIN_POINTER_BUTTONS: usize = 9;
 /// On headless or remote machines the XTEST virtual pointer often only advertises
 /// buttons 1-3 (or 1-7). Without extending the map, libxdo's calls for buttons
 /// 8/9 are silently ignored by the X server.
+///
+/// NOTE: `XSetPointerMapping` mutates the global X11 pointer map (not per-client).
+/// On typical desktops with >= 9 buttons this is a no-op. On minimal/headless
+/// servers it appends identity entries that persist for the X server's lifetime.
+/// Called once from `EnigoXdo::default()` which is a lazy_static singleton.
 fn ensure_x11_button_map() {
     // Open an independent display connection rather than extracting the pointer
     // from xdo_t's private struct layout (which is an undocumented ABI detail).


### PR DESCRIPTION
## Summary

- Mouse back/forward buttons (X11 buttons 8/9) were silently dropped in Linux remote sessions because Flutter's Linux embedder never delivers these button events to Dart code
- Intercept buttons 8/9 at the GDK level via `button-press-event`/`button-release-event` handlers on all windows (main + sub-windows) and forward them through a dedicated platform channel (`org.rustdesk.rustdesk/side_buttons`) to the active session's InputModel
- Add `forward` to the `MouseButtons` enum (only `back` was defined)
- Add defensive `XSetPointerMapping` call during enigo init to extend the X11 core pointer button map on servers with minimal X configurations

## Details

**Client side (C)** — `flutter/linux/my_application.cc`:
- GDK signal handler filters for buttons 8/9, ignores double/triple-click synthetic events
- Per-window `FlMethodChannel` with proper GObject lifecycle (`g_object_set_data_full`)
- Sub-windows handled via unified `on_subwindow_created` callback (also chains existing Wayland shortcuts inhibition)

**Client side (Dart)** — `flutter/lib/models/input_model.dart`:
- Separate `_sideButtonDownModel` tracking ensures button-up is routed to the model that received button-down, even if the pointer has left the remote view
- `disposeSideButtonTracking()` clears stale references on session close

**Server side (Rust)** — `libs/enigo/src/linux/xdo.rs`:
- `ensure_x11_button_map()` extends core pointer to 9+ buttons if needed (defensive, most X servers already have sufficient buttons)

## Test plan
- [x] Tested on X11: side buttons (back/forward) register correctly in remote session
- [ ] Wayland: not tested (no Wayland test environment), but side button code is X11-only and Wayland shortcuts inhibition path is preserved
- [ ] Multi-window: sub-window callback handles side button setup for remote session windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux side-mouse-button support extended to both back and forward buttons, forwarded to the active remote view.

* **Bug Fixes**
  * Better tracking and cleanup of side-button routing when views/sessions close; unmatched release events are dropped to prevent stray actions.

* **Chores**
  * Added X11 pointer-button diagnostics to detect and log Linux mouse compatibility issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->