### PR TITLE
try to fix https://github.com/rustdesk/rustdesk/issues/15291

### DIFF
--- a/libs/clipboard/src/windows/wf_cliprdr.c
+++ b/libs/clipboard/src/windows/wf_cliprdr.c
@@ -1406,10 +1406,10 @@ static UINT32 get_remote_format_id(wfClipboard *clipboard, UINT32 local_format)
 	return local_format;
 }
 
-static void map_ensure_capacity(wfClipboard *clipboard)
+static BOOL map_ensure_capacity(wfClipboard *clipboard)
 {
 	if (!clipboard)
-		return;
+		return FALSE;
 
 	if (clipboard->map_size >= clipboard->map_capacity)
 	{
@@ -1420,11 +1420,20 @@ static void map_ensure_capacity(wfClipboard *clipboard)
 			(formatMapping *)realloc(clipboard->format_mappings, sizeof(formatMapping) * new_size);
 
 		if (!new_map)
-			return;
+			return FALSE;
+
+		// `realloc` does not initialize the grown region. `clear_format_map()` frees
+		// `map->name` for every slot up to `map_capacity`, so the newly added slots
+		// must be zeroed; otherwise `free()` is called on uninitialized (garbage)
+		// pointers, which corrupts the heap (issue #15291).
+		ZeroMemory(new_map + clipboard->map_capacity,
+				   (new_size - clipboard->map_capacity) * sizeof(formatMapping));
 
 		clipboard->format_mappings = new_map;
 		clipboard->map_capacity = new_size;
 	}
+
+	return TRUE;
 }
 
 static BOOL clear_format_map(wfClipboard *clipboard)
@@ -2448,6 +2457,11 @@ static UINT wf_cliprdr_server_format_list(CliprdrClientContext *context,
 
 	for (i = 0; i < formatList->numFormats; i++)
 	{
+		// Ensure room for slot `i` (== current map_size) BEFORE writing it, and bail
+		// out if the table cannot be grown, so we never write past the allocation.
+		if (!map_ensure_capacity(clipboard))
+			return ERROR_INTERNAL_ERROR;
+
 		format = &(formatList->formats[i]);
 		mapping = &(clipboard->format_mappings[i]);
 		mapping->remote_format_id = format->formatId;
@@ -2472,7 +2486,6 @@ static UINT wf_cliprdr_server_format_list(CliprdrClientContext *context,
 		}
 
 		clipboard->map_size++;
-		map_ensure_capacity(clipboard);
 	}
 
 	if (file_transferring(clipboard))

--- a/tests/test_invariant_wf_cliprdr.c
+++ b/tests/test_invariant_wf_cliprdr.c
@@ -1,6 +1,7 @@
 #include <check.h>
 #include <stdlib.h>
 #include <stddef.h>
+#include <string.h>
 
 #include "../libs/clipboard/src/windows/wf_cliprdr.c"
 
@@ -56,10 +57,91 @@ START_TEST(test_descriptor_size_rejects_extreme_count)
 }
 END_TEST
 
+/* Regression tests for issue #15291: map_ensure_capacity() must zero-initialize
+ * the region added by realloc(), because clear_format_map() frees map->name for
+ * every slot up to map_capacity. Without zeroing, those slots hold uninitialized
+ * (garbage) pointers and free() corrupts the heap. */
+
+START_TEST(test_map_ensure_capacity_zeroes_grown_slots)
+{
+	wfClipboard cb;
+	size_t i;
+	size_t old_capacity;
+
+	/* Dirty the heap so that a non-zeroing realloc would hand back non-NULL
+	 * garbage for the grown region, making the regression deterministic. */
+	for (i = 0; i < 64; i++)
+	{
+		void *p = malloc(256 * sizeof(formatMapping));
+		if (p)
+		{
+			memset(p, 0xFF, 256 * sizeof(formatMapping));
+			free(p);
+		}
+	}
+
+	memset(&cb, 0, sizeof(cb));
+	cb.map_capacity = 2;
+	cb.map_size = 0;
+	cb.format_mappings = (formatMapping *)calloc(cb.map_capacity, sizeof(formatMapping));
+	ck_assert_ptr_nonnull(cb.format_mappings);
+
+	old_capacity = cb.map_capacity;
+	cb.map_size = cb.map_capacity; /* force a grow on the next ensure */
+	ck_assert_int_eq(map_ensure_capacity(&cb), TRUE);
+	ck_assert_uint_gt(cb.map_capacity, old_capacity);
+
+	for (i = old_capacity; i < cb.map_capacity; i++)
+	{
+		ck_assert_ptr_null(cb.format_mappings[i].name);
+		ck_assert_uint_eq(cb.format_mappings[i].remote_format_id, 0);
+		ck_assert_uint_eq(cb.format_mappings[i].local_format_id, 0);
+	}
+
+	clear_format_map(&cb);
+	free(cb.format_mappings);
+}
+END_TEST
+
+START_TEST(test_clear_format_map_safe_after_realloc_growth)
+{
+	wfClipboard cb;
+	UINT i;
+
+	memset(&cb, 0, sizeof(cb));
+	cb.map_capacity = 2;
+	cb.map_size = 0;
+	cb.format_mappings = (formatMapping *)calloc(cb.map_capacity, sizeof(formatMapping));
+	ck_assert_ptr_nonnull(cb.format_mappings);
+
+	/* Populate a format list larger than the initial capacity, the same way
+	 * wf_cliprdr_server_format_list() does: ensure capacity, then write slot i. */
+	for (i = 0; i < 10; i++)
+	{
+		ck_assert_int_eq(map_ensure_capacity(&cb), TRUE);
+		cb.format_mappings[i].remote_format_id = i + 1;
+		cb.format_mappings[i].local_format_id = i + 1;
+		cb.format_mappings[i].name = _wcsdup(L"fmt");
+		ck_assert_ptr_nonnull(cb.format_mappings[i].name);
+		cb.map_size++;
+	}
+
+	ck_assert_uint_ge(cb.map_capacity, 10);
+
+	/* clear_format_map() frees name across the full capacity; the untouched grown
+	 * slots must be NULL so this neither crashes nor corrupts the heap. */
+	ck_assert_int_eq(clear_format_map(&cb), TRUE);
+	ck_assert_uint_eq(cb.map_size, 0);
+
+	free(cb.format_mappings);
+}
+END_TEST
+
 Suite *wf_cliprdr_invariant_suite(void)
 {
 	Suite *s;
 	TCase *tc_core;
+	TCase *tc_format_map;
 
 	s = suite_create("wf_cliprdr_invariants");
 	tc_core = tcase_create("descriptor_size");
@@ -72,6 +154,12 @@ Suite *wf_cliprdr_invariant_suite(void)
 	tcase_add_test(tc_core, test_descriptor_size_rejects_extreme_count);
 
 	suite_add_tcase(s, tc_core);
+
+	tc_format_map = tcase_create("format_map");
+	tcase_add_test(tc_format_map, test_map_ensure_capacity_zeroes_grown_slots);
+	tcase_add_test(tc_format_map, test_clear_format_map_safe_after_realloc_growth);
+	suite_add_tcase(s, tc_format_map);
+
 	return s;
 }
 


### PR DESCRIPTION
  Root cause (verified)

  The crash signatures — heap corruption 0xc0000374 and an access violation reading 0xFFFFFFFFFFFFFFFF — are the classic fingerprint of free() being called on an uninitialized pointer. In
  libs/clipboard/src/windows/wf_cliprdr.c the format-mapping table does exactly that:
  
  - map_ensure_capacity() grows clipboard->format_mappings with realloc() — which leaves the new slots uninitialized (garbage).
  - clear_format_map() then frees map->name for every slot up to map_capacity — including those never-written, garbage slots → heap corruption / wild free.

  The format count fed to wf_cliprdr_server_format_list() comes straight from the peer's FormatList (Rust server_format_list forwards the count verbatim, it is not capped), so this is reachable from
  clipboard data the peer controls. It's the same hardening class the maintainers already addressed in #15142 (wf_cliprdr_file_group_descriptor_size_valid + the invariant test), which is why I extended that
  exact test harness.
  
  This was the convergent finding of a 50-agent adversarial audit (flagged by 6 findings across 5 independent angles, rated real by ~10 verifiers) and matches my own full read of the module.

  What I changed (git diff --stat: 2 files, +105/−4)

  1. map_ensure_capacity() — ZeroMemory() the realloc-grown region so freed-as-pointers slots are always NULL; return BOOL and propagate realloc failure.
  2. wf_cliprdr_server_format_list() — ensure capacity before writing slot i and bail on failure, so a write can never land past the allocation (removes the old write-then-grow fragility and the
  realloc-failure OOB).
  3. tests/test_invariant_wf_cliprdr.c — two regression tests: grown slots are zero-initialized, and clear_format_map() is safe after a realloc growth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory corruption issue in clipboard format mapping that could occur during storage expansion.

* **Tests**
  * Added regression tests to validate clipboard format mapping safety and proper cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->