### PR TITLE
fix(clipboard): unix, refresh cached file size/mtime on re-copy

### DIFF
--- a/libs/clipboard/src/platform/unix/serv_files.rs
+++ b/libs/clipboard/src/platform/unix/serv_files.rs
@@ -73,7 +73,11 @@ impl ClipFiles {
         self.files_pdu.clear();
     }
 
-    fn sync_files(&mut self, clipboard_files: &[String]) -> Result<(), CliprdrError> {
+    fn sync_files(
+        &mut self,
+        clipboard_files: &[String],
+        sigs: Vec<FileSig>,
+    ) -> Result<(), CliprdrError> {
         let clipboard_paths = clipboard_files
             .iter()
             .map(|s| PathBuf::from(s))
@@ -85,7 +89,7 @@ impl ClipFiles {
             .position(|f| !f.path.is_dir())
             .unwrap_or(usize::MAX);
         self.files = clipboard_files.to_vec();
-        self.sigs = fingerprint(clipboard_files);
+        self.sigs = sigs;
         Ok(())
     }
 
@@ -296,7 +300,7 @@ pub fn sync_files(files: &[String]) -> Result<(), CliprdrError> {
     {
         return Ok(());
     }
-    files_lock.sync_files(files)?;
+    files_lock.sync_files(files, current)?;
     Ok(files_lock.build_file_list_pdu())
 }
 

--- a/libs/clipboard/src/platform/unix/serv_files.rs
+++ b/libs/clipboard/src/platform/unix/serv_files.rs
@@ -5,7 +5,7 @@ use hbb_common::{
     log,
 };
 use parking_lot::Mutex;
-use std::{path::PathBuf, sync::Arc, usize};
+use std::{path::PathBuf, sync::Arc, time::SystemTime, usize};
 
 lazy_static::lazy_static! {
     // local files are cached, this value should not be changed when copying files
@@ -30,9 +30,35 @@ enum FileContentsRequest {
     },
 }
 
+// Cheap fingerprint of one top-level selected entry. A change in size/mtime --
+// or a directory in the selection -- forces sync_files() to rebuild (see below).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct FileSig {
+    size: u64,
+    mtime: Option<SystemTime>,
+    is_dir: bool,
+}
+
+// Stat the top-level selected paths only (no recursion), same order as `files`.
+fn fingerprint(files: &[String]) -> Vec<FileSig> {
+    files
+        .iter()
+        .map(|s| match std::fs::metadata(s) {
+            Ok(mt) => FileSig {
+                size: mt.len(),
+                mtime: mt.modified().ok(),
+                is_dir: mt.is_dir(),
+            },
+            Err(_) => FileSig::default(),
+        })
+        .collect()
+}
+
 #[derive(Default)]
 struct ClipFiles {
     files: Vec<String>,
+    // Fingerprint of `files` (same len/order); detects in-place edits on re-copy.
+    sigs: Vec<FileSig>,
     file_list: Vec<LocalFile>,
     first_file_index: usize,
     files_pdu: Vec<u8>,
@@ -41,6 +67,7 @@ struct ClipFiles {
 impl ClipFiles {
     fn clear(&mut self) {
         self.files.clear();
+        self.sigs.clear();
         self.file_list.clear();
         self.first_file_index = usize::MAX;
         self.files_pdu.clear();
@@ -58,6 +85,7 @@ impl ClipFiles {
             .position(|f| !f.path.is_dir())
             .unwrap_or(usize::MAX);
         self.files = clipboard_files.to_vec();
+        self.sigs = fingerprint(clipboard_files);
         Ok(())
     }
 
@@ -258,8 +286,14 @@ pub fn read_file_contents(
 }
 
 pub fn sync_files(files: &[String]) -> Result<(), CliprdrError> {
+    // Dedup: skip the rebuild only when paths + sizes + mtimes match and no dir is
+    // selected (a dir's own mtime doesn't change when a file inside it is edited).
+    let current = fingerprint(files);
     let mut files_lock = CLIP_FILES.lock();
-    if files_lock.files == files {
+    if files_lock.files == files
+        && files_lock.sigs == current
+        && !current.iter().any(|sig| sig.is_dir)
+    {
         return Ok(());
     }
     files_lock.sync_files(files)?;
@@ -268,4 +302,112 @@ pub fn sync_files(files: &[String]) -> Result<(), CliprdrError> {
 
 pub fn get_file_list_pdu() -> Vec<u8> {
     CLIP_FILES.lock().files_pdu.clone()
+}
+
+#[cfg(test)]
+mod sig_test {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    // Unique temp dir under the system temp dir; removed on drop (no dev-dep).
+    struct TmpDir(PathBuf);
+    impl TmpDir {
+        fn new(tag: &str) -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let mut dir = std::env::temp_dir();
+            dir.push(format!("rustdesk_sig_test_{}_{}", tag, nanos));
+            fs::create_dir_all(&dir).unwrap();
+            TmpDir(dir)
+        }
+        fn join(&self, name: &str) -> PathBuf {
+            self.0.join(name)
+        }
+    }
+    impl Drop for TmpDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn path_str(p: &PathBuf) -> String {
+        p.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn fingerprint_missing_path_is_default() {
+        let tmp = TmpDir::new("missing");
+        let missing = path_str(&tmp.join("does_not_exist.bin"));
+        let sigs = fingerprint(&[missing]);
+        assert_eq!(sigs.len(), 1);
+        // A path that can't be stat'd -> default sig, which forces a rebuild.
+        assert_eq!(sigs[0], FileSig::default());
+        assert_eq!(sigs[0].mtime, None);
+    }
+
+    #[test]
+    fn fingerprint_detects_inplace_edit() {
+        let tmp = TmpDir::new("edit");
+        let file = tmp.join("a.bin");
+        fs::write(&file, b"small").unwrap();
+        let p = path_str(&file);
+
+        let before = fingerprint(&[p.clone()]);
+        // Same content, same path: fingerprint must be stable.
+        let again = fingerprint(&[p.clone()]);
+        assert_eq!(before, again);
+        assert_eq!(before[0].size, 5);
+        assert!(!before[0].is_dir);
+
+        // Edit in place so the file grows.
+        fs::write(&file, b"much larger contents than before").unwrap();
+        let after = fingerprint(&[p]);
+        assert_ne!(before, after);
+        assert!(after[0].size > before[0].size);
+    }
+
+    #[test]
+    fn fingerprint_flags_directory() {
+        let tmp = TmpDir::new("dir");
+        let sub = tmp.join("subdir");
+        fs::create_dir_all(&sub).unwrap();
+        let sigs = fingerprint(&[path_str(&sub)]);
+        assert_eq!(sigs.len(), 1);
+        assert!(sigs[0].is_dir);
+    }
+
+    #[test]
+    fn recopy_after_edit_refreshes_cached_size() {
+        let tmp = TmpDir::new("recopy");
+        let file = tmp.join("doc.bin");
+        fs::write(&file, b"v1").unwrap(); // 2 bytes
+        let files = vec![path_str(&file)];
+
+        // Drive the public, guarded `sync_files` over the global CLIP_FILES;
+        // reset first (this is the only test that touches the global).
+        clear_files();
+
+        sync_files(&files).unwrap();
+        {
+            let cache = CLIP_FILES.lock();
+            let idx = cache.first_file_index;
+            assert_eq!(cache.file_list[idx].size, 2);
+        }
+
+        // In-place edit grows the file; the re-copy must rebuild. Pre-fix the
+        // path-only guard early-returned and left the cached size stale at 2.
+        fs::write(&file, b"v2 is bigger").unwrap(); // 12 bytes
+        sync_files(&files).unwrap();
+        {
+            let cache = CLIP_FILES.lock();
+            let idx = cache.first_file_index;
+            assert_eq!(cache.file_list[idx].size, 12);
+        }
+
+        clear_files(); // leave the global clean for other tests
+    }
 }


### PR DESCRIPTION
## Problem
On the unix file-clipboard path (controller = macOS/Linux), copying a file,
then **editing it in place and re-copying the same path**, delivers the
**old, byte-truncated content** — for *any* file type. The peer keeps the
first copy's size/mtime and the bytes are clamped to the old (smaller) size.
This is silent (no error). It is especially destructive for formats whose
index/trailer sits at the end of the file (PDF, .zip, OOXML such as
.pptx/.docx/.xlsx, many images), which then won't open at all.
Reconnecting or deleting the file on the receiver doesn't help (only an app
restart does).

## Steps to reproduce
Controller = macOS or Linux, controlled = Ubuntu/Linux, file copy & paste enabled.
1. On the controller:  `printf 'v1' > a.bin`  (2 bytes). Copy it in the file
   manager, paste on the remote -> remote receives 2 bytes ("v1"), correct.
2. Edit in place so content/size change:  `printf 'v2 is bigger' > a.bin`  (12 bytes).
3. Copy `a.bin` again, paste on the remote.
4. The remote file still reports the **old size (2) and old mtime**, and its
   bytes are truncated to the old size -> wrong content ("v2"). `stat` / `md5sum`
   on the two ends disagree. Deleting it on the remote and reconnecting don't
   refresh it.
A same-size in-place edit is also affected (the mtime change is missed too).

## Root cause
`sync_files()` in `libs/clipboard/src/platform/unix/serv_files.rs` early-returns
on a **path-string-only** dedup (`files_lock.files == files`). A re-copied edited
file has the same path, so the cached `LocalFile` size/mtime and the file-group
descriptor PDU are never refreshed; `serve_file_contents()` then clamps reads to
the stale size, and the stale size/mtime let the receiver's FUSE/page cache treat
the file as unchanged. (`CLIP_FILES` is a process-global `lazy_static`; the unused
`clear_files()` and the disconnect path don't reset it, so reconnect can't help.)

## Fix
Skip the rebuild only when nothing changed: identical paths **and** identical
`(size, mtime)` for every top-level selected entry **and** no directory selected.
- `FileSig { size, mtime, is_dir }` is `stat`'d for **top-level paths only** (no
  recursion), same `std::fs::metadata` semantics as `construct_file_list`/`LocalFile`.
  `mtime` catches same-size edits; a missing path -> `FileSig::default()` (forces rebuild).
  No `unwrap`/`expect`.
- Directory selections always rebuild (a directory's own mtime doesn't change when a
  child is edited). The fingerprint is computed before taking the lock.

## Scope
- One file: `libs/clipboard/src/platform/unix/serv_files.rs`.
- unix sender only; the Windows `wf_cliprdr.c` path re-stats per request and is
  unaffected; receiver code (FUSE / macOS pasteboard) is unchanged.
- (Unrelated: `clear_files()` has no production caller -- only the new test calls it --
  and does not reset the process-global cache; left as-is, out of scope for this fix.)

## Testing
- 4 regression tests in `#[cfg(test)] mod sig_test` (std-only temp dir, no new deps).
  `recopy_after_edit_refreshes_cached_size` drives the public guarded `sync_files` over
  the global cache and pins the fix: after an in-place edit it asserts the cached size
  refreshes 2 -> 12; against the pre-fix path-only guard it fails (left 2, right 12).
- `cargo test -p clipboard --features unix-file-copy-paste sig_test` -- all 4 pass.
- No new dependencies; `Cargo.lock` unchanged. (CI runs the full
  `cargo build/test --locked --workspace`.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Enhanced clipboard file synchronization with fingerprint-based change detection (size and optional modification time), reducing unnecessary rebuilds on repeated re-syncs while still catching in-place edits.
  * Improved handling of file selections to properly track and reuse cached metadata when the same paths are re-synced.

* **Tests**
  * Added unit tests covering missing paths, fingerprint stability across calls, in-place growth detection, directory flagging, and refreshed cached file metadata after edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->