### PR TITLE
fix(custom-client): desktop, incoming only, touch drag

### DIFF
--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -592,13 +592,13 @@ class _DesktopTabState extends State<DesktopTab>
   }
 
   Widget _buildBar() {
+    final isIncomingHomePage = bind.isIncomingOnly() && isInHomePage();
     return Row(
       children: [
         Expanded(
             child: GestureDetector(
                 // custom double tap handler
-                onTap: !(bind.isIncomingOnly() && isInHomePage()) &&
-                        showMaximize
+                onTap: !isIncomingHomePage && showMaximize
                     ? () {
                         final current = DateTime.now().millisecondsSinceEpoch;
                         final elapsed = current - _lastClickTime;
@@ -609,7 +609,7 @@ class _DesktopTabState extends State<DesktopTab>
                               .then((value) => stateGlobal.setMaximized(value));
                         }
                       }
-                    : null,
+                    : (isIncomingHomePage ? () {} : null), // Keep tap recognizer for Windows touch.
                 onPanStart: (_) => startDragging(isMainWindow),
                 onPanCancel: () {
                   // We want to disable dragging of the tab area in the tab bar.


### PR DESCRIPTION
Fix desktop, touch & drag, the main window can't be dragged. Users have to double-tap and drag to move the window.

The accept (CM) window works fine.

Only `bind.isIncomingOnly() && isInHomePage()` is affected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gesture recognizer responsiveness on Windows touch devices when maximize toggling is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->