### PR TITLE
Refact/printer driver default unchecked

### DIFF
--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -46,7 +46,7 @@ class _InstallPageState extends State<InstallPage> {
       enableResizeEdges: windowManagerEnableResizeEdges,
       child: Container(
         child: Scaffold(
-            backgroundColor: Theme.of(context).colorScheme.surface,
+            backgroundColor: Theme.of(context).colorScheme.background,
             body: DesktopTab(controller: tabController)),
       ),
     );

--- a/flutter/lib/desktop/pages/install_page.dart
+++ b/flutter/lib/desktop/pages/install_page.dart
@@ -46,7 +46,7 @@ class _InstallPageState extends State<InstallPage> {
       enableResizeEdges: windowManagerEnableResizeEdges,
       child: Container(
         child: Scaffold(
-            backgroundColor: Theme.of(context).colorScheme.background,
+            backgroundColor: Theme.of(context).colorScheme.surface,
             body: DesktopTab(controller: tabController)),
       ),
     );
@@ -65,7 +65,7 @@ class _InstallPageBodyState extends State<_InstallPageBody>
   late final TextEditingController controller;
   final RxBool startmenu = true.obs;
   final RxBool desktopicon = true.obs;
-  final RxBool printer = true.obs;
+  final RxBool printer = false.obs;
   final RxBool showProgress = false.obs;
   final RxBool btnEnabled = true.obs;
 
@@ -80,7 +80,7 @@ class _InstallPageBodyState extends State<_InstallPageBody>
     final installOptions = jsonDecode(bind.installInstallOptions());
     startmenu.value = installOptions['STARTMENUSHORTCUTS'] != '0';
     desktopicon.value = installOptions['DESKTOPSHORTCUTS'] != '0';
-    printer.value = installOptions['PRINTER'] != '0';
+    printer.value = installOptions['PRINTER'] == '1';
   }
 
   @override

--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -67,7 +67,7 @@
 			Some msi packages reset the `VersionNT` value to 1000 on Windows 10.
 			https://www.advancedinstaller.com/user-guide/qa-OS-dependent-install.html -->
 			<!-- Remote printer also works on Win8.1 in my test. -->
-			<Custom Action="InstallPrinter" Before="InstallFinalize" Condition="VersionNT &gt;= 603 AND PRINTER = 1 OR PRINTER = &quot;Y&quot; OR PRINTER = &quot;y&quot;" />
+			<Custom Action="InstallPrinter" Before="InstallFinalize" Condition="VersionNT &gt;= 603 AND (PRINTER = 1 OR PRINTER = &quot;Y&quot; OR PRINTER = &quot;y&quot;)" />
 			<Custom Action="InstallPrinter.SetParam" Before="InstallPrinter" Condition="VersionNT &gt;= 603" />
 
 			<!--Workaround of "fire:FirewallException". If Outbound="Yes" or Outbound="true", the following error occurs.-->

--- a/res/msi/Package/Fragments/ShortcutProperties.wxs
+++ b/res/msi/Package/Fragments/ShortcutProperties.wxs
@@ -4,17 +4,17 @@
 		<?include ..\Includes.wxi?>
 
 		<!--
-		Properties and related actions for specifying whether to install start menu/desktop shortcuts.
+		Properties and related actions for specifying whether to install shortcuts and the printer.
 		-->
 
 		<!-- These are the actual properties that get used in conditions to determine whether to
-				 install start menu shortcuts, they are initialized with a default value to install shortcuts.
-				 They should not be set directly from the command line or registry, instead the CREATE* properties
-				 below should be set, then they will update these properties with their values only if set. -->
+				 install start menu shortcuts or the printer. Shortcut properties default to install;
+				 PRINTER defaults to not install. The CREATE* properties below update shortcut
+				 properties from command line, bundle, or registry values. -->
 		<Property Id="STARTMENUSHORTCUTS" Value="1" Secure="yes"></Property>
 		<Property Id="DESKTOPSHORTCUTS" Value="1" Secure="yes"></Property>
 		<Property Id="STARTUPSHORTCUTS" Value="1" Secure="yes"></Property>
-		<Property Id="PRINTER" Value="1" Secure="yes"></Property>
+		<Property Id="PRINTER" Secure="yes"></Property>
 
 		<!-- These properties get set from either the command line, bundle or registry value,
 				 if set they update the properties above with their value. -->
@@ -68,6 +68,7 @@
 		<SetProperty Id="SavedStartMenuShortcutsCmdLineValue" Value="[CREATESTARTMENUSHORTCUTS]" Before="AppSearch" Sequence="first" Condition="CREATESTARTMENUSHORTCUTS" />
 		<SetProperty Id="SavedDesktopShortcutsCmdLineValue" Value="[CREATEDESKTOPSHORTCUTS]" Before="AppSearch" Sequence="first" Condition="CREATEDESKTOPSHORTCUTS" />
 		<SetProperty Id="SavedPrinterCmdLineValue" Value="[INSTALLPRINTER]" Before="AppSearch" Sequence="first" Condition="INSTALLPRINTER" />
+		<SetProperty Id="SavedPrinterPropertyCmdLineValue" Value="[PRINTER]" Before="AppSearch" Sequence="first" Condition="PRINTER" />
 
 		<!-- If a command line value was stored, restore it after the registry search has been performed -->
 		<SetProperty Action="RestoreSavedStartMenuShortcutsValue" Id="CREATESTARTMENUSHORTCUTS" Value="[SavedStartMenuShortcutsCmdLineValue]" After="AppSearch" Sequence="first" Condition="SavedStartMenuShortcutsCmdLineValue" />
@@ -77,7 +78,10 @@
 		<!-- If a command line value or registry value was set, update the main properties with the value -->
 		<SetProperty Id="STARTMENUSHORTCUTS" Value="" After="RestoreSavedStartMenuShortcutsValue" Sequence="first" Condition="CREATESTARTMENUSHORTCUTS AND NOT (CREATESTARTMENUSHORTCUTS = 1 OR CREATESTARTMENUSHORTCUTS = &quot;Y&quot; OR CREATESTARTMENUSHORTCUTS = &quot;y&quot;)" />
 		<SetProperty Id="DESKTOPSHORTCUTS" Value="" After="RestoreSavedDesktopShortcutsValue" Sequence="first" Condition="CREATEDESKTOPSHORTCUTS AND NOT (CREATEDESKTOPSHORTCUTS = 1 OR CREATEDESKTOPSHORTCUTS = &quot;Y&quot; OR CREATEDESKTOPSHORTCUTS = &quot;y&quot;)" />
-		<SetProperty Id="PRINTER" Value="" After="RestoreSavedPrinterValue" Sequence="first" Condition="INSTALLPRINTER AND NOT (INSTALLPRINTER = 1 OR INSTALLPRINTER = &quot;Y&quot; OR INSTALLPRINTER = &quot;y&quot;)" />
+		<SetProperty Action="SetPrinterValueEnabled" Id="PRINTER" Value="1" After="RestoreSavedPrinterValue" Sequence="first" Condition="INSTALLPRINTER = 1 OR INSTALLPRINTER = &quot;Y&quot; OR INSTALLPRINTER = &quot;y&quot;" />
+		<SetProperty Action="SetPrinterValueDisabled" Id="PRINTER" Value="" After="SetPrinterValueEnabled" Sequence="first" Condition="INSTALLPRINTER AND NOT (INSTALLPRINTER = 1 OR INSTALLPRINTER = &quot;Y&quot; OR INSTALLPRINTER = &quot;y&quot;)" />
+		<SetProperty Action="RestoreSavedPrinterPropertyValue" Id="PRINTER" Value="[SavedPrinterPropertyCmdLineValue]" After="SetPrinterValueDisabled" Sequence="first" Condition="SavedPrinterPropertyCmdLineValue" />
+		<SetProperty Action="NormalizePrinterValueDisabled" Id="PRINTER" Value="" After="RestoreSavedPrinterPropertyValue" Sequence="first" Condition="PRINTER AND NOT (PRINTER = 1 OR PRINTER = &quot;Y&quot; OR PRINTER = &quot;y&quot;)" />
 
 	</Fragment>
 </Wix>

--- a/res/msi/Package/Fragments/ShortcutProperties.wxs
+++ b/res/msi/Package/Fragments/ShortcutProperties.wxs
@@ -68,7 +68,6 @@
 		<SetProperty Id="SavedStartMenuShortcutsCmdLineValue" Value="[CREATESTARTMENUSHORTCUTS]" Before="AppSearch" Sequence="first" Condition="CREATESTARTMENUSHORTCUTS" />
 		<SetProperty Id="SavedDesktopShortcutsCmdLineValue" Value="[CREATEDESKTOPSHORTCUTS]" Before="AppSearch" Sequence="first" Condition="CREATEDESKTOPSHORTCUTS" />
 		<SetProperty Id="SavedPrinterCmdLineValue" Value="[INSTALLPRINTER]" Before="AppSearch" Sequence="first" Condition="INSTALLPRINTER" />
-		<SetProperty Id="SavedPrinterPropertyCmdLineValue" Value="[PRINTER]" Before="AppSearch" Sequence="first" Condition="PRINTER" />
 
 		<!-- If a command line value was stored, restore it after the registry search has been performed -->
 		<SetProperty Action="RestoreSavedStartMenuShortcutsValue" Id="CREATESTARTMENUSHORTCUTS" Value="[SavedStartMenuShortcutsCmdLineValue]" After="AppSearch" Sequence="first" Condition="SavedStartMenuShortcutsCmdLineValue" />
@@ -78,10 +77,11 @@
 		<!-- If a command line value or registry value was set, update the main properties with the value -->
 		<SetProperty Id="STARTMENUSHORTCUTS" Value="" After="RestoreSavedStartMenuShortcutsValue" Sequence="first" Condition="CREATESTARTMENUSHORTCUTS AND NOT (CREATESTARTMENUSHORTCUTS = 1 OR CREATESTARTMENUSHORTCUTS = &quot;Y&quot; OR CREATESTARTMENUSHORTCUTS = &quot;y&quot;)" />
 		<SetProperty Id="DESKTOPSHORTCUTS" Value="" After="RestoreSavedDesktopShortcutsValue" Sequence="first" Condition="CREATEDESKTOPSHORTCUTS AND NOT (CREATEDESKTOPSHORTCUTS = 1 OR CREATEDESKTOPSHORTCUTS = &quot;Y&quot; OR CREATEDESKTOPSHORTCUTS = &quot;y&quot;)" />
+		<!-- PRINTER defaults to empty now, so a saved or command-line INSTALLPRINTER=1
+				 must explicitly enable the main PRINTER property. Non-truthy INSTALLPRINTER
+				 values still clear PRINTER so upgrades preserve an explicit disabled choice. -->
 		<SetProperty Action="SetPrinterValueEnabled" Id="PRINTER" Value="1" After="RestoreSavedPrinterValue" Sequence="first" Condition="INSTALLPRINTER = 1 OR INSTALLPRINTER = &quot;Y&quot; OR INSTALLPRINTER = &quot;y&quot;" />
 		<SetProperty Action="SetPrinterValueDisabled" Id="PRINTER" Value="" After="SetPrinterValueEnabled" Sequence="first" Condition="INSTALLPRINTER AND NOT (INSTALLPRINTER = 1 OR INSTALLPRINTER = &quot;Y&quot; OR INSTALLPRINTER = &quot;y&quot;)" />
-		<SetProperty Action="RestoreSavedPrinterPropertyValue" Id="PRINTER" Value="[SavedPrinterPropertyCmdLineValue]" After="SetPrinterValueDisabled" Sequence="first" Condition="SavedPrinterPropertyCmdLineValue" />
-		<SetProperty Action="NormalizePrinterValueDisabled" Id="PRINTER" Value="" After="RestoreSavedPrinterPropertyValue" Sequence="first" Condition="PRINTER AND NOT (PRINTER = 1 OR PRINTER = &quot;Y&quot; OR PRINTER = &quot;y&quot;)" />
 
 	</Fragment>
 </Wix>

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -262,10 +262,7 @@ pub fn core_main() -> Option<Vec<String>> {
                 if config::is_disable_installation() {
                     return None;
                 }
-                #[cfg(not(windows))]
                 let options = "desktopicon startmenu";
-                #[cfg(windows)]
-                let options = "desktopicon startmenu printer";
                 let res = platform::install_me(options, "".to_owned(), true, args.len() > 1);
                 let text = match res {
                     Ok(_) => translate("Installation Successful!".to_string()),

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -262,7 +262,7 @@ pub fn core_main() -> Option<Vec<String>> {
                 if config::is_disable_installation() {
                     return None;
                 }
-                let options = "desktopicon startmenu";
+                let options = platform::get_silent_install_options();
                 let res = platform::install_me(options, "".to_owned(), true, args.len() > 1);
                 let text = match res {
                     Ok(_) => translate("Installation Successful!".to_string()),

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -262,8 +262,9 @@ pub fn core_main() -> Option<Vec<String>> {
                 if config::is_disable_installation() {
                     return None;
                 }
-                let options = platform::get_silent_install_options();
-                let res = platform::install_me(options, "".to_owned(), true, args.len() > 1);
+                let (printer_override, debug) = parse_silent_install_args(&args);
+                let options = platform::get_silent_install_options(printer_override);
+                let res = platform::install_me(options, "".to_owned(), true, debug);
                 let text = match res {
                     Ok(_) => translate("Installation Successful!".to_string()),
                     Err(err) => {
@@ -928,6 +929,23 @@ fn is_cli_setting_change_disabled() -> bool {
     let allow_command_line_settings =
         config::option2bool(option, &crate::get_builtin_option(option));
     config::is_disable_settings() && !allow_command_line_settings
+}
+
+#[cfg(windows)]
+fn parse_silent_install_args(args: &[String]) -> (Option<bool>, bool) {
+    let mut printer_override = None;
+    let mut debug = false;
+
+    for arg in args.iter().skip(1) {
+        match arg.as_str() {
+            "printer=1" => printer_override = Some(true),
+            "printer=0" => printer_override = Some(false),
+            "debug" => debug = true,
+            _ => {}
+        }
+    }
+
+    (printer_override, debug)
 }
 
 #[cfg(test)]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1324,11 +1324,17 @@ pub fn get_install_options() -> String {
     serde_json::to_string(&opts).unwrap_or("{}".to_owned())
 }
 
-pub fn get_silent_install_options() -> &'static str {
-    let app_name = crate::get_app_name();
-    let subkey = format!(".{}", app_name.to_lowercase());
-    let printer = get_reg_of_hkcr(&subkey, REG_NAME_INSTALL_PRINTER);
-    if printer.as_deref() == Some("1") && is_win_10_or_greater() {
+pub fn get_silent_install_options(printer_override: Option<bool>) -> &'static str {
+    let install_printer = match printer_override {
+        Some(override_value) => override_value,
+        None => {
+            let app_name = crate::get_app_name();
+            let subkey = format!(".{}", app_name.to_lowercase());
+            let printer = get_reg_of_hkcr(&subkey, REG_NAME_INSTALL_PRINTER);
+            printer.as_deref() == Some("1")
+        }
+    };
+    if install_printer && is_win_10_or_greater() {
         "desktopicon startmenu printer"
     } else {
         "desktopicon startmenu"

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1324,6 +1324,17 @@ pub fn get_install_options() -> String {
     serde_json::to_string(&opts).unwrap_or("{}".to_owned())
 }
 
+pub fn get_silent_install_options() -> &'static str {
+    let app_name = crate::get_app_name();
+    let subkey = format!(".{}", app_name.to_lowercase());
+    let printer = get_reg_of_hkcr(&subkey, REG_NAME_INSTALL_PRINTER);
+    if printer.as_deref() == Some("1") && is_win_10_or_greater() {
+        "desktopicon startmenu printer"
+    } else {
+        "desktopicon startmenu"
+    }
+}
+
 // This function return Option<String>, because some registry value may be empty.
 fn get_reg_of_hkcr(subkey: &str, name: &str) -> Option<String> {
     let hkcr = RegKey::predef(HKEY_CLASSES_ROOT);


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/15184

1. Disable the printer driver by default.

2. Fix the logic `Condition="VersionNT &gt;= 603 AND PRINTER = 1 OR PRINTER = &quot;Y&quot; OR PRINTER = &quot;y&quot;" />`.

3. Install with the `--silent-install` argument, optionally followed by `printer=1` or `printer=1`.

    1. No `printer` or `no-printer` (default option):
        - For a fresh installation, the printer driver will not be installed.
        - For an update installation, the printer driver installation status depends on the previous version's settings.
    ```shell
    rustdesk.exe --silent-install
    ```
    2. `printer=1` -- Force install the printer driver:
    ```shell
    rustdesk.exe --silent-install printer=1
    ```
    3. `printer=0` -- Force not to install the printer driver:
    ```shell
    rustdesk.exe --silent-install printer=0
    ```



## Testing

EXE & MSI

- [x] Refresh install, with and without the install driver
- [x] `--silent-install` and `/qn`
```
msiexec /i RustDesk-1.msi /qn INSTALLFOLDER="D:\Program Files\RustDesk"INSTALLPRINTER="N" /l*v install.log
```
- [x] Upgrade from 1.4.5 to this version, the options are kept.
- [x] Upgrade from this version to a new version, the options are kept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Printer installation now defaults to disabled and will only install when explicitly enabled.
  * Installation will only attempt printer setup on supported Windows versions (Windows 10+).

* **Improvements**
  * Installer behavior is now consistent across UI, MSI, and silent installs.
  * Silent installs respect explicit printer choices and debug-mode flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->