### PR TITLE
Fix Adjust Window sizing across DPI

### DIFF
--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1391,10 +1391,8 @@ class ScreenAdjustor {
       double left = wndRect.left + (wndRect.width - width) / 2;
       double top = wndRect.top + (wndRect.height - height) / 2;
 
-      Rect frameRect = _screen!.frame;
-      if (!isFullscreen) {
-        frameRect = _screen!.visibleFrame;
-      }
+      // Adjust Window exits fullscreen before setting the window frame.
+      Rect frameRect = _screen!.visibleFrame;
       if (isLinux && bind.mainCurrentIsWayland()) {
         // In testing, Wayland at 200% reported an unscaled screen frame while
         // GTK window sizes used logical units, so convert the frame first.

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1454,18 +1454,26 @@ class ScreenAdjustor {
         : views.first;
     await updateScreen();
     if (_screen != null) {
+      final wc = WindowController.fromWindowId(windowId);
       final wasFullscreen = isFullscreen;
       cbExitFullscreen();
       if (wasFullscreen) {
         // Wait for the native fullscreen exit to update the window frame.
         await Future.delayed(Duration(milliseconds: 700));
       }
+      if (isLinux) {
+        if (await wc.isMaximized()) {
+          // setFrame may be ignored while the native window is maximized.
+          await wc.unmaximize();
+          stateGlobal.setMaximized(false);
+        }
+      }
       final mediaSize = MediaQueryData.fromView(view).size;
       final frame = await _getAdjustedWindowFrame(mediaSize);
       if (frame == null) {
         return;
       }
-      await WindowController.fromWindowId(windowId).setFrame(frame);
+      await wc.setFrame(frame);
       stateGlobal.setMaximized(false);
     }
   }

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1370,7 +1370,14 @@ class ScreenAdjustor {
       // Windows window frames use physical pixels while Flutter view sizes are
       // logical. macOS and Linux window frames use the same units as Flutter.
       double scale = isWindows ? screen.scaleFactor : 1.0;
-      final wndRect = await WindowController.fromWindowId(windowId).getFrame();
+      final Rect wndRect;
+      try {
+        wndRect = await WindowController.fromWindowId(windowId).getFrame();
+      } catch (e) {
+        debugPrint(
+            "Failed to get frame of window $windowId, it may be hidden");
+        return null;
+      }
       // On Windows, wndRect is GetWindowRect while mediaSize is GetClientRect.
       // https://stackoverflow.com/a/7561083
       double magicWidth =

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1406,13 +1406,14 @@ class ScreenAdjustor {
           );
         }
       }
-      // A window frame cannot be smaller than its client area. Negative values
-      // mean the native frame and Flutter view metrics are not synchronized.
-      if (magicWidth < 0 || magicHeight < 0) {
+      // A window frame cannot be smaller than its client area. Tolerate small
+      // floating-point differences; larger negative values mean the native
+      // frame and Flutter view metrics are not synchronized.
+      if (magicWidth < -0.1 || magicHeight < -0.1) {
         return null;
       }
-      // During the macOS fullscreen exit animation, WindowController.getFrame()
-      // once returned a transient 4.0x60.0 frame. Reject it for safety.
+      // Transient fullscreen metrics once produced a calculated 4.0x60.0
+      // target frame. Reject implausibly small targets to avoid hiding the window.
       if (width < 300 || height < 300) {
         return null;
       }

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1348,7 +1348,7 @@ class ScreenAdjustor {
 
   adjustWindow(BuildContext context) {
     return futureBuilder(
-        future: isWindowCanBeAdjusted(),
+        future: isWindowCanBeAdjusted(context),
         hasData: (data) {
           final visible = data as bool;
           if (!visible) return Offstage();
@@ -1364,20 +1364,20 @@ class ScreenAdjustor {
         });
   }
 
-  doAdjustWindow(BuildContext context) async {
-    await updateScreen();
+  Future<Rect?> _getAdjustedWindowFrame(Size mediaSize) async {
     if (_screen != null) {
-      cbExitFullscreen();
-      double scale = _screen!.scaleFactor;
+      // See the platform coordinate-unit notes above ScreenAdjustor.
+      double scale = isWindows ? _screen!.scaleFactor : 1.0;
       final wndRect = await WindowController.fromWindowId(windowId).getFrame();
-      final mediaSize = MediaQueryData.fromView(View.of(context)).size;
-      // On windows, wndRect is equal to GetWindowRect and mediaSize is equal to GetClientRect.
+      // On Windows, wndRect is GetWindowRect while mediaSize is GetClientRect.
       // https://stackoverflow.com/a/7561083
       double magicWidth =
           wndRect.right - wndRect.left - mediaSize.width * scale;
       double magicHeight =
           wndRect.bottom - wndRect.top - mediaSize.height * scale;
       final canvasModel = ffi.canvasModel;
+      // canvasModel.scale is the rendered scale and already applies kIgnoreDpi.
+      // Use it instead of the remote source resolution.
       final width = (canvasModel.getDisplayWidth() * canvasModel.scale +
                   CanvasModel.leftToEdge +
                   CanvasModel.rightToEdge) *
@@ -1395,6 +1395,34 @@ class ScreenAdjustor {
       if (!isFullscreen) {
         frameRect = _screen!.visibleFrame;
       }
+      if (isLinux && bind.mainCurrentIsWayland()) {
+        // In testing, Wayland at 200% reported an unscaled screen frame while
+        // GTK window sizes used logical units, so convert the frame first.
+        double screenScale = _screen!.scaleFactor;
+        if (screenScale > 1) {
+          frameRect = Rect.fromLTRB(
+            frameRect.left / screenScale,
+            frameRect.top / screenScale,
+            frameRect.right / screenScale,
+            frameRect.bottom / screenScale,
+          );
+        }
+      }
+      // A window frame cannot be smaller than its client area. Negative values
+      // mean the native frame and Flutter view metrics are not synchronized.
+      if (magicWidth < 0 || magicHeight < 0) {
+        return null;
+      }
+      // During the macOS fullscreen exit animation, WindowController.getFrame()
+      // once returned a transient 4.0x60.0 frame. Reject it for safety.
+      if (width < 300 || height < 300) {
+        return null;
+      }
+      // The remote size may change after the menu is built. Require the target
+      // frame to be strictly smaller than the available screen area.
+      if (width >= frameRect.width || height >= frameRect.height) {
+        return null;
+      }
       if (left < frameRect.left) {
         left = frameRect.left;
       }
@@ -1407,8 +1435,32 @@ class ScreenAdjustor {
       if ((top + height) > frameRect.bottom) {
         top = frameRect.bottom - height;
       }
-      await WindowController.fromWindowId(windowId)
-          .setFrame(Rect.fromLTWH(left, top, width, height));
+      return Rect.fromLTWH(left, top, width, height);
+    }
+    return null;
+  }
+
+  doAdjustWindow([BuildContext? context]) async {
+    // A resolution change is adjusted after a delay, when the menu context may
+    // already be disposed. Each desktop_multi_window window has its own engine,
+    // so that engine's first view is the current window.
+    final view = context != null
+        ? View.of(context)
+        : WidgetsBinding.instance.platformDispatcher.views.first;
+    await updateScreen();
+    if (_screen != null) {
+      final wasFullscreen = isFullscreen;
+      cbExitFullscreen();
+      if (wasFullscreen) {
+        // Wait for the native fullscreen exit to update the window frame.
+        await Future.delayed(Duration(milliseconds: 700));
+      }
+      final mediaSize = MediaQueryData.fromView(view).size;
+      final frame = await _getAdjustedWindowFrame(mediaSize);
+      if (frame == null) {
+        return;
+      }
+      await WindowController.fromWindowId(windowId).setFrame(frame);
       stateGlobal.setMaximized(false);
     }
   }
@@ -1438,7 +1490,12 @@ class ScreenAdjustor {
     return v.result;
   }
 
-  Future<bool> isWindowCanBeAdjusted() async {
+  Future<bool> isWindowCanBeAdjusted([BuildContext? context]) async {
+    // Capture the view before awaiting because the menu context may be disposed.
+    final view = context != null
+        ? View.of(context)
+        : WidgetsBinding.instance.platformDispatcher.views.first;
+    final mediaSize = MediaQueryData.fromView(view).size;
     final viewStyle =
         await bind.sessionGetViewStyle(sessionId: ffi.sessionId) ?? '';
     if (viewStyle != kRemoteViewStyleOriginal) {
@@ -1453,23 +1510,7 @@ class ScreenAdjustor {
     if (_screen == null) {
       return false;
     }
-    final scale = kIgnoreDpi ? 1.0 : _screen!.scaleFactor;
-    double selfWidth = _screen!.visibleFrame.width;
-    double selfHeight = _screen!.visibleFrame.height;
-    if (isFullscreen) {
-      selfWidth = _screen!.frame.width;
-      selfHeight = _screen!.frame.height;
-    }
-
-    final canvasModel = ffi.canvasModel;
-    final displayWidth = canvasModel.getDisplayWidth();
-    final displayHeight = canvasModel.getDisplayHeight();
-    final requiredWidth =
-        CanvasModel.leftToEdge + displayWidth + CanvasModel.rightToEdge;
-    final requiredHeight =
-        CanvasModel.topToEdge + displayHeight + CanvasModel.bottomToEdge;
-    return selfWidth > (requiredWidth * scale) &&
-        selfHeight > (requiredHeight * scale);
+    return await _getAdjustedWindowFrame(mediaSize) != null;
   }
 }
 
@@ -2177,7 +2218,9 @@ class _ResolutionsMenuState extends State<_ResolutionsMenu> {
       }
       if (w == rect.width.toInt() && h == rect.height.toInt()) {
         if (await widget.screenAdjustor.isWindowCanBeAdjusted()) {
-          widget.screenAdjustor.doAdjustWindow(context);
+          // This delayed callback can outlive the menu State, so its context
+          // is unsafe.
+          widget.screenAdjustor.doAdjustWindow();
         }
       }
     });

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1460,6 +1460,7 @@ class ScreenAdjustor {
       if (wasFullscreen) {
         // Wait for the native fullscreen exit to update the window frame.
         await Future.delayed(Duration(milliseconds: 700));
+        await updateScreen();
       }
       if (isLinux) {
         if (await wc.isMaximized()) {
@@ -1504,6 +1505,9 @@ class ScreenAdjustor {
   }
 
   Future<bool> isWindowCanBeAdjusted([BuildContext? context]) async {
+    if (isWeb) {
+      return false;
+    }
     // Capture the view before awaiting because the menu context may be disposed.
     final views = WidgetsBinding.instance.platformDispatcher.views;
     if (context == null && views.isEmpty) {
@@ -1513,6 +1517,7 @@ class ScreenAdjustor {
         ? View.of(context)
         : views.first;
     final mediaSize = MediaQueryData.fromView(view).size;
+    await updateScreen();
     final viewStyle =
         await bind.sessionGetViewStyle(sessionId: ffi.sessionId) ?? '';
     if (viewStyle != kRemoteViewStyleOriginal) {

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -1365,9 +1365,11 @@ class ScreenAdjustor {
   }
 
   Future<Rect?> _getAdjustedWindowFrame(Size mediaSize) async {
-    if (_screen != null) {
-      // See the platform coordinate-unit notes above ScreenAdjustor.
-      double scale = isWindows ? _screen!.scaleFactor : 1.0;
+    final screen = _screen;
+    if (screen != null) {
+      // Windows window frames use physical pixels while Flutter view sizes are
+      // logical. macOS and Linux window frames use the same units as Flutter.
+      double scale = isWindows ? screen.scaleFactor : 1.0;
       final wndRect = await WindowController.fromWindowId(windowId).getFrame();
       // On Windows, wndRect is GetWindowRect while mediaSize is GetClientRect.
       // https://stackoverflow.com/a/7561083
@@ -1392,11 +1394,11 @@ class ScreenAdjustor {
       double top = wndRect.top + (wndRect.height - height) / 2;
 
       // Adjust Window exits fullscreen before setting the window frame.
-      Rect frameRect = _screen!.visibleFrame;
+      Rect frameRect = screen.visibleFrame;
       if (isLinux && bind.mainCurrentIsWayland()) {
         // In testing, Wayland at 200% reported an unscaled screen frame while
         // GTK window sizes used logical units, so convert the frame first.
-        double screenScale = _screen!.scaleFactor;
+        double screenScale = screen.scaleFactor;
         if (screenScale > 1) {
           frameRect = Rect.fromLTRB(
             frameRect.left / screenScale,
@@ -1443,9 +1445,13 @@ class ScreenAdjustor {
     // A resolution change is adjusted after a delay, when the menu context may
     // already be disposed. Each desktop_multi_window window has its own engine,
     // so that engine's first view is the current window.
+    final views = WidgetsBinding.instance.platformDispatcher.views;
+    if (context == null && views.isEmpty) {
+      return;
+    }
     final view = context != null
         ? View.of(context)
-        : WidgetsBinding.instance.platformDispatcher.views.first;
+        : views.first;
     await updateScreen();
     if (_screen != null) {
       final wasFullscreen = isFullscreen;
@@ -1491,9 +1497,13 @@ class ScreenAdjustor {
 
   Future<bool> isWindowCanBeAdjusted([BuildContext? context]) async {
     // Capture the view before awaiting because the menu context may be disposed.
+    final views = WidgetsBinding.instance.platformDispatcher.views;
+    if (context == null && views.isEmpty) {
+      return false;
+    }
     final view = context != null
         ? View.of(context)
-        : WidgetsBinding.instance.platformDispatcher.views.first;
+        : views.first;
     final mediaSize = MediaQueryData.fromView(view).size;
     final viewStyle =
         await bind.sessionGetViewStyle(sessionId: ffi.sessionId) ?? '';


### PR DESCRIPTION
# Summary

- Apply scaleFactor to the target size only on Windows. Use scale 1 on macOS and Linux; divide the Wayland screen frame by scaleFactor.
- Wait for fullscreen exit before reading window geometry.
- Use the same frame calculation for menu availability and resizing, rejecting invalid or oversized frames.
- Avoid using a disposed menu context during delayed resolution changes.
- Fix the Adjust Window failure when the Linux window is maximized by first restoring the window from the maximized state.

Normalized measurements at scale factor 2, using the 100% size as 1:

| Measurement | macOS (HiDPI) | Windows | X11 | Wayland |
|--------------|:-------------:|:-------:|:---:|:--------:|
| `WindowController.getFrame`(`wndRect`) | 0.5 | 1 | 0.5 | 0.5 |
| `MediaQueryData.fromView(view).size` (`mediaSize`) | 0.5 | 0.5 | 0.5 | 0.5 |
| `window_size.screen`(`_screen`) | 0.5 | 1 | 0.5 | 1 |

macOS 0.5: The native resolution is 1920×1080. After enabling HiDPI using third-party software, all APIs still report the resolution as 1920×1080.

# Tested

Adjust Window and remote resolution changes on macOS (non-HiDPI and HiDPI), Windows (100% and 200%), and GNOME X11/Wayland (100% and 200%).

 ## Known issues
  - macOS HiDPI was tested using software-simulated HiDPI, not a Retina display, Linux testing was performed on Ubuntu GNOME.
  - In fullscreen mode, Adjust Window may be shown but perform no resize.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the **Adjust Window** action so it only enables when the target position/size can be computed reliably for the current display setup (including platform-specific visible-frame behavior).
  * Added stronger validation to avoid invalid, overly small, or off-screen window sizing, and only apply changes when a feasible frame is available.
  * Refined **Adjust Window** behavior around fullscreen exit and resolution changes so adjustments apply more consistently.
  * Prevented delayed adjustments from relying on stale UI context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->