### PR TITLE
fix(macos): prevent remote keyboard focus leaks

### DIFF
--- a/flutter/lib/desktop/pages/macos_full_screen_focus_recovery.dart
+++ b/flutter/lib/desktop/pages/macos_full_screen_focus_recovery.dart
@@ -1,0 +1,24 @@
+class MacOSFullScreenFocusRecovery {
+  int _generation = 0;
+  int? _pendingGeneration;
+
+  int? get pendingGeneration => _pendingGeneration;
+
+  int queue() {
+    _generation += 1;
+    _pendingGeneration = _generation;
+    return _generation;
+  }
+
+  void cancel() {
+    _pendingGeneration = null;
+  }
+
+  bool isCurrent(int generation) => _pendingGeneration == generation;
+
+  bool consume(int generation) {
+    if (!isCurrent(generation)) return false;
+    _pendingGeneration = null;
+    return true;
+  }
+}

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -507,7 +507,9 @@ class _RemotePageState extends State<RemotePage>
     // Restore relative mouse mode constraints when window regains focus.
     if (_ffi.inputModel.relativeMouseMode.value) {
       if (isMacOS) {
-        // Relative mode does not emit PointerEnter after window focus returns.
+        // Native relative mode retains pointer capture and does not emit
+        // PointerEnter after window focus returns, so restore both latches.
+        _cursorOverImage.value = true;
         _macOSLocalFocusLost = false;
       } else {
         _rawKeyFocusNode.requestFocus();

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -22,6 +22,7 @@ import '../../utils/image.dart';
 import '../widgets/remote_toolbar.dart';
 import '../widgets/kb_layout_type_chooser.dart';
 import '../widgets/tabbar_widget.dart';
+import 'macos_full_screen_focus_recovery.dart';
 
 import 'package:flutter_hbb/native/custom_cursor.dart'
     if (dart.library.html) 'package:flutter_hbb/web/custom_cursor.dart';
@@ -94,7 +95,7 @@ class _RemotePageState extends State<RemotePage>
   bool _macOSLocalFocusLost = false;
   bool _macOSInputActive = false;
   bool _macOSInputSuppressed = false;
-  bool _macOSFullScreenFocusRecoveryPending = false;
+  final _macOSFullScreenFocusRecovery = MacOSFullScreenFocusRecovery();
   bool _macOSExplicitFocusRequestPending = false;
   StreamSubscription<DesktopTabState>? _tabStateSubscription;
   final _cursorOverImage = false.obs;
@@ -271,7 +272,7 @@ class _RemotePageState extends State<RemotePage>
 
   void _onMacOSTabStateChanged(DesktopTabState _) {
     if (!_isSelectedTab) {
-      _macOSFullScreenFocusRecoveryPending = false;
+      _macOSFullScreenFocusRecovery.cancel();
       _syncMacOSKeyboardGrab();
       return;
     }
@@ -285,7 +286,7 @@ class _RemotePageState extends State<RemotePage>
   }
 
   void _releaseMacOSRemoteInput() {
-    _macOSFullScreenFocusRecoveryPending = false;
+    _macOSFullScreenFocusRecovery.cancel();
     _macOSExplicitFocusRequestPending = false;
     _macOSInputSuppressed = true;
     _macOSLocalFocusLost = true;
@@ -330,7 +331,8 @@ class _RemotePageState extends State<RemotePage>
     final lifecycleAllowsInput = allowInactiveLifecycle ||
         _macOSLifecycleState == null ||
         _macOSLifecycleState == AppLifecycleState.resumed;
-    // Window focus alone must not enable the global hook without pointer presence.
+    // Input stays pointer-gated except for focused fullscreen recovery, which
+    // compensates when macOS omits PointerEnter during a Space switch.
     final shouldFocus = lifecycleAllowsInput &&
         _isMacOSKeyboardContextActive &&
         !_macOSInputSuppressed &&
@@ -356,45 +358,73 @@ class _RemotePageState extends State<RemotePage>
     }
   }
 
-  void _restoreMacOSKeyboardAfterFullScreen() {
-    // Returning while hidden intentionally preserves the pending recovery.
-    if (!_macOSFullScreenFocusRecoveryPending ||
-        _macOSLifecycleState == AppLifecycleState.hidden) {
+  void _restoreMacOSKeyboardAfterFullScreen({
+    required int generation,
+    bool allowHiddenLifecycle = false,
+  }) {
+    // Fullscreen callbacks preserve recovery while hidden. Native window focus
+    // may bypass a stale hidden lifecycle for the newly visible Space.
+    if (!_macOSFullScreenFocusRecovery.isCurrent(generation) ||
+        (!allowHiddenLifecycle &&
+            _macOSLifecycleState == AppLifecycleState.hidden)) {
       return;
     }
-    if (!stateGlobal.isFocused.value ||
-        _isWindowBlur ||
-        !_isSelectedTab ||
-        !_cursorOverImage.value) {
+    final contextActive =
+        stateGlobal.isFocused.value && !_isWindowBlur && _isSelectedTab;
+    // macOS can focus a fullscreen Space without sending PointerEnter. Native
+    // window focus is authoritative here; a later blur cancels this generation
+    // before an off-screen window can restore input.
+    final shouldInferPointerInside = !_cursorOverImage.value &&
+        allowHiddenLifecycle &&
+        stateGlobal.fullscreen.isTrue &&
+        contextActive;
+    final canRestore =
+        contextActive && (_cursorOverImage.value || shouldInferPointerInside);
+    if (!_macOSFullScreenFocusRecovery.consume(generation)) return;
+    if (!canRestore) {
       // Consuming recovery here requires a later pointer/window/tab event.
-      _macOSFullScreenFocusRecoveryPending = false;
       return;
     }
-    _macOSFullScreenFocusRecoveryPending = false;
+    if (shouldInferPointerInside) {
+      _cursorOverImage.value = true;
+    }
     _macOSLocalFocusLost = false;
     stateGlobal.getInputSource(force: true);
     _syncMacOSKeyboardGrab(reassert: true, allowInactiveLifecycle: true);
   }
 
-  void _scheduleMacOSKeyboardAfterFullScreen() {
+  void _scheduleMacOSKeyboardAfterFullScreen({
+    required int generation,
+    bool allowHiddenLifecycle = false,
+  }) {
     // Fullscreen can deliver FocusNode loss after its callback; wait for frame
     // completion and then advance one event-loop turn before restoring.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       Timer.run(() {
-        if (mounted) _restoreMacOSKeyboardAfterFullScreen();
+        if (mounted) {
+          _restoreMacOSKeyboardAfterFullScreen(
+            generation: generation,
+            allowHiddenLifecycle: allowHiddenLifecycle,
+          );
+        }
       });
     });
     WidgetsBinding.instance.ensureVisualUpdate();
   }
 
-  void _queueMacOSKeyboardAfterFullScreen() {
-    _macOSFullScreenFocusRecoveryPending = true;
+  void _queueMacOSKeyboardAfterFullScreen({
+    bool allowHiddenLifecycle = false,
+  }) {
+    final generation = _macOSFullScreenFocusRecovery.queue();
     if (_macOSLifecycleState == AppLifecycleState.paused ||
         _macOSLifecycleState == AppLifecycleState.detached) {
-      _macOSFullScreenFocusRecoveryPending = false;
+      _macOSFullScreenFocusRecovery.cancel();
       return;
     }
-    _scheduleMacOSKeyboardAfterFullScreen();
+    _scheduleMacOSKeyboardAfterFullScreen(
+      generation: generation,
+      allowHiddenLifecycle: allowHiddenLifecycle,
+    );
   }
 
   @override
@@ -409,13 +439,14 @@ class _RemotePageState extends State<RemotePage>
       _macOSInputActive = false;
     }
 
-    if (!_macOSFullScreenFocusRecoveryPending) return;
+    final generation = _macOSFullScreenFocusRecovery.pendingGeneration;
+    if (generation == null) return;
     if (state == AppLifecycleState.inactive ||
         state == AppLifecycleState.resumed) {
-      _scheduleMacOSKeyboardAfterFullScreen();
+      _scheduleMacOSKeyboardAfterFullScreen(generation: generation);
     } else if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.detached) {
-      _macOSFullScreenFocusRecoveryPending = false;
+      _macOSFullScreenFocusRecovery.cancel();
     }
   }
 
@@ -429,7 +460,7 @@ class _RemotePageState extends State<RemotePage>
       _isWindowBlur = true;
     }
     if (isMacOS) {
-      _macOSFullScreenFocusRecoveryPending = false;
+      _macOSFullScreenFocusRecovery.cancel();
       // A blur or Space switch may not emit PointerExit, so cursor state alone
       // cannot prevent the old remote surface from reclaiming the keyboard.
       _macOSLocalFocusLost = true;
@@ -460,14 +491,18 @@ class _RemotePageState extends State<RemotePage>
     if (isMacOS) stateGlobal.getInputSource(force: true);
     stateGlobal.isFocused.value = true;
 
-    // On macOS, normal pointer mode waits for PointerEnter or PointerDown to clear
-    // local focus loss. After switching directly between two fullscreen remote
-    // Spaces without moving or clicking, Flutter may delay PointerEnter until the
-    // pointer moves. Clearing the latch here could let the off-screen session
-    // reclaim keyboard input.
-    //
-    // Test case: After switching directly between two fullscreen remote Spaces,
-    // the newly visible session may require a slight pointer movement to regain keyboard input.
+    // Normal macOS windows wait for PointerEnter or PointerDown. A focused
+    // fullscreen Space queues delayed recovery; if this window blurs again, the
+    // pending recovery is cancelled before native input can reactivate.
+    // Regression: switch directly between fullscreen remote Spaces without
+    // moving or clicking; only the newly focused session may receive input.
+    if (isMacOS &&
+        stateGlobal.fullscreen.isTrue &&
+        !_ffi.inputModel.relativeMouseMode.value) {
+      // Native window focus is authoritative when a secondary engine retains a
+      // stale hidden lifecycle state after its fullscreen Space becomes visible.
+      _queueMacOSKeyboardAfterFullScreen(allowHiddenLifecycle: true);
+    }
 
     // Restore relative mouse mode constraints when window regains focus.
     if (_ffi.inputModel.relativeMouseMode.value) {
@@ -541,7 +576,7 @@ class _RemotePageState extends State<RemotePage>
     super.onWindowMinimize();
     WakelockManager.disable(_uniqueKey);
     if (isMacOS) {
-      _macOSFullScreenFocusRecoveryPending = false;
+      _macOSFullScreenFocusRecovery.cancel();
       _isWindowBlur = true;
       _cursorOverImage.value = false;
       stateGlobal.isFocused.value = false;

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -89,6 +89,14 @@ class _RemotePageState extends State<RemotePage>
   Timer? _timer;
   String keyboardMode = "legacy";
   bool _isWindowBlur = false;
+  // Known macOS remote-input trade-offs (kept simple intentionally):
+  // 1. Dialogs rely on FocusNode loss plus middleBlocked, not mirrored dialog
+  //    state. Reproduce: activate remote input, open a dialog, then type.
+  // 2. Delayed fullscreen recovery can race a local-control focus change; no
+  //    owner state is added. Reproduce: focus the toolbar during a Space switch.
+  // 3. Input-source switching releases native input without updating this
+  //    page's cache. Reproduce: switch sources, then type before and after
+  //    clicking the remote image; the click reasserts input.
   // These latches compensate for out-of-order macOS focus events. Treat them
   // as coupled when changing a transition or _syncMacOSKeyboardGrab().
   AppLifecycleState? _macOSLifecycleState;

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -460,6 +460,15 @@ class _RemotePageState extends State<RemotePage>
     if (isMacOS) stateGlobal.getInputSource(force: true);
     stateGlobal.isFocused.value = true;
 
+    // On macOS, normal pointer mode waits for PointerEnter or PointerDown to clear
+    // local focus loss. After switching directly between two fullscreen remote
+    // Spaces without moving or clicking, Flutter may delay PointerEnter until the
+    // pointer moves. Clearing the latch here could let the off-screen session
+    // reclaim keyboard input.
+    //
+    // Test case: After switching directly between two fullscreen remote Spaces,
+    // the newly visible session may require a slight pointer movement to regain keyboard input.
+
     // Restore relative mouse mode constraints when window regains focus.
     if (_ffi.inputModel.relativeMouseMode.value) {
       if (isMacOS) {

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -64,6 +64,13 @@ class RemotePage extends StatefulWidget {
 
   FFI get ffi => (_lastState.value! as _RemotePageState)._ffi;
 
+  void releaseMacOSInputForTabTransfer() {
+    if (!isMacOS) return;
+    // Release before removing the source tab. Its delayed disposal must not
+    // disable a native keyboard hook already acquired by the destination page.
+    (_lastState.value! as _RemotePageState)._releaseMacOSRemoteInput();
+  }
+
   @override
   State<RemotePage> createState() {
     final state = _RemotePageState(id);
@@ -76,10 +83,20 @@ class _RemotePageState extends State<RemotePage>
     with
         AutomaticKeepAliveClientMixin,
         MultiWindowListener,
+        WidgetsBindingObserver,
         TickerProviderStateMixin {
   Timer? _timer;
   String keyboardMode = "legacy";
   bool _isWindowBlur = false;
+  // These latches compensate for out-of-order macOS focus events. Treat them
+  // as coupled when changing a transition or _syncMacOSKeyboardGrab().
+  AppLifecycleState? _macOSLifecycleState;
+  bool _macOSLocalFocusLost = false;
+  bool _macOSInputActive = false;
+  bool _macOSInputSuppressed = false;
+  bool _macOSFullScreenFocusRecoveryPending = false;
+  bool _macOSExplicitFocusRequestPending = false;
+  StreamSubscription<DesktopTabState>? _tabStateSubscription;
   final _cursorOverImage = false.obs;
   late RxBool _showRemoteCursor;
   late RxBool _zoomCursor;
@@ -122,6 +139,13 @@ class _RemotePageState extends State<RemotePage>
   void initState() {
     super.initState();
     _ffi = FFI(widget.sessionId);
+    if (isMacOS) {
+      // SchedulerBinding.instance.lifecycleState is null in the first connection in a new window.
+      _macOSLifecycleState = SchedulerBinding.instance.lifecycleState;
+      WidgetsBinding.instance.addObserver(this);
+      _tabStateSubscription =
+          widget.tabController?.state.listen(_onMacOSTabStateChanged);
+    }
     Get.put<FFI>(_ffi, tag: widget.id);
     _ffi.imageModel.addCallbackOnFirstImage((String peerId) {
       _ffi.canvasModel.activateLocalCursor();
@@ -231,19 +255,192 @@ class _RemotePageState extends State<RemotePage>
     _pointerLockCenterDebounceTimer = null;
   }
 
+  bool get _isSelectedTab {
+    final controller = widget.tabController;
+    if (controller == null) return true;
+    final tabState = controller.state.value;
+    final selected = tabState.selected;
+    return selected >= 0 &&
+        selected < tabState.tabs.length &&
+        tabState.tabs[selected].key == widget.id;
+  }
+
+  bool get _isMacOSKeyboardContextActive {
+    return stateGlobal.isFocused.value && !_isWindowBlur && _isSelectedTab;
+  }
+
+  void _onMacOSTabStateChanged(DesktopTabState _) {
+    if (!_isSelectedTab) {
+      _macOSFullScreenFocusRecoveryPending = false;
+      _syncMacOSKeyboardGrab();
+      return;
+    }
+    // Tab listeners run synchronously. Defer the selected page so the previous
+    // page releases first; a late leave from it can disable the new session.
+    scheduleMicrotask(() {
+      if (mounted) {
+        _syncMacOSKeyboardGrab(reassert: true);
+      }
+    });
+  }
+
+  void _releaseMacOSRemoteInput() {
+    _macOSFullScreenFocusRecoveryPending = false;
+    _macOSExplicitFocusRequestPending = false;
+    _macOSInputSuppressed = true;
+    _macOSLocalFocusLost = true;
+    _ffi.inputModel.enterOrLeave(false);
+    _macOSInputActive = false;
+    _rawKeyFocusNode.unfocus();
+  }
+
+  void _onMacOSFocusChange() {
+    // requestFocus() notifies later; only a recorded explicit request may clear
+    // the local-focus-loss latch.
+    if (_rawKeyFocusNode.hasPrimaryFocus) {
+      final explicitRequest = _macOSExplicitFocusRequestPending;
+      _macOSExplicitFocusRequestPending = false;
+      if (explicitRequest && _isMacOSKeyboardContextActive) {
+        _macOSLocalFocusLost = false;
+      }
+      _syncMacOSKeyboardGrab(allowInactiveLifecycle: explicitRequest);
+    } else {
+      if (_macOSInputActive) {
+        _ffi.inputModel.enterOrLeave(false);
+        _macOSInputActive = false;
+      }
+      if (_isMacOSKeyboardContextActive) {
+        _macOSLocalFocusLost = true;
+      }
+    }
+  }
+
+  // 1. Sync the keyboard grab state with the current context.
+  // 2. Call enterOrLeave() to update the input state in the FFI layer.
+  // 3. Request or unfocus the raw key focus node based on the current context.
+  // Flutter focus and native input are separate; native input activates only
+  // after the FocusNode has primary focus.
+  void _syncMacOSKeyboardGrab({
+    bool reassert = false,
+    bool allowInactiveLifecycle = false,
+  }) {
+    if (!isMacOS) return;
+    // A secondary engine may stay hidden while its window is visible, so
+    // explicit pointer/fullscreen recovery must bypass the global lifecycle.
+    final lifecycleAllowsInput = allowInactiveLifecycle ||
+        _macOSLifecycleState == null ||
+        _macOSLifecycleState == AppLifecycleState.resumed;
+    // Window focus alone must not enable the global hook without pointer presence.
+    final shouldFocus = lifecycleAllowsInput &&
+        _isMacOSKeyboardContextActive &&
+        !_macOSInputSuppressed &&
+        _cursorOverImage.value &&
+        !_macOSLocalFocusLost;
+    final hasFocus = _rawKeyFocusNode.hasPrimaryFocus;
+    final shouldActivateInput = shouldFocus && hasFocus;
+
+    if (shouldActivateInput != _macOSInputActive ||
+        (shouldActivateInput && reassert)) {
+      _ffi.inputModel.enterOrLeave(shouldActivateInput);
+    }
+    _macOSInputActive = shouldActivateInput;
+
+    if (!shouldFocus) {
+      _macOSExplicitFocusRequestPending = false;
+      if (hasFocus) _rawKeyFocusNode.unfocus();
+    } else if (!hasFocus) {
+      _macOSExplicitFocusRequestPending = allowInactiveLifecycle;
+      _rawKeyFocusNode.requestFocus();
+    } else {
+      _macOSExplicitFocusRequestPending = false;
+    }
+  }
+
+  void _restoreMacOSKeyboardAfterFullScreen() {
+    // Returning while hidden intentionally preserves the pending recovery.
+    if (!_macOSFullScreenFocusRecoveryPending ||
+        _macOSLifecycleState == AppLifecycleState.hidden) {
+      return;
+    }
+    if (!stateGlobal.isFocused.value ||
+        _isWindowBlur ||
+        !_isSelectedTab ||
+        !_cursorOverImage.value) {
+      // Consuming recovery here requires a later pointer/window/tab event.
+      _macOSFullScreenFocusRecoveryPending = false;
+      return;
+    }
+    _macOSFullScreenFocusRecoveryPending = false;
+    _macOSLocalFocusLost = false;
+    stateGlobal.getInputSource(force: true);
+    _syncMacOSKeyboardGrab(reassert: true, allowInactiveLifecycle: true);
+  }
+
+  void _scheduleMacOSKeyboardAfterFullScreen() {
+    // Fullscreen can deliver FocusNode loss after its callback; wait for frame
+    // completion and then advance one event-loop turn before restoring.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Timer.run(() {
+        if (mounted) _restoreMacOSKeyboardAfterFullScreen();
+      });
+    });
+    WidgetsBinding.instance.ensureVisualUpdate();
+  }
+
+  void _queueMacOSKeyboardAfterFullScreen() {
+    _macOSFullScreenFocusRecoveryPending = true;
+    if (_macOSLifecycleState == AppLifecycleState.paused ||
+        _macOSLifecycleState == AppLifecycleState.detached) {
+      _macOSFullScreenFocusRecoveryPending = false;
+      return;
+    }
+    _scheduleMacOSKeyboardAfterFullScreen();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (!isMacOS || _macOSLifecycleState == state) return;
+    _macOSLifecycleState = state;
+    if (state == AppLifecycleState.resumed) {
+      _syncMacOSKeyboardGrab(reassert: true);
+    } else if (_macOSInputActive) {
+      _ffi.inputModel.enterOrLeave(false);
+      _macOSInputActive = false;
+    }
+
+    if (!_macOSFullScreenFocusRecoveryPending) return;
+    if (state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.resumed) {
+      _scheduleMacOSKeyboardAfterFullScreen();
+    } else if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.detached) {
+      _macOSFullScreenFocusRecoveryPending = false;
+    }
+  }
+
   @override
   void onWindowBlur() {
     super.onWindowBlur();
     // On windows, we use `focus` way to handle keyboard better.
     // Now on Linux, there's some rdev issues which will break the input.
-    // We disable the `focus` way for non-Windows temporarily.
-    if (isWindows) {
+    // We disable the `focus` way for Linux temporarily.
+    if (isWindows || isMacOS) {
       _isWindowBlur = true;
+    }
+    if (isMacOS) {
+      _macOSFullScreenFocusRecoveryPending = false;
+      // A blur or Space switch may not emit PointerExit, so cursor state alone
+      // cannot prevent the old remote surface from reclaiming the keyboard.
+      _macOSLocalFocusLost = true;
+    }
+    if (isWindows) {
       // unfocus the primary-focus when the whole window is lost focus,
       // and let OS to handle events instead.
       _rawKeyFocusNode.unfocus();
     }
     stateGlobal.isFocused.value = false;
+    _syncMacOSKeyboardGrab();
 
     // When window loses focus, temporarily release relative mouse mode constraints
     // to allow user to interact with other applications normally.
@@ -257,16 +454,23 @@ class _RemotePageState extends State<RemotePage>
   void onWindowFocus() {
     super.onWindowFocus();
     // See [onWindowBlur].
-    if (isWindows) {
+    if (isWindows || isMacOS) {
       _isWindowBlur = false;
     }
+    if (isMacOS) stateGlobal.getInputSource(force: true);
     stateGlobal.isFocused.value = true;
 
     // Restore relative mouse mode constraints when window regains focus.
     if (_ffi.inputModel.relativeMouseMode.value) {
-      _rawKeyFocusNode.requestFocus();
+      if (isMacOS) {
+        // Relative mode does not emit PointerEnter after window focus returns.
+        _macOSLocalFocusLost = false;
+      } else {
+        _rawKeyFocusNode.requestFocus();
+      }
       _ffi.inputModel.onWindowFocus();
     }
+    _syncMacOSKeyboardGrab(reassert: true, allowInactiveLifecycle: true);
   }
 
   @override
@@ -327,6 +531,13 @@ class _RemotePageState extends State<RemotePage>
   void onWindowMinimize() {
     super.onWindowMinimize();
     WakelockManager.disable(_uniqueKey);
+    if (isMacOS) {
+      _macOSFullScreenFocusRecoveryPending = false;
+      _isWindowBlur = true;
+      _cursorOverImage.value = false;
+      stateGlobal.isFocused.value = false;
+      _syncMacOSKeyboardGrab();
+    }
     // Release cursor constraints when minimized
     if (_ffi.inputModel.relativeMouseMode.value) {
       _ffi.inputModel.onWindowBlur();
@@ -338,6 +549,7 @@ class _RemotePageState extends State<RemotePage>
     super.onWindowEnterFullScreen();
     if (isMacOS) {
       stateGlobal.setFullscreen(true);
+      _queueMacOSKeyboardAfterFullScreen();
     }
   }
 
@@ -346,6 +558,7 @@ class _RemotePageState extends State<RemotePage>
     super.onWindowLeaveFullScreen();
     if (isMacOS) {
       stateGlobal.setFullscreen(false);
+      _queueMacOSKeyboardAfterFullScreen();
     }
   }
 
@@ -354,6 +567,14 @@ class _RemotePageState extends State<RemotePage>
     final closeSession = closeSessionOnDispose.remove(widget.id) ?? true;
 
     // https://github.com/flutter/flutter/issues/64935
+    if (isMacOS) {
+      // Tab moves release before transfer to avoid a late retained-session leave.
+      if (closeSession) {
+        _releaseMacOSRemoteInput();
+      }
+      _tabStateSubscription?.cancel();
+      WidgetsBinding.instance.removeObserver(this);
+    }
     super.dispose();
     debugPrint("REMOTE PAGE dispose session $sessionId ${widget.id}");
 
@@ -368,8 +589,9 @@ class _RemotePageState extends State<RemotePage>
     _ffi.inputModel.onRelativeMouseModeDisabled = null;
     // Relative mouse mode cleanup is centralized in FFI.close(closeSession: ...).
     _ffi.textureModel.onRemotePageDispose(closeSession);
-    if (closeSession) {
+    if (closeSession && !isMacOS) {
       // ensure we leave this session, this is a double check
+      // enterOrLeave() is already called previously in _releaseMacOSRemoteInput() for macOS.
       _ffi.inputModel.enterOrLeave(false);
     }
     DesktopMultiWindow.removeListener(this);
@@ -444,6 +666,8 @@ class _RemotePageState extends State<RemotePage>
                       } else {
                         _ffi.inputModel.enterOrLeave(false);
                       }
+                    } else if (isMacOS) {
+                      _onMacOSFocusChange();
                     }
                   },
                   inputModel: _ffi.inputModel,
@@ -549,7 +773,11 @@ class _RemotePageState extends State<RemotePage>
     }
 
     // See [onWindowBlur].
-    if (!isWindows) {
+    if (isMacOS) {
+      _macOSLocalFocusLost = false;
+      stateGlobal.getInputSource(force: true);
+      _syncMacOSKeyboardGrab(reassert: true, allowInactiveLifecycle: true);
+    } else if (!isWindows) {
       if (!_rawKeyFocusNode.hasFocus) {
         _rawKeyFocusNode.requestFocus();
       }
@@ -575,7 +803,9 @@ class _RemotePageState extends State<RemotePage>
     }
 
     // See [onWindowBlur].
-    if (!isWindows) {
+    if (isMacOS) {
+      _syncMacOSKeyboardGrab();
+    } else if (!isWindows) {
       _ffi.inputModel.enterOrLeave(false);
     }
   }
@@ -600,17 +830,29 @@ class _RemotePageState extends State<RemotePage>
       onEnter: onEnter,
       onExit: onExit,
       onPointerDown: (event) {
-        // A double check for blur status.
+        // A double check for blur status on Windows and macOS.
         // Note: If there's an `onPointerDown` event is triggered, `_isWindowBlur` is expected being false.
         // Sometimes the system does not send the necessary focus event to flutter. We should manually
         // handle this inconsistent status by setting `_isWindowBlur` to false. So we can
         // ensure the grab-key thread is running when our users are clicking the remote canvas.
-        if (_isWindowBlur) {
+        if ((isWindows || isMacOS) && _isWindowBlur) {
           debugPrint(
               "Unexpected status: onPointerDown is triggered while the remote window is in blur status");
           _isWindowBlur = false;
         }
-        if (!_rawKeyFocusNode.hasFocus) {
+        if (isMacOS) {
+          // Regions without matching enter/exit callbacks cannot safely own
+          // keyboard state.
+          if (onEnter == null || onExit == null) return;
+          if (!stateGlobal.isFocused.value) {
+            stateGlobal.isFocused.value = true;
+          }
+          _cursorOverImage.value = true;
+          _macOSLocalFocusLost = false;
+          stateGlobal.getInputSource(force: true);
+          _syncMacOSKeyboardGrab(
+              reassert: !isInputSourceFlutter, allowInactiveLifecycle: true);
+        } else if (!_rawKeyFocusNode.hasFocus) {
           _rawKeyFocusNode.requestFocus();
         }
       },

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -336,6 +336,7 @@ class _RemotePageState extends State<RemotePage>
     final shouldFocus = lifecycleAllowsInput &&
         _isMacOSKeyboardContextActive &&
         !_macOSInputSuppressed &&
+        _blockableOverlayState.middleBlocked.isFalse &&
         _cursorOverImage.value &&
         !_macOSLocalFocusLost;
     final hasFocus = _rawKeyFocusNode.hasPrimaryFocus;
@@ -378,8 +379,9 @@ class _RemotePageState extends State<RemotePage>
         allowHiddenLifecycle &&
         stateGlobal.fullscreen.isTrue &&
         contextActive;
-    final canRestore =
-        contextActive && (_cursorOverImage.value || shouldInferPointerInside);
+    final canRestore = contextActive &&
+        _blockableOverlayState.middleBlocked.isFalse &&
+        (_cursorOverImage.value || shouldInferPointerInside);
     if (!_macOSFullScreenFocusRecovery.consume(generation)) return;
     if (!canRestore) {
       // Consuming recovery here requires a later pointer/window/tab event.
@@ -508,9 +510,12 @@ class _RemotePageState extends State<RemotePage>
     if (_ffi.inputModel.relativeMouseMode.value) {
       if (isMacOS) {
         // Native relative mode retains pointer capture and does not emit
-        // PointerEnter after window focus returns, so restore both latches.
-        _cursorOverImage.value = true;
-        _macOSLocalFocusLost = false;
+        // PointerEnter after window focus returns. Restore both latches unless
+        // a local overlay still owns input.
+        if (_blockableOverlayState.middleBlocked.isFalse) {
+          _cursorOverImage.value = true;
+          _macOSLocalFocusLost = false;
+        }
       } else {
         _rawKeyFocusNode.requestFocus();
       }

--- a/flutter/lib/desktop/pages/remote_tab_page.dart
+++ b/flutter/lib/desktop/pages/remote_tab_page.dart
@@ -513,15 +513,17 @@ class _ConnectionTabPageState extends State<ConnectionTabPage> {
       final args = jsonDecode(call.arguments);
       final id = args['id'];
       final close = args['close'];
+      RemotePage? remotePage;
       try {
-        final remotePage = tabController.state.value.tabs
+        remotePage = tabController.state.value.tabs
             .firstWhere((tab) => tab.key == id)
             .page as RemotePage;
         returnValue = remotePage.ffi.ffiModel.cachedPeerData.toString();
       } catch (e) {
         debugPrint('Failed to get cached session data: $e');
       }
-      if (close && returnValue != null) {
+      if (close && returnValue != null && remotePage != null) {
+        remotePage.releaseMacOSInputForTabTransfer();
         closeSessionOnDispose[id] = false;
         tabController.closeBy(id);
       }

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -2484,9 +2484,7 @@ class _KeyboardMenu extends StatelessWidget {
             ? (v) async {
                 if (v != null) {
                   await stateGlobal.setInputSource(ffi.sessionId, v);
-                  // Keep native input released while the toolbar owns focus.
-                  // This bypasses RemotePage's input-state cache, so explicit
-                  // pointer input must reassert it until ownership is centralized.
+                  // Release native input; see the macOS trade-offs in RemotePage.
                   if (isMacOS) ffi.inputModel.enterOrLeave(false);
                   await ffi.ffiModel.checkDesktopKeyboardMode();
                   await ffi.inputModel.updateKeyboardMode();

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -2484,6 +2484,10 @@ class _KeyboardMenu extends StatelessWidget {
             ? (v) async {
                 if (v != null) {
                   await stateGlobal.setInputSource(ffi.sessionId, v);
+                  // Keep native input released while the toolbar owns focus.
+                  // This bypasses RemotePage's input-state cache, so explicit
+                  // pointer input must reassert it until ownership is centralized.
+                  if (isMacOS) ffi.inputModel.enterOrLeave(false);
                   await ffi.ffiModel.checkDesktopKeyboardMode();
                   await ffi.inputModel.updateKeyboardMode();
                 }


### PR DESCRIPTION
This PR may fix the following issues on macOS.

https://github.com/rustdesk/rustdesk/discussions/13398

Also some reports:

> 1. rustdesk is effectively incompatible with fullscreen on mac. I tend to put my heavily used apps on their own fullscreen desktop to avoid distraction while working, but the way that rustdesk pulls focus means that even if I don't have that desktop open, my typing might end up on whatever PC I am remoted into instead of slack or outlook, or my local IDE or anywhere else. If you are like me and might be controlling robots or instruments where bad settings can cause damage, this is pretty scary so it seems like best practice is to never fullscreen rust desk and fully quit and close connections if you are going to be working in another window for a while
> 2. Some users report keyboard input occasionally remaining directed to the remote session after switching away, while others report the opposite behavior, where keyboard input doesn't transfer to the active remote session. Other users with similar workflows cannot reproduce either issue. 
> 3. it appears to preferentially pull the keyboard but not the mouse. Sometimes I can get away with typing a sentence in another window by "typing" with copy/paste so I don't need to use my mouse
> 4. Huh, I tend to do the same (keeping a bunch of full-screen RustDesk sessions on Mac, each on their own fullscreen desktop), but I've never had an issue with it pulling the focus for a desktop that is not currently being shown on my screen before. I did encounter a kind of an oppositeds problem, though -- sometimes it refuses to move the focus to the host system that is currently shown on screen. Perhaps there're specific keyboard/accessibility settings or other apps that break it…

I can only reproduce a similar issue with the following steps:
1. Use two displays on macOS.
2. Connect, use "Input source 1".
3. In the first display, open TextEdit, and run `(sleep 8; open -a TextEdit) &` to gain focus after 8 seconds.
4. Put the remote window in the second display.
5. Enter full screen.
6. 8 seconds later, TextEdit gains focus, but what I type is still sent to the remote side.

## Changes

### 1. Derive native keyboard ownership from the complete macOS context

`RemotePage` now tracks the macOS-specific facts needed to synchronize Flutter focus with native input:

- current app lifecycle state;
- whether local/window focus was lost;
- whether native remote input is currently active;
- whether the page has been permanently suppressed for close or transfer;
- whether fullscreen focus recovery is pending;
- whether the current `FocusNode` request was an explicit remote-input request;
- whether this page is the selected remote tab.

`_syncMacOSKeyboardGrab()` is the central reconciliation point. It enables native remote input only when all applicable conditions are satisfied:

- the lifecycle permits input, or the action is an explicit pointer/fullscreen
  recovery for a visible secondary window;
- the RustDesk window is focused and not blurred;
- this remote page is the selected tab;
- the pointer is over the remote image;
- local RustDesk focus has not taken ownership;
- the page has not been suppressed for close or transfer;
- the remote image's `FocusNode` has primary focus.

The native hook is disabled before the Flutter focus node is released. A `reassert` path is retained for cases where the native input source needs to be refreshed even though the derived boolean state did not change.

### 2. Release input on every ownership-loss boundary

On macOS, remote keyboard input is synchronized or released when:

- the window loses focus;
- the app lifecycle leaves `resumed`;
- the pointer leaves the remote image;
- the raw-key `FocusNode` loses primary focus;
- the page becomes an unselected tab;
- the window is minimized;
- the session is closed;
- a tab is transferred to another window.

Window focus alone does not authorize normal remote keyboard input. The pointer must explicitly enter or press the remote image before the page can reacquire input. This prevents a window or Space switch from silently restoring the native hook while the user is typing elsewhere.

### 3. Recover input after native fullscreen transitions

Entering or leaving native fullscreen queues a macOS focus recovery operation. Recovery waits until the next rendered frame and then advances one event-loop turn because macOS can deliver `FocusNode` loss after the fullscreen callback.

The recovery is preserved while lifecycle state is `hidden`, because secondary Flutter engines can temporarily remain hidden while their remote window is visible. It is cancelled for a blurred window, an unselected tab, a minimized or detached lifecycle, or a page that no longer contains the pointer.

When the page remains the valid owner, the input source is refreshed and both Flutter focus and native input are reasserted. This allows typing to continue after fullscreen entry or exit without requiring an unrelated app switch or reconnect.

### 4. Handle relative mouse mode separately

Normal pointer mode deliberately keeps the local-focus-loss latch after an ordinary window-focus event. Relative mouse mode is different: while capture is active, the pointer cannot leave the remote window, so normal `PointerExit`/`PointerEnter` ownership transitions do not occur. Blur temporarily releases the relative-mode constraints, and restoring them when window focus returns still does not generate a new `PointerEnter` event.

When a macOS window regains focus while relative mouse mode is active, the change clears that latch before running the existing synchronization logic. Pointer presence, selected-tab state, window focus, and primary Flutter focus are still required, so the exception is limited to the path that cannot produce its own pointer-enter event.

### 5. Make tab selection and tab-to-window transfer ordered

Each macOS remote page observes selected-tab changes. The old tab releases input synchronously. Acquisition by the newly selected page is deferred to a microtask, ensuring the previous page cannot disable a hook just acquired by the new page.

Before a source tab is removed during a tab-to-window transfer, it explicitly releases and suppresses its native input. Its later retained-page disposal then does not issue another leave operation that could disable input already acquired by the destination window.

### 6. Keep toolbar input-source changes local

Changing the macOS keyboard input source from the toolbar explicitly releases native remote input while the toolbar owns focus. Returning to the remote image uses the explicit pointer path, which refreshes the input source and reasserts the native state.

## Note

Important macOS cases include:

- Switching Spaces or blurring a window may not emit `PointerExit`.
- A fullscreen transition may report `hidden` or `inactive` even while a secondary Flutter window is visible.
- `FocusNode` loss may arrive after the fullscreen callback and after the next rendered frame.
- A new Flutter engine may initially have no lifecycle state.
- A page retained during tab-to-window transfer may be disposed of after the destination page has already acquired native input.
- Relative mouse mode confines the pointer to the remote window while capture is active. Restoring that capture after a blur/focus cycle does not emit a new `PointerEnter` event.

## Testing

This PR is macOS only.

### macOS

- [x] On the first connection, type in the remote image in windowed mode.
- [x] Enter fullscreen for the first time and type immediately without clicking the remote image again.
- [x] Leave and re-enter fullscreen repeatedly, including a second fullscreen cycle, and confirm typing remains available.
- [x] Put one remote session in a fullscreen Space, switch to TextEdit without moving the pointer, and confirm all typing remains local.
- [x] Put two remote sessions in separate fullscreen Spaces and confirm that only the visible, selected session receives its marker. 
- [x] Switch among RustDesk, local applications, Mission Control, and Spaces with both mouse and trackpad workflows.
- [x] Open a RustDesk toolbar menu, dialog, chat field, or other local control and confirm typing is not sent remotely.
- [x] Return to the remote image with PointerEnter and PointerDown paths and confirm input is restored exactly once.
- [x] Minimize and restore the window while the pointer is over the remote image;  confirm local typing does not leak while minimized.
- [x] Close and reconnect a session and confirm no stale focus state survives.
- [x] Swith between "Input source 1" and "Input source 2". 
- [x] Switch rapidly between two remote tabs while the pointer remains over the page area; only the selected tab may receive input.
- [x] Move the active tab into a new window and confirm the source releases before the destination acquires input.
- [x] Close a selected tab and a multi-tab remote window while the pointer is inside the image; subsequent local typing must remain local.

### Windows and Linux

- [x] Windows: enter/leave the remote image, Alt-Tab, switch tabs, close a tab,  and transfer a tab to another window.
- [x] Linux: enter/leave the remote image, blur/refocus, switch tabs, close a tab, and transfer a tab to another window.

## Changed behavior

"Input source 2" also needs the pointer inside the window to send keyboard events.

In the master commit, the mouse doesn't need to be in the window—it only needs focus.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Updates

* **Bug Fixes**
  * Improved macOS keyboard/input focus consistency across tab switching, window focus/blur, and fullscreen transitions.
  * Added a macOS reset when changing the keyboard input source to prevent stuck/held input.
  * Improved reliability of remote tab/session closing, including safe handling when session data isn’t available.
  * Ensured macOS remote input is released and synchronized before completing tab/session transfer.

* **New Features**
  * Introduced generation-based macOS fullscreen focus recovery for more reliable focus restoration timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->