### PR TITLE
fix(linux): forward forced display server to user server

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -646,6 +646,16 @@ fn try_start_server_(desktop: Option<&Desktop>) -> ResultType<Option<Child>> {
             if !desktop.dbus.is_empty() {
                 envs.push(("DBUS_SESSION_BUS_ADDRESS", desktop.dbus.clone()));
             }
+            if let Ok(forced_display_server) =
+                std::env::var("RUSTDESK_FORCED_DISPLAY_SERVER")
+            {
+                if !forced_display_server.is_empty() {
+                    envs.push((
+                        "RUSTDESK_FORCED_DISPLAY_SERVER",
+                        forced_display_server,
+                    ));
+                }
+            }
             envs.push((
                 "TERM",
                 get_cur_term(&desktop.uid).unwrap_or_else(|| suggest_best_term()),


### PR DESCRIPTION
## Summary

Forward `RUSTDESK_FORCED_DISPLAY_SERVER` from the root service process to the per-user `--server` process.

## Problem

On a KDE X11 session, `loginctl` can incorrectly report the active seat session as `Type=wayland`. Setting `RUSTDESK_FORCED_DISPLAY_SERVER=x11` on `rustdesk.service` correctly affects the root service, but `try_start_server_` constructs a curated environment for the user `--server` process and drops this override. The user server then detects Wayland, attempts PipeWire/xdg-desktop-portal capture, receives portal response code 2, and the remote connection closes without video.

## Fix

Pass a non-empty `RUSTDESK_FORCED_DISPLAY_SERVER` value through the existing environment list used by `run_as_user`.

## Verification

- Built successfully with `cargo build --release --features linux-pkg-config,inline`.
- Confirmed the spawned user `--server` command and `/proc/<pid>/environ` contain `RUSTDESK_FORCED_DISPLAY_SERVER=x11`.
- Confirmed the server uses the X11 capture/input path instead of Wayland PipeWire Portal on the affected host.

`cargo fmt --check` also reports pre-existing formatting differences in unrelated files; the changed file itself is formatted and `git diff --check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Linux server startup by honoring the configured display server environment setting when launching the server process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->