### PR TITLE
fix(linux): Increase sleep duration to resolve Linux background process spawning (#11959)

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -872,7 +872,7 @@ pub fn start_os_service() {
         let keeps_session = sid == desktop.sid;
         if keeps_headless || keeps_session {
             // for fixing https://github.com/rustdesk/rustdesk/issues/3129 to avoid too much dbus calling,
-            sleep_millis(500);
+            sleep_millis(5000);
         } else {
             sleep_millis(super::SERVICE_INTERVAL);
         }


### PR DESCRIPTION
Prevent frequent CPU wakeups from deep sleep caused by continuous child process creation, which drastically shortens laptop battery life. In my test environment, this fix cuts CPU wakeups from ~1300 per second down to ~700 per second, reducing overall power consumption by approximately 20%.

Before the fix:
<img width="916" height="610" alt="rustdesk-befor-fix" src="https://github.com/user-attachments/assets/728284a6-771a-43b5-93a9-3309b244fdff" />
After the fix:
<img width="925" height="615" alt="rustdesk-after-fix" src="https://github.com/user-attachments/assets/dd1767bd-6b38-4534-952d-e737b774da28" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced how often the desktop session maintenance loop runs when the session is already stable, which should lower unnecessary background activity and improve efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->