### PR TITLE
feat(macos): auto update support

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -485,7 +485,7 @@ class _GeneralState extends State<_General> {
   Widget other() {
     final incomingOnly = bind.isIncomingOnly();
     final outgoingOnly = bind.isOutgoingOnly();
-    final showAutoUpdate = isWindows && bind.mainIsInstalled();
+    final showAutoUpdate = (isWindows || isMacOS) && bind.mainIsInstalled();
     final children = <Widget>[
       if (!isWeb && !incomingOnly)
         _OptionCheckBox(context, 'Confirm before closing multiple tabs',

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -159,7 +159,7 @@ fn check_update(manually: bool) -> ResultType<()> {
             } else {
                 "x86_64"
             };
-            format!("{}/rustdesk-{}.{}.dmg", download_url, version, arch)
+            format!("{}/rustdesk-{}-{}.dmg", download_url, version, arch)
         };
         log::debug!("New version available: {}", &version);
         let client = create_http_client_with_url(&download_url);

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -152,6 +152,15 @@ fn check_update(manually: bool) -> ResultType<()> {
         } else {
             format!("{}/rustdesk-{}-x86-sciter.exe", download_url, version)
         };
+        #[cfg(target_os = "macos")]
+        let download_url = {
+            let arch = if std::env::consts::ARCH == "aarch64" {
+                "aarch64"
+            } else {
+                "x86_64"
+            };
+            format!("{}/rustdesk-{}.{}.dmg", download_url, version, arch)
+        };
         log::debug!("New version available: {}", &version);
         let client = create_http_client_with_url(&download_url);
         let Some(file_path) = get_download_file_from_url(&download_url) else {
@@ -198,6 +207,8 @@ fn check_update(manually: bool) -> ResultType<()> {
         if has_no_active_conns() {
             #[cfg(target_os = "windows")]
             update_new_version(update_msi, &version, &file_path);
+            #[cfg(target_os = "macos")]
+            update_new_version_macos(&version, &file_path);
         }
     }
     Ok(())
@@ -288,6 +299,30 @@ fn update_new_version(update_msi: bool, version: &str, file_path: &PathBuf) {
             "Failed to convert the file path to string: {}",
             file_path.display()
         );
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn update_new_version_macos(version: &str, file_path: &std::path::PathBuf) {
+    log::debug!(
+        "New version downloaded, starting macOS update: version={}, file={:?}",
+        version,
+        file_path.to_str()
+    );
+    let Some(p) = file_path.to_str() else {
+        log::error!("Failed to convert file path to string: {}", file_path.display());
+        return;
+    };
+    match crate::platform::update_from_dmg(p) {
+        Ok(_) => {
+            log::debug!("macOS update process started for version \"{}\".", version);
+            // update_from_dmg launches the new binary and returns;
+            // the new process calls --update which calls update_me() and exits the old one.
+        }
+        Err(e) => {
+            log::error!("Failed to start macOS update to \"{}\": {}", version, e);
+            std::fs::remove_file(file_path).ok();
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Extends the existing auto-update feature (Windows, PR #11476) to macOS.

## Changes

- `src/updater.rs`: builds arch-aware DMG download URL (aarch64/x86_64) and calls `update_new_version_macos()` when no active connections exist
- `flutter/lib/desktop/pages/desktop_setting_page.dart`: exposes the `allow-auto-update` toggle on macOS in Settings → General

## How it works

The full install pipeline (`update_from_dmg` → `extract_dmg` → `update_extracted` → `update_me`) was already implemented in `src/platform/macos.rs` since 1.4.4. This PR connects the existing auto-update scheduler to that pipeline.

## Note

I have not been able to run a full local build yet due to environment setup. Opening as a draft for feedback on the approach before investing in full testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS users can now see the **Auto update** option in Desktop settings.
  * macOS software updates are now supported with downloads tailored to Intel and Apple Silicon devices.
* **Bug Fixes**
  * Update checks now handle macOS update installation after confirming the app is not actively connected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->