### PR TITLE
feat: add JIS keyboard support for macOS in RustDesk (AI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6920,7 +6920,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/rustdesk-org/rdev#f9b60b1dd0f3300a1b797d7a74c116683cd232c8"
+source = "git+https://github.com/fufesou/rdev?rev=154c76278d4ab27a3dce5739a3d4af1a9e42f0e4#154c76278d4ab27a3dce5739a3d4af1a9e42f0e4"
 dependencies = [
  "cocoa 0.24.1",
  "core-foundation 0.9.4",
@@ -6929,6 +6929,7 @@ dependencies = [
  "dispatch",
  "enum-map",
  "epoll",
+ "foreign-types 0.3.2",
  "inotify",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ portable-pty = { git = "https://github.com/rustdesk-org/wezterm", branch = "rust
 system_shutdown = "4.0"
 qrcode-generator = "4.1"
 
+[patch."https://github.com/rustdesk-org/rdev"]
+rdev = { git = "https://github.com/fufesou/rdev", rev = "154c76278d4ab27a3dce5739a3d4af1a9e42f0e4" }
+
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = [
     "winuser",

--- a/flutter/lib/desktop/widgets/kb_layout_type_chooser.dart
+++ b/flutter/lib/desktop/widgets/kb_layout_type_chooser.dart
@@ -14,13 +14,25 @@ const double _kImageBoarderWidth = 4.0;
 const double _kImagePaddingWidth = 4.0;
 const Color _kImageBorderColor = Color.fromARGB(125, 202, 247, 2);
 const double _kBorderRadius = 6.0;
+const String _kKBLayoutTypeUnknown = 'Unknown';
+const String _kKBLayoutTypeANSI = 'ANSI';
 const String _kKBLayoutTypeISO = 'ISO';
+const String _kKBLayoutTypeJIS = 'JIS';
 const String _kKBLayoutTypeNotISO = 'Not ISO';
 
 const _kKBLayoutImageMap = {
+  _kKBLayoutTypeUnknown: 'kb_layout_not_iso',
+  _kKBLayoutTypeANSI: 'kb_layout_not_iso',
   _kKBLayoutTypeISO: 'kb_layout_iso',
-  _kKBLayoutTypeNotISO: 'kb_layout_not_iso',
+  _kKBLayoutTypeJIS: 'kb_layout_not_iso',
 };
+
+const _kKBLayoutTypes = [
+  _kKBLayoutTypeUnknown,
+  _kKBLayoutTypeANSI,
+  _kKBLayoutTypeISO,
+  _kKBLayoutTypeJIS,
+];
 
 class _KBImage extends StatelessWidget {
   final String kbLayoutType;
@@ -142,24 +154,18 @@ class KBLayoutTypeChooser extends StatelessWidget {
       width: width,
       height: height,
       child: Center(
-        child: Row(
-          children: [
-            _KBChooser(
-              kbLayoutType: _kKBLayoutTypeISO,
-              imageWidth: imageWidth,
-              chosenType: chosenType,
-              cb: cb,
-            ),
-            VerticalDivider(
-              width: dividerWidth * 2,
-            ),
-            _KBChooser(
-              kbLayoutType: _kKBLayoutTypeNotISO,
-              imageWidth: imageWidth,
-              chosenType: chosenType,
-              cb: cb,
-            ),
-          ],
+        child: Wrap(
+          children: _kKBLayoutTypes
+              .map((kbLayoutType) => SizedBox(
+                    width: imageWidth,
+                    child: _KBChooser(
+                      kbLayoutType: kbLayoutType,
+                      imageWidth: imageWidth,
+                      chosenType: chosenType,
+                      cb: cb,
+                    ),
+                  ))
+              .toList(),
         ),
       ),
     );
@@ -178,6 +184,8 @@ String getLocalPlatformForKBLayoutType(String peerPlatform) {
     localPlatform = kPeerPlatformWindows;
   } else if (isLinux) {
     localPlatform = kPeerPlatformLinux;
+  } else if (isMacOS) {
+    localPlatform = kPeerPlatformMacOS;
   } else if (isWebOnWindows || isWebOnLinux) {
     localPlatform = kPeerPlatformWebDesktop;
   }
@@ -193,8 +201,11 @@ showKBLayoutTypeChooserIfNeeded(
     return;
   }
   KBLayoutType.value = bind.getLocalKbLayoutType();
-  if (KBLayoutType.value == _kKBLayoutTypeISO ||
-      KBLayoutType.value == _kKBLayoutTypeNotISO) {
+  if (KBLayoutType.value == _kKBLayoutTypeNotISO) {
+    await bind.setLocalKbLayoutType(kbLayoutType: _kKBLayoutTypeANSI);
+    KBLayoutType.value = bind.getLocalKbLayoutType();
+  }
+  if (_kKBLayoutTypes.contains(KBLayoutType.value)) {
     return;
   }
   showKBLayoutTypeChooser(localPlatform, dialogManager);
@@ -211,7 +222,7 @@ showKBLayoutTypeChooser(
       content: KBLayoutTypeChooser(
           chosenType: KBLayoutType,
           width: 360,
-          height: 200,
+          height: 320,
           dividerWidth: 4.0,
           cb: (String v) async {
             await bind.setLocalKbLayoutType(kbLayoutType: v);

--- a/libs/enigo/src/macos/macos_impl.rs
+++ b/libs/enigo/src/macos/macos_impl.rs
@@ -625,16 +625,19 @@ impl Enigo {
         unsafe {
             let (keyboard, _layout) = get_layout();
             if !keyboard.is_null() {
+                let mut jis_code = u16::MAX;
                 let name_ref = TISGetInputSourceProperty(keyboard, kTISPropertyInputSourceID);
                 if !name_ref.is_null() {
                     if let Some(name) = get_string(name_ref as _) {
                         if name.contains("JIS") {
-                            CFRelease(keyboard);
-                            return self.map_key_board_jis(ch);
+                            jis_code = self.map_key_board_jis(ch);
                         }
                     }
                 }
                 CFRelease(keyboard);
+                if jis_code != u16::MAX {
+                    return jis_code;
+                }
             }
         }
 
@@ -774,7 +777,7 @@ impl Enigo {
             '/' => kVK_ANSI_Slash,
             '`' => kVK_ANSI_Grave,
             '"' => kVK_ANSI_2,
-            _ => self.map_key_board_en(ch),
+            _ => u16::MAX,
         }
     }
 

--- a/libs/enigo/src/macos/macos_impl.rs
+++ b/libs/enigo/src/macos/macos_impl.rs
@@ -621,29 +621,24 @@ impl Enigo {
 
     #[inline]
     fn map_key_board(&mut self, ch: char) -> CGKeyCode {
-        // no idea why below char not working with shift, https://github.com/rustdesk/rustdesk/issues/406#issuecomment-1145157327
-        // seems related to numpad char
-        if ch == '-' || ch == '=' || ch == '.' || ch == '/' || (ch >= '0' && ch <= '9') {
-            // Fallback to JIS if current keyboard layout is JIS
-            unsafe {
-                let (keyboard, _layout) = get_layout();
-                if !keyboard.is_null() {
-                    let name_ref = TISGetInputSourceProperty(keyboard, kTISPropertyInputSourceID);
-                    if !name_ref.is_null() {
-                        if let Some(name) = get_string(name_ref as _) {
-                            if name.contains("JIS") {
-                                CFRelease(keyboard);
-                                return self.map_key_board_jis(ch);
-                            }
+        // Check if current layout is JIS for any character
+        unsafe {
+            let (keyboard, _layout) = get_layout();
+            if !keyboard.is_null() {
+                let name_ref = TISGetInputSourceProperty(keyboard, kTISPropertyInputSourceID);
+                if !name_ref.is_null() {
+                    if let Some(name) = get_string(name_ref as _) {
+                        if name.contains("JIS") {
+                            CFRelease(keyboard);
+                            return self.map_key_board_jis(ch);
                         }
                     }
-                    CFRelease(keyboard);
                 }
+                CFRelease(keyboard);
             }
-
-            // fallback ANSI
-            return self.map_key_board_en(ch);
         }
+
+        // Dynamic layout mapping
         let mut code = u16::MAX;
         unsafe {
             let (keyboard, layout) = get_layout();
@@ -669,6 +664,8 @@ impl Enigo {
         if code != u16::MAX {
             return code;
         }
+
+        // fallback ANSI
         self.map_key_board_en(ch)
     }
 

--- a/libs/enigo/src/macos/macos_impl.rs
+++ b/libs/enigo/src/macos/macos_impl.rs
@@ -234,10 +234,7 @@ impl MouseControllable for Enigo {
         // Use saturating_sub to prevent negative thresholds on very small displays
         let right = (display_width as i32).saturating_sub(margin);
         let bottom = (display_height as i32).saturating_sub(margin);
-        let near_edge = new_x < margin
-            || new_x > right
-            || new_y < margin
-            || new_y > bottom;
+        let near_edge = new_x < margin || new_x > right || new_y < margin || new_y > bottom;
 
         if near_edge {
             // Reset cursor to screen center to allow continuous movement
@@ -510,9 +507,7 @@ impl Enigo {
 
         let dest = CGPoint::new(x as f64, y as f64);
         if let Some(src) = self.event_source.as_ref() {
-            if let Ok(event) =
-                CGEvent::new_mouse_event(src.clone(), event_type, dest, button)
-            {
+            if let Ok(event) = CGEvent::new_mouse_event(src.clone(), event_type, dest, button) {
                 // Set delta fields for relative mouse movement
                 // This is essential for Pointer Lock API in browsers
                 if let Some((dx, dy)) = delta {
@@ -629,6 +624,24 @@ impl Enigo {
         // no idea why below char not working with shift, https://github.com/rustdesk/rustdesk/issues/406#issuecomment-1145157327
         // seems related to numpad char
         if ch == '-' || ch == '=' || ch == '.' || ch == '/' || (ch >= '0' && ch <= '9') {
+            // Fallback to JIS if current keyboard layout is JIS
+            unsafe {
+                let (keyboard, _layout) = get_layout();
+                if !keyboard.is_null() {
+                    let name_ref = TISGetInputSourceProperty(keyboard, kTISPropertyInputSourceID);
+                    if !name_ref.is_null() {
+                        if let Some(name) = get_string(name_ref as _) {
+                            if name.contains("JIS") {
+                                CFRelease(keyboard);
+                                return self.map_key_board_jis(ch);
+                            }
+                        }
+                    }
+                    CFRelease(keyboard);
+                }
+            }
+
+            // fallback ANSI
             return self.map_key_board_en(ch);
         }
         let mut code = u16::MAX;
@@ -710,6 +723,61 @@ impl Enigo {
             '/' => kVK_ANSI_Slash,
             '`' => kVK_ANSI_Grave,
             _ => u16::MAX,
+        }
+    }
+
+    #[inline]
+    fn map_key_board_jis(&mut self, ch: char) -> CGKeyCode {
+        match ch {
+            'a' => kVK_ANSI_A,
+            'b' => kVK_ANSI_B,
+            'c' => kVK_ANSI_C,
+            'd' => kVK_ANSI_D,
+            'e' => kVK_ANSI_E,
+            'f' => kVK_ANSI_F,
+            'g' => kVK_ANSI_G,
+            'h' => kVK_ANSI_H,
+            'i' => kVK_ANSI_I,
+            'j' => kVK_ANSI_J,
+            'k' => kVK_ANSI_K,
+            'l' => kVK_ANSI_L,
+            'm' => kVK_ANSI_M,
+            'n' => kVK_ANSI_N,
+            'o' => kVK_ANSI_O,
+            'p' => kVK_ANSI_P,
+            'q' => kVK_ANSI_Q,
+            'r' => kVK_ANSI_R,
+            's' => kVK_ANSI_S,
+            't' => kVK_ANSI_T,
+            'u' => kVK_ANSI_U,
+            'v' => kVK_ANSI_V,
+            'w' => kVK_ANSI_W,
+            'x' => kVK_ANSI_X,
+            'y' => kVK_ANSI_Y,
+            'z' => kVK_ANSI_Z,
+            '0' => kVK_ANSI_0,
+            '1' => kVK_ANSI_1,
+            '2' => kVK_ANSI_2,
+            '3' => kVK_ANSI_3,
+            '4' => kVK_ANSI_4,
+            '5' => kVK_ANSI_5,
+            '6' => kVK_ANSI_6,
+            '7' => kVK_ANSI_7,
+            '8' => kVK_ANSI_8,
+            '9' => kVK_ANSI_9,
+            '-' => kVK_ANSI_Minus,
+            '=' => kVK_ANSI_Equal,
+            '\\' => kVK_ANSI_Backslash,
+            '@' => kVK_ANSI_Quote,
+            ':' => kVK_ANSI_Semicolon,
+            ';' => kVK_ANSI_Semicolon,
+            '*' => kVK_ANSI_Quote,
+            ',' => kVK_ANSI_Comma,
+            '.' => kVK_ANSI_Period,
+            '/' => kVK_ANSI_Slash,
+            '`' => kVK_ANSI_Grave,
+            '"' => kVK_ANSI_2,
+            _ => self.map_key_board_en(ch),
         }
     }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1250,6 +1250,25 @@ pub fn map_keyboard_mode(_peer: &str, event: &Event, key_event: KeyEvent) -> Vec
         .unwrap_or_default()
 }
 
+pub const KB_LAYOUT_TYPE_UNKNOWN: &str = "Unknown";
+pub const KB_LAYOUT_TYPE_ANSI: &str = "ANSI";
+pub const KB_LAYOUT_TYPE_ISO: &str = "ISO";
+pub const KB_LAYOUT_TYPE_JIS: &str = "JIS";
+const KB_LAYOUT_TYPE_NOT_ISO: &str = "Not ISO";
+
+fn local_macos_keyboard_type() -> KeyboardType {
+    match hbb_common::config::LocalConfig::get_kb_layout_type().as_str() {
+        KB_LAYOUT_TYPE_ISO => KeyboardType::KeyboardTypeIso,
+        KB_LAYOUT_TYPE_JIS => KeyboardType::KeyboardTypeJis,
+        KB_LAYOUT_TYPE_ANSI | KB_LAYOUT_TYPE_NOT_ISO => KeyboardType::KeyboardTypeAnsi,
+        _ => KeyboardType::KeyboardTypeUnknown,
+    }
+}
+
+fn is_local_macos_iso_keyboard() -> bool {
+    hbb_common::config::LocalConfig::get_kb_layout_type() == KB_LAYOUT_TYPE_ISO
+}
+
 fn _map_keyboard_mode(_peer: &str, event: &Event, mut key_event: KeyEvent) -> Option<KeyEvent> {
     match event.event_type {
         EventType::KeyPress(..) => {
@@ -1272,7 +1291,8 @@ fn _map_keyboard_mode(_peer: &str, event: &Event, mut key_event: KeyEvent) -> Op
             event.position_code
         }
         OS_LOWER_MACOS => {
-            if hbb_common::config::LocalConfig::get_kb_layout_type() == "ISO" {
+            key_event.keyboard_type = local_macos_keyboard_type().into();
+            if is_local_macos_iso_keyboard() {
                 rdev::win_scancode_to_macos_iso_code(event.position_code)?
             } else {
                 rdev::win_scancode_to_macos_code(event.position_code)?
@@ -1284,7 +1304,10 @@ fn _map_keyboard_mode(_peer: &str, event: &Event, mut key_event: KeyEvent) -> Op
     #[cfg(target_os = "macos")]
     let keycode = match _peer {
         OS_LOWER_WINDOWS => rdev::macos_code_to_win_scancode(event.platform_code as _)?,
-        OS_LOWER_MACOS => event.platform_code as _,
+        OS_LOWER_MACOS => {
+            key_event.keyboard_type = local_macos_keyboard_type().into();
+            event.platform_code as _
+        }
         OS_LOWER_ANDROID => rdev::macos_code_to_android_key_code(event.platform_code as _)?,
         _ => rdev::macos_code_to_linux_code(event.platform_code as _)?,
     };
@@ -1292,7 +1315,8 @@ fn _map_keyboard_mode(_peer: &str, event: &Event, mut key_event: KeyEvent) -> Op
     let keycode = match _peer {
         OS_LOWER_WINDOWS => rdev::linux_code_to_win_scancode(event.position_code as _)?,
         OS_LOWER_MACOS => {
-            if hbb_common::config::LocalConfig::get_kb_layout_type() == "ISO" {
+            key_event.keyboard_type = local_macos_keyboard_type().into();
+            if is_local_macos_iso_keyboard() {
                 rdev::linux_code_to_macos_iso_code(event.position_code as _)?
             } else {
                 rdev::linux_code_to_macos_code(event.position_code as _)?
@@ -1306,7 +1330,8 @@ fn _map_keyboard_mode(_peer: &str, event: &Event, mut key_event: KeyEvent) -> Op
         OS_LOWER_WINDOWS => rdev::usb_hid_code_to_win_scancode(event.usb_hid as _)?,
         OS_LOWER_LINUX => rdev::usb_hid_code_to_linux_code(event.usb_hid as _)?,
         OS_LOWER_MACOS => {
-            if hbb_common::config::LocalConfig::get_kb_layout_type() == "ISO" {
+            key_event.keyboard_type = local_macos_keyboard_type().into();
+            if is_local_macos_iso_keyboard() {
                 rdev::usb_hid_code_to_macos_iso_code(event.usb_hid as _)?
             } else {
                 rdev::usb_hid_code_to_macos_code(event.usb_hid as _)?

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -559,12 +559,13 @@ lazy_static::lazy_static! {
 #[cfg(target_os = "macos")]
 struct VirtualInputState {
     virtual_input: VirtualInput,
+    keyboard_type: rdev::MacKeyboardType,
     capslock_down: bool,
 }
 
 #[cfg(target_os = "macos")]
 impl VirtualInputState {
-    fn new() -> Option<Self> {
+    fn new(keyboard_type: rdev::MacKeyboardType) -> Option<Self> {
         VirtualInput::new(
             CGEventSourceStateID::CombinedSessionState,
             // Note: `CGEventTapLocation::Session` will be affected by the mouse events.
@@ -583,7 +584,8 @@ impl VirtualInputState {
             CGEventTapLocation::Session,
         )
         .map(|virtual_input| Self {
-            virtual_input,
+            virtual_input: virtual_input.with_keyboard_type(keyboard_type),
+            keyboard_type,
             capslock_down: false,
         })
         .ok()
@@ -599,6 +601,16 @@ impl VirtualInputState {
 static mut VIRTUAL_INPUT_MTX: Mutex<()> = Mutex::new(());
 #[cfg(target_os = "macos")]
 static mut VIRTUAL_INPUT_STATE: Option<VirtualInputState> = None;
+
+#[cfg(target_os = "macos")]
+fn mac_keyboard_type(keyboard_type: KeyboardType) -> rdev::MacKeyboardType {
+    match keyboard_type {
+        KeyboardType::KeyboardTypeAnsi => rdev::MacKeyboardType::Ansi,
+        KeyboardType::KeyboardTypeIso => rdev::MacKeyboardType::Iso,
+        KeyboardType::KeyboardTypeJis => rdev::MacKeyboardType::Jis,
+        _ => rdev::MacKeyboardType::Current,
+    }
+}
 
 // First call set_uinput() will create keyboard and mouse clients.
 // The clients are ipc connections that must live shorter than tokio runtime.
@@ -1361,7 +1373,7 @@ pub fn handle_key(evt: &KeyEvent) {
 fn reset_input() {
     unsafe {
         let _lock = VIRTUAL_INPUT_MTX.lock();
-        VIRTUAL_INPUT_STATE = VirtualInputState::new();
+        VIRTUAL_INPUT_STATE = VirtualInputState::new(rdev::MacKeyboardType::Current);
     }
 }
 
@@ -1392,6 +1404,24 @@ fn sim_rdev_rawkey_position(code: KeyCode, keydown: bool) {
     simulate_(&event_type);
 }
 
+#[cfg(target_os = "macos")]
+fn sim_rdev_rawkey_position_with_keyboard_type(
+    code: KeyCode,
+    keydown: bool,
+    keyboard_type: KeyboardType,
+) {
+    let rawkey = RawKey::MacVirtualKeycode(code);
+
+    record_pressed_key(KeysDown::RdevKey(rawkey), keydown);
+
+    let event_type = if keydown {
+        EventType::KeyPress(RdevKey::RawKey(rawkey))
+    } else {
+        EventType::KeyRelease(RdevKey::RawKey(rawkey))
+    };
+    simulate_with_keyboard_type(&event_type, mac_keyboard_type(keyboard_type));
+}
+
 #[cfg(target_os = "windows")]
 fn sim_rdev_rawkey_virtual(code: u32, keydown: bool) {
     let rawkey = RawKey::WinVirtualKeycode(code);
@@ -1411,6 +1441,24 @@ fn simulate_(event_type: &EventType) {
         let _lock = VIRTUAL_INPUT_MTX.lock();
         if let Some(input) = VIRTUAL_INPUT_STATE.as_ref() {
             let _ = input.simulate(&event_type);
+        }
+    }
+}
+
+#[inline]
+#[cfg(target_os = "macos")]
+fn simulate_with_keyboard_type(event_type: &EventType, keyboard_type: rdev::MacKeyboardType) {
+    unsafe {
+        let _lock = VIRTUAL_INPUT_MTX.lock();
+        let reset_input = VIRTUAL_INPUT_STATE
+            .as_ref()
+            .map(|input| input.keyboard_type != keyboard_type)
+            .unwrap_or(true);
+        if reset_input {
+            VIRTUAL_INPUT_STATE = VirtualInputState::new(keyboard_type);
+        }
+        if let Some(input) = VIRTUAL_INPUT_STATE.as_ref() {
+            let _ = input.simulate(event_type);
         }
     }
 }
@@ -1477,6 +1525,15 @@ fn map_keyboard_mode(evt: &KeyEvent) {
         return;
     }
 
+    #[cfg(target_os = "macos")]
+    {
+        sim_rdev_rawkey_position_with_keyboard_type(
+            evt.chr() as _,
+            evt.down,
+            evt.keyboard_type.enum_value_or(KeyboardType::KeyboardTypeUnknown),
+        );
+    }
+    #[cfg(not(target_os = "macos"))]
     sim_rdev_rawkey_position(evt.chr() as _, evt.down);
 }
 


### PR DESCRIPTION
This fixes the issue where Shift+2 produced @ instead of " enables Japanese input in Codex and preserves full ANSI/ISO layout support as a fallback

Fixes #15003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JIS (Japanese) keyboard support on macOS with fallback to standard mapping.
  * Added a new config option: "enable-perm-change-in-accept-window".
  * Exposed keyboard layout types (Unknown/ANSI/ISO/JIS) and keyboard-type-aware input handling for macOS.

* **UI**
  * Keyboard layout chooser now shows explicit layout options (ANSI/ISO/JIS/Unknown), uses a responsive picker, and increased dialog height.

* **Bug Fixes**
  * Improved detection and handling of macOS keyboard input sources for more consistent mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/15062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->