### PR TITLE
refact(password): encrypt

### DIFF
--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2471,23 +2471,13 @@ pub fn is_disable_installation() -> SyncReturn<bool> {
 }
 
 pub fn is_preset_password() -> bool {
-    let hard = config::HARD_SETTINGS
-        .read()
-        .unwrap()
-        .get("password")
-        .cloned()
-        .unwrap_or_default();
-    if hard.is_empty() {
-        return false;
-    }
-
     // On desktop, service owns the authoritative config; query it via IPC and return only a boolean.
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     return crate::ipc::is_permanent_password_preset();
 
     // On mobile, we have no service IPC; verify against local storage.
     #[cfg(any(target_os = "android", target_os = "ios"))]
-    return config::Config::matches_permanent_password_plain(&hard);
+    return config::Config::is_using_preset_password();
 }
 
 // Don't call this function for desktop version.

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -839,15 +839,7 @@ async fn handle(data: Data, stream: &mut Connection) {
                         "N".to_owned()
                     });
                 } else if name == "permanent-password-is-preset" {
-                    let hard = config::HARD_SETTINGS
-                        .read()
-                        .unwrap()
-                        .get("password")
-                        .cloned()
-                        .unwrap_or_default();
-                    let is_preset =
-                        !hard.is_empty() && Config::matches_permanent_password_plain(&hard);
-                    value = Some(if is_preset {
+                    value = Some(if Config::is_using_preset_password() {
                         "Y".to_owned()
                     } else {
                         "N".to_owned()
@@ -898,7 +890,7 @@ async fn handle(data: Data, stream: &mut Connection) {
                         log::warn!("Changing permanent password is disabled");
                         updated = false;
                     } else {
-                        Config::set_permanent_password(&value);
+                        updated = Config::set_permanent_password(&value);
                     }
                     // Explicitly ACK/NACK permanent-password writes. This allows UIs/FFI to
                     // distinguish "accepted by daemon" vs "IPC send succeeded" without

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1542,11 +1542,6 @@ fn apply_permanent_password_storage_and_salt_payload(payload: Option<&str>) -> R
         bail!("Invalid permanent-password-storage-and-salt payload");
     };
 
-    if storage.is_empty() {
-        Config::set_permanent_password_storage_for_sync("", "")?;
-        return Ok(());
-    }
-
     Config::set_permanent_password_storage_for_sync(storage, salt)?;
     Ok(())
 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -30,8 +30,12 @@ use cidr_utils::cidr::IpCidr;
 #[cfg(target_os = "android")]
 use hbb_common::protobuf::EnumOrUnknown;
 use hbb_common::{
-    config::decode_permanent_password_h1_from_storage,
     config::{self, keys, Config, TrustedDevice},
+    config::{
+        decode_permanent_password_h1_from_storage,
+        local_permanent_password_storage_is_usable_for_auth,
+        preset_permanent_password_storage_is_usable_for_auth,
+    },
     fs::{self, can_enable_overwrite_detection, JobType},
     futures::{SinkExt, StreamExt},
     get_time, get_version_number,
@@ -412,8 +416,9 @@ impl Connection {
         let _raii_id = raii::ConnectionID::new(id);
         let _raii_control_permissions_id =
             raii::ControlPermissionsID::new(id, &control_permissions);
+        let salt = Config::get_effective_permanent_password_salt();
         let hash = Hash {
-            salt: Config::get_salt(),
+            salt,
             challenge: Config::get_auto_password(6),
             ..Default::default()
         };
@@ -2109,6 +2114,16 @@ impl Connection {
         self.validate_password_plain(storage)
     }
 
+    fn validate_preset_password_storage(&self, storage: &str, salt: &str) -> bool {
+        if salt.is_empty() {
+            return self.validate_password_plain(storage);
+        }
+        let Some(h1) = decode_permanent_password_h1_from_storage(storage) else {
+            return false;
+        };
+        self.verify_h1(&h1[..])
+    }
+
     // This is coarse brute-force protection for the current temporary password value.
     // We only care whether the active temporary password itself was presented correctly,
     // not whether later authorization steps succeed. A successful temporary-password
@@ -2180,23 +2195,22 @@ impl Connection {
                     log::info!("Permanent password accepted via logon-screen fallback");
                 }
             };
-            // Since hashed storage uses a prefix-based encoding, a hard plaintext that
-            // happens to look like hashed storage could be mis-detected. Validate local storage
-            // and hard/preset plaintext via separate paths to avoid that ambiguity.
-            let (local_storage, _) = Config::get_local_permanent_password_storage_and_salt();
+            // Strictly check storage usability before auth so malformed encrypted/hash storage
+            // cannot fall back to being accepted as legacy plaintext.
+            let (local_storage, local_salt) =
+                Config::get_local_permanent_password_storage_and_salt();
             if !local_storage.is_empty() {
-                if self.validate_password_storage(&local_storage) {
+                if local_permanent_password_storage_is_usable_for_auth(&local_storage, &local_salt)
+                    && self.validate_password_storage(&local_storage)
+                {
                     print_fallback();
                     return true;
                 }
             } else {
-                let hard = config::HARD_SETTINGS
-                    .read()
-                    .unwrap()
-                    .get("password")
-                    .cloned()
-                    .unwrap_or_default();
-                if !hard.is_empty() && self.validate_password_plain(&hard) {
+                let (hard, salt) = Config::get_preset_password_storage_and_salt();
+                if preset_permanent_password_storage_is_usable_for_auth(&hard, &salt)
+                    && self.validate_preset_password_storage(&hard, &salt)
+                {
                     print_fallback();
                     return true;
                 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -32,7 +32,7 @@ use hbb_common::protobuf::EnumOrUnknown;
 use hbb_common::{
     config::{self, keys, Config, TrustedDevice},
     config::{
-        decode_permanent_password_h1_from_storage,
+        decode_permanent_password_h1_from_storage, decode_preset_password_h1_from_storage,
         local_permanent_password_storage_is_usable_for_auth,
         preset_permanent_password_storage_is_usable_for_auth,
     },
@@ -2118,7 +2118,7 @@ impl Connection {
         if salt.is_empty() {
             return self.validate_password_plain(storage);
         }
-        let Some(h1) = decode_permanent_password_h1_from_storage(storage) else {
+        let Some(h1) = decode_preset_password_h1_from_storage(storage) else {
             return false;
         };
         self.verify_h1(&h1[..])

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -30,11 +30,10 @@ use cidr_utils::cidr::IpCidr;
 #[cfg(target_os = "android")]
 use hbb_common::protobuf::EnumOrUnknown;
 use hbb_common::{
-    config::{self, keys, Config, TrustedDevice},
     config::{
-        decode_permanent_password_h1_from_storage, decode_preset_password_h1_from_storage,
-        local_permanent_password_storage_is_usable_for_auth,
-        preset_permanent_password_storage_is_usable_for_auth,
+        self, decode_permanent_password_h1_from_storage, decode_preset_password_h1_from_storage,
+        keys, local_permanent_password_storage_is_usable_for_auth,
+        preset_permanent_password_storage_is_usable_for_auth, Config, TrustedDevice,
     },
     fs::{self, can_enable_overwrite_detection, JobType},
     futures::{SinkExt, StreamExt},

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -647,8 +647,7 @@ pub fn set_permanent_password_with_result(password: String) -> bool {
     }
     #[cfg(any(target_os = "android", target_os = "ios"))]
     {
-        config::Config::set_permanent_password(&password);
-        return true;
+        return config::Config::set_permanent_password(&password);
     }
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     {


### PR DESCRIPTION

This PR hardens permanent password storage and custom client preset password handling.

- Store permanent passwords as `01<local-encrypted("00" + base64(sha256(password + salt)))>`.
- Keep compatibility with the 1.4.6 local encrypted plaintext format.
- Change custom client preset passwords from plaintext to `00 + base64(sha256(password + salt))`.
- Keep legacy custom client configs without password salt working as plaintext.

## Permanent password format

New local storage format:

```text
01<local-encrypted("00" + base64(H1))>
H1 = sha256(password + salt)
```

Compatibility rules:

- 1.4.6 `00<local-encrypted(plaintext)>` is migrated to the new encrypted-hash format.
- Existing plaintext storage is migrated to the new encrypted-hash format.
- Hash-only storage from unreleased commits is intentionally not supported.

## Custom client preset password

Server-generated custom client preset passwords now use:

```text
00 + base64(sha256(password + salt))
```

Compatibility rules:

- Old custom client configs without salt keep the old plaintext behavior.
- New custom clients receive a generated salt and a hashed preset password.

## Testing

 - [x] Use the latest release and then this build; no need to change the password of the controlled side.
 - [x] Custom client, preset password. Plain password and the hashed password both work.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of preset-password detection on mobile.
  * Strengthened validation of stored authentication data to stop malformed/unsupported formats from bypassing checks.
  * Fixed permanent-password update handling so configuration writes return correct success/failure status.

* **Chores**
  * Updated an internal subproject reference to a newer version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/15073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->