### PR TITLE
Translate 'Continue' to 'Continuar' in ptbr.rs

### DIFF
--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -332,7 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Conexão via Relay"),
         ("Secure Connection", "Conexão Segura"),
         ("Insecure Connection", "Conexão Insegura"),
-        ("Continue", ""),
+        ("Continue", "Continuar"),
         ("Scale original", "Escala original"),
         ("Scale adaptive", "Escala adaptada"),
         ("General", "Geral"),


### PR DESCRIPTION
Translate 'Continue' to 'Continuar' in ptbr.rs

Fix lang for https://github.com/rustdesk/rustdesk/pull/15514

@rustdesk 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Portuguese-Brazilian translation for the “Continue” button to display “Continuar.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->