### PR TITLE
Inject custom server config (rebased on 1.4.7)

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -163,6 +163,41 @@ jobs:
           head -n 100 "${VCPKG_ROOT}/buildtrees/ffmpeg/build-${{ matrix.job.vcpkg-triplet }}-rel-out.log" || true
         shell: bash
 
+      - name: Inject custom server config (Windows)
+        if: runner.os == 'Windows' && env.RENDEZVOUS_SERVER != '' && env.RS_PUB_KEY != ''
+        env:
+          RENDEZVOUS_SERVER: ${{ secrets.RENDEZVOUS_SERVER }}
+          RS_PUB_KEY: ${{ secrets.RS_PUB_KEY }}
+        shell: pwsh
+        run: |
+          $rendezvousServer = $env:RENDEZVOUS_SERVER
+          $pubKey = $env:RS_PUB_KEY
+          
+          Write-Host "========================================"
+          Write-Host "Injecting custom server configuration"
+          Write-Host "Rendezvous Server: $rendezvousServer"
+          Write-Host "Public Key: $($pubKey.Substring(0,20))..."
+          Write-Host "========================================"
+          
+          $configFile = "libs/hbb_common/src/config.rs"
+          if (-not (Test-Path $configFile)) {
+            Write-Error "Config file not found: $configFile"
+            exit 1
+          }
+          
+          $content = Get-Content $configFile -Raw
+          $content | Set-Content "$configFile.backup" -Encoding UTF8
+          
+          # RENDEZVOUS_SERVERS: &[&str] = &["rs-ny.rustdesk.com"];
+          $content = $content -replace '(pub\s+const\s+RENDEZVOUS_SERVERS:\s*&\[&str\]\s*=\s*&\[)[^\]]*(\])', "`${1}`"$rendezvousServer`"`${2}"
+          
+          # RS_PUB_KEY: &str = "xxx";
+          $content = $content -replace '(pub\s+const\s+RS_PUB_KEY:\s*&str\s*=\s*)"[^"]*"', "`${1}`"$pubKey`""
+          
+          $content | Set-Content $configFile -Encoding UTF8
+          Write-Host "✅ Config injected successfully"
+          Select-String $configFile -Pattern "RENDEZVOUS_SERVERS|RS_PUB_KEY" | ForEach-Object { Write-Host $_ }
+
       - name: Build rustdesk
         run: |
           # Windows: build RustDesk
@@ -356,6 +391,41 @@ jobs:
           head -n 100 "${VCPKG_ROOT}/buildtrees/ffmpeg/build-${{ matrix.job.vcpkg-triplet }}-rel-out.log" || true
         shell: bash
 
+      - name: Inject custom server config (Windows)
+        if: runner.os == 'Windows' && env.RENDEZVOUS_SERVER != '' && env.RS_PUB_KEY != ''
+        env:
+          RENDEZVOUS_SERVER: ${{ secrets.RENDEZVOUS_SERVER }}
+          RS_PUB_KEY: ${{ secrets.RS_PUB_KEY }}
+        shell: pwsh
+        run: |
+          $rendezvousServer = $env:RENDEZVOUS_SERVER
+          $pubKey = $env:RS_PUB_KEY
+          
+          Write-Host "========================================"
+          Write-Host "Injecting custom server configuration"
+          Write-Host "Rendezvous Server: $rendezvousServer"
+          Write-Host "Public Key: $($pubKey.Substring(0,20))..."
+          Write-Host "========================================"
+          
+          $configFile = "libs/hbb_common/src/config.rs"
+          if (-not (Test-Path $configFile)) {
+            Write-Error "Config file not found: $configFile"
+            exit 1
+          }
+          
+          $content = Get-Content $configFile -Raw
+          $content | Set-Content "$configFile.backup" -Encoding UTF8
+          
+          # RENDEZVOUS_SERVERS: &[&str] = &["rs-ny.rustdesk.com"];
+          $content = $content -replace '(pub\s+const\s+RENDEZVOUS_SERVERS:\s*&\[&str\]\s*=\s*&\[)[^\]]*(\])', "`${1}`"$rendezvousServer`"`${2}"
+          
+          # RS_PUB_KEY: &str = "xxx";
+          $content = $content -replace '(pub\s+const\s+RS_PUB_KEY:\s*&str\s*=\s*)"[^"]*"', "`${1}`"$pubKey`""
+          
+          $content | Set-Content $configFile -Encoding UTF8
+          Write-Host "✅ Config injected successfully"
+          Select-String $configFile -Pattern "RENDEZVOUS_SERVERS|RS_PUB_KEY" | ForEach-Object { Write-Host $_ }
+
       - name: Build rustdesk
         id: build
         shell: bash
@@ -527,6 +597,39 @@ jobs:
         with:
           name: liblibrustdesk.a
           path: target/aarch64-apple-ios/release/liblibrustdesk.a
+
+      - name: Inject custom server config (macOS/Linux)
+        if: runner.os != 'Windows' && env.RENDEZVOUS_SERVER != '' && env.RS_PUB_KEY != ''
+        env:
+          RENDEZVOUS_SERVER: ${{ secrets.RENDEZVOUS_SERVER }}
+          RS_PUB_KEY: ${{ secrets.RS_PUB_KEY }}
+        shell: bash
+        run: |
+          echo "========================================"
+          echo "Injecting custom server configuration"
+          echo "Rendezvous Server: $RENDEZVOUS_SERVER"
+          echo "Public Key: ${RS_PUB_KEY:0:20}..."
+          echo "========================================"
+          
+          configFile="libs/hbb_common/src/config.rs"
+          if [ ! -f "$configFile" ]; then
+            echo "❌ Config file not found: $configFile"
+            exit 1
+          fi
+          
+          cp "$configFile" "$configFile.backup"
+          
+          # macOS 用 sed -i ''，Linux 用 sed -i
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            sed -i '' "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i '' "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          else
+            sed -i "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          fi
+          
+          echo "✅ Config injected successfully"
+          grep -E "RENDEZVOUS_SERVERS|RS_PUB_KEY" "$configFile" | head -2
 
       - name: Build rustdesk
         shell: bash
@@ -710,6 +813,39 @@ jobs:
           rustup default
           cargo -V
           rustc -V
+
+      - name: Inject custom server config (macOS/Linux)
+        if: runner.os != 'Windows' && env.RENDEZVOUS_SERVER != '' && env.RS_PUB_KEY != ''
+        env:
+          RENDEZVOUS_SERVER: ${{ secrets.RENDEZVOUS_SERVER }}
+          RS_PUB_KEY: ${{ secrets.RS_PUB_KEY }}
+        shell: bash
+        run: |
+          echo "========================================"
+          echo "Injecting custom server configuration"
+          echo "Rendezvous Server: $RENDEZVOUS_SERVER"
+          echo "Public Key: ${RS_PUB_KEY:0:20}..."
+          echo "========================================"
+          
+          configFile="libs/hbb_common/src/config.rs"
+          if [ ! -f "$configFile" ]; then
+            echo "❌ Config file not found: $configFile"
+            exit 1
+          fi
+          
+          cp "$configFile" "$configFile.backup"
+          
+          # macOS 用 sed -i ''，Linux 用 sed -i
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            sed -i '' "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i '' "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          else
+            sed -i "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          fi
+          
+          echo "✅ Config injected successfully"
+          grep -E "RENDEZVOUS_SERVERS|RS_PUB_KEY" "$configFile" | head -2
 
       - name: Build rustdesk
         run: |
@@ -1007,6 +1143,39 @@ jobs:
           name: librustdesk.so.${{ matrix.job.target }}
           path: ./target/${{ matrix.job.target }}/release/liblibrustdesk.so
 
+      - name: Inject custom server config (macOS/Linux)
+        if: runner.os != 'Windows' && env.RENDEZVOUS_SERVER != '' && env.RS_PUB_KEY != ''
+        env:
+          RENDEZVOUS_SERVER: ${{ secrets.RENDEZVOUS_SERVER }}
+          RS_PUB_KEY: ${{ secrets.RS_PUB_KEY }}
+        shell: bash
+        run: |
+          echo "========================================"
+          echo "Injecting custom server configuration"
+          echo "Rendezvous Server: $RENDEZVOUS_SERVER"
+          echo "Public Key: ${RS_PUB_KEY:0:20}..."
+          echo "========================================"
+          
+          configFile="libs/hbb_common/src/config.rs"
+          if [ ! -f "$configFile" ]; then
+            echo "❌ Config file not found: $configFile"
+            exit 1
+          fi
+          
+          cp "$configFile" "$configFile.backup"
+          
+          # macOS 用 sed -i ''，Linux 用 sed -i
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            sed -i '' "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i '' "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          else
+            sed -i "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          fi
+          
+          echo "✅ Config injected successfully"
+          grep -E "RENDEZVOUS_SERVERS|RS_PUB_KEY" "$configFile" | head -2
+
       - name: Build rustdesk
         shell: bash
         env:
@@ -1216,6 +1385,39 @@ jobs:
           name: librustdesk.so.i686-linux-android
           path: ./flutter/android/app/src/main/jniLibs/x86
 
+      - name: Inject custom server config (macOS/Linux)
+        if: runner.os != 'Windows' && env.RENDEZVOUS_SERVER != '' && env.RS_PUB_KEY != ''
+        env:
+          RENDEZVOUS_SERVER: ${{ secrets.RENDEZVOUS_SERVER }}
+          RS_PUB_KEY: ${{ secrets.RS_PUB_KEY }}
+        shell: bash
+        run: |
+          echo "========================================"
+          echo "Injecting custom server configuration"
+          echo "Rendezvous Server: $RENDEZVOUS_SERVER"
+          echo "Public Key: ${RS_PUB_KEY:0:20}..."
+          echo "========================================"
+          
+          configFile="libs/hbb_common/src/config.rs"
+          if [ ! -f "$configFile" ]; then
+            echo "❌ Config file not found: $configFile"
+            exit 1
+          fi
+          
+          cp "$configFile" "$configFile.backup"
+          
+          # macOS 用 sed -i ''，Linux 用 sed -i
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            sed -i '' "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i '' "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          else
+            sed -i "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          fi
+          
+          echo "✅ Config injected successfully"
+          grep -E "RENDEZVOUS_SERVERS|RS_PUB_KEY" "$configFile" | head -2
+
       - name: Build rustdesk
         shell: bash
         env:
@@ -1409,6 +1611,39 @@ jobs:
         with:
           name: bridge-artifact
           path: ./
+
+      - name: Inject custom server config (macOS/Linux)
+        if: runner.os != 'Windows' && env.RENDEZVOUS_SERVER != '' && env.RS_PUB_KEY != ''
+        env:
+          RENDEZVOUS_SERVER: ${{ secrets.RENDEZVOUS_SERVER }}
+          RS_PUB_KEY: ${{ secrets.RS_PUB_KEY }}
+        shell: bash
+        run: |
+          echo "========================================"
+          echo "Injecting custom server configuration"
+          echo "Rendezvous Server: $RENDEZVOUS_SERVER"
+          echo "Public Key: ${RS_PUB_KEY:0:20}..."
+          echo "========================================"
+          
+          configFile="libs/hbb_common/src/config.rs"
+          if [ ! -f "$configFile" ]; then
+            echo "❌ Config file not found: $configFile"
+            exit 1
+          fi
+          
+          cp "$configFile" "$configFile.backup"
+          
+          # macOS 用 sed -i ''，Linux 用 sed -i
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            sed -i '' "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i '' "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          else
+            sed -i "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          fi
+          
+          echo "✅ Config injected successfully"
+          grep -E "RENDEZVOUS_SERVERS|RS_PUB_KEY" "$configFile" | head -2
 
       - uses: rustdesk-org/run-on-arch-action@d3fcfbb632b84cf7f6bc772bfaaa2c2f4f8789a8 # no release tag; commit 2026-05-26
         name: Build rustdesk
@@ -1694,6 +1929,39 @@ jobs:
           RUST_TOOLCHAIN_VERSION=$(cargo --version | awk '{print $2}')
           echo "RUST_TOOLCHAIN_VERSION=$RUST_TOOLCHAIN_VERSION" >> $GITHUB_ENV
 
+      - name: Inject custom server config (macOS/Linux)
+        if: runner.os != 'Windows' && env.RENDEZVOUS_SERVER != '' && env.RS_PUB_KEY != ''
+        env:
+          RENDEZVOUS_SERVER: ${{ secrets.RENDEZVOUS_SERVER }}
+          RS_PUB_KEY: ${{ secrets.RS_PUB_KEY }}
+        shell: bash
+        run: |
+          echo "========================================"
+          echo "Injecting custom server configuration"
+          echo "Rendezvous Server: $RENDEZVOUS_SERVER"
+          echo "Public Key: ${RS_PUB_KEY:0:20}..."
+          echo "========================================"
+          
+          configFile="libs/hbb_common/src/config.rs"
+          if [ ! -f "$configFile" ]; then
+            echo "❌ Config file not found: $configFile"
+            exit 1
+          fi
+          
+          cp "$configFile" "$configFile.backup"
+          
+          # macOS 用 sed -i ''，Linux 用 sed -i
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            sed -i '' "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i '' "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          else
+            sed -i "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          fi
+          
+          echo "✅ Config injected successfully"
+          grep -E "RENDEZVOUS_SERVERS|RS_PUB_KEY" "$configFile" | head -2
+
       - uses: rustdesk-org/run-on-arch-action@d3fcfbb632b84cf7f6bc772bfaaa2c2f4f8789a8 # no release tag; commit 2026-05-26
         name: Build rustdesk sciter binary for ${{ matrix.job.arch }}
         id: vcpkg
@@ -1953,6 +2221,39 @@ jobs:
       - name: Rename Binary
         run: |
           mv rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}${{ matrix.job.suffix }}.deb flatpak/rustdesk.deb
+
+      - name: Inject custom server config (macOS/Linux)
+        if: runner.os != 'Windows' && env.RENDEZVOUS_SERVER != '' && env.RS_PUB_KEY != ''
+        env:
+          RENDEZVOUS_SERVER: ${{ secrets.RENDEZVOUS_SERVER }}
+          RS_PUB_KEY: ${{ secrets.RS_PUB_KEY }}
+        shell: bash
+        run: |
+          echo "========================================"
+          echo "Injecting custom server configuration"
+          echo "Rendezvous Server: $RENDEZVOUS_SERVER"
+          echo "Public Key: ${RS_PUB_KEY:0:20}..."
+          echo "========================================"
+          
+          configFile="libs/hbb_common/src/config.rs"
+          if [ ! -f "$configFile" ]; then
+            echo "❌ Config file not found: $configFile"
+            exit 1
+          fi
+          
+          cp "$configFile" "$configFile.backup"
+          
+          # macOS 用 sed -i ''，Linux 用 sed -i
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            sed -i '' "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i '' "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          else
+            sed -i "s|pub const RENDEZVOUS_SERVERS: &\[&str\] = &\[\"[^\"]*\"\]|pub const RENDEZVOUS_SERVERS: \&[\&str] = \&[\"$RENDEZVOUS_SERVER\"]|g" "$configFile"
+            sed -i "s|pub const RS_PUB_KEY: &str = \"[^\"]*\"|pub const RS_PUB_KEY: \&str = \"$RS_PUB_KEY\"|g" "$configFile"
+          fi
+          
+          echo "✅ Config injected successfully"
+          grep -E "RENDEZVOUS_SERVERS|RS_PUB_KEY" "$configFile" | head -2
 
       - uses: rustdesk-org/run-on-arch-action@d3fcfbb632b84cf7f6bc772bfaaa2c2f4f8789a8 # no release tag; commit 2026-05-26
         name: Build rustdesk flatpak package for ${{ matrix.job.arch }}


### PR DESCRIPTION
Add steps to inject custom server configuration for Windows and macOS/Linux builds. Rebased from 1.4.6 to 1.4.7, using updated run-on-arch-action commit hash.

- Uses RENDEZVOUS_SERVER and RS_PUB_KEY from GitHub Secrets
- Injects into libs/hbb_common/src/config.rs before build
- Supports both Windows (PowerShell) and macOS/Linux (bash) runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build automation to support dynamic rendezvous server configuration injection across all platform builds, enabling streamlined deployment configuration without code modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->