### PR TITLE
Fix: replace unwrap() with proper error handling in CLI password prompt

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,13 @@ impl Session {
     pub fn new(id: &str, sender: mpsc::UnboundedSender<Data>) -> Self {
         let mut password = "".to_owned();
         if PeerConfig::load(id).password.is_empty() {
-            password = rpassword::prompt_password("Enter password: ").unwrap();
+            match rpassword::prompt_password("Enter password: ") {
+                Ok(p) => password = p,
+                Err(e) => {
+                    log::error!("Failed to read password: {:?}", e);
+                    password = "".to_owned();
+                }
+            }
         }
         let session = Self {
             id: id.to_owned(),


### PR DESCRIPTION
Fix: replace unwrap() with proper error handling in CLI password prompt

- Replaced unwrap() with proper error handling for password prompt in src/cli.rs
- Follows project's Rust rules (no unwrap/expect)
- Matches error handling pattern used elsewhere in same file (msgbox function)
- Prevents potential panic if password prompt fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password prompt error handling to prevent application crashes. The app now gracefully logs password prompt failures and continues operation instead of terminating unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->