### PR TITLE
Allow macOS monitor switching in privacy mode

### DIFF
--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -16,6 +16,12 @@ import 'package:get/get.dart';
 
 bool isEditOsPassword = false;
 
+// macOS privacy mode blacks out all online displays, so switching the remote
+// display does not weaken the local privacy protection.
+bool allowDisplaySwitchInPrivacyMode(PeerInfo pi) {
+  return pi.platform == kPeerPlatformMacOS;
+}
+
 class TTextMenu {
   final Widget child;
   final VoidCallback? onPressed;
@@ -684,8 +690,9 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
         child: Text(translate('Lock after session end'))));
   }
 
+  final privacyModeState = PrivacyModeState.find(id);
   if (pi.isSupportMultiDisplay &&
-      PrivacyModeState.find(id).isEmpty &&
+      (privacyModeState.isEmpty || allowDisplaySwitchInPrivacyMode(pi)) &&
       pi.displaysCount.value > 1 &&
       bind.mainGetUserDefaultOption(key: kKeyShowMonitorsToolbar) == 'Y') {
     final value =
@@ -776,7 +783,8 @@ List<TToggleMenu> toolbarPrivacyMode(
         onChanged: enabled
             ? (value) {
                 if (value == null) return;
-                if (ffiModel.pi.currentDisplay != 0 &&
+                if (!allowDisplaySwitchInPrivacyMode(pi) &&
+                    ffiModel.pi.currentDisplay != 0 &&
                     ffiModel.pi.currentDisplay != kAllDisplayValue) {
                   msgBox(
                       sessionId,

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -376,7 +376,8 @@ class _RemoteToolbarState extends State<RemoteToolbar> {
     }
 
     toolbarItems.add(Obx(() {
-      if (PrivacyModeState.find(widget.id).isEmpty &&
+      if ((PrivacyModeState.find(widget.id).isEmpty ||
+              allowDisplaySwitchInPrivacyMode(pi)) &&
           pi.displaysCount.value > 1) {
         return _MonitorMenu(
             id: widget.id,


### PR DESCRIPTION
## Summary
- allow desktop clients to show monitor controls while macOS privacy mode is active
- skip the legacy Display 1 requirement for macOS privacy mode
- keep the existing privacy-mode display-switch restriction for other peer platforms

## Rationale
macOS privacy mode blacks out all online displays via CoreGraphics gamma tables and fails the privacy-mode enable path if not all displays can be protected. Switching the remote display therefore does not weaken the local privacy protection for macOS peers.

## Testing
- git diff --check
- not run: dart/flutter is not available in this local environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Display switching now functions during privacy mode on macOS, removing the previous restriction that required switching to Display 1 first.
  * Monitor-selection menu visibility improved for multi-display setups when privacy mode is active on macOS.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/15004)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->