### PR TITLE
fix(keyboard): win, key, Pause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6920,7 +6920,7 @@ dependencies = [
 [[package]]
 name = "rdev"
 version = "0.5.0-2"
-source = "git+https://github.com/rustdesk-org/rdev#f9b60b1dd0f3300a1b797d7a74c116683cd232c8"
+source = "git+https://github.com/rustdesk-org/rdev#871bf1c856d6a30af2f56ab8848396a025140855"
 dependencies = [
  "cocoa 0.24.1",
  "core-foundation 0.9.4",

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1245,9 +1245,47 @@ pub fn legacy_keyboard_mode(event: &Event, mut key_event: KeyEvent) -> Vec<KeyEv
 
 #[inline]
 pub fn map_keyboard_mode(_peer: &str, event: &Event, key_event: KeyEvent) -> Vec<KeyEvent> {
+    if let Some(evt) = windows_peer_special_key(_peer, event) {
+        return vec![evt];
+    }
+
     _map_keyboard_mode(_peer, event, key_event)
         .map(|e| vec![e])
         .unwrap_or_default()
+}
+
+fn windows_peer_special_key(peer: &str, event: &Event) -> Option<KeyEvent> {
+    if peer != OS_LOWER_WINDOWS {
+        return None;
+    }
+
+    let (key, down) = match event.event_type {
+        EventType::KeyPress(key) => (key, true),
+        EventType::KeyRelease(key) => (key, false),
+        _ => return None,
+    };
+
+    // Handle only `Pause` for Windows peers for now.
+    // Windows has no normal scan code for `Pause`, so send it as a legacy control key.
+    #[cfg(target_os = "windows")]
+    let is_pause = {
+        // The Windows scan code can look like `NumLock`; VK_PAUSE distinguishes it.
+        let pause_vk_code = rdev::win_code_from_key(Key::Pause);
+        key == Key::Pause || pause_vk_code == Some(event.platform_code as _)
+    };
+    #[cfg(not(target_os = "windows"))]
+    let is_pause = key == Key::Pause;
+    if !is_pause {
+        return None;
+    }
+
+    let mut key_event = KeyEvent::new();
+    key_event.mode = KeyboardMode::Legacy.into();
+    key_event.down = down;
+    key_event.set_control_key(ControlKey::Pause);
+    let (alt, ctrl, shift, command) = client::get_modifiers_state(false, false, false, false);
+    client::legacy_modifiers(&mut key_event, alt, ctrl, shift, command);
+    Some(key_event)
 }
 
 fn _map_keyboard_mode(_peer: &str, event: &Event, mut key_event: KeyEvent) -> Option<KeyEvent> {
@@ -1420,6 +1458,11 @@ fn is_press(event: &Event) -> bool {
 // https://github.com/rustdesk/rustdesk/wiki/FAQ#keyboard-translation-modes
 pub fn translate_keyboard_mode(peer: &str, event: &Event, key_event: KeyEvent) -> Vec<KeyEvent> {
     let mut events: Vec<KeyEvent> = Vec::new();
+
+    if let Some(evt) = windows_peer_special_key(peer, event) {
+        events.push(evt);
+        return events;
+    }
 
     if let Some(unicode_info) = &event.unicode {
         if unicode_info.is_dead {


### PR DESCRIPTION

Key `Pause` can't be handled by the scan code on Windows.
We have to use the Windows virtual key code to simulate `Pause`.

The legacy handle `ControlKey::Pause` is also a good way.

```rust
    let mut key_event = KeyEvent::new();
    key_event.mode = KeyboardMode::Legacy.into();
    key_event.down = down;
    key_event.set_control_key(ControlKey::Pause);
```

## Testing

RustDesk -> Windows

- [x] Windows, Linux, iPad. `Win` + `Pause` and `Pause`
- [x] Android. `Pause`
  - The `Win` key is not detectable on Android Flutter.
- [x] macOS
  - `Pause` is treated as `F15`. `0x71`  https://stackoverflow.com/a/16125341     https://github.com/rustdesk-org/rdev/blob/871bf1c856d6a30af2f56ab8848396a025140855/src/keycodes/macos.rs#L143
- [x] Desktop -> Windows.
  - Input source 1, Legacy, Map, Translate mode.
  - Input source 2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard event processing for the Pause key when connecting from Windows systems, ensuring proper key recognition and modifier state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->