### PR TITLE
fix: show hide cm in settings and fixed window not being hidden on new connection

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1227,8 +1227,8 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
             if (usePassword && !isChangePermanentPasswordDisabled())
               _SubButton('Set permanent password', setPasswordDialog,
                   permEnabled && !locked),
-            // if (usePassword)
-            //   hide_cm(!locked).marginOnly(left: _kContentHSubMargin - 6),
+            if (usePassword)
+              hide_cm(!locked).marginOnly(left: _kContentHSubMargin - 6),
             if (usePassword) radios[2],
           ]);
         })));
@@ -1406,6 +1406,7 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
           final enableHideCm = model.approveMode == 'password' &&
               model.verificationMethod == kUsePermanentPassword;
           onHideCmChanged(bool? b) {
+            model.setHideCm(b);
             if (b != null) {
               bind.mainSetOption(
                   key: 'allow-hide-cm', value: bool2option('allow-hide-cm', b));

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -288,13 +288,19 @@ void runMultiWindow(
 
 void runConnectionManagerScreen() async {
   await initEnv(kAppTypeConnectionManager);
+
+  final hide = option2bool(
+    'allow-hide-cm',
+    await bind.mainGetOption(key: 'allow-hide-cm'),
+  );
+  gFFI.serverModel.hideCm = hide;
+
   _runApp(
     '',
     const DesktopServerPage(),
     MyTheme.currentThemeMode(),
   );
-  final hide = await bind.cmGetConfig(name: "hide_cm") == 'true';
-  gFFI.serverModel.hideCm = hide;
+
   if (hide) {
     await hideCmWindow(isStartup: true);
   } else {

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -84,12 +84,11 @@ class ServerModel with ChangeNotifier {
 
   setVerificationMethod(String method) async {
     await bind.mainSetOption(key: kOptionVerificationMethod, value: method);
-    /*
+
     if (method != kUsePermanentPassword) {
       await bind.mainSetOption(
           key: 'allow-hide-cm', value: bool2option('allow-hide-cm', false));
     }
-    */
   }
 
   String get temporaryPasswordLength {
@@ -106,12 +105,25 @@ class ServerModel with ChangeNotifier {
 
   setApproveMode(String mode) async {
     await bind.mainSetOption(key: kOptionApproveMode, value: mode);
-    /*
+
     if (mode != 'password') {
       await bind.mainSetOption(
           key: 'allow-hide-cm', value: bool2option('allow-hide-cm', false));
     }
-    */
+  }
+
+  Future<void> setHideCm(bool? val) async {
+    final newValue = val ?? false;
+    if (hideCm == newValue) return;
+
+    hideCm = newValue;
+
+    await bind.mainSetOption(
+      key: 'allow-hide-cm',
+      value: bool2option('allow-hide-cm', newValue),
+    );
+
+    notifyListeners();
   }
 
   bool get allowNumericOneTimePassword => _allowNumericOneTimePassword;
@@ -134,18 +146,16 @@ class ServerModel with ChangeNotifier {
     _emptyIdShow = translate("Generating ...");
     _serverId = IDTextEditingController(text: _emptyIdShow);
 
-    /*
     // initital _hideCm at startup
     final verificationMethod =
         bind.mainGetOptionSync(key: kOptionVerificationMethod);
     final approveMode = bind.mainGetOptionSync(key: kOptionApproveMode);
-    _hideCm = option2bool(
+    hideCm = option2bool(
         'allow-hide-cm', bind.mainGetOptionSync(key: 'allow-hide-cm'));
     if (!(approveMode == 'password' &&
         verificationMethod == kUsePermanentPassword)) {
-      _hideCm = false;
+      hideCm = false;
     }
-    */
 
     timerCallback() async {
       final connectionStatus =
@@ -237,14 +247,15 @@ class ServerModel with ChangeNotifier {
     final approveMode = await bind.mainGetOption(key: kOptionApproveMode);
     final numericOneTimePassword =
         await mainGetBoolOption(kOptionAllowNumericOneTimePassword);
-    /*
-    var hideCm = option2bool(
-        'allow-hide-cm', await bind.mainGetOption(key: 'allow-hide-cm'));
-    if (!(approveMode == 'password' &&
-        verificationMethod == kUsePermanentPassword)) {
-      hideCm = false;
-    }
-    */
+
+    final newHideCm = approveMode == 'password' &&
+        verificationMethod == kUsePermanentPassword
+      ? option2bool(
+          'allow-hide-cm',
+          await bind.mainGetOption(key: 'allow-hide-cm'),
+        )
+      : false;
+
     if (_approveMode != approveMode) {
       _approveMode = approveMode;
       update = true;
@@ -279,9 +290,9 @@ class ServerModel with ChangeNotifier {
       _allowNumericOneTimePassword = numericOneTimePassword;
       update = true;
     }
-    /*
-    if (_hideCm != hideCm) {
-      _hideCm = hideCm;
+
+    if (hideCm != newHideCm) {
+      hideCm = newHideCm;
       if (desktopType == DesktopType.cm) {
         if (hideCm) {
           await hideCmWindow();
@@ -291,7 +302,7 @@ class ServerModel with ChangeNotifier {
       }
       update = true;
     }
-    */
+
     if (update) {
       notifyListeners();
     }


### PR DESCRIPTION
Enabled settings for **Hide Connection management window** in Security tab

<img width="450" height="auto" alt="image" src="https://github.com/user-attachments/assets/3a296e76-8e37-49fa-81fb-0f490a81147b" />

Disabled when not using password

<img width="407" height="281" alt="image" src="https://github.com/user-attachments/assets/506be919-b51e-4c33-bb88-23808eb8ef7a" />

On connection, no connection management window shows, making the user control remote screen without displaying this window so that the remote user does not get distracted,
really required when doing presentation

Applied fix in the connection area to wait for setting load and hide cm window initially when this settings enabled. There was bug before which was causing this window to always display due to setting wasn't loaded with await before creating screen and has been fixed with this change.

Also, the checkbox in settings wasn't refreshing after user change this settings and has been fixed using setHideCm added function.

**Reason for change**: Sometime connection drop and reconnects making this window shows in middle and distract the presentation. Also sometime remote user wants control in middle of presentation and don't want to distract users with this window displayed while presentation is happening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed connection manager window hiding state synchronization between user settings and application behavior
  * Connection manager window now correctly loads hiding preference from persisted settings during startup
  * Improved consistency of hiding behavior when password verification or specific approval modes are enabled
  * Enhanced real-time synchronization when users toggle the hiding setting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/15057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->