### PR TITLE
Preserve leading and trailing spaces in OS passwords

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -902,7 +902,7 @@ _connectDialog(
         }
       }
       final osUsername = osUsernameController?.text.trim() ?? '';
-      final osPassword = osPasswordController?.text.trim() ?? '';
+      final osPassword = osPasswordController?.text ?? '';
       final password = passwordController?.text.trim() ?? '';
       if (passwordController != null && password.isEmpty) return;
       if (rememberAccount) {
@@ -1374,7 +1374,7 @@ showSetOSPassword(
     }
 
     submit() {
-      var text = controller.text.trim();
+      var text = controller.text;
       bind.sessionPeerOption(
           sessionId: sessionId, name: 'os-password', value: text);
       bind.sessionPeerOption(

--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -1450,7 +1450,7 @@ showSetOSAccount(
   dialogManager.show((setState, close, context) {
     submit() {
       final username = usernameController.text.trim();
-      final password = usernameController.text.trim();
+      final password = passwdController.text;
       bind.sessionPeerOption(
           sessionId: sessionId, name: 'os-username', value: username);
       bind.sessionPeerOption(

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -81,7 +81,7 @@ function editOSPassword(login=false) {
     msgbox("custom-os-password", 'OS Password', p0, "", function(res=null) {
         if (!res) return;
         var a0 = handler.get_option('auto-login') != '';
-        var p = (res.password || '').trim();
+        var p = (res.password || '');
         var a = res.autoLogin || false;
         if (p == p0 && a == a0) return;
         if (p != p0) handler.set_option('os-password', p);

--- a/src/ui/msgbox.tis
+++ b/src/ui/msgbox.tis
@@ -348,7 +348,7 @@ class MsgboxComponent: Reactor.Component {
         }
         if (this.type == "session-login") {
             values.osusername = (values.osusername || "").trim();
-            values.ospassword = (values.ospassword || "").trim();
+            values.ospassword = (values.ospassword || "");
             if (!values.osusername || !values.ospassword) {
                 return;
             }
@@ -356,7 +356,7 @@ class MsgboxComponent: Reactor.Component {
         if (this.type == "session-login-password") {
             values.password = (values.password || "").trim();
             values.osusername = (values.osusername || "").trim();
-            values.ospassword = (values.ospassword || "").trim();
+            values.ospassword = (values.ospassword || "");
             if (!values.osusername || !values.ospassword || !values.password) {
                 return;
             }


### PR DESCRIPTION
This PR fixes an issue where OS passwords were being trimmed before being saved or submitted.

Some operating system passwords may intentionally include whitespace at the beginning or end. In the current flow, the UI was calling trim() on the OS password in both Flutter and Sciter paths, which caused the stored/sent value to differ from what the user actually entered.

This change removes trimming only for the os-password field in the affected login and save flows, while keeping the existing behavior unchanged for other fields such as usernames and the main RustDesk password.

**Updated areas**
- Flutter OS password save flow
- Flutter session login flow
- Sciter OS password dialog flow
- Sciter session login flow

**Result**
- OS passwords are now stored and submitted exactly as entered
- Leading and trailing spaces are preserved
- Existing trimming behavior for unrelated fields remains unchanged

**Notes**
- No backend config change was required
- The issue was caused in the UI layer before persistence/submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OS password fields now preserve exactly what users enter (including leading/trailing spaces) across prompts, dialogs, and login attempts.
  * Fixed an issue where the OS password could be incorrectly taken from the username input; passwords are now read from the correct password input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->