### PR TITLE
fix: macOS server memory growth, wrap BackingScaleFactor in autoreleasepool

### DIFF
--- a/src/platform/macos.mm
+++ b/src/platform/macos.mm
@@ -118,16 +118,18 @@ extern "C" bool MacCheckAdminAuthorization() {
 
 // https://gist.github.com/briankc/025415e25900750f402235dbf1b74e42
 extern "C" float BackingScaleFactor(uint32_t display) {
-    NSArray<NSScreen *> *screens = [NSScreen screens];
-    for (NSScreen *screen in screens) {
-        NSDictionary *deviceDescription = [screen deviceDescription];
-        NSNumber *screenNumber = [deviceDescription objectForKey:@"NSScreenNumber"];
-        CGDirectDisplayID screenDisplayID = [screenNumber unsignedIntValue];
-        if (screenDisplayID == display) {
-            return [screen backingScaleFactor];
+    @autoreleasepool {
+        NSArray<NSScreen *> *screens = [NSScreen screens];
+        for (NSScreen *screen in screens) {
+            NSDictionary *deviceDescription = [screen deviceDescription];
+            NSNumber *screenNumber = [deviceDescription objectForKey:@"NSScreenNumber"];
+            CGDirectDisplayID screenDisplayID = [screenNumber unsignedIntValue];
+            if (screenDisplayID == display) {
+                return [screen backingScaleFactor];
+            }
         }
+        return 1;
     }
-    return 1;
 }
 
 // https://github.com/jhford/screenresolution/blob/master/cg_utils.c


### PR DESCRIPTION
## What this PR does

Wraps the body of `BackingScaleFactor()` (`src/platform/macos.mm`) in `@autoreleasepool`.

Fixes the unbounded memory growth of the macOS `--server` process reported in #14603 (and matching #13277, #8899, #7747).

## Root cause

`BackingScaleFactor()` iterates `[NSScreen screens]` and calls `[screen deviceDescription]` on each screen. Both return autoreleased objects. The function is reached via scrap's `Display::scale()` (which `width()`/`height()` also call internally) from the display service loop, which runs every 300 ms for as long as a peer is subscribed, on a plain Rust thread that never drains an autorelease pool. The ObjC runtime accumulates the autoreleased dictionaries in implicit pool pages that would only drain at thread exit, so they accumulate for the lifetime of the process.

On a host with 10 days of uptime this reached 16 GB of phys_footprint: `heap` shows ~20.9M live `NSDeviceDescriptionKey` dictionaries (448 B storage each on macOS 26, where AppKit returns them Swift-bridged), 2 `NSValue`s per dictionary, and ~137k autorelease pool pages pinning them. `leaks` reports nothing because everything is still reachable from the pools, which is likely why #14603 was labeled unreproducible. Full analysis with numbers in https://github.com/rustdesk/rustdesk/issues/14603#issuecomment-5012040507.

Every other NSScreen helper in the codebase already runs under a pool (`get_focused_display`, `get_cursor`, `get_cursor_data` are wrapped in `src/platform/macos.rs`); this was the only unwrapped path.

## Verification

Manual, on macOS 26.3 / MacBook Pro M4 Max: `vmmap --summary` allocation count of `DefaultMallocZone` grows by tens per second during an active session on unpatched builds (~130–140 MB/h) and is flat when idle. No automated test added: the leak lives in an ObjC helper driven by wall-clock service loops, so it isn't reachable by unit tests; measurement methodology and full numbers are in the linked issue comment.

## Symptoms this explains

- Memory grows only while a peer is connected, proportional to connection time; idle is completely flat.
- Growth lives in MALLOC_SMALL, average allocation ~132 B.
- Invisible to `leaks`; visible in `vmmap`/`heap`/footprint.
- Growth rate differs between macOS versions (Swift-bridged dictionaries on macOS 26 are ~3× larger than the ObjC ones on earlier systems).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display-scale lookup stability on macOS.
  * Preserved accurate scaling for matched displays, with a safe default when no match is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->