### PR TITLE
fix(android): preserve Hangul/CJK jamo composition in soft-keyboard input (#7727)

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -20,6 +20,7 @@ import '../../common/widgets/dialog.dart';
 import '../../common/widgets/remote_input.dart';
 import '../../models/input_model.dart';
 import '../../models/model.dart';
+import '../../models/soft_keyboard_input_utils.dart';
 import '../../models/platform_model.dart';
 import '../../utils/image.dart';
 import '../widgets/dialog.dart';
@@ -286,6 +287,8 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
     var subNewValue = newValue.substring(j + 1);
     var subOldValue = oldValue.substring(j + 1);
 
+    // ponytail: the Android path factors this content-diff out as computeSoftKeyboardEdit() in
+    // models/soft_keyboard_input_utils.dart; kept inline here to avoid touching working iOS code.
     // get common prefix of subNewValue and subOldValue
     var common = 0;
     for (;
@@ -326,43 +329,29 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
   }
 
   void _handleNonIOSSoftKeyboardInput(String newValue) {
-    var oldValue = _value;
+    // Diff by CONTENT, not length: Korean/CJK IMEs mutate the composing syllable in place
+    // (ㅁ→마→만), which keeps the text-field length unchanged. The old length-only diff no-op'd
+    // on equal length and silently dropped every medial/final jamo (issue #7727). The shared
+    // helper backspaces the changed tail then retypes it, which converges regardless.
+    final effectiveOld = clipboardAdjustedOldValue(_value, newValue);
     _value = newValue;
-    if (oldValue.isNotEmpty &&
-        newValue.isNotEmpty &&
-        oldValue[0] == '1' &&
-        newValue[0] != '1') {
-      // clipboard
-      oldValue = '';
+    final edit = computeSoftKeyboardEdit(effectiveOld, newValue);
+    for (var k = 0; k < edit.backspaces; k++) {
+      inputModel.inputKey('VK_BACK');
     }
-    if (newValue.length == oldValue.length) {
-      // ?
-    } else if (newValue.length < oldValue.length) {
-      final char = 'VK_BACK';
-      inputModel.inputKey(char);
+    if (edit.insert.isEmpty) {
+      return;
+    }
+    if (isAutoInsertedBracketPair(effectiveOld, edit.backspaces, edit.insert)) {
+      // can not only input insert[0], because when input ], [ are also auto insert, which cause ] never be input
+      bind.sessionInputString(sessionId: sessionId, value: edit.insert);
+      _openKeyboardUnlocked();
+      return;
+    }
+    if (edit.insert.length > 1) {
+      bind.sessionInputString(sessionId: sessionId, value: edit.insert);
     } else {
-      final content = newValue.substring(oldValue.length);
-      if (content.length > 1) {
-        if (oldValue != '' &&
-            content.length == 2 &&
-            (content == '""' ||
-                content == '()' ||
-                content == '[]' ||
-                content == '<>' ||
-                content == "{}" ||
-                content == '”“' ||
-                content == '《》' ||
-                content == '（）' ||
-                content == '【】')) {
-          // can not only input content[0], because when input ], [ are also auo insert, which cause ] never be input
-          bind.sessionInputString(sessionId: sessionId, value: content);
-          _openKeyboardUnlocked();
-          return;
-        }
-        bind.sessionInputString(sessionId: sessionId, value: content);
-      } else {
-        inputChar(content);
-      }
+      inputChar(edit.insert);
     }
   }
 

--- a/flutter/lib/models/soft_keyboard_input_utils.dart
+++ b/flutter/lib/models/soft_keyboard_input_utils.dart
@@ -1,0 +1,70 @@
+// Pure soft-keyboard text-diff helpers for the Android (non-iOS) controller input path.
+//
+// ponytail: the iOS handler (_handleIOSSoftKeyboardInput, remote_page.dart ~281-318) keeps its
+// own inline copy of this diff; it is intentionally not rewired through here. Touching the
+// already-correct iOS path purely to deduplicate would add regression risk for no behavioral
+// gain. If the diff ever has to change for both platforms, unify then.
+
+/// Computes the edit to push to the remote host given the previous (`oldValue`) and current
+/// (`newValue`) soft-keyboard text-field contents, both seeded with the `'1' * N` sentinel.
+///
+/// Returns the number of `VK_BACK` presses to send (`backspaces`) followed by the literal text
+/// to type (`insert`). Mirrors the iOS algorithm at remote_page.dart ~281-318 (minus the
+/// iOS-only composing-hold). Diffs on CONTENT, not length, so Hangul/CJK in-place composing
+/// mutation (ㅁ→마→만 — same UTF-16 length) is handled instead of silently dropped.
+({int backspaces, String insert}) computeSoftKeyboardEdit(
+    String oldValue, String newValue) {
+  // Align the diff window to the text after the last sentinel '1' in each string.
+  var i = newValue.length - 1;
+  for (; i >= 0 && newValue[i] != '1'; --i) {}
+  var j = oldValue.length - 1;
+  for (; j >= 0 && oldValue[j] != '1'; --j) {}
+  if (i < j) j = i;
+  final subNewValue = newValue.substring(j + 1);
+  final subOldValue = oldValue.substring(j + 1);
+
+  // Longest common prefix of the two windows.
+  var common = 0;
+  for (;
+      common < subOldValue.length &&
+          common < subNewValue.length &&
+          subNewValue[common] == subOldValue[common];
+      ++common) {}
+
+  final insert =
+      subNewValue.length > common ? subNewValue.substring(common) : '';
+  final backspaces = subOldValue.length - common;
+  return (backspaces: backspaces, insert: insert);
+}
+
+/// Reproduces the Android clipboard guard (remote_page.dart ~331-337): when the sentinel-prefixed
+/// buffer is replaced by pasted text (old starts with '1', new does not), treat the old value as
+/// empty so the whole new text is sent.
+///
+/// Both `isNotEmpty` checks are required: `_value` starts empty and seeding the controller text
+/// does not fire `onChanged`, so the first keystroke can arrive with an empty `oldValue`; without
+/// the guards `oldValue[0]` would throw a RangeError.
+String clipboardAdjustedOldValue(String oldValue, String newValue) {
+  if (oldValue.isNotEmpty &&
+      newValue.isNotEmpty &&
+      oldValue[0] == '1' &&
+      newValue[0] != '1') {
+    return '';
+  }
+  return oldValue;
+}
+
+const _autoInsertedBracketPairs = <String>{
+  '""', '()', '[]', '<>', '{}', '”“', '《》', '（）', '【】'
+};
+
+/// True when `insert` is a two-character bracket pair appended (no backspaces) onto a non-empty
+/// buffer — the case where a host editor auto-inserts the closing bracket, so the whole pair must
+/// be sent as a string (sending only the opener lets the host auto-close swallow later input).
+/// Mirrors remote_page.dart ~346-356.
+bool isAutoInsertedBracketPair(
+    String effectiveOldValue, int backspaces, String insert) {
+  return effectiveOldValue != '' &&
+      backspaces == 0 &&
+      _autoInsertedBracketPairs.contains(insert);
+}

--- a/flutter/test/soft_keyboard_input_utils_test.dart
+++ b/flutter/test/soft_keyboard_input_utils_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_hbb/models/soft_keyboard_input_utils.dart';
+
+void main() {
+  group('computeSoftKeyboardEdit', () {
+    test('1 in-place jamo build ㅁ->마 sends backspace+replacement', () {
+      expect(computeSoftKeyboardEdit('1ㅁ', '1마'),
+          (backspaces: 1, insert: '마'));
+    });
+    test('2 in-place jamo build 마->만', () {
+      expect(computeSoftKeyboardEdit('1마', '1만'),
+          (backspaces: 1, insert: '만'));
+    });
+    test('3 new syllable append ㄴ', () {
+      expect(computeSoftKeyboardEdit('1만', '1만ㄴ'),
+          (backspaces: 0, insert: 'ㄴ'));
+    });
+    test('4 syllable build 만ㄴ->만나', () {
+      expect(computeSoftKeyboardEdit('1만ㄴ', '1만나'),
+          (backspaces: 1, insert: '나'));
+    });
+    test('5 first jamo of buffer', () {
+      expect(computeSoftKeyboardEdit('1', '1ㅇ'),
+          (backspaces: 0, insert: 'ㅇ'));
+    });
+    test('6 batchim delete 만->마', () {
+      expect(computeSoftKeyboardEdit('1만', '1마'),
+          (backspaces: 1, insert: '마'));
+    });
+    test('7 multi-unit delete sends N backspaces', () {
+      expect(computeSoftKeyboardEdit('1가나', '1'),
+          (backspaces: 2, insert: ''));
+    });
+    test('8 single delete', () {
+      expect(computeSoftKeyboardEdit('1가', '1'),
+          (backspaces: 1, insert: ''));
+    });
+    test('9 bracket pair append', () {
+      expect(computeSoftKeyboardEdit('1', '1()'),
+          (backspaces: 0, insert: '()'));
+    });
+    test('10 non-pair multi-char append', () {
+      expect(computeSoftKeyboardEdit('1', '1ab'),
+          (backspaces: 0, insert: 'ab'));
+    });
+  });
+
+  group('clipboardAdjustedOldValue', () {
+    test('11 paste replaces sentinel -> empty old', () {
+      expect(clipboardAdjustedOldValue('1111', 'hello'), '');
+    });
+    test('12 normal typing keeps old', () {
+      expect(clipboardAdjustedOldValue('1만', '1마'), '1만');
+    });
+    test('13 empty old does not throw RangeError', () {
+      expect(clipboardAdjustedOldValue('', '1ㅁ'), '');
+    });
+    test('14 empty new does not throw RangeError', () {
+      expect(clipboardAdjustedOldValue('1111', ''), '1111');
+    });
+  });
+
+  group('isAutoInsertedBracketPair', () {
+    test('15 pair appended onto non-empty buffer', () {
+      expect(isAutoInsertedBracketPair('1', 0, '()'), true);
+    });
+    test('16 not a known pair', () {
+      expect(isAutoInsertedBracketPair('1', 0, 'ab'), false);
+    });
+    test('17 empty old (post-clipboard) is not auto-pair', () {
+      expect(isAutoInsertedBracketPair('', 0, '()'), false);
+    });
+    test('18 backspaces present is not a host auto-pair', () {
+      expect(isAutoInsertedBracketPair('1', 1, '()'), false);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Fixes #7727. On Android (as the controller) typing Korean to a remote host, Hangul jamo composition breaks:

- `안녕` arrives as `ㅇㄴ`
- `만나` arrives as `ㅁ나`

Only the **first jamo of each syllable** survives; medial vowels and final consonants (받침) are dropped. Reported on Galaxy phones with both Samsung Keyboard and Gboard.

## Root cause

`_handleNonIOSSoftKeyboardInput` in `flutter/lib/mobile/pages/remote_page.dart` diffed the hidden soft-keyboard text field by **string length** and did nothing when the length was unchanged:

```dart
if (newValue.length == oldValue.length) {
  // ?
}
```

Korean/CJK IMEs mutate the composing syllable **in place** (ㅁ → 마 → 만). Each precomposed Hangul syllable (U+AC00–U+D7A3) and isolated compatibility jamo is a single UTF-16 code unit, so an in-place mutation keeps `String.length` identical → the no-op branch runs → the medial/final jamo are silently dropped. Only a length-increasing transition (the first jamo of a new syllable, an append) ever reaches the host, which is exactly the observed `안녕 → ㅇㄴ` / `만나 → ㅁ나`.

The iOS handler `_handleIOSSoftKeyboardInput` does **not** have this bug — it diffs by content (common prefix → backspace the changed tail → retype).

## Fix

Factor the iOS content-diff into a small pure helper and route the Android handler through it. The mechanism is *backspace-the-changed-tail then retype*, which converges to the correct host text regardless of whether Android reports a composing range.

- **New** `flutter/lib/models/soft_keyboard_input_utils.dart` — pure `computeSoftKeyboardEdit(old, new)` plus the clipboard-guard and bracket-auto-pair helpers, so the Android-specific behaviour is preserved.
- `_handleNonIOSSoftKeyboardInput` rewired to it. The **iOS handler is left untouched** (only a one-line breadcrumb comment), so there is no iOS regression surface.
- This also fixes a secondary bug: a multi-unit delete previously emitted only a single `VK_BACK`; it now emits one per removed code unit.

## Tests

`flutter/test/soft_keyboard_input_utils_test.dart` — 18 pure unit tests covering: in-place jamo build-up (ㅁ→마→만, 안녕), 받침 delete, multi-unit delete, clipboard paste, bracket auto-pair, and empty-input safety. All pass (`flutter test test/soft_keyboard_input_utils_test.dart`).

## Notes

- PR #9769 addressed a **different** path — the physical-key `usbHidUsage` handling for Backspace/Enter in `input_model.dart` — and did not touch this soft-keyboard composing path, which is why #7727 stayed open.
- Scope is the Flutter mobile client only; no Rust/native/host-injection changes.

## Verification status (honest)

I have automated unit coverage of the diff logic, but I have **not** yet been able to validate on a physical Galaxy device against a live Windows host. I would appreciate a maintainer or the original reporter confirming on-device behaviour, in particular:

- Samsung Korean QWERTY **and** 천지인/Chunjiin 12-key layouts
- whether `_textController.value.isComposingRangeValid` is actually populated during composition on Android (if so, an optional flicker-reducing composing-hold could be added as a follow-up; this PR deliberately does not depend on it)

Marking as draft until on-device confirmation; happy to adjust per maintainer preference (e.g. routing the iOS handler through the shared helper too, if you'd rather unify them).
