### PR TITLE
scrap/wayland: insert videoconvert to fix screencast on COSMIC / DMA-BUF portals

### DIFF
--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -276,12 +276,21 @@ impl PipeWireRecorder {
         // see: https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/982
         src.set_property("always-copy", &true)?;
 
+        // COSMIC/Wayland fix: insert videoconvert between pipewiresrc and appsink.
+        // xdg-desktop-portal-cosmic's modifier negotiation fails when the downstream
+        // format set is too narrow (appsink only accepts BGRx/RGBx), producing
+        // "no more output formats" / not-negotiated (-4). videoconvert accepts any
+        // system-memory video/x-raw format, widening negotiation so the portal can
+        // settle on a format it can deliver via its SHM path.
+        let convert = gst::ElementFactory::make("videoconvert", None)?;
+
         let sink = gst::ElementFactory::make("appsink", None)?;
         sink.set_property("drop", &true)?;
         sink.set_property("max-buffers", &1u32)?;
 
-        pipeline.add_many(&[&src, &sink])?;
-        src.link(&sink)?;
+        pipeline.add_many(&[&src, &convert, &sink])?;
+        src.link(&convert)?;
+        convert.link(&sink)?;
 
         let appsink = sink
             .dynamic_cast::<AppSink>()


### PR DESCRIPTION
## Problem

On Wayland compositors whose `xdg-desktop-portal` backend delivers screencast frames as **DMA-BUF** buffers — notably `xdg-desktop-portal-cosmic` 0.1.0 on Pop!_OS 24.04 / COSMIC — inbound screen capture fails entirely (the remote viewer sees "failed to capture screen").

`PipeWireRecorder::new` (`libs/scrap/src/wayland/pipewire.rs`) links `pipewiresrc` directly to an `appsink` whose caps only accept `video/x-raw` `BGRx`/`RGBx` in system memory. That format set is too narrow for the portal's buffer-type / modifier negotiation, which fails:

```
pw.link: negotiating -> error no more output formats (-22)
gstpipewiresrc: stream error: no more output formats
gstbasesrc: streaming stopped, reason not-negotiated (-4)
ERROR src/server/wayland.rs: Failed scrap Element failed to change its state
```

## Fix

Insert a `videoconvert` element between `pipewiresrc` and `appsink`. `videoconvert` accepts any system-memory `video/x-raw` format, which widens the negotiable set so the portal can settle on a format it can deliver via its SHM path; `videoconvert` then converts to the `BGRx`/`RGBx` the appsink expects.

When the negotiated format already matches, `videoconvert` is a no-op pass-through, so there is no effect on portals/compositors that already work.

## Verification

Reproduced and verified with `gst-launch` on Pop!_OS 24.04 / COSMIC against a live portal node:

```
# fails — reproduces the bug:
gst-launch-1.0 pipewiresrc path=<N> ! video/x-raw,format=BGRx ! fakesink
# works — the fix:
gst-launch-1.0 pipewiresrc path=<N> ! videoconvert ! video/x-raw,format=BGRx ! fakesink
```

Then built RustDesk 1.4.6 with this change and confirmed end-to-end: inbound connections capture and stream the desktop normally, the `Failed scrap` error is gone, and the pipeline reaches and stays in `PLAYING`.

Tested on: Pop!_OS 24.04 LTS, COSMIC desktop, `xdg-desktop-portal-cosmic` 0.1.0, PipeWire 1.5.85, GStreamer 1.24.2.

## Tests

- [x] Pop!_OS 24.04 LTS, COSMIC desktop. `1.4.6` can't share the screen; this PR fixes it.
- [x] Ubuntu 24.04 & KUbuntu 22.04, screen sharing is not broken.

## Notes

- Inbound capture uses the standard `xdg-desktop-portal` ScreenCast flow: the user approves screen sharing once, and a restore token is persisted so subsequent connections are not re-prompted. This patch does not change that flow.
- The branch is based on the `1.4.6` tag (where the change was built and tested) — happy to rebase onto `master` if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video format compatibility and handling during screen recording operations through enhanced format negotiation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/15063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->