### PR TITLE
fix(scrap): configure AOM/VPX codecs through C shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
+ "log",
+ "prettyplease",
  "proc-macro2 1.0.93",
  "quote 1.0.36",
  "regex",
@@ -7601,8 +7603,9 @@ name = "scrap"
 version = "0.5.0"
 dependencies = [
  "android_logger",
- "bindgen 0.65.1",
+ "bindgen 0.71.1",
  "block",
+ "cc",
  "cfg-if 1.0.0",
  "dbus",
  "docopt",

--- a/libs/scrap/Cargo.toml
+++ b/libs/scrap/Cargo.toml
@@ -48,9 +48,9 @@ quest = "0.3"
 
 [build-dependencies]
 target_build_utils = "0.3"
-bindgen = "0.65"
+bindgen = "0.71.1"
 pkg-config = { version = "0.3.27", optional = true }
-
+cc = "1"
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = { version = "0.9", optional = true }
 tracing = { version = "0.1", optional = true }

--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -6,133 +6,141 @@ use std::{
 
 #[cfg(all(target_os = "linux", feature = "linux-pkg-config"))]
 fn link_pkg_config(name: &str) -> Vec<PathBuf> {
-    // sometimes an override is needed
     let pc_name = match name {
         "libvpx" => "vpx",
         _ => name,
     };
-    let lib = pkg_config::probe_library(pc_name)
-        .expect(format!(
-            "unable to find '{pc_name}' development headers with pkg-config (feature linux-pkg-config is enabled).
-            try installing '{pc_name}-dev' from your system package manager.").as_str());
+
+    let lib = pkg_config::probe_library(pc_name).expect(
+        format!(
+            "unable to find '{pc_name}' development headers with pkg-config \
+             (feature linux-pkg-config is enabled). try installing \
+             '{pc_name}-dev' from your system package manager."
+        )
+        .as_str(),
+    );
 
     lib.include_paths
 }
+
 #[cfg(not(all(target_os = "linux", feature = "linux-pkg-config")))]
 fn link_pkg_config(_name: &str) -> Vec<PathBuf> {
     unimplemented!()
 }
 
-/// Link vcpkg package.
 fn link_vcpkg(mut path: PathBuf, name: &str) -> PathBuf {
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let mut target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    if target_arch == "x86_64" {
-        target_arch = "x64".to_owned();
-    } else if target_arch == "x86" {
-        target_arch = "x86".to_owned();
-    } else if target_arch == "loongarch64" {
-        target_arch = "loongarch64".to_owned();
-    } else if target_arch == "aarch64" {
-        target_arch = "arm64".to_owned();
-    } else {
-        target_arch = "arm".to_owned();
-    }
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let mut target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+
+    target_arch = match target_arch.as_str() {
+        "x86_64" => "x64".to_owned(),
+        "x86" => "x86".to_owned(),
+        "loongarch64" => "loongarch64".to_owned(),
+        "aarch64" => "arm64".to_owned(),
+        _ => "arm".to_owned(),
+    };
+
     let mut target = if target_os == "macos" {
-        if target_arch == "x64" {
-            "x64-osx".to_owned()
-        } else if target_arch == "arm64" {
-            "arm64-osx".to_owned()
-        } else {
-            format!("{}-{}", target_arch, target_os)
+        match target_arch.as_str() {
+            "x64" => "x64-osx".to_owned(),
+            "arm64" => "arm64-osx".to_owned(),
+            _ => format!("{}-{}", target_arch, target_os),
         }
     } else if target_os == "windows" {
         format!("{}-windows-static", target_arch)
     } else {
         format!("{}-{}", target_arch, target_os)
     };
+
     if target_arch == "x86" {
         target = target.replace("x64", "x86");
     }
-    println!("cargo:info={}", target);
-    if let Ok(vcpkg_root) = std::env::var("VCPKG_INSTALLED_ROOT") {
+
+    println!("cargo:warning=vcpkg triplet: {}", target);
+
+    if let Ok(vcpkg_root) = env::var("VCPKG_INSTALLED_ROOT") {
         path = vcpkg_root.into();
     } else {
         path.push("installed");
     }
+
     path.push(target);
+
+    let lib_dir = path.join("lib");
+    let include = path.join("include");
+
     println!(
         "cargo:rustc-link-lib=static={}",
         name.trim_start_matches("lib")
     );
-    println!(
-        "cargo:rustc-link-search={}",
-        path.join("lib").to_str().unwrap()
-    );
-    let include = path.join("include");
-    println!("cargo:include={}", include.to_str().unwrap());
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    println!("cargo:include={}", include.display());
+
     include
 }
 
-/// Link homebrew package(for Mac M1).
 fn link_homebrew_m1(name: &str) -> PathBuf {
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+
     if target_os != "macos" || target_arch != "aarch64" {
-        panic!("Couldn't find VCPKG_ROOT, also can't fallback to homebrew because it's only for macos aarch64.");
-    }
-    let mut path = PathBuf::from("/opt/homebrew/Cellar");
-    path.push(name);
-    let entries = if let Ok(dir) = std::fs::read_dir(&path) {
-        dir
-    } else {
-        panic!("Could not find package in {}. Make sure your homebrew and package {} are all installed.", path.to_str().unwrap(),&name);
-    };
-    let mut directories = entries
-        .into_iter()
-        .filter(|x| x.is_ok())
-        .map(|x| x.unwrap().path())
-        .filter(|x| x.is_dir())
-        .collect::<Vec<_>>();
-    // Find the newest version.
-    directories.sort_unstable();
-    if directories.is_empty() {
         panic!(
-            "There's no installed version of {} in /opt/homebrew/Cellar",
-            name
+            "Couldn't find VCPKG_ROOT, also can't fallback to homebrew \
+             because it's only for macos aarch64."
         );
     }
+
+    let mut path = PathBuf::from("/opt/homebrew/Cellar");
+    path.push(name);
+
+    let entries = fs::read_dir(&path).unwrap_or_else(|_| {
+        panic!(
+            "Could not find package in {}. Make sure homebrew package {} is installed.",
+            path.display(),
+            name
+        )
+    });
+
+    let mut directories = entries
+        .filter_map(Result::ok)
+        .map(|x| x.path())
+        .filter(|x| x.is_dir())
+        .collect::<Vec<_>>();
+
+    directories.sort_unstable();
+
+    if directories.is_empty() {
+        panic!("There's no installed version of {} in /opt/homebrew/Cellar", name);
+    }
+
     path.push(directories.pop().unwrap());
-    // Link the library.
+
     println!(
         "cargo:rustc-link-lib=static={}",
         name.trim_start_matches("lib")
     );
-    // Add the library path.
     println!(
-        "cargo:rustc-link-search={}",
-        path.join("lib").to_str().unwrap()
+        "cargo:rustc-link-search=native={}",
+        path.join("lib").display()
     );
-    // Add the include path.
+
     let include = path.join("include");
-    println!("cargo:include={}", include.to_str().unwrap());
+    println!("cargo:include={}", include.display());
+
     include
 }
 
-/// Find package. By default, it will try to find vcpkg first, then homebrew(currently only for Mac M1).
-/// If building for linux and feature "linux-pkg-config" is enabled, will try to use pkg-config
-/// unless check fails (e.g. NO_PKG_CONFIG_libyuv=1)
 fn find_package(name: &str) -> Vec<PathBuf> {
     let no_pkg_config_var_name = format!("NO_PKG_CONFIG_{name}");
     println!("cargo:rerun-if-env-changed={no_pkg_config_var_name}");
+
     if cfg!(all(target_os = "linux", feature = "linux-pkg-config"))
-        && std::env::var(no_pkg_config_var_name).as_deref() != Ok("1")
+        && env::var(no_pkg_config_var_name).as_deref() != Ok("1")
     {
         link_pkg_config(name)
-    } else if let Ok(vcpkg_root) = std::env::var("VCPKG_ROOT") {
+    } else if let Ok(vcpkg_root) = env::var("VCPKG_ROOT") {
         vec![link_vcpkg(vcpkg_root.into(), name)]
     } else {
-        // Try using homebrew
         vec![link_homebrew_m1(name)]
     }
 }
@@ -151,117 +159,131 @@ fn generate_bindings(
         .allowlist_function(regex)
         .rustified_enum(regex)
         .trust_clang_mangling(false)
-        .layout_tests(false) // breaks 32/64-bit compat
-        .generate_comments(false); // comments have prefix /*!\
+        .layout_tests(false)
+        .generate_comments(false)
+        .clang_arg("-DVPX_CODEC_USE_ENCODER=1")
+        .clang_arg("-DVPX_CODEC_USE_DECODER=1")
+        .clang_arg("-DAOM_CODEC_USE_ENCODER=1")
+        .clang_arg("-DAOM_CODEC_USE_DECODER=1");
 
     for dir in include_paths {
         b = b.clang_arg(format!("-I{}", dir.display()));
     }
 
-    b.generate().unwrap().write_to_file(ffi_rs).unwrap();
-    fs::copy(ffi_rs, exact_file).ok(); // ignore failure
+    if let Some(parent) = ffi_rs.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+
+    if let Some(parent) = exact_file.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+
+    let bindings = b.generate().unwrap_or_else(|err| {
+        panic!(
+            "bindgen failed for header: {}\ninclude paths: {:#?}\nregex: {}\nerror: {:?}",
+            ffi_header.display(),
+            include_paths,
+            regex,
+            err
+        )
+    });
+
+    bindings.write_to_file(ffi_rs).unwrap_or_else(|err| {
+        panic!("failed to write bindings to {}: {:?}", ffi_rs.display(), err)
+    });
+
+    fs::copy(ffi_rs, exact_file).unwrap_or_else(|err| {
+        panic!(
+            "failed to copy bindings from {} to {}: {:?}",
+            ffi_rs.display(),
+            exact_file.display(),
+            err
+        )
+    });
+
+    println!("cargo:warning=generated bindings: {}", ffi_rs.display());
+    println!("cargo:warning=copied bindings: {}", exact_file.display());
 }
 
 fn gen_vcpkg_package(package: &str, ffi_header: &str, generated: &str, regex: &str) {
     let includes = find_package(package);
+
     let src_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap();
     let src_dir = Path::new(&src_dir);
+
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir);
 
     let ffi_header = src_dir.join("src").join("bindings").join(ffi_header);
-    println!("rerun-if-changed={}", ffi_header.display());
+
+    if !ffi_header.exists() {
+        panic!("FFI header does not exist: {}", ffi_header.display());
+    }
+
+    println!("cargo:rerun-if-changed={}", ffi_header.display());
+
     for dir in &includes {
-        println!("rerun-if-changed={}", dir.display());
+        println!("cargo:rerun-if-changed={}", dir.display());
     }
 
     let ffi_rs = out_dir.join(generated);
     let exact_file = src_dir.join("generated").join(generated);
+
     generate_bindings(&ffi_header, &includes, &ffi_rs, &exact_file, regex);
 }
 
-// If you have problems installing ffmpeg, you can download $VCPKG_ROOT/installed from ci
-// Linux require link in hwcodec
-/*
-fn ffmpeg() {
-    // ffmpeg
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let static_libs = vec!["avcodec", "avutil", "avformat"];
-    static_libs.iter().for_each(|lib| {
-        find_package(lib);
-    });
-    if target_os == "windows" {
-        println!("cargo:rustc-link-lib=static=libmfx");
+fn build_codec_cfg_shim() {
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+
+    let mut include_paths = Vec::new();
+    include_paths.extend(find_package("aom"));
+    include_paths.extend(find_package("libvpx"));
+
+    let mut build = cc::Build::new();
+    build.file(
+        manifest_dir
+            .join("src")
+            .join("bindings")
+            .join("codec_cfg_shim.c"),
+    );
+
+    for include in include_paths {
+        build.include(include);
     }
 
-    // os
-    let dyn_libs: Vec<&str> = if target_os == "windows" {
-        ["User32", "bcrypt", "ole32", "advapi32"].to_vec()
-    } else if target_os == "linux" {
-        let mut v = ["va", "va-drm", "va-x11", "vdpau", "X11", "stdc++"].to_vec();
-        if target_arch == "x86_64" {
-            v.push("z");
-        }
-        v
-    } else if target_os == "macos" || target_os == "ios" {
-        ["c++", "m"].to_vec()
-    } else if target_os == "android" {
-        ["z", "m", "android", "atomic"].to_vec()
-    } else {
-        panic!("unsupported os");
-    };
-    dyn_libs
-        .iter()
-        .map(|lib| println!("cargo:rustc-link-lib={}", lib))
-        .count();
-
-    if target_os == "macos" || target_os == "ios" {
-        println!("cargo:rustc-link-lib=framework=CoreFoundation");
-        println!("cargo:rustc-link-lib=framework=CoreVideo");
-        println!("cargo:rustc-link-lib=framework=CoreMedia");
-        println!("cargo:rustc-link-lib=framework=VideoToolbox");
-        println!("cargo:rustc-link-lib=framework=AVFoundation");
-    }
+    build.compile("codec_cfg_shim");
 }
-*/
 
 fn main() {
-    // in this crate, these are also valid configurations
     println!("cargo:rustc-check-cfg=cfg(dxgi,quartz,x11)");
 
-    // there is problem with cfg(target_os) in build.rs, so use our workaround
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
-    // note: all link symbol names in x86 (32-bit) are prefixed wth "_".
-    // run "rustup show" to show current default toolchain, if it is stable-x86-pc-windows-msvc,
-    // please install x64 toolchain by "rustup toolchain install stable-x86_64-pc-windows-msvc",
-    // then set x64 to default by "rustup default stable-x86_64-pc-windows-msvc"
     let target = target_build_utils::TargetInfo::new();
     if target.unwrap().target_pointer_width() != "64" {
         // panic!("Only support 64bit system");
     }
+
     env::remove_var("CARGO_CFG_TARGET_FEATURE");
     env::set_var("CARGO_CFG_TARGET_FEATURE", "crt-static");
 
     find_package("libyuv");
+
     gen_vcpkg_package("libvpx", "vpx_ffi.h", "vpx_ffi.rs", "^[vV].*");
     gen_vcpkg_package("aom", "aom_ffi.h", "aom_ffi.rs", "^(aom|AOM|OBU|AV1).*");
     gen_vcpkg_package("libyuv", "yuv_ffi.h", "yuv_ffi.rs", ".*");
-    // ffmpeg();
+
+    build_codec_cfg_shim();
 
     if target_os == "ios" {
         // nothing
     } else if target_os == "android" {
         println!("cargo:rustc-cfg=android");
     } else if cfg!(windows) {
-        // The first choice is Windows because DXGI is amazing.
         println!("cargo:rustc-cfg=dxgi");
     } else if cfg!(target_os = "macos") {
-        // Quartz is second because macOS is the (annoying) exception.
         println!("cargo:rustc-cfg=quartz");
     } else if cfg!(unix) {
-        // On UNIX we pray that X11 (with XCB) is available.
         println!("cargo:rustc-cfg=x11");
     }
 }

--- a/libs/scrap/src/bindings/codec_cfg_shim.c
+++ b/libs/scrap/src/bindings/codec_cfg_shim.c
@@ -1,0 +1,301 @@
+#include <stdlib.h>
+
+#define AOM_CODEC_USE_ENCODER 1
+#define AOM_CODEC_USE_DECODER 1
+
+#include <aom/aom_encoder.h>
+#include <aom/aom_decoder.h>
+#include <aom/aomcx.h>
+#include <aom/aomdx.h>
+
+#define VPX_CODEC_USE_ENCODER 1
+#define VPX_CODEC_USE_DECODER 1
+
+#include <vpx/vpx_encoder.h>
+#include <vpx/vpx_decoder.h>
+#include <vpx/vp8cx.h>
+#include <vpx/vp8dx.h>
+
+/* AOM encoder/decoder config helpers.
+ *
+ * Keep direct field access to aom_codec_*_cfg_t in C so Rust can treat those
+ * bindgen-generated structs as opaque when newer libclang versions emit them
+ * with only an _address field.
+ */
+aom_codec_err_t rustdesk_aom_enc_cfg_alloc_default(
+    const aom_codec_iface_t* iface,
+    unsigned int usage,
+    aom_codec_enc_cfg_t** out
+) {
+    aom_codec_err_t result;
+
+    if (!out) {
+        return AOM_CODEC_INVALID_PARAM;
+    }
+
+    *out = (aom_codec_enc_cfg_t*)calloc(1, sizeof(aom_codec_enc_cfg_t));
+    if (!*out) {
+        return AOM_CODEC_MEM_ERROR;
+    }
+
+    result = aom_codec_enc_config_default(iface, *out, usage);
+    if (result != AOM_CODEC_OK) {
+        free(*out);
+        *out = NULL;
+    }
+
+    return result;
+}
+
+void rustdesk_aom_enc_cfg_free(aom_codec_enc_cfg_t* cfg) {
+    free(cfg);
+}
+
+void rustdesk_aom_enc_cfg_set_basic(
+    aom_codec_enc_cfg_t* c,
+    unsigned int w,
+    unsigned int h,
+    unsigned int threads,
+    unsigned int bitrate,
+    unsigned int timebase_den,
+    unsigned int bit_depth,
+    unsigned int usage_profile,
+    unsigned int lag_in_frames
+) {
+    if (!c) {
+        return;
+    }
+
+    c->g_w = w;
+    c->g_h = h;
+    c->g_threads = threads;
+    c->g_timebase.num = 1;
+    c->g_timebase.den = timebase_den;
+    c->g_input_bit_depth = bit_depth;
+
+    c->rc_target_bitrate = bitrate;
+    c->rc_undershoot_pct = 50;
+    c->rc_overshoot_pct = 50;
+    c->rc_buf_initial_sz = 600;
+    c->rc_buf_optimal_sz = 600;
+    c->rc_buf_sz = 1000;
+
+    c->g_usage = usage_profile;
+    c->g_error_resilient = 0;
+    c->rc_end_usage = AOM_CBR;
+    c->g_pass = AOM_RC_ONE_PASS;
+    c->g_lag_in_frames = lag_in_frames;
+}
+
+void rustdesk_aom_enc_cfg_set_quantizer(
+    aom_codec_enc_cfg_t* c,
+    unsigned int q_min,
+    unsigned int q_max
+) {
+    if (!c) {
+        return;
+    }
+
+    c->rc_min_quantizer = q_min;
+    c->rc_max_quantizer = q_max;
+}
+
+void rustdesk_aom_enc_cfg_set_keyframe(
+    aom_codec_enc_cfg_t* c,
+    unsigned int min_dist,
+    unsigned int max_dist,
+    int disabled
+) {
+    if (!c) {
+        return;
+    }
+
+    if (disabled) {
+        c->kf_mode = AOM_KF_DISABLED;
+    } else {
+        c->kf_min_dist = min_dist;
+        c->kf_max_dist = max_dist;
+    }
+}
+
+void rustdesk_aom_enc_cfg_set_profile(
+    aom_codec_enc_cfg_t* c,
+    unsigned int profile
+) {
+    if (!c) {
+        return;
+    }
+
+    c->g_profile = profile;
+}
+
+unsigned int rustdesk_aom_enc_cfg_get_w(const aom_codec_enc_cfg_t* c) {
+    return c ? c->g_w : 0;
+}
+
+unsigned int rustdesk_aom_enc_cfg_get_h(const aom_codec_enc_cfg_t* c) {
+    return c ? c->g_h : 0;
+}
+
+unsigned int rustdesk_aom_enc_cfg_get_threads(const aom_codec_enc_cfg_t* c) {
+    return c ? c->g_threads : 0;
+}
+
+unsigned int rustdesk_aom_enc_cfg_get_target_bitrate(const aom_codec_enc_cfg_t* c) {
+    return c ? c->rc_target_bitrate : 0;
+}
+
+aom_codec_err_t rustdesk_aom_dec_cfg_alloc(
+    unsigned int threads,
+    unsigned int w,
+    unsigned int h,
+    unsigned int allow_lowbitdepth,
+    aom_codec_dec_cfg_t** out
+) {
+    if (!out) {
+        return AOM_CODEC_INVALID_PARAM;
+    }
+
+    *out = (aom_codec_dec_cfg_t*)calloc(1, sizeof(aom_codec_dec_cfg_t));
+    if (!*out) {
+        return AOM_CODEC_MEM_ERROR;
+    }
+
+    (*out)->threads = threads;
+    (*out)->w = w;
+    (*out)->h = h;
+    (*out)->allow_lowbitdepth = allow_lowbitdepth;
+
+    return AOM_CODEC_OK;
+}
+
+void rustdesk_aom_dec_cfg_free(aom_codec_dec_cfg_t* cfg) {
+    free(cfg);
+}
+
+/* VPX encoder/decoder config helpers. */
+vpx_codec_err_t rustdesk_vpx_enc_cfg_alloc_default(
+    const vpx_codec_iface_t* iface,
+    unsigned int usage,
+    vpx_codec_enc_cfg_t** out
+) {
+    vpx_codec_err_t result;
+
+    if (!out) {
+        return VPX_CODEC_INVALID_PARAM;
+    }
+
+    *out = (vpx_codec_enc_cfg_t*)calloc(1, sizeof(vpx_codec_enc_cfg_t));
+    if (!*out) {
+        return VPX_CODEC_MEM_ERROR;
+    }
+
+    result = vpx_codec_enc_config_default(iface, *out, usage);
+    if (result != VPX_CODEC_OK) {
+        free(*out);
+        *out = NULL;
+    }
+
+    return result;
+}
+
+void rustdesk_vpx_enc_cfg_free(vpx_codec_enc_cfg_t* cfg) {
+    free(cfg);
+}
+
+void rustdesk_vpx_enc_cfg_set_basic(
+    vpx_codec_enc_cfg_t* c,
+    unsigned int w,
+    unsigned int h,
+    unsigned int threads,
+    unsigned int bitrate,
+    unsigned int profile
+) {
+    if (!c) {
+        return;
+    }
+
+    c->g_w = w;
+    c->g_h = h;
+    c->g_timebase.num = 1;
+    c->g_timebase.den = 1000;
+    c->rc_undershoot_pct = 95;
+    c->rc_dropframe_thresh = 25;
+    c->g_threads = threads;
+    c->g_error_resilient = VPX_ERROR_RESILIENT_DEFAULT;
+    c->rc_end_usage = VPX_CBR;
+    c->rc_target_bitrate = bitrate;
+    c->g_profile = profile;
+}
+
+void rustdesk_vpx_enc_cfg_set_quantizer(
+    vpx_codec_enc_cfg_t* c,
+    unsigned int q_min,
+    unsigned int q_max
+) {
+    if (!c) {
+        return;
+    }
+
+    c->rc_min_quantizer = q_min;
+    c->rc_max_quantizer = q_max;
+}
+
+void rustdesk_vpx_enc_cfg_set_keyframe(
+    vpx_codec_enc_cfg_t* c,
+    unsigned int min_dist,
+    unsigned int max_dist,
+    int disabled
+) {
+    if (!c) {
+        return;
+    }
+
+    if (disabled) {
+        c->kf_mode = VPX_KF_DISABLED;
+    } else {
+        c->kf_min_dist = min_dist;
+        c->kf_max_dist = max_dist;
+    }
+}
+
+void rustdesk_vpx_enc_cfg_set_target_bitrate(
+    vpx_codec_enc_cfg_t* c,
+    unsigned int bitrate
+) {
+    if (!c) {
+        return;
+    }
+
+    c->rc_target_bitrate = bitrate;
+}
+
+unsigned int rustdesk_vpx_enc_cfg_get_target_bitrate(const vpx_codec_enc_cfg_t* c) {
+    return c ? c->rc_target_bitrate : 0;
+}
+
+vpx_codec_err_t rustdesk_vpx_dec_cfg_alloc(
+    unsigned int threads,
+    unsigned int w,
+    unsigned int h,
+    vpx_codec_dec_cfg_t** out
+) {
+    if (!out) {
+        return VPX_CODEC_INVALID_PARAM;
+    }
+
+    *out = (vpx_codec_dec_cfg_t*)calloc(1, sizeof(vpx_codec_dec_cfg_t));
+    if (!*out) {
+        return VPX_CODEC_MEM_ERROR;
+    }
+
+    (*out)->threads = threads;
+    (*out)->w = w;
+    (*out)->h = h;
+
+    return VPX_CODEC_OK;
+}
+
+void rustdesk_vpx_dec_cfg_free(vpx_codec_dec_cfg_t* cfg) {
+    free(cfg);
+}

--- a/libs/scrap/src/common/aom.rs
+++ b/libs/scrap/src/common/aom.rs
@@ -13,7 +13,6 @@ use crate::{EncodeInput, EncodeYuvFormat, Pixfmt};
 use hbb_common::{
     anyhow::{anyhow, Context},
     bytes::Bytes,
-    log,
     message_proto::{Chroma, EncodedVideoFrame, EncodedVideoFrames, VideoFrame},
     ResultType,
 };
@@ -23,10 +22,59 @@ generate_call_macro!(call_aom, false);
 generate_call_macro!(call_aom_allow_err, true);
 generate_call_ptr_macro!(call_aom_ptr);
 
-impl Default for aom_codec_enc_cfg_t {
-    fn default() -> Self {
-        unsafe { std::mem::zeroed() }
-    }
+extern "C" {
+    pub fn rustdesk_aom_enc_cfg_alloc_default(
+        iface: *const aom_codec_iface,
+        usage: ::std::os::raw::c_uint,
+        out: *mut *mut aom_codec_enc_cfg_t,
+    ) -> aom_codec_err_t;
+
+    pub fn rustdesk_aom_enc_cfg_free(cfg: *mut aom_codec_enc_cfg_t);
+
+    pub fn rustdesk_aom_enc_cfg_set_basic(
+        c: *mut aom_codec_enc_cfg_t,
+        w: ::std::os::raw::c_uint,
+        h: ::std::os::raw::c_uint,
+        threads: ::std::os::raw::c_uint,
+        bitrate: ::std::os::raw::c_uint,
+        timebase_den: ::std::os::raw::c_uint,
+        bit_depth: ::std::os::raw::c_uint,
+        usage_profile: ::std::os::raw::c_uint,
+        lag_in_frames: ::std::os::raw::c_uint,
+    );
+
+    pub fn rustdesk_aom_enc_cfg_set_quantizer(
+        c: *mut aom_codec_enc_cfg_t,
+        q_min: ::std::os::raw::c_uint,
+        q_max: ::std::os::raw::c_uint,
+    );
+
+    pub fn rustdesk_aom_enc_cfg_set_keyframe(
+        c: *mut aom_codec_enc_cfg_t,
+        min_dist: ::std::os::raw::c_uint,
+        max_dist: ::std::os::raw::c_uint,
+        disabled: ::std::os::raw::c_int,
+    );
+
+    pub fn rustdesk_aom_enc_cfg_set_profile(
+        c: *mut aom_codec_enc_cfg_t,
+        profile: ::std::os::raw::c_uint,
+    );
+
+    pub fn rustdesk_aom_enc_cfg_get_w(c: *const aom_codec_enc_cfg_t) -> ::std::os::raw::c_uint;
+    pub fn rustdesk_aom_enc_cfg_get_h(c: *const aom_codec_enc_cfg_t) -> ::std::os::raw::c_uint;
+    pub fn rustdesk_aom_enc_cfg_get_threads(c: *const aom_codec_enc_cfg_t) -> ::std::os::raw::c_uint;
+    pub fn rustdesk_aom_enc_cfg_get_target_bitrate(c: *const aom_codec_enc_cfg_t) -> ::std::os::raw::c_uint;
+
+    pub fn rustdesk_aom_dec_cfg_alloc(
+        threads: ::std::os::raw::c_uint,
+        w: ::std::os::raw::c_uint,
+        h: ::std::os::raw::c_uint,
+        allow_lowbitdepth: ::std::os::raw::c_uint,
+        out: *mut *mut aom_codec_dec_cfg_t,
+    ) -> aom_codec_err_t;
+
+    pub fn rustdesk_aom_dec_cfg_free(cfg: *mut aom_codec_dec_cfg_t);
 }
 
 impl Default for aom_codec_ctx_t {
@@ -51,25 +99,22 @@ pub struct AomEncoderConfig {
 
 pub struct AomEncoder {
     ctx: aom_codec_ctx_t,
+    cfg: *mut aom_codec_enc_cfg_t,
     width: usize,
     height: usize,
     i444: bool,
     yuvfmt: EncodeYuvFormat,
 }
 
-// https://webrtc.googlesource.com/src/+/refs/heads/main/modules/video_coding/codecs/av1/libaom_av1_encoder.cc
 mod webrtc {
     use super::*;
 
     const kUsageProfile: u32 = AOM_USAGE_REALTIME;
     const kBitDepth: u32 = 8;
-    const kLagInFrames: u32 = 0; // No look ahead.
+    const kLagInFrames: u32 = 0;
     pub(super) const kTimeBaseDen: i64 = 1000;
 
-    // Only positive speeds, range for real-time coding currently is: 6 - 8.
-    // Lower means slower/better quality, higher means fastest/lower quality.
     fn get_cpu_speed(width: u32, height: u32) -> u32 {
-        // aux_config_ = nullptr, kComplexityHigh
         if width * height <= 320 * 180 {
             8
         } else if width * height <= 640 * 360 {
@@ -93,55 +138,64 @@ mod webrtc {
         i: *const aom_codec_iface,
         cfg: AomEncoderConfig,
         i444: bool,
-    ) -> ResultType<aom_codec_enc_cfg> {
-        let mut c = unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
-        call_aom!(aom_codec_enc_config_default(i, &mut c, kUsageProfile));
+    ) -> ResultType<*mut aom_codec_enc_cfg_t> {
+        let mut c: *mut aom_codec_enc_cfg_t = ptr::null_mut();
 
-        // Overwrite default config with input encoder settings & RTC-relevant values.
-        c.g_w = cfg.width;
-        c.g_h = cfg.height;
-        c.g_threads = codec_thread_num(64) as _;
-        c.g_timebase.num = 1;
-        c.g_timebase.den = kTimeBaseDen as _;
-        c.g_input_bit_depth = kBitDepth;
-        if let Some(keyframe_interval) = cfg.keyframe_interval {
-            c.kf_min_dist = 0;
-            c.kf_max_dist = keyframe_interval as _;
-        } else {
-            c.kf_mode = aom_kf_mode::AOM_KF_DISABLED;
+        call_aom!(rustdesk_aom_enc_cfg_alloc_default(
+            i,
+            kUsageProfile,
+            &mut c
+        ));
+
+        if c.is_null() {
+            return Err(anyhow!("aom config allocation returned null"));
         }
-        let (q_min, q_max) = AomEncoder::calc_q_values(cfg.quality);
-        c.rc_min_quantizer = q_min;
-        c.rc_max_quantizer = q_max;
-        c.rc_target_bitrate = AomEncoder::bitrate(cfg.width as _, cfg.height as _, cfg.quality);
-        c.rc_undershoot_pct = 50;
-        c.rc_overshoot_pct = 50;
-        c.rc_buf_initial_sz = 600;
-        c.rc_buf_optimal_sz = 600;
-        c.rc_buf_sz = 1000;
-        c.g_usage = kUsageProfile;
-        c.g_error_resilient = 0;
-        // Low-latency settings.
-        c.rc_end_usage = aom_rc_mode::AOM_CBR; // Constant Bit Rate (CBR) mode
-        c.g_pass = aom_enc_pass::AOM_RC_ONE_PASS; // One-pass rate control
-        c.g_lag_in_frames = kLagInFrames; // No look ahead when lag equals 0.
 
-        // https://aomedia.googlesource.com/aom/+/refs/tags/v3.6.0/av1/common/enums.h#82
-        c.g_profile = if i444 { 1 } else { 0 };
+        let (q_min, q_max) = AomEncoder::calc_q_values(cfg.quality);
+        let bitrate = AomEncoder::bitrate(cfg.width, cfg.height, cfg.quality);
+
+        unsafe {
+            rustdesk_aom_enc_cfg_set_basic(
+                c,
+                cfg.width,
+                cfg.height,
+                codec_thread_num(64) as _,
+                bitrate,
+                kTimeBaseDen as _,
+                kBitDepth,
+                kUsageProfile,
+                kLagInFrames,
+            );
+
+            rustdesk_aom_enc_cfg_set_quantizer(c, q_min, q_max);
+
+            if let Some(keyframe_interval) = cfg.keyframe_interval {
+                rustdesk_aom_enc_cfg_set_keyframe(c, 0, keyframe_interval as _, 0);
+            } else {
+                rustdesk_aom_enc_cfg_set_keyframe(c, 0, 0, 1);
+            }
+
+            rustdesk_aom_enc_cfg_set_profile(c, if i444 { 1 } else { 0 });
+        }
 
         Ok(c)
     }
 
-    pub fn set_controls(ctx: *mut aom_codec_ctx_t, cfg: &aom_codec_enc_cfg) -> ResultType<()> {
+    pub fn set_controls(ctx: *mut aom_codec_ctx_t, cfg: *const aom_codec_enc_cfg_t) -> ResultType<()> {
         use aom_tune_content::*;
         use aome_enc_control_id::*;
+
         macro_rules! call_ctl {
             ($ctx:expr, $av1e:expr, $arg:expr) => {{
                 call_aom_allow_err!(aom_codec_control($ctx, $av1e as i32, $arg));
             }};
         }
 
-        call_ctl!(ctx, AOME_SET_CPUUSED, get_cpu_speed(cfg.g_w, cfg.g_h));
+        let w = unsafe { rustdesk_aom_enc_cfg_get_w(cfg) };
+        let h = unsafe { rustdesk_aom_enc_cfg_get_h(cfg) };
+        let threads = unsafe { rustdesk_aom_enc_cfg_get_threads(cfg) };
+
+        call_ctl!(ctx, AOME_SET_CPUUSED, get_cpu_speed(w, h));
         call_ctl!(ctx, AV1E_SET_ENABLE_CDEF, 1);
         call_ctl!(ctx, AV1E_SET_ENABLE_TPL_MODEL, 0);
         call_ctl!(ctx, AV1E_SET_DELTAQ_MODE, 0);
@@ -151,28 +205,23 @@ mod webrtc {
         call_ctl!(ctx, AV1E_SET_COEFF_COST_UPD_FREQ, 3);
         call_ctl!(ctx, AV1E_SET_MODE_COST_UPD_FREQ, 3);
         call_ctl!(ctx, AV1E_SET_MV_COST_UPD_FREQ, 3);
-        // kScreensharing
         call_ctl!(ctx, AV1E_SET_TUNE_CONTENT, AOM_CONTENT_SCREEN);
         call_ctl!(ctx, AV1E_SET_ENABLE_PALETTE, 1);
-        let tile_set = if cfg.g_threads == 4 && cfg.g_w == 640 && (cfg.g_h == 360 || cfg.g_h == 480)
-        {
+
+        let tile_set = if threads == 4 && w == 640 && (h == 360 || h == 480) {
             AV1E_SET_TILE_ROWS
         } else {
             AV1E_SET_TILE_COLUMNS
         };
-        // Failed on android
-        call_ctl!(ctx, tile_set, (cfg.g_threads as f64 * 1.0f64).log2().ceil());
+
+        call_ctl!(ctx, tile_set, (threads as f64).log2().ceil());
         call_ctl!(ctx, AV1E_SET_ROW_MT, 1);
         call_ctl!(ctx, AV1E_SET_ENABLE_OBMC, 0);
         call_ctl!(ctx, AV1E_SET_NOISE_SENSITIVITY, 0);
         call_ctl!(ctx, AV1E_SET_ENABLE_WARPED_MOTION, 0);
         call_ctl!(ctx, AV1E_SET_ENABLE_GLOBAL_MOTION, 0);
         call_ctl!(ctx, AV1E_SET_ENABLE_REF_FRAME_MVS, 0);
-        call_ctl!(
-            ctx,
-            AV1E_SET_SUPERBLOCK_SIZE,
-            get_super_block_size(cfg.g_w, cfg.g_h, cfg.g_threads)
-        );
+        call_ctl!(ctx, AV1E_SET_SUPERBLOCK_SIZE, get_super_block_size(w, h, threads));
         call_ctl!(ctx, AV1E_SET_ENABLE_CFL_INTRA, 0);
         call_ctl!(ctx, AV1E_SET_ENABLE_SMOOTH_INTRA, 0);
         call_ctl!(ctx, AV1E_SET_ENABLE_ANGLE_DELTA, 0);
@@ -210,18 +259,36 @@ impl EncoderApi for AomEncoder {
                 let c = webrtc::enc_cfg(i, config, i444)?;
 
                 let mut ctx = Default::default();
-                // Flag options: AOM_CODEC_USE_PSNR and AOM_CODEC_USE_HIGHBITDEPTH
                 let flags: aom_codec_flags_t = 0;
-                call_aom!(aom_codec_enc_init_ver(
-                    &mut ctx,
-                    i,
-                    &c,
-                    flags,
-                    AOM_ENCODER_ABI_VERSION as _
-                ));
-                webrtc::set_controls(&mut ctx, &c)?;
+
+                let init_result = unsafe {
+                    aom_codec_enc_init_ver(
+                        &mut ctx,
+                        i,
+                        c,
+                        flags,
+                        AOM_ENCODER_ABI_VERSION as _,
+                    )
+                };
+
+                if init_result != aom_codec_err_t::AOM_CODEC_OK {
+                    unsafe {
+                        rustdesk_aom_enc_cfg_free(c);
+                    }
+                    call_aom!(init_result);
+                }
+
+                if let Err(err) = webrtc::set_controls(&mut ctx, c) {
+                    unsafe {
+                        let _ = aom_codec_destroy(&mut ctx);
+                        rustdesk_aom_enc_cfg_free(c);
+                    }
+                    return Err(err);
+                }
+
                 Ok(Self {
                     ctx,
+                    cfg: c,
                     width: config.width as _,
                     height: config.height as _,
                     i444,
@@ -240,14 +307,14 @@ impl EncoderApi for AomEncoder {
         {
             frames.push(Self::create_frame(frame));
         }
-        if frames.len() > 0 {
+        if !frames.is_empty() {
             Ok(Self::create_video_frame(frames))
         } else {
             Err(anyhow!("no valid frame"))
         }
     }
 
-    fn yuvfmt(&self) -> crate::EncodeYuvFormat {
+    fn yuvfmt(&self) -> EncodeYuvFormat {
         self.yuvfmt.clone()
     }
 
@@ -257,18 +324,30 @@ impl EncoderApi for AomEncoder {
     }
 
     fn set_quality(&mut self, ratio: f32) -> ResultType<()> {
-        let mut c = unsafe { *self.ctx.config.enc.to_owned() };
         let (q_min, q_max) = Self::calc_q_values(ratio);
-        c.rc_min_quantizer = q_min;
-        c.rc_max_quantizer = q_max;
-        c.rc_target_bitrate = Self::bitrate(self.width as _, self.height as _, ratio);
-        call_aom!(aom_codec_enc_config_set(&mut self.ctx, &c));
+        let bitrate = Self::bitrate(self.width as _, self.height as _, ratio);
+
+        unsafe {
+            rustdesk_aom_enc_cfg_set_quantizer(self.cfg, q_min, q_max);
+            rustdesk_aom_enc_cfg_set_basic(
+                self.cfg,
+                self.width as _,
+                self.height as _,
+                codec_thread_num(64) as _,
+                bitrate,
+                webrtc::kTimeBaseDen as _,
+                8,
+                AOM_USAGE_REALTIME,
+                0,
+            );
+        }
+
+        call_aom!(aom_codec_enc_config_set(&mut self.ctx, self.cfg));
         Ok(())
     }
 
     fn bitrate(&self) -> u32 {
-        let c = unsafe { *self.ctx.config.enc.to_owned() };
-        c.rc_target_bitrate
+        unsafe { rustdesk_aom_enc_cfg_get_target_bitrate(self.cfg) }
     }
 
     fn support_changing_quality(&self) -> bool {
@@ -292,6 +371,7 @@ impl AomEncoder {
         if data.len() < self.width * self.height * bpp / 8 {
             return Err(Error::FailedCall("len not enough".to_string()));
         }
+
         let fmt = if self.i444 {
             aom_img_fmt::AOM_IMG_FMT_I444
         } else {
@@ -307,14 +387,16 @@ impl AomEncoder {
             stride_align as _,
             data.as_ptr() as _,
         ));
+
         let pts = webrtc::kTimeBaseDen / 1000 * ms;
         let duration = webrtc::kTimeBaseDen / 1000;
+
         call_aom!(aom_codec_encode(
             &mut self.ctx,
             &image,
             pts as _,
-            duration as _, // Duration
-            0,             // Flags
+            duration as _,
+            0,
         ));
 
         Ok(EncodeFrames {
@@ -360,7 +442,7 @@ impl AomEncoder {
 
         let t = b as f32 / 200.0;
 
-        let mut q_min: u32 = ((1.0 - t) * q_min1 as f32 + t * q_min2 as f32).round() as u32;
+        let mut q_min = ((1.0 - t) * q_min1 as f32 + t * q_min2 as f32).round() as u32;
         let mut q_max = ((1.0 - t) * q_max1 as f32 + t * q_max2 as f32).round() as u32;
 
         q_min = q_min.clamp(q_min2, q_min1);
@@ -376,6 +458,7 @@ impl AomEncoder {
         } else {
             aom_img_fmt::AOM_IMG_FMT_I420
         };
+
         unsafe {
             aom_img_wrap(
                 &mut img,
@@ -386,6 +469,7 @@ impl AomEncoder {
                 0x1 as _,
             );
         }
+
         let pixfmt = if i444 { Pixfmt::I444 } else { Pixfmt::I420 };
         EncodeYuvFormat {
             pixfmt,
@@ -402,6 +486,7 @@ impl Drop for AomEncoder {
     fn drop(&mut self) {
         unsafe {
             let result = aom_codec_destroy(&mut self.ctx);
+            rustdesk_aom_enc_cfg_free(self.cfg);
             if result != aom_codec_err_t::AOM_CODEC_OK {
                 panic!("failed to destroy aom codec");
             }
@@ -416,6 +501,7 @@ pub struct EncodeFrames<'a> {
 
 impl<'a> Iterator for EncodeFrames<'a> {
     type Item = EncodeFrame<'a>;
+
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             unsafe {
@@ -429,8 +515,6 @@ impl<'a> Iterator for EncodeFrames<'a> {
                         key: (f.flags & AOM_FRAME_IS_KEY) != 0,
                         pts: f.pts,
                     });
-                } else {
-                    // Ignore the packet.
                 }
             }
         }
@@ -445,19 +529,37 @@ impl AomDecoder {
     pub fn new() -> Result<Self> {
         let i = call_aom_ptr!(aom_codec_av1_dx());
         let mut ctx = Default::default();
-        let cfg = aom_codec_dec_cfg_t {
-            threads: codec_thread_num(64) as _,
-            w: 0,
-            h: 0,
-            allow_lowbitdepth: 1,
-        };
-        call_aom!(aom_codec_dec_init_ver(
-            &mut ctx,
-            i,
-            &cfg,
+
+        let mut cfg: *mut aom_codec_dec_cfg_t = ptr::null_mut();
+
+        call_aom!(rustdesk_aom_dec_cfg_alloc(
+            codec_thread_num(64) as _,
             0,
-            AOM_DECODER_ABI_VERSION as _,
+            0,
+            1,
+            &mut cfg,
         ));
+
+        if cfg.is_null() {
+            return Err(Error::FailedCall("aom decoder config allocation returned null".to_string()));
+        }
+
+        let init_result = unsafe {
+            aom_codec_dec_init_ver(
+                &mut ctx,
+                i,
+                cfg,
+                0,
+                AOM_DECODER_ABI_VERSION as _,
+            )
+        };
+
+        unsafe {
+            rustdesk_aom_dec_cfg_free(cfg);
+        }
+
+        call_aom!(init_result);
+
         Ok(Self { ctx })
     }
 
@@ -475,7 +577,6 @@ impl AomDecoder {
         })
     }
 
-    /// Notify the decoder to return any pending frame
     pub fn flush<'a>(&'a mut self) -> Result<DecodeFrames<'a>> {
         call_aom!(aom_codec_decode(
             &mut self.ctx,
@@ -483,6 +584,7 @@ impl AomDecoder {
             0,
             ptr::null_mut(),
         ));
+
         Ok(DecodeFrames {
             ctx: &mut self.ctx,
             iter: ptr::null(),
@@ -508,17 +610,19 @@ pub struct DecodeFrames<'a> {
 
 impl<'a> Iterator for DecodeFrames<'a> {
     type Item = Image;
+
     fn next(&mut self) -> Option<Self::Item> {
         let img = unsafe { aom_codec_get_frame(self.ctx, &mut self.iter) };
         if img.is_null() {
-            return None;
+            None
         } else {
-            return Some(Image(img));
+            Some(Image(img))
         }
     }
 }
 
 pub struct Image(*mut aom_image_t);
+
 impl Image {
     #[inline]
     pub fn new() -> Self {

--- a/libs/scrap/src/common/vpx.rs
+++ b/libs/scrap/src/common/vpx.rs
@@ -5,12 +5,6 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
-impl Default for vpx_codec_enc_cfg {
-    fn default() -> Self {
-        unsafe { std::mem::zeroed() }
-    }
-}
-
 impl Default for vpx_codec_ctx {
     fn default() -> Self {
         unsafe { std::mem::zeroed() }
@@ -24,3 +18,53 @@ impl Default for vpx_image_t {
 }
 
 include!(concat!(env!("OUT_DIR"), "/vpx_ffi.rs"));
+
+extern "C" {
+    pub fn rustdesk_vpx_enc_cfg_alloc_default(
+        iface: *const vpx_codec_iface,
+        usage: ::std::os::raw::c_uint,
+        out: *mut *mut vpx_codec_enc_cfg_t,
+    ) -> vpx_codec_err_t;
+
+    pub fn rustdesk_vpx_enc_cfg_free(cfg: *mut vpx_codec_enc_cfg_t);
+
+    pub fn rustdesk_vpx_enc_cfg_set_basic(
+        c: *mut vpx_codec_enc_cfg_t,
+        w: ::std::os::raw::c_uint,
+        h: ::std::os::raw::c_uint,
+        threads: ::std::os::raw::c_uint,
+        bitrate: ::std::os::raw::c_uint,
+        profile: ::std::os::raw::c_uint,
+    );
+
+    pub fn rustdesk_vpx_enc_cfg_set_quantizer(
+        c: *mut vpx_codec_enc_cfg_t,
+        q_min: ::std::os::raw::c_uint,
+        q_max: ::std::os::raw::c_uint,
+    );
+
+    pub fn rustdesk_vpx_enc_cfg_set_keyframe(
+        c: *mut vpx_codec_enc_cfg_t,
+        min_dist: ::std::os::raw::c_uint,
+        max_dist: ::std::os::raw::c_uint,
+        disabled: ::std::os::raw::c_int,
+    );
+
+    pub fn rustdesk_vpx_enc_cfg_set_target_bitrate(
+        c: *mut vpx_codec_enc_cfg_t,
+        bitrate: ::std::os::raw::c_uint,
+    );
+
+    pub fn rustdesk_vpx_enc_cfg_get_target_bitrate(
+        c: *const vpx_codec_enc_cfg_t,
+    ) -> ::std::os::raw::c_uint;
+
+    pub fn rustdesk_vpx_dec_cfg_alloc(
+        threads: ::std::os::raw::c_uint,
+        w: ::std::os::raw::c_uint,
+        h: ::std::os::raw::c_uint,
+        out: *mut *mut vpx_codec_dec_cfg_t,
+    ) -> vpx_codec_err_t;
+
+    pub fn rustdesk_vpx_dec_cfg_free(cfg: *mut vpx_codec_dec_cfg_t);
+}

--- a/libs/scrap/src/common/vpxcodec.rs
+++ b/libs/scrap/src/common/vpxcodec.rs
@@ -4,7 +4,6 @@
 // https://github.com/chromium/chromium/blob/e7b24573bc2e06fed4749dd6b6abfce67f29052f/media/video/vpx_video_encoder.cc#L522
 
 use hbb_common::anyhow::{anyhow, Context};
-use hbb_common::log;
 use hbb_common::message_proto::{Chroma, EncodedVideoFrame, EncodedVideoFrames, VideoFrame};
 use hbb_common::ResultType;
 
@@ -34,6 +33,7 @@ impl Default for VpxVideoCodecId {
 
 pub struct VpxEncoder {
     ctx: vpx_codec_ctx_t,
+    cfg: *mut vpx_codec_enc_cfg_t,
     width: usize,
     height: usize,
     id: VpxVideoCodecId,
@@ -56,45 +56,42 @@ impl EncoderApi for VpxEncoder {
                     VpxVideoCodecId::VP8 => call_vpx_ptr!(vpx_codec_vp8_cx()),
                     VpxVideoCodecId::VP9 => call_vpx_ptr!(vpx_codec_vp9_cx()),
                 };
-                let mut c = unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
-                call_vpx!(vpx_codec_enc_config_default(i, &mut c, 0));
+                let mut c: *mut vpx_codec_enc_cfg_t = ptr::null_mut();
+                call_vpx!(rustdesk_vpx_enc_cfg_alloc_default(i, 0, &mut c));
 
-                // https://www.webmproject.org/docs/encoder-parameters/
-                // default: c.rc_min_quantizer = 0, c.rc_max_quantizer = 63
-                // try rc_resize_allowed later
-
-                c.g_w = config.width;
-                c.g_h = config.height;
-                c.g_timebase.num = 1;
-                c.g_timebase.den = 1000; // Output timestamp precision
-                c.rc_undershoot_pct = 95;
-                // When the data buffer falls below this percentage of fullness, a dropped frame is indicated. Set the threshold to zero (0) to disable this feature.
-                // In dynamic scenes, low bitrate gets low fps while high bitrate gets high fps.
-                c.rc_dropframe_thresh = 25;
-                c.g_threads = codec_thread_num(64) as _;
-                c.g_error_resilient = VPX_ERROR_RESILIENT_DEFAULT;
-                // https://developers.google.com/media/vp9/bitrate-modes/
-                // Constant Bitrate mode (CBR) is recommended for live streaming with VP9.
-                c.rc_end_usage = vpx_rc_mode::VPX_CBR;
-                if let Some(keyframe_interval) = config.keyframe_interval {
-                    c.kf_min_dist = 0;
-                    c.kf_max_dist = keyframe_interval as _;
-                } else {
-                    c.kf_mode = vpx_kf_mode::VPX_KF_DISABLED; // reduce bandwidth a lot
+                if c.is_null() {
+                    return Err(anyhow!("vpx encoder config allocation returned null"));
                 }
 
+                // https://www.webmproject.org/docs/encoder-parameters/
+                // default: rc_min_quantizer = 0, rc_max_quantizer = 63
+                // try rc_resize_allowed later
                 let (q_min, q_max) = Self::calc_q_values(config.quality);
-                c.rc_min_quantizer = q_min;
-                c.rc_max_quantizer = q_max;
-                c.rc_target_bitrate =
-                    Self::bitrate(config.width as _, config.height as _, config.quality);
-                // https://chromium.googlesource.com/webm/libvpx/+/refs/heads/main/vp9/common/vp9_enums.h#29
-                // https://chromium.googlesource.com/webm/libvpx/+/refs/heads/main/vp8/vp8_cx_iface.c#282
-                c.g_profile = if i444 && config.codec == VpxVideoCodecId::VP9 {
+                let bitrate = Self::bitrate(config.width as _, config.height as _, config.quality);
+                let profile = if i444 && config.codec == VpxVideoCodecId::VP9 {
                     1
                 } else {
                     0
                 };
+
+                unsafe {
+                    rustdesk_vpx_enc_cfg_set_basic(
+                        c,
+                        config.width,
+                        config.height,
+                        codec_thread_num(64) as _,
+                        bitrate,
+                        profile,
+                    );
+
+                    rustdesk_vpx_enc_cfg_set_quantizer(c, q_min, q_max);
+
+                    if let Some(keyframe_interval) = config.keyframe_interval {
+                        rustdesk_vpx_enc_cfg_set_keyframe(c, 0, keyframe_interval as _, 0);
+                    } else {
+                        rustdesk_vpx_enc_cfg_set_keyframe(c, 0, 0, 1);
+                    }
+                }
 
                 /*
                 The VPX encoder supports two-pass encoding for rate control purposes.
@@ -105,61 +102,82 @@ impl EncoderApi for VpxEncoder {
                 */
 
                 let mut ctx = Default::default();
-                call_vpx!(vpx_codec_enc_init_ver(
-                    &mut ctx,
-                    i,
-                    &c,
-                    0,
-                    VPX_ENCODER_ABI_VERSION as _
-                ));
-
-                if config.codec == VpxVideoCodecId::VP9 {
-                    // set encoder internal speed settings
-                    // in ffmpeg, it is --speed option
-                    /*
-                    set to 0 or a positive value 1-16, the codec will try to adapt its
-                    complexity depending on the time it spends encoding. Increasing this
-                    number will make the speed go up and the quality go down.
-                    Negative values mean strict enforcement of this
-                    while positive values are adaptive
-                    */
-                    /* https://developers.google.com/media/vp9/live-encoding
-                    Speed 5 to 8 should be used for live / real-time encoding.
-                    Lower numbers (5 or 6) are higher quality but require more CPU power.
-                    Higher numbers (7 or 8) will be lower quality but more manageable for lower latency
-                    use cases and also for lower CPU power devices such as mobile.
-                    */
-                    call_vpx!(vpx_codec_control_(&mut ctx, VP8E_SET_CPUUSED as _, 7,));
-                    // set row level multi-threading
-                    /*
-                    as some people in comments and below have already commented,
-                    more recent versions of libvpx support -row-mt 1 to enable tile row
-                    multi-threading. This can increase the number of tiles by up to 4x in VP9
-                    (since the max number of tile rows is 4, regardless of video height).
-                    To enable this, use -tile-rows N where N is the number of tile rows in
-                    log2 units (so -tile-rows 1 means 2 tile rows and -tile-rows 2 means 4 tile
-                    rows). The total number of active threads will then be equal to
-                    $tile_rows * $tile_columns
-                    */
-                    call_vpx!(vpx_codec_control_(
+                let init_result = unsafe {
+                    vpx_codec_enc_init_ver(
                         &mut ctx,
-                        VP9E_SET_ROW_MT as _,
-                        1 as c_int
-                    ));
+                        i,
+                        c,
+                        0,
+                        VPX_ENCODER_ABI_VERSION as _,
+                    )
+                };
 
-                    call_vpx!(vpx_codec_control_(
-                        &mut ctx,
-                        VP9E_SET_TILE_COLUMNS as _,
-                        4 as c_int
-                    ));
-                } else if config.codec == VpxVideoCodecId::VP8 {
-                    // https://github.com/webmproject/libvpx/blob/972149cafeb71d6f08df89e91a0130d6a38c4b15/vpx/vp8cx.h#L172
-                    // https://groups.google.com/a/webmproject.org/g/webm-discuss/c/DJhSrmfQ61M
-                    call_vpx!(vpx_codec_control_(&mut ctx, VP8E_SET_CPUUSED as _, 12,));
+                if init_result != VPX_CODEC_OK {
+                    unsafe {
+                        rustdesk_vpx_enc_cfg_free(c);
+                    }
+                    call_vpx!(init_result);
+                }
+
+                let control_result: ResultType<()> = (|| {
+                    if config.codec == VpxVideoCodecId::VP9 {
+                        // set encoder internal speed settings
+                        // in ffmpeg, it is --speed option
+                        /*
+                        set to 0 or a positive value 1-16, the codec will try to adapt its
+                        complexity depending on the time it spends encoding. Increasing this
+                        number will make the speed go up and the quality go down.
+                        Negative values mean strict enforcement of this
+                        while positive values are adaptive
+                        */
+                        /* https://developers.google.com/media/vp9/live-encoding
+                        Speed 5 to 8 should be used for live / real-time encoding.
+                        Lower numbers (5 or 6) are higher quality but require more CPU power.
+                        Higher numbers (7 or 8) will be lower quality but more manageable for lower latency
+                        use cases and also for lower CPU power devices such as mobile.
+                        */
+                        call_vpx!(vpx_codec_control_(&mut ctx, VP8E_SET_CPUUSED as _, 7,));
+                        // set row level multi-threading
+                        /*
+                        as some people in comments and below have already commented,
+                        more recent versions of libvpx support -row-mt 1 to enable tile row
+                        multi-threading. This can increase the number of tiles by up to 4x in VP9
+                        (since the max number of tile rows is 4, regardless of video height).
+                        To enable this, use -tile-rows N where N is the number of tile rows in
+                        log2 units (so -tile-rows 1 means 2 tile rows and -tile-rows 2 means 4 tile
+                        rows). The total number of active threads will then be equal to
+                        $tile_rows * $tile_columns
+                        */
+                        call_vpx!(vpx_codec_control_(
+                            &mut ctx,
+                            VP9E_SET_ROW_MT as _,
+                            1 as c_int
+                        ));
+
+                        call_vpx!(vpx_codec_control_(
+                            &mut ctx,
+                            VP9E_SET_TILE_COLUMNS as _,
+                            4 as c_int
+                        ));
+                    } else if config.codec == VpxVideoCodecId::VP8 {
+                        // https://github.com/webmproject/libvpx/blob/972149cafeb71d6f08df89e91a0130d6a38c4b15/vpx/vp8cx.h#L172
+                        // https://groups.google.com/a/webmproject.org/g/webm-discuss/c/DJhSrmfQ61M
+                        call_vpx!(vpx_codec_control_(&mut ctx, VP8E_SET_CPUUSED as _, 12,));
+                    }
+                    Ok(())
+                })();
+
+                if let Err(err) = control_result {
+                    unsafe {
+                        let _ = vpx_codec_destroy(&mut ctx);
+                        rustdesk_vpx_enc_cfg_free(c);
+                    }
+                    return Err(err);
                 }
 
                 Ok(Self {
                     ctx,
+                    cfg: c,
                     width: config.width as _,
                     height: config.height as _,
                     id: config.codec,
@@ -201,18 +219,20 @@ impl EncoderApi for VpxEncoder {
     }
 
     fn set_quality(&mut self, ratio: f32) -> ResultType<()> {
-        let mut c = unsafe { *self.ctx.config.enc.to_owned() };
         let (q_min, q_max) = Self::calc_q_values(ratio);
-        c.rc_min_quantizer = q_min;
-        c.rc_max_quantizer = q_max;
-        c.rc_target_bitrate = Self::bitrate(self.width as _, self.height as _, ratio);
-        call_vpx!(vpx_codec_enc_config_set(&mut self.ctx, &c));
+        let bitrate = Self::bitrate(self.width as _, self.height as _, ratio);
+
+        unsafe {
+            rustdesk_vpx_enc_cfg_set_quantizer(self.cfg, q_min, q_max);
+            rustdesk_vpx_enc_cfg_set_target_bitrate(self.cfg, bitrate);
+        }
+
+        call_vpx!(vpx_codec_enc_config_set(&mut self.ctx, self.cfg));
         Ok(())
     }
 
     fn bitrate(&self) -> u32 {
-        let c = unsafe { *self.ctx.config.enc.to_owned() };
-        c.rc_target_bitrate
+        unsafe { rustdesk_vpx_enc_cfg_get_target_bitrate(self.cfg) }
     }
 
     fn support_changing_quality(&self) -> bool {
@@ -369,6 +389,7 @@ impl Drop for VpxEncoder {
     fn drop(&mut self) {
         unsafe {
             let result = vpx_codec_destroy(&mut self.ctx);
+            rustdesk_vpx_enc_cfg_free(self.cfg);
             if result != VPX_CODEC_OK {
                 panic!("failed to destroy vpx codec");
             }
@@ -448,23 +469,39 @@ impl VpxDecoder {
             VpxVideoCodecId::VP9 => call_vpx_ptr!(vpx_codec_vp9_dx()),
         };
         let mut ctx = Default::default();
-        let cfg = vpx_codec_dec_cfg_t {
-            threads: codec_thread_num(64) as _,
-            w: 0,
-            h: 0,
-        };
+        let mut cfg: *mut vpx_codec_dec_cfg_t = ptr::null_mut();
+
+        call_vpx!(rustdesk_vpx_dec_cfg_alloc(
+            codec_thread_num(64) as _,
+            0,
+            0,
+            &mut cfg,
+        ));
+
+        if cfg.is_null() {
+            return Err(Error::FailedCall("vpx decoder config allocation returned null".to_string()));
+        }
+
         /*
         unsafe {
             println!("{}", vpx_codec_get_caps(i));
         }
         */
-        call_vpx!(vpx_codec_dec_init_ver(
-            &mut ctx,
-            i,
-            &cfg,
-            0,
-            VPX_DECODER_ABI_VERSION as _,
-        ));
+        let init_result = unsafe {
+            vpx_codec_dec_init_ver(
+                &mut ctx,
+                i,
+                cfg,
+                0,
+                VPX_DECODER_ABI_VERSION as _,
+            )
+        };
+
+        unsafe {
+            rustdesk_vpx_dec_cfg_free(cfg);
+        }
+
+        call_vpx!(init_result);
         Ok(Self { ctx })
     }
 


### PR DESCRIPTION
## Summary

This PR makes the AOM and VPX codec configuration code resilient to opaque bindgen-generated types.

With newer LLVM/bindgen toolchains, `aom_codec_enc_cfg_t`, `aom_codec_dec_cfg_t`, `vpx_codec_enc_cfg_t`, and `vpx_codec_dec_cfg_t` may be emitted as opaque types, preventing Rust from accessing their fields directly. This results in build failures because the codec wrappers currently configure the codecs by writing directly into those structures.

To avoid depending on bindgen exposing the internal layout of these codec configuration structs, this PR introduces a small C shim that owns all direct access to the codec configuration fields. The Rust wrappers now interact with the codec configuration through a stable C interface instead of manipulating the generated bindings directly.

## Changes

* Add a C shim for AOM and VPX codec configuration.
* Replace direct Rust field access with helper functions provided by the shim.
* Build the shim using the `cc` crate.
* Update the `scrap` build script to compile the shim.
* Update `bindgen` used by `scrap`.

## Benefits

* Removes reliance on bindgen exposing codec configuration layouts.
* Improves compatibility with newer LLVM/bindgen toolchains.
* Encapsulates codec-specific implementation details within the native codec layer.
* Preserves existing encoder and decoder behavior while avoiding layout assumptions in Rust.

## Testing

* Successfully built the Windows (MSVC) Flutter target.
* Verified successful application startup after the changes.
* Verified that codec initialization and configuration complete successfully using the shim-based implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video codec initialization and configuration handling for smoother encoding and decoding.

* **Bug Fixes**
  * Added stronger error handling when codec setup or frame generation fails.
  * Improved stability for AOM and VPX encoding/decoding, including better cleanup of resources.
  * Enhanced build-time support for codec bindings and native library linking across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->