### PR TITLE
Translate Continue into Simplified Chinese

### DIFF
--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -332,7 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "中继连接"),
         ("Secure Connection", "安全连接"),
         ("Insecure Connection", "非安全连接"),
-        ("Continue", ""),
+        ("Continue", "继续"),
         ("Scale original", "原始尺寸"),
         ("Scale adaptive", "适应窗口"),
         ("General", "常规"),


### PR DESCRIPTION
## Summary

Add the missing Simplified Chinese translation for the "Continue" button.

## Changes

- Translate `Continue` as `继续` in `src/lang/cn.rs`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added the Chinese translation for the “Continue” action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->