### PR TITLE
Replace cmd shell-out in consent process check

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3113,11 +3113,7 @@ pub fn get_unicode_from_vk(vk: u32) -> Option<u16> {
 }
 
 pub fn is_process_consent_running() -> ResultType<bool> {
-    let output = std::process::Command::new("cmd")
-        .args(&["/C", "tasklist | findstr consent.exe"])
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()?;
-    Ok(output.status.success() && !output.stdout.is_empty())
+    Ok(!get_pids("consent.exe")?.is_empty())
 }
 
 pub struct WakeLock(u32);


### PR DESCRIPTION
This pull request refactors the way the code checks if the `consent.exe` process is running on Windows. Instead of invoking a shell command to parse process lists, it now uses the internal `get_pids` function for improved reliability and efficiency.

The continual shelling out to `cmd.exe` with the old code made large amounts of noise when trying to debug process creation over remote connections.

Resolves #10390
Resolves #10387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized process detection mechanism for improved system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->