### PR TITLE
fix: check valid id

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -2623,6 +2623,20 @@ pub fn is_direct_ip_access(peer: &str) -> bool {
     hbb_common::is_ip_str(peer) || hbb_common::is_domain_port_str(peer)
 }
 
+// Align the maximum length of the peer id to the maximum length of the peer id in the server.
+const MAX_UNTRUSTED_PEER_ID_LEN: usize = 253;
+const UNTRUSTED_PEER_ID_FORBIDDEN_CHARS: &[char] = &['"', '<', '>', '/', '\\', '|', '?', '*'];
+
+// Shared validation for peer/connect ids that cross untrusted boundaries before
+// they are stored or written into command/script contexts.
+pub fn is_valid_untrusted_peer_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= MAX_UNTRUSTED_PEER_ID_LEN
+        && !id.chars().any(|ch| {
+            ch.is_control() || ch.is_whitespace() || UNTRUSTED_PEER_ID_FORBIDDEN_CHARS.contains(&ch)
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2651,6 +2665,29 @@ mod tests {
             Instant::now() + Duration::from_secs(1),
             Duration::from_secs(1),
         )
+    }
+
+    #[test]
+    fn untrusted_peer_id_validation() {
+        let cases = [
+            ("123456789", true),
+            ("m\u{00FC}nchen-pc", true),
+            ("192.168.1.10:21118", true),
+            ("9123456234@public", true),
+            (
+                r#"1" & oWS.Run("cmd.exe /k whoami /priv",1,False) & ""#,
+                false,
+            ),
+            ("", false),
+            ("peer id", false),
+            ("peer\nid", false),
+            ("peer/id", false),
+            ("peer?id", false),
+        ];
+
+        for (id, expected) in cases {
+            assert_eq!(is_valid_untrusted_peer_id(id), expected, "{id:?}");
+        }
     }
 
     // ThrottledInterval tick at the same time as tokio interval, if no sleeps

--- a/src/lan.rs
+++ b/src/lan.rs
@@ -241,6 +241,14 @@ fn wait_response(
                     Some(rendezvous_message::Union::PeerDiscovery(p)) => {
                         last_recv_time = Instant::now();
                         if p.cmd == "pong" {
+                            if !crate::common::is_valid_untrusted_peer_id(&p.id) {
+                                log::warn!(
+                                    "Ignoring LAN discovery response from {} with invalid peer id",
+                                    addr
+                                );
+                                continue;
+                            }
+
                             let local_mac = if try_get_ip_by_peer {
                                 if let Some(self_addr) = get_ipaddr_by_peer(&addr) {
                                     get_mac(&self_addr)

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2278,6 +2278,10 @@ fn get_shortcut_icon_location(install_dir: &str, exe: &str) -> String {
 }
 
 pub fn create_shortcut(id: &str) -> ResultType<()> {
+    if !crate::common::is_valid_untrusted_peer_id(id) {
+        bail!("Invalid peer id for shortcut");
+    }
+
     let exe = std::env::current_exe()?.to_str().unwrap_or("").to_owned();
     // https://github.com/rustdesk/rustdesk/issues/13735
     // Replace ':' with '_' for filename since ':' is not allowed in Windows filenames


### PR DESCRIPTION
LAN discovery accepts peer IDs from unauthenticated peers.

These IDs are later written into a temporary VBScript file when creating a Windows desktop shortcut. If the IDs contain malicious commands, they could be executed unexpectedly. 

To prevent this, reject IDs with unsafe characters before storage, and validate again before shortcut creation.

## Testing

See `untrusted_peer_id_validation()`.

```bash
cargo test -p rustdesk untrusted_peer_id_validation -- --nocapture
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for peer identifiers to reject empty values, overly long IDs, and unsafe characters.
  * Improved handling of LAN discovery responses so invalid peer data is ignored instead of processed.
  * Prevented shortcut creation when a peer ID is not valid, reducing the risk of malformed input being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->