### PR TITLE
Enable configurable connection management notification window

### DIFF
--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1282,8 +1282,8 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
             if (usePassword && !isChangePermanentPasswordDisabled())
               _SubButton('Set permanent password', setPasswordDialog,
                   permEnabled && !locked),
-            // if (usePassword)
-            //   hide_cm(!locked).marginOnly(left: _kContentHSubMargin - 6),
+            if (usePassword)
+              hide_cm(!locked).marginOnly(left: _kContentHSubMargin - 6),
             if (usePassword) radios[2],
           ]);
         })));

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -84,12 +84,10 @@ class ServerModel with ChangeNotifier {
 
   setVerificationMethod(String method) async {
     await bind.mainSetOption(key: kOptionVerificationMethod, value: method);
-    /*
     if (method != kUsePermanentPassword) {
       await bind.mainSetOption(
           key: 'allow-hide-cm', value: bool2option('allow-hide-cm', false));
     }
-    */
   }
 
   String get temporaryPasswordLength {
@@ -106,12 +104,10 @@ class ServerModel with ChangeNotifier {
 
   setApproveMode(String mode) async {
     await bind.mainSetOption(key: kOptionApproveMode, value: mode);
-    /*
     if (mode != 'password') {
       await bind.mainSetOption(
           key: 'allow-hide-cm', value: bool2option('allow-hide-cm', false));
     }
-    */
   }
 
   bool get allowNumericOneTimePassword => _allowNumericOneTimePassword;
@@ -134,18 +130,16 @@ class ServerModel with ChangeNotifier {
     _emptyIdShow = translate("Generating ...");
     _serverId = IDTextEditingController(text: _emptyIdShow);
 
-    /*
-    // initital _hideCm at startup
+    // initial hideCm at startup
     final verificationMethod =
         bind.mainGetOptionSync(key: kOptionVerificationMethod);
     final approveMode = bind.mainGetOptionSync(key: kOptionApproveMode);
-    _hideCm = option2bool(
+    hideCm = option2bool(
         'allow-hide-cm', bind.mainGetOptionSync(key: 'allow-hide-cm'));
     if (!(approveMode == 'password' &&
         verificationMethod == kUsePermanentPassword)) {
-      _hideCm = false;
+      hideCm = false;
     }
-    */
 
     timerCallback() async {
       final connectionStatus =
@@ -237,14 +231,12 @@ class ServerModel with ChangeNotifier {
     final approveMode = await bind.mainGetOption(key: kOptionApproveMode);
     final numericOneTimePassword =
         await mainGetBoolOption(kOptionAllowNumericOneTimePassword);
-    /*
-    var hideCm = option2bool(
+    var newHideCm = option2bool(
         'allow-hide-cm', await bind.mainGetOption(key: 'allow-hide-cm'));
     if (!(approveMode == 'password' &&
         verificationMethod == kUsePermanentPassword)) {
-      hideCm = false;
+      newHideCm = false;
     }
-    */
     if (_approveMode != approveMode) {
       _approveMode = approveMode;
       update = true;
@@ -279,9 +271,8 @@ class ServerModel with ChangeNotifier {
       _allowNumericOneTimePassword = numericOneTimePassword;
       update = true;
     }
-    /*
-    if (_hideCm != hideCm) {
-      _hideCm = hideCm;
+    if (hideCm != newHideCm) {
+      hideCm = newHideCm;
       if (desktopType == DesktopType.cm) {
         if (hideCm) {
           await hideCmWindow();
@@ -291,7 +282,6 @@ class ServerModel with ChangeNotifier {
       }
       update = true;
     }
-    */
     if (update) {
       notifyListeners();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Security setting to hide or show the connection management window when password protection is enabled.
  - The setting now takes effect automatically when verification or approval modes change.

- **Bug Fixes**
  - Corrected startup and password-update handling so the connection management window consistently reflects the configured preference.
  - Prevented the window from being hidden in permanent-password mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->