### PR TITLE
fix: custom id registration with self-hosted servers

### DIFF
--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -1500,12 +1500,13 @@ pub async fn change_id_shared_(id: String, old_id: String) -> &'static str {
 
     let mut futs = Vec::new();
     let err: Arc<Mutex<&str>> = Default::default();
+    let pk = Config::get_key_pair().1;
     for rendezvous_server in rendezvous_servers {
         let err = err.clone();
         let id = id.to_owned();
         let uuid = uuid.clone();
         let old_id = old_id.clone();
-        let pk = Config::get_key_pair().1;
+        let pk = pk.clone();
         futs.push(tokio::spawn(async move {
             let tmp = check_id(rendezvous_server, old_id, id, uuid, pk).await;
             if !tmp.is_empty() {

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -1505,8 +1505,9 @@ pub async fn change_id_shared_(id: String, old_id: String) -> &'static str {
         let id = id.to_owned();
         let uuid = uuid.clone();
         let old_id = old_id.clone();
+        let pk = Config::get_key_pair().1;
         futs.push(tokio::spawn(async move {
-            let tmp = check_id(rendezvous_server, old_id, id, uuid).await;
+            let tmp = check_id(rendezvous_server, old_id, id, uuid, pk).await;
             if !tmp.is_empty() {
                 *err.lock().unwrap() = tmp;
             }
@@ -1531,6 +1532,7 @@ async fn check_id(
     old_id: String,
     id: String,
     uuid: Bytes,
+    pk: Vec<u8>,
 ) -> &'static str {
     if let Ok(mut socket) = hbb_common::socket_client::connect_tcp(
         crate::check_port(rendezvous_server, RENDEZVOUS_PORT),
@@ -1543,6 +1545,7 @@ async fn check_id(
             old_id,
             id,
             uuid,
+            pk: pk.into(),
             ..Default::default()
         });
         let mut ok = false;


### PR DESCRIPTION
Change ID was sending `RegisterPk` without the device public key, which self-hosted servers can reject even when the requested ID is valid.

This adds the existing device public key to the Change ID registration request so it matches the normal registration flow.

This should close #9150 (#9149)

<img width="597" height="318" alt="Screenshot 2026-06-24 at 20 52 44" src="https://github.com/user-attachments/assets/a3998730-2b55-419d-b33f-d19ab3c77ace" />
<img width="224" height="177" alt="Screenshot 2026-06-24 at 20 52 52" src="https://github.com/user-attachments/assets/b4853eec-f9e1-4bd8-8bb4-303e3b93acb9" />

For my self-hosted RustDesk setup, I used the RustDesk Server LXC for Proxmox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of connection-related background registration by consistently reusing the same local public key across repeated attempts.
  * Reduced the chance of sending inconsistent key data during registration, helping connections complete more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->