### PR TITLE
Fix spelling and grammar errors in comments

### DIFF
--- a/libs/enigo/src/lib.rs
+++ b/libs/enigo/src/lib.rs
@@ -113,11 +113,11 @@ pub enum MouseButton {
 
     /// Scroll up button
     ScrollUp,
-    /// Left right button
+    /// Scroll down button
     ScrollDown,
-    /// Left right button
+    /// Scroll left button
     ScrollLeft,
-    /// Left right button
+    /// Scroll right button
     ScrollRight,
 }
 

--- a/libs/enigo/src/win/win_impl.rs
+++ b/libs/enigo/src/win/win_impl.rs
@@ -223,7 +223,7 @@ impl KeyboardControllable for Enigo {
             // Windows uses uft-16 encoding. We need to check
             // for variable length characters. As such some
             // characters can be 32 bit long and those are
-            // encoded in such called hight and low surrogates
+            // encoded in so-called high and low surrogates
             // each 16 bit wide that needs to be send after
             // another to the SendInput function without
             // being interrupted by "keyup"

--- a/res/startwm.sh
+++ b/res/startwm.sh
@@ -45,7 +45,7 @@ pre_start()
   return 0
 }
 
-# When loging out from the interactive shell, the execution sequence is:
+# When logging out from the interactive shell, the execution sequence is:
 #
 # IF ~/.bash_logout exists THEN
 #     execute ~/.bash_logout

--- a/src/server/dbus.rs
+++ b/src/server/dbus.rs
@@ -1,7 +1,7 @@
 /// Url handler based on dbus
 ///
 /// Note:
-/// On linux, we use dbus to communicate multiple rustdesk process.
+/// On linux, we use dbus to communicate between multiple rustdesk processes.
 /// [Flutter]: handle uni links for linux
 use dbus::blocking::Connection;
 use dbus_crossroads::{Crossroads, IfaceBuilder};


### PR DESCRIPTION
- dbus.rs: fix grammar (add 'between', pluralize 'processes')
- win_impl.rs: fix typo 'hight' -> 'high', idiom 'such called' -> 'so-called'
- startwm.sh: fix typo 'loging' -> 'logging'
- lib.rs: fix copy-paste error in doc comments for scroll buttons
- message.proto: fix typo 'Clipobard' -> 'Clipboard'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected and clarified internal documentation comments for better accuracy and consistency.

* **Chores**
  * Updated project dependencies.
  * Fixed minor spelling and wording inconsistencies across configuration files and internal comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->