### PR TITLE
chore: gitignore makepkg artifacts (res/pkg/, res/*.pkg.tar.zst)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ vcpkg_installed
 flutter/lib/generated_plugin_registrant.dart
 libsciter.dylib
 flutter/web/
+# makepkg artifacts (Arch / Manjaro pacman build path)
+res/pkg/
+res/*.pkg.tar.zst


### PR DESCRIPTION
`python3 build.py --flutter` on Arch / Manjaro routes through `build_flutter_arch_manjaro` → `makepkg`, which drops:

- `res/pkg/` — transient working dir
- `res/rustdesk-<version>-manjaro-arch.pkg.tar.zst` — final installable
- `res/rustdesk-debug-...pkg.tar.zst` — debug symbols sibling

Both showed up as untracked after every release build. Ignore them so `git status` stays clean.