### PR TITLE
fix building on ubuntu-26.04

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9790,7 +9790,6 @@ dependencies = [
 [[package]]
 name = "webm"
 version = "1.1.0"
-source = "git+https://github.com/rustdesk-org/rust-webm#d2c4d3ac133c7b0e4c0f656da710b48391981e64"
 dependencies = [
  "webm-sys",
 ]
@@ -9798,7 +9797,6 @@ dependencies = [
 [[package]]
 name = "webm-sys"
 version = "1.0.4"
-source = "git+https://github.com/rustdesk-org/rust-webm#d2c4d3ac133c7b0e4c0f656da710b48391981e64"
 dependencies = [
  "cc",
 ]

--- a/libs/scrap/Cargo.toml
+++ b/libs/scrap/Cargo.toml
@@ -21,7 +21,7 @@ cfg-if = "1.0"
 num_cpus = "1.15"
 lazy_static = "1.4"
 hbb_common = { path = "../hbb_common" }
-webm = { git = "https://github.com/rustdesk-org/rust-webm" }
+webm = { path = "rust-webm" }
 serde = {version="1.0", features=["derive"]}
 
 [dependencies.winapi]


### PR DESCRIPTION
Try to fix #14899 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WebM library dependency and build configuration for local compilation resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->