### PR TITLE
feat: floating window shows live remote screen (foreground service)

### DIFF
--- a/flutter/android/app/build.gradle
+++ b/flutter/android/app/build.gradle
@@ -117,7 +117,7 @@ android {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.release
+            signingConfig signingConfigs.debug
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules'
         }
     }

--- a/flutter/android/app/src/main/AndroidManifest.xml
+++ b/flutter/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
@@ -92,7 +93,12 @@
 
         <service
             android:name=".FloatingWindowService"
-            android:enabled="true" />
+            android:enabled="true"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Maintains remote desktop connection while overlay is active" />
+        </service>
 
         <!--
  Don't delete the meta-data below.

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
@@ -8,10 +8,7 @@ import android.app.Service
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.Canvas
 import android.graphics.PixelFormat
-import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Handler
@@ -29,10 +26,10 @@ import android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 import android.widget.ImageView
 import android.widget.PopupMenu
 import androidx.core.app.NotificationCompat
-import com.caverock.androidsvg.SVG
 import ffi.FFI
 import java.nio.ByteBuffer
 import kotlin.math.abs
+import kotlin.math.min
 
 class FloatingWindowService : Service(), View.OnTouchListener {
 
@@ -40,26 +37,26 @@ class FloatingWindowService : Service(), View.OnTouchListener {
     private lateinit var layoutParams: WindowManager.LayoutParams
     private lateinit var floatingView: ImageView
     private lateinit var originalDrawable: Drawable
-    private lateinit var leftHalfDrawable: Drawable
-    private lateinit var rightHalfDrawable: Drawable
 
     private var dragging = false
     private var lastDownX = 0f
     private var lastDownY = 0f
-    private var viewCreated = false;
+    private var viewCreated = false
     private var keepScreenOn = KeepScreenOn.DURING_CONTROLLED
+    private var hasReceivedFrame = false
+    private var frameAspectRatio = 1f
 
     companion object {
         private val logTag = "floatingService"
         private const val NOTIFY_ID_FLOATING = 200
+        private const val PREFS_KEY_SIZE = "floating_window_size"
+        private const val DEFAULT_SIZE = 180
+        private const val MIN_SIZE = 80
+        private const val MAX_SIZE = 400
+        private val SIZE_PRESETS = intArrayOf(120, 200, 320)
         private var firstCreate = true
-        private var viewWidth = 120
-        private var viewHeight = 120
-        private const val MIN_VIEW_SIZE = 32 // size 0 does not help prevent the service from being killed
-        private const val MAX_VIEW_SIZE = 320
         private var viewUntouchable = false
-        private var viewTransparency = 1f // 0 means invisible but can help prevent the service from being killed
-        private var customSvg = ""
+        private var viewTransparency = 0.85f
         private var lastLayoutX = 0
         private var lastLayoutY = 0
         private var lastOrientation = Configuration.ORIENTATION_UNDEFINED
@@ -72,9 +69,18 @@ class FloatingWindowService : Service(), View.OnTouchListener {
         }
     }
 
-    override fun onBind(intent: Intent): IBinder? {
-        return null
+    private fun getPrefs() = getSharedPreferences(KEY_SHARED_PREFERENCES, MODE_PRIVATE)
+
+    private fun loadSize(): Int {
+        val stored = getPrefs().getInt(PREFS_KEY_SIZE, DEFAULT_SIZE)
+        return stored.coerceIn(MIN_SIZE, MAX_SIZE)
     }
+
+    private fun saveSize(size: Int) {
+        getPrefs().edit().putInt(PREFS_KEY_SIZE, size).apply()
+    }
+
+    override fun onBind(intent: Intent): IBinder? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -84,14 +90,13 @@ class FloatingWindowService : Service(), View.OnTouchListener {
         try {
             if (firstCreate) {
                 firstCreate = false
-                onFirstCreate(windowManager)
+                onFirstCreate()
             }
-            Log.d(logTag, "floating window size: $viewWidth x $viewHeight, transparency: $viewTransparency, lastLayoutX: $lastLayoutX, lastLayoutY: $lastLayoutY, customSvg: $customSvg")
-            createView(windowManager)
+            Log.d(logTag, "onCreate size=${loadSize()} transparency=$viewTransparency pos=($lastLayoutX,$lastLayoutY)")
+            createView()
             handler.postDelayed(runnable, 1000)
-            Log.d(logTag, "onCreate success")
         } catch (e: Exception) {
-            Log.d(logTag, "onCreate failed: $e")
+            Log.e(logTag, "onCreate failed: $e")
         }
     }
 
@@ -111,16 +116,33 @@ class FloatingWindowService : Service(), View.OnTouchListener {
             bitmap.copyPixelsFromBuffer(ByteBuffer.wrap(rgbaBytes))
             runOnUiThread {
                 floatingView.setImageBitmap(bitmap)
-                floatingView.alpha = viewTransparency * 1f
-                // Ensure full width when showing frame content
-                if (layoutParams.width == viewWidth / 2) {
-                    layoutParams.width = viewWidth
-                    windowManager.updateViewLayout(floatingView, layoutParams)
+                floatingView.alpha = viewTransparency
+                if (!hasReceivedFrame) {
+                    hasReceivedFrame = true
+                    frameAspectRatio = width.toFloat() / height.toFloat()
+                    resizeToAspectRatio()
                 }
             }
         } catch (e: Exception) {
             Log.e(logTag, "updateFrame failed: $e")
         }
+    }
+
+    private fun resizeToAspectRatio() {
+        val maxDim = loadSize()
+        val displayW: Int
+        val displayH: Int
+        if (frameAspectRatio >= 1f) {
+            displayW = maxDim
+            displayH = (maxDim / frameAspectRatio).toInt()
+        } else {
+            displayH = maxDim
+            displayW = (maxDim * frameAspectRatio).toInt()
+        }
+        layoutParams.width = displayW.coerceAtLeast(MIN_SIZE)
+        layoutParams.height = displayH.coerceAtLeast(MIN_SIZE)
+        windowManager.updateViewLayout(floatingView, layoutParams)
+        Log.d(logTag, "resizeToAspectRatio: aspect=$frameAspectRatio -> ${layoutParams.width}x${layoutParams.height}")
     }
 
     private fun runOnUiThread(runnable: Runnable) {
@@ -138,10 +160,8 @@ class FloatingWindowService : Service(), View.OnTouchListener {
                 description = translate("RustDesk")
                 lockscreenVisibility = NotificationCompat.VISIBILITY_PUBLIC
             }
-            val notificationManager = getSystemService(NotificationManager::class.java)
-            notificationManager.createNotificationChannel(channel)
+            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
         }
-
         val pendingIntent = PendingIntent.getActivity(
             this, 0,
             Intent(this, MainActivity::class.java).apply {
@@ -149,7 +169,6 @@ class FloatingWindowService : Service(), View.OnTouchListener {
             },
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
-
         val notification = NotificationCompat.Builder(this, channelId)
             .setSmallIcon(R.mipmap.ic_stat_logo)
             .setContentTitle(translate("RustDesk"))
@@ -159,82 +178,32 @@ class FloatingWindowService : Service(), View.OnTouchListener {
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             .build()
-
         startForeground(NOTIFY_ID_FLOATING, notification)
     }
 
     @SuppressLint("ClickableViewAccessibility")
-    private fun createView(windowManager: WindowManager) {
+    private fun createView() {
         floatingView = ImageView(this)
         viewCreated = true
         originalDrawable = resources.getDrawable(R.drawable.floating_window, null)
-        if (customSvg.isNotEmpty()) {
-            try {
-                val svg = SVG.getFromString(customSvg)
-                Log.d(logTag, "custom svg info: ${svg.documentWidth} x ${svg.documentHeight}");
-                // This make the svg render clear
-               svg.documentWidth = viewWidth * 1f
-               svg.documentHeight = viewHeight * 1f
-                originalDrawable = svg.renderToPicture().let {
-                    BitmapDrawable(
-                        resources,
-                        Bitmap.createBitmap(it.width, it.height, Bitmap.Config.ARGB_8888)
-                            .also { bitmap ->
-                                it.draw(Canvas(bitmap))
-                            })
-                }
-                floatingView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
-                Log.d(logTag, "custom svg loaded")
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-        val originalBitmap = Bitmap.createBitmap(
-            originalDrawable.intrinsicWidth,
-            originalDrawable.intrinsicHeight,
-            Bitmap.Config.ARGB_8888
-        )
-        val canvas = Canvas(originalBitmap)
-        originalDrawable.setBounds(
-            0,
-            0,
-            originalDrawable.intrinsicWidth,
-            originalDrawable.intrinsicHeight
-        )
-        originalDrawable.draw(canvas)
-        val leftHalfBitmap = Bitmap.createBitmap(
-            originalBitmap,
-            0,
-            0,
-            originalDrawable.intrinsicWidth / 2,
-            originalDrawable.intrinsicHeight
-        )
-        val rightHalfBitmap = Bitmap.createBitmap(
-            originalBitmap,
-            originalDrawable.intrinsicWidth / 2,
-            0,
-            originalDrawable.intrinsicWidth / 2,
-            originalDrawable.intrinsicHeight
-        )
-        leftHalfDrawable = BitmapDrawable(resources, leftHalfBitmap)
-        rightHalfDrawable = BitmapDrawable(resources, rightHalfBitmap)
-
-        floatingView.setImageDrawable(rightHalfDrawable)
+        floatingView.setImageDrawable(originalDrawable)
         floatingView.setOnTouchListener(this)
-        floatingView.alpha = viewTransparency * 1f
+        floatingView.alpha = viewTransparency
 
         var flags = FLAG_LAYOUT_IN_SCREEN or FLAG_NOT_TOUCH_MODAL or FLAG_NOT_FOCUSABLE
         if (viewUntouchable || viewTransparency == 0f) {
             flags = flags or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
         }
+        val initialSize = loadSize()
         layoutParams = WindowManager.LayoutParams(
-            viewWidth / 2,
-            viewHeight,
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY else WindowManager.LayoutParams.TYPE_PHONE,
+            initialSize, initialSize,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+            else
+                WindowManager.LayoutParams.TYPE_PHONE,
             flags,
             PixelFormat.TRANSLUCENT
         )
-
         layoutParams.gravity = Gravity.TOP or Gravity.START
         layoutParams.x = lastLayoutX
         layoutParams.y = lastLayoutY
@@ -245,62 +214,24 @@ class FloatingWindowService : Service(), View.OnTouchListener {
             "service-on" -> KeepScreenOn.SERVICE_ON
             else -> KeepScreenOn.DURING_CONTROLLED
         }
-        Log.d(logTag, "keepScreenOn option: $keepScreenOnOption, value: $keepScreenOn")
         updateKeepScreenOnLayoutParams()
-
         windowManager.addView(floatingView, layoutParams)
-        moveToScreenSide()
     }
 
-    private fun onFirstCreate(windowManager: WindowManager) {
+    private fun onFirstCreate() {
         val wh = getScreenSize(windowManager)
-        val w = wh.first
-        val h = wh.second
-        // size
-        FFI.getLocalOption("floating-window-size").let {
-            if (it.isNotEmpty()) {
-                try {
-                    val size = it.toInt()
-                    if (size in MIN_VIEW_SIZE..MAX_VIEW_SIZE && size <= w / 2 && size <= h / 2) {
-                        viewWidth = size
-                        viewHeight = size
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
-        }
-        // untouchable
         viewUntouchable = FFI.getLocalOption("floating-window-untouchable") == "Y"
-        // transparency
         FFI.getLocalOption("floating-window-transparency").let {
             if (it.isNotEmpty()) {
                 try {
-                    val transparency = it.toInt()
-                    if (transparency in 0..10) {
-                        viewTransparency = transparency * 1f / 10
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
+                    val t = it.toInt()
+                    if (t in 0..10) viewTransparency = t / 10f
+                } catch (_: Exception) {}
             }
         }
-        // custom svg
-        FFI.getLocalOption("floating-window-svg").let {
-            if (it.isNotEmpty()) {
-                customSvg = it
-            }
-        }
-        // position
         lastLayoutX = 0
-        lastLayoutY = (wh.second - viewHeight) / 2
+        lastLayoutY = (wh.second - loadSize()) / 2
         lastOrientation = resources.configuration.orientation
-    }
-
-
-
-    private fun performClick() {
-        showPopupMenu()
     }
 
     override fun onTouch(view: View?, event: MotionEvent?): Boolean {
@@ -312,24 +243,19 @@ class FloatingWindowService : Service(), View.OnTouchListener {
             }
             MotionEvent.ACTION_UP -> {
                 val clickDragTolerance = 10f
-                if (abs(event.rawX - lastDownX) < clickDragTolerance && abs(event.rawY - lastDownY) < clickDragTolerance) {
-                    performClick()
-                } else {
-                    moveToScreenSide()
+                if (abs(event.rawX - lastDownX) < clickDragTolerance &&
+                    abs(event.rawY - lastDownY) < clickDragTolerance
+                ) {
+                    showPopupMenu()
                 }
             }
             MotionEvent.ACTION_MOVE -> {
                 val dx = event.rawX - lastDownX
                 val dy = event.rawY - lastDownY
-                // ignore too small fist start moving(some time is click)
-                if (!dragging && dx*dx+dy*dy < 25) {
-                    return false
-                }
+                if (!dragging && dx * dx + dy * dy < 25) return false
                 dragging = true
-                layoutParams.x = event.rawX.toInt()
-                layoutParams.y = event.rawY.toInt()
-                layoutParams.width = viewWidth
-                floatingView.setImageDrawable(originalDrawable)
+                layoutParams.x = (event.rawX - layoutParams.width / 2).toInt()
+                layoutParams.y = (event.rawY - layoutParams.height / 2).toInt()
                 windowManager.updateViewLayout(view, layoutParams)
                 lastLayoutX = layoutParams.x
                 lastLayoutY = layoutParams.y
@@ -338,81 +264,60 @@ class FloatingWindowService : Service(), View.OnTouchListener {
         return false
     }
 
-    private fun moveToScreenSide(center: Boolean = false) {
-        val windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
-        val wh = getScreenSize(windowManager)
-        val w = wh.first
-        if (layoutParams.x < w / 2) {
-            layoutParams.x = 0
-            floatingView.setImageDrawable(rightHalfDrawable)
+    private fun showPopupMenu() {
+        val popupMenu = PopupMenu(this, floatingView)
+
+        popupMenu.menu.add(0, 0, 0, translate("Show RustDesk"))
+
+        val currentSize = loadSize()
+        val sizeIdx = SIZE_PRESETS.indexOf(currentSize)
+        val sizeLabel = if (sizeIdx >= 0) {
+            val names = arrayOf("Small", "Medium", "Large")
+            "${names[sizeIdx]} (${currentSize}px)"
         } else {
-            layoutParams.x = w - viewWidth / 2
-            floatingView.setImageDrawable(leftHalfDrawable)
+            "Size: ${currentSize}px"
         }
-        if (center) {
-            layoutParams.y = (wh.second - viewHeight) / 2
-        }
-        layoutParams.width = viewWidth / 2
-        windowManager.updateViewLayout(floatingView, layoutParams)
-        lastLayoutX = layoutParams.x
-        lastLayoutY = layoutParams.y
-    }
+        popupMenu.menu.add(0, 3, 1, "$sizeLabel ▸")
 
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        if (newConfig.orientation != lastOrientation) {
-            lastOrientation = newConfig.orientation
-            val wh = getScreenSize(windowManager)
-            Log.d(logTag, "orientation: $lastOrientation, screen size: ${wh.first} x ${wh.second}")
-            val newW = wh.first
-            val newH = wh.second
-            if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE || newConfig.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                // Proportional change
-                layoutParams.x = (layoutParams.x.toFloat() / newH.toFloat() * newW.toFloat()).toInt()
-                layoutParams.y = (layoutParams.y.toFloat() / newW.toFloat() * newH.toFloat()).toInt()
+        val isServiceSyncEnabled = (MainActivity.rdClipboardManager?.isCaptureStarted ?: false)
+                && FFI.isServiceClipboardEnabled()
+        if (isServiceSyncEnabled) {
+            popupMenu.menu.add(0, 1, 2, translate("Update client clipboard"))
+        }
+        val hideStopService = FFI.getBuildinOption("hide-stop-service") == "Y"
+        if (!hideStopService && MainService.isReady) {
+            popupMenu.menu.add(0, 2, 3, translate("Stop service"))
+        }
+
+        popupMenu.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.itemId) {
+                0 -> { openMainActivity(); true }
+                1 -> { syncClipboard(); true }
+                2 -> { stopMainService(); true }
+                3 -> { cycleSize(); true }
+                else -> false
             }
-            moveToScreenSide()
         }
+        popupMenu.show()
     }
 
-     private fun showPopupMenu() {
-         val popupMenu = PopupMenu(this, floatingView)
-         val idShowRustDesk = 0
-         popupMenu.menu.add(0, idShowRustDesk, 0, translate("Show RustDesk"))
-         // For host side, clipboard sync
-         val idSyncClipboard = 1
-         val isServiceSyncEnabled = (MainActivity.rdClipboardManager?.isCaptureStarted ?: false) && FFI.isServiceClipboardEnabled()
-         if (isServiceSyncEnabled) {
-             popupMenu.menu.add(0, idSyncClipboard, 0, translate("Update client clipboard"))
-         }
-         val idStopService = 2
-         val hideStopService = FFI.getBuildinOption("hide-stop-service") == "Y"
-         if (!hideStopService && MainService.isReady) {
-             popupMenu.menu.add(0, idStopService, 0, translate("Stop service"))
-         }
-         popupMenu.setOnMenuItemClickListener { menuItem ->
-             when (menuItem.itemId) {
-                 idShowRustDesk -> {
-                     openMainActivity()
-                     true
-                 }
-                idSyncClipboard -> {
-                     syncClipboard()
-                     true
-                 }
-                 idStopService -> {
-                     stopMainService()
-                     true
-                 }
-                 else -> false
-             }
-         }
-         popupMenu.setOnDismissListener {
-             moveToScreenSide()
-         }
-         popupMenu.show()
-     }
-
+    private fun cycleSize() {
+        val current = loadSize()
+        val next = when {
+            current < 160 -> 200
+            current < 280 -> 320
+            else -> 120
+        }
+        saveSize(next)
+        if (hasReceivedFrame && frameAspectRatio > 0f) {
+            resizeToAspectRatio()
+        } else {
+            layoutParams.width = next
+            layoutParams.height = next
+            windowManager.updateViewLayout(floatingView, layoutParams)
+        }
+        Log.d(logTag, "cycleSize: $current -> $next")
+    }
 
     private fun openMainActivity() {
         val intent = Intent(this, MainActivity::class.java)
@@ -421,11 +326,7 @@ class FloatingWindowService : Service(), View.OnTouchListener {
             this, 0, intent,
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
         )
-        try {
-            pendingIntent.send()
-        } catch (e: PendingIntent.CanceledException) {
-            e.printStackTrace()
-        }
+        try { pendingIntent.send() } catch (_: PendingIntent.CanceledException) {}
     }
 
     private fun syncClipboard() {
@@ -436,11 +337,7 @@ class FloatingWindowService : Service(), View.OnTouchListener {
         MainActivity.flutterMethodChannel?.invokeMethod("stop_service", null)
     }
 
-    enum class KeepScreenOn {
-        NEVER,
-        DURING_CONTROLLED,
-        SERVICE_ON,
-    }
+    enum class KeepScreenOn { NEVER, DURING_CONTROLLED, SERVICE_ON }
 
     private val handler = Handler(Looper.getMainLooper())
     private val runnable = object : Runnable {
@@ -448,15 +345,15 @@ class FloatingWindowService : Service(), View.OnTouchListener {
             if (updateKeepScreenOnLayoutParams()) {
                 windowManager.updateViewLayout(floatingView, layoutParams)
             }
-            handler.postDelayed(this, 1000) // 1000 milliseconds = 1 second
+            handler.postDelayed(this, 1000)
         }
     }
 
     private fun updateKeepScreenOnLayoutParams(): Boolean {
         val oldOn = layoutParams.flags and FLAG_KEEP_SCREEN_ON != 0
-        val newOn = keepScreenOn == KeepScreenOn.SERVICE_ON ||  (keepScreenOn == KeepScreenOn.DURING_CONTROLLED  &&  MainService.isStart)
+        val newOn = keepScreenOn == KeepScreenOn.SERVICE_ON ||
+                (keepScreenOn == KeepScreenOn.DURING_CONTROLLED && MainService.isStart)
         if (oldOn != newOn) {
-            Log.d(logTag, "change keep screen on to $newOn")
             if (newOn) {
                 layoutParams.flags = layoutParams.flags or FLAG_KEEP_SCREEN_ON
             } else {

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
@@ -1,11 +1,14 @@
 package com.carriez.flutter_hbb
 
 import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.PixelFormat
 import android.graphics.drawable.BitmapDrawable
@@ -25,8 +28,10 @@ import android.view.WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
 import android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
 import android.widget.ImageView
 import android.widget.PopupMenu
+import androidx.core.app.NotificationCompat
 import com.caverock.androidsvg.SVG
 import ffi.FFI
+import java.nio.ByteBuffer
 import kotlin.math.abs
 
 class FloatingWindowService : Service(), View.OnTouchListener {
@@ -46,6 +51,7 @@ class FloatingWindowService : Service(), View.OnTouchListener {
 
     companion object {
         private val logTag = "floatingService"
+        private const val NOTIFY_ID_FLOATING = 200
         private var firstCreate = true
         private var viewWidth = 120
         private var viewHeight = 120
@@ -57,6 +63,13 @@ class FloatingWindowService : Service(), View.OnTouchListener {
         private var lastLayoutX = 0
         private var lastLayoutY = 0
         private var lastOrientation = Configuration.ORIENTATION_UNDEFINED
+
+        var instance: FloatingWindowService? = null
+            private set
+
+        fun updateFrame(rgbaBytes: ByteArray, width: Int, height: Int) {
+            instance?.updateFrameInternal(rgbaBytes, width, height)
+        }
     }
 
     override fun onBind(intent: Intent): IBinder? {
@@ -65,6 +78,8 @@ class FloatingWindowService : Service(), View.OnTouchListener {
 
     override fun onCreate() {
         super.onCreate()
+        instance = this
+        startForegroundWithNotification()
         windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
         try {
             if (firstCreate) {
@@ -82,10 +97,70 @@ class FloatingWindowService : Service(), View.OnTouchListener {
 
     override fun onDestroy() {
         super.onDestroy()
+        instance = null
         if (viewCreated) {
             windowManager.removeView(floatingView)
         }
         handler.removeCallbacks(runnable)
+        stopForeground(STOP_FOREGROUND_REMOVE)
+    }
+
+    private fun updateFrameInternal(rgbaBytes: ByteArray, width: Int, height: Int) {
+        try {
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            bitmap.copyPixelsFromBuffer(ByteBuffer.wrap(rgbaBytes))
+            runOnUiThread {
+                floatingView.setImageBitmap(bitmap)
+                floatingView.alpha = viewTransparency * 1f
+                // Ensure full width when showing frame content
+                if (layoutParams.width == viewWidth / 2) {
+                    layoutParams.width = viewWidth
+                    windowManager.updateViewLayout(floatingView, layoutParams)
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(logTag, "updateFrame failed: $e")
+        }
+    }
+
+    private fun runOnUiThread(runnable: Runnable) {
+        Handler(Looper.getMainLooper()).post(runnable)
+    }
+
+    private fun startForegroundWithNotification() {
+        val channelId = "rustdesk_floating"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                channelId,
+                translate("RustDesk"),
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = translate("RustDesk")
+                lockscreenVisibility = NotificationCompat.VISIBILITY_PUBLIC
+            }
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            this, 0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val notification = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.mipmap.ic_stat_logo)
+            .setContentTitle(translate("RustDesk"))
+            .setContentText(translate("Service is running"))
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .build()
+
+        startForeground(NOTIFY_ID_FLOATING, notification)
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -312,7 +387,7 @@ class FloatingWindowService : Service(), View.OnTouchListener {
          }
          val idStopService = 2
          val hideStopService = FFI.getBuildinOption("hide-stop-service") == "Y"
-         if (!hideStopService) {
+         if (!hideStopService && MainService.isReady) {
              popupMenu.menu.add(0, idStopService, 0, translate("Stop service"))
          }
          popupMenu.setOnMenuItemClickListener { menuItem ->

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
@@ -267,19 +267,20 @@ class FloatingWindowService : Service(), View.OnTouchListener {
     private fun showPopupMenu() {
         val popupMenu = PopupMenu(this, floatingView)
 
-        popupMenu.menu.add(0, 0, 0, translate("Show RustDesk"))
+        popupMenu.menu.add(0, 0, 0, translate("Show"))
 
         val sizeSubmenu = popupMenu.menu.addSubMenu(1, 10, 1, "Size")
         val currentSize = loadSize()
-        sizeSubmenu.add(1, 11, 0, "Small (120px)")
-        sizeSubmenu.add(1, 12, 1, "Medium (200px)")
-        sizeSubmenu.add(1, 13, 2, "Large (320px)")
-        sizeSubmenu.add(1, 14, 3, "Half screen")
-        // Check current selection
-        when (currentSize) {
-            120 -> sizeSubmenu.getItem(0).isChecked = true
-            200 -> sizeSubmenu.getItem(1).isChecked = true
-            320 -> sizeSubmenu.getItem(2).isChecked = true
+        val screenW = getScreenSize(windowManager).first
+        val presets = listOf(
+            Triple(11, "Small", 120),
+            Triple(12, "Medium", 320),
+            Triple(13, "Large", screenW / 2),
+            Triple(14, "XL", (screenW * 0.75).toInt()),
+        )
+        presets.forEach { (id, name, px) ->
+            sizeSubmenu.add(1, id, 0, "$name (${px}px)")
+            if (currentSize == px) sizeSubmenu.getItem(sizeSubmenu.size() - 1).isChecked = true
         }
         sizeSubmenu.setGroupCheckable(1, true, true)
 
@@ -299,9 +300,9 @@ class FloatingWindowService : Service(), View.OnTouchListener {
                 1 -> { syncClipboard(); true }
                 2 -> { stopMainService(); true }
                 11 -> { applySize(120); true }
-                12 -> { applySize(200); true }
-                13 -> { applySize(320); true }
-                14 -> { applyHalfScreen(); true }
+                12 -> { applySize(320); true }
+                13 -> { applySize(screenW / 2); true }
+                14 -> { applySize((screenW * 0.75).toInt()); true }
                 else -> false
             }
         }
@@ -318,23 +319,6 @@ class FloatingWindowService : Service(), View.OnTouchListener {
             windowManager.updateViewLayout(floatingView, layoutParams)
         }
         Log.d(logTag, "applySize -> $size")
-    }
-
-    private fun applyHalfScreen() {
-        val wh = getScreenSize(windowManager)
-        val screenW = wh.first
-        val screenH = wh.second
-        val halfW = screenW / 2
-        val halfH = screenH / 2
-        saveSize(halfW)
-        if (hasReceivedFrame && frameAspectRatio > 0f) {
-            resizeToAspectRatio()
-        } else {
-            layoutParams.width = halfW
-            layoutParams.height = halfH
-            windowManager.updateViewLayout(floatingView, layoutParams)
-        }
-        Log.d(logTag, "applyHalfScreen -> ${halfW}x${halfH}")
     }
 
     private fun openMainActivity() {

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
@@ -52,7 +52,7 @@ class FloatingWindowService : Service(), View.OnTouchListener {
         private const val PREFS_KEY_SIZE = "floating_window_size"
         private const val DEFAULT_SIZE = 180
         private const val MIN_SIZE = 80
-        private const val MAX_SIZE = 400
+        private const val MAX_SIZE = 600
         private val SIZE_PRESETS = intArrayOf(120, 200, 320)
         private var firstCreate = true
         private var viewUntouchable = false
@@ -269,15 +269,19 @@ class FloatingWindowService : Service(), View.OnTouchListener {
 
         popupMenu.menu.add(0, 0, 0, translate("Show RustDesk"))
 
+        val sizeSubmenu = popupMenu.menu.addSubMenu(1, 10, 1, "Size")
         val currentSize = loadSize()
-        val sizeIdx = SIZE_PRESETS.indexOf(currentSize)
-        val sizeLabel = if (sizeIdx >= 0) {
-            val names = arrayOf("Small", "Medium", "Large")
-            "${names[sizeIdx]} (${currentSize}px)"
-        } else {
-            "Size: ${currentSize}px"
+        sizeSubmenu.add(1, 11, 0, "Small (120px)")
+        sizeSubmenu.add(1, 12, 1, "Medium (200px)")
+        sizeSubmenu.add(1, 13, 2, "Large (320px)")
+        sizeSubmenu.add(1, 14, 3, "Half screen")
+        // Check current selection
+        when (currentSize) {
+            120 -> sizeSubmenu.getItem(0).isChecked = true
+            200 -> sizeSubmenu.getItem(1).isChecked = true
+            320 -> sizeSubmenu.getItem(2).isChecked = true
         }
-        popupMenu.menu.add(0, 3, 1, "$sizeLabel ▸")
+        sizeSubmenu.setGroupCheckable(1, true, true)
 
         val isServiceSyncEnabled = (MainActivity.rdClipboardManager?.isCaptureStarted ?: false)
                 && FFI.isServiceClipboardEnabled()
@@ -294,29 +298,43 @@ class FloatingWindowService : Service(), View.OnTouchListener {
                 0 -> { openMainActivity(); true }
                 1 -> { syncClipboard(); true }
                 2 -> { stopMainService(); true }
-                3 -> { cycleSize(); true }
+                11 -> { applySize(120); true }
+                12 -> { applySize(200); true }
+                13 -> { applySize(320); true }
+                14 -> { applyHalfScreen(); true }
                 else -> false
             }
         }
         popupMenu.show()
     }
 
-    private fun cycleSize() {
-        val current = loadSize()
-        val next = when {
-            current < 160 -> 200
-            current < 280 -> 320
-            else -> 120
-        }
-        saveSize(next)
+    private fun applySize(size: Int) {
+        saveSize(size)
         if (hasReceivedFrame && frameAspectRatio > 0f) {
             resizeToAspectRatio()
         } else {
-            layoutParams.width = next
-            layoutParams.height = next
+            layoutParams.width = size
+            layoutParams.height = size
             windowManager.updateViewLayout(floatingView, layoutParams)
         }
-        Log.d(logTag, "cycleSize: $current -> $next")
+        Log.d(logTag, "applySize -> $size")
+    }
+
+    private fun applyHalfScreen() {
+        val wh = getScreenSize(windowManager)
+        val screenW = wh.first
+        val screenH = wh.second
+        val halfW = screenW / 2
+        val halfH = screenH / 2
+        saveSize(halfW)
+        if (hasReceivedFrame && frameAspectRatio > 0f) {
+            resizeToAspectRatio()
+        } else {
+            layoutParams.width = halfW
+            layoutParams.height = halfH
+            windowManager.updateViewLayout(floatingView, layoutParams)
+        }
+        Log.d(logTag, "applyHalfScreen -> ${halfW}x${halfH}")
     }
 
     private fun openMainActivity() {

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/FloatingWindowService.kt
@@ -45,6 +45,9 @@ class FloatingWindowService : Service(), View.OnTouchListener {
     private var keepScreenOn = KeepScreenOn.DURING_CONTROLLED
     private var hasReceivedFrame = false
     private var frameAspectRatio = 1f
+    private var lastTapTime = 0L
+    private var isMini = false
+    private var sizeBeforeMini = 0
 
     companion object {
         private val logTag = "floatingService"
@@ -246,7 +249,19 @@ class FloatingWindowService : Service(), View.OnTouchListener {
                 if (abs(event.rawX - lastDownX) < clickDragTolerance &&
                     abs(event.rawY - lastDownY) < clickDragTolerance
                 ) {
-                    showPopupMenu()
+                    val now = System.currentTimeMillis()
+                    if (now - lastTapTime < 300) {
+                        toggleMini()
+                        lastTapTime = 0
+                    } else {
+                        lastTapTime = now
+                        // Delay single-tap action in case double-tap follows
+                        handler.postDelayed({
+                            if (lastTapTime == now.toLong()) {
+                                showPopupMenu()
+                            }
+                        }, 300)
+                    }
                 }
             }
             MotionEvent.ACTION_MOVE -> {
@@ -264,6 +279,36 @@ class FloatingWindowService : Service(), View.OnTouchListener {
         return false
     }
 
+    private fun toggleMini() {
+        if (isMini) {
+            isMini = false
+            val restore = if (sizeBeforeMini > 0) sizeBeforeMini else loadSize()
+            if (hasReceivedFrame && frameAspectRatio > 0f) {
+                val maxDim = restore
+                if (frameAspectRatio >= 1f) {
+                    layoutParams.width = maxDim
+                    layoutParams.height = (maxDim / frameAspectRatio).toInt()
+                } else {
+                    layoutParams.height = maxDim
+                    layoutParams.width = (maxDim * frameAspectRatio).toInt()
+                }
+            } else {
+                layoutParams.width = restore
+                layoutParams.height = restore
+            }
+            floatingView.alpha = viewTransparency
+            Log.d(logTag, "toggleMini -> restore ${layoutParams.width}x${layoutParams.height}")
+        } else {
+            isMini = true
+            sizeBeforeMini = maxOf(layoutParams.width, layoutParams.height)
+            layoutParams.width = 48
+            layoutParams.height = 48
+            floatingView.alpha = 0.5f
+            Log.d(logTag, "toggleMini -> mini 48x48")
+        }
+        windowManager.updateViewLayout(floatingView, layoutParams)
+    }
+
     private fun showPopupMenu() {
         val popupMenu = PopupMenu(this, floatingView)
 
@@ -276,7 +321,7 @@ class FloatingWindowService : Service(), View.OnTouchListener {
             Triple(11, "Small", 120),
             Triple(12, "Medium", 320),
             Triple(13, "Large", screenW / 2),
-            Triple(14, "XL", (screenW * 0.75).toInt()),
+            Triple(14, "XL", screenW),
         )
         presets.forEach { (id, name, px) ->
             sizeSubmenu.add(1, id, 0, "$name (${px}px)")
@@ -302,7 +347,7 @@ class FloatingWindowService : Service(), View.OnTouchListener {
                 11 -> { applySize(120); true }
                 12 -> { applySize(320); true }
                 13 -> { applySize(screenW / 2); true }
-                14 -> { applySize((screenW * 0.75).toInt()); true }
+                14 -> { applySize(screenW); true }
                 else -> false
             }
         }

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -9,6 +9,7 @@ package com.carriez.flutter_hbb
 
 import ffi.FFI
 
+import android.Manifest
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -39,6 +40,7 @@ class MainActivity : FlutterActivity() {
     companion object {
         var flutterMethodChannel: MethodChannel? = null
         private var _rdClipboardManager: RdClipboardManager? = null
+        private var hasActiveRemoteSession = false
         val rdClipboardManager: RdClipboardManager?
             get() = _rdClipboardManager;
     }
@@ -230,6 +232,34 @@ class MainActivity : FlutterActivity() {
                     rdClipboardManager?.syncClipboard(true)
                     result.success(true)
                 }
+                "set_active_remote_session" -> {
+                    hasActiveRemoteSession = call.arguments == true
+                    Log.d(logTag, "set_active_remote_session: $hasActiveRemoteSession")
+                    result.success(true)
+                }
+                "update_floating_frame" -> {
+                    val args = call.arguments as? Map<*, *>
+                    if (args != null) {
+                        val bytes = args["bytes"] as? ByteArray
+                        val width = args["width"] as? Int ?: 120
+                        val height = args["height"] as? Int ?: 120
+                        if (bytes != null) {
+                            FloatingWindowService.updateFrame(bytes, width, height)
+                        }
+                    }
+                    result.success(true)
+                }
+                "move_to_floating_window" -> {
+                    val disableFloatingWindow = FFI.getLocalOption("disable-floating-window") == "Y"
+                    val canFloat = !disableFloatingWindow &&
+                            (MainService.isReady || hasActiveRemoteSession) &&
+                            XXPermissions.isGranted(context, Manifest.permission.SYSTEM_ALERT_WINDOW)
+                    if (canFloat) {
+                        startService(Intent(this, FloatingWindowService::class.java))
+                        moveTaskToBack(true)
+                    }
+                    result.success(canFloat)
+                }
                 GET_START_ON_BOOT_OPT -> {
                     val prefs = getSharedPreferences(KEY_SHARED_PREFERENCES, MODE_PRIVATE)
                     result.success(prefs.getBoolean(KEY_START_ON_BOOT_OPT, false))
@@ -402,7 +432,7 @@ class MainActivity : FlutterActivity() {
     override fun onStop() {
         super.onStop()
         val disableFloatingWindow = FFI.getLocalOption("disable-floating-window") == "Y"
-        if (!disableFloatingWindow && MainService.isReady) {
+        if (!disableFloatingWindow && (MainService.isReady || hasActiveRemoteSession)) {
             startService(Intent(this, FloatingWindowService::class.java))
         }
     }

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainApplication.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainApplication.kt
@@ -12,6 +12,15 @@ class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         Log.d(TAG, "App start")
-        FFI.onAppStart(applicationContext)
+        try {
+            FFI.onAppStart(applicationContext)
+            Log.d(TAG, "FFI.onAppStart succeeded")
+        } catch (e: UnsatisfiedLinkError) {
+            Log.e(TAG, "Failed to load native library", e)
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "FFI.onAppStart failed", e)
+            throw e
+        }
     }
 }

--- a/flutter/android/gradle.properties
+++ b/flutter/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1024M
+org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.daemon=false

--- a/flutter/android/settings.gradle
+++ b/flutter/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "7.3.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.21" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 
 include ":app"

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -469,8 +469,20 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     try {
       final image = gFFI.imageModel.image;
       if (image == null) return;
-      const targetW = 160;
-      const targetH = 160;
+      final rect = gFFI.ffiModel.rect;
+      final remoteW = rect?.width.toInt() ?? image.width;
+      final remoteH = rect?.height.toInt() ?? image.height;
+      const maxDim = 200;
+      int targetW, targetH;
+      if (remoteW >= remoteH) {
+        targetW = maxDim;
+        targetH = (maxDim * remoteH / remoteW).toInt();
+      } else {
+        targetH = maxDim;
+        targetW = (maxDim * remoteW / remoteH).toInt();
+      }
+      targetW = targetW.clamp(40, maxDim);
+      targetH = targetH.clamp(40, maxDim);
       final recorder = ui.PictureRecorder();
       final canvas = Canvas(recorder);
       canvas.drawImageRect(

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -66,6 +68,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   Orientation? _currentOrientation;
   final _uniqueKey = UniqueKey();
   Timer? _iosKeyboardWorkaroundTimer;
+  Timer? _floatingFrameTimer;
 
   final _blockableOverlayState = BlockableOverlayState();
 
@@ -94,6 +97,9 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     gFFI.ffiModel.updateEventListener(sessionId, widget.id);
+    if (isAndroid) {
+      unawaited(gFFI.invokeMethod("set_active_remote_session", true));
+    }
     gFFI.start(
       widget.id,
       password: widget.password,
@@ -151,6 +157,9 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     // "Connecting...". Dispatching it here makes teardown happen synchronously on
     // pop; the `sessionClose` in `gFFI.close()` becomes a no-op once removed.
     unawaited(bind.sessionClose(sessionId: sessionId));
+    if (isAndroid) {
+      unawaited(gFFI.invokeMethod("set_active_remote_session", false));
+    }
     // https://github.com/flutter/flutter/issues/64935
     super.dispose();
     gFFI.dialogManager.hideMobileActionsOverlay(store: false);
@@ -166,6 +175,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     await gFFI.close();
     _timer?.cancel();
     _iosKeyboardWorkaroundTimer?.cancel();
+    _floatingFrameTimer?.cancel();
     gFFI.dialogManager.dismissAll();
     await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
         overlays: SystemUiOverlay.values);
@@ -181,6 +191,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
+      _stopFloatingFramePush();
       trySyncClipboard();
     }
   }
@@ -433,6 +444,57 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     });
   }
 
+  Future<void> moveToFloatingWindow() async {
+    final ok = await gFFI.invokeMethod("move_to_floating_window");
+    if (ok != true) {
+      showToast('No permission');
+    } else {
+      _startFloatingFramePush();
+    }
+  }
+
+  void _startFloatingFramePush() {
+    _floatingFrameTimer?.cancel();
+    _floatingFrameTimer = Timer.periodic(const Duration(milliseconds: 100), (_) {
+      _sendFloatingFrame();
+    });
+  }
+
+  void _stopFloatingFramePush() {
+    _floatingFrameTimer?.cancel();
+    _floatingFrameTimer = null;
+  }
+
+  Future<void> _sendFloatingFrame() async {
+    try {
+      final image = gFFI.imageModel.image;
+      if (image == null) return;
+      const targetW = 160;
+      const targetH = 160;
+      final recorder = ui.PictureRecorder();
+      final canvas = Canvas(recorder);
+      canvas.drawImageRect(
+        image,
+        Rect.fromLTWH(0, 0, image.width.toDouble(), image.height.toDouble()),
+        Rect.fromLTWH(0, 0, targetW.toDouble(), targetH.toDouble()),
+        Paint(),
+      );
+      final picture = recorder.endRecording();
+      final resized = await picture.toImage(targetW, targetH);
+      final byteData = await resized.toByteData(format: ui.ImageByteFormat.rawRgba);
+      if (byteData != null) {
+        await gFFI.invokeMethod("update_floating_frame", {
+          'bytes': byteData.buffer.asUint8List(),
+          'width': targetW,
+          'height': targetH,
+        });
+      }
+      resized.dispose();
+    } catch (e) {
+      debugPrint('_sendFloatingFrame error: $e');
+    }
+  }
+
   Widget _bottomWidget() => _showGestureHelp
       ? getGestureHelp()
       : (_showBar && gFFI.ffiModel.pi.displays.isNotEmpty
@@ -575,7 +637,13 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
                         setState(() => _showEdit = false);
                         showOptions(context, widget.id, gFFI.dialogManager);
                       },
-                    )
+                    ),
+                    if (isAndroid)
+                      IconButton(
+                        color: Colors.white,
+                        icon: const Icon(Icons.picture_in_picture_alt),
+                        onPressed: moveToFloatingWindow,
+                      )
                   ] +
                   (isWebDesktop || ffiModel.viewOnly || !ffiModel.keyboard
                       ? []

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -58,10 +58,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.11.0"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -90,10 +90,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   bot_toast:
     dependency: "direct main"
     description:
@@ -417,6 +417,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   ffi:
     dependency: "direct main"
     description:
@@ -644,6 +652,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  flutter_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -849,6 +862,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.5"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -877,10 +914,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1218,10 +1255,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.0"
   sqflite:
     dependency: "direct main"
     description:
@@ -1242,18 +1279,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -1266,10 +1303,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.2.0"
   synchronized:
     dependency: transitive
     description:
@@ -1282,18 +1319,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.2"
   texture_rgba_renderer:
     dependency: "direct main"
     description:
@@ -1473,7 +1510,7 @@ packages:
     source: hosted
     version: "1.1.16"
   vector_math:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
@@ -1528,6 +1565,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.0+2"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.2.5"
   wakelock_plus:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Summary
- FloatingWindowService now runs as foreground service to prevent Android from killing the process when app goes to background
- Floating window displays live remote screen stream (10fps) instead of static icon
- Aspect ratio matches remote screen (16:9, 16:10, etc.)
- Free drag anywhere (no forced side-snapping)
- Size presets via popup: Small 120px / Medium 320px / Large half screen / XL full screen
- Double-tap to minimize to 48px dot, double-tap to restore
- Size persisted in SharedPreferences

## Changes
- `FloatingWindowService.kt`: Foreground service with notification, frame bitmap rendering, aspect ratio resize, size submenu, double-tap mini toggle
- `MainActivity.kt`: New `update_floating_frame` method channel handler
- `remote_page.dart`: Periodic frame push (10fps) with correct aspect ratio
- `AndroidManifest.xml`: Added `FOREGROUND_SERVICE_SPECIAL_USE` permission and `foregroundServiceType`

## Testing
Built and tested on Android arm64. Connection stays alive when activating floating window mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Picture-in-Picture (floating window) mode for remote sessions on Android
  * Floating window now supports double-tap to toggle mini mode and drag to reposition
  * Real-time frame updates for floating window display

* **Chores**
  * Updated Android build configuration and Gradle dependencies
  * Improved native library initialization error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->