### PR TITLE
fix(input): win, key sequence, sleep interval 20ms

### DIFF
--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -6,7 +6,7 @@ use winapi;
 
 use crate::win::keycodes::*;
 use crate::{Key, KeyboardControllable, MouseButton, MouseControllable};
-use std::mem::*;
+use std::{mem::*, time::Duration};
 
 extern "system" {
     pub fn GetLastError() -> DWORD;
@@ -19,6 +19,7 @@ static mut LAYOUT: HKL = std::ptr::null_mut();
 
 /// The dwExtraInfo value in keyboard and mouse structure that used in SendInput()
 pub const ENIGO_INPUT_EXTRA_VALUE: ULONG_PTR = 100;
+const UNICODE_KEY_SEQUENCE_DELAY: Duration = Duration::from_millis(20);
 
 fn mouse_event(flags: u32, data: u32, dx: i32, dy: i32) -> DWORD {
     let mut u = INPUT_u::default();
@@ -237,6 +238,7 @@ impl KeyboardControllable for Enigo {
                 // do i need to produce a keyup?
                 // self.unicode_key_up(0);
             }
+            std::thread::sleep(UNICODE_KEY_SEQUENCE_DELAY);
         }
     }
 

--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -19,10 +19,10 @@ static mut LAYOUT: HKL = std::ptr::null_mut();
 
 /// The dwExtraInfo value in keyboard and mouse structure that used in SendInput()
 pub const ENIGO_INPUT_EXTRA_VALUE: ULONG_PTR = 100;
-// Empirical testing against Notepad showed corrupted input with 0ms, 5ms and 10ms
-// delays, while 15ms, and 20ms behaved correctly. Use 20ms as a conservative 
-// default to avoid regressions while keeping latency low; revisit this
-// if further testing shows smaller values are reliable.
+// Empirical testing against Notepad showed corrupted input with 0ms, 5ms, and 10ms
+// delays, while 15ms and 20ms behaved correctly. Use 20ms as a conservative
+// default to avoid regressions while keeping latency low; revisit this if further
+// testing shows smaller values are reliable.
 const UNICODE_KEY_SEQUENCE_DELAY: Duration = Duration::from_millis(20);
 
 fn mouse_event(flags: u32, data: u32, dx: i32, dy: i32) -> DWORD {

--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -19,6 +19,10 @@ static mut LAYOUT: HKL = std::ptr::null_mut();
 
 /// The dwExtraInfo value in keyboard and mouse structure that used in SendInput()
 pub const ENIGO_INPUT_EXTRA_VALUE: ULONG_PTR = 100;
+// Empirical testing against Notepad showed corrupted input with 0ms, 5ms and 10ms
+// delays, while 15ms, and 20ms behaved correctly. Use 20ms as a conservative 
+// default to avoid regressions while keeping latency low; revisit this
+// if further testing shows smaller values are reliable.
 const UNICODE_KEY_SEQUENCE_DELAY: Duration = Duration::from_millis(20);
 
 fn mouse_event(flags: u32, data: u32, dx: i32, dy: i32) -> DWORD {

--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -220,7 +220,8 @@ impl KeyboardControllable for Enigo {
     fn key_sequence(&mut self, sequence: &str) {
         let mut buffer = [0; 2];
 
-        for c in sequence.chars() {
+        let mut chars = sequence.chars().peekable();
+        while let Some(c) = chars.next() {
             // Windows uses uft-16 encoding. We need to check
             // for variable length characters. As such some
             // characters can be 32 bit long and those are
@@ -238,7 +239,9 @@ impl KeyboardControllable for Enigo {
                 // do i need to produce a keyup?
                 // self.unicode_key_up(0);
             }
-            std::thread::sleep(UNICODE_KEY_SEQUENCE_DELAY);
+            if chars.peek().is_some() {
+                std::thread::sleep(UNICODE_KEY_SEQUENCE_DELAY);
+            }
         }
     }
 


### PR DESCRIPTION
`key_sequence()` works fine in VS Code but not in Notepad. It seems the output depends on the target application.

The following outputs are from Notepad with different `UNICODE_KEY_SEQUENCE_DELAY` values.

```rust
    enigo.key_sequence("Hello World! here is a lot of text ");
    
    enigo.key_sequence("abcdefgh ");
    enigo.key_sequence("abcdefgh ");
    enigo.key_sequence("abcdefgh ");
    enigo.key_sequence("abcdefgh ");

    enigo.key_sequence("abcd❤️fgh ");
```

```
0 ms: Hello bbbbbbbcdefgh                             
5 ms: Hello rrrld!hhere    ttt    aaaaaabcdefgh ccccccccccccdefgh ddddddddddddd❤️fgh 
10 ms: Hello World! here is a lot of text abcdefgh bbcdefgh bbcdefgh abcdefgh bbcd❤️fgh 
15 ms: Hello World! here is a lot of text abcdefgh abcdefgh bbcdefgh abcdefgh abcd❤️fgh 
20 ms: Hello World! here is a lot of text abcdefgh abcdefgh bbcdefgh abcdefgh abcd❤️fgh 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Introduces a short inter-character delay (~20ms) when sending Unicode keystrokes, improving reliability in applications that previously missed rapid input.
  * Ensures the delay is applied only between characters and not after the final character, preserving expected end-of-sequence behavior and avoiding unnecessary pauses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->