### PR TITLE
fix(ipc): never adopt an empty id from the main IPC

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1689,19 +1689,24 @@ pub fn clear_trusted_devices() {
 }
 
 pub fn get_id() -> String {
+    // An empty id may come from a process that took over the main IPC with a
+    // config scope that has no id yet (e.g. a user GUI that became the server
+    // while the installed service was restarting). Treat it as no answer,
+    // otherwise the empty id is adopted below and wipes the local one.
     if let Ok(Some(v)) = get_config("id") {
-        // update salt also, so that next time reinstallation not causing first-time auto-login failure
-        if let Ok(Some(v2)) = get_config("salt") {
-            Config::set_salt(&v2);
+        if !v.is_empty() {
+            // update salt also, so that next time reinstallation not causing first-time auto-login failure
+            if let Ok(Some(v2)) = get_config("salt") {
+                Config::set_salt(&v2);
+            }
+            if v != Config::get_id() {
+                Config::set_key_confirmed(false);
+                Config::set_id(&v);
+            }
+            return v;
         }
-        if v != Config::get_id() {
-            Config::set_key_confirmed(false);
-            Config::set_id(&v);
-        }
-        v
-    } else {
-        Config::get_id()
     }
+    Config::get_id()
 }
 
 pub async fn get_rendezvous_server(ms_timeout: u64) -> (String, Vec<String>) {


### PR DESCRIPTION
`--get-id` can print an empty line and quietly clear the local id. The chain:

- The installed service restarts (update, scripted deploy), so the main IPC is briefly free.
- A running user GUI is in the client retry loop in `start_server(false)`. When its connect fails it promotes itself to server and takes the main IPC, serving its own user scope config, which may have no id yet.
- `ipc::get_id()` asks whoever owns the main IPC and gets `Some("")`. It prints that, and because `"" != Config::get_id()` it also runs `Config::set_id("")` and `Config::set_key_confirmed(false)`, wiping the id in the caller's config scope.

Hit this while mass staging Windows machines: with a stray GUI process alive, `rustdesk --get-id` printed nothing usable on every attempt and started working as soon as the process was killed (1.4.4, Windows 11).

An empty id is never a valid answer, so treat it as no answer: skip the adopt/salt-sync path and fall back to `Config::get_id()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identifier handling when the daemon returns an empty value.
  * Preserved the configured identifier and salt instead of storing incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->