### PR TITLE
fix(sicter): control side, privacy mode

### DIFF
--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -602,7 +602,13 @@ function togglePrivacyMode(privacy_id) {
     if (!supported) {
         msgbox("nocancel", translate("Privacy mode"), translate("Unsupported"), "", function() { });
     } else {
-        handler.toggle_option(privacy_id);
+        var privacy_mode_impls = pi.platform_additions?.supported_privacy_mode_impl;
+        if (privacy_mode_impls == null || privacy_mode_impls == undefined) {
+            handler.toggle_option(privacy_id);
+            return;
+        }
+        var is_on = handler.get_toggle_option("privacy-mode");
+        handler.toggle_privacy_mode("", !is_on);
     }
 }
 

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -85,6 +85,22 @@ impl SciterHandler {
                     serde_json::Value::Bool(b) => {
                         value.set_item(k, b);
                     }
+                    serde_json::Value::Array(arr) if k == "supported_privacy_mode_impl" => {
+                        let mut impls = Value::array(0);
+                        for item in arr {
+                            if let serde_json::Value::Array(entry) = item {
+                                let impl_key = entry.get(0).and_then(|v| v.as_str());
+                                let impl_name = entry.get(1).and_then(|v| v.as_str());
+                                if let (Some(impl_key), Some(impl_name)) = (impl_key, impl_name) {
+                                    let mut impl_item = Value::array(0);
+                                    impl_item.push(impl_key);
+                                    impl_item.push(impl_name);
+                                    impls.push(impl_item);
+                                }
+                            }
+                        }
+                        value.set_item(k, impls);
+                    }
                     _ => {
                         // ignore for now
                     }
@@ -550,6 +566,7 @@ impl sciter::EventHandler for SciterSession {
         fn get_toggle_option(String);
         fn is_privacy_mode_supported();
         fn toggle_option(String);
+        fn toggle_privacy_mode(String, bool);
         fn get_remember();
         fn peer_platform();
         fn set_write_override(i32, i32, bool, bool, bool);


### PR DESCRIPTION
Fix sciter: align implementation with https://github.com/rustdesk/rustdesk/blob/47e4c65d8e888b9d27e33bd596f6e8ca4d69e451/flutter/lib/common/widgets/toolbar.dart#L791

The menu button has been outdated (peer version >= `1.2.4`) since PR #6406.

The options "Mode 1" & "Mode 2" are not aligned. Since it is rarely used in the Sciter version.

## Tests

Controlled side version `1.2.3-2` and `1.4.6`.
