### PR TITLE
Translate various labels to Portuguese-BR

### DIFF
--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -740,9 +740,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("keep-awake-during-outgoing-sessions-label", "Manter tela ativa durante sessões de saída"),
         ("keep-awake-during-incoming-sessions-label", "Manter tela ativa durante sessões de entrada"),
         ("Continue with {}", "Continuar com {}"),
-        ("Display Name", ""),
-        ("password-hidden-tip", ""),
-        ("preset-password-in-use-tip", ""),
-        ("Enable privacy mode", ""),
+        ("Display Name", "Nome de Exibição"),
+        ("password-hidden-tip", "A senha permanente está definida como (oculta)."),
+        ("preset-password-in-use-tip", "A senha predefinida está sendo usada."),
+        ("Enable privacy mode", "Habilitar modo de privacidade"),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
Update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added missing Portuguese-BR translations for password visibility tooltip, display name label, password preset warning, and privacy mode text that previously appeared blank.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/15086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->