### PR TITLE
fix(ci): win arm64

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -58,14 +58,24 @@ jobs:
 
   build-RustDeskTempTopMostWindow:
     uses: ./.github/workflows/third-party-RustDeskTempTopMostWindow.yml
-    with:
-      upload-artifact: ${{ inputs.upload-artifact }}
-      target: windows-2022
-      configuration: Release
-      platform: x64
-      target_version: Windows10
     strategy:
       fail-fast: false
+      matrix:
+        job:
+          - {
+              target: windows-2022,
+              platform: x64,
+            }
+          - {
+              target: windows-11-arm,
+              platform: ARM64,
+            }
+    with:
+      upload-artifact: ${{ inputs.upload-artifact }}
+      target: ${{ matrix.job.target }}
+      configuration: Release
+      platform: ${{ matrix.job.platform }}
+      target_version: Windows10
 
   build-for-windows-flutter:
     name: ${{ matrix.job.target }}
@@ -302,7 +312,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ inputs.upload-artifact }}
         with:
-          name: topmostwindow-artifacts
+          name: ${{ matrix.job.arch == 'aarch64' && 'topmostwindow-artifacts-ARM64' || 'topmostwindow-artifacts-x64' }}
           path: "./rustdesk"
 
       - name: Upload unsigned

--- a/.github/workflows/third-party-RustDeskTempTopMostWindow.yml
+++ b/.github/workflows/third-party-RustDeskTempTopMostWindow.yml
@@ -11,16 +11,6 @@ on:
             required: true
             type: string
             default: 'windows-2022'
-        repository:
-            description: 'Repository'
-            required: false
-            type: string
-            default: 'rustdesk-org/RustDeskTempTopMostWindow'
-        ref:
-            description: 'Git ref'
-            required: false
-            type: string
-            default: 'c7b45f3eaa7ad433b7ccc9d860ec798367dbef41'
         configuration:
             description: 'Configuration'
             required: true
@@ -53,11 +43,11 @@ jobs:
 
       - name: Download the source code
         run: |
-          git clone https://github.com/${{ inputs.repository }} RustDeskTempTopMostWindow
+          git clone https://github.com/rustdesk-org/RustDeskTempTopMostWindow RustDeskTempTopMostWindow
 
       - name: Build the project
         run: |
-          cd RustDeskTempTopMostWindow && git checkout ${{ inputs.ref }}
+          cd RustDeskTempTopMostWindow && git checkout c7b45f3eaa7ad433b7ccc9d860ec798367dbef41
           msbuild ${{ env.project_path }} -p:Configuration=${{ inputs.configuration }} -p:Platform=${{ inputs.platform }} /p:TargetVersion=${{ inputs.target_version }}
 
       - name: Archive build artifacts

--- a/.github/workflows/third-party-RustDeskTempTopMostWindow.yml
+++ b/.github/workflows/third-party-RustDeskTempTopMostWindow.yml
@@ -11,6 +11,16 @@ on:
             required: true
             type: string
             default: 'windows-2022'
+        repository:
+            description: 'Repository'
+            required: false
+            type: string
+            default: 'rustdesk-org/RustDeskTempTopMostWindow'
+        ref:
+            description: 'Git ref'
+            required: false
+            type: string
+            default: 'c7b45f3eaa7ad433b7ccc9d860ec798367dbef41'
         configuration:
             description: 'Configuration'
             required: true
@@ -43,18 +53,17 @@ jobs:
 
       - name: Download the source code
         run: |
-          git clone https://github.com/rustdesk-org/RustDeskTempTopMostWindow RustDeskTempTopMostWindow
+          git clone https://github.com/${{ inputs.repository }} RustDeskTempTopMostWindow
 
-        # Build. commit 3b79772afb754a5a1111804864616c2e81513de8, support multiple monitors
       - name: Build the project
         run: |
-          cd RustDeskTempTopMostWindow && git checkout 3b79772afb754a5a1111804864616c2e81513de8
+          cd RustDeskTempTopMostWindow && git checkout ${{ inputs.ref }}
           msbuild ${{ env.project_path }} -p:Configuration=${{ inputs.configuration }} -p:Platform=${{ inputs.platform }} /p:TargetVersion=${{ inputs.target_version }}
 
       - name: Archive build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ inputs.upload-artifact }}
         with:
-            name: topmostwindow-artifacts
+            name: topmostwindow-artifacts-${{ inputs.platform }}
             path: |
               ./${{ env.build_output_dir }}/WindowInjection.dll


### PR DESCRIPTION
This PR requires https://github.com/rustdesk-org/RustDeskTempTopMostWindow/pull/5 to be merged first.


https://github.com/fufesou/rustdesk/actions/runs/27772683615



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Windows build workflow to run matrix builds for both x64 and ARM64 (Windows 2022 and Windows 11 ARM).
  * Adjusted artifact download/upload to use platform-specific artifact names.
  * Updated the third-party RustDeskTempTopMostWindow source revision used for builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->