### PR TITLE
Add advanced option to allow CLI settings when custom client toggles Disable settings

### DIFF
--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -432,7 +432,7 @@ pub fn core_main() -> Option<Vec<String>> {
             }
             return None;
         } else if args[0] == "--password" {
-            if config::is_disable_settings() {
+            if is_cli_setting_change_disabled() {
                 println!("Settings are disabled!");
                 return None;
             }
@@ -474,7 +474,7 @@ pub fn core_main() -> Option<Vec<String>> {
             println!("{}", crate::ipc::get_id());
             return None;
         } else if args[0] == "--set-id" {
-            if config::is_disable_settings() {
+            if is_cli_setting_change_disabled() {
                 println!("Settings are disabled!");
                 return None;
             }
@@ -521,7 +521,7 @@ pub fn core_main() -> Option<Vec<String>> {
             }
             return None;
         } else if args[0] == "--option" {
-            if config::is_disable_settings() {
+            if is_cli_setting_change_disabled() {
                 println!("Settings are disabled!");
                 return None;
             }
@@ -965,6 +965,14 @@ fn is_user_main_ipc_scope_cli_command(args: &[String]) -> bool {
             | Some("--assign")
             | Some("--deploy")
     )
+}
+
+#[inline]
+fn is_cli_setting_change_disabled() -> bool {
+    let option = config::keys::OPTION_ALLOW_COMMAND_LINE_SETTINGS_WHEN_SETTINGS_DISABLED;
+    let allow_command_line_settings =
+        config::option2bool(option, &crate::get_builtin_option(option));
+    config::is_disable_settings() && !allow_command_line_settings
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Allow configuration via command-line settings when "Disable setting"s is enabled in custom client. When set to Y, only the UI settings are disabled, but command-line settings can still be used to configure the client. Feedback from a Pro user.

Tested: In "Disable settings" state, 
* when `allow-command-line-settings-when-settings-disabled` is not set, command-line settings are not available.
* when `allow-command-line-settings-when-settings-disabled=Y` is set, command-line settings are available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command-line settings configuration now respects explicit allowlist overrides when settings are disabled

* **Chores**
  * Updated internal dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/15138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->