### PR TITLE
Fix/generate py target injection

### DIFF
--- a/libs/portable/generate.py
+++ b/libs/portable/generate.py
@@ -2,6 +2,7 @@
 
 import os
 import optparse
+import subprocess
 from hashlib import md5
 import brotli
 import datetime
@@ -65,11 +66,15 @@ def write_app_metadata(output_folder: str):
     print(f"App metadata has been written to {output_path}")
 
 def build_portable(output_folder: str, target: str):
-    os.chdir(output_folder)
-    if target:
-        os.system("cargo build --locked --release --target " + target)
-    else:
-        os.system("cargo build --locked --release")
+    current_dir = os.getcwd()
+    try:
+        os.chdir(output_folder)
+        cmd = ["cargo", "build", "--locked", "--release"]
+        if target:
+            cmd.extend(["--target", target])
+        subprocess.run(cmd, check=True)
+    finally:
+        os.chdir(current_dir)
 
 # Linux: python3 generate.py -f ../rustdesk-portable-packer/test -o . -e ./test/main.py
 # Windows: python3 .\generate.py -f ..\rustdesk\flutter\build\windows\runner\Debug\ -o . -e ..\rustdesk\flutter\build\windows\runner\Debug\rustdesk.exe

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -30,11 +30,7 @@ fn run_rdp(port: u16) {
         if !password.is_empty() {
             args.push(format!("/pass:{}", password));
         }
-        if !username.is_empty() {
-            println!("RDP credentials provided");
-        } else {
-            println!("RDP credentials not provided");
-        }
+        log::info!("RDP credentials provided");
         std::process::Command::new("cmdkey")
             .args(&args)
             .output()

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -30,7 +30,11 @@ fn run_rdp(port: u16) {
         if !password.is_empty() {
             args.push(format!("/pass:{}", password));
         }
-        println!("{:?}", args);
+        if !username.is_empty() {
+            println!("RDP credentials provided");
+        } else {
+            println!("RDP credentials not provided");
+        }
         std::process::Command::new("cmdkey")
             .args(&args)
             .output()

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -30,7 +30,6 @@ fn run_rdp(port: u16) {
         if !password.is_empty() {
             args.push(format!("/pass:{}", password));
         }
-        log::info!("RDP credentials provided");
         std::process::Command::new("cmdkey")
             .args(&args)
             .output()


### PR DESCRIPTION

https://github.com/rustdesk/rustdesk/pull/13973

1. Use subprocess for portable cargo build

  This avoids passing the portable build target through a shell command string.
  The cargo invocation now uses argument lists while keeping the existing default and `--target` behavior.

2. Avoid printing RDP credential arguments, since they may include a password.

Note: `build.py` is intentionally omitted because it is a build-time script and would require a separate, broader change.

## Testing

- [x] CI https://github.com/fufesou/rustdesk/actions/runs/27340670389
- [x] RDP is not affected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Portable build now fails loudly on build errors so issues are reported more reliably.

* **Chores**
  * Port forwarding output now indicates whether RDP credentials were provided rather than emitting raw debug output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->