### PR TITLE
fix(ipc): cmdline, use scope, deploy

### DIFF
--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -963,6 +963,7 @@ fn is_user_main_ipc_scope_cli_command(args: &[String]) -> bool {
             | Some("--config")
             | Some("--option")
             | Some("--assign")
+            | Some("--deploy")
     )
 }
 


### PR DESCRIPTION
Add missing `--deploy` when checking `is_user_main_ipc_scope_cli_command()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `--deploy` CLI command now works as a management command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/15068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->