### PR TITLE
Tray menu opens on left-click after tray-icon ≥0.17 update (regression from 1.4.6)

### DIFF
--- a/src/tray.rs
+++ b/src/tray.rs
@@ -143,12 +143,21 @@ fn make_tray() -> hbb_common::ResultType<()> {
             }
             // We create the icon once the event loop is actually running
             // to prevent issues like https://github.com/tauri-apps/tray-icon/issues/90
-            let tray = TrayIconBuilder::new()
+            let mut builder = TrayIconBuilder::new()
                 .with_menu(Box::new(tray_menu.clone()))
                 .with_tooltip(tooltip(0))
-                .with_icon(icon.clone())
-                .with_icon_as_template(true) // mac only
-                .build();
+                .with_icon(icon.clone());
+            #[cfg(target_os = "macos")]
+            {
+                builder = builder.with_icon_as_template(true);
+            }
+            #[cfg(target_os = "windows")]
+            {
+                // Required since tray-icon 0.17
+                // Fixes #15215, #15222, #15410
+                builder = builder.with_menu_on_left_click(false);
+            }
+            let tray = builder.build();
             match tray {
                 Ok(tray) => _tray_icon = Arc::new(Mutex::new(Some(tray))),
                 Err(err) => {


### PR DESCRIPTION
# Tray menu opens on left-click after tray-icon ≥0.17 update (regression from 1.4.6)

## Description

Since RustDesk 1.4.7, left-clicking the tray icon on Windows opens both:

1. the RustDesk main window
2. the tray context menu

at the same time.

In RustDesk 1.4.6, a left-click only opened the RustDesk window, while the tray context menu was only shown on right-click.

## Why this is a bug

The current behavior causes two independent UI actions to be triggered by a single left-click:

- Open application window
- Open tray context menu

This leads to overlapping UI elements and inconsistent behavior.

The current implementation therefore produces the following behavior:

| Action | Result |
|----------|----------|
| Left click | Opens RustDesk window AND opens tray menu |
| Right click | Opens tray menu |

This means the tray menu is displayed for both mouse buttons, which is not how RustDesk behaved in previous releases.

## Regression

RustDesk 1.4.6:

- tray-icon 0.14.3
- Left click → open window
- Right click → open tray menu

RustDesk 1.4.7:

- tray-icon 0.21.3
- Left click → open window + open tray menu
- Right click → open tray menu

The issue appears to have been introduced by the tray-icon upgrade from 0.14.3 to 0.21.3.

## Expected behavior:

| Action | Result |
|----------|----------|
| Left click | Open/show RustDesk |
| Right click | Show tray menu |

## Actual behavior

| Action | Result |
|----------|----------|
| Left click | Open/show RustDesk and show tray menu simultaneously |
| Right click | Show tray menu |

## Relevant code in src/tray.rs

The tray icon is created with:

```rust
            let tray = TrayIconBuilder::new()
                .with_menu(Box::new(tray_menu.clone()))
                .with_tooltip(tooltip(0))
                .with_icon(icon.clone())
                .with_icon_as_template(true) // mac only
                .build();
```

This worked fine with tray-icon <0.17 , but starting with tray-icon 0.17 , a new method `with_menu_on_left_click` was added, which is by default `true`, which is a breaking change!

To get the old behavior again, `.with_menu_on_left_click(false)` must be applied to the code.

## Proposed fix

As seen in the PR, I suggest the following fix:

```rust
            let mut builder = TrayIconBuilder::new()
                .with_menu(Box::new(tray_menu.clone()))
                .with_tooltip(tooltip(0))
                .with_icon(icon.clone());

            #[cfg(target_os = "macos")]
            {
              builder = builder.with_icon_as_template(true);
            }

            #[cfg(target_os = "windows")]
            {
                // Required since tray-icon 0.17
                // Fixes #15215, #15222, #15410
                builder = builder.with_menu_on_left_click(false);
            }

            let tray = builder.build();
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system tray behavior across platforms.
  * MacOS now applies the tray icon template setting only where appropriate.
  * Windows tray menus no longer open on left-click, matching expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->