### PR TITLE
feat: add direct domain access support

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1587,6 +1587,7 @@ bool option2bool(String option, String value) {
   } else if (option.startsWith("allow-") ||
       option == kOptionStopService ||
       option == kOptionDirectServer ||
+      option == kOptionDirectDomain ||
       option == kOptionForceAlwaysRelay) {
     res = value == "Y";
   } else {
@@ -1605,6 +1606,7 @@ String bool2option(String option, bool b) {
   } else if (option.startsWith('allow-') ||
       option == kOptionStopService ||
       option == kOptionDirectServer ||
+      option == kOptionDirectDomain ||
       option == kOptionForceAlwaysRelay) {
     res = b ? 'Y' : defaultOptionNo;
   } else {

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -98,6 +98,7 @@ const String kOptionWhitelist = "whitelist";
 const String kOptionEnableAbr = "enable-abr";
 const String kOptionEnableRecordSession = "enable-record-session";
 const String kOptionDirectServer = "direct-server";
+const String kOptionDirectDomain = "direct-domain";
 const String kOptionDirectAccessPort = "direct-access-port";
 const String kOptionAllowAutoDisconnect = "allow-auto-disconnect";
 const String kOptionAutoDisconnectTimeout = "auto-disconnect-timeout";

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1343,6 +1343,8 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
     return [
       _OptionCheckBox(context, 'Enable direct IP access', kOptionDirectServer,
           update: update, enabled: !locked),
+      _OptionCheckBox(context, 'Enable direct domain access', kOptionDirectDomain,
+          update: update, enabled: !locked),
       () {
         // Simple temp wrapper for PR check
         tmpWrapper() {

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -79,6 +79,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
   var _denyLANDiscovery = false;
   var _onlyWhiteList = false;
   var _enableDirectIPAccess = false;
+  var _enableDirectDomainAccess = false;
   var _enableRecordSession = false;
   var _enableHardwareCodec = false;
   var _allowWebSocket = false;
@@ -111,6 +112,8 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
     _onlyWhiteList = whitelistNotEmpty();
     _enableDirectIPAccess = option2bool(
         kOptionDirectServer, bind.mainGetOptionSync(key: kOptionDirectServer));
+    _enableDirectDomainAccess = option2bool(
+        kOptionDirectDomain, bind.mainGetOptionSync(key: kOptionDirectDomain));
     _enableRecordSession = option2bool(kOptionEnableRecordSession,
         bind.mainGetOptionSync(key: kOptionEnableRecordSession));
     _enableHardwareCodec = option2bool(kOptionEnableHwcodec,
@@ -471,6 +474,20 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
                     bool2option(kOptionDirectServer, _enableDirectIPAccess);
                 await bind.mainSetOption(
                     key: kOptionDirectServer, value: value);
+                setState(() {});
+              },
+      ),
+      SettingsTile.switchTile(
+        title: Text(translate("Enable direct domain access")),
+        initialValue: _enableDirectDomainAccess,
+        onToggle: isOptionFixed(kOptionDirectDomain)
+            ? null
+            : (_) async {
+                _enableDirectDomainAccess = !_enableDirectDomainAccess;
+                String value =
+                    bool2option(kOptionDirectDomain, _enableDirectDomainAccess);
+                await bind.mainSetOption(
+                    key: kOptionDirectDomain, value: value);
                 setState(() {});
               },
       ),

--- a/src/client.rs
+++ b/src/client.rs
@@ -270,11 +270,37 @@ impl Client {
                 false,
             ));
         }
-        // Allow connect to {domain}:{port}
-        if hbb_common::is_domain_port_str(peer) {
+        let is_domain = hbb_common::is_domain_str(peer);
+        let is_domain_port = hbb_common::is_domain_port_str(peer);
+        if (is_domain || is_domain_port)
+            && hbb_common::config::option2bool(
+                hbb_common::config::keys::OPTION_DIRECT_DOMAIN,
+                &hbb_common::config::Config::get_option(
+                    hbb_common::config::keys::OPTION_DIRECT_DOMAIN,
+                ),
+            )
+        {
+            let target = if is_domain {
+                check_port(peer, RELAY_PORT + 1)
+            } else {
+                peer.to_string()
+            };
+            let mut resolved_ip = "".to_string();
+            if let Ok(mut addrs) = tokio::net::lookup_host(&target).await {
+                if let Some(addr) = addrs.next() {
+                    resolved_ip = format!("{}:{}", addr.ip(), addr.port());
+                }
+            }
+            if resolved_ip.is_empty() {
+                bail!("Failed to resolve domain");
+            }
+            
+            interface.get_lch().write().unwrap().resolved_id = Some(resolved_ip.clone());
+
             return Ok((
                 (
-                    connect_tcp_local(peer, None, CONNECT_TIMEOUT).await?,
+                    connect_tcp_local(resolved_ip, None, CONNECT_TIMEOUT)
+                        .await?,
                     true,
                     None,
                     None,
@@ -1731,6 +1757,7 @@ struct ConnToken {
 #[derive(Default)]
 pub struct LoginConfigHandler {
     id: String,
+    pub resolved_id: Option<String>,
     pub conn_type: ConnType,
     pub is_terminal_admin: bool,
     hash: Hash,
@@ -2656,7 +2683,8 @@ impl LoginConfigHandler {
             let server = Config::get_rendezvous_server();
             (format!("{my_id}@{server}"), id.clone())
         } else {
-            (my_id, self.id.clone())
+            let current_id = self.resolved_id.clone().unwrap_or_else(|| self.id.clone());
+            (my_id, current_id)
         };
         let mut avatar = get_builtin_option(keys::OPTION_AVATAR);
         if avatar.is_empty() {

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -189,6 +189,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable RDP session sharing", "允许 RDP 会话共享"),
         ("Auto Login", "自动登录（设置断开后锁定才有效）"),
         ("Enable direct IP access", "允许 IP 直接访问"),
+        ("Enable direct domain access", "允许域名直接访问"),
+        ("Direct Domain Access", "域名直接访问"),
         ("Rename", "重命名"),
         ("Space", "空格"),
         ("Create desktop shortcut", "创建桌面快捷方式"),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -189,6 +189,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable RDP session sharing", ""),
         ("Auto Login", ""),
         ("Enable direct IP access", ""),
+        ("Enable direct domain access", ""),
         ("Rename", ""),
         ("Space", ""),
         ("Create desktop shortcut", ""),


### PR DESCRIPTION
Enable direct domain access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “direct domain access” setting on desktop and mobile.
  * Domain-based connections can now use direct access when enabled.
  * Added support for saving and restoring this setting across the app.
* **Bug Fixes**
  * Improved handling of domain connection details during sign-in and connection setup.
* **Documentation / Localization**
  * Added translations for the new setting in Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->