### PR TITLE
fix: refuse Magic Keyboard trackpad pan-zoom on iPad (#15209)

### DIFF
--- a/flutter/lib/common/widgets/gestures.dart
+++ b/flutter/lib/common/widgets/gestures.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hbb/common/widgets/remote_input.dart';
@@ -19,6 +20,26 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
           supportedDevices: supportedDevices,
         ) {
     _init();
+  }
+
+  /// Refuse to claim trackpad pan-zoom events on mobile platforms. The base
+  /// `ScaleGestureRecognizer` returns true unconditionally regardless of
+  /// `supportedDevices` (Flutter framework `scale.dart`), which on iPadOS
+  /// causes Magic Keyboard trackpad two-finger scroll to be converted into a
+  /// local canvas scale/pan via `onTwoFingerScaleUpdate`. Returning false on
+  /// mobile leaves the raw `Listener.onPointerPanZoomUpdate` path
+  /// (input_model.dart) — which sends the scroll to the remote — as the sole
+  /// consumer of trackpad gestures. On desktop we keep the default so existing
+  /// trackpad pinch-zoom in the desktop client continues to work.
+  ///
+  /// Refs: rustdesk/rustdesk#15209.
+  @override
+  bool isPointerPanZoomAllowed(PointerPanZoomStartEvent event) {
+    if (defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.android) {
+      return false;
+    }
+    return super.isPointerPanZoomAllowed(event);
   }
 
   // oneFingerPan

--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -458,7 +458,13 @@ class _RawTouchGestureDetectorRegionState
   }
 
   onTwoFingerScaleUpdate(ScaleUpdateDetails d) async {
-    if (isNotTouchBasedDevice()) {
+    // On mobile, only operate on real touch — `CustomTouchGestureRecognizer`
+    // refuses to claim trackpad pan-zoom on mobile (gestures.dart), so any
+    // call here on iOS/Android is a real two-finger touch. The historical
+    // `isNotTouchBasedDevice()` guard was stateful (lastDeviceKind) and gave
+    // the wrong answer after the first incidental screen touch, breaking
+    // trackpad scroll until restart. See rustdesk/rustdesk#15209.
+    if ((isDesktop || isWebDesktop) && isNotTouchBasedDevice()) {
       return;
     }
 
@@ -484,11 +490,16 @@ class _RawTouchGestureDetectorRegionState
                     .toJson()));
       }
     } else {
-      // mobile
+      // mobile: real two-finger touch.
       ffi.canvasModel.updateScale(d.scale / _scale, d.focalPoint);
       _scale = d.scale;
-      ffi.canvasModel.panX(d.focalPointDelta.dx);
-      ffi.canvasModel.panY(d.focalPointDelta.dy);
+      // Only pan the local canvas when the remote view actually overflows
+      // the viewport — otherwise the pan moves nothing but black bars and
+      // surprises the user. (#15209)
+      if (ffi.canvasModel.isPanScrollUseful()) {
+        ffi.canvasModel.panX(d.focalPointDelta.dx);
+        ffi.canvasModel.panY(d.focalPointDelta.dy);
+      }
     }
   }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2645,6 +2645,19 @@ class CanvasModel with ChangeNotifier {
     notifyListeners();
   }
 
+  /// Returns true when the remote display, at the current scale, exceeds the
+  /// canvas viewport on at least one axis — i.e. when local pan would actually
+  /// reveal more content. Used by gesture handling to decide whether two-finger
+  /// trackpad scroll (or pinch+pan) should pan the local canvas or be passed
+  /// through / no-op'd. See `onTwoFingerScaleUpdate` in
+  /// flutter/lib/common/widgets/remote_input.dart and rustdesk/rustdesk#15209.
+  bool isPanScrollUseful() {
+    if (_size.width == 0 || _size.height == 0) return false;
+    final dw = getDisplayWidth() * _scale;
+    final dh = getDisplayHeight() * _scale;
+    return dw > _size.width || dh > _size.height;
+  }
+
   // mobile only
   updateScale(double v, Offset focalPoint) {
     if (parent.target?.imageModel.image == null) return;

--- a/flutter/test/canvas_overflow_test.dart
+++ b/flutter/test/canvas_overflow_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+
+// Pure-logic test for the canvas-overflow predicate that drives whether
+// a two-finger gesture should pan the local canvas (when remote content
+// overflows the viewport) or be treated as a no-op / pass-through (when
+// it doesn't). Refs: rustdesk/rustdesk#15209.
+//
+// The shim here mirrors the production predicate in
+// `CanvasModel.isPanScrollUseful()` (model.dart). Since CanvasModel pulls
+// in the FFI runtime, the shim lets us iterate on the math in isolation.
+class _OverflowPredicate {
+  double scale;
+  double sizeWidth;
+  double sizeHeight;
+  int displayWidth;
+  int displayHeight;
+  _OverflowPredicate({
+    required this.scale,
+    required this.sizeWidth,
+    required this.sizeHeight,
+    required this.displayWidth,
+    required this.displayHeight,
+  });
+
+  bool isPanScrollUseful() {
+    if (sizeWidth == 0 || sizeHeight == 0) return false;
+    final dw = displayWidth * scale;
+    final dh = displayHeight * scale;
+    return dw > sizeWidth || dh > sizeHeight;
+  }
+}
+
+void main() {
+  group('CanvasModel.isPanScrollUseful (predicate semantics)', () {
+    test('false when remote display fits the viewport exactly', () {
+      final c = _OverflowPredicate(
+          scale: 1.0,
+          sizeWidth: 1920,
+          sizeHeight: 1080,
+          displayWidth: 1920,
+          displayHeight: 1080);
+      expect(c.isPanScrollUseful(), isFalse);
+    });
+
+    test('false when remote display fits well inside the viewport', () {
+      final c = _OverflowPredicate(
+          scale: 0.5,
+          sizeWidth: 1920,
+          sizeHeight: 1080,
+          displayWidth: 1920,
+          displayHeight: 1080);
+      expect(c.isPanScrollUseful(), isFalse);
+    });
+
+    test('true when zoomed-in display overflows on x only', () {
+      final c = _OverflowPredicate(
+          scale: 1.5,
+          sizeWidth: 1920,
+          sizeHeight: 1080,
+          displayWidth: 1920,
+          displayHeight: 600);
+      expect(c.isPanScrollUseful(), isTrue);
+    });
+
+    test('true when zoomed-in display overflows on y only', () {
+      final c = _OverflowPredicate(
+          scale: 1.5,
+          sizeWidth: 1920,
+          sizeHeight: 1080,
+          displayWidth: 800,
+          displayHeight: 1080);
+      expect(c.isPanScrollUseful(), isTrue);
+    });
+
+    test('true when zoomed-in display overflows on both axes', () {
+      final c = _OverflowPredicate(
+          scale: 2.0,
+          sizeWidth: 1920,
+          sizeHeight: 1080,
+          displayWidth: 1920,
+          displayHeight: 1080);
+      expect(c.isPanScrollUseful(), isTrue);
+    });
+
+    test('false when viewport size is zero (model not yet laid out)', () {
+      final c = _OverflowPredicate(
+          scale: 1.0,
+          sizeWidth: 0,
+          sizeHeight: 0,
+          displayWidth: 1920,
+          displayHeight: 1080);
+      expect(c.isPanScrollUseful(), isFalse);
+    });
+  });
+}

--- a/flutter/test/gestures_test.dart
+++ b/flutter/test/gestures_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_hbb/common/widgets/gestures.dart';
+
+// Tests that CustomTouchGestureRecognizer refuses to claim trackpad
+// pan-zoom events on mobile platforms (iOS/Android), but keeps the
+// default behaviour on desktop. Refs: rustdesk/rustdesk#15209.
+//
+// Background: Flutter's base ScaleGestureRecognizer.isPointerPanZoomAllowed
+// returns true unconditionally, regardless of supportedDevices, so on
+// iPadOS the Magic Keyboard trackpad's PointerPanZoom* events get claimed
+// as scale/pan and routed into local canvas pan via onTwoFingerScaleUpdate.
+// We override to return false on mobile so the raw
+// Listener.onPointerPanZoomUpdate path (input_model.dart) — which already
+// sends the scroll to the remote — is the sole consumer.
+
+PointerPanZoomStartEvent _panZoomStart() => const PointerPanZoomStartEvent(
+      pointer: 1,
+      position: Offset(100, 100),
+    );
+
+void main() {
+  group('CustomTouchGestureRecognizer.isPointerPanZoomAllowed', () {
+    test('returns false on iOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final recognizer = CustomTouchGestureRecognizer();
+      addTearDown(recognizer.dispose);
+
+      expect(recognizer.isPointerPanZoomAllowed(_panZoomStart()), isFalse);
+    });
+
+    test('returns false on Android', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final recognizer = CustomTouchGestureRecognizer();
+      addTearDown(recognizer.dispose);
+
+      expect(recognizer.isPointerPanZoomAllowed(_panZoomStart()), isFalse);
+    });
+
+    test('returns true on macOS (desktop) — preserves existing trackpad behaviour', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final recognizer = CustomTouchGestureRecognizer();
+      addTearDown(recognizer.dispose);
+
+      expect(recognizer.isPointerPanZoomAllowed(_panZoomStart()), isTrue);
+    });
+
+    test('returns true on Linux (desktop)', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final recognizer = CustomTouchGestureRecognizer();
+      addTearDown(recognizer.dispose);
+
+      expect(recognizer.isPointerPanZoomAllowed(_panZoomStart()), isTrue);
+    });
+
+    test('returns true on Windows (desktop)', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final recognizer = CustomTouchGestureRecognizer();
+      addTearDown(recognizer.dispose);
+
+      expect(recognizer.isPointerPanZoomAllowed(_panZoomStart()), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #15209.

## Symptom

On iPad with a Magic Keyboard, the trackpad's two-finger pan/scroll gestures (delivered by Flutter as `PointerPanZoom*` events from an indirect input device) corrupt the remote canvas: pan delta is applied to the local canvas transform even when there's no useful pan room, leaving the session's view warped until restart.

The bug fires from the trackpad alone — no on-screen touch needed — because Flutter's base `ScaleGestureRecognizer.isPointerPanZoomAllowed` returns `true` unconditionally regardless of the recognizer's `supportedDevices`, so the trackpad gesture is claimed and routed into `onTwoFingerScaleUpdate`.

## Fix

Three small changes under `flutter/`, layered on purpose so any single residual pan path is also covered:

1. **Recognizer-level refusal** (`flutter/lib/common/widgets/gestures.dart`): `CustomTouchGestureRecognizer` overrides `isPointerPanZoomAllowed()` to return `false` on iOS/Android. The recognizer no longer competes for trackpad pan-zoom on mobile; the raw `Listener.onPointerPanZoomUpdate` path in `input_model.dart` — which already sends scrolls to the remote — becomes the sole consumer. Desktop trackpad pinch-zoom is preserved (returns `super.isPointerPanZoomAllowed` on macOS/Linux/Windows).

2. **Pannability predicate** (`flutter/lib/models/model.dart`): new `CanvasModel.isPanScrollUseful()` returns `true` only when the remote display, at the current scale, exceeds the canvas viewport on at least one axis — i.e. when local pan would actually reveal more content.

3. **Two-finger scale guard** (`flutter/lib/common/widgets/remote_input.dart`): in `onTwoFingerScaleUpdate`, the desktop path keeps its `isNotTouchBasedDevice()` gate (preserving existing desktop pinch behaviour); the mobile path drops the stateful `lastDeviceKind` guard (now real-touch by construction, since the recognizer no longer claims trackpad on mobile) and only applies pan when `isPanScrollUseful()` returns true. This avoids panning into black bars when remote content already fits the viewport.

## Tests

Two new pure-Dart unit test files; 11/11 green locally with `flutter test`:

- `flutter/test/canvas_overflow_test.dart` — 6 tests covering the overflow predicate (fits exactly, fits inside, overflows X only / Y only / both, zero-size viewport).
- `flutter/test/gestures_test.dart` — 5 tests covering the recognizer override (`isPointerPanZoomAllowed` returns `false` on iOS/Android, `true` on macOS/Linux/Windows).

## Manual verification

Confirmed on a physical iPad with Magic Keyboard:
- Trackpad two-finger scroll over the remote canvas no longer warps it.
- On-screen one-finger pan still works.
- Pinch-to-zoom still works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gesture handling on iOS and Android to prevent unwanted trackpad pan-zoom events
  * Enhanced remote canvas panning to only occur when the remote content overflows the viewport
  
* **Tests**
  * Added test coverage for platform-specific gesture recognition behavior
  * Added test coverage for remote canvas overflow detection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->