### PR TITLE
Harden os password （terminal windows and headless linux) anti brute force

### DIFF
--- a/src/platform/linux_desktop_manager.rs
+++ b/src/platform/linux_desktop_manager.rs
@@ -29,6 +29,19 @@ lazy_static::lazy_static! {
     static ref DESKTOP_MANAGER: Arc<Mutex<Option<DesktopManager>>> = Arc::new(Mutex::new(None));
 }
 
+const DESKTOP_LOGIN_MIN_FAILURE_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(Debug)]
+struct DesktopLoginAuthFailed;
+
+impl std::fmt::Display for DesktopLoginAuthFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("desktop login auth failed")
+    }
+}
+
+impl std::error::Error for DesktopLoginAuthFailed {}
+
 #[derive(Debug)]
 struct DesktopManager {
     seat0_username: String,
@@ -94,11 +107,24 @@ fn detect_headless() -> Option<&'static str> {
     None
 }
 
-pub fn try_start_desktop(_username: &str, _passsword: &str) -> String {
+pub fn try_start_desktop(_username: &str, _password: &str) -> String {
+    try_start_desktop_with_auth_result(_username, _password).message
+}
+
+pub(crate) struct DesktopStartResult {
+    pub message: String,
+    pub auth_failed: bool,
+}
+
+pub(crate) fn try_start_desktop_with_auth_result(
+    _username: &str,
+    _password: &str,
+) -> DesktopStartResult {
     debug_assert!(crate::is_server());
-    if _username.is_empty() {
+    let normalized_username = _username.trim();
+    if normalized_username.is_empty() {
         let username = get_username();
-        if username.is_empty() {
+        let message = if username.is_empty() {
             if let Some(msg) = detect_headless() {
                 msg
             } else {
@@ -107,61 +133,99 @@ pub fn try_start_desktop(_username: &str, _passsword: &str) -> String {
         } else {
             ""
         }
-        .to_owned()
+        .to_owned();
+        DesktopStartResult {
+            message,
+            auth_failed: false,
+        }
     } else {
         let username = get_username();
-        if username == _username {
+        if username == normalized_username {
             // No need to verify password here.
-            return "".to_owned();
+            return DesktopStartResult {
+                message: "".to_owned(),
+                auth_failed: false,
+            };
         }
         if !username.is_empty() {
             // Another user is logged in. No need to start a new xsession.
-            return "".to_owned();
+            return DesktopStartResult {
+                message: "".to_owned(),
+                auth_failed: false,
+            };
         }
 
         if let Some(msg) = detect_headless() {
-            return msg.to_owned();
+            return DesktopStartResult {
+                message: msg.to_owned(),
+                auth_failed: false,
+            };
         }
 
-        match try_start_x_session(_username, _passsword) {
+        match try_start_x_session(normalized_username, _password) {
             Ok((username, x11_ready)) => {
-                if x11_ready {
-                    if _username != username {
+                let message = if x11_ready {
+                    if normalized_username != username {
                         LOGIN_MSG_DESKTOP_SESSION_ANOTHER_USER.to_owned()
                     } else {
                         "".to_owned()
                     }
                 } else {
                     LOGIN_MSG_DESKTOP_SESSION_NOT_READY.to_owned()
+                };
+                DesktopStartResult {
+                    message,
+                    auth_failed: false,
                 }
             }
             Err(e) => {
-                log::error!("Failed to start xsession {}", e);
-                LOGIN_MSG_DESKTOP_XSESSION_FAILED.to_owned()
+                let auth_failed = e.downcast_ref::<DesktopLoginAuthFailed>().is_some();
+                if !auth_failed {
+                    log::error!("Failed to start xsession {}", e);
+                }
+                DesktopStartResult {
+                    message: LOGIN_MSG_DESKTOP_XSESSION_FAILED.to_owned(),
+                    auth_failed,
+                }
             }
         }
     }
 }
 
 fn try_start_x_session(username: &str, password: &str) -> ResultType<(String, bool)> {
-    let mut desktop_manager = DESKTOP_MANAGER.lock().unwrap();
-    if let Some(desktop_manager) = &mut (*desktop_manager) {
-        if let Some(seat0_username) = desktop_manager.get_supported_display_seat0_username() {
-            return Ok((seat0_username, true));
+    let started_at = Instant::now();
+    let result: ResultType<(String, bool)> = {
+        let mut desktop_manager = DESKTOP_MANAGER.lock().unwrap();
+        if let Some(desktop_manager) = &mut (*desktop_manager) {
+            if let Some(seat0_username) = desktop_manager.get_supported_display_seat0_username() {
+                Ok((seat0_username, true))
+            } else {
+                let _ = desktop_manager.try_start_x_session(username, password)?;
+                log::debug!(
+                    "try_start_x_session, username: {}, {:?}",
+                    &username,
+                    &desktop_manager
+                );
+                Ok((
+                    desktop_manager.child_username.clone(),
+                    desktop_manager.is_running(),
+                ))
+            }
+        } else {
+            bail!(crate::client::LOGIN_MSG_DESKTOP_NOT_INITED);
         }
-
-        let _ = desktop_manager.try_start_x_session(username, password)?;
-        log::debug!(
-            "try_start_x_session, username: {}, {:?}",
-            &username,
-            &desktop_manager
-        );
-        Ok((
-            desktop_manager.child_username.clone(),
-            desktop_manager.is_running(),
-        ))
-    } else {
-        bail!(crate::client::LOGIN_MSG_DESKTOP_NOT_INITED);
+    };
+    match result {
+        Ok(v) => Ok(v),
+        Err(e) => {
+            if e.downcast_ref::<DesktopLoginAuthFailed>().is_some() {
+                let elapsed = started_at.elapsed();
+                if elapsed < DESKTOP_LOGIN_MIN_FAILURE_DELAY {
+                    std::thread::sleep(DESKTOP_LOGIN_MIN_FAILURE_DELAY - elapsed);
+                }
+            }
+            Err(e)
+        }
     }
 }
 
@@ -272,12 +336,14 @@ impl DesktopManager {
                         }
                     }
                     Err(e) => {
-                        bail!("failed to check user pass for {}, {}", username, e);
+                        log::warn!("PAM authenticate failed for '{}': {}", username, e);
+                        bail!(DesktopLoginAuthFailed);
                     }
                 }
             }
             None => {
-                bail!("failed to get userinfo of {}", username);
+                log::warn!("Desktop login username not found: '{}'", username);
+                bail!(DesktopLoginAuthFailed);
             }
         }
     }

--- a/src/platform/linux_desktop_manager.rs
+++ b/src/platform/linux_desktop_manager.rs
@@ -2,7 +2,7 @@ use super::{linux::*, ResultType};
 use crate::client::{
     LOGIN_MSG_DESKTOP_NO_DESKTOP, LOGIN_MSG_DESKTOP_SESSION_ANOTHER_USER,
     LOGIN_MSG_DESKTOP_SESSION_NOT_READY, LOGIN_MSG_DESKTOP_XORG_NOT_FOUND,
-    LOGIN_MSG_DESKTOP_XSESSION_FAILED,
+    LOGIN_MSG_DESKTOP_XSESSION_FAILED, LOGIN_MSG_PASSWORD_WRONG,
 };
 use hbb_common::{
     allow_err, bail, log,
@@ -28,19 +28,6 @@ lazy_static::lazy_static! {
     static ref DESKTOP_RUNNING: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
     static ref DESKTOP_MANAGER: Arc<Mutex<Option<DesktopManager>>> = Arc::new(Mutex::new(None));
 }
-
-const DESKTOP_LOGIN_MIN_FAILURE_DELAY: Duration = Duration::from_secs(1);
-
-#[derive(Debug)]
-struct DesktopLoginAuthFailed;
-
-impl std::fmt::Display for DesktopLoginAuthFailed {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("desktop login auth failed")
-    }
-}
-
-impl std::error::Error for DesktopLoginAuthFailed {}
 
 #[derive(Debug)]
 struct DesktopManager {
@@ -107,24 +94,54 @@ fn detect_headless() -> Option<&'static str> {
     None
 }
 
-pub fn try_start_desktop(_username: &str, _password: &str) -> String {
-    try_start_desktop_with_auth_result(_username, _password).message
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum XSessionStartErrorKind {
+    Auth,
+    Env,
 }
 
-pub(crate) struct DesktopStartResult {
-    pub message: String,
-    pub auth_failed: bool,
+const XSESSION_AUTH_FAILURE_DETAIL: &str = "authentication failed";
+
+#[derive(Debug)]
+struct XSessionStartError {
+    kind: XSessionStartErrorKind,
+    detail: String,
 }
 
-pub(crate) fn try_start_desktop_with_auth_result(
-    _username: &str,
-    _password: &str,
-) -> DesktopStartResult {
+impl XSessionStartError {
+    fn auth(detail: String) -> Self {
+        Self {
+            kind: XSessionStartErrorKind::Auth,
+            detail,
+        }
+    }
+
+    fn env(detail: String) -> Self {
+        Self {
+            kind: XSessionStartErrorKind::Env,
+            detail,
+        }
+    }
+}
+
+impl std::fmt::Display for XSessionStartError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.detail)
+    }
+}
+
+fn map_xsession_start_error_to_login_msg(kind: XSessionStartErrorKind) -> &'static str {
+    match kind {
+        XSessionStartErrorKind::Auth => LOGIN_MSG_PASSWORD_WRONG,
+        XSessionStartErrorKind::Env => LOGIN_MSG_DESKTOP_XSESSION_FAILED,
+    }
+}
+
+pub fn try_start_desktop(_username: &str, _passsword: &str) -> String {
     debug_assert!(crate::is_server());
-    let normalized_username = _username.trim();
-    if normalized_username.is_empty() {
+    if _username.is_empty() {
         let username = get_username();
-        let message = if username.is_empty() {
+        if username.is_empty() {
             if let Some(msg) = detect_headless() {
                 msg
             } else {
@@ -133,99 +150,63 @@ pub(crate) fn try_start_desktop_with_auth_result(
         } else {
             ""
         }
-        .to_owned();
-        DesktopStartResult {
-            message,
-            auth_failed: false,
-        }
+        .to_owned()
     } else {
         let username = get_username();
-        if username == normalized_username {
+        if username == _username {
             // No need to verify password here.
-            return DesktopStartResult {
-                message: "".to_owned(),
-                auth_failed: false,
-            };
+            return "".to_owned();
         }
         if !username.is_empty() {
             // Another user is logged in. No need to start a new xsession.
-            return DesktopStartResult {
-                message: "".to_owned(),
-                auth_failed: false,
-            };
+            return "".to_owned();
         }
 
         if let Some(msg) = detect_headless() {
-            return DesktopStartResult {
-                message: msg.to_owned(),
-                auth_failed: false,
-            };
+            return msg.to_owned();
         }
 
-        match try_start_x_session(normalized_username, _password) {
+        match try_start_x_session(_username, _passsword) {
             Ok((username, x11_ready)) => {
-                let message = if x11_ready {
-                    if normalized_username != username {
+                if x11_ready {
+                    if _username != username {
                         LOGIN_MSG_DESKTOP_SESSION_ANOTHER_USER.to_owned()
                     } else {
                         "".to_owned()
                     }
                 } else {
                     LOGIN_MSG_DESKTOP_SESSION_NOT_READY.to_owned()
-                };
-                DesktopStartResult {
-                    message,
-                    auth_failed: false,
                 }
             }
             Err(e) => {
-                let auth_failed = e.downcast_ref::<DesktopLoginAuthFailed>().is_some();
-                if !auth_failed {
-                    log::error!("Failed to start xsession {}", e);
-                }
-                DesktopStartResult {
-                    message: LOGIN_MSG_DESKTOP_XSESSION_FAILED.to_owned(),
-                    auth_failed,
-                }
+                log::error!("Failed to start xsession {}", e);
+                map_xsession_start_error_to_login_msg(e.kind).to_owned()
             }
         }
     }
 }
 
-fn try_start_x_session(username: &str, password: &str) -> ResultType<(String, bool)> {
-    let started_at = Instant::now();
-    let result: ResultType<(String, bool)> = {
-        let mut desktop_manager = DESKTOP_MANAGER.lock().unwrap();
-        if let Some(desktop_manager) = &mut (*desktop_manager) {
-            if let Some(seat0_username) = desktop_manager.get_supported_display_seat0_username() {
-                Ok((seat0_username, true))
-            } else {
-                let _ = desktop_manager.try_start_x_session(username, password)?;
-                log::debug!(
-                    "try_start_x_session, username: {}, {:?}",
-                    &username,
-                    &desktop_manager
-                );
-                Ok((
-                    desktop_manager.child_username.clone(),
-                    desktop_manager.is_running(),
-                ))
-            }
-        } else {
-            bail!(crate::client::LOGIN_MSG_DESKTOP_NOT_INITED);
+fn try_start_x_session(username: &str, password: &str) -> Result<(String, bool), XSessionStartError> {
+    let mut desktop_manager = DESKTOP_MANAGER.lock().unwrap();
+    if let Some(desktop_manager) = &mut (*desktop_manager) {
+        if let Some(seat0_username) = desktop_manager.get_supported_display_seat0_username() {
+            return Ok((seat0_username, true));
         }
-    };
-    match result {
-        Ok(v) => Ok(v),
-        Err(e) => {
-            if e.downcast_ref::<DesktopLoginAuthFailed>().is_some() {
-                let elapsed = started_at.elapsed();
-                if elapsed < DESKTOP_LOGIN_MIN_FAILURE_DELAY {
-                    std::thread::sleep(DESKTOP_LOGIN_MIN_FAILURE_DELAY - elapsed);
-                }
-            }
-            Err(e)
-        }
+
+        let _ = desktop_manager.try_start_x_session(username, password)?;
+        log::debug!(
+            "try_start_x_session, username: {}, {:?}",
+            &username,
+            &desktop_manager
+        );
+        Ok((
+            desktop_manager.child_username.clone(),
+            desktop_manager.is_running(),
+        ))
+    } else {
+        Err(XSessionStartError::env(
+            crate::client::LOGIN_MSG_DESKTOP_NOT_INITED.to_owned(),
+        ))
     }
 }
 
@@ -311,10 +292,15 @@ impl DesktopManager {
         self.is_child_running.load(Ordering::SeqCst)
     }
 
-    fn try_start_x_session(&mut self, username: &str, password: &str) -> ResultType<()> {
+    fn try_start_x_session(
+        &mut self,
+        username: &str,
+        password: &str,
+    ) -> Result<(), XSessionStartError> {
         match get_user_by_name(username) {
             Some(userinfo) => {
-                let mut client = pam::Client::with_password(&pam_get_service_name())?;
+                let mut client = pam::Client::with_password(&pam_get_service_name())
+                    .map_err(|e| XSessionStartError::env(format!("failed to init pam client, {}", e)))?;
                 client
                     .conversation_mut()
                     .set_credentials(username, password);
@@ -331,19 +317,24 @@ impl DesktopManager {
                                 Ok(())
                             }
                             Err(e) => {
-                                bail!("failed to start x session, {}", e);
+                                Err(XSessionStartError::env(format!(
+                                    "failed to start x session, {}",
+                                    e
+                                )))
                             }
                         }
                     }
-                    Err(e) => {
-                        log::warn!("PAM authenticate failed for '{}': {}", username, e);
-                        bail!(DesktopLoginAuthFailed);
+                    Err(_e) => {
+                        Err(XSessionStartError::auth(
+                            XSESSION_AUTH_FAILURE_DETAIL.to_owned(),
+                        ))
                     }
                 }
             }
             None => {
-                log::warn!("Desktop login username not found: '{}'", username);
-                bail!(DesktopLoginAuthFailed);
+                Err(XSessionStartError::auth(
+                    XSESSION_AUTH_FAILURE_DETAIL.to_owned(),
+                ))
             }
         }
     }

--- a/src/platform/linux_desktop_manager.rs
+++ b/src/platform/linux_desktop_manager.rs
@@ -179,7 +179,14 @@ pub fn try_start_desktop(_username: &str, _passsword: &str) -> String {
                 }
             }
             Err(e) => {
-                log::error!("Failed to start xsession {}", e);
+                match e.kind {
+                    XSessionStartErrorKind::Auth => {
+                        log::warn!("Failed to authenticate xsession user {}", e);
+                    }
+                    XSessionStartErrorKind::Env => {
+                        log::error!("Failed to start xsession {}", e);
+                    }
+                }
                 map_xsession_start_error_to_login_msg(e.kind).to_owned()
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -67,6 +67,7 @@ pub mod input_service {
 }
 
 mod connection;
+mod login_failure_check;
 pub mod display_service;
 #[cfg(windows)]
 pub mod portable_service;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2517,6 +2517,16 @@ impl Connection {
                 && !allow_logon_screen_password)
                 || password::approve_mode() == ApproveMode::Both && !password::has_valid_password()
             {
+                #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                if should_defer_cm_ipc_until_terminal_authorization(
+                    self.terminal,
+                    &lr.os_login.username,
+                ) {
+                    if let Some(keep_alive) = self.prepare_terminal_login_for_authorization().await
+                    {
+                        return keep_alive;
+                    }
+                }
                 self.try_start_cm(lr.my_id, lr.my_name, false);
                 if hbb_common::get_version_number(&lr.version)
                     >= hbb_common::get_version_number("1.2.0")
@@ -2538,6 +2548,17 @@ impl Connection {
                 }
             } else if lr.password.is_empty() {
                 if err_msg.is_empty() {
+                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                    if should_defer_cm_ipc_until_terminal_authorization(
+                        self.terminal,
+                        &lr.os_login.username,
+                    ) {
+                        if let Some(keep_alive) =
+                            self.prepare_terminal_login_for_authorization().await
+                        {
+                            return keep_alive;
+                        }
+                    }
                     self.try_start_cm(lr.my_id, lr.my_name, false);
                 } else {
                     self.send_login_error(
@@ -3661,8 +3682,14 @@ impl Connection {
             if let TerminalAuthorizationMode::OsLogin { failure, scope } = auth_mode {
                 self.update_failure_with_scope(failure, false, 0, scope);
             }
+            let auth_context = if is_terminal_os_login {
+                "OS credential login verification"
+            } else {
+                "Terminal session-user authorization"
+            };
             log::warn!(
-                "OS credential login verification failed: ip={} conn_id={} scope={:?} msg='{}'",
+                "{} failed: ip={} conn_id={} scope={:?} msg='{}'",
+                auth_context,
                 self.ip,
                 self.inner.id(),
                 failure_scope,
@@ -3783,11 +3810,13 @@ impl Connection {
                 let cur = m.get(&key).copied().unwrap_or((0, 0, 0));
                 m.insert(key, Self::bump_failure_entry(cur, time));
             }
-            m.insert(self.ip.clone(), Self::bump_failure_entry(failure, time));
+            let current_ip = m.get(&self.ip).copied().unwrap_or(failure);
+            m.insert(self.ip.clone(), Self::bump_failure_entry(current_ip, time));
         } else {
-            // Update full IP: bump from the *original* passed-in failure
+            // Re-read the full IP bucket in case another failed attempt updated it.
             let mut m = map_mutex.lock().unwrap();
-            m.insert(self.ip.clone(), Self::bump_failure_entry(failure, time));
+            let current_ip = m.get(&self.ip).copied().unwrap_or(failure);
+            m.insert(self.ip.clone(), Self::bump_failure_entry(current_ip, time));
         }
 
         if os_credential_scope {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3783,6 +3783,13 @@ impl Connection {
         scope: FailureScope,
     ) {
         let os_credential_scope = matches!(scope, FailureScope::TerminalOsLogin);
+        if os_credential_scope {
+            if !remove {
+                record_os_credential_failure(scope);
+            }
+            return;
+        }
+
         let map_mutex = &LOGIN_FAILURES[i];
         if remove {
             if failure.0 != 0 {
@@ -3796,9 +3803,6 @@ impl Connection {
                     map_mutex.lock().unwrap().remove(&self.ip);
                 }
             }
-            // Intentionally keep OS-credential backoff state as global.
-            // Reason: if one successful login cleared this state, an attacker could use
-            // intermittent successes to repeatedly reset throttling.
             return;
         }
         // Bump the prefixes, fetching existing values
@@ -3815,10 +3819,6 @@ impl Connection {
             let mut m = map_mutex.lock().unwrap();
             let current_ip = m.get(&self.ip).copied().unwrap_or((0, 0, 0));
             m.insert(self.ip.clone(), Self::bump_failure_entry(current_ip, time));
-        }
-
-        if os_credential_scope {
-            record_os_credential_failure(scope);
         }
     }
 
@@ -3869,6 +3869,39 @@ impl Connection {
     ) -> (((i32, i32, i32), i32), bool) {
         let time = (get_time() / 60_000) as i32;
 
+        if matches!(scope, FailureScope::TerminalOsLogin) {
+            let decision = evaluate_os_credential_policy(scope, get_time());
+            let res = if decision.allowed {
+                true
+            } else {
+                log::warn!(
+                    "OS credential login blocked by policy: ip={} conn_id={} i={} msg='{}'",
+                    self.ip,
+                    self.inner.id(),
+                    i,
+                    decision.login_error.as_deref().unwrap_or("")
+                );
+                if let Some(login_error) = decision.login_error {
+                    // Rare branch and currently temporary response copy; translation can be added later if needed.
+                    self.send_login_error(login_error).await;
+                }
+                if let Some(audit) = decision.audit {
+                    // For OS blocked/backoff events, we currently emit one alarm report per blocked attempt.
+                    // TODO: Add unified cumulative/aggregation fields across alarm producers.
+                    Self::post_alarm_audit(
+                        audit,
+                        json!({
+                                    "ip": self.ip,
+                                    "id": self.lr.my_id.clone(),
+                                    "name": self.lr.my_name.clone(),
+                        }),
+                    );
+                }
+                false
+            };
+            return (((0, 0, 0), time), res);
+        }
+
         // IPv6 addresses are cheap to make so we check prefix/netblock as well
         if let Some((p64, p56, p48)) = self.get_ipv6_prefixes() {
             if let Some(res) = self.check_failure_ipv6_prefix(i, time, &p64, 64, 60).await {
@@ -3912,36 +3945,6 @@ impl Connection {
                 }),
             );
             false
-        } else if matches!(scope, FailureScope::TerminalOsLogin) {
-            let decision = evaluate_os_credential_policy(scope, get_time());
-            if decision.allowed {
-                true
-            } else {
-                log::warn!(
-                    "OS credential login blocked by policy: ip={} conn_id={} i={} msg='{}'",
-                    self.ip,
-                    self.inner.id(),
-                    i,
-                    decision.login_error.as_deref().unwrap_or("")
-                );
-                if let Some(login_error) = decision.login_error {
-                    // Rare branch and currently temporary response copy; translation can be added later if needed.
-                    self.send_login_error(login_error).await;
-                }
-                if let Some(audit) = decision.audit {
-                    // For OS blocked/backoff events, we currently emit one alarm report per blocked attempt.
-                    // TODO: Add unified cumulative/aggregation fields across alarm producers.
-                    Self::post_alarm_audit(
-                        audit,
-                        json!({
-                                    "ip": self.ip,
-                                    "id": self.lr.my_id.clone(),
-                                    "name": self.lr.my_name.clone(),
-                        }),
-                    );
-                }
-                false
-            }
         } else {
             true
         };

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -126,11 +126,8 @@ fn should_record_linux_headless_os_auth_failure(
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-fn should_defer_cm_ipc_until_terminal_authorization(
-    is_terminal: bool,
-    os_login_username: &str,
-) -> bool {
-    is_terminal && !os_login_username.trim().is_empty()
+fn should_use_terminal_os_login_scope(is_terminal: bool, os_login_username: &str) -> bool {
+    cfg!(target_os = "windows") && is_terminal && !os_login_username.trim().is_empty()
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
@@ -2445,10 +2442,7 @@ impl Connection {
             }
 
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
-            if !should_defer_cm_ipc_until_terminal_authorization(
-                self.terminal,
-                &lr.os_login.username,
-            ) {
+            if !should_use_terminal_os_login_scope(self.terminal, &lr.os_login.username) {
                 self.try_start_cm_ipc();
             }
 
@@ -2513,15 +2507,11 @@ impl Connection {
                 crate::get_builtin_option(keys::OPTION_ALLOW_LOGON_SCREEN_PASSWORD) == "Y"
                     && is_logon();
 
-            if (password::approve_mode() == ApproveMode::Click
-                && !allow_logon_screen_password)
+            if (password::approve_mode() == ApproveMode::Click && !allow_logon_screen_password)
                 || password::approve_mode() == ApproveMode::Both && !password::has_valid_password()
             {
                 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                if should_defer_cm_ipc_until_terminal_authorization(
-                    self.terminal,
-                    &lr.os_login.username,
-                ) {
+                if should_use_terminal_os_login_scope(self.terminal, &lr.os_login.username) {
                     if let Some(keep_alive) = self.prepare_terminal_login_for_authorization().await
                     {
                         return keep_alive;
@@ -2549,10 +2539,7 @@ impl Connection {
             } else if lr.password.is_empty() {
                 if err_msg.is_empty() {
                     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                    if should_defer_cm_ipc_until_terminal_authorization(
-                        self.terminal,
-                        &lr.os_login.username,
-                    ) {
+                    if should_use_terminal_os_login_scope(self.terminal, &lr.os_login.username) {
                         if let Some(keep_alive) =
                             self.prepare_terminal_login_for_authorization().await
                         {
@@ -3611,9 +3598,7 @@ impl Connection {
         }
 
         let normalized_username = self.lr.os_login.username.trim().to_owned();
-        let auth_mode = if normalized_username.is_empty() {
-            TerminalAuthorizationMode::SessionUser
-        } else {
+        let auth_mode = if should_use_terminal_os_login_scope(self.terminal, &normalized_username) {
             // Check failure state
             let failure_scope = FailureScope::TerminalOsLogin;
             let (failure, res) = self.check_failure_with_scope(0, failure_scope).await;
@@ -3632,6 +3617,8 @@ impl Connection {
                 failure,
                 scope: failure_scope,
             }
+        } else {
+            TerminalAuthorizationMode::SessionUser
         };
 
         let is_terminal_os_login = matches!(auth_mode, TerminalAuthorizationMode::OsLogin { .. });

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(target_os = "windows")]
 use super::login_failure_check::try_acquire_os_credential_login_gate;
 use super::login_failure_check::{
     evaluate_os_credential_policy, record_os_credential_failure, FailureScope,
@@ -102,6 +102,35 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
         x |= a[i] ^ b[i];
     }
     x == 0
+}
+
+#[cfg(target_os = "linux")]
+fn should_check_linux_headless_os_auth_before_desktop_start(
+    is_headless_allowed: bool,
+    username: &str,
+) -> bool {
+    is_headless_allowed
+        && !username.trim().is_empty()
+        && linux_desktop_manager::get_username().is_empty()
+}
+
+#[cfg(target_os = "linux")]
+fn should_record_linux_headless_os_auth_failure(
+    is_headless_allowed: bool,
+    username: &str,
+    err_msg: &str,
+) -> bool {
+    is_headless_allowed
+        && !username.trim().is_empty()
+        && err_msg == crate::client::LOGIN_MSG_PASSWORD_WRONG
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn should_defer_cm_ipc_until_terminal_authorization(
+    is_terminal: bool,
+    os_login_username: &str,
+) -> bool {
+    is_terminal && !os_login_username.trim().is_empty()
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
@@ -1507,10 +1536,6 @@ impl Connection {
             // Keep the connection alive so the client can continue with 2FA.
             return true;
         }
-        #[cfg(target_os = "linux")]
-        if let Some(keep_alive) = self.prepare_linux_headless_login_for_authorization().await {
-            return keep_alive;
-        }
         if let Some(keep_alive) = self.prepare_terminal_login_for_authorization().await {
             return keep_alive;
         }
@@ -2335,97 +2360,6 @@ impl Connection {
         }
     }
 
-    #[cfg(target_os = "linux")]
-    async fn prepare_linux_headless_login(&mut self, lr: &LoginRequest) -> String {
-        let normalized_username = lr.os_login.username.trim().to_owned();
-        let is_headless_allowed = self.linux_headless_handle.is_headless_allowed;
-        // For OS credential login, defer PAM auth / desktop start until after primary auth(+2FA).
-        if is_headless_allowed && normalized_username.is_empty() {
-            let username = "".to_owned();
-            let password = lr.os_login.password.clone();
-            match hbb_common::tokio::task::spawn_blocking(move || {
-                linux_desktop_manager::try_start_desktop(&username, &password)
-            })
-            .await
-            {
-                Ok(message) => message,
-                Err(e) => {
-                    log::error!("Failed to join linux headless desktop start task: {}", e);
-                    crate::client::LOGIN_MSG_DESKTOP_XSESSION_FAILED.to_owned()
-                }
-            }
-        } else {
-            "".to_owned()
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    async fn prepare_linux_headless_login_for_authorization(&mut self) -> Option<bool> {
-        let normalized_username = self.lr.os_login.username.trim().to_owned();
-        if !self.linux_headless_handle.is_headless_allowed || normalized_username.is_empty() {
-            return None;
-        }
-
-        let failure_scope = FailureScope::LinuxHeadlessOsLogin;
-        let (failure, res) = self.check_failure_with_scope(0, failure_scope).await;
-        if !res {
-            return Some(true);
-        }
-
-        let guard = try_acquire_os_credential_login_gate();
-        if guard.is_err() {
-            log::warn!(
-                "Linux headless OS login blocked by concurrency gate: ip={} conn_id={}",
-                self.ip,
-                self.inner.id(),
-            );
-            self.send_login_error("Please try 1 minute later").await;
-            sleep(1.).await;
-            Self::post_alarm_audit(
-                AlarmAuditType::LinuxHeadlessOsLoginConcurrency,
-                json!({
-                    "ip": self.ip,
-                    "id": self.lr.my_id.clone(),
-                    "name": self.lr.my_name.clone(),
-                }),
-            );
-            return Some(true);
-        }
-        let linux_headless_os_login_concurrency_guard = guard.ok();
-
-        let password = self.lr.os_login.password.clone();
-        let desktop_start_result = match hbb_common::tokio::task::spawn_blocking(move || {
-            linux_desktop_manager::try_start_desktop_with_auth_result(
-                &normalized_username,
-                &password,
-            )
-        })
-        .await
-        {
-            Ok(result) => result,
-            Err(e) => {
-                log::error!("Failed to join linux headless desktop start task: {}", e);
-                linux_desktop_manager::DesktopStartResult {
-                    message: crate::client::LOGIN_MSG_DESKTOP_XSESSION_FAILED.to_owned(),
-                    auth_failed: false,
-                }
-            }
-        };
-
-        drop(linux_headless_os_login_concurrency_guard);
-        if !desktop_start_result.message.is_empty() {
-            if desktop_start_result.auth_failed {
-                self.update_failure_with_scope(failure, false, 0, failure_scope);
-            }
-            self.send_login_error(desktop_start_result.message).await;
-            return Some(true);
-        }
-
-        self.update_failure_with_scope(failure, true, 0, failure_scope);
-        self.linux_headless_handle.wait_desktop_cm_ready().await;
-        None
-    }
-
     async fn on_message(&mut self, msg: Message) -> bool {
         if let Some(message::Union::Misc(misc)) = &msg.union {
             // Move the CloseReason forward, as this message needs to be received when unauthorized, especially for kcp.
@@ -2443,7 +2377,7 @@ impl Connection {
                 return true;
             }
             match lr.union {
-                Some(login_request::Union::FileTransfer(ref ft)) => {
+                Some(login_request::Union::FileTransfer(ft)) => {
                     if !Self::permission(
                         keys::OPTION_ENABLE_FILE_TRANSFER,
                         &self.control_permissions,
@@ -2453,9 +2387,9 @@ impl Connection {
                         sleep(1.).await;
                         return false;
                     }
-                    self.file_transfer = Some((ft.dir.clone(), ft.show_hidden));
+                    self.file_transfer = Some((ft.dir, ft.show_hidden));
                 }
-                Some(login_request::Union::ViewCamera(ref _vc)) => {
+                Some(login_request::Union::ViewCamera(_vc)) => {
                     if !Self::permission(keys::OPTION_ENABLE_CAMERA, &self.control_permissions) {
                         self.send_login_error("No permission of viewing camera")
                             .await;
@@ -2464,14 +2398,14 @@ impl Connection {
                     }
                     self.view_camera = true;
                 }
-                Some(login_request::Union::Terminal(ref terminal)) => {
+                Some(login_request::Union::Terminal(terminal)) => {
                     if !Self::permission(keys::OPTION_ENABLE_TERMINAL, &self.control_permissions) {
                         self.send_login_error("No permission of terminal").await;
                         sleep(1.).await;
                         return false;
                     }
                     #[cfg(target_os = "windows")]
-                    if !lr.os_login.username.trim().is_empty() && !crate::platform::is_installed() {
+                    if !lr.os_login.username.is_empty() && !crate::platform::is_installed() {
                         self.send_login_error("Supported only in the installed version.")
                             .await;
                         sleep(1.).await;
@@ -2483,15 +2417,14 @@ impl Connection {
                         self.terminal_persistent =
                             o.terminal_persistent.enum_value() == Ok(BoolOption::Yes);
                     }
-                    self.terminal_service_id = terminal.service_id.clone();
+                    self.terminal_service_id = terminal.service_id;
                 }
-                Some(login_request::Union::PortForward(ref pf)) => {
+                Some(login_request::Union::PortForward(mut pf)) => {
                     if !Self::permission(keys::OPTION_ENABLE_TUNNEL, &self.control_permissions) {
                         self.send_login_error("No permission of IP tunneling").await;
                         sleep(1.).await;
                         return false;
                     }
-                    let mut pf = pf.clone();
                     let (addr, _is_rdp) = Self::normalize_port_forward_target(&mut pf);
                     self.port_forward_address = addr;
                 }
@@ -2502,17 +2435,56 @@ impl Connection {
                 }
             }
 
+            if !hbb_common::is_ip_str(&lr.username)
+                && !hbb_common::is_domain_port_str(&lr.username)
+                && lr.username != Config::get_id()
+            {
+                self.send_login_error(crate::client::LOGIN_MSG_OFFLINE)
+                    .await;
+                return false;
+            }
+
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
-            self.try_start_cm_ipc();
+            if !should_defer_cm_ipc_until_terminal_authorization(
+                self.terminal,
+                &lr.os_login.username,
+            ) {
+                self.try_start_cm_ipc();
+            }
+
+            #[cfg(target_os = "linux")]
+            if should_check_linux_headless_os_auth_before_desktop_start(
+                self.linux_headless_handle.is_headless_allowed,
+                &lr.os_login.username,
+            ) {
+                let (_failure, res) = self.check_failure(0).await;
+                if !res {
+                    return true;
+                }
+            }
 
             #[cfg(not(target_os = "linux"))]
             let err_msg = "".to_owned();
             #[cfg(target_os = "linux")]
-            let err_msg = self.prepare_linux_headless_login(&lr).await;
+            let err_msg = self
+                .linux_headless_handle
+                .try_start_desktop(lr.os_login.as_ref());
 
             // If err is LOGIN_MSG_DESKTOP_SESSION_NOT_READY, just keep this msg and go on checking password.
             if !err_msg.is_empty() && err_msg != crate::client::LOGIN_MSG_DESKTOP_SESSION_NOT_READY
             {
+                #[cfg(target_os = "linux")]
+                if should_record_linux_headless_os_auth_failure(
+                    self.linux_headless_handle.is_headless_allowed,
+                    &lr.os_login.username,
+                    &err_msg,
+                ) {
+                    let (failure, res) = self.check_failure(0).await;
+                    if !res {
+                        return true;
+                    }
+                    self.update_failure(failure, false, 0);
+                }
                 self.send_login_error(err_msg).await;
                 return true;
             }
@@ -2541,14 +2513,7 @@ impl Connection {
                 crate::get_builtin_option(keys::OPTION_ALLOW_LOGON_SCREEN_PASSWORD) == "Y"
                     && is_logon();
 
-            if !hbb_common::is_ip_str(&lr.username)
-                && !hbb_common::is_domain_port_str(&lr.username)
-                && lr.username != Config::get_id()
-            {
-                self.send_login_error(crate::client::LOGIN_MSG_OFFLINE)
-                    .await;
-                return false;
-            } else if (password::approve_mode() == ApproveMode::Click
+            if (password::approve_mode() == ApproveMode::Click
                 && !allow_logon_screen_password)
                 || password::approve_mode() == ApproveMode::Both && !password::has_valid_password()
             {
@@ -2562,12 +2527,12 @@ impl Connection {
                 return true;
             } else if self.is_recent_session(false) {
                 if err_msg.is_empty() {
+                    #[cfg(target_os = "linux")]
+                    self.linux_headless_handle.wait_desktop_cm_ready().await;
                     if !self.send_logon_response_and_keep_alive().await {
                         return false;
                     }
-                    if self.authorized || self.require_2fa.is_some() {
-                        self.try_start_cm(lr.my_id.clone(), lr.my_name.clone(), self.authorized);
-                    }
+                    self.try_start_cm(lr.my_id.clone(), lr.my_name.clone(), self.authorized);
                 } else {
                     self.send_login_error(err_msg).await;
                 }
@@ -2601,12 +2566,12 @@ impl Connection {
                 } else {
                     self.update_failure_with_scope(failure, true, 0, FailureScope::Default);
                     if err_msg.is_empty() {
+                        #[cfg(target_os = "linux")]
+                        self.linux_headless_handle.wait_desktop_cm_ready().await;
                         if !self.send_logon_response_and_keep_alive().await {
                             return false;
                         }
-                        if self.authorized || self.require_2fa.is_some() {
-                            self.try_start_cm(lr.my_id, lr.my_name, self.authorized);
-                        }
+                        self.try_start_cm(lr.my_id, lr.my_name, self.authorized);
                     } else {
                         self.send_login_error(err_msg).await;
                     }
@@ -2626,13 +2591,11 @@ impl Connection {
                         if !self.send_logon_response_and_keep_alive().await {
                             return false;
                         }
-                        if self.authorized || self.require_2fa.is_some() {
-                            self.try_start_cm(
-                                self.lr.my_id.to_owned(),
-                                self.lr.my_name.to_owned(),
-                                self.authorized,
-                            );
-                        }
+                        self.try_start_cm(
+                            self.lr.my_id.to_owned(),
+                            self.lr.my_name.to_owned(),
+                            self.authorized,
+                        );
                         if !tfa.hwid.is_empty() && Self::enable_trusted_devices() {
                             Config::add_trusted_device(TrustedDevice {
                                 hwid: tfa.hwid,
@@ -2682,13 +2645,11 @@ impl Connection {
                             if !self.send_logon_response_and_keep_alive().await {
                                 return false;
                             }
-                            if self.authorized || self.require_2fa.is_some() {
-                                self.try_start_cm(
-                                    lr.my_id.clone(),
-                                    lr.my_name.clone(),
-                                    self.authorized,
-                                );
-                            }
+                            self.try_start_cm(
+                                lr.my_id.clone(),
+                                lr.my_name.clone(),
+                                self.authorized,
+                            );
                             #[cfg(not(any(target_os = "android", target_os = "ios")))]
                             self.try_start_cm_ipc();
                         }
@@ -3632,17 +3593,19 @@ impl Connection {
         let auth_mode = if normalized_username.is_empty() {
             TerminalAuthorizationMode::SessionUser
         } else {
+            // Check failure state
             let failure_scope = FailureScope::TerminalOsLogin;
             let (failure, res) = self.check_failure_with_scope(0, failure_scope).await;
             if !res {
-                // Rate-limit blocks should keep the connection alive for retries.
                 log::warn!(
                     "OS credential login blocked by failure policy: ip={} conn_id={} scope={:?}",
                     self.ip,
                     self.inner.id(),
                     failure_scope
                 );
-                return Some(true);
+                // Terminal OS login is sensitive. Close this connection instead of keeping it
+                // alive for retries on the same socket after a rate-limit block.
+                return Some(false);
             }
             TerminalAuthorizationMode::OsLogin {
                 failure,
@@ -3661,6 +3624,7 @@ impl Connection {
         let terminal_login_error = {
             #[cfg(target_os = "windows")]
             {
+                // Concurrency gate for terminal OS login with credentials, to prevent brute-force attacks.
                 let _os_login_concurrency_guard = if is_terminal_os_login {
                     let guard = try_acquire_os_credential_login_gate();
                     if guard.is_err() {
@@ -3680,7 +3644,7 @@ impl Connection {
                                 "name": self.lr.my_name.clone(),
                             }),
                         );
-                        return Some(true);
+                        return Some(false);
                     }
                     guard.ok()
                 } else {
@@ -3718,15 +3682,13 @@ impl Connection {
             if let Some(user_token) = &self.terminal_user_token {
                 let has_service_token = user_token.to_terminal_service_token().is_some();
                 if is_user != has_service_token {
-                    log::warn!(
-                        "Terminal service user mismatch: ip={} conn_id={} service_is_user={} has_service_token={}",
+                    log::error!(
+                        "Terminal service user mismatch: ip={} conn_id={} service_is_user={} has_service_token={}. The service ID may have been manually changed in the configuration, causing validation to fail.",
                         self.ip,
                         self.inner.id(),
                         is_user,
                         has_service_token
                     );
-                    // This occurs when the service id (in the configuration) is manually changed by the user, causing a mismatch in validation.
-                    log::error!("Terminal service user mismatch detected. The service ID may have been manually changed in the configuration, causing validation to fail.");
                     // No need to translate the following message, because it is in an abnormal case.
                     self.send_login_error("Terminal service user mismatch detected.")
                         .await;
@@ -3795,10 +3757,7 @@ impl Connection {
         i: usize,
         scope: FailureScope,
     ) {
-        let os_credential_scope = matches!(
-            scope,
-            FailureScope::TerminalOsLogin | FailureScope::LinuxHeadlessOsLogin
-        );
+        let os_credential_scope = matches!(scope, FailureScope::TerminalOsLogin);
         let map_mutex = &LOGIN_FAILURES[i];
         if remove {
             if failure.0 != 0 {
@@ -3926,10 +3885,7 @@ impl Connection {
                 }),
             );
             false
-        } else if matches!(
-            scope,
-            FailureScope::TerminalOsLogin | FailureScope::LinuxHeadlessOsLogin
-        ) {
+        } else if matches!(scope, FailureScope::TerminalOsLogin) {
             let decision = evaluate_os_credential_policy(scope, get_time());
             if decision.allowed {
                 true
@@ -5441,8 +5397,6 @@ pub enum AlarmAuditType {
     ExceedIPv6PrefixAttempts = 6,
     TerminalOsLoginBackoff = 7,
     TerminalOsLoginConcurrency = 8,
-    LinuxHeadlessOsLoginBackoff = 9,
-    LinuxHeadlessOsLoginConcurrency = 10,
 }
 
 pub enum FileAuditType {
@@ -5691,6 +5645,19 @@ impl LinuxHeadlessHandle {
             wait_ipc_timeout: 10_000,
             rx_cm_stream_ready,
             tx_desktop_ready,
+        }
+    }
+
+    pub fn try_start_desktop(&mut self, os_login: Option<&OSLogin>) -> String {
+        if self.is_headless_allowed {
+            match os_login {
+                Some(os_login) => {
+                    linux_desktop_manager::try_start_desktop(&os_login.username, &os_login.password)
+                }
+                None => linux_desktop_manager::try_start_desktop("", ""),
+            }
+        } else {
+            "".to_string()
         }
     }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2439,6 +2439,19 @@ impl Connection {
                 return false;
             }
 
+            #[cfg(target_os = "windows")]
+            if self.terminal
+                && lr.os_login.username.trim().is_empty()
+                && crate::platform::is_prelogin()
+            {
+                self.send_login_error(
+                    "No active console user logged on, please connect and logon first.",
+                )
+                .await;
+                sleep(1.).await;
+                return false;
+            }
+
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             if !should_use_terminal_os_login_scope(self.terminal, &lr.os_login.username) {
                 self.try_start_cm_ipc();

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1,6 +1,7 @@
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use super::login_failure_check::try_acquire_os_credential_login_gate;
 use super::login_failure_check::{
-    clear_terminal_failure_state, evaluate_terminal_policy, record_terminal_failure,
-    try_acquire_terminal_os_login_gate, FailureScope,
+    evaluate_os_credential_policy, record_os_credential_failure, FailureScope,
 };
 use super::{input_service::*, *};
 #[cfg(feature = "unix-file-copy-paste")]
@@ -88,7 +89,8 @@ lazy_static::lazy_static! {
     static ref PENDING_SWITCH_SIDES_UUID: Arc::<Mutex<HashMap<String, (Instant, uuid::Uuid)>>> = Default::default();
 }
 
-const TERMINAL_OS_LOGIN_FAILED_MSG: &str = "Terminal login failed.";
+#[cfg(target_os = "windows")]
+const TERMINAL_OS_LOGIN_FAILED_MSG: &str = "Incorrect username or password.";
 
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
@@ -1505,6 +1507,10 @@ impl Connection {
             // Keep the connection alive so the client can continue with 2FA.
             return true;
         }
+        #[cfg(target_os = "linux")]
+        if let Some(keep_alive) = self.prepare_linux_headless_login_for_authorization().await {
+            return keep_alive;
+        }
         if let Some(keep_alive) = self.prepare_terminal_login_for_authorization().await {
             return keep_alive;
         }
@@ -2329,6 +2335,97 @@ impl Connection {
         }
     }
 
+    #[cfg(target_os = "linux")]
+    async fn prepare_linux_headless_login(&mut self, lr: &LoginRequest) -> String {
+        let normalized_username = lr.os_login.username.trim().to_owned();
+        let is_headless_allowed = self.linux_headless_handle.is_headless_allowed;
+        // For OS credential login, defer PAM auth / desktop start until after primary auth(+2FA).
+        if is_headless_allowed && normalized_username.is_empty() {
+            let username = "".to_owned();
+            let password = lr.os_login.password.clone();
+            match hbb_common::tokio::task::spawn_blocking(move || {
+                linux_desktop_manager::try_start_desktop(&username, &password)
+            })
+            .await
+            {
+                Ok(message) => message,
+                Err(e) => {
+                    log::error!("Failed to join linux headless desktop start task: {}", e);
+                    crate::client::LOGIN_MSG_DESKTOP_XSESSION_FAILED.to_owned()
+                }
+            }
+        } else {
+            "".to_owned()
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn prepare_linux_headless_login_for_authorization(&mut self) -> Option<bool> {
+        let normalized_username = self.lr.os_login.username.trim().to_owned();
+        if !self.linux_headless_handle.is_headless_allowed || normalized_username.is_empty() {
+            return None;
+        }
+
+        let failure_scope = FailureScope::LinuxHeadlessOsLogin;
+        let (failure, res) = self.check_failure_with_scope(0, failure_scope).await;
+        if !res {
+            return Some(true);
+        }
+
+        let guard = try_acquire_os_credential_login_gate();
+        if guard.is_err() {
+            log::warn!(
+                "Linux headless OS login blocked by concurrency gate: ip={} conn_id={}",
+                self.ip,
+                self.inner.id(),
+            );
+            self.send_login_error("Please try 1 minute later").await;
+            sleep(1.).await;
+            Self::post_alarm_audit(
+                AlarmAuditType::LinuxHeadlessOsLoginConcurrency,
+                json!({
+                    "ip": self.ip,
+                    "id": self.lr.my_id.clone(),
+                    "name": self.lr.my_name.clone(),
+                }),
+            );
+            return Some(true);
+        }
+        let linux_headless_os_login_concurrency_guard = guard.ok();
+
+        let password = self.lr.os_login.password.clone();
+        let desktop_start_result = match hbb_common::tokio::task::spawn_blocking(move || {
+            linux_desktop_manager::try_start_desktop_with_auth_result(
+                &normalized_username,
+                &password,
+            )
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                log::error!("Failed to join linux headless desktop start task: {}", e);
+                linux_desktop_manager::DesktopStartResult {
+                    message: crate::client::LOGIN_MSG_DESKTOP_XSESSION_FAILED.to_owned(),
+                    auth_failed: false,
+                }
+            }
+        };
+
+        drop(linux_headless_os_login_concurrency_guard);
+        if !desktop_start_result.message.is_empty() {
+            if desktop_start_result.auth_failed {
+                self.update_failure_with_scope(failure, false, 0, failure_scope);
+            }
+            self.send_login_error(desktop_start_result.message).await;
+            return Some(true);
+        }
+
+        self.update_failure_with_scope(failure, true, 0, failure_scope);
+        self.linux_headless_handle.wait_desktop_cm_ready().await;
+        None
+    }
+
     async fn on_message(&mut self, msg: Message) -> bool {
         if let Some(message::Union::Misc(misc)) = &msg.union {
             // Move the CloseReason forward, as this message needs to be received when unauthorized, especially for kcp.
@@ -2346,7 +2443,7 @@ impl Connection {
                 return true;
             }
             match lr.union {
-                Some(login_request::Union::FileTransfer(ft)) => {
+                Some(login_request::Union::FileTransfer(ref ft)) => {
                     if !Self::permission(
                         keys::OPTION_ENABLE_FILE_TRANSFER,
                         &self.control_permissions,
@@ -2356,9 +2453,9 @@ impl Connection {
                         sleep(1.).await;
                         return false;
                     }
-                    self.file_transfer = Some((ft.dir, ft.show_hidden));
+                    self.file_transfer = Some((ft.dir.clone(), ft.show_hidden));
                 }
-                Some(login_request::Union::ViewCamera(_vc)) => {
+                Some(login_request::Union::ViewCamera(ref _vc)) => {
                     if !Self::permission(keys::OPTION_ENABLE_CAMERA, &self.control_permissions) {
                         self.send_login_error("No permission of viewing camera")
                             .await;
@@ -2367,14 +2464,14 @@ impl Connection {
                     }
                     self.view_camera = true;
                 }
-                Some(login_request::Union::Terminal(terminal)) => {
+                Some(login_request::Union::Terminal(ref terminal)) => {
                     if !Self::permission(keys::OPTION_ENABLE_TERMINAL, &self.control_permissions) {
                         self.send_login_error("No permission of terminal").await;
                         sleep(1.).await;
                         return false;
                     }
                     #[cfg(target_os = "windows")]
-                    if !lr.os_login.username.is_empty() && !crate::platform::is_installed() {
+                    if !lr.os_login.username.trim().is_empty() && !crate::platform::is_installed() {
                         self.send_login_error("Supported only in the installed version.")
                             .await;
                         sleep(1.).await;
@@ -2386,14 +2483,15 @@ impl Connection {
                         self.terminal_persistent =
                             o.terminal_persistent.enum_value() == Ok(BoolOption::Yes);
                     }
-                    self.terminal_service_id = terminal.service_id;
+                    self.terminal_service_id = terminal.service_id.clone();
                 }
-                Some(login_request::Union::PortForward(mut pf)) => {
+                Some(login_request::Union::PortForward(ref pf)) => {
                     if !Self::permission(keys::OPTION_ENABLE_TUNNEL, &self.control_permissions) {
                         self.send_login_error("No permission of IP tunneling").await;
                         sleep(1.).await;
                         return false;
                     }
+                    let mut pf = pf.clone();
                     let (addr, _is_rdp) = Self::normalize_port_forward_target(&mut pf);
                     self.port_forward_address = addr;
                 }
@@ -2405,20 +2503,12 @@ impl Connection {
             }
 
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
-            {
-                let should_delay_terminal_cm_ipc =
-                    self.terminal && !lr.os_login.username.trim().is_empty();
-                if !should_delay_terminal_cm_ipc {
-                    self.try_start_cm_ipc();
-                }
-            }
+            self.try_start_cm_ipc();
 
             #[cfg(not(target_os = "linux"))]
             let err_msg = "".to_owned();
             #[cfg(target_os = "linux")]
-            let err_msg = self
-                .linux_headless_handle
-                .try_start_desktop(lr.os_login.as_ref());
+            let err_msg = self.prepare_linux_headless_login(&lr).await;
 
             // If err is LOGIN_MSG_DESKTOP_SESSION_NOT_READY, just keep this msg and go on checking password.
             if !err_msg.is_empty() && err_msg != crate::client::LOGIN_MSG_DESKTOP_SESSION_NOT_READY
@@ -2472,8 +2562,6 @@ impl Connection {
                 return true;
             } else if self.is_recent_session(false) {
                 if err_msg.is_empty() {
-                    #[cfg(target_os = "linux")]
-                    self.linux_headless_handle.wait_desktop_cm_ready().await;
                     if !self.send_logon_response_and_keep_alive().await {
                         return false;
                     }
@@ -2498,7 +2586,7 @@ impl Connection {
                     return true;
                 }
                 if !self.validate_password(allow_logon_screen_password) {
-                    self.update_failure(failure, false, 0);
+                    self.update_failure_with_scope(failure, false, 0, FailureScope::Default);
                     self.check_update_temporary_password(false);
                     if err_msg.is_empty() {
                         self.send_login_error(crate::client::LOGIN_MSG_PASSWORD_WRONG)
@@ -2511,10 +2599,8 @@ impl Connection {
                         .await;
                     }
                 } else {
-                    self.update_failure(failure, true, 0);
+                    self.update_failure_with_scope(failure, true, 0, FailureScope::Default);
                     if err_msg.is_empty() {
-                        #[cfg(target_os = "linux")]
-                        self.linux_headless_handle.wait_desktop_cm_ready().await;
                         if !self.send_logon_response_and_keep_alive().await {
                             return false;
                         }
@@ -2604,13 +2690,7 @@ impl Connection {
                                 );
                             }
                             #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                            {
-                                let should_delay_terminal_cm_ipc =
-                                    self.terminal && !self.lr.os_login.username.trim().is_empty();
-                                if !should_delay_terminal_cm_ipc {
-                                    self.try_start_cm_ipc();
-                                }
-                            }
+                            self.try_start_cm_ipc();
                         }
                     }
                 }
@@ -3539,65 +3619,86 @@ impl Connection {
             return None;
         }
 
-        let is_terminal_os_login = !self.lr.os_login.username.trim().is_empty();
-        let failure_scope = if is_terminal_os_login {
-            FailureScope::TerminalOsLogin
+        #[derive(Copy, Clone)]
+        enum TerminalAuthorizationMode {
+            OsLogin {
+                failure: ((i32, i32, i32), i32),
+                scope: FailureScope,
+            },
+            SessionUser,
+        }
+
+        let normalized_username = self.lr.os_login.username.trim().to_owned();
+        let auth_mode = if normalized_username.is_empty() {
+            TerminalAuthorizationMode::SessionUser
         } else {
-            FailureScope::Default
-        };
-        let mut terminal_failure = None;
-        if is_terminal_os_login {
+            let failure_scope = FailureScope::TerminalOsLogin;
             let (failure, res) = self.check_failure_with_scope(0, failure_scope).await;
             if !res {
                 // Rate-limit blocks should keep the connection alive for retries.
                 log::warn!(
-                    "Terminal OS login blocked by failure policy: ip={} conn_id={} scope={:?}",
+                    "OS credential login blocked by failure policy: ip={} conn_id={} scope={:?}",
                     self.ip,
                     self.inner.id(),
                     failure_scope
                 );
                 return Some(true);
             }
-            terminal_failure = Some(failure);
-        }
-
-        #[cfg(target_os = "windows")]
-        let _os_login_concurrency_guard = if !self.lr.os_login.username.trim().is_empty() {
-            let guard = try_acquire_terminal_os_login_gate();
-            if guard.is_err() {
-                if let Some(failure) = terminal_failure {
-                    self.update_failure_with_scope(failure, false, 0, failure_scope);
-                }
-                log::warn!(
-                    "Terminal OS login blocked by concurrency gate: ip={} conn_id={} scope={:?}",
-                    self.ip,
-                    self.inner.id(),
-                    failure_scope
-                );
-                self.send_login_error("Please try 1 minute later").await;
-                Self::post_alarm_audit(
-                    AlarmAuditType::TerminalOsLoginConcurrency,
-                    json!({
-                        "ip": self.ip,
-                        "id": self.lr.my_id.clone(),
-                        "name": self.lr.my_name.clone(),
-                    }),
-                );
-                return Some(true);
+            TerminalAuthorizationMode::OsLogin {
+                failure,
+                scope: failure_scope,
             }
-            guard.ok()
-        } else {
-            None
         };
 
-        let username = self.lr.os_login.username.clone();
+        let is_terminal_os_login = matches!(auth_mode, TerminalAuthorizationMode::OsLogin { .. });
+        let failure_scope = match auth_mode {
+            TerminalAuthorizationMode::OsLogin { scope, .. } => scope,
+            TerminalAuthorizationMode::SessionUser => FailureScope::Default,
+        };
+
+        let username = normalized_username;
         let password = self.lr.os_login.password.clone();
-        if let Some(msg) = self.fill_terminal_user_token(&username, &password) {
-            if let Some(failure) = terminal_failure {
-                self.update_failure_with_scope(failure, false, 0, failure_scope);
+        let terminal_login_error = {
+            #[cfg(target_os = "windows")]
+            {
+                let _os_login_concurrency_guard = if is_terminal_os_login {
+                    let guard = try_acquire_os_credential_login_gate();
+                    if guard.is_err() {
+                        log::warn!(
+                            "OS credential login blocked by concurrency gate: ip={} conn_id={} scope={:?}",
+                            self.ip,
+                            self.inner.id(),
+                            failure_scope
+                        );
+                        self.send_login_error("Please try 1 minute later").await;
+                        sleep(1.).await;
+                        Self::post_alarm_audit(
+                            AlarmAuditType::TerminalOsLoginConcurrency,
+                            json!({
+                                "ip": self.ip,
+                                "id": self.lr.my_id.clone(),
+                                "name": self.lr.my_name.clone(),
+                            }),
+                        );
+                        return Some(true);
+                    }
+                    guard.ok()
+                } else {
+                    None
+                };
+                self.fill_terminal_user_token(&username, &password)
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                self.fill_terminal_user_token(&username, &password)
+            }
+        };
+        if let Some(msg) = terminal_login_error {
+            if let TerminalAuthorizationMode::OsLogin { failure, scope } = auth_mode {
+                self.update_failure_with_scope(failure, false, 0, scope);
             }
             log::warn!(
-                "Terminal OS login verification failed: ip={} conn_id={} scope={:?} msg='{}'",
+                "OS credential login verification failed: ip={} conn_id={} scope={:?} msg='{}'",
                 self.ip,
                 self.inner.id(),
                 failure_scope,
@@ -3607,8 +3708,8 @@ impl Connection {
             sleep(1.).await;
             return Some(false);
         }
-        if is_terminal_os_login {
-            clear_terminal_failure_state();
+        if let TerminalAuthorizationMode::OsLogin { failure, scope } = auth_mode {
+            self.update_failure_with_scope(failure, true, 0, scope);
         }
 
         if let Some(is_user) =
@@ -3694,7 +3795,10 @@ impl Connection {
         i: usize,
         scope: FailureScope,
     ) {
-        let terminal_scope = scope == FailureScope::TerminalOsLogin;
+        let os_credential_scope = matches!(
+            scope,
+            FailureScope::TerminalOsLogin | FailureScope::LinuxHeadlessOsLogin
+        );
         let map_mutex = &LOGIN_FAILURES[i];
         if remove {
             if failure.0 != 0 {
@@ -3708,9 +3812,9 @@ impl Connection {
                     map_mutex.lock().unwrap().remove(&self.ip);
                 }
             }
-            if terminal_scope {
-                clear_terminal_failure_state();
-            }
+            // Intentionally keep OS-credential backoff state as global.
+            // Reason: if one successful login cleared this state, an attacker could use
+            // intermittent successes to repeatedly reset throttling.
             return;
         }
         // Bump the prefixes, fetching existing values
@@ -3727,8 +3831,8 @@ impl Connection {
             m.insert(self.ip.clone(), Self::bump_failure_entry(failure, time));
         }
 
-        if terminal_scope {
-            record_terminal_failure();
+        if os_credential_scope {
+            record_os_credential_failure(scope);
         }
     }
 
@@ -3822,13 +3926,16 @@ impl Connection {
                 }),
             );
             false
-        } else if scope == FailureScope::TerminalOsLogin {
-            let decision = evaluate_terminal_policy(get_time());
+        } else if matches!(
+            scope,
+            FailureScope::TerminalOsLogin | FailureScope::LinuxHeadlessOsLogin
+        ) {
+            let decision = evaluate_os_credential_policy(scope, get_time());
             if decision.allowed {
                 true
             } else {
                 log::warn!(
-                    "Terminal OS login blocked by policy: ip={} conn_id={} i={} msg='{}'",
+                    "OS credential login blocked by policy: ip={} conn_id={} i={} msg='{}'",
                     self.ip,
                     self.inner.id(),
                     i,
@@ -3839,6 +3946,8 @@ impl Connection {
                     self.send_login_error(login_error).await;
                 }
                 if let Some(audit) = decision.audit {
+                    // For OS blocked/backoff events, we currently emit one alarm report per blocked attempt.
+                    // TODO: Add unified cumulative/aggregation fields across alarm producers.
                     Self::post_alarm_audit(
                         audit,
                         json!({
@@ -5332,6 +5441,8 @@ pub enum AlarmAuditType {
     ExceedIPv6PrefixAttempts = 6,
     TerminalOsLoginBackoff = 7,
     TerminalOsLoginConcurrency = 8,
+    LinuxHeadlessOsLoginBackoff = 9,
+    LinuxHeadlessOsLoginConcurrency = 10,
 }
 
 pub enum FileAuditType {
@@ -5580,19 +5691,6 @@ impl LinuxHeadlessHandle {
             wait_ipc_timeout: 10_000,
             rx_cm_stream_ready,
             tx_desktop_ready,
-        }
-    }
-
-    pub fn try_start_desktop(&mut self, os_login: Option<&OSLogin>) -> String {
-        if self.is_headless_allowed {
-            match os_login {
-                Some(os_login) => {
-                    linux_desktop_manager::try_start_desktop(&os_login.username, &os_login.password)
-                }
-                None => linux_desktop_manager::try_start_desktop("", ""),
-            }
-        } else {
-            "".to_string()
         }
     }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1,3 +1,7 @@
+use super::login_failure_check::{
+    clear_terminal_failure_state, evaluate_terminal_policy, record_terminal_failure,
+    try_acquire_terminal_os_login_gate, FailureScope,
+};
 use super::{input_service::*, *};
 #[cfg(feature = "unix-file-copy-paste")]
 use crate::clipboard::try_empty_clipboard_files;
@@ -83,6 +87,8 @@ lazy_static::lazy_static! {
     static ref SWITCH_SIDES_UUID: Arc::<Mutex<HashMap<String, (Instant, uuid::Uuid)>>> = Default::default();
     static ref PENDING_SWITCH_SIDES_UUID: Arc::<Mutex<HashMap<String, (Instant, uuid::Uuid)>>> = Default::default();
 }
+
+const TERMINAL_OS_LOGIN_FAILED_MSG: &str = "Terminal login failed.";
 
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
@@ -1499,6 +1505,9 @@ impl Connection {
             // Keep the connection alive so the client can continue with 2FA.
             return true;
         }
+        if let Some(keep_alive) = self.prepare_terminal_login_for_authorization().await {
+            return keep_alive;
+        }
         if !self.connect_port_forward_if_needed().await {
             return false;
         }
@@ -2378,33 +2387,6 @@ impl Connection {
                             o.terminal_persistent.enum_value() == Ok(BoolOption::Yes);
                     }
                     self.terminal_service_id = terminal.service_id;
-                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                    if let Some(msg) =
-                        self.fill_terminal_user_token(&lr.os_login.username, &lr.os_login.password)
-                    {
-                        self.send_login_error(msg).await;
-                        sleep(1.).await;
-                        return false;
-                    }
-
-                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                    if let Some(is_user) =
-                        terminal_service::is_service_specified_user(&self.terminal_service_id)
-                    {
-                        if let Some(user_token) = &self.terminal_user_token {
-                            let has_service_token =
-                                user_token.to_terminal_service_token().is_some();
-                            if is_user != has_service_token {
-                                // This occurs when the service id (in the configuration) is manually changed by the user, causing a mismatch in validation.
-                                log::error!("Terminal service user mismatch detected. The service ID may have been manually changed in the configuration, causing validation to fail.");
-                                // No need to translate the following message, because it is in an abnormal case.
-                                self.send_login_error("Terminal service user mismatch detected.")
-                                    .await;
-                                sleep(1.).await;
-                                return false;
-                            }
-                        }
-                    }
                 }
                 Some(login_request::Union::PortForward(mut pf)) => {
                     if !Self::permission(keys::OPTION_ENABLE_TUNNEL, &self.control_permissions) {
@@ -2423,7 +2405,13 @@ impl Connection {
             }
 
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
-            self.try_start_cm_ipc();
+            {
+                let should_delay_terminal_cm_ipc =
+                    self.terminal && !lr.os_login.username.trim().is_empty();
+                if !should_delay_terminal_cm_ipc {
+                    self.try_start_cm_ipc();
+                }
+            }
 
             #[cfg(not(target_os = "linux"))]
             let err_msg = "".to_owned();
@@ -2489,7 +2477,9 @@ impl Connection {
                     if !self.send_logon_response_and_keep_alive().await {
                         return false;
                     }
-                    self.try_start_cm(lr.my_id.clone(), lr.my_name.clone(), self.authorized);
+                    if self.authorized || self.require_2fa.is_some() {
+                        self.try_start_cm(lr.my_id.clone(), lr.my_name.clone(), self.authorized);
+                    }
                 } else {
                     self.send_login_error(err_msg).await;
                 }
@@ -2528,7 +2518,9 @@ impl Connection {
                         if !self.send_logon_response_and_keep_alive().await {
                             return false;
                         }
-                        self.try_start_cm(lr.my_id, lr.my_name, self.authorized);
+                        if self.authorized || self.require_2fa.is_some() {
+                            self.try_start_cm(lr.my_id, lr.my_name, self.authorized);
+                        }
                     } else {
                         self.send_login_error(err_msg).await;
                     }
@@ -2548,11 +2540,13 @@ impl Connection {
                         if !self.send_logon_response_and_keep_alive().await {
                             return false;
                         }
-                        self.try_start_cm(
-                            self.lr.my_id.to_owned(),
-                            self.lr.my_name.to_owned(),
-                            self.authorized,
-                        );
+                        if self.authorized || self.require_2fa.is_some() {
+                            self.try_start_cm(
+                                self.lr.my_id.to_owned(),
+                                self.lr.my_name.to_owned(),
+                                self.authorized,
+                            );
+                        }
                         if !tfa.hwid.is_empty() && Self::enable_trusted_devices() {
                             Config::add_trusted_device(TrustedDevice {
                                 hwid: tfa.hwid,
@@ -2602,13 +2596,21 @@ impl Connection {
                             if !self.send_logon_response_and_keep_alive().await {
                                 return false;
                             }
-                            self.try_start_cm(
-                                lr.my_id.clone(),
-                                lr.my_name.clone(),
-                                self.authorized,
-                            );
+                            if self.authorized || self.require_2fa.is_some() {
+                                self.try_start_cm(
+                                    lr.my_id.clone(),
+                                    lr.my_name.clone(),
+                                    self.authorized,
+                                );
+                            }
                             #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                            self.try_start_cm_ipc();
+                            {
+                                let should_delay_terminal_cm_ipc =
+                                    self.terminal && !self.lr.os_login.username.trim().is_empty();
+                                if !should_delay_terminal_cm_ipc {
+                                    self.try_start_cm_ipc();
+                                }
+                            }
                         }
                     }
                 }
@@ -3486,16 +3488,16 @@ impl Connection {
                     self.terminal_user_token = Some(TerminalUserToken::SelfUser);
                     None
                 } else {
-                    Some("The user is not an administrator.")
+                    Some(TERMINAL_OS_LOGIN_FAILED_MSG)
                 }
             }
             Ok(Err(e)) => {
                 log::error!("Failed to check if the user is an administrator: {}", e);
-                Some("Failed to check if the user is an administrator.")
+                Some(TERMINAL_OS_LOGIN_FAILED_MSG)
             }
             Err(e) => {
                 log::error!("Failed to get logon user token: {}", e);
-                Some("Incorrect username or password.")
+                Some(TERMINAL_OS_LOGIN_FAILED_MSG)
             }
         }
     }
@@ -3531,6 +3533,118 @@ impl Connection {
         }
     }
 
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    async fn prepare_terminal_login_for_authorization(&mut self) -> Option<bool> {
+        if !self.terminal || self.terminal_user_token.is_some() {
+            return None;
+        }
+
+        let is_terminal_os_login = !self.lr.os_login.username.trim().is_empty();
+        let failure_scope = if is_terminal_os_login {
+            FailureScope::TerminalOsLogin
+        } else {
+            FailureScope::Default
+        };
+        let mut terminal_failure = None;
+        if is_terminal_os_login {
+            let (failure, res) = self.check_failure_with_scope(0, failure_scope).await;
+            if !res {
+                // Rate-limit blocks should keep the connection alive for retries.
+                log::warn!(
+                    "Terminal OS login blocked by failure policy: ip={} conn_id={} scope={:?}",
+                    self.ip,
+                    self.inner.id(),
+                    failure_scope
+                );
+                return Some(true);
+            }
+            terminal_failure = Some(failure);
+        }
+
+        #[cfg(target_os = "windows")]
+        let _os_login_concurrency_guard = if !self.lr.os_login.username.trim().is_empty() {
+            let guard = try_acquire_terminal_os_login_gate();
+            if guard.is_err() {
+                if let Some(failure) = terminal_failure {
+                    self.update_failure_with_scope(failure, false, 0, failure_scope);
+                }
+                log::warn!(
+                    "Terminal OS login blocked by concurrency gate: ip={} conn_id={} scope={:?}",
+                    self.ip,
+                    self.inner.id(),
+                    failure_scope
+                );
+                self.send_login_error("Please try 1 minute later").await;
+                Self::post_alarm_audit(
+                    AlarmAuditType::TerminalOsLoginConcurrency,
+                    json!({
+                        "ip": self.ip,
+                        "id": self.lr.my_id.clone(),
+                        "name": self.lr.my_name.clone(),
+                    }),
+                );
+                return Some(true);
+            }
+            guard.ok()
+        } else {
+            None
+        };
+
+        let username = self.lr.os_login.username.clone();
+        let password = self.lr.os_login.password.clone();
+        if let Some(msg) = self.fill_terminal_user_token(&username, &password) {
+            if let Some(failure) = terminal_failure {
+                self.update_failure_with_scope(failure, false, 0, failure_scope);
+            }
+            log::warn!(
+                "Terminal OS login verification failed: ip={} conn_id={} scope={:?} msg='{}'",
+                self.ip,
+                self.inner.id(),
+                failure_scope,
+                msg
+            );
+            self.send_login_error(msg).await;
+            sleep(1.).await;
+            return Some(false);
+        }
+        if is_terminal_os_login {
+            clear_terminal_failure_state();
+        }
+
+        if let Some(is_user) =
+            terminal_service::is_service_specified_user(&self.terminal_service_id)
+        {
+            if let Some(user_token) = &self.terminal_user_token {
+                let has_service_token = user_token.to_terminal_service_token().is_some();
+                if is_user != has_service_token {
+                    log::warn!(
+                        "Terminal service user mismatch: ip={} conn_id={} service_is_user={} has_service_token={}",
+                        self.ip,
+                        self.inner.id(),
+                        is_user,
+                        has_service_token
+                    );
+                    // This occurs when the service id (in the configuration) is manually changed by the user, causing a mismatch in validation.
+                    log::error!("Terminal service user mismatch detected. The service ID may have been manually changed in the configuration, causing validation to fail.");
+                    // No need to translate the following message, because it is in an abnormal case.
+                    self.send_login_error("Terminal service user mismatch detected.")
+                        .await;
+                    sleep(1.).await;
+                    return Some(false);
+                }
+            }
+        }
+        if is_terminal_os_login {
+            self.try_start_cm_ipc();
+        }
+        None
+    }
+
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    async fn prepare_terminal_login_for_authorization(&mut self) -> Option<bool> {
+        None
+    }
+
     // Try to parse connection IP as IPv6 address, returning /64, /56, and /48 prefixes.
     // Parsing an IPv4 address just returns None.
     // note: we specifically don't use hbb_common::is_ipv6_str to avoid divergence issues
@@ -3557,18 +3671,30 @@ impl Connection {
         Some((p64, p56, p48))
     }
 
-    fn update_failure(&self, (failure, time): ((i32, i32, i32), i32), remove: bool, i: usize) {
-        fn bump(mut cur: (i32, i32, i32), time: i32) -> (i32, i32, i32) {
-            if cur.0 == time {
-                cur.1 += 1;
-                cur.2 += 1;
-            } else {
-                cur.0 = time;
-                cur.1 = 1;
-                cur.2 += 1;
-            }
-            cur
+    fn bump_failure_entry(mut cur: (i32, i32, i32), time: i32) -> (i32, i32, i32) {
+        if cur.0 == time {
+            cur.1 += 1;
+            cur.2 += 1;
+        } else {
+            cur.0 = time;
+            cur.1 = 1;
+            cur.2 += 1;
         }
+        cur
+    }
+
+    fn update_failure(&self, failure: ((i32, i32, i32), i32), remove: bool, i: usize) {
+        self.update_failure_with_scope(failure, remove, i, FailureScope::Default);
+    }
+
+    fn update_failure_with_scope(
+        &self,
+        (failure, time): ((i32, i32, i32), i32),
+        remove: bool,
+        i: usize,
+        scope: FailureScope,
+    ) {
+        let terminal_scope = scope == FailureScope::TerminalOsLogin;
         let map_mutex = &LOGIN_FAILURES[i];
         if remove {
             if failure.0 != 0 {
@@ -3582,6 +3708,9 @@ impl Connection {
                     map_mutex.lock().unwrap().remove(&self.ip);
                 }
             }
+            if terminal_scope {
+                clear_terminal_failure_state();
+            }
             return;
         }
         // Bump the prefixes, fetching existing values
@@ -3589,14 +3718,17 @@ impl Connection {
             let mut m = map_mutex.lock().unwrap();
             for key in [p64, p56, p48] {
                 let cur = m.get(&key).copied().unwrap_or((0, 0, 0));
-                m.insert(key, bump(cur, time));
+                m.insert(key, Self::bump_failure_entry(cur, time));
             }
-            // Update full IP: bump from the *original* passed-in failure
-            m.insert(self.ip.clone(), bump(failure, time));
+            m.insert(self.ip.clone(), Self::bump_failure_entry(failure, time));
         } else {
             // Update full IP: bump from the *original* passed-in failure
             let mut m = map_mutex.lock().unwrap();
-            m.insert(self.ip.clone(), bump(failure, time));
+            m.insert(self.ip.clone(), Self::bump_failure_entry(failure, time));
+        }
+
+        if terminal_scope {
+            record_terminal_failure();
         }
     }
 
@@ -3636,6 +3768,15 @@ impl Connection {
     }
 
     async fn check_failure(&mut self, i: usize) -> (((i32, i32, i32), i32), bool) {
+        self.check_failure_with_scope(i, FailureScope::Default)
+            .await
+    }
+
+    async fn check_failure_with_scope(
+        &mut self,
+        i: usize,
+        scope: FailureScope,
+    ) -> (((i32, i32, i32), i32), bool) {
         let time = (get_time() / 60_000) as i32;
 
         // IPv6 addresses are cheap to make so we check prefix/netblock as well
@@ -3681,6 +3822,34 @@ impl Connection {
                 }),
             );
             false
+        } else if scope == FailureScope::TerminalOsLogin {
+            let decision = evaluate_terminal_policy(get_time());
+            if decision.allowed {
+                true
+            } else {
+                log::warn!(
+                    "Terminal OS login blocked by policy: ip={} conn_id={} i={} msg='{}'",
+                    self.ip,
+                    self.inner.id(),
+                    i,
+                    decision.login_error.as_deref().unwrap_or("")
+                );
+                if let Some(login_error) = decision.login_error {
+                    // Rare branch and currently temporary response copy; translation can be added later if needed.
+                    self.send_login_error(login_error).await;
+                }
+                if let Some(audit) = decision.audit {
+                    Self::post_alarm_audit(
+                        audit,
+                        json!({
+                                    "ip": self.ip,
+                                    "id": self.lr.my_id.clone(),
+                                    "name": self.lr.my_name.clone(),
+                        }),
+                    );
+                }
+                false
+            }
         } else {
             true
         };
@@ -5161,6 +5330,8 @@ pub enum AlarmAuditType {
     // MultipleLoginsAttemptsWithinOneMinute = 4,
     // MultipleLoginsAttemptsWithinOneHour = 5,
     ExceedIPv6PrefixAttempts = 6,
+    TerminalOsLoginBackoff = 7,
+    TerminalOsLoginConcurrency = 8,
 }
 
 pub enum FileAuditType {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -3797,12 +3797,12 @@ impl Connection {
                 let cur = m.get(&key).copied().unwrap_or((0, 0, 0));
                 m.insert(key, Self::bump_failure_entry(cur, time));
             }
-            let current_ip = m.get(&self.ip).copied().unwrap_or(failure);
+            let current_ip = m.get(&self.ip).copied().unwrap_or((0, 0, 0));
             m.insert(self.ip.clone(), Self::bump_failure_entry(current_ip, time));
         } else {
             // Re-read the full IP bucket in case another failed attempt updated it.
             let mut m = map_mutex.lock().unwrap();
-            let current_ip = m.get(&self.ip).copied().unwrap_or(failure);
+            let current_ip = m.get(&self.ip).copied().unwrap_or((0, 0, 0));
             m.insert(self.ip.clone(), Self::bump_failure_entry(current_ip, time));
         }
 

--- a/src/server/login_failure_check.rs
+++ b/src/server/login_failure_check.rs
@@ -1,0 +1,180 @@
+use crate::AlarmAuditType;
+use hbb_common::{
+    get_time, log,
+    tokio::sync::{Mutex as TokioMutex, OwnedMutexGuard},
+};
+use std::sync::{Arc, Mutex};
+
+const TERMINAL_OS_LOGIN_TOTAL_IDLE_RESET_MS: i64 = 120 * 60 * 1_000;
+const TERMINAL_OS_LOGIN_BACKOFF_BASE_SECONDS: i64 = 15;
+const TERMINAL_OS_LOGIN_BACKOFF_MAX_SECONDS: i64 = 30 * 60;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum FailureScope {
+    Default,
+    TerminalOsLogin,
+}
+
+pub(crate) struct TerminalPolicyDecision {
+    pub allowed: bool,
+    pub login_error: Option<String>,
+    pub audit: Option<AlarmAuditType>,
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+struct TerminalFailureState {
+    total_failures: i32,
+    backoff_until_ms: Option<i64>,
+    last_failure_ms: Option<i64>,
+}
+
+lazy_static::lazy_static! {
+    static ref TERMINAL_FAILURE_STATE: Mutex<TerminalFailureState> = Mutex::new(TerminalFailureState::default());
+    static ref TERMINAL_OS_LOGIN_MUTEX: Arc<TokioMutex<()>> = Arc::new(TokioMutex::new(()));
+}
+
+fn terminal_os_login_backoff_seconds(total_failures: i32) -> i64 {
+    if total_failures <= 2 {
+        return 0;
+    }
+    let exp = (total_failures - 3).min(6);
+    let seconds = TERMINAL_OS_LOGIN_BACKOFF_BASE_SECONDS * (1_i64 << exp);
+    seconds.min(TERMINAL_OS_LOGIN_BACKOFF_MAX_SECONDS)
+}
+
+fn normalize_backoff(state: &mut TerminalFailureState, now_ms: i64) {
+    if let Some(until_ms) = state.backoff_until_ms {
+        if until_ms <= now_ms {
+            state.backoff_until_ms = None;
+        }
+    }
+}
+
+fn reset_totals_on_idle(state: &mut TerminalFailureState, now_ms: i64) {
+    if let Some(last_ms) = state.last_failure_ms {
+        if now_ms.saturating_sub(last_ms) >= TERMINAL_OS_LOGIN_TOTAL_IDLE_RESET_MS {
+            state.total_failures = 0;
+            state.backoff_until_ms = None;
+            state.last_failure_ms = None;
+        }
+    }
+}
+
+fn allow_decision() -> TerminalPolicyDecision {
+    TerminalPolicyDecision {
+        allowed: true,
+        login_error: None,
+        audit: None,
+    }
+}
+
+fn block_decision(login_error: String, alarm_type: AlarmAuditType) -> TerminalPolicyDecision {
+    TerminalPolicyDecision {
+        allowed: false,
+        login_error: Some(login_error),
+        audit: Some(alarm_type),
+    }
+}
+
+pub(crate) fn evaluate_terminal_policy(now_ms: i64) -> TerminalPolicyDecision {
+    let mut state = TERMINAL_FAILURE_STATE.lock().unwrap();
+    reset_totals_on_idle(&mut state, now_ms);
+    normalize_backoff(&mut state, now_ms);
+
+    let decision = if let Some(until_ms) = state.backoff_until_ms {
+        let remaining_ms = (until_ms - now_ms).max(0);
+        let remaining_seconds = ((remaining_ms + 999) / 1_000).max(1);
+        log::warn!(
+            "Terminal OS login blocked by backoff policy: remaining_seconds={}",
+            remaining_seconds
+        );
+        block_decision(
+            format!("Please try {} seconds later", remaining_seconds),
+            AlarmAuditType::TerminalOsLoginBackoff,
+        )
+    } else {
+        allow_decision()
+    };
+
+    decision
+}
+
+pub(crate) fn record_terminal_failure() {
+    let now_ms = get_time();
+    let mut state = TERMINAL_FAILURE_STATE.lock().unwrap();
+    reset_totals_on_idle(&mut state, now_ms);
+    normalize_backoff(&mut state, now_ms);
+    state.total_failures += 1;
+    state.last_failure_ms = Some(now_ms);
+    let backoff_seconds = terminal_os_login_backoff_seconds(state.total_failures);
+    if backoff_seconds > 0 {
+        state.backoff_until_ms = Some(now_ms + backoff_seconds * 1_000);
+    }
+}
+
+pub(crate) fn clear_terminal_failure_state() {
+    *TERMINAL_FAILURE_STATE.lock().unwrap() = TerminalFailureState::default();
+}
+
+pub(crate) fn try_acquire_terminal_os_login_gate() -> Result<OwnedMutexGuard<()>, ()> {
+    TERMINAL_OS_LOGIN_MUTEX
+        .clone()
+        .try_lock_owned()
+        .map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn terminal_policy_prioritizes_backoff() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        clear_terminal_failure_state();
+        let now_ms = get_time();
+        for _ in 0..3 {
+            record_terminal_failure();
+        }
+        let decision = evaluate_terminal_policy(now_ms);
+        assert!(!decision.allowed);
+        assert!(decision.login_error.is_some());
+        clear_terminal_failure_state();
+    }
+
+    #[test]
+    fn terminal_policy_idle_window_resets_total_counter() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        clear_terminal_failure_state();
+        let now_ms = get_time();
+        for _ in 0..13 {
+            record_terminal_failure();
+        }
+        let blocked = evaluate_terminal_policy(now_ms);
+        assert!(!blocked.allowed);
+
+        let after_idle_ms = now_ms + TERMINAL_OS_LOGIN_TOTAL_IDLE_RESET_MS + 1_000;
+        let allowed = evaluate_terminal_policy(after_idle_ms);
+        assert!(allowed.allowed);
+    }
+
+    #[test]
+    fn terminal_policy_first_backoff_is_not_too_short() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        clear_terminal_failure_state();
+        for _ in 0..3 {
+            record_terminal_failure();
+        }
+
+        let decision = evaluate_terminal_policy(get_time());
+        assert!(!decision.allowed);
+        let msg = decision.login_error.unwrap_or_default();
+        let seconds = msg
+            .split_whitespace()
+            .nth(2)
+            .and_then(|s| s.parse::<i64>().ok())
+            .unwrap_or(0);
+        assert!(seconds >= TERMINAL_OS_LOGIN_BACKOFF_BASE_SECONDS);
+    }
+}

--- a/src/server/login_failure_check.rs
+++ b/src/server/login_failure_check.rs
@@ -1,9 +1,10 @@
 use crate::AlarmAuditType;
-use hbb_common::{
-    get_time,
-    tokio::sync::{Mutex as TokioMutex, OwnedMutexGuard},
-};
-use std::sync::{Arc, Mutex};
+use hbb_common::get_time;
+#[cfg(target_os = "windows")]
+use hbb_common::tokio::sync::{Mutex as TokioMutex, OwnedMutexGuard};
+use std::sync::Mutex;
+#[cfg(target_os = "windows")]
+use std::sync::Arc;
 
 const OS_CREDENTIAL_LOGIN_TOTAL_IDLE_RESET_MS: i64 = 120 * 60 * 1_000;
 const OS_CREDENTIAL_LOGIN_BACKOFF_BASE_SECONDS: i64 = 15;
@@ -13,8 +14,6 @@ const OS_CREDENTIAL_LOGIN_BACKOFF_MAX_SECONDS: i64 = 30 * 60;
 pub(crate) enum FailureScope {
     Default,
     TerminalOsLogin,
-    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-    LinuxHeadlessOsLogin,
 }
 
 pub(crate) struct OsCredentialPolicyDecision {
@@ -33,14 +32,15 @@ struct OsCredentialFailureState {
 lazy_static::lazy_static! {
     static ref OS_CREDENTIAL_LOGIN_FAILURE_STATE: Mutex<OsCredentialFailureState> =
         Mutex::new(OsCredentialFailureState::default());
+}
+
+#[cfg(target_os = "windows")]
+lazy_static::lazy_static! {
     static ref OS_CREDENTIAL_LOGIN_MUTEX: Arc<TokioMutex<()>> = Arc::new(TokioMutex::new(()));
 }
 
 fn is_os_credential_scope(scope: FailureScope) -> bool {
-    matches!(
-        scope,
-        FailureScope::TerminalOsLogin | FailureScope::LinuxHeadlessOsLogin
-    )
+    matches!(scope, FailureScope::TerminalOsLogin)
 }
 
 fn state_for_os_credential_scope(
@@ -56,7 +56,6 @@ fn state_for_os_credential_scope(
 fn backoff_audit_type_for_scope(scope: FailureScope) -> Option<AlarmAuditType> {
     match scope {
         FailureScope::TerminalOsLogin => Some(AlarmAuditType::TerminalOsLoginBackoff),
-        FailureScope::LinuxHeadlessOsLogin => Some(AlarmAuditType::LinuxHeadlessOsLoginBackoff),
         FailureScope::Default => None,
     }
 }
@@ -124,8 +123,16 @@ pub(crate) fn evaluate_os_credential_policy(
     if let Some(until_ms) = state.backoff_until_ms {
         let remaining_ms = (until_ms - now_ms).max(0);
         let remaining_seconds = ((remaining_ms + 999) / 1_000).max(1);
+        let seconds_label = if remaining_seconds == 1 {
+            "second"
+        } else {
+            "seconds"
+        };
         block_decision(
-            format!("Please try {} seconds later", remaining_seconds),
+            format!(
+                "Please try again in {} {}.",
+                remaining_seconds, seconds_label
+            ),
             backoff_audit_type_for_scope(scope),
         )
     } else {
@@ -152,6 +159,7 @@ pub(crate) fn record_os_credential_failure(scope: FailureScope) {
     }
 }
 
+#[cfg(target_os = "windows")]
 pub(crate) fn try_acquire_os_credential_login_gate() -> Result<OwnedMutexGuard<()>, ()> {
     OS_CREDENTIAL_LOGIN_MUTEX
         .clone()
@@ -200,29 +208,6 @@ mod tests {
         let allowed = evaluate_os_credential_policy(FailureScope::TerminalOsLogin, after_idle_ms);
         assert!(allowed.allowed);
         clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
-    }
-
-    #[test]
-    fn os_credential_policy_scopes_share_global_state() {
-        let _guard = TEST_MUTEX.lock().unwrap();
-        clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
-        clear_os_credential_failure_state(FailureScope::LinuxHeadlessOsLogin);
-
-        for _ in 0..3 {
-            record_os_credential_failure(FailureScope::LinuxHeadlessOsLogin);
-        }
-
-        let now_ms = get_time();
-        let terminal = evaluate_os_credential_policy(FailureScope::TerminalOsLogin, now_ms);
-        let linux =
-            evaluate_os_credential_policy(FailureScope::LinuxHeadlessOsLogin, now_ms + 1_000);
-        assert!(!terminal.allowed);
-        assert!(!linux.allowed);
-        assert!(terminal.audit.is_some());
-        assert!(linux.audit.is_some());
-
-        clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
-        clear_os_credential_failure_state(FailureScope::LinuxHeadlessOsLogin);
     }
 
     #[test]

--- a/src/server/login_failure_check.rs
+++ b/src/server/login_failure_check.rs
@@ -147,8 +147,8 @@ pub(crate) fn record_os_credential_failure(scope: FailureScope) {
     let Some(state_mutex) = state_for_os_credential_scope(scope) else {
         return;
     };
-    let now_ms = get_time();
     let mut state = state_mutex.lock().unwrap();
+    let now_ms = get_time();
     reset_totals_on_idle(&mut state, now_ms);
     normalize_backoff(&mut state, now_ms);
     state.total_failures = state.total_failures.saturating_add(1);

--- a/src/server/login_failure_check.rs
+++ b/src/server/login_failure_check.rs
@@ -1,48 +1,76 @@
 use crate::AlarmAuditType;
 use hbb_common::{
-    get_time, log,
+    get_time,
     tokio::sync::{Mutex as TokioMutex, OwnedMutexGuard},
 };
 use std::sync::{Arc, Mutex};
 
-const TERMINAL_OS_LOGIN_TOTAL_IDLE_RESET_MS: i64 = 120 * 60 * 1_000;
-const TERMINAL_OS_LOGIN_BACKOFF_BASE_SECONDS: i64 = 15;
-const TERMINAL_OS_LOGIN_BACKOFF_MAX_SECONDS: i64 = 30 * 60;
+const OS_CREDENTIAL_LOGIN_TOTAL_IDLE_RESET_MS: i64 = 120 * 60 * 1_000;
+const OS_CREDENTIAL_LOGIN_BACKOFF_BASE_SECONDS: i64 = 15;
+const OS_CREDENTIAL_LOGIN_BACKOFF_MAX_SECONDS: i64 = 30 * 60;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum FailureScope {
     Default,
     TerminalOsLogin,
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    LinuxHeadlessOsLogin,
 }
 
-pub(crate) struct TerminalPolicyDecision {
+pub(crate) struct OsCredentialPolicyDecision {
     pub allowed: bool,
     pub login_error: Option<String>,
     pub audit: Option<AlarmAuditType>,
 }
 
 #[derive(Copy, Clone, Debug, Default)]
-struct TerminalFailureState {
+struct OsCredentialFailureState {
     total_failures: i32,
     backoff_until_ms: Option<i64>,
     last_failure_ms: Option<i64>,
 }
 
 lazy_static::lazy_static! {
-    static ref TERMINAL_FAILURE_STATE: Mutex<TerminalFailureState> = Mutex::new(TerminalFailureState::default());
-    static ref TERMINAL_OS_LOGIN_MUTEX: Arc<TokioMutex<()>> = Arc::new(TokioMutex::new(()));
+    static ref OS_CREDENTIAL_LOGIN_FAILURE_STATE: Mutex<OsCredentialFailureState> =
+        Mutex::new(OsCredentialFailureState::default());
+    static ref OS_CREDENTIAL_LOGIN_MUTEX: Arc<TokioMutex<()>> = Arc::new(TokioMutex::new(()));
 }
 
-fn terminal_os_login_backoff_seconds(total_failures: i32) -> i64 {
+fn is_os_credential_scope(scope: FailureScope) -> bool {
+    matches!(
+        scope,
+        FailureScope::TerminalOsLogin | FailureScope::LinuxHeadlessOsLogin
+    )
+}
+
+fn state_for_os_credential_scope(
+    scope: FailureScope,
+) -> Option<&'static Mutex<OsCredentialFailureState>> {
+    if is_os_credential_scope(scope) {
+        Some(&OS_CREDENTIAL_LOGIN_FAILURE_STATE)
+    } else {
+        None
+    }
+}
+
+fn backoff_audit_type_for_scope(scope: FailureScope) -> Option<AlarmAuditType> {
+    match scope {
+        FailureScope::TerminalOsLogin => Some(AlarmAuditType::TerminalOsLoginBackoff),
+        FailureScope::LinuxHeadlessOsLogin => Some(AlarmAuditType::LinuxHeadlessOsLoginBackoff),
+        FailureScope::Default => None,
+    }
+}
+
+fn os_credential_login_backoff_seconds(total_failures: i32) -> i64 {
     if total_failures <= 2 {
         return 0;
     }
-    let exp = (total_failures - 3).min(6);
-    let seconds = TERMINAL_OS_LOGIN_BACKOFF_BASE_SECONDS * (1_i64 << exp);
-    seconds.min(TERMINAL_OS_LOGIN_BACKOFF_MAX_SECONDS)
+    let exp = (total_failures - 3).min(7);
+    let seconds = OS_CREDENTIAL_LOGIN_BACKOFF_BASE_SECONDS * (1_i64 << exp);
+    seconds.min(OS_CREDENTIAL_LOGIN_BACKOFF_MAX_SECONDS)
 }
 
-fn normalize_backoff(state: &mut TerminalFailureState, now_ms: i64) {
+fn normalize_backoff(state: &mut OsCredentialFailureState, now_ms: i64) {
     if let Some(until_ms) = state.backoff_until_ms {
         if until_ms <= now_ms {
             state.backoff_until_ms = None;
@@ -50,9 +78,9 @@ fn normalize_backoff(state: &mut TerminalFailureState, now_ms: i64) {
     }
 }
 
-fn reset_totals_on_idle(state: &mut TerminalFailureState, now_ms: i64) {
+fn reset_totals_on_idle(state: &mut OsCredentialFailureState, now_ms: i64) {
     if let Some(last_ms) = state.last_failure_ms {
-        if now_ms.saturating_sub(last_ms) >= TERMINAL_OS_LOGIN_TOTAL_IDLE_RESET_MS {
+        if now_ms.saturating_sub(last_ms) >= OS_CREDENTIAL_LOGIN_TOTAL_IDLE_RESET_MS {
             state.total_failures = 0;
             state.backoff_until_ms = None;
             state.last_failure_ms = None;
@@ -60,64 +88,72 @@ fn reset_totals_on_idle(state: &mut TerminalFailureState, now_ms: i64) {
     }
 }
 
-fn allow_decision() -> TerminalPolicyDecision {
-    TerminalPolicyDecision {
+fn allow_decision() -> OsCredentialPolicyDecision {
+    OsCredentialPolicyDecision {
         allowed: true,
         login_error: None,
         audit: None,
     }
 }
 
-fn block_decision(login_error: String, alarm_type: AlarmAuditType) -> TerminalPolicyDecision {
-    TerminalPolicyDecision {
+fn block_decision(
+    login_error: String,
+    alarm_type: Option<AlarmAuditType>,
+) -> OsCredentialPolicyDecision {
+    OsCredentialPolicyDecision {
         allowed: false,
         login_error: Some(login_error),
-        audit: Some(alarm_type),
+        audit: alarm_type,
     }
 }
 
-pub(crate) fn evaluate_terminal_policy(now_ms: i64) -> TerminalPolicyDecision {
-    let mut state = TERMINAL_FAILURE_STATE.lock().unwrap();
+pub(crate) fn evaluate_os_credential_policy(
+    scope: FailureScope,
+    now_ms: i64,
+) -> OsCredentialPolicyDecision {
+    if !is_os_credential_scope(scope) {
+        return allow_decision();
+    }
+    let Some(state_mutex) = state_for_os_credential_scope(scope) else {
+        return allow_decision();
+    };
+    let mut state = state_mutex.lock().unwrap();
     reset_totals_on_idle(&mut state, now_ms);
     normalize_backoff(&mut state, now_ms);
 
-    let decision = if let Some(until_ms) = state.backoff_until_ms {
+    if let Some(until_ms) = state.backoff_until_ms {
         let remaining_ms = (until_ms - now_ms).max(0);
         let remaining_seconds = ((remaining_ms + 999) / 1_000).max(1);
-        log::warn!(
-            "Terminal OS login blocked by backoff policy: remaining_seconds={}",
-            remaining_seconds
-        );
         block_decision(
             format!("Please try {} seconds later", remaining_seconds),
-            AlarmAuditType::TerminalOsLoginBackoff,
+            backoff_audit_type_for_scope(scope),
         )
     } else {
         allow_decision()
-    };
-
-    decision
+    }
 }
 
-pub(crate) fn record_terminal_failure() {
+pub(crate) fn record_os_credential_failure(scope: FailureScope) {
+    if !is_os_credential_scope(scope) {
+        return;
+    }
+    let Some(state_mutex) = state_for_os_credential_scope(scope) else {
+        return;
+    };
     let now_ms = get_time();
-    let mut state = TERMINAL_FAILURE_STATE.lock().unwrap();
+    let mut state = state_mutex.lock().unwrap();
     reset_totals_on_idle(&mut state, now_ms);
     normalize_backoff(&mut state, now_ms);
-    state.total_failures += 1;
+    state.total_failures = state.total_failures.saturating_add(1);
     state.last_failure_ms = Some(now_ms);
-    let backoff_seconds = terminal_os_login_backoff_seconds(state.total_failures);
+    let backoff_seconds = os_credential_login_backoff_seconds(state.total_failures);
     if backoff_seconds > 0 {
         state.backoff_until_ms = Some(now_ms + backoff_seconds * 1_000);
     }
 }
 
-pub(crate) fn clear_terminal_failure_state() {
-    *TERMINAL_FAILURE_STATE.lock().unwrap() = TerminalFailureState::default();
-}
-
-pub(crate) fn try_acquire_terminal_os_login_gate() -> Result<OwnedMutexGuard<()>, ()> {
-    TERMINAL_OS_LOGIN_MUTEX
+pub(crate) fn try_acquire_os_credential_login_gate() -> Result<OwnedMutexGuard<()>, ()> {
+    OS_CREDENTIAL_LOGIN_MUTEX
         .clone()
         .try_lock_owned()
         .map_err(|_| ())
@@ -129,52 +165,82 @@ mod tests {
 
     static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
+    fn clear_os_credential_failure_state(scope: FailureScope) {
+        if let Some(state_mutex) = state_for_os_credential_scope(scope) {
+            *state_mutex.lock().unwrap() = OsCredentialFailureState::default();
+        }
+    }
+
     #[test]
-    fn terminal_policy_prioritizes_backoff() {
+    fn os_credential_policy_prioritizes_backoff() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        clear_terminal_failure_state();
+        clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
         let now_ms = get_time();
         for _ in 0..3 {
-            record_terminal_failure();
+            record_os_credential_failure(FailureScope::TerminalOsLogin);
         }
-        let decision = evaluate_terminal_policy(now_ms);
+        let decision = evaluate_os_credential_policy(FailureScope::TerminalOsLogin, now_ms);
         assert!(!decision.allowed);
         assert!(decision.login_error.is_some());
-        clear_terminal_failure_state();
+        clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
     }
 
     #[test]
-    fn terminal_policy_idle_window_resets_total_counter() {
+    fn os_credential_policy_idle_window_resets_total_counter() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        clear_terminal_failure_state();
-        let now_ms = get_time();
+        clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
         for _ in 0..13 {
-            record_terminal_failure();
+            record_os_credential_failure(FailureScope::TerminalOsLogin);
         }
-        let blocked = evaluate_terminal_policy(now_ms);
+        let blocked = evaluate_os_credential_policy(FailureScope::TerminalOsLogin, get_time());
         assert!(!blocked.allowed);
 
-        let after_idle_ms = now_ms + TERMINAL_OS_LOGIN_TOTAL_IDLE_RESET_MS + 1_000;
-        let allowed = evaluate_terminal_policy(after_idle_ms);
+        let after_failures_ms = get_time();
+        let after_idle_ms = after_failures_ms + OS_CREDENTIAL_LOGIN_TOTAL_IDLE_RESET_MS + 1_000;
+        let allowed = evaluate_os_credential_policy(FailureScope::TerminalOsLogin, after_idle_ms);
         assert!(allowed.allowed);
+        clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
     }
 
     #[test]
-    fn terminal_policy_first_backoff_is_not_too_short() {
+    fn os_credential_policy_scopes_share_global_state() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        clear_terminal_failure_state();
+        clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
+        clear_os_credential_failure_state(FailureScope::LinuxHeadlessOsLogin);
+
         for _ in 0..3 {
-            record_terminal_failure();
+            record_os_credential_failure(FailureScope::LinuxHeadlessOsLogin);
         }
 
-        let decision = evaluate_terminal_policy(get_time());
-        assert!(!decision.allowed);
-        let msg = decision.login_error.unwrap_or_default();
-        let seconds = msg
-            .split_whitespace()
-            .nth(2)
-            .and_then(|s| s.parse::<i64>().ok())
-            .unwrap_or(0);
-        assert!(seconds >= TERMINAL_OS_LOGIN_BACKOFF_BASE_SECONDS);
+        let now_ms = get_time();
+        let terminal = evaluate_os_credential_policy(FailureScope::TerminalOsLogin, now_ms);
+        let linux =
+            evaluate_os_credential_policy(FailureScope::LinuxHeadlessOsLogin, now_ms + 1_000);
+        assert!(!terminal.allowed);
+        assert!(!linux.allowed);
+        assert!(terminal.audit.is_some());
+        assert!(linux.audit.is_some());
+
+        clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
+        clear_os_credential_failure_state(FailureScope::LinuxHeadlessOsLogin);
+    }
+
+    #[test]
+    fn os_credential_policy_audits_every_backoff_block() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
+
+        for _ in 0..3 {
+            record_os_credential_failure(FailureScope::TerminalOsLogin);
+        }
+        let now_ms = get_time();
+        let first = evaluate_os_credential_policy(FailureScope::TerminalOsLogin, now_ms);
+        let second = evaluate_os_credential_policy(FailureScope::TerminalOsLogin, now_ms + 1_000);
+        assert!(!first.allowed);
+        assert!(!second.allowed);
+        assert!(first.audit.is_some());
+        assert!(second.audit.is_some());
+
+        clear_os_credential_failure_state(FailureScope::TerminalOsLogin);
     }
 }


### PR DESCRIPTION
Windows terminal sessions could previously submit OS username/password attempts without a dedicated rate or failure policy. The new policy tracks OS credential failures separately and applies a backoff window after repeated failures.

## Changes

- Add a dedicated OS-credential failure policy with exponential backoff for terminal OS login attempts.
- Add a Windows terminal OS-login concurrency gate so only one credential check runs at a time.
- Move terminal OS credential authorization into the logon response path, and start CM IPC only after terminal OS authorization succeeds.
- Add Linux headless OS-auth checks before desktop startup, and record password failures for failed headless X-session login attempts.
- Validate the target device before running Linux headless OS-auth work, so wrong-target requests do not consume failure budget or trigger PAM/X-session work.
- Split Linux X-session startup errors into auth and environment failures, and avoid logging usernames or PAM details for auth failures.

## Desc

1. For terminal OS-login, CM IPC startup is deferred until the OS credential check and terminal service-user validation have completed. This avoids starting the connection-manager IPC path for failed terminal OS-login attempts. Terminal sessions without a supplied OS username keep the existing current-session user flow.

2. Blocked OS-credential attempts use the existing alarm audit path for backoff and concurrency events.

3. Terminal OS-login failures intentionally share the existing per-source login failure bucket with regular password login. This keeps the lockout behavior conservative across authentication entry points, while the OS-credential backoff adds an additional global throttle for OS password attempts.

4. Linux headless startup now checks the existing login-failure state before trying to start a desktop session with supplied OS credentials. Password-related X-session failures are mapped to the normal password error path, while environment/startup failures keep the desktop-session error path.

5. Linux headless OS-auth work now runs only after the request has been validated for the current device. This avoids touching PAM or X-session startup for wrong-target requests.

6. Linux authentication failures use a generic log detail instead of including the username or PAM error text, so credential-failure metadata is not exposed in logs.

7. The OS-credential backoff is intentionally not keyed by client IP. A client may reconnect through different source IPs, so an IP-only policy would be easy to bypass.

8. The backoff state is also not cleared by a single successful OS-credential login. This is intentional: after too many failed attempts, the penalty should stay in place for the idle reset window. To clear it immediately, restart the RustDesk service.

9. Some rare failure messages reuse existing English text, such as `"Please try 1 minute later"`. These paths are not expected during normal use, and adding new translated strings for them is not necessary for this change.

## Tests

- [x] Normal connect
- Terminal connect
  - [x] password
  - [x] accept
- Terminal (Run as administrator)
  - [x] connect
  - [x] wrong username/password 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login throttling with exponential backoff and scoped failure tracking for OS-credential logins.
  * Enhanced terminal OS login authorization with concurrency gating and conditional startup sequencing.
  * Earlier rejection of invalid terminal usernames and improved handling of authorization flows.

* **Bug Fixes**
  * Clearer, context-sensitive login messages distinguishing authentication vs environment/startup failures.
  * More consistent handling and reporting of desktop start and OS-credential failures across platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/14985)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->