### PR TITLE
fix(android): sync input service state with Flutter

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
@@ -8,6 +8,7 @@ package com.carriez.flutter_hbb
 
 import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.GestureDescription
+import android.content.Intent
 import android.graphics.Path
 import android.os.Build
 import android.os.Bundle
@@ -66,6 +67,16 @@ class InputService : AccessibilityService() {
         var ctx: InputService? = null
         val isOpen: Boolean
             get() = ctx != null
+    }
+
+    private fun notifyInputState() {
+        val inputState = isOpen.toString()
+        Handler(Looper.getMainLooper()).post {
+            MainActivity.flutterMethodChannel?.invokeMethod(
+                "on_state_changed",
+                mapOf("name" to "input", "value" to inputState)
+            )
+        }
     }
 
     private val logTag = "input service"
@@ -716,6 +727,7 @@ class InputService : AccessibilityService() {
     override fun onServiceConnected() {
         super.onServiceConnected()
         ctx = this
+        notifyInputState()
         val info = AccessibilityServiceInfo()
         if (Build.VERSION.SDK_INT >= 33) {
             info.flags = FLAG_INPUT_METHOD_EDITOR or FLAG_RETRIEVE_INTERACTIVE_WINDOWS
@@ -734,7 +746,15 @@ class InputService : AccessibilityService() {
 
     override fun onDestroy() {
         ctx = null
+        // Keep this fallback even though onUnbind usually notifies first.
+        notifyInputState()
         super.onDestroy()
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        ctx = null
+        notifyInputState()
+        return super.onUnbind(intent)
     }
 
     override fun onInterrupt() {}

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -200,12 +200,13 @@ class MainActivity : FlutterActivity() {
                 "stop_input" -> {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                         InputService.ctx?.disableSelf()
+                    } else {
+                        InputService.ctx = null
+                        Companion.flutterMethodChannel?.invokeMethod(
+                            "on_state_changed",
+                            mapOf("name" to "input", "value" to InputService.isOpen.toString())
+                        )
                     }
-                    InputService.ctx = null
-                    Companion.flutterMethodChannel?.invokeMethod(
-                        "on_state_changed",
-                        mapOf("name" to "input", "value" to InputService.isOpen.toString())
-                    )
                     result.success(true)
                 }
                 "cancel_notification" -> {


### PR DESCRIPTION
## Summary

- Notify Flutter when the Android accessibility service is connected.
- Notify Flutter when the accessibility service is unbound or destroyed.
- Avoid clearing `InputService.ctx` before Android completes `disableSelf()`.

## Problem

The Input Control switch may not match the actual Android accessibility service
state after enabling and disabling the service multiple times.

`InputService.onServiceConnected()` previously updated `ctx` without notifying
Flutter. Also, `MainActivity` cleared `InputService.ctx` immediately after
calling `disableSelf()`, although disabling an accessibility service is
asynchronous.

This could leave the Flutter UI displaying an outdated state.

## Fix

The accessibility service now reports its actual lifecycle state from:

- `onServiceConnected()`
- `onUnbind()`
- `onDestroy()`

`MainActivity` no longer clears `InputService.ctx` or sends a premature disabled
state after calling `disableSelf()`.

## Testing

Tested on a physical Android 13, API 33, arm64 device.

- Reproduced the issue repeatedly with the original master branch.
- Enabled and disabled Input Control multiple times.
- Enabled and disabled Screen Capture between Input Control operations.
- The issue was no longer reproducible after applying this fix.
- `app:compileDebugKotlin` completed successfully.

Fixes #15418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input mode status tracking by reliably notifying the app when the input service opens or closes, including during disconnect/unbind scenarios.
  * Refined the “stop input” behavior on newer Android versions to prevent stale input state and better synchronize the UI with the current input lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->