### PR TITLE
fix: key help tools wasting vertical space on wide screens

### DIFF
--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -986,6 +986,14 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
       return Offstage();
     }
     final size = MediaQuery.of(context).size;
+    // On wide screens (foldables, tablets, phones in landscape) the key groups
+    // fit in one or two flowing rows, so keep them on the same row instead of
+    // forcing a line break before each group. Narrow (portrait phone) screens
+    // keep the forced breaks so each group starts on its own row.
+    final isWideScreen = size.width >= 600;
+    // A zero-height box wider than any screen makes `Wrap` start a new run.
+    final groupBreak =
+        isWideScreen ? const SizedBox.shrink() : const SizedBox(width: 9999);
 
     final pi = gFFI.ffiModel.pi;
     final isMac = pi.platform == kPeerPlatformMacOS;
@@ -1037,7 +1045,7 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
           active: _more),
     ];
     final fn = <Widget>[
-      SizedBox(width: 9999),
+      groupBreak,
     ];
     for (var i = 1; i <= 12; ++i) {
       final name = 'F$i';
@@ -1046,7 +1054,7 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
       }));
     }
     final more = <Widget>[
-      SizedBox(width: 9999),
+      groupBreak,
       wrap('Esc', () {
         inputModel.inputKey('VK_ESCAPE');
       }),
@@ -1093,7 +1101,7 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
       wrap('Enter', () {
         inputModel.inputKey('VK_ENTER');
       }),
-      SizedBox(width: 9999),
+      groupBreak,
       wrap('', () {
         inputModel.inputKey('VK_LEFT');
       }, icon: Icons.keyboard_arrow_left),

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -999,6 +999,17 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
     final isMac = pi.platform == kPeerPlatformMacOS;
     final isWin = pi.platform == kPeerPlatformWindows;
     final isLinux = pi.platform == kPeerPlatformLinux;
+    final moreButton = wrap(
+        ' ... ',
+        () => setState(
+              () {
+                _more = !_more;
+                if (_more) {
+                  _fn = false;
+                }
+              },
+            ),
+        active: _more);
     final modifiers = <Widget>[
       wrap('Ctrl ', () {
         setState(() => inputModel.ctrl = !inputModel.ctrl);
@@ -1032,17 +1043,7 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
               ),
           active: _pin,
           icon: Icons.push_pin),
-      wrap(
-          ' ... ',
-          () => setState(
-                () {
-                  _more = !_more;
-                  if (_more) {
-                    _fn = false;
-                  }
-                },
-              ),
-          active: _more),
+      if (!isWideScreen) moreButton,
     ];
     final fn = <Widget>[
       groupBreak,
@@ -1129,20 +1130,33 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
     Future.delayed(Duration(milliseconds: 500), () {
       _updateRect();
     });
+    final keyGroups = Wrap(
+      spacing: space,
+      runSpacing: space,
+      children: <Widget>[SizedBox(width: 9999)] +
+          modifiers +
+          keys +
+          (_fn ? fn : []) +
+          (_more ? more : []),
+    );
     return Container(
         key: _key,
         color: Color(0xAA000000),
         padding: EdgeInsets.only(
             top: _keyboardVisibilityController.isVisible ? 24 : 4, bottom: 8),
-        child: Wrap(
-          spacing: space,
-          runSpacing: space,
-          children: <Widget>[SizedBox(width: 9999)] +
-              modifiers +
-              keys +
-              (_fn ? fn : []) +
-              (_more ? more : []),
-        ));
+        child: isWideScreen
+            ? Stack(
+                children: [
+                  // Keep the overflow toggle at the far right instead of
+                  // allowing it to flow between the modifier and extra keys.
+                  Padding(
+                    padding: EdgeInsets.only(right: 52),
+                    child: keyGroups,
+                  ),
+                  Positioned(top: space, right: 0, child: moreButton),
+                ],
+              )
+            : keyGroups);
   }
 }
 

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -990,7 +990,7 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
     // fit in one or two flowing rows, so keep them on the same row instead of
     // forcing a line break before each group. Narrow (portrait phone) screens
     // keep the forced breaks so each group starts on its own row.
-    final isWideScreen = size.width >= 600;
+    final isWideScreen = size.width >= kMobilePageConstraints.maxWidth;
     // A zero-height box wider than any screen makes `Wrap` start a new run.
     final groupBreak =
         isWideScreen ? const SizedBox.shrink() : const SizedBox(width: 9999);

--- a/flutter/lib/mobile/pages/terminal_page.dart
+++ b/flutter/lib/mobile/pages/terminal_page.dart
@@ -137,6 +137,20 @@ class _TerminalPageState extends State<TerminalPage>
     }
   }
 
+  /// Re-measure the key bar after this frame; its height changes when the
+  /// layout switches between one and two rows (e.g. on rotation, or when a
+  /// foldable is folded/unfolded), and the terminal padding must follow.
+  void _scheduleKeyboardHeightUpdate() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _keyboardKey.currentContext == null) return;
+      final renderBox =
+          _keyboardKey.currentContext!.findRenderObject() as RenderBox;
+      if (_keyboardHeight != renderBox.size.height) {
+        setState(() => _keyboardHeight = renderBox.size.height);
+      }
+    });
+  }
+
   EdgeInsets _calculatePadding(double heightPx) {
     if (_cellHeight == null) {
       return const EdgeInsets.symmetric(horizontal: 5.0, vertical: 2.0);
@@ -328,7 +342,9 @@ class _TerminalPageState extends State<TerminalPage>
     // the bar's height. Narrow (portrait phone) screens keep the original two
     // fixed rows. The Wrap still breaks into a second row when the keys
     // genuinely don't fit.
-    final isWideScreen = MediaQuery.of(context).size.width >= 600;
+    final isWideScreen =
+        MediaQuery.sizeOf(context).width >= kMobilePageConstraints.maxWidth;
+    _scheduleKeyboardHeightUpdate();
     return AnimatedPositioned(
       duration: const Duration(milliseconds: 200),
       left: 0,

--- a/flutter/lib/mobile/pages/terminal_page.dart
+++ b/flutter/lib/mobile/pages/terminal_page.dart
@@ -137,20 +137,6 @@ class _TerminalPageState extends State<TerminalPage>
     }
   }
 
-  /// Re-measure the key bar after this frame; its height changes when the
-  /// layout switches between one and two rows (e.g. on rotation, or when a
-  /// foldable is folded/unfolded), and the terminal padding must follow.
-  void _scheduleKeyboardHeightUpdate() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || _keyboardKey.currentContext == null) return;
-      final renderBox =
-          _keyboardKey.currentContext!.findRenderObject() as RenderBox;
-      if (_keyboardHeight != renderBox.size.height) {
-        setState(() => _keyboardHeight = renderBox.size.height);
-      }
-    });
-  }
-
   EdgeInsets _calculatePadding(double heightPx) {
     if (_cellHeight == null) {
       return const EdgeInsets.symmetric(horizontal: 5.0, vertical: 2.0);
@@ -324,27 +310,7 @@ class _TerminalPageState extends State<TerminalPage>
     );
   }
 
-  static const _keyRow1 = ['Esc', '/', '|', 'Home', '↑', 'End', 'PgUp'];
-  static const _keyRow2 = ['Tab', 'Ctrl+C', '~', '←', '↓', '→', 'PgDn'];
-
-  Widget _buildKeyRow(List<String> labels) {
-    return Wrap(
-      alignment: WrapAlignment.center,
-      spacing: 2,
-      runSpacing: 2,
-      children: [for (final label in labels) _buildKeyButton(label)],
-    );
-  }
-
   Widget _buildFloatingKeyboard() {
-    // On wide screens (unfolded foldables, tablets, phones in landscape) all
-    // keys fit in a single row, so lay them out in one flowing row to halve
-    // the bar's height. Narrow (portrait phone) screens keep the original two
-    // fixed rows. The Wrap still breaks into a second row when the keys
-    // genuinely don't fit.
-    final isWideScreen =
-        MediaQuery.sizeOf(context).width >= kMobilePageConstraints.maxWidth;
-    _scheduleKeyboardHeightUpdate();
     return AnimatedPositioned(
       duration: const Duration(milliseconds: 200),
       left: 0,
@@ -357,14 +323,44 @@ class _TerminalPageState extends State<TerminalPage>
         child: Column(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
-          children: isWideScreen
-              ? [
-                  _buildKeyRow([..._keyRow1, ..._keyRow2])
-                ]
-              : [
-                  _buildKeyRow(_keyRow1),
-                  _buildKeyRow(_keyRow2),
-                ],
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _buildKeyButton('Esc'),
+                const SizedBox(width: 2),
+                _buildKeyButton('/'),
+                const SizedBox(width: 2),
+                _buildKeyButton('|'),
+                const SizedBox(width: 2),
+                _buildKeyButton('Home'),
+                const SizedBox(width: 2),
+                _buildKeyButton('↑'),
+                const SizedBox(width: 2),
+                _buildKeyButton('End'),
+                const SizedBox(width: 2),
+                _buildKeyButton('PgUp'),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _buildKeyButton('Tab'),
+                const SizedBox(width: 2),
+                _buildKeyButton('Ctrl+C'),
+                const SizedBox(width: 2),
+                _buildKeyButton('~'),
+                const SizedBox(width: 2),
+                _buildKeyButton('←'),
+                const SizedBox(width: 2),
+                _buildKeyButton('↓'),
+                const SizedBox(width: 2),
+                _buildKeyButton('→'),
+                const SizedBox(width: 2),
+                _buildKeyButton('PgDn'),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/flutter/lib/mobile/pages/terminal_page.dart
+++ b/flutter/lib/mobile/pages/terminal_page.dart
@@ -310,7 +310,25 @@ class _TerminalPageState extends State<TerminalPage>
     );
   }
 
+  static const _keyRow1 = ['Esc', '/', '|', 'Home', '↑', 'End', 'PgUp'];
+  static const _keyRow2 = ['Tab', 'Ctrl+C', '~', '←', '↓', '→', 'PgDn'];
+
+  Widget _buildKeyRow(List<String> labels) {
+    return Wrap(
+      alignment: WrapAlignment.center,
+      spacing: 2,
+      runSpacing: 2,
+      children: [for (final label in labels) _buildKeyButton(label)],
+    );
+  }
+
   Widget _buildFloatingKeyboard() {
+    // On wide screens (unfolded foldables, tablets, phones in landscape) all
+    // keys fit in a single row, so lay them out in one flowing row to halve
+    // the bar's height. Narrow (portrait phone) screens keep the original two
+    // fixed rows. The Wrap still breaks into a second row when the keys
+    // genuinely don't fit.
+    final isWideScreen = MediaQuery.of(context).size.width >= 600;
     return AnimatedPositioned(
       duration: const Duration(milliseconds: 200),
       left: 0,
@@ -323,44 +341,14 @@ class _TerminalPageState extends State<TerminalPage>
         child: Column(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                _buildKeyButton('Esc'),
-                const SizedBox(width: 2),
-                _buildKeyButton('/'),
-                const SizedBox(width: 2),
-                _buildKeyButton('|'),
-                const SizedBox(width: 2),
-                _buildKeyButton('Home'),
-                const SizedBox(width: 2),
-                _buildKeyButton('↑'),
-                const SizedBox(width: 2),
-                _buildKeyButton('End'),
-                const SizedBox(width: 2),
-                _buildKeyButton('PgUp'),
-              ],
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                _buildKeyButton('Tab'),
-                const SizedBox(width: 2),
-                _buildKeyButton('Ctrl+C'),
-                const SizedBox(width: 2),
-                _buildKeyButton('~'),
-                const SizedBox(width: 2),
-                _buildKeyButton('←'),
-                const SizedBox(width: 2),
-                _buildKeyButton('↓'),
-                const SizedBox(width: 2),
-                _buildKeyButton('→'),
-                const SizedBox(width: 2),
-                _buildKeyButton('PgDn'),
-              ],
-            ),
-          ],
+          children: isWideScreen
+              ? [
+                  _buildKeyRow([..._keyRow1, ..._keyRow2])
+                ]
+              : [
+                  _buildKeyRow(_keyRow1),
+                  _buildKeyRow(_keyRow2),
+                ],
         ),
       ),
     );


### PR DESCRIPTION
## Problem

The mobile remote-page key help tools are laid out for narrow portrait phones. A line break is forced before each key group, so the overlay always occupies three or more rows on wide screens such as unfolded foldables, tablets, and landscape phones, leaving most of each row empty.

## Change

- At widths of at least `kMobilePageConstraints.maxWidth` (600dp), forced group breaks become no-ops and the existing `Wrap` lays keys out naturally in fewer rows.
- The existing **More keys** (`...`) toggle stays separate from the expanded key group and is pinned to the right on wide screens.
- Screens narrower than 600dp keep the existing layout unchanged.

The terminal-keyboard portion was removed from this PR because #15532 redesigns that area. This PR now modifies only `remote_page.dart`, and a test merge with the current #15532 head completes without conflicts.

## Screenshots

Captured on an Android 14 emulator connected to a Linux peer. "Before" is the official 1.4.9 release APK and "after" is this PR build.

| | Before | After |
|---|---|---|
| **Foldable unfolded (about 830dp wide)** | ![](https://raw.githubusercontent.com/33modeling/rustdesk/pr-15607-assets/pr_before_fold_keyhelp.png) | ![](https://raw.githubusercontent.com/33modeling/rustdesk/pr-15607-assets/pr_after_fold_keyhelp.png) |
| **Phone (about 393dp wide), unchanged** | ![](https://raw.githubusercontent.com/33modeling/rustdesk/pr-15607-assets/pr_before_phone_keyhelp.png) | ![](https://raw.githubusercontent.com/33modeling/rustdesk/pr-15607-assets/pr_after_phone_keyhelp.png) |