### PR TITLE
fix(custom-client): show options, incoming-only

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -483,13 +483,15 @@ class _GeneralState extends State<_General> {
   }
 
   Widget other() {
+    final incomingOnly = bind.isIncomingOnly();
+    final outgoingOnly = bind.isOutgoingOnly();
     final showAutoUpdate = isWindows && bind.mainIsInstalled();
     final children = <Widget>[
-      if (!isWeb && !bind.isIncomingOnly())
+      if (!isWeb && !incomingOnly)
         _OptionCheckBox(context, 'Confirm before closing multiple tabs',
             kOptionEnableConfirmClosingTabs,
             isServer: false),
-      if (!bind.isIncomingOnly())
+      if (!incomingOnly)
         _OptionCheckBox(
           context,
           'allow-remote-toolbar-docking-any-edge',
@@ -499,9 +501,10 @@ class _GeneralState extends State<_General> {
             reloadAllWindows();
           },
         ),
-      _OptionCheckBox(context, 'Adaptive bitrate', kOptionEnableAbr),
+      if (!isWeb && !outgoingOnly)
+        _OptionCheckBox(context, 'Adaptive bitrate', kOptionEnableAbr),
       if (!isWeb) wallpaper(),
-      if (!isWeb && !bind.isIncomingOnly()) ...[
+      if (!isWeb && !incomingOnly) ...[
         _OptionCheckBox(
           context,
           'Open connection in new tab',
@@ -540,40 +543,40 @@ class _GeneralState extends State<_General> {
               isServer: false,
             ),
           ),
-        if (!isWeb && !bind.isCustomClient())
-          _OptionCheckBox(
-            context,
-            'Check for software update on startup',
-            kOptionEnableCheckUpdate,
-            isServer: false,
-          ),
-        if (showAutoUpdate)
-          _OptionCheckBox(
-            context,
-            'Auto update',
-            kOptionAllowAutoUpdate,
-            isServer: true,
-          ),
-        if (isWindows && !bind.isOutgoingOnly())
-          _OptionCheckBox(
-            context,
-            'Capture screen using DirectX',
-            kOptionDirectxCapture,
-          ),
-        if (!bind.isIncomingOnly()) ...[
-          _OptionCheckBox(
-            context,
-            'Enable UDP hole punching',
-            kOptionEnableUdpPunch,
-            isServer: false,
-          ),
-          _OptionCheckBox(
-            context,
-            'Enable IPv6 P2P connection',
-            kOptionEnableIpv6Punch,
-            isServer: false,
-          ),
-        ],
+      ],
+      if (!isWeb && !bind.isCustomClient())
+        _OptionCheckBox(
+          context,
+          'Check for software update on startup',
+          kOptionEnableCheckUpdate,
+          isServer: false,
+        ),
+      if (showAutoUpdate)
+        _OptionCheckBox(
+          context,
+          'Auto update',
+          kOptionAllowAutoUpdate,
+          isServer: true,
+        ),
+      if (isWindows && !outgoingOnly)
+        _OptionCheckBox(
+          context,
+          'Capture screen using DirectX',
+          kOptionDirectxCapture,
+        ),
+      if (!isWeb && !incomingOnly) ...[
+        _OptionCheckBox(
+          context,
+          'Enable UDP hole punching',
+          kOptionEnableUdpPunch,
+          isServer: false,
+        ),
+        _OptionCheckBox(
+          context,
+          'Enable IPv6 P2P connection',
+          kOptionEnableIpv6Punch,
+          isServer: false,
+        ),
       ],
     ];
 


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/15391

1. Desktop. Move `'Adaptive bitrate'` into `!isWeb && !bind.isOutgoingOnly()`. Android has applied the same condition.
https://github.com/rustdesk/rustdesk/blob/09bc9056c936c0a8858f206c06b462f53a3db8cc/flutter/lib/mobile/pages/settings_page.dart#L938
https://github.com/rustdesk/rustdesk/blob/09bc9056c936c0a8858f206c06b462f53a3db8cc/flutter/lib/mobile/pages/settings_page.dart#L403
2. Desktop. Move `'Check for software update on startup'`, `'Auto update'`, `'Capture screen using DirectX'` out of `!isWeb && !bind.isIncomingOnly()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved visibility conditions for network-related settings in the desktop settings panel. "Adaptive bitrate," "Enable UDP hole punching," and "Enable IPv6 P2P connection" options are now correctly hidden based on web status and connection mode (incoming-only or outgoing-only).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->