### PR TITLE
fix(desktop): align custom scale cursor overlay scaling and pan offsets

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -792,7 +792,9 @@ class _ImagePaintState extends State<ImagePaint> {
                 cursorScale = s * c.devicePixelRatio;
               }
             } else {
-              if (zoomCursor.value || isViewOriginal()) {
+              if (zoomCursor.value ||
+                  isViewOriginal() ||
+                  c.viewStyle.style == kRemoteViewStyleCustom) {
                 cursorScale = s;
               }
             }
@@ -1063,7 +1065,8 @@ class CursorPaint extends StatelessWidget {
 
     double cx = c.x;
     double cy = c.y;
-    if (c.viewStyle.style == kRemoteViewStyleOriginal &&
+    if ((c.viewStyle.style == kRemoteViewStyleOriginal ||
+            c.viewStyle.style == kRemoteViewStyleCustom) &&
         c.scrollStyle == ScrollStyle.scrollbar) {
       final rect = c.parent.target!.ffiModel.rect;
       if (rect == null) {
@@ -1084,8 +1087,10 @@ class CursorPaint extends StatelessWidget {
     double x = (m.x - hotx) * c.scale + cx;
     double y = (m.y - hoty) * c.scale + cy;
     double scale = 1.0;
-    final isViewOriginal = c.viewStyle.style == kRemoteViewStyleOriginal;
-    if (zoomCursor.value || isViewOriginal) {
+    final isViewOriginalOrCustom =
+        c.viewStyle.style == kRemoteViewStyleOriginal ||
+            c.viewStyle.style == kRemoteViewStyleCustom;
+    if (zoomCursor.value || isViewOriginalOrCustom) {
       x = m.x - hotx + cx / c.scale;
       y = m.y - hoty + cy / c.scale;
       scale = c.scale;


### PR DESCRIPTION
This PR resolves display usability and mouse alignment issues when using client-side custom zoom/magnification features in RustDesk.

### Problem
When `Scale custom` style is selected (`kRemoteViewStyleCustom` mode) and the display is zoomed/panned:
1. The remote cursor overlay did not calculate nor apply local scroll offsets `cx` and `cy`, causing it to float at incorrect positions relative to the scrolled viewport.
2. The remote cursor rendered at a constant `1.0` scale, making it tiny and mismatching the zoomed-in host viewport.

### Solution
* **`getCursorScale`**: Enabled custom cursor image scaling by the active zoom factor when `c.viewStyle.style == kRemoteViewStyleCustom`.
* **`CursorPaint` scroll offsets**: Added custom scale checks to compute and apply scroll offsets (`cx`, `cy`) in scrollbar viewports.
* **`CursorPaint` cursor sizing**: Updated pointer coordinates and size scaling to use `c.scale` in custom scale mode, aligning its behavior with `Scale original`.