### PR TITLE
fix(deploy): don't wipe local id when --deploy gets an empty --id

### DIFF
--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -667,7 +667,8 @@ pub fn core_main() -> Option<Vec<String>> {
                         None
                     }
                 };
-                let new_id = get_value("--id");
+                // An empty --id (e.g. an unset var) would deploy a blank id; the Android flow guards this too (#15146).
+                let new_id = get_value("--id").filter(|s| !s.is_empty());
                 match crate::ui_interface::deploy_device(token, new_id) {
                     crate::ui_interface::DeployResult::Ok => {
                         println!("Device deployed.");

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -881,8 +881,14 @@ async fn handle(data: Data, stream: &mut Connection) {
             Some(value) => {
                 let mut updated = true;
                 if name == "id" {
-                    Config::set_key_confirmed(false);
-                    Config::set_id(&value);
+                    // An empty id would wipe the local id and unconfirm the key (cf. #15626).
+                    if value.is_empty() {
+                        log::warn!("Ignoring empty id write over IPC");
+                        updated = false;
+                    } else {
+                        Config::set_key_confirmed(false);
+                        Config::set_id(&value);
+                    }
                 } else if name == "temporary-password" {
                     password::update_temporary_password();
                 } else if name == "permanent-password" {


### PR DESCRIPTION
`rustdesk --deploy --id ""` deploys a blank id, then wipes the local id and unconfirms the key.

The empty value flows from the CLI through `deploy_device` into the IPC config write, which runs `Config::set_key_confirmed(false); Config::set_id("")`. This is easy to hit from a deployment script where the id variable is unset, so `--id "$VAR"` becomes `--id ""`, and the device silently loses its id and key confirmation.

The Android deploy flow already guards an empty id (#15146). This applies the same guard to the CLI, and also rejects an empty id at the IPC write boundary, the same way the read path was handled in #15626.

Two small changes:

- `core_main.rs`: treat an empty `--id` as no id.
- `ipc.rs`: ignore an empty id on the config write instead of persisting it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty IDs from being accepted during deployment.
  * Prevented configuration updates from clearing the local ID.
  * Preserved key confirmation when an empty ID is submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->