### PR TITLE
terminal: remap Ctrl+V to passthrough and Ctrl+Shift+V to paste

### DIFF
--- a/flutter/lib/desktop/pages/terminal_page.dart
+++ b/flutter/lib/desktop/pages/terminal_page.dart
@@ -178,6 +178,25 @@ class _TerminalPageState extends State<TerminalPage>
             focusNode: _terminalFocusNode,
             // Note: autofocus is not used here because focus is managed manually
             // via _onTabStateChanged() to handle tab switching properly.
+            onKeyEvent: (node, event) {
+              if (event is! KeyDownEvent) return KeyEventResult.ignored;
+              final ctrl = HardwareKeyboard.instance.isControlPressed;
+              final shift = HardwareKeyboard.instance.isShiftPressed;
+              final isV = event.logicalKey == LogicalKeyboardKey.keyV;
+              if (ctrl && shift && isV) {
+                Clipboard.getData('text/plain').then((data) {
+                  final text = data?.text;
+                  if (text != null && mounted) {
+                    _terminalModel.terminal.paste(text);
+                  }
+                });
+                return KeyEventResult.handled;
+              } else if (ctrl && isV) {
+                _terminalModel.sendVirtualKey('\x16');
+                return KeyEventResult.handled;
+              }
+              return KeyEventResult.ignored;
+            },
             backgroundOpacity: 0.7,
             padding: _calculatePadding(heightPx),
             onSecondaryTapDown: (details, offset) async {


### PR DESCRIPTION
Remap keyboard shortcuts in the terminal to better support vim workflows:

        `Ctrl+V` → send ^V to remote shell, enabling vim visual block mode
        `Ctrl+Shift+V` → paste clipboard content into terminal

Previously Ctrl+V triggered a local paste, making vim's visual block mode inaccessible. The fix uses TerminalView.onKeyEvent to intercept both shortcuts before xterm's default input handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for clipboard operations in the terminal: Ctrl+Shift+V pastes clipboard content, and Ctrl+V sends the terminal paste command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->