### PR TITLE
Fix mouse right click and ESC key exit

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -21,4 +21,5 @@ jobs:
   run-ci:
     uses: ./.github/workflows/flutter-build.yml
     with:
-      upload-artifact: false
+      upload-artifact: true
+      upload-tag: "custom-build"

--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -260,28 +260,28 @@ class _RawTouchGestureDetectorRegionState
   }
 
   // for mobiles
+  // Modified: Always send right click event for long press, regardless of peer platform
+  // This fixes the issue where right click exits to Android home screen
   onLongPress() async {
     if (isNotTouchBasedDevice()) {
       return;
     }
-    if (!ffi.ffiModel.isPeerMobile) {
-      if (handleTouch) {
-        final isMoved = await ffi.cursorModel
-            .move(_cacheLongPressPosition.dx, _cacheLongPressPosition.dy);
-        if (!isMoved) {
-          return;
-        }
-      } else {
-        if (shouldBlockMouseModeEvent()) {
-          return;
-        }
+    // Always handle long press as right click for all platforms
+    if (handleTouch) {
+      final isMoved = await ffi.cursorModel
+          .move(_cacheLongPressPosition.dx, _cacheLongPressPosition.dy);
+      if (!isMoved) {
+        return;
       }
-      await inputModel.tap(MouseButtons.right);
     } else {
-      // It's better to send a message to tell the controlled device that the long press event is triggered.
-      // We're now using a `TimerTask` in `InputService.kt` to decide whether to trigger the long press event.
-      // It's not accurate and it's better to use the same detection logic in the controlling side.
+      if (shouldBlockMouseModeEvent()) {
+        return;
+      }
+      // Move cursor to position for mouse mode
+      await ffi.cursorModel.move(_doubleFinerTapPosition.dx, _doubleFinerTapPosition.dy);
     }
+    // Send right click event
+    await inputModel.tap(MouseButtons.right);
   }
 
   onLongPressMoveUpdate(LongPressMoveUpdateDetails d) async {

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -1046,6 +1046,12 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
     final more = <Widget>[
       SizedBox(width: 9999),
       wrap('Esc', () {
+        // Modified: ESC key now disconnects from remote session
+        // This provides a quick way to exit RustDesk connection
+        clientClose(sessionId, gFFI);
+      }),
+      wrap('Send Esc', () {
+        // New button: Send ESC key to remote system
         inputModel.inputKey('VK_ESCAPE');
       }),
       wrap('Tab', () {


### PR DESCRIPTION
## Changes

### Problem
When using RustDesk to connect to a Windows device from Android:
1. Right mouse click causes RustDesk to exit instead of sending right click to remote
2. No easy way to disconnect from session

### Solution
1. Modified onLongPress() to always send right click event to remote system
2. Changed ESC button to disconnect from session
3. Added new Send Esc button to send ESC key to remote Windows system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Send Esc”** option to transmit the escape key to the remote system.
* **Bug Fixes / Behavior Changes**
  * Unified long-press behavior across all platforms to consistently perform a right-click.
  * Updated the **Esc** button to close/disconnect the current remote session instead of sending the escape key.
* **Chores**
  * Improved Flutter CI build uploads by enabling artifact uploading with a custom tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->