### PR TITLE
Update translation for remote toolbar docking message

### DIFF
--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -744,7 +744,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("password-hidden-tip", "A senha permanente está definida como (oculta)."),
         ("preset-password-in-use-tip", "A senha predefinida está sendo usada."),
         ("Enable privacy mode", "Habilitar modo de privacidade"),
-        ("allow-remote-toolbar-docking-any-edge", "Permitir fixar a barra de ferramentas remota em qualquer borda da janela"),
+        ("allow-remote-toolbar-docking-any-edge", "Fixar a barra de ferramentas remota em qualquer borda da janela"),
         ("API Token", "Token de API"),
         ("Deploy", "Implantar"),
         ("Custom ID (optional)", "ID personalizado (opcional)"),

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -430,7 +430,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Strong", "Forte"),
         ("Switch Sides", "Trocar de lado"),
         ("Please confirm if you want to share your desktop?", "Por favor, confirme se você deseja compartilhar sua área de trabalho?"),
-        ("Display", "Tela"),
+        ("Display", "Exibição"),
         ("Default View Style", "Estilo de Visualização Padrão"),
         ("Default Scroll Style", "Estilo de Rolagem Padrão"),
         ("Default Image Quality", "Qualidade de Imagem Padrão"),

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -430,7 +430,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Strong", "Forte"),
         ("Switch Sides", "Trocar de lado"),
         ("Please confirm if you want to share your desktop?", "Por favor, confirme se você deseja compartilhar sua área de trabalho?"),
-        ("Display", "Display"),
+        ("Display", "Tela"),
         ("Default View Style", "Estilo de Visualização Padrão"),
         ("Default Scroll Style", "Estilo de Rolagem Padrão"),
         ("Default Image Quality", "Qualidade de Imagem Padrão"),


### PR DESCRIPTION
Update translation for remote toolbar docking message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Portuguese (pt-BR) translation wording for the remote toolbar docking feature, including the display label and the related permission text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->