### PR TITLE
fix(android): reduce Connected & Screen messages when host screen is off

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
@@ -91,7 +91,8 @@ class InputService : AccessibilityService() {
 
     private val volumeController: VolumeController by lazy { VolumeController(applicationContext.getSystemService(AUDIO_SERVICE) as AudioManager) }
 
-    fun wakeUpDevice() {
+    // Just HOME. Caller handles the actual wake lock.
+    internal fun goHome() {
         performGlobalAction(GLOBAL_ACTION_HOME)
     }
 

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
@@ -91,6 +91,10 @@ class InputService : AccessibilityService() {
 
     private val volumeController: VolumeController by lazy { VolumeController(applicationContext.getSystemService(AUDIO_SERVICE) as AudioManager) }
 
+    fun wakeUpDevice() {
+        performGlobalAction(GLOBAL_ACTION_HOME)
+    }
+
     @RequiresApi(Build.VERSION_CODES.N)
     fun onMouseInput(mask: Int, _x: Int, _y: Int) {
         val x = max(0, _x)

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -62,6 +62,8 @@ const val VIDEO_KEY_FRAME_RATE = 30
 
 class MainService : Service() {
 
+    private val wakeRetryHandler = Handler(Looper.getMainLooper())
+
     @Keep
     @RequiresApi(Build.VERSION_CODES.N)
     fun rustPointerInput(kind: Int, mask: Int, x: Int, y: Int) {
@@ -128,6 +130,7 @@ class MainService : Service() {
                     }
                     if (authorized) {
                         if (!isFileTransfer && !isStart) {
+                            wakeAndRefreshIncomingScreenIfNeeded("authorized_connection")
                             startCapture()
                         }
                         onClientAuthorizedNotification(id, type, username, peerId)
@@ -228,6 +231,41 @@ class MainService : Service() {
     private lateinit var notificationChannel: String
     private lateinit var notificationBuilder: NotificationCompat.Builder
 
+    private fun wakeScreen(reason: String) {
+        if (wakeLock.isHeld) {
+            Log.d(logTag, "WakeLock release before wake, reason:$reason")
+            wakeLock.release()
+        }
+        Log.d(logTag, "Wake screen, reason:$reason")
+        wakeLock.acquire(5000)
+    }
+
+    private fun wakeAndRefreshIncomingScreenIfNeeded(reason: String) {
+        if (powerManager.isInteractive) {
+            return
+        }
+        wakeRetryHandler.removeCallbacksAndMessages(null)
+        wakeScreen(reason)
+        wakeRetryHandler.postDelayed({
+            if (powerManager.isInteractive) {
+                Log.d(logTag, "Skip delayed wake refresh, device already interactive, reason:$reason")
+                return@postDelayed
+            }
+            // HOME works better here than faking a tap.
+            InputService.ctx?.wakeUpDevice()
+            FFI.refreshScreen()
+        }, 500)
+        wakeRetryHandler.postDelayed({
+            if (powerManager.isInteractive) {
+                Log.d(logTag, "Skip retry wake refresh, device already interactive, reason:$reason")
+                return@postDelayed
+            }
+            wakeScreen("$reason-retry")
+            InputService.ctx?.wakeUpDevice()
+            FFI.refreshScreen()
+        }, 1200)
+    }
+
     override fun onCreate() {
         super.onCreate()
         Log.d(logTag,"MainService onCreate, sdk int:${Build.VERSION.SDK_INT} reuseVirtualDisplay:$reuseVirtualDisplay")
@@ -249,6 +287,7 @@ class MainService : Service() {
     }
 
     override fun onDestroy() {
+        wakeRetryHandler.removeCallbacksAndMessages(null)
         checkMediaPermission()
         stopService(Intent(this, FloatingWindowService::class.java))
         super.onDestroy()

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -62,19 +62,32 @@ const val VIDEO_KEY_FRAME_RATE = 30
 
 class MainService : Service() {
 
+    companion object {
+        private const val WAKELOCK_TIMEOUT_MS = 5000L
+        private const val WAKE_POLL_INTERVAL_MS = 100L
+        private const val WAKE_MAX_WAIT_MS = 2000L
+        private const val WAKE_THROTTLE_MS = 10_000L
+        private const val WAKE_RETRY_AFTER_MS = 1200L
+    }
+
     private val wakeRetryHandler = Handler(Looper.getMainLooper())
+    private val keyguardManager: KeyguardManager by lazy {
+        applicationContext.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+    }
+    private var lastWakeAttemptAt = 0L
+    private var wakePendingReason: String? = null
+    private var wakeStartedAt = 0L
+    private var wakeDeadlineAt = 0L
+    private var wakeDidHome = false
+    private var wakeRetried = false
+    private var wakeNotifiedLocked = false
 
     @Keep
     @RequiresApi(Build.VERSION_CODES.N)
     fun rustPointerInput(kind: Int, mask: Int, x: Int, y: Int) {
         // turn on screen with LEFT_DOWN when screen off
         if (!powerManager.isInteractive && (kind == 0 || mask == LEFT_DOWN)) {
-            if (wakeLock.isHeld) {
-                Log.d(logTag, "Turn on Screen, WakeLock release")
-                wakeLock.release()
-            }
-            Log.d(logTag,"Turn on Screen")
-            wakeLock.acquire(5000)
+            wakeScreen("pointer_input")
         } else {
             when (kind) {
                 0 -> { // touch
@@ -231,39 +244,80 @@ class MainService : Service() {
     private lateinit var notificationChannel: String
     private lateinit var notificationBuilder: NotificationCompat.Builder
 
+    private val wakePollRunnable = object : Runnable {
+        override fun run() {
+            val reason = wakePendingReason ?: return
+            val now = SystemClock.elapsedRealtime()
+            if (now >= wakeDeadlineAt) {
+                Log.w(
+                    logTag,
+                    "wake timeout, interactive=${powerManager.isInteractive}, input=${InputService.isOpen}, reason:$reason"
+                )
+                setTextNotification(null, "Remote session: cannot wake screen")
+                wakePendingReason = null
+                return
+            }
+
+            if (!powerManager.isInteractive) {
+                if (!wakeRetried && now - wakeStartedAt >= WAKE_RETRY_AFTER_MS) {
+                    wakeRetried = true
+                    wakeScreen("$reason-retry")
+                }
+                wakeRetryHandler.postDelayed(this, WAKE_POLL_INTERVAL_MS)
+                return
+            }
+
+            if (keyguardManager.isKeyguardLocked) {
+                if (!wakeNotifiedLocked) {
+                    wakeNotifiedLocked = true
+                    Log.w(logTag, "keyguard locked, skip refresh, reason:$reason")
+                    setTextNotification(null, "Remote session: device locked")
+                }
+                wakeRetryHandler.postDelayed(this, WAKE_POLL_INTERVAL_MS)
+                return
+            }
+
+            if (!wakeDidHome && InputService.isOpen) {
+                wakeDidHome = true
+                InputService.ctx?.goHome()
+            } else if (!InputService.isOpen) {
+                Log.w(logTag, "input service not open, skip HOME, reason:$reason")
+            }
+
+            FFI.refreshScreen()
+            wakePendingReason = null
+        }
+    }
+
     private fun wakeScreen(reason: String) {
         if (wakeLock.isHeld) {
             Log.d(logTag, "WakeLock release before wake, reason:$reason")
             wakeLock.release()
         }
         Log.d(logTag, "Wake screen, reason:$reason")
-        wakeLock.acquire(5000)
+        wakeLock.acquire(WAKELOCK_TIMEOUT_MS)
     }
 
     private fun wakeAndRefreshIncomingScreenIfNeeded(reason: String) {
         if (powerManager.isInteractive) {
             return
         }
-        wakeRetryHandler.removeCallbacksAndMessages(null)
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastWakeAttemptAt < WAKE_THROTTLE_MS) {
+            Log.i(logTag, "skip wake due to throttle, reason:$reason")
+            return
+        }
+        lastWakeAttemptAt = now
+
+        wakeRetryHandler.removeCallbacks(wakePollRunnable)
+        wakePendingReason = reason
+        wakeStartedAt = now
+        wakeDeadlineAt = now + WAKE_MAX_WAIT_MS
+        wakeDidHome = false
+        wakeRetried = false
+        wakeNotifiedLocked = false
         wakeScreen(reason)
-        wakeRetryHandler.postDelayed({
-            if (powerManager.isInteractive) {
-                Log.d(logTag, "Skip delayed wake refresh, device already interactive, reason:$reason")
-                return@postDelayed
-            }
-            // HOME works better here than faking a tap.
-            InputService.ctx?.wakeUpDevice()
-            FFI.refreshScreen()
-        }, 500)
-        wakeRetryHandler.postDelayed({
-            if (powerManager.isInteractive) {
-                Log.d(logTag, "Skip retry wake refresh, device already interactive, reason:$reason")
-                return@postDelayed
-            }
-            wakeScreen("$reason-retry")
-            InputService.ctx?.wakeUpDevice()
-            FFI.refreshScreen()
-        }, 1200)
+        wakeRetryHandler.postDelayed(wakePollRunnable, WAKE_POLL_INTERVAL_MS)
     }
 
     override fun onCreate() {
@@ -287,7 +341,11 @@ class MainService : Service() {
     }
 
     override fun onDestroy() {
-        wakeRetryHandler.removeCallbacksAndMessages(null)
+        wakeRetryHandler.removeCallbacks(wakePollRunnable)
+        wakePendingReason = null
+        if (wakeLock.isHeld) {
+            wakeLock.release()
+        }
         checkMediaPermission()
         stopService(Intent(this, FloatingWindowService::class.java))
         super.onDestroy()

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -62,14 +62,6 @@ const val VIDEO_KEY_FRAME_RATE = 30
 
 class MainService : Service() {
 
-    companion object {
-        private const val WAKELOCK_TIMEOUT_MS = 5000L
-        private const val WAKE_POLL_INTERVAL_MS = 100L
-        private const val WAKE_MAX_WAIT_MS = 2000L
-        private const val WAKE_THROTTLE_MS = 10_000L
-        private const val WAKE_RETRY_AFTER_MS = 1200L
-    }
-
     private val wakeRetryHandler = Handler(Looper.getMainLooper())
     private val keyguardManager: KeyguardManager by lazy {
         applicationContext.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
@@ -81,6 +73,7 @@ class MainService : Service() {
     private var wakeDidHome = false
     private var wakeRetried = false
     private var wakeNotifiedLocked = false
+    private var wakeNotifiedInputDisabled = false
 
     @Keep
     @RequiresApi(Build.VERSION_CODES.N)
@@ -211,6 +204,12 @@ class MainService : Service() {
     private val wakeLock: PowerManager.WakeLock by lazy { powerManager.newWakeLock(PowerManager.ACQUIRE_CAUSES_WAKEUP or PowerManager.SCREEN_BRIGHT_WAKE_LOCK, "rustdesk:wakelock")}
 
     companion object {
+        private const val WAKELOCK_TIMEOUT_MS = 5000L
+        private const val WAKE_POLL_INTERVAL_MS = 100L
+        private const val WAKE_MAX_WAIT_MS = 2000L
+        private const val WAKE_THROTTLE_MS = 10_000L
+        private const val WAKE_RETRY_AFTER_MS = 1200L
+
         private var _isReady = false // media permission ready status
         private var _isStart = false // screen capture start status
         private var _isAudioStart = false // audio capture start status
@@ -249,6 +248,10 @@ class MainService : Service() {
             val reason = wakePendingReason ?: return
             val now = SystemClock.elapsedRealtime()
             if (now >= wakeDeadlineAt) {
+                if (wakeNotifiedLocked) {
+                    wakePendingReason = null
+                    return
+                }
                 Log.w(
                     logTag,
                     "wake timeout, interactive=${powerManager.isInteractive}, input=${InputService.isOpen}, reason:$reason"
@@ -281,7 +284,11 @@ class MainService : Service() {
                 wakeDidHome = true
                 InputService.ctx?.goHome()
             } else if (!InputService.isOpen) {
-                Log.w(logTag, "input service not open, skip HOME, reason:$reason")
+                if (!wakeNotifiedInputDisabled) {
+                    wakeNotifiedInputDisabled = true
+                    Log.w(logTag, "input service not open, skip HOME, reason:$reason")
+                    setTextNotification(null, "Remote session: enable Accessibility")
+                }
             }
 
             FFI.refreshScreen()
@@ -299,6 +306,10 @@ class MainService : Service() {
     }
 
     private fun wakeAndRefreshIncomingScreenIfNeeded(reason: String) {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            wakeRetryHandler.post { wakeAndRefreshIncomingScreenIfNeeded(reason) }
+            return
+        }
         if (powerManager.isInteractive) {
             return
         }
@@ -316,6 +327,7 @@ class MainService : Service() {
         wakeDidHome = false
         wakeRetried = false
         wakeNotifiedLocked = false
+        wakeNotifiedInputDisabled = false
         wakeScreen(reason)
         wakeRetryHandler.postDelayed(wakePollRunnable, WAKE_POLL_INTERVAL_MS)
     }

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -292,6 +292,9 @@ class MainService : Service() {
             }
 
             FFI.refreshScreen()
+            if (wakeNotifiedLocked || wakeNotifiedInputDisabled) {
+                setTextNotification(null, null)
+            }
             wakePendingReason = null
         }
     }
@@ -313,6 +316,10 @@ class MainService : Service() {
         if (powerManager.isInteractive) {
             return
         }
+
+        // Reset any previous transient status text for a new attempt.
+        setTextNotification(null, null)
+
         val now = SystemClock.elapsedRealtime()
         if (now - lastWakeAttemptAt < WAKE_THROTTLE_MS) {
             Log.i(logTag, "skip wake due to throttle, reason:$reason")


### PR DESCRIPTION
 ## Summary
The Android controlled-side wake flow for incoming screen share sessions, when an authorized session starts and the Android host is non interactive, it wakes the device proactively. where clients can get stuck on `Connected, waiting for image...` when the Android host screen is off.

Wake behavior now runs automatically on authorized incoming Android screen share sessions, `HOME` may change device state differently too.

Closes #11479



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activate idle devices automatically with coordinated wake management and timeouts.
  * Automatic screen refresh with one retry and a “cannot wake screen” notification when limits are exceeded.
  * Throttled wake attempts to avoid repeated wake spam.
  * Keyguard-aware behavior to avoid unwanted UI actions when the device is locked.
  * Optional automatic navigation to the home screen when accessibility input is open and cancellation of pending wake/refresh when the service stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->