### PR TITLE
Add Android device deployment flow

### DIFF
--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -27,6 +27,7 @@ import 'common.dart';
 import 'consts.dart';
 import 'mobile/pages/home_page.dart';
 import 'mobile/pages/server_page.dart';
+import 'mobile/pages/settings_page.dart';
 import 'models/platform_model.dart';
 
 import 'package:flutter_hbb/plugin/handlers.dart'
@@ -573,6 +574,14 @@ _registerEventHandler() {
   if (isDesktop) {
     platformFFI.registerEventHandler('native_ui', 'native_ui', (evt) async {
       NativeUiHandler.instance.onEvent(evt);
+    });
+  }
+  if (isAndroid) {
+    platformFFI.registerEventHandler('android_needs_deploy',
+        'android_needs_deploy', (_) async {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        showDeployPromptDialog();
+      });
     });
   }
 }

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -27,7 +27,7 @@ import 'common.dart';
 import 'consts.dart';
 import 'mobile/pages/home_page.dart';
 import 'mobile/pages/server_page.dart';
-import 'mobile/pages/settings_page.dart';
+import 'mobile/widgets/deploy_dialog.dart';
 import 'models/platform_model.dart';
 
 import 'package:flutter_hbb/plugin/handlers.dart'
@@ -577,8 +577,8 @@ _registerEventHandler() {
     });
   }
   if (isAndroid) {
-    platformFFI.registerEventHandler('android_needs_deploy',
-        'android_needs_deploy', (_) async {
+    platformFFI.registerEventHandler(
+        'android_needs_deploy', 'android_needs_deploy', (_) async {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         showDeployPromptDialog();
       });

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -728,7 +728,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
                 onPressed: (context) {
                   changeSocks5Proxy();
                 }),
-          if (isAndroid && gFFI.serverModel.isStart)
+          if (isAndroid && !bind.isOutgoingOnly())
             SettingsTile(
                 title: Text(translate('Deploy')),
                 leading: Icon(Icons.cloud_upload),

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -1427,6 +1427,9 @@ void showDeployDialog() {
           TextField(
             controller: tokenController,
             decoration: InputDecoration(labelText: translate("API Token")),
+            obscureText: true,
+            enableSuggestions: false,
+            autocorrect: false,
             autofocus: true,
           ).workaroundFreezeLinuxMint(),
           TextField(

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -728,6 +728,13 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
                 onPressed: (context) {
                   changeSocks5Proxy();
                 }),
+          if (isAndroid && gFFI.serverModel.isStart)
+            SettingsTile(
+                title: Text(translate('Deploy')),
+                leading: Icon(Icons.cloud_upload),
+                onPressed: (context) {
+                  showDeployDialog();
+                }),
           if (!disabledSettings && !_hideNetwork && !_hideWebSocket)
             SettingsTile.switchTile(
               title: Text(translate('Use WebSocket')),
@@ -1351,4 +1358,103 @@ SettingsTile _getPopupDialogRadioEntry({
       child: Obx(() => Text(translate(valueText.value))),
     ),
   );
+}
+
+const _deployDialogTag = 'android-deploy-device';
+
+void showDeployPromptDialog() {
+  gFFI.dialogManager.dismissByTag(_deployDialogTag);
+  gFFI.dialogManager.show<bool>((setState, close, context) {
+    submit() => close(true);
+    return CustomAlertDialog(
+      title: Text(translate("Deploy")),
+      content: Text(translate("server_requires_deployment_tip")),
+      actions: [
+        dialogButton("Cancel", onPressed: close, isOutline: true),
+        dialogButton("OK", onPressed: submit),
+      ],
+      onSubmit: submit,
+      onCancel: close,
+    );
+  }, tag: _deployDialogTag).then((deploy) {
+    if (deploy == true) {
+      showDeployDialog();
+    }
+  });
+}
+
+void showDeployDialog() {
+  gFFI.dialogManager.dismissByTag(_deployDialogTag);
+  final tokenController = TextEditingController();
+  final idController = TextEditingController();
+  var errorText = "";
+  var isInProgress = false;
+  gFFI.dialogManager.show((setState, close, context) {
+    submit() async {
+      if (isInProgress) return;
+      final token = tokenController.text.trim();
+      if (token.isEmpty) {
+        setState(() {
+          errorText = translate("token is required!");
+        });
+        return;
+      }
+      setState(() {
+        errorText = "";
+        isInProgress = true;
+      });
+      final res = await bind.mainDeployDevice(
+          token: token, id: idController.text.trim());
+      setState(() {
+        isInProgress = false;
+      });
+      if (res.isEmpty) {
+        close();
+        await gFFI.serverModel.fetchID();
+        showToast(translate("Successful"));
+      } else {
+        setState(() {
+          errorText = translate(res.toString());
+        });
+      }
+    }
+
+    return CustomAlertDialog(
+      title: Text(translate("Deploy")),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: tokenController,
+            decoration: InputDecoration(labelText: translate("API Token")),
+            autofocus: true,
+          ).workaroundFreezeLinuxMint(),
+          TextField(
+            controller: idController,
+            decoration:
+                InputDecoration(labelText: translate("Custom ID (optional)")),
+          ).workaroundFreezeLinuxMint(),
+          if (errorText.isNotEmpty)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: SelectableText(
+                errorText,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                  fontSize: 12,
+                ),
+              ).paddingOnly(top: 8),
+            ),
+          if (isInProgress) const LinearProgressIndicator().paddingOnly(top: 8),
+        ],
+      ),
+      actions: [
+        dialogButton("Cancel",
+            onPressed: isInProgress ? null : close, isOutline: true),
+        dialogButton("OK", onPressed: isInProgress ? null : submit),
+      ],
+      onSubmit: submit,
+      onCancel: isInProgress ? null : close,
+    );
+  }, tag: _deployDialogTag);
 }

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -17,6 +17,7 @@ import '../../common/widgets/login.dart';
 import '../../consts.dart';
 import '../../models/model.dart';
 import '../../models/platform_model.dart';
+import '../widgets/deploy_dialog.dart';
 import '../widgets/dialog.dart';
 import 'home_page.dart';
 import 'scan_page.dart';
@@ -1358,106 +1359,4 @@ SettingsTile _getPopupDialogRadioEntry({
       child: Obx(() => Text(translate(valueText.value))),
     ),
   );
-}
-
-const _deployDialogTag = 'android-deploy-device';
-
-void showDeployPromptDialog() {
-  gFFI.dialogManager.dismissByTag(_deployDialogTag);
-  gFFI.dialogManager.show<bool>((setState, close, context) {
-    submit() => close(true);
-    return CustomAlertDialog(
-      title: Text(translate("Deploy")),
-      content: Text(translate("server_requires_deployment_tip")),
-      actions: [
-        dialogButton("Cancel", onPressed: close, isOutline: true),
-        dialogButton("OK", onPressed: submit),
-      ],
-      onSubmit: submit,
-      onCancel: close,
-    );
-  }, tag: _deployDialogTag).then((deploy) {
-    if (deploy == true) {
-      showDeployDialog();
-    }
-  });
-}
-
-void showDeployDialog() {
-  gFFI.dialogManager.dismissByTag(_deployDialogTag);
-  final tokenController = TextEditingController();
-  final idController = TextEditingController();
-  var errorText = "";
-  var isInProgress = false;
-  gFFI.dialogManager.show((setState, close, context) {
-    submit() async {
-      if (isInProgress) return;
-      final token = tokenController.text.trim();
-      if (token.isEmpty) {
-        setState(() {
-          errorText = translate("token is required!");
-        });
-        return;
-      }
-      setState(() {
-        errorText = "";
-        isInProgress = true;
-      });
-      final res = await bind.mainDeployDevice(
-          token: token, id: idController.text.trim());
-      setState(() {
-        isInProgress = false;
-      });
-      if (res.isEmpty) {
-        close();
-        await gFFI.serverModel.fetchID();
-        showToast(translate("Successful"));
-      } else {
-        setState(() {
-          errorText = translate(res.toString());
-        });
-      }
-    }
-
-    return CustomAlertDialog(
-      title: Text(translate("Deploy")),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          TextField(
-            controller: tokenController,
-            decoration: InputDecoration(labelText: translate("API Token")),
-            obscureText: true,
-            enableSuggestions: false,
-            autocorrect: false,
-            autofocus: true,
-          ).workaroundFreezeLinuxMint(),
-          TextField(
-            controller: idController,
-            decoration:
-                InputDecoration(labelText: translate("Custom ID (optional)")),
-          ).workaroundFreezeLinuxMint(),
-          if (errorText.isNotEmpty)
-            Align(
-              alignment: Alignment.centerLeft,
-              child: SelectableText(
-                errorText,
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.error,
-                  fontSize: 12,
-                ),
-              ).paddingOnly(top: 8),
-            ),
-          if (isInProgress) const LinearProgressIndicator().paddingOnly(top: 8),
-        ],
-      ),
-      actions: [
-        dialogButton("Cancel",
-            onPressed: isInProgress ? null : close, isOutline: true),
-        dialogButton("OK", onPressed: isInProgress ? null : submit),
-      ],
-      onSubmit: submit,
-      onCancel: isInProgress ? null : close,
-    );
-  }, tag: _deployDialogTag);
 }

--- a/flutter/lib/mobile/widgets/deploy_dialog.dart
+++ b/flutter/lib/mobile/widgets/deploy_dialog.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../common.dart';
+import '../../models/platform_model.dart';
+
+const _deployDialogTag = 'android-deploy-device';
+
+void showDeployPromptDialog() {
+  gFFI.dialogManager.dismissByTag(_deployDialogTag);
+  gFFI.dialogManager.show<bool>((setState, close, context) {
+    submit() => close(true);
+    return CustomAlertDialog(
+      title: Text(translate("Deploy")),
+      content: Text(translate("server_requires_deployment_tip")),
+      actions: [
+        dialogButton("Cancel", onPressed: close, isOutline: true),
+        dialogButton("OK", onPressed: submit),
+      ],
+      onSubmit: submit,
+      onCancel: close,
+    );
+  }, tag: _deployDialogTag).then((deploy) {
+    if (deploy == true) {
+      showDeployDialog();
+    }
+  });
+}
+
+void showDeployDialog() {
+  gFFI.dialogManager.dismissByTag(_deployDialogTag);
+  final tokenController = TextEditingController();
+  final idController = TextEditingController();
+  var errorText = "";
+  var isInProgress = false;
+  gFFI.dialogManager.show((setState, close, context) {
+    submit() async {
+      if (isInProgress) return;
+      final token = tokenController.text.trim();
+      if (token.isEmpty) {
+        setState(() {
+          errorText = translate("token is required!");
+        });
+        return;
+      }
+      setState(() {
+        errorText = "";
+        isInProgress = true;
+      });
+      String res;
+      try {
+        res = await bind.mainDeployDevice(
+            token: token, id: idController.text.trim());
+      } catch (e) {
+        setState(() {
+          errorText = translate(e.toString());
+          isInProgress = false;
+        });
+        return;
+      }
+      if (res.isEmpty) {
+        close();
+        await gFFI.serverModel.fetchID();
+        showToast(translate("Successful"));
+      } else {
+        setState(() {
+          errorText = translate(res.toString());
+          isInProgress = false;
+        });
+      }
+    }
+
+    return CustomAlertDialog(
+      title: Text(translate("Deploy")),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: tokenController,
+            decoration: InputDecoration(labelText: translate("API Token")),
+            obscureText: true,
+            enableSuggestions: false,
+            autocorrect: false,
+            autofocus: true,
+          ).workaroundFreezeLinuxMint(),
+          TextField(
+            controller: idController,
+            decoration:
+                InputDecoration(labelText: translate("Custom ID (optional)")),
+          ).workaroundFreezeLinuxMint(),
+          if (errorText.isNotEmpty)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: SelectableText(
+                errorText,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                  fontSize: 12,
+                ),
+              ).paddingOnly(top: 8),
+            ),
+          if (isInProgress) const LinearProgressIndicator().paddingOnly(top: 8),
+        ],
+      ),
+      actions: [
+        dialogButton("Cancel",
+            onPressed: isInProgress ? null : close, isOutline: true),
+        dialogButton("OK", onPressed: isInProgress ? null : submit),
+      ],
+      onSubmit: submit,
+      onCancel: isInProgress ? null : close,
+    );
+  }, tag: _deployDialogTag);
+}

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -2034,7 +2034,14 @@ class RustdeskImpl {
   }
 
   String mainResolveAvatarUrl({required String avatar, dynamic hint}) {
-    return js.context.callMethod('getByName', ['resolve_avatar_url', avatar])?.toString() ?? avatar;
+    return js.context.callMethod(
+            'getByName', ['resolve_avatar_url', avatar])?.toString() ??
+        avatar;
+  }
+
+  Future<String> mainDeployDevice(
+      {required String token, required String id, dynamic hint}) {
+    throw UnimplementedError("mainDeployDevice");
   }
 
   void dispose() {}

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -661,72 +661,28 @@ pub fn core_main() -> Option<Vec<String>> {
                     }
                 };
                 let new_id = get_value("--id");
-                let local_id = crate::ipc::get_id();
-                let id_to_deploy = new_id.clone().unwrap_or_else(|| local_id.clone());
-                let uuid = crate::encode64(hbb_common::get_uuid());
-                let pk = crate::encode64(
-                    hbb_common::config::Config::get_key_pair().1,
-                );
-                let body = serde_json::json!({
-                    "id": id_to_deploy,
-                    "uuid": uuid,
-                    "pk": pk,
-                });
-                let header = "Authorization: Bearer ".to_owned() + &token;
-                let url = crate::ui_interface::get_api_server() + "/api/devices/deploy";
-                match crate::post_request_sync(url, body.to_string(), &header) {
-                    Err(err) => {
-                        println!("Request failed: {}", err);
-                        std::process::exit(1);
+                match crate::ui_interface::deploy_device(token, new_id) {
+                    crate::ui_interface::DeployResult::Ok => {
+                        println!("Device deployed.");
                     }
-                    Ok(text) => {
-                        let parsed: serde_json::Value =
-                            serde_json::from_str(&text).unwrap_or(serde_json::Value::Null);
-                        let result = parsed["result"].as_str().unwrap_or("");
-                        match result {
-                            "OK" => {
-                                if let Some(ref new_id) = new_id {
-                                    if *new_id != local_id {
-                                        if let Err(err) =
-                                            crate::ipc::set_config("id", new_id.clone())
-                                        {
-                                            println!(
-                                                "Failed to persist deployed id locally: {}",
-                                                err
-                                            );
-                                            std::process::exit(1);
-                                        }
-                                    }
-                                }
-                                if let Err(err) = crate::ipc::notify_deployed() {
-                                    log::warn!("Failed to notify deployed state: {}", err);
-                                }
-                                println!("Device deployed.");
-                            }
-                            "NOT_ENABLED" => {
-                                println!("Server does not require deployment.");
-                                std::process::exit(3);
-                            }
-                            "INVALID_INPUT" => {
-                                println!("Invalid input.");
-                                std::process::exit(5);
-                            }
-                            "ID_TAKEN" => {
-                                println!(
-                                    "Id `{}` is already used by another machine on the server.",
-                                    id_to_deploy
-                                );
-                                std::process::exit(6);
-                            }
-                            _ => {
-                                if text.is_empty() {
-                                    println!("Unknown response.");
-                                } else {
-                                    println!("{}", text);
-                                }
-                                std::process::exit(1);
-                            }
-                        }
+                    crate::ui_interface::DeployResult::NotEnabled => {
+                        println!("Server does not require deployment.");
+                        std::process::exit(3);
+                    }
+                    crate::ui_interface::DeployResult::InvalidInput => {
+                        println!("Invalid input.");
+                        std::process::exit(5);
+                    }
+                    crate::ui_interface::DeployResult::IdTaken(id) => {
+                        println!(
+                            "Id `{}` is already used by another machine on the server.",
+                            id
+                        );
+                        std::process::exit(6);
+                    }
+                    crate::ui_interface::DeployResult::Error(err) => {
+                        println!("{}", err);
+                        std::process::exit(1);
                     }
                 }
             } else {

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -644,6 +644,8 @@ pub fn core_main() -> Option<Vec<String>> {
         } else if args[0] == "--deploy" {
             if config::Config::no_register_device() {
                 println!("Cannot deploy an unregistrable device!");
+            } else if config::is_outgoing_only() {
+                println!("Cannot deploy Outgoing-only clients.");
             } else if crate::platform::is_installed() && is_root() {
                 let max = args.len() - 1;
                 let pos = args.iter().position(|x| x == "--token").unwrap_or(max);

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1153,6 +1153,22 @@ pub fn main_get_api_server() -> String {
     get_api_server()
 }
 
+pub fn main_deploy_device(token: String, id: String) -> String {
+    #[cfg(target_os = "android")]
+    {
+        let new_id = match id.trim() {
+            "" => None,
+            id => Some(id.to_owned()),
+        };
+        ui_interface::deploy_device(token, new_id).message()
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = (token, id);
+        "Deployment is not supported on this platform.".to_owned()
+    }
+}
+
 pub fn main_resolve_avatar_url(avatar: String) -> SyncReturn<String> {
     SyncReturn(resolve_avatar_url(avatar))
 }
@@ -2116,6 +2132,7 @@ pub fn main_start_service() {
     #[cfg(target_os = "android")]
     {
         config::Config::set_option("stop-service".into(), "".into());
+        crate::rendezvous_mediator::reset_needs_deploy_notification();
         crate::rendezvous_mediator::RendezvousMediator::restart();
     }
 }
@@ -3055,6 +3072,7 @@ pub mod server_side {
     pub unsafe extern "system" fn Java_ffi_FFI_startService(_env: JNIEnv, _class: JClass) {
         log::debug!("startService from jvm");
         config::Config::set_option("stop-service".into(), "".into());
+        crate::rendezvous_mediator::reset_needs_deploy_notification();
         crate::rendezvous_mediator::RendezvousMediator::restart();
     }
 

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "كلمة المرور المحددة مسبقًا قيد الاستخدام"),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Пададзены пароль цяпер выкарыстоўваецца"),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -748,7 +748,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("API Token", "API 令牌"),
         ("Deploy", "部署"),
         ("Custom ID (optional)", "自定义 ID（可选）"),
-        ("server_requires_deployment_tip", "服务器需要部署。是否部署此设备？"),
-        ("Server does not require deployment.", "服务器不需要部署。")
+        ("server_requires_deployment_tip", "服务器要求显式部署此设备。是否立即部署？"),
+        ("The server does not require explicit deployment.", "服务器不需要显式部署。"),
+        ("Unknown response.", "未知响应。"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", "部署"),
         ("Custom ID (optional)", "自定义 ID（可选）"),
         ("server_requires_deployment_tip", "服务器需要部署。是否部署此设备？"),
+        ("Server does not require deployment.", "服务器不需要部署。")
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "当前使用预设密码"),
         ("Enable privacy mode", "允许隐私模式"),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", "API 令牌"),
+        ("Deploy", "部署"),
+        ("Custom ID (optional)", "自定义 ID（可选）"),
+        ("server_requires_deployment_tip", "服务器需要部署。是否部署此设备？"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Das voreingestellte Passwort wird derzeit verwendet."),
         ("Enable privacy mode", "Datenschutzmodus aktivieren"),
         ("allow-remote-toolbar-docking-any-edge", "Andocken der Remote-Symbolleiste an jeden Fensterrand zulassen"),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -275,6 +275,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("password-hidden-tip", "Permanent password is set (hidden)."),
         ("preset-password-in-use-tip", "Preset password is currently in use."),
         ("allow-remote-toolbar-docking-any-edge", "Allow docking remote toolbar to any window edge"),
-        ("server_requires_deployment_tip", "Server requires deployment. Deploy this device?"),
+        ("server_requires_deployment_tip", "The server requires this device to be deployed explicitly. Deploy now?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -275,5 +275,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("password-hidden-tip", "Permanent password is set (hidden)."),
         ("preset-password-in-use-tip", "Preset password is currently in use."),
         ("allow-remote-toolbar-docking-any-edge", "Allow docking remote toolbar to any window edge"),
+        ("server_requires_deployment_tip", "Server requires deployment. Deploy this device?"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Se está usando la contraseña predeterminada."),
         ("Enable privacy mode", "Habilitar modo privado"),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Le mot de passe prédéfini est actuellement utilisé."),
         ("Enable privacy mode", "Activer le mode de confidentialité"),
         ("allow-remote-toolbar-docking-any-edge", "Autoriser l’ancrage de la barre d’outils à distance sur n’importe quel bord de la fenêtre"),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "પ્રીસેટ પાસવર્ડ વપરાશમાં છે."),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "पूर्व-निर्धारित पासवर्ड उपयोग में है।"),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Jelenleg az alapértelmezett jelszót használja."),
         ("Enable privacy mode", "Adatvédelmi mód aktiválása"),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "È attualmente in uso la password preimpostata."),
         ("Enable privacy mode", "Abilita modalità privacy"),
         ("allow-remote-toolbar-docking-any-edge", "Consenti ancoraggio barra strumenti remota a qualsiasi bordo della finestra"),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "プリセットパスワードが現在使用されています"),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "현재 사전 설정된 비밀번호가 사용 중입니다."),
         ("Enable privacy mode", "개인정보 보호 모드 사용함"),
         ("allow-remote-toolbar-docking-any-edge", "원격 도구 모음을 창 가장자리에 도킹 허용"),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Iepriekš iestatītā parole pašlaik tiek izmantota."),
         ("Enable privacy mode", "Iespējot privātuma režīmu"),
         ("allow-remote-toolbar-docking-any-edge", "Atļaut attālās rīkjoslas piestiprināšanu pie jebkuras loga malas"),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "പ്രീസെറ്റ് പാസ്‌വേഡ് ഉപയോഗത്തിലാണ്."),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Het basis wachtwoord is momenteel in gebruik."),
         ("Enable privacy mode", "Privacymodus inschakelen"),
         ("allow-remote-toolbar-docking-any-edge", "Sta toe om de werkbalk-op-afstand aan de rand van het venster te plaatsen"),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Obecnie używane jest hasło domyślne."),
         ("Enable privacy mode", "Włącz tryb prywatny"),
         ("allow-remote-toolbar-docking-any-edge", "Zezwalaj na dokowanie zdalnego paska narzędzi do dowolnej krawędzi"),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "A senha predefinida está sendo usada."),
         ("Enable privacy mode", "Habilitar modo de privacidade"),
         ("allow-remote-toolbar-docking-any-edge", "Permitir fixar a barra de ferramentas remota em qualquer borda da janela"),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Se folosește o parolă prestabilită. Se recomandă setarea unei parole personalizate pentru securitate sporită."),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Установленный пароль сейчас используется."),
         ("Enable privacy mode", "Использовать режим конфиденциальности"),
         ("allow-remote-toolbar-docking-any-edge", "Разрешать прикрепление удалённой панели инструментов к любому краю окна"),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "Önceden ayarlanmış parola kullanılıyor"),
         ("Enable privacy mode", "Gizlilik modunu etkinleştir"),
         ("allow-remote-toolbar-docking-any-edge", "Uzak araç çubuğunun pencerenin herhangi bir kenarına sabitlenmesine izin ver"),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", "目前正在使用預設密碼"),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -749,5 +749,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
+        ("Server does not require deployment.", "")
     ].iter().cloned().collect();
 }

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -749,6 +749,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Deploy", ""),
         ("Custom ID (optional)", ""),
         ("server_requires_deployment_tip", ""),
-        ("Server does not require deployment.", "")
+        ("The server does not require explicit deployment.", ""),
+        ("Unknown response.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -745,5 +745,9 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("preset-password-in-use-tip", ""),
         ("Enable privacy mode", ""),
         ("allow-remote-toolbar-docking-any-edge", ""),
+        ("API Token", ""),
+        ("Deploy", ""),
+        ("Custom ID (optional)", ""),
+        ("server_requires_deployment_tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -2,7 +2,7 @@ use std::{
     net::SocketAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, RwLock,
+        Arc, Mutex as StdMutex, RwLock,
     },
     time::{Duration, Instant},
 };
@@ -47,7 +47,7 @@ static NOTIFIED_NEEDS_DEPLOY: AtomicBool = AtomicBool::new(false);
 // register_pk retry interval (ms) when device is awaiting deployment
 const DEPLOY_RETRY_INTERVAL: i64 = 30_000;
 lazy_static::lazy_static! {
-    static ref LAST_NOT_DEPLOYED_REGISTER: Mutex<Option<Instant>> = Mutex::new(None);
+    static ref LAST_NOT_DEPLOYED_REGISTER: StdMutex<Option<Instant>> = StdMutex::new(None);
 }
 
 // Single source of truth for the "awaiting deployment" backoff. The server has
@@ -63,7 +63,7 @@ async fn deploy_register_throttled() -> bool {
     }
     LAST_NOT_DEPLOYED_REGISTER
         .lock()
-        .await
+        .unwrap()
         .map(|t| (t.elapsed().as_millis() as i64) < DEPLOY_RETRY_INTERVAL)
         .unwrap_or(false)
 }
@@ -84,6 +84,8 @@ fn notify_android_needs_deploy() {
 
 #[cfg(target_os = "android")]
 pub(crate) fn reset_needs_deploy_notification() {
+    NEEDS_DEPLOY.store(false, Ordering::SeqCst);
+    *LAST_NOT_DEPLOYED_REGISTER.lock().unwrap() = None;
     NOTIFIED_NEEDS_DEPLOY.store(false, Ordering::SeqCst);
 }
 
@@ -752,7 +754,7 @@ impl RendezvousMediator {
         // DEPLOY_RETRY_INTERVAL ms is wasted traffic until the operator runs
         // `rustdesk --deploy --token <api_token>`.
         if NEEDS_DEPLOY.load(Ordering::SeqCst) {
-            let mut last = LAST_NOT_DEPLOYED_REGISTER.lock().await;
+            let mut last = LAST_NOT_DEPLOYED_REGISTER.lock().unwrap();
             if let Some(t) = *last {
                 if (t.elapsed().as_millis() as i64) < DEPLOY_RETRY_INTERVAL {
                     return Ok(());
@@ -760,7 +762,7 @@ impl RendezvousMediator {
             }
             *last = Some(Instant::now());
         } else {
-            *LAST_NOT_DEPLOYED_REGISTER.lock().await = None;
+            *LAST_NOT_DEPLOYED_REGISTER.lock().unwrap() = None;
         }
         let mut msg_out = Message::new();
         let pk = Config::get_key_pair().1;

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -42,6 +42,8 @@ static SHOULD_EXIT: AtomicBool = AtomicBool::new(false);
 static MANUAL_RESTARTED: AtomicBool = AtomicBool::new(false);
 static SENT_REGISTER_PK: AtomicBool = AtomicBool::new(false);
 pub(crate) static NEEDS_DEPLOY: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "android")]
+static NOTIFIED_NEEDS_DEPLOY: AtomicBool = AtomicBool::new(false);
 // register_pk retry interval (ms) when device is awaiting deployment
 const DEPLOY_RETRY_INTERVAL: i64 = 30_000;
 lazy_static::lazy_static! {
@@ -64,6 +66,25 @@ async fn deploy_register_throttled() -> bool {
         .await
         .map(|t| (t.elapsed().as_millis() as i64) < DEPLOY_RETRY_INTERVAL)
         .unwrap_or(false)
+}
+
+#[cfg(target_os = "android")]
+fn notify_android_needs_deploy() {
+    if NOTIFIED_NEEDS_DEPLOY.load(Ordering::SeqCst) {
+        return;
+    }
+    let event = serde_json::json!({ "name": "android_needs_deploy" }).to_string();
+    if matches!(
+        crate::flutter::push_global_event(crate::flutter::APP_TYPE_MAIN, event),
+        Some(true)
+    ) {
+        NOTIFIED_NEEDS_DEPLOY.store(true, Ordering::SeqCst);
+    }
+}
+
+#[cfg(target_os = "android")]
+pub(crate) fn reset_needs_deploy_notification() {
+    NOTIFIED_NEEDS_DEPLOY.store(false, Ordering::SeqCst);
 }
 
 #[derive(Clone)]
@@ -322,6 +343,8 @@ impl RendezvousMediator {
                         Config::set_host_key_confirmed(&self.host_prefix, true);
                         *SOLVING_PK_MISMATCH.lock().await = "".to_owned();
                         NEEDS_DEPLOY.store(false, Ordering::SeqCst);
+                        #[cfg(target_os = "android")]
+                        reset_needs_deploy_notification();
                     }
                     Ok(register_pk_response::Result::UUID_MISMATCH) => {
                         self.handle_uuid_mismatch(sink).await?;
@@ -336,6 +359,8 @@ impl RendezvousMediator {
                         // was deleted by an admin while running.
                         Config::set_key_confirmed(false);
                         Config::set_host_key_confirmed(&self.host_prefix, false);
+                        #[cfg(target_os = "android")]
+                        notify_android_needs_deploy();
                     }
                     _ => {
                         log::error!("unknown RegisterPkResponse");

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -2,7 +2,7 @@ use std::{
     net::SocketAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex as StdMutex, RwLock,
+        Arc, RwLock,
     },
     time::{Duration, Instant},
 };
@@ -47,7 +47,7 @@ static NOTIFIED_NEEDS_DEPLOY: AtomicBool = AtomicBool::new(false);
 // register_pk retry interval (ms) when device is awaiting deployment
 const DEPLOY_RETRY_INTERVAL: i64 = 30_000;
 lazy_static::lazy_static! {
-    static ref LAST_NOT_DEPLOYED_REGISTER: StdMutex<Option<Instant>> = StdMutex::new(None);
+    static ref LAST_NOT_DEPLOYED_REGISTER: Mutex<Option<Instant>> = Mutex::new(None);
 }
 
 // Single source of truth for the "awaiting deployment" backoff. The server has
@@ -63,7 +63,7 @@ async fn deploy_register_throttled() -> bool {
     }
     LAST_NOT_DEPLOYED_REGISTER
         .lock()
-        .unwrap()
+        .await
         .map(|t| (t.elapsed().as_millis() as i64) < DEPLOY_RETRY_INTERVAL)
         .unwrap_or(false)
 }
@@ -85,7 +85,6 @@ fn notify_android_needs_deploy() {
 #[cfg(target_os = "android")]
 pub(crate) fn reset_needs_deploy_notification() {
     NEEDS_DEPLOY.store(false, Ordering::SeqCst);
-    *LAST_NOT_DEPLOYED_REGISTER.lock().unwrap() = None;
     NOTIFIED_NEEDS_DEPLOY.store(false, Ordering::SeqCst);
 }
 
@@ -140,6 +139,7 @@ impl RendezvousMediator {
             crate::platform::linux_desktop_manager::start_xdesktop();
         }
         scrap::codec::test_av1();
+        *LAST_NOT_DEPLOYED_REGISTER.lock().await = None;
         loop {
             let timeout = Arc::new(RwLock::new(CONNECT_TIMEOUT));
             let conn_start_time = Instant::now();
@@ -754,7 +754,7 @@ impl RendezvousMediator {
         // DEPLOY_RETRY_INTERVAL ms is wasted traffic until the operator runs
         // `rustdesk --deploy --token <api_token>`.
         if NEEDS_DEPLOY.load(Ordering::SeqCst) {
-            let mut last = LAST_NOT_DEPLOYED_REGISTER.lock().unwrap();
+            let mut last = LAST_NOT_DEPLOYED_REGISTER.lock().await;
             if let Some(t) = *last {
                 if (t.elapsed().as_millis() as i64) < DEPLOY_RETRY_INTERVAL {
                     return Ok(());
@@ -762,7 +762,7 @@ impl RendezvousMediator {
             }
             *last = Some(Instant::now());
         } else {
-            *LAST_NOT_DEPLOYED_REGISTER.lock().unwrap() = None;
+            *LAST_NOT_DEPLOYED_REGISTER.lock().await = None;
         }
         let mut msg_out = Message::new();
         let pk = Config::get_key_pair().1;

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -1032,10 +1032,13 @@ impl DeployResult {
     pub fn message(&self) -> String {
         match self {
             Self::Ok => "".to_owned(),
-            Self::NotEnabled => "Server does not require deployment.".to_owned(),
+            Self::NotEnabled => "The server does not require explicit deployment.".to_owned(),
             Self::InvalidInput => "Invalid input.".to_owned(),
             Self::IdTaken(id) => {
-                format!("Id `{}` is already used by another machine on the server.", id)
+                format!(
+                    "Id `{}` is already used by another machine on the server.",
+                    id
+                )
             }
             Self::Error(err) => err.clone(),
         }

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -1020,6 +1020,99 @@ pub fn get_api_server() -> String {
     )
 }
 
+pub enum DeployResult {
+    Ok,
+    NotEnabled,
+    InvalidInput,
+    IdTaken(String),
+    Error(String),
+}
+
+impl DeployResult {
+    pub fn message(&self) -> String {
+        match self {
+            Self::Ok => "".to_owned(),
+            Self::NotEnabled => "Server does not require deployment.".to_owned(),
+            Self::InvalidInput => "Invalid input.".to_owned(),
+            Self::IdTaken(id) => {
+                format!("Id `{}` is already used by another machine on the server.", id)
+            }
+            Self::Error(err) => err.clone(),
+        }
+    }
+}
+
+pub fn deploy_device(token: String, new_id: Option<String>) -> DeployResult {
+    if Config::no_register_device() {
+        return DeployResult::Error("Cannot deploy an unregistrable device!".to_owned());
+    }
+    let token = token.trim();
+    if token.is_empty() {
+        return DeployResult::Error("token is required!".to_owned());
+    }
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    let local_id = Config::get_id();
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    let local_id = ipc::get_id();
+    let id_to_deploy = new_id.clone().unwrap_or_else(|| local_id.clone());
+    let uuid = crate::encode64(hbb_common::get_uuid());
+    let pk = crate::encode64(Config::get_key_pair().1);
+    let body = serde_json::json!({
+        "id": id_to_deploy,
+        "uuid": uuid,
+        "pk": pk,
+    });
+    let header = "Authorization: Bearer ".to_owned() + token;
+    let url = get_api_server() + "/api/devices/deploy";
+    let text = match crate::post_request_sync(url, body.to_string(), &header) {
+        Ok(text) => text,
+        Err(err) => return DeployResult::Error(format!("Request failed: {}", err)),
+    };
+    let parsed: serde_json::Value = serde_json::from_str(&text).unwrap_or(serde_json::Value::Null);
+    match parsed["result"].as_str().unwrap_or("") {
+        "OK" => {
+            if let Some(new_id) = new_id {
+                if new_id != local_id {
+                    #[cfg(any(target_os = "android", target_os = "ios"))]
+                    {
+                        Config::set_key_confirmed(false);
+                        Config::set_id(&new_id);
+                    }
+                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+                    if let Err(err) = ipc::set_config("id", new_id) {
+                        return DeployResult::Error(format!(
+                            "Failed to persist deployed id locally: {}",
+                            err
+                        ));
+                    }
+                }
+            }
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
+            if let Err(err) = ipc::notify_deployed() {
+                log::warn!("Failed to notify deployed state: {}", err);
+            }
+            #[cfg(target_os = "android")]
+            {
+                crate::rendezvous_mediator::NEEDS_DEPLOY
+                    .store(false, std::sync::atomic::Ordering::SeqCst);
+                crate::rendezvous_mediator::reset_needs_deploy_notification();
+                crate::rendezvous_mediator::RendezvousMediator::restart();
+            }
+            DeployResult::Ok
+        }
+        "NOT_ENABLED" => DeployResult::NotEnabled,
+        "INVALID_INPUT" => DeployResult::InvalidInput,
+        "ID_TAKEN" => DeployResult::IdTaken(id_to_deploy),
+        _ => {
+            if text.is_empty() {
+                DeployResult::Error("Unknown response.".to_owned())
+            } else {
+                DeployResult::Error(text)
+            }
+        }
+    }
+}
+
 #[inline]
 pub fn has_hwcodec() -> bool {
     // Has real hardware codec using gpu


### PR DESCRIPTION
Notify the Android Flutter UI when the server requires deployment, and show the Deploy menu in Settings.

# Testing

- [x] Android: when the device is not deployed, starting the service shows the deploy dialog. Canceling the dialog does not show it again for the same service run, and stopping then starting the service shows it again.
- [x] Android: deployment succeeds in the normal case. After a successful deployment, restarting the service does not show the deploy dialog again.
- [x] Android: when deployment is not enabled on the server, the device can register normally without showing the deploy dialog.
- [x] Android and desktop: other server responses and desktop deploy flows were tested, including `ID_TAKEN`, request failures, missing token, and custom ID deployment.
- [x] Android and desktop: deployment uses the same UUID and public key as normal registration, and the device can be connected after both normal registration and deployment.


<img width="1080" height="2400" alt="Screenshot_20260530-194819 RustDesk" src="https://github.com/user-attachments/assets/b6f08369-64f4-40a7-9584-0580c7c36f9c" />


<img width="1080" height="2400" alt="Screenshot_20260530-194836 RustDesk" src="https://github.com/user-attachments/assets/3aff2148-e43d-4328-a2c6-47e5fd4f3b21" />

<img width="1080" height="2400" alt="Screenshot_20260530-195051 RustDesk" src="https://github.com/user-attachments/assets/a2c1fb5b-7432-4209-8cfc-6bd9d62180b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device deployment flow: confirmation prompt, deploy form (API token + optional custom ID), progress handling, success toast and error messages.
  * Android: Settings shows a Deploy tile when deployment is available; the app can also prompt Android users to deploy.

* **Localization**
  * Added deployment-related UI strings across many locales (placeholders; translations pending).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->