### PR TITLE
fix(update): msi, norestart

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3648,7 +3648,7 @@ pub fn update_to(file: &str) -> ResultType<()> {
 //    We need also to handle the command line parsing to find the tray processes.
 pub fn update_me_msi(msi: &str, quiet: bool) -> ResultType<()> {
     let cmds = format!(
-        "chcp 65001 && msiexec /i {msi} {}",
+        "chcp 65001 && msiexec /i {msi} {} REBOOT=ReallySuppress /norestart",
         if quiet { "/qn LAUNCH_TRAY_APP=N" } else { "" }
     );
     run_cmds(cmds, false, "update-msi")?;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3647,10 +3647,9 @@ pub fn update_to(file: &str) -> ResultType<()> {
 //    `1` and `3` must be done in custom actions.
 //    We need also to handle the command line parsing to find the tray processes.
 pub fn update_me_msi(msi: &str, quiet: bool) -> ResultType<()> {
-    let cmds = format!(
-        "chcp 65001 && msiexec /i {msi} {} REBOOT=ReallySuppress /norestart",
-        if quiet { "/qn LAUNCH_TRAY_APP=N" } else { "" }
-    );
+    let quiet_args = if quiet { " /qn LAUNCH_TRAY_APP=N" } else { "" };
+    let cmds =
+        format!("chcp 65001 && msiexec /i \"{msi}\"{quiet_args} REBOOT=ReallySuppress /norestart");
     run_cmds(cmds, false, "update-msi")?;
     Ok(())
 }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/15436

Note: The custom client update does not update via `msiexec`.

## Testing

Manually update via `msiexec`

`msiexec /i "D:\downloads\rustdesk-1.4.8-x86_64.msi" REBOOT=ReallySuppress /norestart`

`msiexec /i "D:\downloads\rustdesk-1.4.8-x86_64.msi" REBOOT=ReallySuppress /norestart /qn LAUNCH_TRAY_APP=N`

`msiexec /i "D:\downloads\rustdesk-1.4.8-x86_64.msi" /qn LAUNCH_TRAY_APP=N` REBOOT=ReallySuppress /norestart 

- [x] Auto update on Windows Server 2022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows MSI installation handling by properly quoting the installer path.
  * Added reboot-suppression options so installations are less likely to trigger an automatic restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->