### PR TITLE
Add monitor switch button to mobile remote toolbar

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -550,6 +550,63 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     );
   }
 
+  Widget buildMobileMonitorSwitchButton() {
+    return Obx(() {
+      final pi = gFFI.ffiModel.pi;
+      final total = pi.displays.length;
+
+      if (total < 2) {
+        return const Offstage();
+      }
+
+      final current = CurrentDisplayState.find(widget.id).value;
+      final inRange = current >= 0 && current < total;
+      final label = inRange ? '${current + 1}' : '*';
+      final target = ((inRange ? current : -1) + 1) % total;
+
+      return IconButton(
+        tooltip: '${translate('Switch display')} ($label/$total)',
+        color: Colors.white,
+        icon: SizedBox(
+          width: 28,
+          height: 28,
+          child: Stack(
+            alignment: const Alignment(0, -0.125),
+            children: [
+              SvgPicture.asset(
+                'assets/display_switcher.svg',
+                colorFilter: const ColorFilter.mode(
+                  Colors.white,
+                  BlendMode.srcIn,
+                ),
+                width: 28,
+                height: 28,
+              ),
+              Text(
+                label,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: Colors.black,
+                  fontSize: 10,
+                  height: 1,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+        ),
+        onPressed: () {
+          openMonitorInTheSameTab(
+            target,
+            gFFI,
+            pi,
+            updateCursorPos: false,
+          );
+        },
+      );
+    });
+  }
+
   Widget getBottomAppBar() {
     final ffiModel = Provider.of<FfiModel>(context);
     return BottomAppBar(
@@ -575,7 +632,8 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
                         setState(() => _showEdit = false);
                         showOptions(context, widget.id, gFFI.dialogManager);
                       },
-                    )
+                    ),
+                    buildMobileMonitorSwitchButton(),
                   ] +
                   (isWebDesktop || ffiModel.viewOnly || !ffiModel.keyboard
                       ? []


### PR DESCRIPTION
Adds a monitor switch button to the mobile remote toolbar when the remote peer has multiple displays.

The button cycles through available displays using the existing CurrentDisplayState and openMonitorInTheSameTab logic, similar to the desktop monitor switch implementation.

Tested locally on iOS with a multi-monitor remote peer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a display switcher button to the mobile interface. When multiple displays are connected, users can now quickly cycle through them using the new button in the bottom app bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->