### PR TITLE
fix(rpm): require libxdo for X11 input

### DIFF
--- a/res/rpm-flutter.spec
+++ b/res/rpm-flutter.spec
@@ -5,8 +5,8 @@ Summary:    RPM package
 License:    GPL-3.0
 URL:        https://rustdesk.com
 Vendor:     rustdesk <info@rustdesk.com>
-Requires:   gtk3 libxcb libXfixes alsa-lib libva pam gstreamer1-plugins-base
-Recommends: libayatana-appindicator-gtk3 libxdo
+Requires:   gtk3 libxcb libXfixes alsa-lib libva pam gstreamer1-plugins-base libxdo
+Recommends: libayatana-appindicator-gtk3
 Provides:   libdesktop_drop_plugin.so()(64bit), libdesktop_multi_window_plugin.so()(64bit), libfile_selector_linux_plugin.so()(64bit), libflutter_custom_cursor_plugin.so()(64bit), libflutter_linux_gtk.so()(64bit), libscreen_retriever_plugin.so()(64bit), libtray_manager_plugin.so()(64bit), liburl_launcher_linux_plugin.so()(64bit), libwindow_manager_plugin.so()(64bit), libwindow_size_plugin.so()(64bit), libtexture_rgba_renderer_plugin.so()(64bit)
 
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/

--- a/res/rpm.spec
+++ b/res/rpm.spec
@@ -5,8 +5,8 @@ Summary:    RPM package
 License:    GPL-3.0
 URL:        https://rustdesk.com
 Vendor:     rustdesk <info@rustdesk.com>
-Requires:   gtk3 libxcb libXfixes alsa-lib libva2 pam gstreamer1-plugins-base
-Recommends: libayatana-appindicator-gtk3 libxdo
+Requires:   gtk3 libxcb libXfixes alsa-lib libva2 pam gstreamer1-plugins-base libxdo
+Recommends: libayatana-appindicator-gtk3
 
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/
 


### PR DESCRIPTION
enigo loads libxdo at runtime and every mouse and key event becomes a silent no-op when it is missing (libs/enigo/src/linux/xdo.rs). The deb (libxdo3 | libxdo4) and Arch (xdotool) packages depend on it, but the rpm only Recommends it. On RHEL and Rocky libxdo lives in EPEL, so the weak dependency is skipped on a stock install and X11 sessions connect with dead mouse and keyboard control, with nothing but a log warning.

Make libxdo a hard Requires in both rpm specs, matching the deb and Arch packages, so it is pulled in (or reported as missing at install time) instead of silently absent.