### PR TITLE
refactor: ConnectionMeta + audit conn_id (part 1 of #15407 split)

### DIFF
--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -28,10 +28,14 @@ use hbb_common::{
 
 use crate::{
     check_port,
-    server::{check_zombie, new as new_server, ServerPtr},
+    server::{check_zombie, new as new_server, ConnectionMeta, ServerPtr},
 };
 
 type Message = RendezvousMessage;
+
+fn connection_meta(control_permissions: Option<ControlPermissions>) -> ConnectionMeta {
+    ConnectionMeta::from_control_permissions(control_permissions)
+}
 
 lazy_static::lazy_static! {
     static ref SOLVING_PK_MISMATCH: Mutex<String> = Default::default();
@@ -490,6 +494,7 @@ impl RendezvousMediator {
         if last.0 == addr && last.1.elapsed().as_millis() < 100 {
             return Ok(());
         }
+        let meta = connection_meta(rr.control_permissions.clone().into_option());
 
         self.create_relay(
             rr.socket_addr.into(),
@@ -499,7 +504,7 @@ impl RendezvousMediator {
             rr.secure,
             false,
             Default::default(),
-            rr.control_permissions.clone().into_option(),
+            meta,
         )
         .await
     }
@@ -513,7 +518,7 @@ impl RendezvousMediator {
         secure: bool,
         initiate: bool,
         socket_addr_v6: bytes::Bytes,
-        control_permissions: Option<ControlPermissions>,
+        meta: ConnectionMeta,
     ) -> ResultType<()> {
         let peer_addr = AddrMangle::decode(&socket_addr);
         log::info!(
@@ -565,14 +570,9 @@ impl RendezvousMediator {
         let relay_server = self.get_relay_server(fla.relay_server.clone());
         let relay = use_ws() || Config::is_proxy();
         let mut socket_addr_v6 = Default::default();
+        let meta = connection_meta(fla.control_permissions.clone().into_option());
         if peer_addr_v6.port() > 0 && !relay {
-            socket_addr_v6 = start_ipv6(
-                peer_addr_v6,
-                addr,
-                server.clone(),
-                fla.control_permissions.clone().into_option(),
-            )
-            .await;
+            socket_addr_v6 = start_ipv6(peer_addr_v6, addr, server.clone(), meta.clone()).await;
         }
         if is_ipv4(&self.addr) && !relay && !config::is_disable_tcp_listen() {
             if let Err(err) = self
@@ -581,6 +581,7 @@ impl RendezvousMediator {
                     server.clone(),
                     relay_server.clone(),
                     socket_addr_v6.clone(),
+                    meta.clone(),
                 )
                 .await
             {
@@ -598,7 +599,7 @@ impl RendezvousMediator {
             true,
             true,
             socket_addr_v6,
-            fla.control_permissions.into_option(),
+            meta,
         )
         .await
     }
@@ -609,6 +610,7 @@ impl RendezvousMediator {
         server: ServerPtr,
         relay_server: String,
         socket_addr_v6: bytes::Bytes,
+        meta: ConnectionMeta,
     ) -> ResultType<()> {
         let peer_addr = AddrMangle::decode(&fla.socket_addr);
         log::debug!("Handle intranet from {:?}", peer_addr);
@@ -629,14 +631,7 @@ impl RendezvousMediator {
         });
         let bytes = msg_out.write_to_bytes()?;
         socket.send_raw(bytes).await?;
-        crate::accept_connection(
-            server.clone(),
-            socket,
-            peer_addr,
-            true,
-            fla.control_permissions.into_option(),
-        )
-        .await;
+        crate::accept_connection(server.clone(), socket, peer_addr, true, meta).await;
         Ok(())
     }
 
@@ -651,15 +646,10 @@ impl RendezvousMediator {
         let peer_addr_v6 = hbb_common::AddrMangle::decode(&ph.socket_addr_v6);
         let relay = use_ws() || Config::is_proxy() || ph.force_relay;
         let mut socket_addr_v6 = Default::default();
-        let control_permissions = ph.control_permissions.into_option();
+        let meta = connection_meta(ph.control_permissions.into_option());
         if peer_addr_v6.port() > 0 && !relay {
-            socket_addr_v6 = start_ipv6(
-                peer_addr_v6,
-                peer_addr,
-                server.clone(),
-                control_permissions.clone(),
-            )
-            .await;
+            socket_addr_v6 =
+                start_ipv6(peer_addr_v6, peer_addr, server.clone(), meta.clone()).await;
         }
         let relay_server = self.get_relay_server(ph.relay_server);
         // for ensure, websocket go relay directly
@@ -678,7 +668,7 @@ impl RendezvousMediator {
                     true,
                     true,
                     socket_addr_v6.clone(),
-                    control_permissions,
+                    meta,
                 )
                 .await;
         }
@@ -695,7 +685,7 @@ impl RendezvousMediator {
         };
         if ph.udp_port > 0 {
             peer_addr.set_port(ph.udp_port as u16);
-            self.punch_udp_hole(peer_addr, server, msg_punch, control_permissions)
+            self.punch_udp_hole(peer_addr, server, msg_punch, meta)
                 .await?;
             return Ok(());
         }
@@ -712,8 +702,7 @@ impl RendezvousMediator {
         msg_out.set_punch_hole_sent(msg_punch);
         let bytes = msg_out.write_to_bytes()?;
         socket.send_raw(bytes).await?;
-        crate::accept_connection(server.clone(), socket, peer_addr, true, control_permissions)
-            .await;
+        crate::accept_connection(server.clone(), socket, peer_addr, true, meta).await;
         Ok(())
     }
 
@@ -722,7 +711,7 @@ impl RendezvousMediator {
         peer_addr: SocketAddr,
         server: ServerPtr,
         msg_punch: PunchHoleSent,
-        control_permissions: Option<ControlPermissions>,
+        meta: ConnectionMeta,
     ) -> ResultType<()> {
         let mut msg_out = Message::new();
         msg_out.set_punch_hole_sent(msg_punch);
@@ -737,14 +726,7 @@ impl RendezvousMediator {
                 socket.send_to(&data, addr).await.ok();
             }
         });
-        udp_nat_listen(
-            socket_cloned.clone(),
-            peer_addr,
-            peer_addr,
-            server,
-            control_permissions,
-        )
-        .await?;
+        udp_nat_listen(socket_cloned, peer_addr, peer_addr, server, meta).await?;
         Ok(())
     }
 
@@ -901,7 +883,7 @@ async fn direct_server(server: ServerPtr) {
                             hbb_common::Stream::from(stream, local_addr),
                             addr,
                             false,
-                            None, // Direct connections don't have control_permissions
+                            ConnectionMeta::default(), // Direct connections don't have server-side user context.
                         )
                         .await
                     );
@@ -933,21 +915,14 @@ async fn start_ipv6(
     peer_addr_v6: SocketAddr,
     peer_addr_v4: SocketAddr,
     server: ServerPtr,
-    control_permissions: Option<ControlPermissions>,
+    meta: ConnectionMeta,
 ) -> bytes::Bytes {
     crate::test_ipv6().await;
     if let Some((socket, local_addr_v6)) = crate::get_ipv6_socket().await {
         let server = server.clone();
         tokio::spawn(async move {
             allow_err!(
-                udp_nat_listen(
-                    socket.clone(),
-                    peer_addr_v6,
-                    peer_addr_v4,
-                    server,
-                    control_permissions
-                )
-                .await
+                udp_nat_listen(socket.clone(), peer_addr_v6, peer_addr_v4, server, meta).await
             );
         });
         return local_addr_v6;
@@ -960,7 +935,7 @@ async fn udp_nat_listen(
     peer_addr: SocketAddr,
     peer_addr_v4: SocketAddr,
     server: ServerPtr,
-    control_permissions: Option<ControlPermissions>,
+    meta: ConnectionMeta,
 ) -> ResultType<()> {
     let tm = Instant::now();
     let socket_cloned = socket.clone();
@@ -973,14 +948,7 @@ async fn udp_nat_listen(
             res,
         )
         .await?;
-        crate::server::create_tcp_connection(
-            server,
-            stream.1,
-            peer_addr_v4,
-            true,
-            control_permissions,
-        )
-        .await?;
+        crate::server::create_tcp_connection(server, stream.1, peer_addr_v4, true, meta).await?;
         Ok(())
     };
     func.await.map_err(|e: anyhow::Error| {

--- a/src/server.rs
+++ b/src/server.rs
@@ -81,6 +81,19 @@ pub mod printer_service;
 pub type Childs = Arc<Mutex<Vec<std::process::Child>>>;
 type ConnMap = HashMap<i32, ConnInner>;
 
+/// Bundles per-connection metadata passed from rendezvous/server entry points.
+/// Part 1 carries only `control_permissions`; part 2 extends this with controller audit context.
+#[derive(Clone, Default)]
+pub struct ConnectionMeta {
+    pub control_permissions: Option<ControlPermissions>,
+}
+
+impl ConnectionMeta {
+    pub fn from_control_permissions(control_permissions: Option<ControlPermissions>) -> Self {
+        Self { control_permissions }
+    }
+}
+
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 const CONFIG_SYNC_INTERVAL_SECS: f32 = 0.3;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -163,7 +176,7 @@ async fn accept_connection_(
     server: ServerPtr,
     socket: Stream,
     secure: bool,
-    control_permissions: Option<ControlPermissions>,
+    meta: ConnectionMeta,
 ) -> ResultType<()> {
     let local_addr = socket.local_addr();
     drop(socket);
@@ -180,7 +193,7 @@ async fn accept_connection_(
             Stream::from(stream, stream_addr),
             addr,
             secure,
-            control_permissions,
+            meta,
         )
         .await?;
     }
@@ -192,7 +205,7 @@ pub async fn create_tcp_connection(
     stream: Stream,
     addr: SocketAddr,
     secure: bool,
-    control_permissions: Option<ControlPermissions>,
+    meta: ConnectionMeta,
 ) -> ResultType<()> {
     let mut stream = stream;
     let id = server.write().unwrap().get_new_id();
@@ -260,14 +273,7 @@ pub async fn create_tcp_connection(
         }
         log::info!("wake up macos");
     }
-    Connection::start(
-        addr,
-        stream,
-        id,
-        Arc::downgrade(&server),
-        control_permissions,
-    )
-    .await;
+    Connection::start(addr, stream, id, Arc::downgrade(&server), meta).await;
     Ok(())
 }
 
@@ -276,9 +282,9 @@ pub async fn accept_connection(
     socket: Stream,
     peer_addr: SocketAddr,
     secure: bool,
-    control_permissions: Option<ControlPermissions>,
+    meta: ConnectionMeta,
 ) {
-    if let Err(err) = accept_connection_(server, socket, secure, control_permissions).await {
+    if let Err(err) = accept_connection_(server, socket, secure, meta).await {
         log::warn!("Failed to accept connection from {}: {}", peer_addr, err);
     }
 }
@@ -290,7 +296,7 @@ pub async fn create_relay_connection(
     peer_addr: SocketAddr,
     secure: bool,
     ipv4: bool,
-    control_permissions: Option<ControlPermissions>,
+    meta: ConnectionMeta,
 ) {
     if let Err(err) = create_relay_connection_(
         server,
@@ -299,7 +305,7 @@ pub async fn create_relay_connection(
         peer_addr,
         secure,
         ipv4,
-        control_permissions,
+        meta,
     )
     .await
     {
@@ -319,7 +325,7 @@ async fn create_relay_connection_(
     peer_addr: SocketAddr,
     secure: bool,
     ipv4: bool,
-    control_permissions: Option<ControlPermissions>,
+    meta: ConnectionMeta,
 ) -> ResultType<()> {
     let mut stream = socket_client::connect_tcp(
         socket_client::ipv4_to_ipv6(crate::check_port(relay_server, RELAY_PORT), ipv4),
@@ -334,7 +340,7 @@ async fn create_relay_connection_(
         ..Default::default()
     });
     stream.send(&msg_out).await?;
-    create_tcp_connection(server, stream, peer_addr, secure, control_permissions).await?;
+    create_tcp_connection(server, stream, peer_addr, secure, meta).await?;
     Ok(())
 }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -407,8 +407,11 @@ impl Connection {
         stream: super::Stream,
         id: i32,
         server: super::ServerPtrWeak,
-        control_permissions: Option<ControlPermissions>,
+        meta: super::ConnectionMeta,
     ) {
+        let super::ConnectionMeta {
+            control_permissions,
+        } = meta;
         // Android is not supported yet, so we always set control_permissions to None.
         #[cfg(target_os = "android")]
         let control_permissions = None;
@@ -1308,7 +1311,7 @@ impl Connection {
         {
             self.send_login_error("Your ip is blocked by the peer")
                 .await;
-            Self::post_alarm_audit(
+            self.post_alarm_audit(
                 AlarmAuditType::IpWhitelist, //"ip whitelist",
                 json!({ "ip":addr.ip() }),
             );
@@ -1408,6 +1411,7 @@ impl Connection {
             "id":json!(Config::get_id()),
             "uuid":json!(crate::encode64(hbb_common::get_uuid())),
             "peer_id":json!(self.lr.my_id),
+            "conn_id":json!(self.inner.id()),
             "type": r#type as i8,
             "path":path,
             "is_file":is_file,
@@ -1418,7 +1422,7 @@ impl Connection {
         });
     }
 
-    pub fn post_alarm_audit(typ: AlarmAuditType, info: Value) {
+    fn post_alarm_audit(&self, typ: AlarmAuditType, info: Value) {
         let url = crate::get_audit_server(
             Config::get_option("api-server"),
             Config::get_option("custom-rendezvous-server"),
@@ -1432,6 +1436,7 @@ impl Connection {
         v["uuid"] = json!(crate::encode64(hbb_common::get_uuid()));
         v["typ"] = json!(typ as i8);
         v["info"] = serde_json::Value::String(info.to_string());
+        v["conn_id"] = json!(self.inner.id());
         tokio::spawn(async move {
             allow_err!(Self::post_audit_async(url, v).await);
         });
@@ -3668,7 +3673,7 @@ impl Connection {
                         );
                         self.send_login_error("Please try 1 minute later").await;
                         sleep(1.).await;
-                        Self::post_alarm_audit(
+                        self.post_alarm_audit(
                             AlarmAuditType::TerminalOsLoginConcurrency,
                             json!({
                                 "ip": self.ip,
@@ -3856,7 +3861,7 @@ impl Connection {
                 prefix_num
             ))
             .await;
-            Self::post_alarm_audit(
+            self.post_alarm_audit(
                 AlarmAuditType::ExceedIPv6PrefixAttempts,
                 json!({
                             "ip": self.ip,
@@ -3901,7 +3906,7 @@ impl Connection {
                 if let Some(audit) = decision.audit {
                     // For OS blocked/backoff events, we currently emit one alarm report per blocked attempt.
                     // TODO: Add unified cumulative/aggregation fields across alarm producers.
-                    Self::post_alarm_audit(
+                    self.post_alarm_audit(
                         audit,
                         json!({
                                     "ip": self.ip,
@@ -3938,7 +3943,7 @@ impl Connection {
 
         let res = if failure.2 > 30 {
             self.send_login_error("Too many wrong attempts").await;
-            Self::post_alarm_audit(
+            self.post_alarm_audit(
                 AlarmAuditType::ExceedThirtyAttempts,
                 json!({
                             "ip": self.ip,
@@ -3949,7 +3954,7 @@ impl Connection {
             false
         } else if time == failure.0 && failure.1 > 6 {
             self.send_login_error("Please try 1 minute later").await;
-            Self::post_alarm_audit(
+            self.post_alarm_audit(
                 AlarmAuditType::SixAttemptsWithinOneMinute,
                 json!({
                             "ip": self.ip,
@@ -5490,6 +5495,7 @@ fn try_activate_screen() {
     });
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum AlarmAuditType {
     IpWhitelist = 0,
     ExceedThirtyAttempts = 1,


### PR DESCRIPTION
## Summary

Split from #15407 into a **mergeable-now** piece that does **not** depend on `hbb_common` / proto changes.

### What this PR does
- Introduces `ConnectionMeta` and threads it through server/rendezvous connection entry points (currently carries only `control_permissions`, same behavior as before).
- Includes `conn_id` in **file** and **alarm** audit payloads so the API server can correlate audits to a connection.
- Makes `post_alarm_audit` an instance method (needed to attach `conn_id`).
- Derives `Clone, Copy, PartialEq, Eq` on `AlarmAuditType`.

### What this PR does NOT do
- No `ControlledContext` / `conn_audit_token` (that is part 2, needs hbb_common first).
- No submodule changes.

## Why split

#15407 cannot merge cleanly today because:
1. It depends on [rustdesk/hbb_common#559](https://github.com/rustdesk/hbb_common/pull/559) which was **closed without merge**.
2. It temporarily retargets `libs/hbb_common` to a personal fork.

This part 1 delivers the safe refactor + audit correlation improvement immediately.

## Follow-ups

| PR | Depends on hbb_common? | Purpose |
|----|------------------------|---------|
| **This (part 1)** | No | `ConnectionMeta` + `conn_id` in audits |
| [hbb_common ControlledContext](https://github.com/rustdesk/hbb_common/compare/main...harsh-98:hbb_common:add-controlled-context-for-audit) | N/A (is the dep) | Proto types |
| part 2 `pr-15407-part2-controller-audit-token` | **Yes** | Full controller-user audit attribution |

## Test plan

- [ ] Build/CI green (no proto changes)
- [ ] Existing audit flows unchanged except extra `conn_id` field on file/alarm posts
- [ ] Old servers ignoring extra `conn_id` still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connection setup now carries richer per-connection context, improving how access details are tracked across connection types.
  * Audit events now include connection identifiers, making activity tracing more consistent.

* **Bug Fixes**
  * IP whitelist denials now generate alarm audits before the connection is rejected.
  * Several connection backoff and limit-triggered events now record more complete audit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->