### PR TITLE
fix(flutter): sync pubspec.lock with vector_math direct dependency

### DIFF
--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -1473,7 +1473,7 @@ packages:
     source: hosted
     version: "1.1.16"
   vector_math:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"


### PR DESCRIPTION
## Problem

`vector_math` was promoted to a direct dependency in `pubspec.yaml` in #13247 (edge scrolling), but the regenerated `pubspec.lock` was never committed. The lock still labels `vector_math` as `transitive`.

Running `flutter pub get` on a fresh checkout reproduces this one-line diff for anyone working on the Flutter side.

## Change

Commit the correctly-regenerated `pubspec.lock` line:

```diff
- dependency: transitive
+ dependency: "direct main"
```

(One line in `flutter/pubspec.lock`.)