### PR TITLE
fix(android): close session on dispose to prevent reconnect wedge

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -126,6 +126,14 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   @override
   Future<void> dispose() async {
     WidgetsBinding.instance.removeObserver(this);
+    // Close the session up-front. `gFFI.close()` below only calls `sessionClose`
+    // after several awaits (canvas save, image update, the `enable_soft_keyboard`
+    // platform call), so if the app is backgrounded while this page is disposing,
+    // dispose can be suspended before reaching it and the connection is never torn
+    // down. The reconnect then re-attaches to the leaked session and is stuck on
+    // "Connecting...". Dispatching it here makes teardown happen synchronously on
+    // pop; the `sessionClose` in `gFFI.close()` becomes a no-op once removed.
+    unawaited(bind.sessionClose(sessionId: sessionId));
     // https://github.com/flutter/flutter/issues/64935
     super.dispose();
     gFFI.dialogManager.hideMobileActionsOverlay(store: false);


### PR DESCRIPTION
## Problem

Fixes #15060.

On the Android/Flutter client, closing a session and immediately reconnecting to the same peer (with an app background/foreground in between) leaves the client stuck on "Connecting…" indefinitely — while the original connection is still alive and streaming.

Root cause: `RemotePage.dispose()` only reaches `bind.sessionClose` at the tail of `gFFI.close()`, behind several awaits (the `enable_soft_keyboard` platform call, `setCanvasConfig`, `imageModel.update`). If the app is backgrounded while the page is disposing, dispose can be suspended before reaching it, so the Rust session is never torn down — io_loop, the relay socket, and the session handler leak. Because mobile reuses a constant `sessionId`, the next reconnect re-attaches to the leaked session in `session_start_` (it correctly skips spawning a second io_loop) and never re-emits the connection state, so the UI stays on "Connecting…" while the orphaned io_loop keeps streaming.

## Fix

Dispatch `sessionClose` at the start of `dispose()`, so teardown happens synchronously on route pop, before any backgrounding can interrupt it. The `sessionClose` in `gFFI.close()` becomes a no-op once the session is already removed. One line + comment, mobile-only.

## Verification

Reproduced and fixed against a self-hosted hbbs/hbbr (used as ground truth for client-side vs server-side):

- **Before:** a single relay session that never closes across close+reconnect; a native thread dump of the wedged client shows `io_loop` alive and the relay still streaming video underneath the "Connecting…" dialog.
- **After:** close → server logs `Relay … closed` → reconnect → a fresh relay session. Confirmed end-to-end at the UI, at the broker (relay closed + new request), and at the socket (fresh established session).

## Note

This supersedes #15061, which targeted a "stale disconnected session blocks io_loop spawn" premise. Live diagnostics disproved that: io_loop spawns fine and the session is connected (not disconnected) — the actual defect is the teardown being skippable when the app is backgrounded mid-dispose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote session disconnection handling to ensure sessions close promptly, preventing connections from getting stuck in "Connecting…" state and reducing session leakage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rustdesk/rustdesk/pull/15143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->