### PR TITLE
Feature: Make the address book & accessible devices side panels resizable to some degree

### DIFF
--- a/flutter/lib/common/widgets/address_book.dart
+++ b/flutter/lib/common/widgets/address_book.dart
@@ -9,6 +9,7 @@ import 'package:flutter_hbb/common/hbbs/hbbs.dart';
 import 'package:flutter_hbb/common/widgets/peer_card.dart';
 import 'package:flutter_hbb/common/widgets/peers_view.dart';
 import 'package:flutter_hbb/consts.dart';
+import 'package:flutter_hbb/common/widgets/resizable_side_panel.dart';
 import 'package:flutter_hbb/desktop/widgets/popup_menu.dart';
 import 'package:flutter_hbb/models/ab_model.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
@@ -36,6 +37,8 @@ class AddressBook extends StatefulWidget {
 
 class _AddressBookState extends State<AddressBook> {
   var menuPos = RelativeRect.fill;
+  final _tagsPanel = ResizablePanelController(
+      optionKey: kOptionAbTagsPanelWidth, defaultWidth: 200, maxWidth: 300);
 
   @override
   Widget build(BuildContext context) => Obx(() {
@@ -77,33 +80,32 @@ class _AddressBookState extends State<AddressBook> {
       children: [
         Offstage(
             offstage: hideAbTagsPanel.value,
-            child: Container(
-              decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(
-                      color: Theme.of(context).colorScheme.background)),
-              child: Container(
-                width: 200,
-                height: double.infinity,
-                child: Column(
-                  children: [
-                    _buildAbDropdown(),
-                    _buildTagHeader().marginOnly(
-                        left: 8.0,
-                        right: gFFI.abModel.legacyMode.value ? 8.0 : 0,
-                        top: gFFI.abModel.legacyMode.value ? 8.0 : 0),
-                    Expanded(
-                      child: Container(
-                        width: double.infinity,
-                        height: double.infinity,
-                        child: _buildTags(),
+            child: Obx(() => Container(
+                  decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                          color: Theme.of(context).colorScheme.background)),
+                  width: _tagsPanel.width.value,
+                  height: double.infinity,
+                  child: Column(
+                    children: [
+                      _buildAbDropdown(),
+                      _buildTagHeader().marginOnly(
+                          left: 8.0,
+                          right: gFFI.abModel.legacyMode.value ? 8.0 : 0,
+                          top: gFFI.abModel.legacyMode.value ? 8.0 : 0),
+                      Expanded(
+                        child: Container(
+                          width: double.infinity,
+                          height: double.infinity,
+                          child: _buildTags(),
+                        ),
                       ),
-                    ),
-                    _buildAbPermission(),
-                  ],
-                ),
-              ),
-            ).marginOnly(right: 12.0)),
+                      _buildAbPermission(),
+                    ],
+                  ),
+                ))),
+        if (!hideAbTagsPanel.value) _tagsPanel.buildDivider(),
         _buildPeersViews()
       ],
     );

--- a/flutter/lib/common/widgets/address_book.dart
+++ b/flutter/lib/common/widgets/address_book.dart
@@ -76,38 +76,43 @@ class _AddressBookState extends State<AddressBook> {
       });
 
   Widget _buildAddressBookLandscape() {
-    return Row(
-      children: [
-        Offstage(
-            offstage: hideAbTagsPanel.value,
-            child: Obx(() => Container(
-                  decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(12),
-                      border: Border.all(
-                          color: Theme.of(context).colorScheme.background)),
-                  width: _tagsPanel.width.value,
-                  height: double.infinity,
-                  child: Column(
-                    children: [
-                      _buildAbDropdown(),
-                      _buildTagHeader().marginOnly(
-                          left: 8.0,
-                          right: gFFI.abModel.legacyMode.value ? 8.0 : 0,
-                          top: gFFI.abModel.legacyMode.value ? 8.0 : 0),
-                      Expanded(
-                        child: Container(
-                          width: double.infinity,
-                          height: double.infinity,
-                          child: _buildTags(),
-                        ),
-                      ),
-                      _buildAbPermission(),
-                    ],
-                  ),
-                ))),
-        if (!hideAbTagsPanel.value) _tagsPanel.buildDivider(),
-        _buildPeersViews()
-      ],
+    final panel = Container(
+      decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          border:
+              Border.all(color: Theme.of(context).colorScheme.background)),
+      height: double.infinity,
+      child: Column(
+        children: [
+          _buildAbDropdown(),
+          _buildTagHeader().marginOnly(
+              left: 8.0,
+              right: gFFI.abModel.legacyMode.value ? 8.0 : 0,
+              top: gFFI.abModel.legacyMode.value ? 8.0 : 0),
+          Expanded(
+            child: Container(
+              width: double.infinity,
+              height: double.infinity,
+              child: _buildTags(),
+            ),
+          ),
+          _buildAbPermission(),
+        ],
+      ),
+    );
+    return LayoutBuilder(
+      builder: (context, constraints) => Row(
+        children: [
+          Offstage(
+              offstage: hideAbTagsPanel.value,
+              child: Obx(() => SizedBox(
+                    width: _tagsPanel.effectiveWidth(constraints.maxWidth),
+                    child: panel,
+                  ))),
+          if (!hideAbTagsPanel.value) _tagsPanel.buildDivider(context),
+          _buildPeersViews()
+        ],
+      ),
     );
   }
 

--- a/flutter/lib/common/widgets/my_group.dart
+++ b/flutter/lib/common/widgets/my_group.dart
@@ -63,39 +63,42 @@ class _MyGroupState extends State<MyGroup> {
   }
 
   Widget _buildLandscape() {
-    return Row(
-      children: [
-        Obx(
-          () => Container(
-            decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                    color: Theme.of(context).colorScheme.background)),
-            width: _devicesPanel.width.value,
-            height: double.infinity,
-            child: Column(
-              children: [
-                _buildLeftHeader(),
-                Expanded(
-                  child: Container(
-                    width: double.infinity,
-                    height: double.infinity,
-                    child: _buildLeftList(),
-                  ),
-                )
-              ],
+    final panel = Container(
+      decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          border:
+              Border.all(color: Theme.of(context).colorScheme.background)),
+      height: double.infinity,
+      child: Column(
+        children: [
+          _buildLeftHeader(),
+          Expanded(
+            child: Container(
+              width: double.infinity,
+              height: double.infinity,
+              child: _buildLeftList(),
             ),
-          ),
-        ),
-        _devicesPanel.buildDivider(),
-        Expanded(
-          child: Align(
-              alignment: Alignment.topLeft,
-              child: MyGroupPeerView(
-                menuPadding: widget.menuPadding,
+          )
+        ],
+      ),
+    );
+    return LayoutBuilder(
+      builder: (context, constraints) => Row(
+        children: [
+          Obx(() => SizedBox(
+                width: _devicesPanel.effectiveWidth(constraints.maxWidth),
+                child: panel,
               )),
-        )
-      ],
+          _devicesPanel.buildDivider(context),
+          Expanded(
+            child: Align(
+                alignment: Alignment.topLeft,
+                child: MyGroupPeerView(
+                  menuPadding: widget.menuPadding,
+                )),
+          )
+        ],
+      ),
     );
   }
 

--- a/flutter/lib/common/widgets/my_group.dart
+++ b/flutter/lib/common/widgets/my_group.dart
@@ -5,6 +5,7 @@ import 'package:flutter_hbb/common/hbbs/hbbs.dart';
 import 'package:flutter_hbb/common/widgets/login.dart';
 import 'package:flutter_hbb/common/widgets/peers_view.dart';
 import 'package:flutter_hbb/models/state_model.dart';
+import 'package:flutter_hbb/common/widgets/resizable_side_panel.dart';
 import 'package:get/get.dart';
 
 import '../../common.dart';
@@ -26,6 +27,10 @@ class _MyGroupState extends State<MyGroup> {
   RxString get searchAccessibleItemNameText =>
       gFFI.groupModel.searchAccessibleItemNameText;
   static TextEditingController searchUserController = TextEditingController();
+  final _devicesPanel = ResizablePanelController(
+      optionKey: kOptionAccessibleDevicesPanelWidth,
+      defaultWidth: 150,
+      maxWidth: 300);
 
   @override
   Widget build(BuildContext context) {
@@ -60,13 +65,13 @@ class _MyGroupState extends State<MyGroup> {
   Widget _buildLandscape() {
     return Row(
       children: [
-        Container(
-          decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              border:
-                  Border.all(color: Theme.of(context).colorScheme.background)),
-          child: Container(
-            width: 150,
+        Obx(
+          () => Container(
+            decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                    color: Theme.of(context).colorScheme.background)),
+            width: _devicesPanel.width.value,
             height: double.infinity,
             child: Column(
               children: [
@@ -81,7 +86,8 @@ class _MyGroupState extends State<MyGroup> {
               ],
             ),
           ),
-        ).marginOnly(right: 12.0),
+        ),
+        _devicesPanel.buildDivider(),
         Expanded(
           child: Align(
               alignment: Alignment.topLeft,

--- a/flutter/lib/common/widgets/resizable_side_panel.dart
+++ b/flutter/lib/common/widgets/resizable_side_panel.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hbb/desktop/widgets/dragable_divider.dart';
+import 'dart:math';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:get/get.dart';
 
@@ -13,6 +13,9 @@ class ResizablePanelController {
   final double minWidth;
   final double maxWidth;
   late final RxDouble width;
+
+  static const double dividerHitWidth = 12.0;
+  static const double minContentWidth = 120.0;
 
   ResizablePanelController({
     required this.optionKey,
@@ -29,21 +32,31 @@ class ResizablePanelController {
     width.value = (width.value + dx).clamp(minWidth, maxWidth).toDouble();
   }
 
+  double effectiveWidth(double available) {
+    if (!available.isFinite) return width.value;
+    final maxAllowed = available - dividerHitWidth - minContentWidth;
+    return width.value.clamp(minWidth, max(minWidth, maxAllowed)).toDouble();
+  }
+
   void _persist() {
     bind.mainSetLocalOption(
         key: optionKey, value: width.value.toStringAsFixed(0));
   }
 
-  Widget buildDivider() {
-    return GestureDetector(
-      behavior: HitTestBehavior.translucent,
-      onHorizontalDragUpdate: (details) => _onDrag(details.delta.dx),
-      onHorizontalDragEnd: (_) => _persist(),
-      onHorizontalDragCancel: _persist,
-      child: DraggableDivider(
-        axis: Axis.vertical,
-        padding: const EdgeInsets.symmetric(horizontal: 4.0),
-        color: Colors.transparent,
+  Widget buildDivider(BuildContext context) {
+    final sign = Directionality.of(context) == TextDirection.rtl ? -1.0 : 1.0;
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeLeftRight,
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onHorizontalDragUpdate: (details) => _onDrag(sign * details.delta.dx),
+        onHorizontalDragEnd: (_) => _persist(),
+        onHorizontalDragCancel: _persist,
+        child: Container(
+          width: dividerHitWidth,
+          height: double.infinity,
+          color: Colors.transparent,
+        ),
       ),
     );
   }

--- a/flutter/lib/common/widgets/resizable_side_panel.dart
+++ b/flutter/lib/common/widgets/resizable_side_panel.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hbb/desktop/widgets/dragable_divider.dart';
+import 'package:flutter_hbb/models/platform_model.dart';
+import 'package:get/get.dart';
+
+// Persisted-width option keys for the resizable left panels.
+const String kOptionAbTagsPanelWidth = 'ab-tags-panel-width';
+const String kOptionAccessibleDevicesPanelWidth = 'accessible-devices-panel-width';
+
+class ResizablePanelController {
+  final String optionKey;
+  final double defaultWidth;
+  final double minWidth;
+  final double maxWidth;
+  late final RxDouble width;
+
+  ResizablePanelController({
+    required this.optionKey,
+    required this.defaultWidth,
+    this.minWidth = 120,
+    this.maxWidth = 300,
+  }) {
+    final saved = double.tryParse(bind.mainGetLocalOption(key: optionKey));
+    width =
+        RxDouble((saved ?? defaultWidth).clamp(minWidth, maxWidth).toDouble());
+  }
+
+  void _onDrag(double dx) {
+    width.value = (width.value + dx).clamp(minWidth, maxWidth).toDouble();
+  }
+
+  void _persist() {
+    bind.mainSetLocalOption(
+        key: optionKey, value: width.value.toStringAsFixed(0));
+  }
+
+  Widget buildDivider() {
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onHorizontalDragUpdate: (details) => _onDrag(details.delta.dx),
+      onHorizontalDragEnd: (_) => _persist(),
+      onHorizontalDragCancel: _persist,
+      child: DraggableDivider(
+        axis: Axis.vertical,
+        padding: const EdgeInsets.symmetric(horizontal: 4.0),
+        color: Colors.transparent,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Replace the fixed-width left panels in the Address book and Accessible devices tabs with a draggable splitter.

The chosen width is clamped to 120-300px and remembered as a local option so it survives restarts.

The divider is invisible but still shows the resize cursor on hover.

Ran dart format on existing modified files to keep consistent.

## Issue
If you have long names in the Address book or Accessible devices tabs they become two lines and formatting looks off. Adding some extra space clears it up.

# Preview

### Before
<img width="326" height="847" alt="Screenshot 2026-06-16 192502" src="https://github.com/user-attachments/assets/d3346fe3-1ffd-49ba-8317-9fdab8a60f6f" />

### After
<img width="325" height="802" alt="Screenshot 2026-06-16 192753" src="https://github.com/user-attachments/assets/88d8239b-21c8-4011-885a-118adf3f09c0" />


https://github.com/user-attachments/assets/960788e2-4946-4f1a-be00-1cde6d56599f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**New Features**
* Added resizable landscape side panels for the Address Book tags view and the My Group devices view.
* Users can drag the divider to adjust available space between sections (with RTL-aware behavior).
* Panel widths are saved and restored across visits, including divider-aware sizing for smoother, more consistent resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->