### PR TITLE
refact: insecure conn, toast notification

### DIFF
--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -522,14 +522,11 @@ class _AppState extends State<App> with WidgetsBindingObserver {
             BotToastNavigatorObserver(),
           ],
           builder: isAndroid
-              ? (context, child) => AccessibilityListener(
-                    child: MediaQuery(
-                      data: MediaQuery.of(context).copyWith(
-                        textScaler: TextScaler.linear(1.0),
-                      ),
-                      child: child ?? Container(),
-                    ),
-                  )
+              ? (context, child) {
+                  child = _keepScaleBuilder(context, child);
+                  child = botToastBuilder(context, child);
+                  return AccessibilityListener(child: child);
+                }
               : (context, child) {
                   child = _keepScaleBuilder(context, child);
                   child = botToastBuilder(context, child);

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -899,6 +899,15 @@ class FfiModel with ChangeNotifier {
     final text = evt['text'];
     final link = evt['link'];
 
+    if (type is String && type.startsWith('toast-')) {
+      handleToast({
+        'type': type.substring('toast-'.length),
+        'text': text,
+        'dur_msec': evt['dur_msec'] ?? 5000,
+      }, sessionId, peerId);
+      return;
+    }
+
     // Disable relative mouse mode on any error-type message to ensure cursor is released.
     // This includes connection errors, session-ending messages, elevation errors, etc.
     // Safety: releasing pointer lock on errors prevents the user from being stuck.
@@ -3796,6 +3805,10 @@ class FFI {
 
     if (isDesktop) {
       inputModel.updateTrackpadSpeed();
+    }
+
+    if (isWeb) {
+      ffiModel.updateEventListener(sessionId, id);
     }
 
     // CAUTION: `sessionStart()` and `sessionStartWithDisplays()` are an async functions.

--- a/src/client.rs
+++ b/src/client.rs
@@ -3709,6 +3709,10 @@ pub trait Interface: Send + Clone + 'static + Sized {
     /// Send message data to remote peer.
     fn send(&self, data: Data);
     fn msgbox(&self, msgtype: &str, title: &str, text: &str, link: &str);
+    fn toast(&self, msgtype: &str, text: &str) {
+        let msgtype = format!("toast-{msgtype}");
+        self.msgbox(&msgtype, "", text, "");
+    }
     fn handle_login_error(&self, err: &str) -> bool;
     fn handle_peer_info(&self, pi: PeerInfo);
     fn set_multiple_windows_session(&self, sessions: Vec<WindowsSession>);

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -72,6 +72,7 @@ pub struct Remote<T: InvokeUiSession> {
     last_update_jobs_status: (Instant, HashMap<i32, u64>),
     is_connected: bool,
     first_frame: bool,
+    pending_insecure_connection_toast: bool,
     #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]
     client_conn_id: i32, // used for file clipboard
     data_count: Arc<AtomicUsize>,
@@ -119,6 +120,7 @@ impl<T: InvokeUiSession> Remote<T> {
             last_update_jobs_status: (Instant::now(), Default::default()),
             is_connected: false,
             first_frame: false,
+            pending_insecure_connection_toast: false,
             #[cfg(any(target_os = "windows", feature = "unix-file-copy-paste"))]
             client_conn_id: 0,
             data_count: Arc::new(AtomicUsize::new(0)),
@@ -183,8 +185,10 @@ impl<T: InvokeUiSession> Remote<T> {
                     .lock()
                     .unwrap()
                     .set_connected();
+                let is_secured = peer.is_secured();
                 self.handler
-                    .set_connection_type(peer.is_secured(), direct, stream_type); // flutter -> connection_ready
+                    .set_connection_type(is_secured, direct, stream_type); // flutter -> connection_ready
+                self.pending_insecure_connection_toast = !is_secured;
                 self.handler.update_direct(Some(direct));
                 if conn_type == ConnType::DEFAULT_CONN || conn_type == ConnType::VIEW_CAMERA {
                     self.handler
@@ -1301,6 +1305,10 @@ impl<T: InvokeUiSession> Remote<T> {
                     if !self.first_frame {
                         self.first_frame = true;
                         self.handler.close_success();
+                        if self.pending_insecure_connection_toast {
+                            self.pending_insecure_connection_toast = false;
+                            self.handler.toast("error", "e2ee-failed-tip");
+                        }
                         self.handler.adapt_size();
                         self.send_toggle_virtual_display_msg(peer).await;
                         self.send_toggle_privacy_mode_msg(peer).await;
@@ -1361,6 +1369,10 @@ impl<T: InvokeUiSession> Remote<T> {
                             }
                         }
                         self.handler.handle_peer_info(pi);
+                        if self.handler.is_file_transfer() && self.pending_insecure_connection_toast {
+                            self.pending_insecure_connection_toast = false;
+                            self.handler.toast("error", "e2ee-failed-tip");
+                        }
                         #[cfg(all(target_os = "windows", not(feature = "flutter")))]
                         self.check_clipboard_file_context();
                         if self.handler.is_default() {

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "الإظهار على شريط الأدوات المُصغّر"),
         ("All monitors", "جميع الشاشات"),
         ("#{} monitor", "الشاشة رقم {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Паказваць на згорнутай панэлі інструментаў"),
         ("All monitors", "Усе манітори"),
         ("#{} monitor", "Манітор {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Показване в минимизираната лента с инструменти"),
         ("All monitors", "Всички монитори"),
         ("#{} monitor", "Монитор {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Mostra a la barra d’eines minimitzada"),
         ("All monitors", "Tots els monitors"),
         ("#{} monitor", "Monitor {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "在最小化工具栏上显示"),
         ("All monitors", "所有显示器"),
         ("#{} monitor", "{}号显示器"),
+        ("e2ee-failed-tip", "当前连接不是端对端加密的。\n请更新被控端的 RustDesk 至最新版本。"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Zobrazit na minimalizovaném panelu nástrojů"),
         ("All monitors", "Všechny monitory"),
         ("#{} monitor", "Monitor č. {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Vis på den minimerede værktøjslinje"),
         ("All monitors", "Alle skærme"),
         ("#{} monitor", "Skærm {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "In der minimierten Symbolleiste anzeigen"),
         ("All monitors", "Alle Bildschirme"),
         ("#{} monitor", "Bildschirm {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Εμφάνιση στην ελαχιστοποιημένη γραμμή εργαλείων"),
         ("All monitors", "Όλες οι οθόνες"),
         ("#{} monitor", "Οθόνη {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -279,5 +279,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("wayland-soft-keyboard-input-label", "Soft keyboard input"),
         ("wayland-keyboard-input-reset-choice-tip", "Reset keyboard input choice"),
         ("remember-wayland-keyboard-choice-tip", "Don't ask again for this remote computer"),
+        ("e2ee-failed-tip", "This connection is not end-to-end encrypted.\nPlease update RustDesk on the controlled side to the latest version."),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Montri en la minimumigita ilobreto"),
         ("All monitors", "Ĉiuj monitoroj"),
         ("#{} monitor", "Monitoro {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Mostrar en la barra de herramientas minimizada"),
         ("All monitors", "Todos los monitores"),
         ("#{} monitor", "Monitor {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Näita minimeeritud tööriistaribal"),
         ("All monitors", "Kõik kuvarid"),
         ("#{} monitor", "Kuvar {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Erakutsi minimizatutako tresna-barran"),
         ("All monitors", "Monitore guztiak"),
         ("#{} monitor", "{}. monitorea"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "نمایش در نوار ابزار کوچک‌شده"),
         ("All monitors", "همه نمایشگرها"),
         ("#{} monitor", "نمایشگر {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Näytä pienennetyssä työkalurivissä"),
         ("All monitors", "Kaikki näytöt"),
         ("#{} monitor", "Näyttö {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Afficher dans la barre d’outils réduite"),
         ("All monitors", "Tous les moniteurs"),
         ("#{} monitor", "Moniteur {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "ჩვენება ჩაკეცილ ხელსაწყოთა ზოლზე"),
         ("All monitors", "ყველა მონიტორი"),
         ("#{} monitor", "მონიტორი {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "ન્યૂનતમ કરેલા ટૂલબાર પર બતાવો"),
         ("All monitors", "બધા મોનિટર"),
         ("#{} monitor", "મોનિટર {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "הצגה בסרגל הכלים הממוזער"),
         ("All monitors", "כל המסכים"),
         ("#{} monitor", "מסך {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "न्यूनतम किए गए टूलबार पर दिखाएं"),
         ("All monitors", "सभी मॉनिटर"),
         ("#{} monitor", "मॉनिटर {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Prikaži na minimiziranoj alatnoj traci"),
         ("All monitors", "Svi monitori"),
         ("#{} monitor", "Monitor {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Megjelenítés a kis méretű eszköztáron"),
         ("All monitors", "Minden monitor"),
         ("#{} monitor", "{}. monitor"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Tampilkan di bilah alat yang diperkecil"),
         ("All monitors", "Semua monitor"),
         ("#{} monitor", "Monitor {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Visualizza nella barra strumenti ridotta a icona"),
         ("All monitors", "Tutti gli schermi"),
         ("#{} monitor", "Schermo {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "最小化したツールバーに表示"),
         ("All monitors", "すべてのディスプレイ"),
         ("#{} monitor", "ディスプレイ {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "최소화된 도구 모음에 표시"),
         ("All monitors", "모든 모니터"),
         ("#{} monitor", "#{} 모니터"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Кішірейтілген құралдар тақтасында көрсету"),
         ("All monitors", "Барлық мониторлар"),
         ("#{} monitor", "Монитор {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Rodyti sumažintoje įrankių juostoje"),
         ("All monitors", "Visi monitoriai"),
         ("#{} monitor", "Monitorius {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Rādīt minimizētajā rīkjoslā"),
         ("All monitors", "Visi monitori"),
         ("#{} monitor", "Monitors {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "ചെറുതാക്കിയ ടൂൾബാറിൽ കാണിക്കുക"),
         ("All monitors", "എല്ലാ മോണിറ്ററുകളും"),
         ("#{} monitor", "മോണിറ്റർ {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Vis på den minimerte verktøylinjen"),
         ("All monitors", "Alle skjermer"),
         ("#{} monitor", "Skjerm {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Weergeven op de geminimaliseerde werkbalk"),
         ("All monitors", "Alle monitoren"),
         ("#{} monitor", "Monitor {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Pokaż na zminimalizowanym pasku narzędzi"),
         ("All monitors", "Wszystkie ekrany"),
         ("#{} monitor", "Ekran {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Mostrar na barra de ferramentas minimizada"),
         ("All monitors", "Todos os monitores"),
         ("#{} monitor", "Monitor {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Mostrar na barra de ferramentas minimizada"),
         ("All monitors", "Todas as telas"),
         ("#{} monitor", "Tela {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Afișează în bara de instrumente minimizată"),
         ("All monitors", "Toate monitoarele"),
         ("#{} monitor", "Monitor {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Показывать на свёрнутой панели инструментов"),
         ("All monitors", "Все мониторы"),
         ("#{} monitor", "Монитор {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Mustra in sa barra de aina minimizada"),
         ("All monitors", "Totu sos ischermos"),
         ("#{} monitor", "Ischermu {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Zobraziť na minimalizovanom paneli nástrojov"),
         ("All monitors", "Všetky monitory"),
         ("#{} monitor", "Monitor {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Pokaži v pomanjšani orodni vrstici"),
         ("All monitors", "Vsi zasloni"),
         ("#{} monitor", "Zaslon {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Shfaq te shiriti i minimizuar i veglave"),
         ("All monitors", "Të gjithë monitorët"),
         ("#{} monitor", "Monitori {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Прикажи на умањеној траци са алаткама"),
         ("All monitors", "Svi monitori"),
         ("#{} monitor", "Monitor {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Visa i det minimerade verktygsfältet"),
         ("All monitors", "Alla skärmar"),
         ("#{} monitor", "Skärm {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "சிறிதாக்கப்பட்ட கருவிப்பட்டையில் காட்டு"),
         ("All monitors", "அனைத்து மானிட்டர்களும்"),
         ("#{} monitor", "மானிட்டர் {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", ""),
         ("All monitors", ""),
         ("#{} monitor", ""),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "แสดงบนแถบเครื่องมือที่ย่อเล็กสุด"),
         ("All monitors", "จอภาพทั้งหมด"),
         ("#{} monitor", "จอภาพ {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Simge durumuna küçültülmüş araç çubuğunda göster"),
         ("All monitors", "Tüm monitörler"),
         ("#{} monitor", "Monitör {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "在最小化工具列上顯示"),
         ("All monitors", "所有顯示器"),
         ("#{} monitor", "{}號顯示器"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Показувати на згорнутій панелі інструментів"),
         ("All monitors", "Усі монітори"),
         ("#{} monitor", "Монітор {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -763,5 +763,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Show on the minimized toolbar", "Hiển thị trên thanh công cụ thu nhỏ"),
         ("All monitors", "Tất cả màn hình"),
         ("#{} monitor", "Màn hình {}"),
+        ("e2ee-failed-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/ui/common.tis
+++ b/src/ui/common.tis
@@ -239,10 +239,11 @@ function showToast(type, content) {
     var toast = $(#toast);
     if (!toast) return false;
     var color = type.indexOf("error") >= 0 ? "#e04f5f" : "#2C8CFF";
+    var lines = translate(content).split(/\r?\n/g);
     self.timer(0, toast_timer_func);
     toast.content(<div style="flow: horizontal; width: *;">
         <div style="width: *;" />
-        <div style={"width: 520px; padding: 0.9em 1.2em; background:" + color + "; color: white; border-radius: 4px; line-height: 1.4em; box-shadow: 0 2px 12px rgba(0,0,0,0.35);"}>{translate(content)}</div>
+        <div style={"width: 520px; padding: 0.9em 1.2em; background:" + color + "; color: white; border-radius: 4px; line-height: 1.4em; box-shadow: 0 2px 12px rgba(0,0,0,0.35);"}>{lines.map(function(line) { return <div>{line}</div>; })}</div>
         <div style="width: *;" />
     </div>);
     toast_timer_func = function() {

--- a/src/ui/common.tis
+++ b/src/ui/common.tis
@@ -234,11 +234,35 @@ class ChatBox: Reactor.Component {
 /******************** start of msgbox ****************************************/
 var remember_password = false;
 var last_msgbox_tag = "";
+var toast_timer_func = function() {}
+function showToast(type, content) {
+    var toast = $(#toast);
+    if (!toast) return false;
+    var color = type.indexOf("error") >= 0 ? "#e04f5f" : "#2C8CFF";
+    self.timer(0, toast_timer_func);
+    toast.content(<div style="flow: horizontal; width: *;">
+        <div style="width: *;" />
+        <div style={"width: 520px; padding: 0.9em 1.2em; background:" + color + "; color: white; border-radius: 4px; line-height: 1.4em; box-shadow: 0 2px 12px rgba(0,0,0,0.35);"}>{translate(content)}</div>
+        <div style="width: *;" />
+    </div>);
+    toast_timer_func = function() {
+        var toast = $(#toast);
+        if (toast) toast.content(<span />);
+    };
+    self.timer(5s, toast_timer_func);
+    return true;
+}
+
 function msgbox(type, title, content, link="", callback=null, height=180, width=500, hasRetry=false, contentStyle="") {
     $(body).scrollTo(0, 0);
     if (!type) {
         closeMsgbox();
         return;
+    }
+    if (type.indexOf("toast-") == 0) {
+        if (showToast(type, content)) return;
+        type = "custom-" + type.slice(6);
+        if (!title) title = "Security Alert";
     }
     var remember = false;
     try { remember = handler.get_remember(); } catch(e) {}

--- a/src/ui/remote.html
+++ b/src/ui/remote.html
@@ -39,6 +39,7 @@
     <div #file-transfer-wrapper>
     </div>
     <div #msgbox />
+    <div #toast style="position: absolute; bottom: 2em; left: 0; width: *; z-index: 2147483647; text-align: center;" />
 </body>
 
 </html>

--- a/src/ui/remote.tis
+++ b/src/ui/remote.tis
@@ -597,5 +597,5 @@ handler.setPermission = function(name, enabled) {
 
 handler.closeSuccess = function() {
     // handler.msgbox("success", "Successful", "Ready to go.");
-    handler.msgbox("", "", "");
+    msgbox("", "", "");
 }


### PR DESCRIPTION

Show toast on connections that fail to establish end-to-end encryption.

## Preview

### Mobile

Android and iOS

https://github.com/user-attachments/assets/42c7e79b-5a85-4934-8c8d-e23a3a52b356



### Sciter


https://github.com/user-attachments/assets/891bb10f-793c-4bc1-9ad1-f5421dd9f068


### Flutter


https://github.com/user-attachments/assets/976b5f21-5200-48e1-9576-b8e392d74e56



### Web



https://github.com/user-attachments/assets/bbb73f97-ceb4-443d-8d4b-d143d7047692




## Testing

- [x] Connections that fail to establish end-to-end encryption
- [x] Connections that fail to establish end-to-end encryption


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added toast-style alerts for connection/security events (including a dedicated convenience call for toast messages).
  * Improved notification handling on web so toast events are wired up correctly.

* **Bug Fixes**
  * Insecure or non end-to-end encrypted connections now trigger the warning reliably (including when the first video frame arrives or during file-transfer flows).
  * Android UI behavior now respects default text scaling/accessibility settings.

* **Localization**
  * Added a new i18n key for the E2EE security warning across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->