### PR TITLE
Add authentication details to connection audit

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -247,8 +247,7 @@ enum ConnAuditPrimaryAuth {
     Click = 1,
     TemporaryPassword = 2,
     PermanentPassword = 3,
-    VerifiedInSameSession = 4,
-    SwitchSides = 5,
+    SwitchSides = 4,
 }
 
 impl ConnAuditPrimaryAuth {
@@ -263,7 +262,6 @@ enum ConnAuditTwoFactor {
     None = 0,
     Totp = 1,
     TrustedDevice = 2,
-    VerifiedInSameSession = 3,
 }
 
 impl ConnAuditTwoFactor {
@@ -2327,9 +2325,9 @@ impl Connection {
                     || !tfa && self.validate_password_plain(&session.random_password))
             {
                 if tfa {
-                    self.set_conn_audit_two_factor(ConnAuditTwoFactor::VerifiedInSameSession);
+                    self.set_conn_audit_two_factor(ConnAuditTwoFactor::Totp);
                 } else {
-                    self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::VerifiedInSameSession);
+                    self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::TemporaryPassword);
                 }
                 log::info!("is recent session");
                 return true;

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -246,10 +246,9 @@ enum ConnAuditPrimaryAuth {
     None = 0,
     Click = 1,
     TemporaryPassword = 2,
-    LocalPermanentPassword = 3,
-    PresetPermanentPassword = 4,
-    VerifiedInSameSession = 5,
-    SwitchSides = 6,
+    PermanentPassword = 3,
+    VerifiedInSameSession = 4,
+    SwitchSides = 5,
 }
 
 impl ConnAuditPrimaryAuth {
@@ -2293,7 +2292,7 @@ impl Connection {
                 if local_permanent_password_storage_is_usable_for_auth(&local_storage, &local_salt)
                     && self.validate_password_storage(&local_storage)
                 {
-                    self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::LocalPermanentPassword);
+                    self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::PermanentPassword);
                     print_fallback();
                     return true;
                 }
@@ -2302,7 +2301,7 @@ impl Connection {
                 if preset_permanent_password_storage_is_usable_for_auth(&hard, &salt)
                     && self.validate_preset_password_storage(&hard, &salt)
                 {
-                    self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::PresetPermanentPassword);
+                    self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::PermanentPassword);
                     print_fallback();
                     return true;
                 }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1517,7 +1517,7 @@ impl Connection {
         self.conn_audit_two_factor = two_factor;
     }
 
-    fn normalize_conn_audit_primary_auth(&mut self) {
+    fn normalize_conn_audit_auth_fields(&mut self) {
         if matches!(
             self.conn_audit_primary_auth,
             ConnAuditPrimaryAuth::Click | ConnAuditPrimaryAuth::SwitchSides
@@ -1649,7 +1649,7 @@ impl Connection {
             .unwrap()
             .get(&self.session_key())
             .map(|s| s.last_recv_time.clone());
-        self.normalize_conn_audit_primary_auth();
+        self.normalize_conn_audit_auth_fields();
         let mut audit = json!({"peer": ((&self.lr.my_id, &self.lr.my_name)), "type": conn_type});
         if self.conn_audit_primary_auth != ConnAuditPrimaryAuth::None {
             audit["primary_auth"] = json!(self.conn_audit_primary_auth.as_i64());

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -240,6 +240,39 @@ pub enum AuthConnType {
     Terminal,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(i64)]
+enum ConnAuditPrimaryAuth {
+    None = 0,
+    Click = 1,
+    TemporaryPassword = 2,
+    LocalPermanentPassword = 3,
+    PresetPermanentPassword = 4,
+    VerifiedInSameSession = 5,
+    SwitchSides = 6,
+}
+
+impl ConnAuditPrimaryAuth {
+    fn as_i64(self) -> i64 {
+        self as i64
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(i64)]
+enum ConnAuditTwoFactor {
+    None = 0,
+    Totp = 1,
+    TrustedDevice = 2,
+    VerifiedInSameSession = 3,
+}
+
+impl ConnAuditTwoFactor {
+    fn as_i64(self) -> i64 {
+        self as i64
+    }
+}
+
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 #[derive(Clone, Debug)]
 enum TerminalUserToken {
@@ -345,6 +378,8 @@ pub struct Connection {
     // For post requests that need to be sent sequentially.
     // eg. post_conn_audit
     tx_post_seq: mpsc::UnboundedSender<(String, Value)>,
+    conn_audit_primary_auth: ConnAuditPrimaryAuth,
+    conn_audit_two_factor: ConnAuditTwoFactor,
     // Tracks read job IDs delegated to CM process.
     // When a read job is delegated to CM (via FS::ReadFile), the job id is added here.
     // Used to filter stale responses (FileBlockFromCM, FileReadDone, etc.) for
@@ -542,6 +577,8 @@ impl Connection {
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             terminal_user_token: None,
             terminal_generic_service: None,
+            conn_audit_primary_auth: ConnAuditPrimaryAuth::None,
+            conn_audit_two_factor: ConnAuditTwoFactor::None,
         };
         let addr = hbb_common::try_into_v4(addr);
         if !conn.on_open(addr).await {
@@ -625,6 +662,7 @@ impl Connection {
                 Some(data) = rx_from_cm.recv() => {
                     match data {
                         ipc::Data::Authorize => {
+                            conn.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::Click);
                             conn.require_2fa.take();
                             if !conn.send_logon_response_and_keep_alive().await {
                                 break;
@@ -1471,6 +1509,23 @@ impl Connection {
         crate::post_request(url, v.to_string(), "").await
     }
 
+    fn set_conn_audit_primary_auth(&mut self, method: ConnAuditPrimaryAuth) {
+        self.conn_audit_primary_auth = method;
+    }
+
+    fn set_conn_audit_two_factor(&mut self, two_factor: ConnAuditTwoFactor) {
+        self.conn_audit_two_factor = two_factor;
+    }
+
+    fn normalize_conn_audit_primary_auth(&mut self) {
+        if matches!(
+            self.conn_audit_primary_auth,
+            ConnAuditPrimaryAuth::Click | ConnAuditPrimaryAuth::SwitchSides
+        ) {
+            self.conn_audit_two_factor = ConnAuditTwoFactor::None;
+        }
+    }
+
     fn normalize_port_forward_target(pf: &mut PortForward) -> (String, bool) {
         let mut is_rdp = false;
         if pf.host == "RDP" && pf.port == 0 {
@@ -1594,10 +1649,15 @@ impl Connection {
             .unwrap()
             .get(&self.session_key())
             .map(|s| s.last_recv_time.clone());
-        self.post_conn_audit(json!({
-            "peer": ((&self.lr.my_id, &self.lr.my_name)),
-            "type": conn_type,
-        }));
+        self.normalize_conn_audit_primary_auth();
+        let mut audit = json!({"peer": ((&self.lr.my_id, &self.lr.my_name)), "type": conn_type});
+        if self.conn_audit_primary_auth != ConnAuditPrimaryAuth::None {
+            audit["primary_auth"] = json!(self.conn_audit_primary_auth.as_i64());
+        }
+        if self.conn_audit_two_factor != ConnAuditTwoFactor::None {
+            audit["two_factor"] = json!(self.conn_audit_two_factor.as_i64());
+        }
+        self.post_conn_audit(audit);
         #[allow(unused_mut)]
         let mut username = crate::platform::get_active_username();
         let mut res = LoginResponse::new();
@@ -2209,6 +2269,7 @@ impl Connection {
         if password::temporary_enabled() {
             let password = password::temporary_password();
             if self.validate_password_plain(&password) {
+                self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::TemporaryPassword);
                 raii::AuthedConnID::update_or_insert_session(
                     self.session_key(),
                     Some(password),
@@ -2232,6 +2293,7 @@ impl Connection {
                 if local_permanent_password_storage_is_usable_for_auth(&local_storage, &local_salt)
                     && self.validate_password_storage(&local_storage)
                 {
+                    self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::LocalPermanentPassword);
                     print_fallback();
                     return true;
                 }
@@ -2240,6 +2302,7 @@ impl Connection {
                 if preset_permanent_password_storage_is_usable_for_auth(&hard, &salt)
                     && self.validate_preset_password_storage(&hard, &salt)
                 {
+                    self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::PresetPermanentPassword);
                     print_fallback();
                     return true;
                 }
@@ -2264,6 +2327,11 @@ impl Connection {
                 && (tfa && session.tfa
                     || !tfa && self.validate_password_plain(&session.random_password))
             {
+                if tfa {
+                    self.set_conn_audit_two_factor(ConnAuditTwoFactor::VerifiedInSameSession);
+                } else {
+                    self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::VerifiedInSameSession);
+                }
                 log::info!("is recent session");
                 return true;
             }
@@ -2357,6 +2425,7 @@ impl Connection {
                     && device.platform == lr.my_platform
                 {
                     log::info!("2FA bypassed by trusted devices");
+                    self.set_conn_audit_two_factor(ConnAuditTwoFactor::TrustedDevice);
                     self.require_2fa = None;
                 }
             }
@@ -2649,6 +2718,7 @@ impl Connection {
                     if res {
                         self.update_failure(failure, true, 1);
                         self.require_2fa.take();
+                        self.set_conn_audit_two_factor(ConnAuditTwoFactor::Totp);
                         raii::AuthedConnID::set_session_2fa(self.session_key());
                         if !self.send_logon_response_and_keep_alive().await {
                             return false;
@@ -2704,6 +2774,7 @@ impl Connection {
                     if let Some((_instant, uuid_old)) = uuid_old {
                         if uuid == uuid_old {
                             self.from_switch = true;
+                            self.set_conn_audit_primary_auth(ConnAuditPrimaryAuth::SwitchSides);
                             if !self.send_logon_response_and_keep_alive().await {
                                 return false;
                             }


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk-server-pro/discussions/862

# Summary

Add authentication details to connection audit payloads so the server can show how a connection was authenticated.

# Test

  - [x] Manual checks for all `primary_auth` and `two_factor`.
  - [x] Connect with `Permanent Password`, then start file transfer from the menu -> `Permanent Password`
  - [x] Connect with `One-time Password`, then start file transfer from the menu -> `One-time Password`
  - [x] Start file transfer from the remote menu after an existing `Permanent Password + 2FA Code` connection -> `Permanent Password + 2FA Code`
  - [x] Start file transfer from the remote menu after an existing `One-time Password + 2FA Code` connection -> `One-time Password + 2FA Code`
 - [x] Start file transfer from the remote menu after an existing `Permanent Password + Trusted Device` connection -> `Permanent Password + Trusted Device`
 - [x] Start file transfer from the remote menu after an existing `One-time Password + Trusted Device` connection -> `One-time Password + Trusted Device`

# ScreenShot

<img width="1640" height="586" alt="image" src="https://github.com/user-attachments/assets/81e6a9eb-59b2-45b6-babd-eef62b76e833" />


<img width="744" height="406" alt="image" src="https://github.com/user-attachments/assets/f3e365e3-f60a-4429-9f63-db72c097aa78" />



<img width="626" height="262" alt="image" src="https://github.com/user-attachments/assets/a13b9ffd-a866-4a27-92de-a4fccab7ceb7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in flow auditing across primary authentication and two-factor verification.
  * Connection/session authorization now records which authentication path succeeded more consistently, including password type and trusted-device scenarios.
  * Refined how two-factor status is handled when moving between primary and two-factor steps to avoid inconsistent session state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->