### PR TITLE
fix(android): clean up stale disconnected session in session_add (fixes #15060)

### DIFF
--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1324,11 +1324,22 @@ pub fn session_add(
 
     // to-do: check the same id session.
     if let Some(session) = sessions::get_session_by_session_id(&session_id) {
-        if session.lc.read().unwrap().conn_type != conn_type {
+        // Mobile reuses one constant session_id for the entire app lifetime
+        // (_constSessionId in flutter/lib/models/model.dart). When a prior
+        // connection wedges silently — typically after Android Doze pauses the
+        // io_loop long enough that no error path fires and session_close is
+        // never called — the entry stays in SESSIONS. Detect that here and
+        // clean it up so the new session_add can succeed instead of bailing,
+        // which would leave the user stuck on a "Connecting..." spinner with
+        // no error surfaced (the Flutter side ignores sessionAddSync's return).
+        if session.connection_round_state.lock().unwrap().is_disconnected() {
+            sessions::remove_session_by_session_id(&session_id);
+        } else if session.lc.read().unwrap().conn_type != conn_type {
             bail!("same session id is found with different conn type?");
+        } else {
+            // The same session is added before?
+            bail!("same session id is found");
         }
-        // The same session is added before?
-        bail!("same session id is found");
     }
 
     LocalConfig::set_remote_id(&id);

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -128,6 +128,10 @@ impl ConnectionRoundState {
             true
         }
     }
+
+    pub fn is_disconnected(&self) -> bool {
+        matches!(self.state, ConnectionState::Disconnected)
+    }
 }
 
 impl Default for ConnectionRoundState {


### PR DESCRIPTION
Fixes #15060.

- Mobile reuses one constant `sessionId` per app lifetime (`_constSessionId` at `flutter/lib/models/model.dart:57`), unlike desktop which generates a fresh UUID per session.
- When a prior connection wedges silently after Android Doze suspends the io_loop long enough that no error path fires and `sessionClose` is never called, the entry stays in the `SESSIONS` map.
- The next user tap calls `sessionAddSync`, which bails with `"same session id is found"`. The Flutter side **ignores** this error (`// ignore: unused_local_variable` at `flutter/lib/models/model.dart:3723`) and calls `sessionStart` regardless.
- `session_start_` then finds the stale handler with its old `event_stream` still attached, the `is_connected` short-circuit at `src/flutter.rs:1411` prevents a new `io_loop` from spawning, and the user is stuck on `"Connecting..."` with no error — no `Client::start` ever runs, so `CONNECT_TIMEOUT` never fires.
- Fix: detect the stale case in `session_add` via the existing `ConnectionRoundState::Disconnected` state (the io_loop sets it on exit at `src/client/io_loop.rs:341`) and clean up the prior session before bailing. Safe — when state is `Disconnected`, the prior `io_loop` has provably exited.
- Foreground network switches are unaffected because the existing error paths fire while the app is awake, which leads to `RemotePage.dispose() → gFFI.close() → bind.sessionClose() → remove_session_by_session_id` cleaning up the session before the next attempt.

Diff is small: +18 / −3 across two files. Adds a `pub fn is_disconnected(&self) -> bool` accessor on `ConnectionRoundState` to expose the existing state machine outside its module.

## Tests

- [x] `cargo check --features flutter` on Linux x86_64 — passes
- [x] `cargo ndk -t arm64-v8a check --features flutter` (cross-compile for Android target) — passes
- [ ] On-device repro on a real Android phone with a self-hosted broker. Original reporter (filer of #15060) is set up for this but the bug is non-deterministic (hours-to-days of backgrounding). Synthetic repro path: kill broker mid-session, wait for io_loop's 30-second receive watchdog to fire (state → `Disconnected`), then reconnect to the same peer. Will follow up here once verified.

Open to any naming / placement adjustments — happy to iterate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session management to properly handle stale disconnected sessions, allowing new connections to proceed instead of being rejected when reconnecting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/15061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->