### PR TITLE
Fix clipboard synchronization not fully disabled in View Only mode

### DIFF
--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1426,7 +1426,8 @@ impl<T: InvokeUiSession> Remote<T> {
                     self.handler.set_cursor_position(cp);
                 }
                 Some(message::Union::Clipboard(cb)) => {
-                    if !self.handler.lc.read().unwrap().disable_clipboard.v {
+                    let lc = self.handler.lc.read().unwrap();
+                    if !lc.disable_clipboard.v && !lc.view_only.v {
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         update_clipboard(vec![cb], ClipboardSide::Client);
                         #[cfg(target_os = "ios")]
@@ -1445,7 +1446,8 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                 }
                 Some(message::Union::MultiClipboards(_mcb)) => {
-                    if !self.handler.lc.read().unwrap().disable_clipboard.v {
+                    let lc = self.handler.lc.read().unwrap();
+                    if !lc.disable_clipboard.v && !lc.view_only.v {
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         update_clipboard(_mcb.clipboards, ClipboardSide::Client);
                         #[cfg(target_os = "ios")]

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -326,12 +326,14 @@ pub fn session_toggle_option(session_id: SessionID, value: String) {
         try_sync_peer_option(&session, &session_id, &value, None);
     }
     #[cfg(not(target_os = "ios"))]
-    if sessions::get_session_by_session_id(&session_id).is_some() && value == "disable-clipboard" {
+    if sessions::get_session_by_session_id(&session_id).is_some()
+        && (value == "disable-clipboard" || value == "view-only")
+    {
         crate::flutter::update_text_clipboard_required();
     }
     #[cfg(feature = "unix-file-copy-paste")]
     if sessions::get_session_by_session_id(&session_id).is_some()
-        && value == config::keys::OPTION_ENABLE_FILE_COPY_PASTE
+        && (value == config::keys::OPTION_ENABLE_FILE_COPY_PASTE || value == "view-only")
     {
         crate::flutter::update_file_clipboard_required();
     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2891,7 +2891,7 @@ impl Connection {
                     self.update_auto_disconnect_timer();
                 }
                 Some(message::Union::Clipboard(cb)) => {
-                    if self.clipboard {
+                    if self.clipboard_enabled() {
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         update_clipboard(vec![cb], ClipboardSide::Host);
                         // ios as the controlled side is actually not supported for now.
@@ -2920,7 +2920,7 @@ impl Connection {
                 }
                 Some(message::Union::MultiClipboards(_mcb)) => {
                     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-                    if self.clipboard {
+                    if self.clipboard_enabled() {
                         update_clipboard(_mcb.clipboards, ClipboardSide::Host);
                     }
                     #[cfg(target_os = "android")]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -2919,12 +2919,12 @@ impl Connection {
                     }
                 }
                 Some(message::Union::MultiClipboards(_mcb)) => {
-                    #[cfg(not(any(target_os = "android", target_os = "ios")))]
                     if self.clipboard_enabled() {
+                        #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         update_clipboard(_mcb.clipboards, ClipboardSide::Host);
+                        #[cfg(target_os = "android")]
+                        crate::clipboard::handle_msg_multi_clipboards(_mcb);
                     }
-                    #[cfg(target_os = "android")]
-                    crate::clipboard::handle_msg_multi_clipboards(_mcb);
                 }
                 #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]
                 Some(message::Union::Cliprdr(clip)) => {

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -175,13 +175,16 @@ impl SessionPermissionConfig {
         *self.server_clipboard_enabled.read().unwrap()
             && *self.server_keyboard_enabled.read().unwrap()
             && !self.lc.read().unwrap().disable_clipboard.v
+            && !self.lc.read().unwrap().view_only.v
     }
 
     #[cfg(feature = "unix-file-copy-paste")]
     pub fn is_file_clipboard_required(&self) -> bool {
+        let lc = self.lc.read().unwrap();
         *self.server_keyboard_enabled.read().unwrap()
             && *self.server_file_transfer_enabled.read().unwrap()
-            && self.lc.read().unwrap().enable_file_copy_paste.v
+            && lc.enable_file_copy_paste.v
+            && !lc.view_only.v
     }
 }
 
@@ -411,13 +414,16 @@ impl<T: InvokeUiSession> Session<T> {
         *self.server_clipboard_enabled.read().unwrap()
             && *self.server_keyboard_enabled.read().unwrap()
             && !self.lc.read().unwrap().disable_clipboard.v
+            && !self.lc.read().unwrap().view_only.v
     }
 
     #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]
     pub fn is_file_clipboard_required(&self) -> bool {
+        let lc = self.lc.read().unwrap();
         *self.server_keyboard_enabled.read().unwrap()
             && *self.server_file_transfer_enabled.read().unwrap()
-            && self.lc.read().unwrap().enable_file_copy_paste.v
+            && lc.enable_file_copy_paste.v
+            && !lc.view_only.v
     }
 
     #[cfg(feature = "flutter")]


### PR DESCRIPTION
## Summary

Fix clipboard synchronization behavior in View Only mode. #15220 

Previously, when entering View Only mode, the UI forced the "Disable clipboard" option to appear enabled, but clipboard synchronization was only disabled in the remote -> local direction. Clipboard updates from the controlling side could still be sent to the remote side.

This PR makes View Only mode consistently disable clipboard synchronization in both directions and correctly restores clipboard functionality when View Only mode is disabled.

## Root Cause

The issue was caused by multiple independent clipboard permission checks that did not consistently account for the `view_only` state.

### Sending side

`is_text_clipboard_required()` only checked:

* `disable_clipboard`

but did not consider:

* `view_only`

As a result, the controlling side continued sending clipboard updates while in View Only mode.

### Receiving side

The controlled side accepted incoming clipboard messages using:

```rust
if self.clipboard
```

which ignored the runtime `disable_clipboard` state.

Therefore, clipboard messages could still be applied even when clipboard synchronization was intended to be disabled.

### State refresh

When View Only mode was toggled, clipboard listener state was not refreshed.

This caused clipboard synchronization from the controlling side to remain inactive after leaving View Only mode until the clipboard option was manually toggled.

## Changes

### Server-side validation

Replace:

```rust
if self.clipboard
```

with:

```rust
if self.clipboard_enabled()
```

for both:

* `Clipboard`
* `MultiClipboards`

message handling.

### Client-side clipboard permission checks

Update clipboard requirement checks to respect:

```rust
!view_only.v
```

for:

* text clipboard
* file clipboard

### Clipboard state refresh

Refresh clipboard listener state when:

```text
view-only
```

is toggled, ensuring clipboard synchronization is restored immediately after leaving View Only mode.

### Defensive receive-side checks

Prevent clipboard updates from being applied locally while View Only mode is active.

## Tested

Environment:

* Local: Linux
* Remote: Windows

Verified:

### Normal mode

* Local -> Remote clipboard sync works
* Remote -> Local clipboard sync works

### View Only mode

* Local -> Remote clipboard sync is blocked
* Remote -> Local clipboard sync is blocked

### Leaving View Only mode

* Clipboard synchronization resumes automatically in both directions

### Disable Clipboard option

* Clipboard synchronization is blocked in both directions when enabled
* Clipboard synchronization resumes normally when disabled

## Notes

File clipboard related permission checks were updated for consistency with text clipboard behavior. These paths were not directly tested due to unavailable file clipboard support in the current Linux test environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clipboard operations are now blocked in view-only sessions so remote updates won't overwrite local view-only clients.
  * Permission checks for clipboard and file copy/paste were unified to prevent unexpected clipboard activity.
  * UI now updates reliably when clipboard-related options (disable clipboard / view-only) change, reflecting actual permission state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->