### PR TITLE
fix: ci: macos: allow signed but not notarized dmg

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -693,15 +693,20 @@ jobs:
 
       - name: Check sign and import sign key
         if: env.MACOS_P12_BASE64 != null
+        env:
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+          MACOS_NOTARIZE_JSON: ${{ secrets.MACOS_NOTARIZE_JSON }}
+        shell: bash
         run: |
           security default-keychain -s rustdesk.keychain
           security find-identity -v
-
-      - name: Check if notarization is configured
-        env:
-          MACOS_NOTARIZE_JSON: ${{ secrets.MACOS_NOTARIZE_JSON }}
-        run: |
-          if [ -n "$MACOS_NOTARIZE_JSON" ];then echo "MACOS_NOTARIZE_ENABLE=1" >> $GITHUB_ENV; fi
+          i=
+          if [ -n "$MACOS_NOTARIZE_JSON" ];then i=1; else i=0; fi
+          echo "MACOS_NOTARIZE_ENABLE=$i" >> $GITHUB_ENV
+          if ! [[ "$MACOS_CODESIGN_IDENTITY" =~ ^[A-Za-z0-9+/]*={0,2}$ ]]; then
+            echo "FATAL: Invalid `secrets.MACOS_CODESIGN_IDENTITY` given. If signing key is stored on your Mac, you can run `security find-identity -v -p codesigning` to find out hex format of your identity." >&2
+            exit 128
+          fi
 
       - name: Import notarize key
         if: env.MACOS_P12_BASE64 != null && env.MACOS_NOTARIZE_ENABLE == 1

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -49,6 +49,7 @@ env:
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"
   MACOS_P12_BASE64: "${{ secrets.MACOS_P12_BASE64 }}"
+  MACOS_NOTARIZE_JSON: "${{ secrets.MACOS_NOTARIZE_JSON }}"
   UPLOAD_ARTIFACT: "${{ inputs.upload-artifact }}"
   SIGN_BASE_URL: "${{ secrets.SIGN_BASE_URL }}-2"
 
@@ -695,21 +696,18 @@ jobs:
         if: env.MACOS_P12_BASE64 != null
         env:
           MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
-          MACOS_NOTARIZE_JSON: ${{ secrets.MACOS_NOTARIZE_JSON }}
         shell: bash
         run: |
           security default-keychain -s rustdesk.keychain
           security find-identity -v
-          i=
-          if [ -n "$MACOS_NOTARIZE_JSON" ];then i=1; else i=0; fi
-          echo "MACOS_NOTARIZE_ENABLE=$i" >> $GITHUB_ENV
-          if ! [[ "$MACOS_CODESIGN_IDENTITY" =~ ^[A-Za-z0-9+/]*={0,2}$ ]]; then
-            echo "FATAL: Invalid `secrets.MACOS_CODESIGN_IDENTITY` given. If signing key is stored on your Mac, you can run `security find-identity -v -p codesigning` to find out hex format of your identity." >&2
+          if ! [[ "$MACOS_CODESIGN_IDENTITY" =~ ^[A-Za-z0-9]+$ ]]; then
+            # Ensure no whitespaces or special characters
+            echo 'FATAL: Invalid `secrets.MACOS_CODESIGN_IDENTITY` given. If signing key is stored on your Mac, you can run `security find-identity -v -p codesigning` to find out hex format of your identity.' >&2
             exit 128
           fi
 
       - name: Import notarize key
-        if: env.MACOS_P12_BASE64 != null && env.MACOS_NOTARIZE_ENABLE == 1
+        if: env.MACOS_P12_BASE64 != null && env.MACOS_NOTARIZE_JSON != null
         uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac # v1.2
         with:
           # https://gregoryszorc.com/docs/apple-codesign/stable/apple_codesign_rcodesign.html#notarizing-and-stapling
@@ -857,12 +855,10 @@ jobs:
           codesign --force --options runtime -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep --strict ./flutter/build/macos/Build/Products/Release/RustDesk.app -vvv
           create-dmg --icon "RustDesk.app" 200 190 --hide-extension "RustDesk.app" --window-size 800 400 --app-drop-link 600 185 rustdesk-${{ env.VERSION }}.dmg ./flutter/build/macos/Build/Products/Release/RustDesk.app
           codesign --force --options runtime -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep --strict rustdesk-${{ env.VERSION }}.dmg -vvv
-
-      - name: Notarize dmg
-        if: env.MACOS_NOTARIZE_ENABLE == 1
-        run: |
-          # notarize the rustdesk-${{ env.VERSION }}.dmg
-          rcodesign notary-submit --api-key-path ${{ github.workspace }}/rustdesk.json  --staple rustdesk-${{ env.VERSION }}.dmg
+          if [ "$MACOS_NOTARIZE_JSON" != "" ]; then
+            # notarize the rustdesk-${{ env.VERSION }}.dmg
+            rcodesign notary-submit --api-key-path ${{ github.workspace }}/rustdesk.json  --staple rustdesk-${{ env.VERSION }}.dmg
+          fi
 
       - name: Rename rustdesk
         if: env.UPLOAD_ARTIFACT == 'true'

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -39,7 +39,7 @@ env:
   # vcpkg version: 2025.08.27
   # If we change the `VCPKG COMMIT_ID`, please remember:
   # 1. Call `$VCPKG_ROOT/vcpkg x-update-baseline` to update the baseline in `vcpkg.json`.
-  #  Or we may face build issue like 
+  #  Or we may face build issue like
   #  https://github.com/rustdesk/rustdesk/actions/runs/14414119794/job/40427970174
   # 2. Update the `VCPKG_COMMIT_ID` in `ci.yml` and `playground.yml`.
   VCPKG_COMMIT_ID: "120deac3062162151622ca4860575a33844ba10b"
@@ -615,7 +615,7 @@ jobs:
         run: |
           rustup target add ${{ matrix.job.target }}
           cargo build --locked --features flutter,hwcodec --release --target aarch64-apple-ios --lib
-          
+
       - name: Upload liblibrustdesk.a Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -697,8 +697,14 @@ jobs:
           security default-keychain -s rustdesk.keychain
           security find-identity -v
 
+      - name: Check if notarization is configured
+        env:
+          MACOS_NOTARIZE_JSON: ${{ secrets.MACOS_NOTARIZE_JSON }}
+        run: |
+          if [ -n "$MACOS_NOTARIZE_JSON" ];then echo "MACOS_NOTARIZE_ENABLE=1" >> $GITHUB_ENV; fi
+
       - name: Import notarize key
-        if: env.MACOS_P12_BASE64 != null
+        if: env.MACOS_P12_BASE64 != null && env.MACOS_NOTARIZE_ENABLE == 1
         uses: timheuer/base64-to-file@adaa40c0c581f276132199d4cf60afa07ce60eac # v1.2
         with:
           # https://gregoryszorc.com/docs/apple-codesign/stable/apple_codesign_rcodesign.html#notarizing-and-stapling
@@ -846,6 +852,10 @@ jobs:
           codesign --force --options runtime -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep --strict ./flutter/build/macos/Build/Products/Release/RustDesk.app -vvv
           create-dmg --icon "RustDesk.app" 200 190 --hide-extension "RustDesk.app" --window-size 800 400 --app-drop-link 600 185 rustdesk-${{ env.VERSION }}.dmg ./flutter/build/macos/Build/Products/Release/RustDesk.app
           codesign --force --options runtime -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep --strict rustdesk-${{ env.VERSION }}.dmg -vvv
+
+      - name: Notarize dmg
+        if: env.MACOS_NOTARIZE_ENABLE == 1
+        run: |
           # notarize the rustdesk-${{ env.VERSION }}.dmg
           rcodesign notary-submit --api-key-path ${{ github.workspace }}/rustdesk.json  --staple rustdesk-${{ env.VERSION }}.dmg
 


### PR DESCRIPTION
Community developers may use self-signed Apple Developer certificates without paying the developer annual fee.

The previous CI process assumed that users carrying `MACOS_P12_BASE64` would also carry `MACOS_NOTARIZE_JSON` . However, this is not feasible for them. Therefore, this Pull Request strengthens the validation in this regard, thereby:

Allowing these developers to use CI to build self-signed packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS builds now conditionally enable notarization when the required notarization secret is present.
* **Bug Fixes**
  * Improved the macOS signing workflow so notarization steps run only when all necessary credentials are available.
  * Added stricter validation for the macOS codesign identity (alphanumeric-only), failing early on invalid values.
  * Prevented notarization from running unconditionally during the signed DMG creation step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->