### PR TITLE
fix(wayland): clipboard, support ext-data-control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "clipboard-master"
 version = "4.0.0-beta.6"
-source = "git+https://github.com/rustdesk-org/clipboard-master#ddc39f00a6211959489ae683aa6ae6eedf03a809"
+source = "git+https://github.com/rustdesk-org/clipboard-master#578fae4805afeb263552a566740991248b18822f"
 dependencies = [
  "objc",
  "objc-foundation",
@@ -9733,9 +9733,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd993de54a40a40fbe5601d9f1fbcaef0aebcc5fda447d7dc8f6dcbaae4f8953"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
 dependencies = [
  "bitflags 2.9.1",
  "wayland-backend",
@@ -10838,16 +10838,15 @@ dependencies = [
 
 [[package]]
 name = "wl-clipboard-rs"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de22eebb1d1e2bad2d970086e96da0e12cde0b411321e5b0f7b2a1f876aa26f"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
 dependencies = [
  "libc",
  "log",
  "os_pipe",
- "rustix 0.38.34",
- "tempfile",
- "thiserror 1.0.61",
+ "rustix 1.1.2",
+ "thiserror 2.0.17",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "clipboard-master"
 version = "4.0.0-beta.6"
-source = "git+https://github.com/rustdesk-org/clipboard-master#578fae4805afeb263552a566740991248b18822f"
+source = "git+https://github.com/rustdesk-org/clipboard-master#7762d74e38db37cfeb6ded88c964b9cdbddfb6db"
 dependencies = [
  "objc",
  "objc-foundation",

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -862,7 +862,6 @@ pub mod clipboard_listener {
     pub fn subscribe(name: String, tx: Sender<CallbackResult>) -> ResultType<()> {
         log::info!("Subscribe clipboard listener: {}", &name);
         let mut listener_lock = CLIPBOARD_LISTENER.lock().unwrap();
-        cleanup_stale_listener(&mut listener_lock);
         listener_lock
             .subscribers
             .lock()

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -862,24 +862,14 @@ pub mod clipboard_listener {
     pub fn subscribe(name: String, tx: Sender<CallbackResult>) -> ResultType<()> {
         log::info!("Subscribe clipboard listener: {}", &name);
         let mut listener_lock = CLIPBOARD_LISTENER.lock().unwrap();
-        let stale_handle = listener_lock
-            .handle
-            .as_ref()
-            .map(|(_, h)| h.is_finished())
-            .unwrap_or(false);
-        if stale_handle {
-            if let Some((shutdown, h)) = listener_lock.handle.take() {
-                log::warn!("Cleaning up stale clipboard listener handle");
-                h.join().ok();
-                drop(shutdown);
-            }
-        }
+        cleanup_stale_listener(&mut listener_lock);
         listener_lock
             .subscribers
             .lock()
             .unwrap()
             .insert(name.clone(), tx);
 
+        cleanup_stale_listener(&mut listener_lock);
         if listener_lock.handle.is_none() {
             log::info!("Start clipboard listener thread");
             let handler = Handler {
@@ -903,6 +893,24 @@ pub mod clipboard_listener {
 
         log::info!("Clipboard listener subscribed: {}", name);
         Ok(())
+    }
+
+    fn cleanup_stale_listener(listener: &mut ClipboardListener) {
+        if !listener
+            .handle
+            .as_ref()
+            .map(|(_, h)| h.is_finished())
+            .unwrap_or(false)
+        {
+            return;
+        }
+        if let Some((shutdown, h)) = listener.handle.take() {
+            log::warn!("Cleaning up stale clipboard listener handle");
+            if let Err(e) = h.join() {
+                log::error!("Clipboard listener thread panicked during stale cleanup: {:?}", e);
+            }
+            drop(shutdown);
+        }
     }
 
     pub fn unsubscribe(name: &str) {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -862,6 +862,18 @@ pub mod clipboard_listener {
     pub fn subscribe(name: String, tx: Sender<CallbackResult>) -> ResultType<()> {
         log::info!("Subscribe clipboard listener: {}", &name);
         let mut listener_lock = CLIPBOARD_LISTENER.lock().unwrap();
+        let stale_handle = listener_lock
+            .handle
+            .as_ref()
+            .map(|(_, h)| h.is_finished())
+            .unwrap_or(false);
+        if stale_handle {
+            if let Some((shutdown, h)) = listener_lock.handle.take() {
+                log::warn!("Cleaning up stale clipboard listener handle");
+                h.join().ok();
+                drop(shutdown);
+            }
+        }
         listener_lock
             .subscribers
             .lock()


### PR DESCRIPTION

This PR is a duplicate of https://github.com/rustdesk/rustdesk/pull/14577

## Testing


```
 wayland-info 2>/dev/null | grep -E 'zwlr_data_control_manager_v1|ext_data_control_manager_v1'
```

- [x] Windows <-> Linux X11
- [x] Windows <-> KDE Plasma < 6.5
  - Fedora 42 KDE, KDE Plasma 6.3.4 (`zwlr_data_control_manager_v1` only)
  - manjaro 24.0.8 KDE, KDE Plasma 6.3.6 (`zwlr_data_control_manager_v1` only)
  - KUbuntu 22.04, KDE Plasma 5.24.7
- [x] Windows <-> KDE Plasma 6.5+
  - KUbuntu 26.04, KDE Plasma 6.6.4 (`ext_data_control_manager_v1` only)
  - Fedora 44 KDE, KDE Plasma 6.6.4  (`ext_data_control_manager_v1` only)
- [x] Windows <-> Ubuntu 26.04 GNOME





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard listener stability by automatically detecting and cleaning up stale background listener thread handles before registering new subscribers, reducing the risk of lingering completed listeners and enhancing overall reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->