### PR TITLE
opt: release clipboard config lock before updates

### DIFF
--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -1426,8 +1426,11 @@ impl<T: InvokeUiSession> Remote<T> {
                     self.handler.set_cursor_position(cp);
                 }
                 Some(message::Union::Clipboard(cb)) => {
-                    let lc = self.handler.lc.read().unwrap();
-                    if !lc.disable_clipboard.v && !lc.view_only.v {
+                    let clipboard_allowed = {
+                        let lc = self.handler.lc.read().unwrap();
+                        !lc.disable_clipboard.v && !lc.view_only.v
+                    };
+                    if clipboard_allowed {
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         update_clipboard(vec![cb], ClipboardSide::Client);
                         #[cfg(target_os = "ios")]
@@ -1446,8 +1449,11 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                 }
                 Some(message::Union::MultiClipboards(_mcb)) => {
-                    let lc = self.handler.lc.read().unwrap();
-                    if !lc.disable_clipboard.v && !lc.view_only.v {
+                    let clipboard_allowed = {
+                        let lc = self.handler.lc.read().unwrap();
+                        !lc.disable_clipboard.v && !lc.view_only.v
+                    };
+                    if clipboard_allowed {
                         #[cfg(not(any(target_os = "android", target_os = "ios")))]
                         update_clipboard(_mcb.clipboards, ClipboardSide::Client);
                         #[cfg(target_os = "ios")]


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/pull/15224

Tested:

  - Old client: when A (controller) enables View Only, clipboard still transfers from A -> B (controlled side).
  - New client: when A enables View Only, clipboard no longer transfers from A -> B.
  - New client: after A disables View Only, clipboard synchronization works normally again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal clipboard handling logic structure for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->