### PR TITLE
feat: theme logo

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3735,9 +3735,27 @@ Future<String?> _resolveLogoAsset(Brightness brightness) async {
   return null;
 }
 
-Widget _buildLogo(BuildContext context) {
-  return FutureBuilder<String?>(
-      future: _resolveLogoAsset(Theme.of(context).brightness),
+class _Logo extends StatefulWidget {
+  const _Logo();
+
+  @override
+  State<_Logo> createState() => _LogoState();
+}
+
+class _LogoState extends State<_Logo> {
+  final Map<Brightness, Future<String?>> _logoFutures = {};
+
+  Future<String?> _logoFutureFor(Brightness brightness) {
+    return _logoFutures.putIfAbsent(
+      brightness,
+      () => _resolveLogoAsset(brightness),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<String?>(
+      future: _logoFutureFor(Theme.of(context).brightness),
       builder: (BuildContext context, AsyncSnapshot<String?> snapshot) {
         final asset = snapshot.data;
         if (asset != null) {
@@ -3754,11 +3772,13 @@ Widget _buildLogo(BuildContext context) {
           ).marginOnly(left: 12, right: 12, top: 12);
         }
         return const Offstage();
-      });
+      },
+    );
+  }
 }
 
 // max 300 x 60
-Widget loadLogo() => Builder(builder: (context) => _buildLogo(context));
+Widget loadLogo() => const _Logo();
 
 Widget loadIcon(double size) {
   return Image.asset('assets/icon.png',

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3717,14 +3717,14 @@ const _kDefaultLogoAsset = 'assets/logo.png';
 const _kLightLogoAsset = 'assets/logo_light.png';
 const _kDarkLogoAsset = 'assets/logo_dark.png';
 
-List<String> logoAssetCandidatesForBrightness(Brightness brightness) {
+List<String> _logoAssetCandidatesForBrightness(Brightness brightness) {
   return brightness == Brightness.dark
       ? [_kDarkLogoAsset, _kDefaultLogoAsset]
       : [_kLightLogoAsset, _kDefaultLogoAsset];
 }
 
 Future<String?> _resolveLogoAsset(Brightness brightness) async {
-  for (final asset in logoAssetCandidatesForBrightness(brightness)) {
+  for (final asset in _logoAssetCandidatesForBrightness(brightness)) {
     try {
       await rootBundle.load(asset);
       return asset;

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3713,14 +3713,36 @@ Widget loadPowered(BuildContext context) {
   ).marginOnly(top: 6);
 }
 
-// max 300 x 60
-Widget loadLogo() {
-  return FutureBuilder<ByteData>(
-      future: rootBundle.load('assets/logo.png'),
-      builder: (BuildContext context, AsyncSnapshot<ByteData> snapshot) {
-        if (snapshot.hasData) {
+const _kDefaultLogoAsset = 'assets/logo.png';
+const _kLightLogoAsset = 'assets/logo_light.png';
+const _kDarkLogoAsset = 'assets/logo_dark.png';
+
+List<String> logoAssetCandidatesForBrightness(Brightness brightness) {
+  return brightness == Brightness.dark
+      ? [_kDarkLogoAsset, _kDefaultLogoAsset]
+      : [_kLightLogoAsset, _kDefaultLogoAsset];
+}
+
+Future<String?> _resolveLogoAsset(Brightness brightness) async {
+  for (final asset in logoAssetCandidatesForBrightness(brightness)) {
+    try {
+      await rootBundle.load(asset);
+      return asset;
+    } on FlutterError {
+      continue;
+    }
+  }
+  return null;
+}
+
+Widget _buildLogo(BuildContext context) {
+  return FutureBuilder<String?>(
+      future: _resolveLogoAsset(Theme.of(context).brightness),
+      builder: (BuildContext context, AsyncSnapshot<String?> snapshot) {
+        final asset = snapshot.data;
+        if (asset != null) {
           final image = Image.asset(
-            'assets/logo.png',
+            asset,
             fit: BoxFit.contain,
             errorBuilder: (ctx, error, stackTrace) {
               return Container();
@@ -3734,6 +3756,9 @@ Widget loadLogo() {
         return const Offstage();
       });
 }
+
+// max 300 x 60
+Widget loadLogo() => Builder(builder: (context) => _buildLogo(context));
 
 Widget loadIcon(double size) {
   return Image.asset('assets/icon.png',


### PR DESCRIPTION

## Preview

https://github.com/user-attachments/assets/fc368668-15fa-4063-9088-f1127c297a7f

## Testing

- [x] Windows, Linux, macOS, Android


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logo now adapts to the current theme brightness, using the matching dark/light variant and automatically falling back if the variant isn’t available.
* **Refactor**
  * Improved logo loading behavior with brightness-aware resolution and caching, including safer handling when no suitable asset can be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->