### PR TITLE
Feature: Add monitor-switch buttons to remote toolbars

### DIFF
--- a/flutter/assets/display_switcher.svg
+++ b/flutter/assets/display_switcher.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <g fill="#000000" fill-rule="evenodd">
+    <rect x="4" y="6" width="24" height="16" rx="3"/>
+    <rect x="14.5" y="22" width="3" height="2"/>
+    <rect x="9.5" y="24" width="13" height="2.5" rx="1.25"/>
+  </g>
+</svg>

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -170,6 +170,8 @@ const String kOptionShowVirtualMouse = "show-virtual-mouse";
 const String kOptionVirtualMouseScale = "virtual-mouse-scale";
 const String kOptionShowVirtualJoystick = "show-virtual-joystick";
 const String kOptionAllowAskForNoteAtEndOfConnection = "allow-ask-for-note";
+const String kOptionAllowMonitorSwitchMainToolbar = "allow-monitor-switch-main-toolbar";
+const String kOptionAllowMonitorSwitchMinToolbar = "allow-monitor-switch-min-toolbar";
 const String kOptionEnableShowTerminalExtraKeys = "enable-show-terminal-extra-keys";
 
 // network options

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -407,6 +407,7 @@ class _GeneralState extends State<_General> {
   final RxBool serviceStop =
       isWeb ? RxBool(false) : Get.find<RxBool>(tag: 'stop-service');
   RxBool serviceBtnEnabled = true.obs;
+  final GlobalKey _minToolbarOptionKey = GlobalKey();
 
   @override
   Widget build(BuildContext context) {
@@ -610,19 +611,42 @@ class _GeneralState extends State<_General> {
       'Show monitor switch button on the main toolbar',
       kOptionAllowMonitorSwitchMainToolbar,
       isServer: false,
-      update: (_) {
+      update: (enabled) async {
+        if (!enabled) {
+          await mainSetLocalBoolOption(
+              kOptionAllowMonitorSwitchMinToolbar, false);
+        }
+        if (mounted) setState(() {});
         reloadAllWindows();
+        if (enabled) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            final ctx = _minToolbarOptionKey.currentContext;
+            if (ctx != null) {
+              Scrollable.ensureVisible(
+                ctx,
+                alignment: 0.5,
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.easeInOut,
+              );
+            }
+          });
+        }
       },
     ));
-    children.add(_OptionCheckBox(
-      context,
-      'Show monitor switch button on the minimized toolbar',
-      kOptionAllowMonitorSwitchMinToolbar,
-      isServer: false,
-      update: (_) {
-        reloadAllWindows();
-      },
-    ));
+    if (mainGetLocalBoolOptionSync(kOptionAllowMonitorSwitchMainToolbar)) {
+      children.add(KeyedSubtree(
+        key: _minToolbarOptionKey,
+        child: _OptionCheckBox(
+          context,
+          'Show on the minimized toolbar',
+          kOptionAllowMonitorSwitchMinToolbar,
+          isServer: false,
+          update: (_) {
+            reloadAllWindows();
+          },
+        ).marginOnly(left: _kCheckBoxLeftMargin * 3),
+      ));
+    }
     return _Card(title: 'Other', children: children);
   }
 

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -605,6 +605,24 @@ class _GeneralState extends State<_General> {
         },
       ));
     }
+    children.add(_OptionCheckBox(
+      context,
+      'Show monitor switch button on the main toolbar',
+      kOptionAllowMonitorSwitchMainToolbar,
+      isServer: false,
+      update: (_) {
+        reloadAllWindows();
+      },
+    ));
+    children.add(_OptionCheckBox(
+      context,
+      'Show monitor switch button on the minimized toolbar',
+      kOptionAllowMonitorSwitchMinToolbar,
+      isServer: false,
+      update: (_) {
+        reloadAllWindows();
+      },
+    ));
     return _Card(title: 'Other', children: children);
   }
 

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -992,7 +992,7 @@ class _MonitorCycle {
     final t = total;
     if (t < 2) return;
     final from = _inRange ? _current : -1;
-    openMonitorInTheSameTab((from + 1) % t, ffi, _pi);
+    openMonitorInTheSameTab((from + 1) % t, ffi, _pi, updateCursorPos: false);
   }
 }
 
@@ -3336,7 +3336,9 @@ class _DraggableShowHideState extends State<_DraggableShowHide> {
       mainAxisSize: MainAxisSize.min,
       children: [
         _buildDraggable(context),
-        _MinimizedMonitorSwitchButton(id: widget.id, ffi: widget.ffi),
+        Obx(() => collapse.isTrue
+            ? _MinimizedMonitorSwitchButton(id: widget.id, ffi: widget.ffi)
+            : const Offstage()),
         Obx(() => buttonWrapper(
               () {
                 widget.setFullscreen(!isFullscreen.value);

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -813,7 +813,7 @@ class _RemoteToolbarState extends State<RemoteToolbar> {
           mainGetLocalBoolOptionSync(kOptionAllowMonitorSwitchMainToolbar)) {
         return _MainMonitorSwitchButton(id: widget.id, ffi: widget.ffi);
       } else {
-        return Offstage();
+        return const Offstage();
       }
     }));
     if (!isWebDesktop) {
@@ -986,6 +986,7 @@ class _MonitorCycle {
   bool get _inRange => _current >= 0 && _current < total;
 
   String get label => _inRange ? '${_current + 1}' : '*';
+  String get tooltip => '${translate('Switch display')} ($label/$total)';
 
   void next() {
     final t = total;
@@ -1013,47 +1014,34 @@ class _MainMonitorSwitchButton extends StatelessWidget {
       final label = cycle.label;
 
       return _IconMenuButton(
-        tooltip: '${translate('Switch display')} ($label/${cycle.total})',
+        tooltip: cycle.tooltip,
         color: _ToolbarTheme.blueColor,
         hoverColor: _ToolbarTheme.hoverBlueColor,
         onPressed: cycle.next,
         icon: SizedBox(
           width: _ToolbarTheme.buttonSize,
           height: _ToolbarTheme.buttonSize,
-          child: Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Container(
-                  width: 23,
-                  height: 16,
-                  alignment: Alignment.center,
-                  decoration: BoxDecoration(
-                    color: Colors.white,
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                  child: Text(
-                    label,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      color: Colors.black,
-                      fontSize: 11,
-                      height: 1,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
+          child: Stack(
+            alignment: const Alignment(0, -0.125),
+            children: [
+              SvgPicture.asset(
+                'assets/display_switcher.svg',
+                colorFilter:
+                    const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+                width: _ToolbarTheme.buttonSize,
+                height: _ToolbarTheme.buttonSize,
+              ),
+              Text(
+                label,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: Colors.black,
+                  fontSize: 11,
+                  height: 1,
+                  fontWeight: FontWeight.bold,
                 ),
-                Container(width: 3, height: 2, color: Colors.white),
-                Container(
-                  width: 9,
-                  height: 2,
-                  decoration: BoxDecoration(
-                    color: Colors.white,
-                    borderRadius: BorderRadius.circular(1),
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       );
@@ -3537,7 +3525,7 @@ class _MinimizedMonitorSwitchButton extends StatelessWidget {
       }
 
       return Tooltip(
-        message: '${translate('Switch display')} ($label/${cycle.total})',
+        message: cycle.tooltip,
         child: TextButton(
           onPressed: cycle.next,
           style: ButtonStyle(
@@ -3551,10 +3539,10 @@ class _MinimizedMonitorSwitchButton extends StatelessWidget {
             }),
           ),
           child: Stack(
-            alignment: const Alignment(0, -0.15),
+            alignment: const Alignment(0, -0.125),
             children: [
               SvgPicture.asset(
-                'assets/display.svg',
+                'assets/display_switcher.svg',
                 colorFilter:
                     ColorFilter.mode(_ToolbarTheme.blueColor, BlendMode.srcIn),
                 width: iconSize,
@@ -3563,7 +3551,7 @@ class _MinimizedMonitorSwitchButton extends StatelessWidget {
               Text(
                 label,
                 style: const TextStyle(
-                  color: _ToolbarTheme.blueColor,
+                  color: Colors.white,
                   fontSize: 9,
                   height: 1,
                   fontWeight: FontWeight.bold,

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1013,7 +1013,7 @@ class _MainMonitorSwitchButton extends StatelessWidget {
       final label = cycle.label;
 
       return _IconMenuButton(
-        tooltip: '${translate('Switch Display')} ($label/${cycle.total})',
+        tooltip: '${translate('Switch display')} ($label/${cycle.total})',
         color: _ToolbarTheme.blueColor,
         hoverColor: _ToolbarTheme.hoverBlueColor,
         onPressed: cycle.next,
@@ -3537,7 +3537,7 @@ class _MinimizedMonitorSwitchButton extends StatelessWidget {
       }
 
       return Tooltip(
-        message: '${translate('Switch Display')} ($label/${cycle.total})',
+        message: '${translate('Switch display')} ($label/${cycle.total})',
         child: TextButton(
           onPressed: cycle.next,
           style: ButtonStyle(

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -779,6 +779,7 @@ class _RemoteToolbarState extends State<RemoteToolbar> {
           borderRadius: borderRadius,
           child: _DraggableShowHide(
             id: widget.id,
+            ffi: widget.ffi,
             sessionId: widget.ffi.sessionId,
             dragging: _dragging,
             fraction: _fraction,
@@ -805,6 +806,16 @@ class _RemoteToolbarState extends State<RemoteToolbar> {
       BuildContext context, _ToolbarEdge edge, bool isHorizontal) {
     final List<Widget> toolbarItems = [];
     toolbarItems.add(_PinMenu(state: widget.state));
+    toolbarItems.add(Obx(() {
+      if ((PrivacyModeState.find(widget.id).isEmpty ||
+              allowDisplaySwitchInPrivacyMode(pi)) &&
+          pi.displaysCount.value > 1 &&
+          mainGetLocalBoolOptionSync(kOptionAllowMonitorSwitchMainToolbar)) {
+        return _MainMonitorSwitchButton(id: widget.id, ffi: widget.ffi);
+      } else {
+        return Offstage();
+      }
+    }));
     if (!isWebDesktop) {
       toolbarItems.add(_MobileActionMenu(ffi: widget.ffi));
     }
@@ -961,6 +972,92 @@ class _MobileActionMenu extends StatelessWidget {
               ? _ToolbarTheme.hoverBlueColor
               : _ToolbarTheme.hoverInactiveColor,
         ));
+  }
+}
+
+class _MonitorCycle {
+  final String id;
+  final FFI ffi;
+  const _MonitorCycle(this.id, this.ffi);
+
+  PeerInfo get _pi => ffi.ffiModel.pi;
+  int get total => _pi.displays.length;
+  int get _current => CurrentDisplayState.find(id).value;
+  bool get _inRange => _current >= 0 && _current < total;
+
+  String get label => _inRange ? '${_current + 1}' : '*';
+
+  void next() {
+    final t = total;
+    if (t < 2) return;
+    final from = _inRange ? _current : -1;
+    openMonitorInTheSameTab((from + 1) % t, ffi, _pi);
+  }
+}
+
+class _MainMonitorSwitchButton extends StatelessWidget {
+  final String id;
+  final FFI ffi;
+
+  const _MainMonitorSwitchButton({
+    Key? key,
+    required this.id,
+    required this.ffi,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final cycle = _MonitorCycle(id, ffi);
+    return Obx(() {
+      if (cycle.total < 2) return const Offstage();
+      final label = cycle.label;
+
+      return _IconMenuButton(
+        tooltip: '${translate('Switch Display')} ($label/${cycle.total})',
+        color: _ToolbarTheme.blueColor,
+        hoverColor: _ToolbarTheme.hoverBlueColor,
+        onPressed: cycle.next,
+        icon: SizedBox(
+          width: _ToolbarTheme.buttonSize,
+          height: _ToolbarTheme.buttonSize,
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 23,
+                  height: 16,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    label,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Colors.black,
+                      fontSize: 11,
+                      height: 1,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                Container(width: 3, height: 2, color: Colors.white),
+                Container(
+                  width: 9,
+                  height: 2,
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(1),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    });
   }
 }
 
@@ -2970,6 +3067,7 @@ class RdoMenuButton<T> extends StatelessWidget {
 
 class _DraggableShowHide extends StatefulWidget {
   final String id;
+  final FFI ffi;
   final SessionID sessionId;
   final RxDouble fraction;
   final Rx<_ToolbarEdge> edge;
@@ -2993,6 +3091,7 @@ class _DraggableShowHide extends StatefulWidget {
   const _DraggableShowHide({
     Key? key,
     required this.id,
+    required this.ffi,
     required this.sessionId,
     required this.fraction,
     required this.edge,
@@ -3249,6 +3348,7 @@ class _DraggableShowHideState extends State<_DraggableShowHide> {
       mainAxisSize: MainAxisSize.min,
       children: [
         _buildDraggable(context),
+        _MinimizedMonitorSwitchButton(id: widget.id, ffi: widget.ffi),
         Obx(() => buttonWrapper(
               () {
                 widget.setFullscreen(!isFullscreen.value);
@@ -3407,5 +3507,72 @@ class EdgeThicknessControl extends StatelessWidget {
     );
 
     return slider;
+  }
+}
+
+class _MinimizedMonitorSwitchButton extends StatelessWidget {
+  final String id;
+  final FFI ffi;
+
+  const _MinimizedMonitorSwitchButton({
+    Key? key,
+    required this.id,
+    required this.ffi,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    const double iconSize = 20;
+    final cycle = _MonitorCycle(id, ffi);
+
+    return Obx(() {
+      final label = cycle.label;
+      if (!mainGetLocalBoolOptionSync(kOptionAllowMonitorSwitchMinToolbar)) {
+        return const Offstage();
+      }
+      if (cycle.total < 2) return const Offstage();
+      if (PrivacyModeState.find(id).isNotEmpty &&
+          !allowDisplaySwitchInPrivacyMode(ffi.ffiModel.pi)) {
+        return const Offstage();
+      }
+
+      return Tooltip(
+        message: '${translate('Switch Display')} ($label/${cycle.total})',
+        child: TextButton(
+          onPressed: cycle.next,
+          style: ButtonStyle(
+            minimumSize: MaterialStateProperty.all(const Size(0, 0)),
+            padding: MaterialStateProperty.all(EdgeInsets.zero),
+            backgroundColor: MaterialStateProperty.resolveWith((states) {
+              if (states.contains(MaterialState.hovered)) {
+                return _ToolbarTheme.blueColor.withOpacity(0.15);
+              }
+              return null;
+            }),
+          ),
+          child: Stack(
+            alignment: const Alignment(0, -0.15),
+            children: [
+              SvgPicture.asset(
+                'assets/display.svg',
+                colorFilter:
+                    ColorFilter.mode(_ToolbarTheme.blueColor, BlendMode.srcIn),
+                width: iconSize,
+                height: iconSize,
+              ),
+              Text(
+                label,
+                style: const TextStyle(
+                  color: _ToolbarTheme.blueColor,
+                  fontSize: 9,
+                  height: 1,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    });
   }
 }


### PR DESCRIPTION
Add a one-click "switch to next monitor" control to both desktop toolbars for faster switching of displays.

_Main toolbar_ 
Always shown when the remote has more than one monitor, styled to match the existing blue icon buttons (white screen, black number).

_Minimized (draggable show/hide) toolbar_
Off by default, toggled via a new "Show monitor switch on minimized toolbar" checkbox in the Display menu and persisted as a local option.

# Preview


## Before

https://github.com/user-attachments/assets/bb4823bf-eb47-44de-888a-c21661e2f828


## After

https://github.com/user-attachments/assets/a3b2b733-25d3-4cf6-ae39-218ee9596898

<img width="531" height="503" alt="image" src="https://github.com/user-attachments/assets/96ddb075-abee-4a67-8306-27d762642fb2" />

### Default behavior is toggled off, Opt-In from General/Other

## Added hbb_common addon for custom client
But I don't think I can fully test this on my end. If this is needed to be include I can, if not I can remove it.
https://github.com/StealUrKill/hbb_common/commit/f1f717c1cb5313b02f27e4e840dcc91acd0c503d

## Testing

Built flutter app and testing locally on Win11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added monitor switch controls to the remote desktop toolbars, allowing quick cycling through multiple displays.
  * Added independent client-side settings to show/hide the monitor switch button on the main toolbar and on the minimized toolbar (changes apply immediately).
  * Display switching controls are shown only when permitted by the current privacy rules and when the peer has multiple displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->