### PR TITLE
feat(i18n): Complete and fix french translations

### DIFF
--- a/docs/CODE_OF_CONDUCT-FR.md
+++ b/docs/CODE_OF_CONDUCT-FR.md
@@ -1,0 +1,143 @@
+
+# Code de conduite des contributeurs
+
+## Notre engagement
+
+En tant que membres, contributeurs et responsables, nous nous engageons à faire
+de la participation à notre communauté une expérience exempte de harcèlement pour
+tous, indépendamment de l'âge, de la taille corporelle, du handicap visible ou
+invisible, de l'origine ethnique, des caractéristiques sexuelles, de l'identité
+et de l'expression de genre, du niveau d'expérience, de l'éducation, du statut
+socio-économique, de la nationalité, de l'apparence personnelle, de la race, de
+la religion ou de l'identité et de l'orientation sexuelle.
+
+Nous nous engageons à agir et à interagir de manière à contribuer à une
+communauté ouverte, accueillante, diversifiée, inclusive et saine.
+
+## Nos standards
+
+Exemples de comportements qui contribuent à un environnement positif pour notre
+communauté :
+
+* Faire preuve d'empathie et de bienveillance envers les autres
+* Respecter les opinions, les points de vue et les expériences différents
+* Donner et accepter gracieusement les retours constructifs
+* Assumer ses responsabilités, s'excuser auprès des personnes affectées par nos
+  erreurs et apprendre de l'expérience
+* Se concentrer sur ce qui est le mieux non seulement pour nous en tant
+  qu'individus, mais pour l'ensemble de la communauté
+
+Exemples de comportements inacceptables :
+
+* L'utilisation de langage ou d'images à caractère sexuel, et les attentions ou
+  avances sexuelles de quelque nature que ce soit
+* Le trolling, les commentaires insultants ou désobligeants, et les attaques
+  personnelles ou politiques
+* Le harcèlement public ou privé
+* La publication d'informations privées d'autrui, telles qu'une adresse physique
+  ou électronique, sans autorisation explicite
+* Tout autre comportement qui pourrait raisonnablement être considéré comme
+  inapproprié dans un cadre professionnel
+
+## Responsabilités en matière d'application
+
+Les responsables de la communauté sont chargés de clarifier et d'appliquer nos
+standards de comportement acceptable et prendront des mesures correctives
+appropriées et équitables en réponse à tout comportement qu'ils jugent
+inapproprié, menaçant, offensant ou nuisible.
+
+Les responsables de la communauté ont le droit et la responsabilité de
+supprimer, modifier ou rejeter les commentaires, commits, code, modifications
+du wiki, issues et autres contributions qui ne sont pas conformes à ce Code de
+conduite, et communiqueront les raisons de leurs décisions de modération le cas
+échéant.
+
+## Portée
+
+Ce Code de conduite s'applique dans tous les espaces communautaires, et
+s'applique également lorsqu'une personne représente officiellement la communauté
+dans les espaces publics. Les exemples de représentation de notre communauté
+incluent l'utilisation d'une adresse e-mail officielle, la publication via un
+compte de réseau social officiel, ou le fait d'agir en tant que représentant
+désigné lors d'un événement en ligne ou hors ligne.
+
+## Application
+
+Les cas de comportements abusifs, harcelants ou autrement inacceptables peuvent
+être signalés aux responsables de la communauté chargés de l'application à
+[info@rustdesk.com](mailto:info@rustdesk.com).
+Toutes les plaintes seront examinées et feront l'objet d'une enquête rapide et
+équitable.
+
+Tous les responsables de la communauté sont tenus de respecter la vie privée et
+la sécurité de la personne ayant signalé un incident.
+
+## Directives d'application
+
+Les responsables de la communauté suivront ces Directives d'impact communautaire
+pour déterminer les conséquences de toute action qu'ils jugent en violation de ce
+Code de conduite :
+
+### 1. Correction
+
+**Impact communautaire** : Utilisation d'un langage inapproprié ou autre
+comportement jugé non professionnel ou indésirable dans la communauté.
+
+**Conséquence** : Un avertissement écrit et privé de la part des responsables de
+la communauté, expliquant la nature de la violation et pourquoi le comportement
+était inapproprié. Des excuses publiques peuvent être demandées.
+
+### 2. Avertissement
+
+**Impact communautaire** : Une violation par un incident isolé ou une série
+d'actions.
+
+**Conséquence** : Un avertissement avec des conséquences en cas de comportement
+répété. Aucune interaction avec les personnes impliquées, y compris les
+interactions non sollicitées avec les personnes chargées d'appliquer le Code de
+conduite, pendant une période déterminée. Cela inclut d'éviter les interactions
+dans les espaces communautaires ainsi que dans les canaux externes comme les
+réseaux sociaux. Le non-respect de ces conditions peut entraîner une exclusion
+temporaire ou permanente.
+
+### 3. Exclusion temporaire
+
+**Impact communautaire** : Une violation grave des standards communautaires, y
+compris un comportement inapproprié persistant.
+
+**Conséquence** : Une exclusion temporaire de toute interaction ou communication
+publique avec la communauté pendant une période déterminée. Aucune interaction
+publique ou privée avec les personnes impliquées, y compris les interactions non
+sollicitées avec les personnes chargées d'appliquer le Code de conduite, n'est
+autorisée pendant cette période. Le non-respect de ces conditions peut entraîner
+une exclusion permanente.
+
+### 4. Exclusion permanente
+
+**Impact communautaire** : Démontrer un schéma de violation des standards
+communautaires, y compris un comportement inapproprié persistant, le harcèlement
+d'une personne, ou une agression envers des catégories de personnes ou leur
+dénigrement.
+
+**Conséquence** : Une exclusion permanente de toute interaction publique au sein
+de la communauté.
+
+## Attribution
+
+Ce Code de conduite est adapté du [Contributor Covenant][homepage], version 2.0,
+disponible à l'adresse
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Les Directives d'impact communautaire ont été inspirées par
+[l'échelle d'application du code de conduite de Mozilla][Mozilla CoC].
+
+Pour des réponses aux questions fréquentes sur ce code de conduite, consultez la
+FAQ à l'adresse [https://www.contributor-covenant.org/faq][FAQ]. Des traductions
+sont disponibles à l'adresse
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/docs/CONTRIBUTING-FR.md
+++ b/docs/CONTRIBUTING-FR.md
@@ -1,0 +1,55 @@
+
+# Contribuer à RustDesk
+
+RustDesk accueille les contributions de tous. Voici les directives si vous
+envisagez de nous aider :
+
+## Contributions
+
+Les contributions à RustDesk ou à ses dépendances doivent être soumises sous
+forme de pull requests GitHub. Chaque pull request sera examinée par un
+contributeur principal (une personne ayant la permission d'intégrer des
+correctifs) et sera soit intégrée dans la branche principale, soit accompagnée
+de retours sur les modifications requises. Toutes les contributions doivent
+suivre ce format, même celles des contributeurs principaux.
+
+Si vous souhaitez travailler sur une issue, veuillez d'abord la revendiquer en
+commentant sur l'issue GitHub indiquant que vous souhaitez la traiter. Cela
+permet d'éviter les efforts en double de la part des contributeurs sur la même
+issue.
+
+## Liste de vérification pour les pull requests
+
+- Partez de la branche master et, si nécessaire, effectuez un rebase sur la
+  branche master actuelle avant de soumettre votre pull request. Si elle ne
+  fusionne pas proprement avec master, il vous sera peut-être demandé de
+  rebaser vos modifications.
+
+- Les commits doivent être aussi petits que possible, tout en s'assurant que
+  chaque commit est correct de manière indépendante (c.-à-d. que chaque commit
+  doit compiler et passer les tests).
+
+- Les commits doivent être accompagnés d'une signature Developer Certificate of
+  Origin (http://developercertificate.org), indiquant que vous (et votre
+  employeur le cas échéant) acceptez d'être liés par les termes de la
+  [licence du projet](../LICENCE). Dans git, il s'agit de l'option `-s` de
+  `git commit`.
+
+- Si votre correctif n'est pas examiné ou si vous avez besoin qu'une personne
+  spécifique l'examine, vous pouvez @-mentionner un relecteur pour demander une
+  revue dans la pull request ou un commentaire, ou vous pouvez demander une
+  revue par [e-mail](mailto:info@rustdesk.com).
+
+- Ajoutez des tests relatifs au bug corrigé ou à la nouvelle fonctionnalité.
+
+Pour des instructions git spécifiques, consultez le
+[GitHub workflow 101](https://github.com/servo/servo/wiki/GitHub-workflow).
+
+## Conduite
+
+https://github.com/rustdesk/rustdesk/blob/master/docs/CODE_OF_CONDUCT.md
+
+## Communication
+
+Les contributeurs de RustDesk se retrouvent fréquemment sur
+[Discord](https://discord.gg/nDceKgxnkV).

--- a/docs/README-FR.md
+++ b/docs/README-FR.md
@@ -34,9 +34,9 @@ Les versions de bureau utilisent [sciter](https://sciter.com/) pour l'interface 
 - Installez [vcpkg](https://github.com/microsoft/vcpkg), et définissez correctement la variable d'environnement `VCPKG_ROOT`.
 
   - Windows : vcpkg install libvpx:x64-windows-static libyuv:x64-windows-static opus:x64-windows-static aom:x64-windows-static
-  - Linux/Osx : vcpkg install libvpx libyuv opus aom
+  - Linux/macOS : vcpkg install libvpx libyuv opus aom
 
-- Exécuter `cargo run`
+- Exécutez `cargo run`
 
 ## Comment compiler/build sous Linux
 
@@ -93,7 +93,7 @@ cd rustdesk
 mkdir -p target/debug
 wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so
 mv libsciter-gtk.so target/debug
-Exécution du cargo
+cargo run
 ```
 
 ## Comment construire avec Docker

--- a/docs/SECURITY-FR.md
+++ b/docs/SECURITY-FR.md
@@ -1,0 +1,16 @@
+
+# Politique de sécurité
+
+## Signaler une vulnérabilité
+
+Nous accordons une très grande importance à la sécurité du projet. Nous
+encourageons tous les utilisateurs à nous signaler toute vulnérabilité qu'ils
+découvrent.
+
+Si vous trouvez une vulnérabilité de sécurité dans le projet RustDesk, veuillez
+la signaler de manière responsable en envoyant un e-mail à info@rustdesk.com.
+
+À ce stade, nous n'avons pas de programme de bug bounty. Nous sommes une petite
+équipe qui s'attaque à un grand défi. Nous vous encourageons vivement à signaler
+toute vulnérabilité de manière responsable afin que nous puissions continuer à
+développer une application sécurisée pour l'ensemble de la communauté.

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -741,7 +741,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-incoming-sessions-label", "Maintenir l’écran allumé lors des sessions entrantes"),
         ("Continue with {}", "Continuer avec {}"),
         ("Display Name", "Nom d’affichage"),
-        ("password-hidden-tip", ""),
-        ("preset-password-in-use-tip", ""),
+        ("password-hidden-tip", "Le mot de passe permanent est défini (masqué)."),
+        ("preset-password-in-use-tip", "Le mot de passe prédéfini est actuellement utilisé."),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
Hi ! Here is a short PR for some translations

### Fill in 2 missing translations:
password-hidden-tip: "Le mot de passe permanent est défini (masqué)."
preset-password-in-use-tip: "Le mot de passe prédéfini est actuellement utilisé."


### README-FR.md

Fix Linux/Osx → Linux/macOS for consistency
Fix verb form Exécuter → Exécutez to match the imperative style used throughout the section
Fix Exécution du cargo (erroneous translation) → cargo run in the shell code block

### docs/

Add CODE_OF_CONDUCT-FR.md — French translation of the Contributor Covenant code of conduct
Add CONTRIBUTING-FR.md — French translation of the contribution guidelines
Add SECURITY-FR.md — French translation of the security policy
These files were present for other languages (DE, IT, JP, KR, NL, NO, PL, RO, TR, ZH) but missing for French.