### PR TITLE
fix(wayland): warn when advertised multi-display geometry is incoherent

### DIFF
--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -1035,7 +1035,9 @@ pub fn try_fix_logical_size(shared_displays: &mut Vec<crate::Display>) {
                         {
                             // If "Full Workspace" is selected in the portal dialog,
                             // the physical size reported by portal may not match the display info.
-                            debug!(
+                            // Warn rather than debug: skipping here on a fractionally scaled
+                            // output leads to clients misplacing input (#15601).
+                            warn!(
                             "Physical size of capturable ({:?}) does not match display info: ({:?}) - ({:?}). Skipping logical size fix.",
                             capturable.position,
                             capturable.physical_size,

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -1033,16 +1033,24 @@ pub fn try_fix_logical_size(shared_displays: &mut Vec<crate::Display>) {
                         if capturable.physical_size.0 != wd.width as usize
                             || capturable.physical_size.1 != wd.height as usize
                         {
-                            // If "Full Workspace" is selected in the portal dialog,
-                            // the physical size reported by portal may not match the display info.
-                            // Warn rather than debug: skipping here on a fractionally scaled
-                            // output leads to clients misplacing input (#15601).
-                            warn!(
-                            "Physical size of capturable ({:?}) does not match display info: ({:?}) - ({:?}). Skipping logical size fix.",
-                            capturable.position,
-                            capturable.physical_size,
-                            (wd.width as usize, wd.height as usize)
-                        );
+                            // A full-workspace capture is a single stream spanning all outputs
+                            // with no per-output logical size, so scale stays 1.0 and input is
+                            // offset on fractionally scaled outputs (#15601).
+                            if capturable.physical_size.0 > wd.width as usize
+                                || capturable.physical_size.1 > wd.height as usize
+                            {
+                                warn!(
+                                    "Capturable {:?} spans multiple outputs; can't apply per-output scale, input will be offset on scaled outputs. Share individual screens or use integer scaling (#15601).",
+                                    capturable.position
+                                );
+                            } else {
+                                warn!(
+                                    "Physical size of capturable ({:?}) does not match display info: ({:?}) - ({:?}). Skipping logical size fix.",
+                                    capturable.position,
+                                    capturable.physical_size,
+                                    (wd.width as usize, wd.height as usize)
+                                );
+                            }
                             break;
                         }
 

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -346,7 +346,55 @@ pub(super) fn check_update_displays(all: &Vec<Display>) {
             }
         })
         .collect::<Vec<DisplayInfo>>();
+    #[cfg(target_os = "linux")]
+    if !is_x11() {
+        warn_on_overlapping_display_rects(&displays);
+    }
     SYNC_DISPLAYS.lock().unwrap().check_changed(displays);
+}
+
+// Clients lay out and hit-test displays by (x, y, width / scale, height / scale).
+// If a fractionally scaled output's logical size was not detected (scale stays 1.0
+// with a physical size), neighboring rects overlap and input lands offset (#15601).
+// This cannot be validated client-side; warn here so host logs pinpoint it.
+#[cfg(target_os = "linux")]
+fn overlapping_display_rects(displays: &[DisplayInfo]) -> Vec<(usize, usize)> {
+    let effective = |d: &DisplayInfo| {
+        let s = if d.scale > 0.0 { d.scale } else { 1.0 };
+        (
+            d.x as f64,
+            d.y as f64,
+            d.width as f64 / s,
+            d.height as f64 / s,
+        )
+    };
+    let mut pairs = Vec::new();
+    for i in 0..displays.len() {
+        for j in (i + 1)..displays.len() {
+            let (ax, ay, aw, ah) = effective(&displays[i]);
+            let (bx, by, bw, bh) = effective(&displays[j]);
+            let overlap_x = (ax + aw).min(bx + bw) - ax.max(bx);
+            let overlap_y = (ay + ah).min(by + bh) - ay.max(by);
+            // Ignore sub-pixel contact from fractional rounding at shared edges.
+            if overlap_x > 1.0 && overlap_y > 1.0 {
+                pairs.push((i, j));
+            }
+        }
+    }
+    pairs
+}
+
+#[cfg(target_os = "linux")]
+fn warn_on_overlapping_display_rects(displays: &[DisplayInfo]) {
+    for (i, j) in overlapping_display_rects(displays) {
+        log::warn!(
+            "Advertised display rects overlap, clients will misplace input. \
+            Display {}: pos ({}, {}), size {}x{}, scale {}. Display {}: pos ({}, {}), size {}x{}, scale {}. \
+            A fractionally scaled output's logical size was probably not detected.",
+            i, displays[i].x, displays[i].y, displays[i].width, displays[i].height, displays[i].scale,
+            j, displays[j].x, displays[j].y, displays[j].width, displays[j].height, displays[j].scale,
+        );
+    }
 }
 
 pub fn is_inited_msg() -> Option<Message> {
@@ -485,4 +533,55 @@ pub fn try_get_displays_(add_amyuni_headless: bool) -> ResultType<Vec<Display>> 
         }
     }
     Ok(displays)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    fn di(x: i32, y: i32, width: i32, height: i32, scale: f64) -> DisplayInfo {
+        DisplayInfo {
+            x,
+            y,
+            width,
+            height,
+            scale,
+            ..Default::default()
+        }
+    }
+
+    // Geometries measured on Plasma 6 / Fedora 44, kscreen-doctor A/B (#15601).
+    #[test]
+    fn overlap_detected_when_scaled_output_advertised_physical() {
+        // 2560x1440 output at 125% (logical 2048 wide) advertised physical with scale 1.0.
+        let displays = vec![di(0, 0, 2560, 1440, 1.0), di(2048, 0, 2560, 1440, 1.0)];
+        assert_eq!(overlapping_display_rects(&displays), vec![(0, 1)]);
+    }
+
+    #[test]
+    fn no_overlap_when_scale_advertised() {
+        let displays = vec![di(0, 0, 2560, 1440, 1.25), di(2048, 0, 2560, 1440, 1.0)];
+        assert!(overlapping_display_rects(&displays).is_empty());
+    }
+
+    #[test]
+    fn no_overlap_on_unscaled_layout() {
+        let displays = vec![di(0, 0, 2560, 1440, 1.0), di(2560, 0, 2560, 1440, 1.0)];
+        assert!(overlapping_display_rects(&displays).is_empty());
+    }
+
+    // Reporter's layout: 2880x1800 laptop panel at 155% plus a 1080p external at
+    // logical x 1859; physical advertisement overlaps ~1021 px.
+    #[test]
+    fn overlap_detected_for_reporter_layout() {
+        let displays = vec![di(0, 718, 2880, 1800, 1.0), di(1859, 0, 1920, 1080, 1.0)];
+        assert_eq!(overlapping_display_rects(&displays), vec![(0, 1)]);
+    }
+
+    #[test]
+    fn subpixel_contact_from_fractional_rounding_ignored() {
+        // 1.5 scale on 2559 px: logical 1706.0, neighbor at 1706 leaves <1 px contact.
+        let displays = vec![di(0, 0, 2559, 1440, 1.5), di(1706, 0, 2560, 1440, 1.0)];
+        assert!(overlapping_display_rects(&displays).is_empty());
+    }
 }


### PR DESCRIPTION
Partial fix for #15601.

On Wayland multi-monitor hosts with a fractionally scaled output, if the output's logical size is not detected, the server advertises the display as logical origin + physical size with `scale = 1.0`. Neighboring display rects then overlap in the client's coordinate space, and absolute input lands offset (clicks hit the wrong monitor). The client cannot detect or correct this, and the existing detection-failure paths are silent (`try_fix_logical_size` skips with a debug log; `get_displays` failures fall back to physical size), so there is nothing in the host logs to point at the cause.

This does not change any advertised value. It adds detection and logging so the failure is diagnosable:

- `check_update_displays` now checks whether the client-effective rects (`x`, `y`, `width / scale`, `height / scale`) overlap, and logs a warning with the full geometry of the offending pair when they do. Sub-pixel contact at shared edges from fractional rounding is ignored.
- The `try_fix_logical_size` skip on a mismatched portal size is raised from `debug` to `warn`, since on a scaled output that skip is what leads to the misplacement.

Why not advertise logical sizes and fix it outright: I tried that on the same rig. Input becomes correct for every client, but `DisplayInfo.width/height` is also the video buffer contract, so rendering breaks into overlapping strips. A real fix needs logical desktop geometry carried separately from physical video dimensions, which is a larger protocol-facing change; this warning is a safe first step that makes the field failures identifiable.

Tested (Fedora 44, KDE Plasma 6 Wayland, host RPM, one 2560x1440 monitor at 125% next to one at 100%, cursor position verified with kdotool):
  - Healthy multi-monitor session (logical sizes detected): no warning logged, input accurate
  - Broken geometry (native 1.4.0 client against the same host): clicks land offset by exactly the 1.25 scale factor onto the wrong monitor; the overlap this patch detects is the advertised-geometry shape that produces it
  - `cargo test -p rustdesk display_service`: 5 passed (includes the reporter's 155% panel layout from the issue)
  - `cargo fmt --check` clean on touched files, clippy clean on touched code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of display layout issues on Linux when fractional scaling is enabled.
  * Added clearer warnings for physical-size mismatches and overlapping display rectangles, skipping logical-size correction when appropriate.
* **Tests**
  * Added Linux unit tests covering overlapping and non-overlapping display scenarios, including fractional rounding edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->