### PR TITLE
fix(linux): remove hourly --server restart that destabilizes desktop sessions

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -21,7 +21,7 @@ use std::{
     string::String,
     sync::atomic::{AtomicBool, Ordering},
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration,
 };
 use terminfo::{capability as cap, Database};
 use wallpaper;
@@ -720,11 +720,8 @@ fn should_start_server(
     is_display_changed: bool,
     uid: &mut String,
     desktop: &Desktop,
-    cm0: &mut bool,
-    last_restart: &mut Instant,
     server: &mut Option<Child>,
 ) -> bool {
-    let cm = get_cm();
     let mut start_new = false;
     let mut should_kill = false;
 
@@ -742,29 +739,19 @@ fn should_start_server(
         should_kill = true;
     }
 
-    if !should_kill
-        && !cm
-        && ((*cm0 && last_restart.elapsed().as_secs() > 60)
-            || last_restart.elapsed().as_secs() > 3600)
-    {
-        let terminal_session_count = crate::ipc::get_terminal_session_count().unwrap_or(0);
-        if terminal_session_count > 0 {
-            // There are terminal sessions, so we don't restart the server.
-            // We also need to keep `cm0` unchanged, so that we can reach this branch the next time.
-            return false;
-        }
-        // restart server if new connections all closed, or every one hour,
-        // as a workaround to resolve "SpotUdp" (dns resolve)
-        // and x server get displays failure issue
-        should_kill = true;
-        log::info!("restart server");
-    }
+    // Note: a previous hourly restart workaround was removed here.
+    // It killed the --server subprocess every 3600s (or 60s after CM closed)
+    // to work around stale DNS and display detection issues. Both are already
+    // handled inline without a restart:
+    //   - DNS: rendezvous_mediator.rs rebinds UDP socket after consecutive failures
+    //   - Displays: display_service.rs polls for changes every 300ms
+    // The restart caused: IPC disconnection errors, tray icon churn, memory
+    // accumulation, and Cinnamon/Muffin instability over multi-day uptime.
 
     if should_kill {
         if let Some(ps) = server.as_mut() {
             allow_err!(ps.kill());
             sleep_millis(30);
-            *last_restart = Instant::now();
         }
     }
 
@@ -779,7 +766,6 @@ fn should_start_server(
     } else {
         start_new = true;
     }
-    *cm0 = cm;
     start_new
 }
 
@@ -814,8 +800,6 @@ pub fn start_os_service() {
         println!("Failed to set Ctrl-C handler: {}", err);
     }
 
-    let mut cm0 = false;
-    let mut last_restart = Instant::now();
     while running.load(Ordering::SeqCst) {
         desktop.refresh();
         update_active_user_lookup_cache(&desktop);
@@ -832,8 +816,6 @@ pub fn start_os_service() {
                 false,
                 &mut uid,
                 &desktop,
-                &mut cm0,
-                &mut last_restart,
                 &mut server,
             ) {
                 stop_subprocess();
@@ -854,8 +836,6 @@ pub fn start_os_service() {
                 is_display_changed,
                 &mut uid,
                 &desktop,
-                &mut cm0,
-                &mut last_restart,
                 &mut user_server,
             ) {
                 stop_subprocess();
@@ -915,23 +895,6 @@ pub fn get_active_userid() -> String {
 /// Returns the active uid from a fresh seat0 lookup, bypassing the service-loop cache.
 pub fn get_active_userid_fresh() -> String {
     get_values_of_seat0(&[1])[0].clone()
-}
-
-fn get_cm() -> bool {
-    // We use `CMD_PS` instead of `ps` to suppress some audit messages on some systems.
-    if let Ok(output) = Command::new(CMD_PS.as_str()).args(vec!["aux"]).output() {
-        for line in String::from_utf8_lossy(&output.stdout).lines() {
-            if line.contains(&format!(
-                "{} --cm",
-                std::env::current_exe()
-                    .unwrap_or("".into())
-                    .to_string_lossy()
-            )) {
-                return true;
-            }
-        }
-    }
-    false
 }
 
 pub fn is_login_wayland() -> bool {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -863,11 +863,8 @@ fn should_start_server(
     is_display_changed: bool,
     uid: &mut String,
     desktop: &Desktop,
-    cm0: &mut bool,
-    last_restart: &mut Instant,
     server: &mut Option<Child>,
 ) -> bool {
-    let cm = get_cm();
     let mut start_new = false;
     let mut should_kill = false;
 
@@ -879,29 +876,10 @@ fn should_start_server(
         should_kill = true;
     }
 
-    if !should_kill
-        && !cm
-        && ((*cm0 && last_restart.elapsed().as_secs() > 60)
-            || last_restart.elapsed().as_secs() > 3600)
-    {
-        let terminal_session_count = crate::ipc::get_terminal_session_count().unwrap_or(0);
-        if terminal_session_count > 0 {
-            // There are terminal sessions, so we don't restart the server.
-            // We also need to keep `cm0` unchanged, so that we can reach this branch the next time.
-            return false;
-        }
-        // restart server if new connections all closed, or every one hour,
-        // as a workaround to resolve "SpotUdp" (dns resolve)
-        // and x server get displays failure issue
-        should_kill = true;
-        log::info!("restart server");
-    }
-
     if should_kill {
         if let Some(ps) = server.as_mut() {
             allow_err!(ps.kill());
             sleep_millis(30);
-            *last_restart = Instant::now();
         }
     }
 
@@ -916,7 +894,6 @@ fn should_start_server(
     } else {
         start_new = true;
     }
-    *cm0 = cm;
     start_new
 }
 
@@ -973,8 +950,6 @@ pub fn start_os_service() {
         println!("Failed to set Ctrl-C handler: {}", err);
     }
 
-    let mut cm0 = false;
-    let mut last_restart = Instant::now();
     while running.load(Ordering::SeqCst) {
         desktop.refresh();
         update_active_user_lookup_cache(&desktop);
@@ -990,8 +965,6 @@ pub fn start_os_service() {
                 false,
                 &mut uid,
                 &desktop,
-                &mut cm0,
-                &mut last_restart,
                 &mut server,
             ) {
                 force_stop_server();
@@ -1042,8 +1015,6 @@ pub fn start_os_service() {
                 is_display_changed,
                 &mut uid,
                 &desktop,
-                &mut cm0,
-                &mut last_restart,
                 &mut user_server,
             ) {
                 force_stop_server();
@@ -1113,23 +1084,6 @@ pub fn get_active_userid_fresh() -> String {
 /// caller to treat as "active session momentarily unknown" rather than stalling on a subprocess.
 pub fn get_active_userid_cached() -> Option<u32> {
     get_active_user_id_name_from_cache().and_then(|(uid, _)| uid.parse::<u32>().ok())
-}
-
-fn get_cm() -> bool {
-    // We use `CMD_PS` instead of `ps` to suppress some audit messages on some systems.
-    if let Ok(output) = Command::new(CMD_PS.as_str()).args(vec!["aux"]).output() {
-        for line in String::from_utf8_lossy(&output.stdout).lines() {
-            if line.contains(&format!(
-                "{} --cm",
-                std::env::current_exe()
-                    .unwrap_or("".into())
-                    .to_string_lossy()
-            )) {
-                return true;
-            }
-        }
-    }
-    false
 }
 
 pub fn is_login_wayland() -> bool {


### PR DESCRIPTION
## Problem

The Linux `--service` process killed and restarted the `--server` subprocess every 3600s (or 60s after connection manager closed). This caused:

- IPC disconnection errors every hour (`ipc connection closed: reset by the peer`)
- Tray icon churn (`XAppStatusIcon` removed and re-registered each cycle)
- Desktop instability over long uptime on some compositors

The tray icon is owned by `--server`. Killing it hourly tears down the icon's connection to the tray manager and re-registers a fresh one — visible flicker and, on some compositors, leaked references. With this fix the tray icon lives for the whole session.

## Root cause

The restart was a workaround for stale DNS and X display detection. Both are already handled inline:

- **DNS**: `rendezvous_mediator.rs` rebinds the UDP socket after consecutive registration failures (`DNS_INTERVAL = 60s`)
- **Displays**: `display_service.rs` polls for display changes every 300ms

So the restart is redundant and harmful.

## Change

- Drop the 3600s timer in `start_os_service` (`src/platform/linux.rs`)
- Remove now-unused `get_cm()`, `cm0`/`last_restart` params, `Instant` import

## Test

Verified on Linux: no IPC errors, stable tray.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux display-server detection for Wayland, X11, and DRM-based environments.
  * Improved recognition of GDM and Wayland login screens.
  * Simplified Linux service restart behavior by removing periodic restart triggers and unnecessary session-specific handling.
* **Changes**
  * Removed Linux headless-session support and related special-case behavior.
  * Improved handling when the display server is explicitly specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR removes the Linux service’s periodic and connection-manager-triggered server restarts while preserving restarts for display, user, and child-process lifecycle changes.
- Removes hourly and post-connection-manager restart state and conditions.
- Removes the obsolete process-scanning helper and related parameters.
- Keeps display/user-change and child-exit restart handling intact.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/platform/linux.rs | Removes the obsolete timed restart path and its associated state and helper without leaving dangling references. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(linux): remove hourly server restart..."](https://github.com/rustdesk/rustdesk/commit/fbe5df24f32efdd5fbf50949deb64edafc67980c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47862435)</sub>

<!-- /greptile_comment -->