### PR TITLE
Fix disabled installation bypass

### DIFF
--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -14,6 +14,7 @@
 typedef char** (*FUNC_RUSTDESK_CORE_MAIN)(int*);
 typedef void (*FUNC_RUSTDESK_FREE_ARGS)( char**, int);
 typedef int (*FUNC_RUSTDESK_GET_APP_NAME)(wchar_t*, int);
+typedef int (*FUNC_RUSTDESK_IS_DISABLE_INSTALLATION)();
 /// Note: `--server`, `--service` are already handled in [core_main.rs].
 const std::vector<std::string> parameters_white_list = {"--install", "--cm"};
 
@@ -62,6 +63,18 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   }
   std::vector<std::string> rust_args(c_args, c_args + args_len);
   free_c_args(c_args, args_len);
+  FUNC_RUSTDESK_IS_DISABLE_INSTALLATION rustdesk_is_disable_installation =
+      (FUNC_RUSTDESK_IS_DISABLE_INSTALLATION)GetProcAddress(hInstance, "rustdesk_is_disable_installation");
+  bool is_disable_installation =
+      rustdesk_is_disable_installation && rustdesk_is_disable_installation() != 0;
+  const auto installParam = std::string("--install");
+  if (is_disable_installation) {
+    command_line_arguments.erase(
+        std::remove(command_line_arguments.begin(),
+                    command_line_arguments.end(),
+                    installParam),
+        command_line_arguments.end());
+  }
 
   std::wstring app_name = L"RustDesk";
   FUNC_RUSTDESK_GET_APP_NAME get_rustdesk_app_name = (FUNC_RUSTDESK_GET_APP_NAME)GetProcAddress(hInstance, "get_rustdesk_app_name");
@@ -118,7 +131,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
     is_cm_page = true;
   }
   bool is_install_page = false;
-  auto installParam = std::string("--install");
   if (!command_line_arguments.empty() && command_line_arguments.front().compare(0, installParam.size(), installParam.c_str()) == 0) {
     is_install_page = true;
   }

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -68,6 +68,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   bool is_disable_installation =
       rustdesk_is_disable_installation && rustdesk_is_disable_installation() != 0;
   const auto installParam = std::string("--install");
+  // Flutter reads the original process command line, not only rust_args, so
+  // remove the `--install` injected by the portable wrapper here as well. This
+  // also lets `no-install.exe` continue as a portable app when installation is
+  // disabled. See: https://github.com/rustdesk/rustdesk-server-pro/issues/991#issuecomment-4978376890
   if (is_disable_installation) {
     command_line_arguments.erase(
         std::remove(command_line_arguments.begin(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -1024,7 +1024,7 @@ pub fn get_full_name() -> String {
 }
 
 pub fn is_setup(name: &str) -> bool {
-    name.to_lowercase().ends_with("install.exe")
+    !config::is_disable_installation() && name.to_lowercase().ends_with("install.exe")
 }
 
 pub fn get_custom_rendezvous_server(custom: String) -> String {

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -127,6 +127,9 @@ pub fn core_main() -> Option<Vec<String>> {
     if args.contains(&"--noinstall".to_string()) {
         args.clear();
     }
+    // The portable wrapper injects `--install` when its name ends with `install.exe`,
+    // including `no-install.exe`. Drop the argument instead of exiting so disabled
+    // clients can continue running as portable applications.
     if config::is_disable_installation() {
         args.retain(|arg| arg != "--install");
         flutter_args.retain(|arg| arg != "--install");

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -127,6 +127,10 @@ pub fn core_main() -> Option<Vec<String>> {
     if args.contains(&"--noinstall".to_string()) {
         args.clear();
     }
+    if config::is_disable_installation() {
+        args.retain(|arg| arg != "--install");
+        flutter_args.retain(|arg| arg != "--install");
+    }
     if args.len() > 0 {
         if args[0] == "--version" {
             println!("{}", crate::VERSION);

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -136,6 +136,12 @@ pub extern "C" fn rustdesk_core_main_args(args_len: *mut c_int) -> *mut *mut c_c
     return std::ptr::null_mut() as _;
 }
 
+#[cfg(windows)]
+#[no_mangle]
+pub extern "C" fn rustdesk_is_disable_installation() -> c_int {
+    hbb_common::config::is_disable_installation() as c_int
+}
+
 // https://gist.github.com/iskakaushik/1c5b8aa75c77479c33c4320913eebef6
 #[cfg(windows)]
 fn rust_args_to_c_args(args: Vec<String>, outlen: *mut c_int) -> *mut *mut c_char {

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -98,12 +98,18 @@ pub fn get_id() -> String {
 
 #[inline]
 pub fn goto_install() {
+    if config::is_disable_installation() {
+        return;
+    }
     allow_err!(crate::run_me(vec!["--install"]));
     std::process::exit(0);
 }
 
 #[inline]
 pub fn install_me(_options: String, _path: String, _silent: bool, _debug: bool) {
+    if config::is_disable_installation() {
+        return;
+    }
     #[cfg(windows)]
     std::thread::spawn(move || {
         allow_err!(crate::platform::windows::install_me(

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -98,18 +98,12 @@ pub fn get_id() -> String {
 
 #[inline]
 pub fn goto_install() {
-    if config::is_disable_installation() {
-        return;
-    }
     allow_err!(crate::run_me(vec!["--install"]));
     std::process::exit(0);
 }
 
 #[inline]
 pub fn install_me(_options: String, _path: String, _silent: bool, _debug: bool) {
-    if config::is_disable_installation() {
-        return;
-    }
     #[cfg(windows)]
     std::thread::spawn(move || {
         allow_err!(crate::platform::windows::install_me(


### PR DESCRIPTION
Fix https://github.com/rustdesk/rustdesk-server-pro/issues/991 

Prevent install.exe and --install from opening the install flow when disable-installation is set.

Tested:
  - install.exe/--install does not open Install Page when `disable-installation` is set.
  - MSI installation is unaffected.

Noted:

When Disable installation is enabled, a 32-bit Sciter executable whose name ends in install.exe may still trigger UAC because Windows Installer Detection runs before RustDesk reads this option; once the prompt is approved, the process runs elevated.

ref: https://learn.microsoft.com/en-us/windows/security/application-security/application-control/user-account-control/architecture#installer-detection-technology


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of disabled installation settings on Windows.
  - Prevented installation-related launch options from opening the installer when installation is disabled.
  - Ensured startup behavior consistently respects the installation restriction across supported launch paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->