### PR TITLE
fix(linux): use Wayland discovery for Wayland sessions with Xwayland

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1904,12 +1904,18 @@ mod desktop {
 
         pub fn refresh(&mut self) {
             if !self.sid.is_empty() && is_active_and_seat0(&self.sid) {
-                // Xwayland display and xauth may not be available in a short time after login.
-                if is_xwayland_running() && !self.is_login_wayland() {
+                // Prefer the session's actual display protocol over the mere presence of
+                // Xwayland. A Wayland session commonly has Xwayland running for X11
+                // compatibility apps, but its display/xauth must still be discovered via the
+                // Wayland path. Routing it through the Xwayland path makes the legacy get_env()
+                // shell pipeline (deprecated, see get_envs) run every refresh, and where the
+                // Xwayland process exports no XAUTHORITY the DISPLAY && XAUTHORITY success
+                // condition can never be met, turning refresh() into a continuous fork storm.
+                if self.is_wayland() {
+                    self.get_display_xauth_wayland();
+                } else if is_xwayland_running() {
                     self.get_display_xauth_xwayland();
                     self.is_rustdesk_subprocess = false;
-                } else if self.is_wayland() {
-                    self.get_display_xauth_wayland();
                 }
                 return;
             }
@@ -1934,11 +1940,12 @@ mod desktop {
 
             self.get_home();
             if self.is_wayland() {
-                if is_xwayland_running() {
-                    self.get_display_xauth_xwayland();
-                } else {
-                    self.get_display_xauth_wayland();
-                }
+                // Always use Wayland discovery for a Wayland session, regardless of whether
+                // Xwayland is running for X11 compatibility apps. get_display_xauth_wayland()
+                // still collects optional DISPLAY/XAUTHORITY when present, and uses native
+                // /proc scanning (get_envs) instead of the deprecated per-variable get_env()
+                // shell pipeline.
+                self.get_display_xauth_wayland();
                 self.is_rustdesk_subprocess = false;
             } else {
                 self.get_display_x11();


### PR DESCRIPTION
## Problem

`Desktop::refresh()` routes a Wayland session into `get_display_xauth_xwayland()` whenever an Xwayland process is running — which is the common case, since most Wayland desktops keep Xwayland around for X11 compatibility apps. That path uses the deprecated per-variable `get_env()` shell pipeline (`ps | grep | tail | awk | xargs cat | tr | grep | sed`) and only succeeds when **both** `DISPLAY` and `XAUTHORITY` are found.

This was analysed in detail in #15554 (credit to @dougvk, including the proposed fix this PR implements). Two failure modes result:

1. **Xwayland with no `XAUTHORITY` (e.g. Hyprland):** the `DISPLAY && XAUTHORITY` gate can never be satisfied, so every refresh burns the full 10×6×4 retry budget — up to **240 forked shell pipelines per refresh** — and the root service becomes a continuous fork storm. #15554 measured **93.1% of one core** while idle, no client connected.

2. **Xwayland with `XAUTHORITY` present (e.g. GNOME/mutter):** the gate succeeds early, but the successful path still runs several `get_env()` shell pipelines *per refresh* instead of a single native `/proc` scan, and `refresh()` re-runs continuously.

### Independent reproduction of case 2 (GNOME/mutter)

On a separate host from the #15554 report — **RustDesk 1.4.9 (Flutter), Ubuntu 25.04, kernel 6.14, GNOME on Wayland (mutter)** — with Xwayland running and exporting all four keys (`DISPLAY`, `WAYLAND_DISPLAY`, `XAUTHORITY`, `DBUS_SESSION_BUS_ADDRESS`):

- `rustdesk --service` (root) sustains **~23–25% of one core** while idle, no client connected.
- It spawns the `ps -u <uid> -f | grep -E 'xdg-desktop-portal' | … | cat /proc/__/environ | …` pipeline **~82 times per second** (≈ every 86 ms), interleaved with `loginctl show-session`, `pgrep -a Xwayland`, and `ps aux`.
- `systemctl show rustdesk -p CPUUsageNSec` confirms ~25% of one core averaged over hours of uptime.
- Upgrading 1.4.8 → 1.4.9 did not change it (measured 24.4% → 23.2%).

This confirms @dougvk's note that the fix "should also be checked on GNOME and KDE Wayland sessions with Xwayland enabled," and regression item #2 in that issue (retain optional `DISPLAY`/`XAUTHORITY` without making them the success condition).

## Fix

Prefer the session's actual display protocol over the mere presence of a compatibility Xwayland process, at **both** refresh sites (the active-session fast path and initial discovery). A Wayland session now always uses `get_display_xauth_wayland()`, which:

- scans `/proc` natively via `get_envs()` instead of the deprecated per-variable `get_env()` shell pipeline (the migration direction already documented on `get_env` / discussion #11959),
- uses `WAYLAND_DISPLAY && DBUS_SESSION_BUS_ADDRESS` as its success condition, and
- **still collects optional `DISPLAY`/`XAUTHORITY` when present**, so nothing is lost where they exist (GNOME).

X11 sessions are unaffected: they still reach `get_display_x11()` / `get_xauth_x11()`, and `get_display_xauth_xwayland()` / `is_xwayland_running()` remain in use for the non-Wayland branch.

```diff
-                if is_xwayland_running() && !self.is_login_wayland() {
+                if self.is_wayland() {
+                    self.get_display_xauth_wayland();
+                } else if is_xwayland_running() {
                     self.get_display_xauth_xwayland();
                     self.is_rustdesk_subprocess = false;
-                } else if self.is_wayland() {
-                    self.get_display_xauth_wayland();
                 }
```

Expected effect: case 1 (Hyprland) drops from ~93% to the baseline `loginctl`/`ps aux` polling level (~8% per #15554's branch-forcing validation); case 2 (GNOME) eliminates the per-refresh shell pipelines in favour of a single native `/proc` scan.

## Testing

- The change is a control-flow reorder of existing, unchanged function calls (`is_wayland()`, `get_display_xauth_wayland()`, `is_xwayland_running()`, `get_display_xauth_xwayland()`) — no signature or type changes. Delimiter balance and dead-code checks pass; both previously-used functions remain referenced. I was not able to run a full local build (vcpkg/toolchain), so I'm relying on CI to compile-verify.
- The equivalent runtime behaviour was validated in #15554 by forcing the existing pure-Wayland branch (idle service CPU 93.1% → 7.9%, with portal capture, HW H.264 encode, uinput init, and a full remote session all continuing to work).
- Happy to run an `strace -f -e trace=execve` capture or test a patched build on GNOME/Wayland if useful.

Fixes #15554.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display and environment discovery for Wayland sessions.
  * Ensured Wayland-native handling is used even when Xwayland is also running.
  * Improved display authentication handling during non-active-seat refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->