### PR TITLE
Revert "fix(iPad): keep touch gestures with external mouse"

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -532,9 +532,7 @@ class _RawTouchGestureDetectorRegionState
       // Official
       TapGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
-              () => TapGestureRecognizer(
-                    supportedDevices: kTouchBasedDeviceKinds,
-                  ), (instance) {
+              () => TapGestureRecognizer(), (instance) {
         instance
           ..onTapDown = onTapDown
           ..onTapUp = onTapUp
@@ -542,18 +540,14 @@ class _RawTouchGestureDetectorRegionState
       }),
       DoubleTapGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<DoubleTapGestureRecognizer>(
-              () => DoubleTapGestureRecognizer(
-                    supportedDevices: kTouchBasedDeviceKinds,
-                  ), (instance) {
+              () => DoubleTapGestureRecognizer(), (instance) {
         instance
           ..onDoubleTapDown = onDoubleTapDown
           ..onDoubleTap = onDoubleTap;
       }),
       LongPressGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<LongPressGestureRecognizer>(
-              () => LongPressGestureRecognizer(
-                    supportedDevices: kTouchBasedDeviceKinds,
-                  ), (instance) {
+              () => LongPressGestureRecognizer(), (instance) {
         instance
           ..onLongPressDown = onLongPressDown
           ..onLongPressUp = onLongPressUp
@@ -563,9 +557,7 @@ class _RawTouchGestureDetectorRegionState
       // Customized
       HoldTapMoveGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<HoldTapMoveGestureRecognizer>(
-              () => HoldTapMoveGestureRecognizer(
-                    supportedDevices: kTouchBasedDeviceKinds,
-                  ),
+              () => HoldTapMoveGestureRecognizer(),
               (instance) => instance
                 ..onHoldDragStart = onHoldDragStart
                 ..onHoldDragUpdate = onHoldDragUpdate
@@ -573,18 +565,14 @@ class _RawTouchGestureDetectorRegionState
                 ..onHoldDragEnd = onHoldDragEnd),
       DoubleFinerTapGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<DoubleFinerTapGestureRecognizer>(
-              () => DoubleFinerTapGestureRecognizer(
-                    supportedDevices: kTouchBasedDeviceKinds,
-                  ), (instance) {
+              () => DoubleFinerTapGestureRecognizer(), (instance) {
         instance
           ..onDoubleFinerTap = onDoubleFinerTap
           ..onDoubleFinerTapDown = onDoubleFinerTapDown;
       }),
       CustomTouchGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<CustomTouchGestureRecognizer>(
-              () => CustomTouchGestureRecognizer(
-                    supportedDevices: kTouchBasedDeviceKinds,
-                  ), (instance) {
+              () => CustomTouchGestureRecognizer(), (instance) {
         instance.onOneFingerPanStart =
             (DragStartDetails d) => onOneFingerPanStart(context, d);
         instance

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -517,10 +517,12 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
                               }
                               return Container(
                                 color: MyTheme.canvasColor,
-                                child: RawTouchGestureDetectorRegion(
-                                  child: getBodyForMobile(),
-                                  ffi: gFFI,
-                                ),
+                                child: inputModel.isPhysicalMouse.value
+                                    ? getBodyForMobile()
+                                    : RawTouchGestureDetectorRegion(
+                                        child: getBodyForMobile(),
+                                        ffi: gFFI,
+                                      ),
                               );
                             }),
                           ),

--- a/flutter/lib/mobile/pages/view_camera_page.dart
+++ b/flutter/lib/mobile/pages/view_camera_page.dart
@@ -259,11 +259,13 @@ class _ViewCameraPageState extends State<ViewCameraPage>
                         }
                         return Container(
                           color: MyTheme.canvasColor,
-                          child: RawTouchGestureDetectorRegion(
-                            child: getBodyForMobile(),
-                            ffi: gFFI,
-                            isCamera: true,
-                          ),
+                          child: inputModel.isPhysicalMouse.value
+                              ? getBodyForMobile()
+                              : RawTouchGestureDetectorRegion(
+                                  child: getBodyForMobile(),
+                                  ffi: gFFI,
+                                  isCamera: true,
+                                ),
                         );
                       }),
                     ),


### PR DESCRIPTION
Reverts rustdesk/rustdesk#14652

Fixing https://github.com/rustdesk/rustdesk/issues/15209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture handling on mobile remote and camera interface pages. Touch gesture detection now adapts based on connected input device type. Gesture recognizers are now reconfigured to handle both mouse and touch inputs without unnecessary processing when using a physical mouse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->