### PR TITLE
Fix input control state not updating after accessibility service changes

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
@@ -26,6 +26,7 @@ import android.accessibilityservice.AccessibilityServiceInfo
 import android.accessibilityservice.AccessibilityServiceInfo.FLAG_INPUT_METHOD_EDITOR
 import android.accessibilityservice.AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
 import android.view.inputmethod.EditorInfo
+import android.content.Intent
 import androidx.annotation.RequiresApi
 import java.util.*
 import java.lang.Character
@@ -34,6 +35,8 @@ import kotlin.math.max
 import hbb.MessageOuterClass.KeyEvent
 import hbb.MessageOuterClass.KeyboardMode
 import hbb.KeyEventConverter
+import com.carriez.flutter_hbb.MainActivity
+import io.flutter.plugin.common.MethodChannel
 
 // const val BUTTON_UP = 2
 // const val BUTTON_BACK = 0x08
@@ -730,6 +733,15 @@ class InputService : AccessibilityService() {
         val layout = fakeEditTextForTextStateCalculation?.getLayout()
         Log.d(logTag, "fakeEditTextForTextStateCalculation layout:$layout")
         Log.d(logTag, "onServiceConnected!")
+        // Notify Flutter that input service is connected
+        MainActivity.flutterMethodChannel?.invokeMethod("on_state_changed", mapOf("name" to "input", "value" to true.toString()))
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        ctx = null
+        // Notify Flutter that input service is disconnected
+        MainActivity.flutterMethodChannel?.invokeMethod("on_state_changed", mapOf("name" to "input", "value" to false.toString()))
+        return super.onUnbind(intent)
     }
 
     override fun onDestroy() {

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
@@ -94,6 +94,13 @@ class InputService : AccessibilityService() {
 
     private val volumeController: VolumeController by lazy { VolumeController(applicationContext.getSystemService(AUDIO_SERVICE) as AudioManager) }
 
+    /**
+     * Handles mouse input events from the remote desktop session.
+     *
+     * @param mask Bitmask indicating which mouse buttons/buttons changed state
+     * @param _x X coordinate of mouse pointer
+     * @param _y Y coordinate of mouse pointer
+     */
     @RequiresApi(Build.VERSION_CODES.N)
     fun onMouseInput(mask: Int, _x: Int, _y: Int) {
         val x = max(0, _x)
@@ -214,6 +221,13 @@ class InputService : AccessibilityService() {
         }
     }
 
+    /**
+     * Handles touch input events from the remote desktop session.
+     *
+     * @param mask Bitmask indicating touch gesture type
+     * @param _x X coordinate of touch point
+     * @param _y Y coordinate of touch point
+     */
     @RequiresApi(Build.VERSION_CODES.N)
     fun onTouchInput(mask: Int, _x: Int, _y: Int) {
         when (mask) {
@@ -716,6 +730,10 @@ class InputService : AccessibilityService() {
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
     }
 
+    /**
+     * Called when the accessibility service is connected.
+     * Sets up the service context and notifies Flutter of connection state.
+     */
     override fun onServiceConnected() {
         super.onServiceConnected()
         ctx = this
@@ -737,6 +755,13 @@ class InputService : AccessibilityService() {
         MainActivity.flutterMethodChannel?.invokeMethod("on_state_changed", mapOf("name" to "input", "value" to true.toString()))
     }
 
+    /**
+     * Called when the accessibility service is unbound from a client.
+     * Clears the service context and notifies Flutter of disconnection.
+     *
+     * @param intent The Intent that was used to bind to this service
+     * @return Boolean indicating whether uncached state should be retained
+     */
     override fun onUnbind(intent: Intent?): Boolean {
         ctx = null
         // Notify Flutter that input service is disconnected

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/InputService.kt
@@ -101,8 +101,15 @@ class InputService : AccessibilityService() {
      * @param _x X coordinate of mouse pointer
      * @param _y Y coordinate of mouse pointer
      */
-    @RequiresApi(Build.VERSION_CODES.N)
-    fun onMouseInput(mask: Int, _x: Int, _y: Int) {
+    /**
+ * Handles mouse input events from the remote desktop session.
+ *
+ * @param mask Bitmask indicating which mouse buttons/buttons changed state
+ * @param _x X coordinate of mouse pointer
+ * @param _y Y coordinate of mouse pointer
+ */
+@RequiresApi(Build.VERSION_CODES.N)
+fun onMouseInput(mask: Int, _x: Int, _y: Int) {
         val x = max(0, _x)
         val y = max(0, _y)
 
@@ -399,6 +406,11 @@ class InputService : AccessibilityService() {
         }
     }
 
+    /**
+     * Handles key events from the remote desktop session.
+     *
+     * @param data ByteArray containing the key event data
+     */
     @RequiresApi(Build.VERSION_CODES.N)
     fun onKeyEvent(data: ByteArray) {
         val keyEvent = KeyEvent.parseFrom(data)
@@ -688,6 +700,12 @@ class InputService : AccessibilityService() {
         return success
     }
 
+    /**
+     * Updates the text of an accessibility node.
+     *
+     * @param node The accessibility node to update
+     * @return True if the text was successfully updated, false otherwise
+     */
     fun updateTextForAccessibilityNode(node: AccessibilityNodeInfo): Boolean {
         var success = false
         this.fakeEditTextForTextStateCalculation?.text?.let {
@@ -701,7 +719,13 @@ class InputService : AccessibilityService() {
         return success
     }
 
-    fun updateTextAndSelectionForAccessibiltyNode(node: AccessibilityNodeInfo): Boolean {
+    /**
+ * Updates the text and selection of an accessibility node.
+ *
+ * @param node The accessibility node to update
+ * @return True if the update was successful, false otherwise
+ */
+fun updateTextAndSelectionForAccessibiltyNode(node: AccessibilityNodeInfo): Boolean {
         var success = updateTextForAccessibilityNode(node)
 
         if (success) {
@@ -769,8 +793,14 @@ class InputService : AccessibilityService() {
         return super.onUnbind(intent)
     }
 
+    /**
+     * Called when the accessibility service is being destroyed.
+     * Cleans up resources and notifies Flutter of disconnection.
+     */
     override fun onDestroy() {
         ctx = null
+        // Notify Flutter that input service is disconnected
+        MainActivity.flutterMethodChannel?.invokeMethod("on_state_changed", mapOf("name" to "input", "value" to false.toString()))
         super.onDestroy()
     }
 

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -201,11 +201,7 @@ class MainActivity : FlutterActivity() {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                         InputService.ctx?.disableSelf()
                     }
-                    InputService.ctx = null
-                    Companion.flutterMethodChannel?.invokeMethod(
-                        "on_state_changed",
-                        mapOf("name" to "input", "value" to InputService.isOpen.toString())
-                    )
+                    // Do not manually set ctx to null or update UI here; let the service lifecycle handle it.
                     result.success(true)
                 }
                 "cancel_notification" -> {

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -197,6 +197,9 @@ class MainActivity : FlutterActivity() {
                     )
                     result.success(true)
                 }
+                // Handles the stop_input method call from Flutter
+                // Requests the input service to disable itself, but lets the service lifecycle
+                // handle the actual state updates to avoid race conditions
                 "stop_input" -> {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                         InputService.ctx?.disableSelf()


### PR DESCRIPTION
Fixes issue where Android input control status is not updated after accessibility service changes.

- Have InputService notify Flutter on service connect/disconnect via onServiceConnected and onUnbind.
- Remove manual ctx = null and UI update from MainActivity.stop_input to avoid race condition.
- This ensures the UI reflects the actual service state.

Fixes rustdesk/rustdesk#15418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input status updates: the app now informs Flutter when the Android input service connects and disconnects.
  * Prevented stale connection indicators by sending a consistent “input true/false” state tied to the service lifecycle.
  * Updated “stop input” behavior to only disable the service on Android N+ and rely on lifecycle events to clear state.
  * Enhanced accessibility text/selection handling documentation for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->