### PR TITLE
Feature: Restore the last viewed monitor on auto reconnect

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3353,6 +3353,7 @@ openMonitorInTheSameTab(int i, FFI ffi, PeerInfo pi,
     {bool updateCursorPos = true, bool recordSelection = true}) {
   if (recordSelection) {
     ffi.ffiModel.lastUserDisplay = i;
+    ffi.ffiModel.cancelPendingRestoreTimer();
     ffi.ffiModel.pendingMonitorRestore = null;
   }
   final displays = i == kAllDisplayValue

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3350,8 +3350,10 @@ Future<List<Rect>> getScreenRectList() async {
 }
 
 openMonitorInTheSameTab(int i, FFI ffi, PeerInfo pi,
-    {bool updateCursorPos = true}) {
-  ffi.ffiModel.lastUserDisplay = i;
+    {bool updateCursorPos = true, bool recordSelection = true}) {
+  if (recordSelection) {
+    ffi.ffiModel.lastUserDisplay = i;
+  }
   final displays = i == kAllDisplayValue
       ? List.generate(pi.displays.length, (index) => index)
       : [i];

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3353,6 +3353,7 @@ openMonitorInTheSameTab(int i, FFI ffi, PeerInfo pi,
     {bool updateCursorPos = true, bool recordSelection = true}) {
   if (recordSelection) {
     ffi.ffiModel.lastUserDisplay = i;
+    ffi.ffiModel.pendingMonitorRestore = null;
   }
   final displays = i == kAllDisplayValue
       ? List.generate(pi.displays.length, (index) => index)

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3351,6 +3351,7 @@ Future<List<Rect>> getScreenRectList() async {
 
 openMonitorInTheSameTab(int i, FFI ffi, PeerInfo pi,
     {bool updateCursorPos = true}) {
+  ffi.ffiModel.lastUserDisplay = i;
   final displays = i == kAllDisplayValue
       ? List.generate(pi.displays.length, (index) => index)
       : [i];

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -112,6 +112,7 @@ class CachedPeerData {
 class FfiModel with ChangeNotifier {
   CachedPeerData cachedPeerData = CachedPeerData();
   PeerInfo _pi = PeerInfo();
+  int? lastUserDisplay;
   Rect? _rect;
 
   var _inputBlocked = false;
@@ -1400,6 +1401,18 @@ class FfiModel with ChangeNotifier {
       if (_pi.currentDisplay < _pi.displays.length) {
         // now replaced to _updateCurDisplay
         updateCurDisplay(sessionId);
+      }
+      // After an auto reconnect, return to the monitor the user last chose.
+      final last = lastUserDisplay;
+      if (!isCache &&
+          last != null &&
+          last != _pi.currentDisplay &&
+          bind.sessionGetUseAllMyDisplaysForTheRemoteSession(
+                  sessionId: sessionId) !=
+              'Y' &&
+          (last == kAllDisplayValue ||
+              (last >= 0 && last < _pi.displays.length))) {
+        openMonitorInTheSameTab(last, parent.target!, _pi);
       }
       if (displays.isNotEmpty) {
         _reconnects = 1;

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -114,6 +114,7 @@ class FfiModel with ChangeNotifier {
   PeerInfo _pi = PeerInfo();
   int? lastUserDisplay;
   int? pendingMonitorRestore;
+  Timer? _pendingRestoreTimer;
   Rect? _rect;
 
   var _inputBlocked = false;
@@ -251,7 +252,7 @@ class FfiModel with ChangeNotifier {
   clear() {
     _pi = PeerInfo();
     lastUserDisplay = null;
-    pendingMonitorRestore = null;
+    _cancelPendingMonitorRestore();
     _secure = null;
     _direct = null;
     _inputBlocked = false;
@@ -936,6 +937,7 @@ class FfiModel with ChangeNotifier {
       // frame briefly, then shows the Connecting overlay.
       if (_restartReconnectDelayTimer == null) {
         parent.target?.inputModel.setRelativeMouseMode(false);
+        _cancelPendingMonitorRestore();
         bind.sessionReconnect(sessionId: sessionId, forceRelay: false);
         clearPermissions();
         // Retry once more after the silent window so restart reconnect attempts
@@ -1088,10 +1090,17 @@ class FfiModel with ChangeNotifier {
     }
   }
 
+  void _cancelPendingMonitorRestore() {
+    _pendingRestoreTimer?.cancel();
+    _pendingRestoreTimer = null;
+    pendingMonitorRestore = null;
+  }
+
   void reconnect(OverlayDialogManager dialogManager, SessionID sessionId,
       bool forceRelay) {
     // Disable relative mouse mode before reconnecting to ensure cursor is released.
     parent.target?.inputModel.setRelativeMouseMode(false);
+    _cancelPendingMonitorRestore();
     bind.sessionReconnect(sessionId: sessionId, forceRelay: forceRelay);
     clearPermissions();
     dialogManager.dismissAll();
@@ -1410,7 +1419,7 @@ class FfiModel with ChangeNotifier {
       final last = lastUserDisplay;
       pendingMonitorRestore = (!isCache &&
               last != null &&
-              last != _pi.currentDisplay &&
+              last != currentDisplay &&
               bind.sessionGetUseAllMyDisplaysForTheRemoteSession(
                       sessionId: sessionId) !=
                   'Y' &&
@@ -1418,6 +1427,12 @@ class FfiModel with ChangeNotifier {
                   (last >= 0 && last < _pi.displays.length)))
           ? last
           : null;
+      // Fallback if the first image event never reaches this tab (multi-UI).
+      _pendingRestoreTimer?.cancel();
+      if (pendingMonitorRestore != null) {
+        _pendingRestoreTimer = Timer(const Duration(milliseconds: 1500),
+            () => parent.target?._applyPendingMonitorRestore());
+      }
       if (displays.isNotEmpty) {
         _reconnects = 1;
         _offlineReconnectStartTime = null;
@@ -3936,13 +3951,20 @@ class FFI {
       for (final cb in imageModel.callbacksOnFirstImage) {
         cb(id);
       }
-      // Skip if the session closed while the canvas was being set up.
-      final restore = ffiModel.pendingMonitorRestore;
-      ffiModel.pendingMonitorRestore = null;
-      if (restore != null && !closed) {
-        openMonitorInTheSameTab(restore, this, ffiModel.pi,
-            recordSelection: false);
-      }
+      _applyPendingMonitorRestore();
+    }
+  }
+
+  void _applyPendingMonitorRestore() {
+    final restore = ffiModel.pendingMonitorRestore;
+    ffiModel._cancelPendingMonitorRestore();
+    if (restore == null || closed) return;
+    // The display list may have changed since the restore was queued.
+    final displays = ffiModel.pi.displays;
+    if ((restore == kAllDisplayValue && displays.isNotEmpty) ||
+        (restore >= 0 && restore < displays.length)) {
+      openMonitorInTheSameTab(restore, this, ffiModel.pi,
+          recordSelection: false);
     }
   }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1096,6 +1096,11 @@ class FfiModel with ChangeNotifier {
     pendingMonitorRestore = null;
   }
 
+  void cancelPendingRestoreTimer() {
+    _pendingRestoreTimer?.cancel();
+    _pendingRestoreTimer = null;
+  }
+
   void reconnect(OverlayDialogManager dialogManager, SessionID sessionId,
       bool forceRelay) {
     // Disable relative mouse mode before reconnecting to ensure cursor is released.
@@ -3943,15 +3948,19 @@ class FFI {
     }
     if (ffiModel.waitForFirstImage.value == true) {
       ffiModel.waitForFirstImage.value = false;
+      ffiModel.cancelPendingRestoreTimer();
       ffiModel.resetRestartReconnectState();
       dialogManager.dismissAll();
-      await canvasModel.updateViewStyle();
-      await canvasModel.updateScrollStyle();
-      await canvasModel.initializeEdgeScrollEdgeThickness();
-      for (final cb in imageModel.callbacksOnFirstImage) {
-        cb(id);
+      try {
+        await canvasModel.updateViewStyle();
+        await canvasModel.updateScrollStyle();
+        await canvasModel.initializeEdgeScrollEdgeThickness();
+        for (final cb in imageModel.callbacksOnFirstImage) {
+          cb(id);
+        }
+      } finally {
+        _applyPendingMonitorRestore();
       }
-      _applyPendingMonitorRestore();
     }
   }
 
@@ -3964,7 +3973,7 @@ class FFI {
     if ((restore == kAllDisplayValue && displays.isNotEmpty) ||
         (restore >= 0 && restore < displays.length)) {
       openMonitorInTheSameTab(restore, this, ffiModel.pi,
-          recordSelection: false);
+          recordSelection: false, updateCursorPos: false);
     }
   }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1414,7 +1414,7 @@ class FfiModel with ChangeNotifier {
               bind.sessionGetUseAllMyDisplaysForTheRemoteSession(
                       sessionId: sessionId) !=
                   'Y' &&
-              (last == kAllDisplayValue ||
+              ((last == kAllDisplayValue && _pi.displays.isNotEmpty) ||
                   (last >= 0 && last < _pi.displays.length)))
           ? last
           : null;

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -113,6 +113,7 @@ class FfiModel with ChangeNotifier {
   CachedPeerData cachedPeerData = CachedPeerData();
   PeerInfo _pi = PeerInfo();
   int? lastUserDisplay;
+  int? pendingMonitorRestore;
   Rect? _rect;
 
   var _inputBlocked = false;
@@ -249,6 +250,8 @@ class FfiModel with ChangeNotifier {
 
   clear() {
     _pi = PeerInfo();
+    lastUserDisplay = null;
+    pendingMonitorRestore = null;
     _secure = null;
     _direct = null;
     _inputBlocked = false;
@@ -1402,18 +1405,19 @@ class FfiModel with ChangeNotifier {
         // now replaced to _updateCurDisplay
         updateCurDisplay(sessionId);
       }
-      // After an auto reconnect, return to the monitor the user last chose.
+      // After reconnecting, restore the last selected monitor once the canvas is ready.
+      // Switching earlier can offset the view if the monitor sizes differ.
       final last = lastUserDisplay;
-      if (!isCache &&
-          last != null &&
-          last != _pi.currentDisplay &&
-          bind.sessionGetUseAllMyDisplaysForTheRemoteSession(
-                  sessionId: sessionId) !=
-              'Y' &&
-          (last == kAllDisplayValue ||
-              (last >= 0 && last < _pi.displays.length))) {
-        openMonitorInTheSameTab(last, parent.target!, _pi);
-      }
+      pendingMonitorRestore = (!isCache &&
+              last != null &&
+              last != _pi.currentDisplay &&
+              bind.sessionGetUseAllMyDisplaysForTheRemoteSession(
+                      sessionId: sessionId) !=
+                  'Y' &&
+              (last == kAllDisplayValue ||
+                  (last >= 0 && last < _pi.displays.length)))
+          ? last
+          : null;
       if (displays.isNotEmpty) {
         _reconnects = 1;
         _offlineReconnectStartTime = null;
@@ -3931,6 +3935,13 @@ class FFI {
       await canvasModel.initializeEdgeScrollEdgeThickness();
       for (final cb in imageModel.callbacksOnFirstImage) {
         cb(id);
+      }
+      // Skip if the session closed while the canvas was being set up.
+      final restore = ffiModel.pendingMonitorRestore;
+      ffiModel.pendingMonitorRestore = null;
+      if (restore != null && !closed) {
+        openMonitorInTheSameTab(restore, this, ffiModel.pi,
+            recordSelection: false);
       }
     }
   }


### PR DESCRIPTION
## Summary

Implements the feature requested in [#15352](https://github.com/rustdesk/rustdesk/discussions/15352). Reconnect to the same monitor you were viewing.

### What it does

- Remembers the operator's last manually selected remote monitor (per session).
- After an auto reconnect, it will automatically switch back to that monitor or stay.
- No operation on the first connect and when there was no monitor manually selected.


### Testing

- Switch to a non default monitor then pull the network cable and on auto reconnect it returns to the selected monitor. 
- Verified the restore path is shared by all reconnect types (network drop, manual reconnect).
- It is skipped for the new-window / cached-replay path, and is skipped in "use all my displays" mode.

### Preview

https://private-user-images.githubusercontent.com/35749471/613449086-01f3f5b7-e57d-4030-9046-c71f8e6ddbc0.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODI0OTQ3MDMsIm5iZiI6MTc4MjQ5NDQwMywicGF0aCI6Ii8zNTc0OTQ3MS82MTM0NDkwODYtMDFmM2Y1YjctZTU3ZC00MDMwLTkwNDYtYzcxZjhlNmRkYmMwLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA2MjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNjI2VDE3MjAwM1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTM3ODlmYWM2MmM5MWFlNzQzYzc4YzE4ZjUxODg2NDgzY2I1MTc2YTgwNzU5YzRhYmJmNTEyNjExMjQ1ODVlMmImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT12aWRlbyUyRm1wNCJ9.U23MQhOK8Qx0wl0sGdzxfwKpePX1oW9fo62JYEGQwxk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * The app now remembers your last selected monitor/display. When you reconnect or refresh a session, it automatically attempts to restore that display in the same tab.

* **Bug Fixes**
  * Restoration is more reliable: it defers until initial setup is complete, validates the saved selection against available displays, respects “use all my displays” mode, and avoids restoring if the session closes during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->