### PR TITLE
fix: Harden Windows installer temp command scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7211,18 +7211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "runas"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96d6b6c505282b007a9b009f2aa38b2fd0359b81a0430ceacc60f69ade4c6a0"
-dependencies = [
- "libc",
- "security-framework-sys",
- "which",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7340,7 +7328,6 @@ dependencies = [
  "reqwest",
  "ringbuf",
  "rubato",
- "runas",
  "rust-pulsectl",
  "samplerate",
  "sciter-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,14 +124,18 @@ windows = { version = "0.61", features = [
     "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
     "Win32_System",
+    "Win32_System_Com",
     "Win32_System_Diagnostics",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Environment",
     "Win32_System_IO",
     "Win32_System_Memory",
     "Win32_System_Pipes",
+    "Win32_System_Registry",
+    "Win32_System_SystemInformation",
     "Win32_System_Threading",
     "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 winreg = "0.11"
 windows-service = "0.6"
@@ -140,7 +144,6 @@ remote_printer = { path = "libs/remote_printer" }
 impersonate_system = { git = "https://github.com/rustdesk-org/impersonate-system" }
 shared_memory = "0.12"
 tauri-winrt-notification = "0.1"
-runas = "1.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -98,11 +98,18 @@ use windows_service::{
 use winreg::{enums::*, RegKey};
 
 mod acl;
+mod installer_handoff;
+mod installer_shell;
 pub(crate) use acl::current_process_user_sid_string;
 pub use acl::{
     set_path_permission, set_path_permission_for_portable_service_shmem_dir,
     set_path_permission_for_portable_service_shmem_file,
     validate_path_for_portable_service_shmem_dir,
+};
+use installer_handoff::run_cmds;
+use installer_shell::{
+    embedded_shortcut_commands, embedded_tray_shortcut_commands, escape_nested_cmd_ampersands,
+    shortcut_bytes, validate_install_value,
 };
 
 pub const FLUTTER_RUNNER_WIN32_WINDOW_CLASS: &'static str = "FLUTTER_RUNNER_WIN32_WINDOW"; // main window, install window
@@ -1499,6 +1506,7 @@ fn get_after_install(
 ) -> String {
     let app_name = crate::get_app_name();
     let ext = app_name.to_lowercase();
+    let nested_exe = escape_nested_cmd_ampersands(exe);
 
     // reg delete HKEY_CURRENT_USER\Software\Classes for
     // https://github.com/rustdesk/rustdesk/commit/f4bdfb6936ae4804fc8ab1cf560db192622ad01a
@@ -1534,17 +1542,17 @@ fn get_after_install(
     {start_menu_shortcuts}
     {reg_printer}
     reg add HKEY_CLASSES_ROOT\\.{ext}\\DefaultIcon /f
-    reg add HKEY_CLASSES_ROOT\\.{ext}\\DefaultIcon /f /ve /t REG_SZ  /d \"\\\"{exe}\\\",0\"
+    reg add HKEY_CLASSES_ROOT\\.{ext}\\DefaultIcon /f /ve /t REG_SZ  /d \"\\\"{nested_exe}\\\",0\"
     reg add HKEY_CLASSES_ROOT\\.{ext}\\shell /f
     reg add HKEY_CLASSES_ROOT\\.{ext}\\shell\\open /f
     reg add HKEY_CLASSES_ROOT\\.{ext}\\shell\\open\\command /f
-    reg add HKEY_CLASSES_ROOT\\.{ext}\\shell\\open\\command /f /ve /t REG_SZ /d \"\\\"{exe}\\\" --play \\\"%%1\\\"\"
+    reg add HKEY_CLASSES_ROOT\\.{ext}\\shell\\open\\command /f /ve /t REG_SZ /d \"\\\"{nested_exe}\\\" --play \\\"%%1\\\"\"
     reg add HKEY_CLASSES_ROOT\\{ext} /f
     reg add HKEY_CLASSES_ROOT\\{ext} /f /v \"URL Protocol\" /t REG_SZ /d \"\"
     reg add HKEY_CLASSES_ROOT\\{ext}\\shell /f
     reg add HKEY_CLASSES_ROOT\\{ext}\\shell\\open /f
     reg add HKEY_CLASSES_ROOT\\{ext}\\shell\\open\\command /f
-    reg add HKEY_CLASSES_ROOT\\{ext}\\shell\\open\\command /f /ve /t REG_SZ /d \"\\\"{exe}\\\" \\\"%%1\\\"\"
+    reg add HKEY_CLASSES_ROOT\\{ext}\\shell\\open\\command /f /ve /t REG_SZ /d \"\\\"{nested_exe}\\\" \\\"%%1\\\"\"
     netsh advfirewall firewall add rule name=\"{app_name} Service\" dir=out action=allow program=\"{exe}\" enable=yes
     netsh advfirewall firewall add rule name=\"{app_name} Service\" dir=in action=allow program=\"{exe}\" enable=yes
     {create_service}
@@ -1578,48 +1586,38 @@ pub fn install_me(options: &str, path: String, silent: bool, debug: bool) -> Res
     let app_name = crate::get_app_name();
 
     let current_exe = std::env::current_exe()?;
-
-    let tmp_path = std::env::temp_dir().to_string_lossy().to_string();
-    let cur_exe = current_exe.to_str().unwrap_or("").to_owned();
-    let shortcut_icon_location = get_shortcut_icon_location(&path, &cur_exe);
-    let mk_shortcut = write_cmds(
-        format!(
-            "
-Set oWS = WScript.CreateObject(\"WScript.Shell\")
-sLinkFile = \"{tmp_path}\\{app_name}.lnk\"
-
-Set oLink = oWS.CreateShortcut(sLinkFile)
-    oLink.TargetPath = \"{exe}\"
-    {shortcut_icon_location}
-oLink.Save
-        "
-        ),
-        "vbs",
+    let cur_exe = current_exe
+        .to_str()
+        .ok_or_else(|| anyhow!("Current executable path is not valid Unicode"))?
+        .to_owned();
+    for value in [&path, &exe, &cur_exe] {
+        validate_install_value(value)?;
+    }
+    let config_path = Config::file();
+    validate_install_value(
+        config_path
+            .to_str()
+            .ok_or_else(|| anyhow!("Configuration path is not valid Unicode"))?,
+    )?;
+    if let Some(icon) = get_custom_icon(&path, &cur_exe) {
+        validate_install_value(&icon)?;
+    }
+    // The elevated runner expands this to `%~f0.dir`, beside its protected copy.
+    // Do not stage privileged shortcut artifacts in the user-writable `%TEMP%`.
+    let tmp_path = "%RUSTDESK_OUTPUT_DIR%".to_owned();
+    let shortcut_icon_location = get_custom_icon(&path, &cur_exe);
+    let mk_shortcut_commands = embedded_shortcut_commands(
+        shortcut_bytes(&exe, None, shortcut_icon_location.as_deref())?,
+        &format!("{app_name}.lnk"),
         "mk_shortcut",
-    )?
-    .to_str()
-    .unwrap_or("")
-    .to_owned();
-    // https://superuser.com/questions/392061/how-to-make-a-shortcut-from-cmd
-    let uninstall_shortcut = write_cmds(
-        format!(
-            "
-Set oWS = WScript.CreateObject(\"WScript.Shell\")
-sLinkFile = \"{tmp_path}\\Uninstall {app_name}.lnk\"
-Set oLink = oWS.CreateShortcut(sLinkFile)
-    oLink.TargetPath = \"{exe}\"
-    oLink.Arguments = \"--uninstall\"
-    oLink.IconLocation = \"msiexec.exe\"
-oLink.Save
-        "
-        ),
-        "vbs",
+    );
+    let uninstall_shortcut_commands = embedded_shortcut_commands(
+        shortcut_bytes(&exe, Some("--uninstall"), Some("msiexec.exe"))?,
+        &format!("Uninstall {app_name}.lnk"),
         "uninstall_shortcut",
-    )?
-    .to_str()
-    .unwrap_or("")
-    .to_owned();
-    let tray_shortcut = get_tray_shortcut(&path, &exe, &cur_exe, &tmp_path)?;
+    );
+    let tray_shortcut_commands =
+        embedded_tray_shortcut_commands(&app_name, &exe, shortcut_icon_location.as_deref())?;
     let mut reg_value_desktop_shortcuts = "0".to_owned();
     let mut reg_value_start_menu_shortcuts = "0".to_owned();
     let mut reg_value_printer = "0".to_owned();
@@ -1660,15 +1658,12 @@ copy /Y \"{tmp_path}\\Uninstall {app_name}.lnk\" \"{start_menu}\\\"
     // Note: without if exist, the bat may exit in advance on some Windows7 https://github.com/rustdesk/rustdesk/issues/895
     let dels = format!(
         "
-if exist \"{mk_shortcut}\" del /f /q \"{mk_shortcut}\"
-if exist \"{uninstall_shortcut}\" del /f /q \"{uninstall_shortcut}\"
-if exist \"{tray_shortcut}\" del /f /q \"{tray_shortcut}\"
 if exist \"{tmp_path}\\{app_name}.lnk\" del /f /q \"{tmp_path}\\{app_name}.lnk\"
 if exist \"{tmp_path}\\Uninstall {app_name}.lnk\" del /f /q \"{tmp_path}\\Uninstall {app_name}.lnk\"
 if exist \"{tmp_path}\\{app_name} Tray.lnk\" del /f /q \"{tmp_path}\\{app_name} Tray.lnk\"
         "
     );
-    let src_exe = std::env::current_exe()?.to_str().unwrap_or("").to_string();
+    let src_exe = cur_exe.clone();
 
     // potential bug here: if run_cmd cancelled, but config file is changed.
     if let Some(lic) = get_license() {
@@ -1681,7 +1676,7 @@ if exist \"{tmp_path}\\{app_name} Tray.lnk\" del /f /q \"{tmp_path}\\{app_name} 
         "".to_owned()
     } else {
         format!("
-cscript \"{tray_shortcut}\"
+{tray_shortcut_commands}
 copy /Y \"{tmp_path}\\{app_name} Tray.lnk\" \"%PROGRAMDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\\"
 ")
     };
@@ -1716,11 +1711,11 @@ reg add {subkey} /f /v Publisher /t REG_SZ /d \"{app_name}\"
 reg add {subkey} /f /v VersionMajor /t REG_DWORD /d {version_major}
 reg add {subkey} /f /v VersionMinor /t REG_DWORD /d {version_minor}
 reg add {subkey} /f /v VersionBuild /t REG_DWORD /d {version_build}
-reg add {subkey} /f /v UninstallString /t REG_SZ /d \"\\\"{exe}\\\" --uninstall\"
+reg add {subkey} /f /v UninstallString /t REG_SZ /d \"\\\"{nested_exe}\\\" --uninstall\"
 reg add {subkey} /f /v EstimatedSize /t REG_DWORD /d {size}
 reg add {subkey} /f /v WindowsInstaller /t REG_DWORD /d 0
-cscript \"{mk_shortcut}\"
-cscript \"{uninstall_shortcut}\"
+{mk_shortcut_commands}
+{uninstall_shortcut_commands}
 {tray_shortcuts}
 {shortcuts}
 copy /Y \"{tmp_path}\\Uninstall {app_name}.lnk\" \"{path}\\\"
@@ -1731,6 +1726,7 @@ copy /Y \"{tmp_path}\\Uninstall {app_name}.lnk\" \"{path}\\\"
 {sleep}
     ",
         display_icon = get_custom_icon(&path, &cur_exe).unwrap_or(exe.to_string()),
+        nested_exe = escape_nested_cmd_ampersands(&exe),
         version = crate::VERSION.replace("-", "."),
         build_date = crate::BUILD_DATE,
         after_install = get_after_install(
@@ -1836,10 +1832,9 @@ pub fn uninstall_me(kill_self: bool) -> ResultType<()> {
     run_cmds(get_uninstall(kill_self, true), true, "uninstall")
 }
 
-fn write_cmds(cmds: String, ext: &str, tip: &str) -> ResultType<std::path::PathBuf> {
-    let mut cmds = cmds;
+fn write_vbs(cmds: String, tip: &str) -> ResultType<PathBuf> {
+    const UTF16LE_BOM: &[u8] = &[0xFF, 0xFE];
     let mut tmp = std::env::temp_dir();
-    // When dir contains these characters, the bat file will not execute in elevated mode.
     if vec!["&", "@", "^"]
         .drain(..)
         .any(|s| tmp.to_string_lossy().to_string().contains(s))
@@ -1848,31 +1843,14 @@ fn write_cmds(cmds: String, ext: &str, tip: &str) -> ResultType<std::path::PathB
             tmp = dir;
         }
     }
-    tmp.push(format!("{}_{}.{}", crate::get_app_name(), tip, ext));
-    let mut file = std::fs::File::create(&tmp)?;
-    if ext == "bat" {
-        let tmp2 = get_undone_file(&tmp)?;
-        std::fs::File::create(&tmp2).ok();
-        cmds = format!(
-            "
-{cmds}
-if exist \"{path}\" del /f /q \"{path}\"
-",
-            path = tmp2.to_string_lossy()
-        );
-    }
-    // in case cmds mixed with \r\n and \n, make sure all ending with \r\n
-    // in some windows, \r\n required for cmd file to run
-    cmds = cmds.replace("\r\n", "\n").replace("\n", "\r\n");
-    if ext == "vbs" {
-        let mut v: Vec<u16> = cmds.encode_utf16().collect();
-        // utf8 -> utf16le which vbs support it only
-        file.write_all(to_le(&mut v))?;
-    } else {
-        file.write_all(cmds.as_bytes())?;
-    }
+    tmp.push(format!("{}_{}.vbs", crate::get_app_name(), tip));
+    let mut file = fs::File::create(&tmp)?;
+    let cmds = cmds.replace("\r\n", "\n").replace('\n', "\r\n");
+    let mut utf16: Vec<u16> = cmds.encode_utf16().collect();
+    file.write_all(UTF16LE_BOM)?;
+    file.write_all(to_le(&mut utf16))?;
     file.sync_all()?;
-    return Ok(tmp);
+    Ok(tmp)
 }
 
 fn to_le(v: &mut [u16]) -> &[u8] {
@@ -1880,37 +1858,6 @@ fn to_le(v: &mut [u16]) -> &[u8] {
         *b = b.to_le()
     }
     unsafe { v.align_to().1 }
-}
-
-fn get_undone_file(tmp: &Path) -> ResultType<PathBuf> {
-    Ok(tmp.with_file_name(format!(
-        "{}.undone",
-        tmp.file_name()
-            .ok_or(anyhow!("Failed to get filename of {:?}", tmp))?
-            .to_string_lossy()
-    )))
-}
-
-fn run_cmds(cmds: String, show: bool, tip: &str) -> ResultType<()> {
-    let tmp = write_cmds(cmds, "bat", tip)?;
-    let tmp2 = get_undone_file(&tmp)?;
-    let tmp_fn = tmp.to_str().unwrap_or("");
-    // https://github.com/rustdesk/rustdesk/issues/6786#issuecomment-1879655410
-    // Specify cmd.exe explicitly to avoid the replacement of cmd commands.
-    let res = runas::Command::new("cmd.exe")
-        .args(&["/C", &tmp_fn])
-        .show(show)
-        .force_prompt(true)
-        .status();
-    if !show {
-        allow_err!(std::fs::remove_file(tmp));
-    }
-    let _ = res?;
-    if tmp2.exists() {
-        allow_err!(std::fs::remove_file(tmp2));
-        bail!("{} failed", tip);
-    }
-    Ok(())
 }
 
 pub fn toggle_blank_screen(v: bool) {
@@ -2288,7 +2235,7 @@ pub fn create_shortcut(id: &str) -> ResultType<()> {
     // https://github.com/rustdesk/hbb_common/blob/8b0e25867375ba9e6bff548acf44fe6d6ffa7c0e/src/config.rs#L1384
     let filename = id.replace(':', "_");
     let shortcut_icon_location = get_shortcut_icon_location("", &exe);
-    let shortcut = write_cmds(
+    let shortcut = write_vbs(
         format!(
             "
 Set oWS = WScript.CreateObject(\"WScript.Shell\")
@@ -2302,7 +2249,6 @@ Set oLink = oWS.CreateShortcut(sLinkFile)
 oLink.Save
         "
         ),
-        "vbs",
         "connect_shortcut",
     )?
     .to_str()
@@ -3187,29 +3133,51 @@ pub fn uninstall_service(show_new_window: bool, _: bool) -> bool {
     std::process::exit(0);
 }
 
+fn get_install_service_commands(path: &str, exe: &str) -> ResultType<String> {
+    let app_name = crate::get_app_name();
+    for value in [path, exe] {
+        validate_install_value(value)?;
+    }
+    let config_path = Config::file();
+    validate_install_value(
+        config_path
+            .to_str()
+            .ok_or_else(|| anyhow!("Configuration path is not valid Unicode"))?,
+    )?;
+    if let Some(icon) = get_custom_icon(path, exe) {
+        validate_install_value(&icon)?;
+    }
+    let shortcut_icon_location = get_custom_icon(path, exe);
+    let tray_shortcut_commands =
+        embedded_tray_shortcut_commands(&app_name, exe, shortcut_icon_location.as_deref())?;
+    let filter = format!(" /FI \"PID ne {}\"", get_current_pid());
+    Ok(format!(
+        "
+chcp 65001
+taskkill /F /IM {app_name}.exe{filter}
+{tray_shortcut_commands}
+copy /Y \"%RUSTDESK_OUTPUT_DIR%\\{app_name} Tray.lnk\" \"%PROGRAMDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\\"
+{import_config}
+{create_service}
+    ",
+        import_config = get_import_config(exe),
+        create_service = get_create_service(exe),
+    ))
+}
+
 pub fn install_service() -> bool {
     log::info!("Installing service...");
     let _installing = crate::platform::InstallingService::new();
     let (_, path, _, exe) = get_install_info();
-    let tmp_path = std::env::temp_dir().to_string_lossy().to_string();
-    let tray_shortcut = get_tray_shortcut(&path, &exe, &exe, &tmp_path).unwrap_or_default();
-    let filter = format!(" /FI \"PID ne {}\"", get_current_pid());
     Config::set_option("stop-service".into(), "".into());
+    let cmds = match get_install_service_commands(&path, &exe) {
+        Ok(cmds) => cmds,
+        Err(err) => {
+            log::error!("Failed to prepare service installation: {err}");
+            return true;
+        }
+    };
     crate::ipc::EXIT_RECV_CLOSE.store(false, Ordering::Relaxed);
-    let cmds = format!(
-        "
-chcp 65001
-taskkill /F /IM {app_name}.exe{filter}
-cscript \"{tray_shortcut}\"
-copy /Y \"{tmp_path}\\{app_name} Tray.lnk\" \"%PROGRAMDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\\"
-{import_config}
-{create_service}
-if exist \"{tray_shortcut}\" del /f /q \"{tray_shortcut}\"
-    ",
-        app_name = crate::get_app_name(),
-        import_config = get_import_config(&exe),
-        create_service = get_create_service(&exe),
-    );
     if let Err(err) = run_cmds(cmds, false, "install") {
         Config::set_option("stop-service".into(), "Y".into());
         crate::ipc::EXIT_RECV_CLOSE.store(true, Ordering::Relaxed);
@@ -3658,39 +3626,13 @@ pub fn update_me_msi(msi: &str, quiet: bool) -> ResultType<()> {
     Ok(())
 }
 
-pub fn get_tray_shortcut(
-    install_dir: &str,
-    exe: &str,
-    icon_source_exe: &str,
-    tmp_path: &str,
-) -> ResultType<String> {
-    let shortcut_icon_location = get_shortcut_icon_location(install_dir, icon_source_exe);
-    Ok(write_cmds(
-        format!(
-            "
-Set oWS = WScript.CreateObject(\"WScript.Shell\")
-sLinkFile = \"{tmp_path}\\{app_name} Tray.lnk\"
-
-Set oLink = oWS.CreateShortcut(sLinkFile)
-    oLink.TargetPath = \"{exe}\"
-    oLink.Arguments = \"--tray\"
-    {shortcut_icon_location}
-oLink.Save
-        ",
-            app_name = crate::get_app_name(),
-        ),
-        "vbs",
-        "tray_shortcut",
-    )?
-    .to_str()
-    .unwrap_or("")
-    .to_owned())
-}
-
 fn get_import_config(exe: &str) -> String {
     if config::is_outgoing_only() {
         return "".to_string();
     }
+    let exe = escape_nested_cmd_ampersands(exe);
+    let config_path = Config::file();
+    let config_path = escape_nested_cmd_ampersands(config_path.to_str().unwrap_or(""));
     format!("
 sc stop {app_name}
 sc delete {app_name}
@@ -3700,7 +3642,6 @@ sc stop {app_name}
 sc delete {app_name}
 ",
     app_name = crate::get_app_name(),
-    config_path=Config::file().to_str().unwrap_or(""),
 )
 }
 
@@ -3714,6 +3655,7 @@ fn get_create_service(exe: &str) -> String {
 if exist \"%PROGRAMDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\{app_name} Tray.lnk\" del /f /q \"%PROGRAMDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\{app_name} Tray.lnk\"
 ", app_name = crate::get_app_name())
     } else {
+        let exe = escape_nested_cmd_ampersands(exe);
         format!("
 sc create {app_name} binpath= \"\\\"{exe}\\\" --service\" start= auto DisplayName= \"{app_name} Service\"
 sc start {app_name}
@@ -4609,6 +4551,17 @@ mod tests {
         assert_eq!(chr, Some('a'));
         let chr = get_char_from_vk(VK_ESCAPE as u32); // VK_ESC
         assert_eq!(chr, None)
+    }
+
+    #[test]
+    fn vbs_files_use_utf16le_with_bom_and_crlf() {
+        const EXPECTED: &[u8] = &[0xFF, 0xFE, b'a', 0, b'\r', 0, b'\n', 0, b'b', 0];
+        let tip = format!("vbs_encoding_{}", uuid::Uuid::new_v4().simple());
+        let path = write_vbs("a\nb".to_owned(), &tip).expect("VBS file should be written");
+        let bytes = std::fs::read(&path).expect("VBS file should be readable");
+        std::fs::remove_file(path).expect("VBS file should be removed");
+
+        assert_eq!(bytes, EXPECTED);
     }
 
     #[cfg(not(target_pointer_width = "64"))]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -120,6 +120,17 @@ const REG_NAME_INSTALL_DESKTOPSHORTCUTS: &str = "DESKTOPSHORTCUTS";
 const REG_NAME_INSTALL_STARTMENUSHORTCUTS: &str = "STARTMENUSHORTCUTS";
 pub const REG_NAME_INSTALL_PRINTER: &str = "PRINTER";
 
+fn validate_install_app_name(app_name: &str) -> ResultType<()> {
+    if app_name.is_empty()
+        || !app_name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+    {
+        bail!("Application name must match [a-zA-Z0-9-]+");
+    }
+    Ok(())
+}
+
 pub fn get_focused_display(displays: Vec<DisplayInfo>) -> Option<usize> {
     unsafe {
         let hwnd = GetForegroundWindow();
@@ -4552,6 +4563,17 @@ mod tests {
         assert_eq!(chr, Some('a'));
         let chr = get_char_from_vk(VK_ESCAPE as u32); // VK_ESC
         assert_eq!(chr, None)
+    }
+
+    #[test]
+    fn install_app_names_enforce_ascii_command_safety() {
+        assert!(validate_install_app_name("RustDesk-Admin1").is_ok());
+        for app_name in ["", "RustDesk_Admin", "RustDesk&whoami", "RustDesk应用"] {
+            assert!(
+                validate_install_app_name(app_name).is_err(),
+                "unsafe application name was accepted: {app_name}"
+            );
+        }
     }
 
     #[test]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3173,6 +3173,7 @@ pub fn install_service() -> bool {
     let cmds = match get_install_service_commands(&path, &exe) {
         Ok(cmds) => cmds,
         Err(err) => {
+            Config::set_option("stop-service".into(), "Y".into());
             log::error!("Failed to prepare service installation: {err}");
             return true;
         }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1610,13 +1610,13 @@ pub fn install_me(options: &str, path: String, silent: bool, debug: bool) -> Res
             .to_str()
             .ok_or_else(|| anyhow!("Configuration path is not valid Unicode"))?,
     )?;
-    if let Some(icon) = get_custom_icon(&path, &cur_exe) {
-        validate_install_value(&icon)?;
+    let shortcut_icon_location = get_custom_icon(&path, &cur_exe);
+    if let Some(icon) = shortcut_icon_location.as_deref() {
+        validate_install_value(icon)?;
     }
     // The elevated runner expands this to `%~f0.dir`, beside its protected copy.
     // Do not stage privileged shortcut artifacts in the user-writable `%TEMP%`.
     let tmp_path = "%RUSTDESK_OUTPUT_DIR%".to_owned();
-    let shortcut_icon_location = get_custom_icon(&path, &cur_exe);
     let mk_shortcut_commands = embedded_shortcut_commands(
         shortcut_bytes(&exe, None, shortcut_icon_location.as_deref())?,
         &format!("{app_name}.lnk"),
@@ -1736,7 +1736,7 @@ copy /Y \"{tmp_path}\\Uninstall {app_name}.lnk\" \"{path}\\\"
 {install_remote_printer}
 {sleep}
     ",
-        display_icon = get_custom_icon(&path, &cur_exe).unwrap_or(exe.to_string()),
+        display_icon = shortcut_icon_location.as_deref().unwrap_or(exe.as_str()),
         nested_exe = escape_nested_cmd_ampersands(&exe),
         version = crate::VERSION.replace("-", "."),
         build_date = crate::BUILD_DATE,
@@ -3155,10 +3155,10 @@ fn get_install_service_commands(path: &str, exe: &str) -> ResultType<String> {
             .to_str()
             .ok_or_else(|| anyhow!("Configuration path is not valid Unicode"))?,
     )?;
-    if let Some(icon) = get_custom_icon(path, exe) {
-        validate_install_value(&icon)?;
-    }
     let shortcut_icon_location = get_custom_icon(path, exe);
+    if let Some(icon) = shortcut_icon_location.as_deref() {
+        validate_install_value(icon)?;
+    }
     let tray_shortcut_commands =
         embedded_tray_shortcut_commands(&app_name, exe, shortcut_icon_location.as_deref())?;
     let filter = format!(" /FI \"PID ne {}\"", get_current_pid());

--- a/src/platform/windows/installer_handoff.rs
+++ b/src/platform/windows/installer_handoff.rs
@@ -51,7 +51,8 @@ impl Drop for InstallCommandScript {
 
 fn prepare_install_commands(commands: &str) -> ResultType<String> {
     let commands = commands.replace("\r\n", "\n").replace('\n', "\r\n");
-    let chcp = path_for_cmd_assignment(&get_system_executable(CHCP_RELATIVE_PATH)?)?;
+    let chcp_path = get_system_executable(CHCP_RELATIVE_PATH)?;
+    let chcp = path_for_cmd_environment(&chcp_path)?;
     Ok(format!(
         "@echo off\r\nsetlocal EnableExtensions DisableDelayedExpansion\r\n\
          \"{chcp}\" {UTF8_CODE_PAGE} > nul || exit /b \
@@ -111,13 +112,14 @@ pub(super) fn verified_install_bootstrap(
     let findstr = path_for_cmd_assignment(&findstr_path)?;
     Ok(format!(
         "setlocal DisableDelayedExpansion & set \"S={source}\" & set \"R={runner}\" & \
-         set \"Q={cmd}\" & set \"C=0\" & set \"E=0\" & setlocal EnableDelayedExpansion & \
+         set \"Q={cmd}\" & set \"H={certutil}\" & set \"F={findstr}\" & \
+         set \"C=0\" & set \"E=0\" & setlocal EnableDelayedExpansion & \
          if exist \"!R!\" (set \"E={INSTALL_HANDOFF_RUNNER_EXISTS_EXIT_CODE}\") else (\
          set \"C=1\" & copy /Y \"!S!\" \"!R!\" > nul || \
          (set \"E={INSTALL_HANDOFF_COPY_FAILURE_EXIT_CODE}\") & \
-         if \"!E!\"==\"0\" (\"{certutil}\" -hashfile \"!R!\" SHA256 > \"!R!.hash\" || \
+         if \"!E!\"==\"0\" (\"!H!\" -hashfile \"!R!\" SHA256 > \"!R!.hash\" || \
          set \"E={INSTALL_HANDOFF_HASH_FAILURE_EXIT_CODE}\") & \
-         if \"!E!\"==\"0\" (\"{findstr}\" /R /I /X /C:\"{}\" \"!R!.hash\" > nul || \
+         if \"!E!\"==\"0\" (\"!F!\" /R /I /X /C:\"{}\" \"!R!.hash\" > nul || \
          set \"E={INSTALL_HANDOFF_HASH_MISMATCH_EXIT_CODE}\") & \
          if \"!E!\"==\"0\" (\"!Q!\" /D /E:ON /V:OFF /C \"\"!R!\"\" & \
          set \"E=!errorlevel!\")) & \
@@ -168,11 +170,23 @@ fn elevated_install_failure_reason(exit_code: u32) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::super::installer_shell::{
-        embedded_shortcut_commands, shortcut_bytes, WIN7_SHELL_EXECUTE_MAX_PARAMETER_CHARS,
+        embedded_shortcut_commands, shortcut_bytes, trusted_install_environment_from_paths,
+        WIN7_SHELL_EXECUTE_MAX_PARAMETER_CHARS,
     };
     use super::*;
     use ::windows::Win32::System::Threading;
     use std::os::windows::process::CommandExt;
+
+    #[test]
+    fn protected_batch_environment_preserves_carets() {
+        let environment = trusted_install_environment_from_paths(
+            Path::new(r"C:\Win^Root\System32"),
+            Path::new(r"C:\Program^Data"),
+            Path::new(r"C:\Users\Pub^lic"),
+        )
+        .expect("protected batch environment should be generated");
+        assert!(environment.contains(r#"set "PATH=C:\Win^Root\System32""#));
+    }
 
     #[test]
     fn native_install_handoff_verifies_before_execution() {
@@ -181,7 +195,7 @@ mod tests {
             uuid::Uuid::new_v4().simple()
         ));
         let runner_dir = std::env::temp_dir().join(format!(
-            "rustdesk_install_!&^@()runner_{}",
+            "rustdesk_install_!RUSTDESK_HANDOFF_EXPAND!&^@()runner_{}",
             uuid::Uuid::new_v4().simple()
         ));
         std::fs::create_dir(&runner_dir).expect("runner directory should be created");
@@ -262,7 +276,8 @@ mod tests {
         let mut command = std::process::Command::new(cmd);
         command
             .env("PROGRAMDATA", "rustdesk_untrusted")
-            .env("PUBLIC", "rustdesk_untrusted");
+            .env("PUBLIC", "rustdesk_untrusted")
+            .env("RUSTDESK_HANDOFF_EXPAND", "expanded");
         command.raw_arg(format!("/D /E:ON /V:ON /C {bootstrap}"));
         command
             .creation_flags(Threading::CREATE_NO_WINDOW.0)

--- a/src/platform/windows/installer_handoff.rs
+++ b/src/platform/windows/installer_handoff.rs
@@ -4,7 +4,7 @@ use super::{
         run_elevated_and_wait, trusted_install_environment,
         BATCH_SHORTCUT_DECODE_FAILURE_EXIT_CODE, CMD_RELATIVE_PATH,
     },
-    ResultType,
+    validate_install_app_name, ResultType,
 };
 use hbb_common::{
     bail, log,
@@ -138,6 +138,7 @@ pub(super) fn verified_install_parameters(script: &InstallCommandScript) -> Resu
 }
 
 pub(super) fn run_cmds(cmds: String, show: bool, tip: &str) -> ResultType<()> {
+    validate_install_app_name(&crate::get_app_name())?;
     let script = write_install_script(cmds)?;
     let cmd_path = get_system_executable(CMD_RELATIVE_PATH)?;
     let parameters = verified_install_parameters(&script)?;

--- a/src/platform/windows/installer_handoff.rs
+++ b/src/platform/windows/installer_handoff.rs
@@ -206,12 +206,6 @@ mod tests {
             "test.lnk",
             "test",
         );
-        assert!(shortcut_commands.contains("certutil"));
-        assert!(shortcut_commands.contains("-decode"));
-        assert!(!shortcut_commands.to_ascii_lowercase().contains("cscript"));
-        assert!(!shortcut_commands
-            .to_ascii_lowercase()
-            .contains("powershell"));
         let script = write_install_script(format!(
             "if \"%PROGRAMDATA%\"==\"rustdesk_untrusted\" exit /b 77\r\n\
              if \"%PUBLIC%\"==\"rustdesk_untrusted\" exit /b 77\r\n\
@@ -222,19 +216,7 @@ mod tests {
         .expect("install script should be created");
         let bootstrap = verified_install_bootstrap(&script, &runner_dir)
             .expect("native verifier bootstrap should be generated");
-        let win7_hash_pattern = script
-            .expected_hash
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<Vec<_>>()
-            .join(" *");
-        assert!(bootstrap.contains(&format!("/R /I /X /C:\"{win7_hash_pattern}\"")));
-        let parameters =
-            verified_install_parameters(&script).expect("elevated parameters should be generated");
-        assert!(bootstrap.contains("certutil.exe"));
-        assert!(bootstrap.contains("findstr.exe"));
-        assert!(!bootstrap.to_ascii_lowercase().contains("powershell"));
-        assert!(parameters.encode_utf16().count() < WIN7_SHELL_EXECUTE_MAX_PARAMETER_CHARS);
+        assert_native_handoff_structure(&script, &shortcut_commands, &bootstrap);
 
         let output = run_install_bootstrap_for_test(&bootstrap);
         assert!(
@@ -246,6 +228,32 @@ mod tests {
         std::fs::remove_file(&marker).expect("test marker should be removed");
         assert_replaced_install_script_is_rejected(&script, &runner_dir, &marker);
         std::fs::remove_dir(runner_dir).expect("runner directory should be empty");
+    }
+
+    fn assert_native_handoff_structure(
+        script: &InstallCommandScript,
+        shortcut_commands: &str,
+        bootstrap: &str,
+    ) {
+        assert!(shortcut_commands.contains("certutil"));
+        assert!(shortcut_commands.contains("-decode"));
+        assert!(!shortcut_commands.to_ascii_lowercase().contains("cscript"));
+        assert!(!shortcut_commands
+            .to_ascii_lowercase()
+            .contains("powershell"));
+        let win7_hash_pattern = script
+            .expected_hash
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<Vec<_>>()
+            .join(" *");
+        assert!(bootstrap.contains(&format!("/R /I /X /C:\"{win7_hash_pattern}\"")));
+        let parameters =
+            verified_install_parameters(script).expect("elevated parameters should be generated");
+        assert!(bootstrap.contains("certutil.exe"));
+        assert!(bootstrap.contains("findstr.exe"));
+        assert!(!bootstrap.to_ascii_lowercase().contains("powershell"));
+        assert!(parameters.encode_utf16().count() < WIN7_SHELL_EXECUTE_MAX_PARAMETER_CHARS);
     }
 
     fn assert_replaced_install_script_is_rejected(

--- a/src/platform/windows/installer_handoff.rs
+++ b/src/platform/windows/installer_handoff.rs
@@ -1,0 +1,272 @@
+use super::{
+    installer_shell::{
+        get_system_executable, path_for_cmd_assignment, path_for_cmd_environment,
+        run_elevated_and_wait, trusted_install_environment,
+        BATCH_SHORTCUT_DECODE_FAILURE_EXIT_CODE, CMD_RELATIVE_PATH,
+    },
+    ResultType,
+};
+use hbb_common::{
+    bail, log,
+    sha2::{Digest, Sha256},
+};
+use std::{
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+const CERTUTIL_RELATIVE_PATH: &str = "certutil.exe";
+const CHCP_RELATIVE_PATH: &str = "chcp.com";
+const FINDSTR_RELATIVE_PATH: &str = "findstr.exe";
+const UTF8_CODE_PAGE: u32 = 65001;
+const INSTALL_HANDOFF_RUNNER_EXISTS_EXIT_CODE: u32 = 0x5253_0001;
+const INSTALL_HANDOFF_COPY_FAILURE_EXIT_CODE: u32 = 0x5253_0002;
+const INSTALL_HANDOFF_HASH_FAILURE_EXIT_CODE: u32 = 0x5253_0003;
+pub(super) const INSTALL_HANDOFF_HASH_MISMATCH_EXIT_CODE: u32 = 0x5253_0004;
+const BATCH_CODE_PAGE_FAILURE_EXIT_CODE: u32 = 0x5253_0005;
+const BATCH_OUTPUT_DIRECTORY_EXISTS_EXIT_CODE: u32 = 0x5253_0006;
+const BATCH_OUTPUT_DIRECTORY_CREATE_FAILURE_EXIT_CODE: u32 = 0x5253_0007;
+const SHA256_HASH_LENGTH: usize = 32;
+
+pub(super) type BatchHash = [u8; SHA256_HASH_LENGTH];
+
+pub(super) struct InstallCommandScript {
+    pub(super) path: PathBuf,
+    pub(super) expected_hash: BatchHash,
+}
+
+impl Drop for InstallCommandScript {
+    fn drop(&mut self) {
+        if let Err(err) = fs::remove_file(&self.path) {
+            if err.kind() != io::ErrorKind::NotFound {
+                log::warn!(
+                    "Failed to remove temporary installer file {:?}: {err}",
+                    self.path
+                );
+            }
+        }
+    }
+}
+
+fn prepare_install_commands(commands: &str) -> ResultType<String> {
+    let commands = commands.replace("\r\n", "\n").replace('\n', "\r\n");
+    let chcp = path_for_cmd_assignment(&get_system_executable(CHCP_RELATIVE_PATH)?)?;
+    Ok(format!(
+        "@echo off\r\nsetlocal EnableExtensions DisableDelayedExpansion\r\n\
+         \"{chcp}\" {UTF8_CODE_PAGE} > nul || exit /b \
+         {BATCH_CODE_PAGE_FAILURE_EXIT_CODE}\r\n\
+         {}\r\n\
+         if exist \"%~f0.dir\" exit /b {BATCH_OUTPUT_DIRECTORY_EXISTS_EXIT_CODE}\r\n\
+         md \"%~f0.dir\" || exit /b {BATCH_OUTPUT_DIRECTORY_CREATE_FAILURE_EXIT_CODE}\r\n\
+         set \"RUSTDESK_OUTPUT_DIR=%~f0.dir\"\r\n{commands}\r\nexit /b 0\r\n",
+        trusted_install_environment()?
+    ))
+}
+
+pub(super) fn write_install_script(cmds: String) -> ResultType<InstallCommandScript> {
+    let directory = std::env::temp_dir();
+    path_for_cmd_environment(&directory)?;
+    let commands = prepare_install_commands(&cmds)?;
+    let expected_hash = Sha256::digest(commands.as_bytes()).into();
+    let path = directory.join(format!(
+        "rustdesk_install_{}.bat",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)?;
+    let script = InstallCommandScript {
+        path,
+        expected_hash,
+    };
+    file.write_all(commands.as_bytes())?;
+    file.sync_all()?;
+    Ok(script)
+}
+
+fn install_hash_pattern(hash: &BatchHash) -> String {
+    hash.iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<Vec<_>>()
+        .join(" *")
+}
+
+pub(super) fn verified_install_bootstrap(
+    script: &InstallCommandScript,
+    runner_directory: &Path,
+) -> ResultType<String> {
+    let source = path_for_cmd_assignment(&script.path)?;
+    let runner = runner_directory.join(format!(
+        "rustdesk_install_{}.bat",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let runner = path_for_cmd_assignment(&runner)?;
+    let cmd_path = get_system_executable(CMD_RELATIVE_PATH)?;
+    let certutil_path = get_system_executable(CERTUTIL_RELATIVE_PATH)?;
+    let findstr_path = get_system_executable(FINDSTR_RELATIVE_PATH)?;
+    let cmd = path_for_cmd_assignment(&cmd_path)?;
+    let certutil = path_for_cmd_assignment(&certutil_path)?;
+    let findstr = path_for_cmd_assignment(&findstr_path)?;
+    Ok(format!(
+        "setlocal DisableDelayedExpansion & set \"S={source}\" & set \"R={runner}\" & \
+         set \"Q={cmd}\" & set \"C=0\" & set \"E=0\" & setlocal EnableDelayedExpansion & \
+         if exist \"!R!\" (set \"E={INSTALL_HANDOFF_RUNNER_EXISTS_EXIT_CODE}\") else (\
+         set \"C=1\" & copy /Y \"!S!\" \"!R!\" > nul || \
+         (set \"E={INSTALL_HANDOFF_COPY_FAILURE_EXIT_CODE}\") & \
+         if \"!E!\"==\"0\" (\"{certutil}\" -hashfile \"!R!\" SHA256 > \"!R!.hash\" || \
+         set \"E={INSTALL_HANDOFF_HASH_FAILURE_EXIT_CODE}\") & \
+         if \"!E!\"==\"0\" (\"{findstr}\" /R /I /X /C:\"{}\" \"!R!.hash\" > nul || \
+         set \"E={INSTALL_HANDOFF_HASH_MISMATCH_EXIT_CODE}\") & \
+         if \"!E!\"==\"0\" (\"!Q!\" /D /E:ON /V:OFF /C \"\"!R!\"\" & \
+         set \"E=!errorlevel!\")) & \
+         if \"!C!\"==\"1\" (rd /s /q \"!R!.dir\" > nul 2>&1 & \
+         del /f /q \"!R!\" \"!R!.*\" > nul 2>&1) & exit /b !E!",
+        install_hash_pattern(&script.expected_hash),
+    ))
+}
+
+pub(super) fn verified_install_parameters(script: &InstallCommandScript) -> ResultType<String> {
+    let system_directory = get_system_executable("")?;
+    Ok(format!(
+        "/D /E:ON /V:ON /C {}",
+        verified_install_bootstrap(script, &system_directory)?
+    ))
+}
+
+pub(super) fn run_cmds(cmds: String, show: bool, tip: &str) -> ResultType<()> {
+    let script = write_install_script(cmds)?;
+    let cmd_path = get_system_executable(CMD_RELATIVE_PATH)?;
+    let parameters = verified_install_parameters(&script)?;
+    let exit_code = run_elevated_and_wait(&cmd_path, &parameters, show)?;
+    if exit_code != 0 {
+        bail!(
+            "{tip} failed with elevated exit code {exit_code}: {}",
+            elevated_install_failure_reason(exit_code)
+        );
+    }
+    Ok(())
+}
+
+fn elevated_install_failure_reason(exit_code: u32) -> &'static str {
+    match exit_code {
+        INSTALL_HANDOFF_RUNNER_EXISTS_EXIT_CODE => "protected runner already exists",
+        INSTALL_HANDOFF_COPY_FAILURE_EXIT_CODE => "failed to copy protected runner",
+        INSTALL_HANDOFF_HASH_FAILURE_EXIT_CODE => "failed to hash protected runner",
+        INSTALL_HANDOFF_HASH_MISMATCH_EXIT_CODE => "protected runner hash mismatch",
+        BATCH_CODE_PAGE_FAILURE_EXIT_CODE => "failed to set the installer code page",
+        BATCH_OUTPUT_DIRECTORY_EXISTS_EXIT_CODE => "installer output directory already exists",
+        BATCH_OUTPUT_DIRECTORY_CREATE_FAILURE_EXIT_CODE => {
+            "failed to create the installer output directory"
+        }
+        BATCH_SHORTCUT_DECODE_FAILURE_EXIT_CODE => "failed to decode an embedded shortcut",
+        _ => "installer command failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::installer_shell::{
+        embedded_shortcut_commands, shortcut_bytes, WIN7_SHELL_EXECUTE_MAX_PARAMETER_CHARS,
+    };
+    use super::*;
+    use ::windows::Win32::System::Threading;
+    use std::os::windows::process::CommandExt;
+
+    #[test]
+    fn native_install_handoff_verifies_before_execution() {
+        let marker = std::env::temp_dir().join(format!(
+            "rustdesk_install_marker_{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let runner_dir = std::env::temp_dir().join(format!(
+            "rustdesk_install_!&^@()runner_{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir(&runner_dir).expect("runner directory should be created");
+        let shortcut_commands = embedded_shortcut_commands(
+            shortcut_bytes(r"C:\RustDesk.exe", None, None)
+                .expect("native shortcut should be generated"),
+            "test.lnk",
+            "test",
+        );
+        assert!(shortcut_commands.contains("certutil"));
+        assert!(shortcut_commands.contains("-decode"));
+        assert!(!shortcut_commands.to_ascii_lowercase().contains("cscript"));
+        assert!(!shortcut_commands
+            .to_ascii_lowercase()
+            .contains("powershell"));
+        let script = write_install_script(format!(
+            "if \"%PROGRAMDATA%\"==\"rustdesk_untrusted\" exit /b 77\r\n\
+             if \"%PUBLIC%\"==\"rustdesk_untrusted\" exit /b 77\r\n\
+             {shortcut_commands}\r\n\
+             > \"{}\" echo verified",
+            marker.display()
+        ))
+        .expect("install script should be created");
+        let bootstrap = verified_install_bootstrap(&script, &runner_dir)
+            .expect("native verifier bootstrap should be generated");
+        let win7_hash_pattern = script
+            .expected_hash
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<Vec<_>>()
+            .join(" *");
+        assert!(bootstrap.contains(&format!("/R /I /X /C:\"{win7_hash_pattern}\"")));
+        let parameters =
+            verified_install_parameters(&script).expect("elevated parameters should be generated");
+        assert!(bootstrap.contains("certutil.exe"));
+        assert!(bootstrap.contains("findstr.exe"));
+        assert!(!bootstrap.to_ascii_lowercase().contains("powershell"));
+        assert!(parameters.encode_utf16().count() < WIN7_SHELL_EXECUTE_MAX_PARAMETER_CHARS);
+
+        let output = run_install_bootstrap_for_test(&bootstrap);
+        assert!(
+            output.status.success(),
+            "unchanged script failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(marker.exists(), "verified install script must execute");
+        std::fs::remove_file(&marker).expect("test marker should be removed");
+        assert_replaced_install_script_is_rejected(&script, &runner_dir, &marker);
+        std::fs::remove_dir(runner_dir).expect("runner directory should be empty");
+    }
+
+    fn assert_replaced_install_script_is_rejected(
+        script: &InstallCommandScript,
+        runner_dir: &Path,
+        marker: &Path,
+    ) {
+        std::fs::write(
+            &script.path,
+            format!("> \"{}\" echo hijacked\r\n", marker.display()),
+        )
+        .expect("install script should be replaceable");
+        let replaced = verified_install_bootstrap(&script, &runner_dir)
+            .expect("replacement verifier should be generated");
+        let output = run_install_bootstrap_for_test(&replaced);
+        assert!(
+            !output.status.success(),
+            "replaced script unexpectedly passed verification"
+        );
+        assert_eq!(
+            output.status.code(),
+            Some(INSTALL_HANDOFF_HASH_MISMATCH_EXIT_CODE as i32)
+        );
+        assert!(!marker.exists(), "replaced script must not execute");
+    }
+
+    fn run_install_bootstrap_for_test(bootstrap: &str) -> std::process::Output {
+        let cmd = get_system_executable(CMD_RELATIVE_PATH).expect("system cmd.exe should resolve");
+        let mut command = std::process::Command::new(cmd);
+        command
+            .env("PROGRAMDATA", "rustdesk_untrusted")
+            .env("PUBLIC", "rustdesk_untrusted");
+        command.raw_arg(format!("/D /E:ON /V:ON /C {bootstrap}"));
+        command
+            .creation_flags(Threading::CREATE_NO_WINDOW.0)
+            .output()
+            .expect("native verifier should run")
+    }
+}

--- a/src/platform/windows/installer_handoff.rs
+++ b/src/platform/windows/installer_handoff.rs
@@ -23,17 +23,17 @@ const UTF8_CODE_PAGE: u32 = 65001;
 const INSTALL_HANDOFF_RUNNER_EXISTS_EXIT_CODE: u32 = 0x5253_0001;
 const INSTALL_HANDOFF_COPY_FAILURE_EXIT_CODE: u32 = 0x5253_0002;
 const INSTALL_HANDOFF_HASH_FAILURE_EXIT_CODE: u32 = 0x5253_0003;
-pub(super) const INSTALL_HANDOFF_HASH_MISMATCH_EXIT_CODE: u32 = 0x5253_0004;
+const INSTALL_HANDOFF_HASH_MISMATCH_EXIT_CODE: u32 = 0x5253_0004;
 const BATCH_CODE_PAGE_FAILURE_EXIT_CODE: u32 = 0x5253_0005;
 const BATCH_OUTPUT_DIRECTORY_EXISTS_EXIT_CODE: u32 = 0x5253_0006;
 const BATCH_OUTPUT_DIRECTORY_CREATE_FAILURE_EXIT_CODE: u32 = 0x5253_0007;
 const SHA256_HASH_LENGTH: usize = 32;
 
-pub(super) type BatchHash = [u8; SHA256_HASH_LENGTH];
+type BatchHash = [u8; SHA256_HASH_LENGTH];
 
-pub(super) struct InstallCommandScript {
-    pub(super) path: PathBuf,
-    pub(super) expected_hash: BatchHash,
+struct InstallCommandScript {
+    path: PathBuf,
+    expected_hash: BatchHash,
 }
 
 impl Drop for InstallCommandScript {
@@ -65,7 +65,7 @@ fn prepare_install_commands(commands: &str) -> ResultType<String> {
     ))
 }
 
-pub(super) fn write_install_script(cmds: String) -> ResultType<InstallCommandScript> {
+fn write_install_script(cmds: String) -> ResultType<InstallCommandScript> {
     let directory = std::env::temp_dir();
     path_for_cmd_environment(&directory)?;
     let commands = prepare_install_commands(&cmds)?;
@@ -94,7 +94,7 @@ fn install_hash_pattern(hash: &BatchHash) -> String {
         .join(" *")
 }
 
-pub(super) fn verified_install_bootstrap(
+fn verified_install_bootstrap(
     script: &InstallCommandScript,
     runner_directory: &Path,
 ) -> ResultType<String> {
@@ -110,6 +110,10 @@ pub(super) fn verified_install_bootstrap(
     let cmd = path_for_cmd_assignment(&cmd_path)?;
     let certutil = path_for_cmd_assignment(&certutil_path)?;
     let findstr = path_for_cmd_assignment(&findstr_path)?;
+    // Short names preserve headroom under the Windows 7 ShellExecuteExW 2,048
+    // UTF-16-character parameter limit. Paths are stored with delayed expansion
+    // disabled, then expanded indirectly so literal `!` survives: S=source,
+    // R=runner, Q=cmd.exe, H=certutil.exe, F=findstr.exe, C=created flag, E=exit code.
     Ok(format!(
         "setlocal DisableDelayedExpansion & set \"S={source}\" & set \"R={runner}\" & \
          set \"Q={cmd}\" & set \"H={certutil}\" & set \"F={findstr}\" & \
@@ -129,7 +133,7 @@ pub(super) fn verified_install_bootstrap(
     ))
 }
 
-pub(super) fn verified_install_parameters(script: &InstallCommandScript) -> ResultType<String> {
+fn verified_install_parameters(script: &InstallCommandScript) -> ResultType<String> {
     let system_directory = get_system_executable("")?;
     Ok(format!(
         "/D /E:ON /V:ON /C {}",
@@ -171,23 +175,11 @@ fn elevated_install_failure_reason(exit_code: u32) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::super::installer_shell::{
-        embedded_shortcut_commands, shortcut_bytes, trusted_install_environment_from_paths,
-        WIN7_SHELL_EXECUTE_MAX_PARAMETER_CHARS,
+        embedded_shortcut_commands, shortcut_bytes, WIN7_SHELL_EXECUTE_MAX_PARAMETER_CHARS,
     };
     use super::*;
     use ::windows::Win32::System::Threading;
     use std::os::windows::process::CommandExt;
-
-    #[test]
-    fn protected_batch_environment_preserves_carets() {
-        let environment = trusted_install_environment_from_paths(
-            Path::new(r"C:\Win^Root\System32"),
-            Path::new(r"C:\Program^Data"),
-            Path::new(r"C:\Users\Pub^lic"),
-        )
-        .expect("protected batch environment should be generated");
-        assert!(environment.contains(r#"set "PATH=C:\Win^Root\System32""#));
-    }
 
     #[test]
     fn native_install_handoff_verifies_before_execution() {

--- a/src/platform/windows/installer_shell.rs
+++ b/src/platform/windows/installer_shell.rs
@@ -150,7 +150,7 @@ pub(super) fn trusted_install_environment() -> ResultType<String> {
     trusted_install_environment_from_paths(&system, &program_data, &public)
 }
 
-pub(super) fn trusted_install_environment_from_paths(
+fn trusted_install_environment_from_paths(
     system: &Path,
     program_data: &Path,
     public: &Path,
@@ -288,10 +288,13 @@ mod tests {
     }
 
     #[test]
-    fn nested_cmd_values_escape_ampersands_and_carets() {
+    fn nested_commands_escape_while_protected_environment_preserves_carets() {
         assert_eq!(
             escape_nested_cmd_ampersands(r"C:\A&^ B\RustDesk.exe"),
             r"C:\A^&^^ B\RustDesk.exe"
         );
+        let path = Path::new(r"C:\Win^Root\System32");
+        let environment = trusted_install_environment_from_paths(path, path, path).unwrap();
+        assert!(environment.contains(r#"set "PATH=C:\Win^Root\System32""#));
     }
 }

--- a/src/platform/windows/installer_shell.rs
+++ b/src/platform/windows/installer_shell.rs
@@ -135,23 +135,36 @@ pub(super) fn path_for_cmd_environment(path: &Path) -> ResultType<&str> {
     Ok(value)
 }
 
+// Bootstrap assignments are parsed before DisableDelayedExpansion takes effect.
+// Escape carets first so `^!` preserves each literal exclamation mark.
 pub(super) fn path_for_cmd_assignment(path: &Path) -> ResultType<String> {
-    Ok(path_for_cmd_environment(path)?.replace('^', "^^"))
+    Ok(path_for_cmd_environment(path)?
+        .replace('^', "^^")
+        .replace('!', "^!"))
 }
 
 pub(super) fn trusted_install_environment() -> ResultType<String> {
     let system = get_system_executable("")?;
     let program_data = get_known_folder(&FOLDERID_ProgramData)?;
     let public = get_known_folder(&FOLDERID_Public)?;
+    trusted_install_environment_from_paths(&system, &program_data, &public)
+}
+
+pub(super) fn trusted_install_environment_from_paths(
+    system: &Path,
+    program_data: &Path,
+    public: &Path,
+) -> ResultType<String> {
     let windows = system
         .parent()
         .ok_or_else(|| anyhow!("System directory has no parent"))?;
     let cmd = system.join(CMD_RELATIVE_PATH);
-    let system = path_for_cmd_assignment(&system)?;
-    let windows = path_for_cmd_assignment(windows)?;
-    let cmd = path_for_cmd_assignment(&cmd)?;
-    let program_data = path_for_cmd_assignment(&program_data)?;
-    let public = path_for_cmd_assignment(&public)?;
+    // These paths are parsed once from the protected BAT, with delayed expansion disabled.
+    let system = path_for_cmd_environment(system)?;
+    let windows = path_for_cmd_environment(windows)?;
+    let cmd = path_for_cmd_environment(&cmd)?;
+    let program_data = path_for_cmd_environment(program_data)?;
+    let public = path_for_cmd_environment(public)?;
     Ok(format!(
         "set \"ComSpec={cmd}\" & set \"PATH={system}\" & \
          set \"SystemRoot={windows}\" & set \"WINDIR={windows}\" & \

--- a/src/platform/windows/installer_shell.rs
+++ b/src/platform/windows/installer_shell.rs
@@ -1,0 +1,284 @@
+use super::{wide_string, ResultType};
+use hbb_common::{
+    anyhow::anyhow,
+    bail,
+    base64::{engine::general_purpose::STANDARD, Engine as _},
+    log,
+};
+use std::{
+    ffi::OsString,
+    io, mem,
+    os::windows::ffi::OsStringExt,
+    path::{Path, PathBuf},
+};
+use windows::{
+    core::{Interface, PCWSTR},
+    Win32::{
+        Foundation::{self, CloseHandle, HANDLE},
+        System::{Com, SystemInformation, Threading},
+        UI::{
+            Shell::{
+                self, FOLDERID_ProgramData, FOLDERID_Public, SHGetKnownFolderPath, KF_FLAG_DEFAULT,
+            },
+            WindowsAndMessaging,
+        },
+    },
+};
+
+pub(super) const CMD_RELATIVE_PATH: &str = "cmd.exe";
+pub(super) const BATCH_SHORTCUT_DECODE_FAILURE_EXIT_CODE: u32 = 0x5253_0008;
+pub(super) const WIN7_SHELL_EXECUTE_MAX_PARAMETER_CHARS: usize = 2048;
+const SHORTCUT_ICON_INDEX: i32 = 0;
+
+pub(super) fn shortcut_bytes(
+    target_path: &str,
+    arguments: Option<&str>,
+    icon_location: Option<&str>,
+) -> ResultType<Vec<u8>> {
+    let _com = initialize_shell_com()?;
+    let link: Shell::IShellLinkW =
+        unsafe { Com::CoCreateInstance(&Shell::ShellLink, None, Com::CLSCTX_INPROC_SERVER) }?;
+    let target_path = wide_string(target_path);
+    unsafe { link.SetPath(PCWSTR(target_path.as_ptr())) }?;
+    if let Some(arguments) = arguments {
+        let arguments = wide_string(arguments);
+        unsafe { link.SetArguments(PCWSTR(arguments.as_ptr())) }?;
+    }
+    if let Some(icon_location) = icon_location {
+        let icon_location = wide_string(icon_location);
+        unsafe { link.SetIconLocation(PCWSTR(icon_location.as_ptr()), SHORTCUT_ICON_INDEX) }?;
+    }
+
+    let stream = unsafe { Shell::SHCreateMemStream(None) }
+        .ok_or_else(|| anyhow!("Failed to create shortcut memory stream"))?;
+    let persist: Com::IPersistStream = link.cast()?;
+    unsafe { persist.Save(&stream, true) }?;
+    let mut stat = Com::STATSTG::default();
+    unsafe { stream.Stat(&mut stat, Com::STATFLAG_NONAME) }?;
+    let size = usize::try_from(stat.cbSize).map_err(|_| anyhow!("Shortcut data is too large"))?;
+    let read_size = u32::try_from(size).map_err(|_| anyhow!("Shortcut data is too large"))?;
+    let mut bytes = vec![0; size];
+    let mut bytes_read = 0;
+    unsafe {
+        stream.Seek(0, Com::STREAM_SEEK_SET, None)?;
+        stream
+            .Read(bytes.as_mut_ptr().cast(), read_size, Some(&mut bytes_read))
+            .ok()?;
+    }
+    if bytes_read != read_size {
+        bail!("Failed to read complete shortcut data");
+    }
+    Ok(bytes)
+}
+
+pub(super) fn embedded_shortcut_commands(bytes: Vec<u8>, filename: &str, name: &str) -> String {
+    let encoded = STANDARD.encode(bytes);
+    let encoded_path = format!("%~f0.{name}.b64");
+    format!(
+        "> \"{encoded_path}\" echo {encoded}\r\n\
+         certutil -f -decode \"{encoded_path}\" \"%RUSTDESK_OUTPUT_DIR%\\{filename}\" > nul || exit /b {BATCH_SHORTCUT_DECODE_FAILURE_EXIT_CODE}"
+    )
+}
+
+pub(super) fn embedded_tray_shortcut_commands(
+    app_name: &str,
+    exe: &str,
+    icon_location: Option<&str>,
+) -> ResultType<String> {
+    let filename = format!("{app_name} Tray.lnk");
+    Ok(embedded_shortcut_commands(
+        shortcut_bytes(exe, Some("--tray"), icon_location)?,
+        &filename,
+        "tray_shortcut",
+    ))
+}
+
+pub(super) fn validate_install_value(value: &str) -> ResultType<()> {
+    if value.contains(['\0', '"', '%', '\r', '\n', '|', '<', '>']) {
+        bail!("Installer path or name contains characters unsafe for cmd.exe");
+    }
+    Ok(())
+}
+
+pub(super) fn get_system_executable(relative_path: &str) -> ResultType<PathBuf> {
+    let mut buffer = vec![0u16; Foundation::MAX_PATH as usize];
+    let len = unsafe { SystemInformation::GetSystemDirectoryW(Some(&mut buffer)) } as usize;
+    if len == 0 {
+        return Err(io::Error::last_os_error().into());
+    }
+    if len >= buffer.len() {
+        bail!("Windows system directory path is too long");
+    }
+    buffer.truncate(len);
+    let mut path = PathBuf::from(OsString::from_wide(&buffer));
+    path.push(relative_path);
+    Ok(path)
+}
+
+fn get_known_folder(id: &windows::core::GUID) -> ResultType<PathBuf> {
+    let value = unsafe { SHGetKnownFolderPath(id, KF_FLAG_DEFAULT, None) }?;
+    let path = unsafe { value.to_string() };
+    unsafe { Com::CoTaskMemFree(Some(value.0.cast())) };
+    Ok(PathBuf::from(path?))
+}
+
+// `%VAR%` is expanded before cmd.exe executes even inside a quoted `set` assignment.
+// Reject all `%` so a handoff path cannot alter the elevated bootstrap before hash verification.
+// https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/set_1
+pub(super) fn path_for_cmd_environment(path: &Path) -> ResultType<&str> {
+    let value = path
+        .to_str()
+        .ok_or_else(|| anyhow!("Path is not valid Unicode: {:?}", path))?;
+    if value.contains(['\0', '"', '%', '\r', '\n']) {
+        bail!("Path is unsafe for an elevated cmd.exe handoff: {:?}", path);
+    }
+    Ok(value)
+}
+
+pub(super) fn path_for_cmd_assignment(path: &Path) -> ResultType<String> {
+    Ok(path_for_cmd_environment(path)?.replace('^', "^^"))
+}
+
+pub(super) fn trusted_install_environment() -> ResultType<String> {
+    let system = get_system_executable("")?;
+    let program_data = get_known_folder(&FOLDERID_ProgramData)?;
+    let public = get_known_folder(&FOLDERID_Public)?;
+    let windows = system
+        .parent()
+        .ok_or_else(|| anyhow!("System directory has no parent"))?;
+    let cmd = system.join(CMD_RELATIVE_PATH);
+    let system = path_for_cmd_assignment(&system)?;
+    let windows = path_for_cmd_assignment(windows)?;
+    let cmd = path_for_cmd_assignment(&cmd)?;
+    let program_data = path_for_cmd_assignment(&program_data)?;
+    let public = path_for_cmd_assignment(&public)?;
+    Ok(format!(
+        "set \"ComSpec={cmd}\" & set \"PATH={system}\" & \
+         set \"SystemRoot={windows}\" & set \"WINDIR={windows}\" & \
+         set \"ProgramData={program_data}\" & set \"PUBLIC={public}\" & \
+         set \"PATHEXT=.COM;.EXE;.BAT;.CMD\" & \
+         set \"NoDefaultCurrentDirectoryInExePath=1\""
+    ))
+}
+
+struct ShellComGuard;
+
+impl Drop for ShellComGuard {
+    fn drop(&mut self) {
+        unsafe { Com::CoUninitialize() };
+    }
+}
+
+fn initialize_shell_com() -> ResultType<Option<ShellComGuard>> {
+    let result = unsafe {
+        Com::CoInitializeEx(
+            None,
+            Com::COINIT_APARTMENTTHREADED | Com::COINIT_DISABLE_OLE1DDE,
+        )
+    };
+    if result == Foundation::RPC_E_CHANGED_MODE {
+        return Ok(None);
+    }
+    if result.is_err() {
+        bail!(
+            "Failed to initialize COM: HRESULT 0x{:08X}",
+            result.0 as u32
+        );
+    }
+    Ok(Some(ShellComGuard))
+}
+
+struct ProcessHandle(HANDLE);
+
+impl Drop for ProcessHandle {
+    fn drop(&mut self) {
+        if let Err(err) = unsafe { CloseHandle(self.0) } {
+            log::warn!("Failed to close elevated process handle: {err}");
+        }
+    }
+}
+
+fn elevated_working_directory(executable: &Path) -> ResultType<&Path> {
+    executable
+        .parent()
+        .ok_or_else(|| anyhow!("Elevated executable has no parent directory"))
+}
+
+pub(super) fn run_elevated_and_wait(
+    executable: &Path,
+    parameters: &str,
+    show: bool,
+) -> ResultType<u32> {
+    let parameter_chars = parameters.encode_utf16().count();
+    if parameter_chars >= WIN7_SHELL_EXECUTE_MAX_PARAMETER_CHARS {
+        bail!("Elevated command is too long: {parameter_chars} UTF-16 characters");
+    }
+    let _com = initialize_shell_com()?;
+    let verb = wide_string("runas");
+    let working_directory = wide_string(path_for_cmd_environment(elevated_working_directory(
+        executable,
+    )?)?);
+    let executable = wide_string(path_for_cmd_environment(executable)?);
+    let parameters = wide_string(parameters);
+    let mut info = Shell::SHELLEXECUTEINFOW::default();
+    info.cbSize = mem::size_of::<Shell::SHELLEXECUTEINFOW>() as u32;
+    info.fMask = Shell::SEE_MASK_NOCLOSEPROCESS | Shell::SEE_MASK_NOASYNC;
+    info.lpVerb = PCWSTR(verb.as_ptr());
+    info.lpFile = PCWSTR(executable.as_ptr());
+    info.lpParameters = PCWSTR(parameters.as_ptr());
+    info.lpDirectory = PCWSTR(working_directory.as_ptr());
+    info.nShow = if show {
+        WindowsAndMessaging::SW_SHOWNORMAL.0
+    } else {
+        WindowsAndMessaging::SW_HIDE.0
+    };
+    unsafe { Shell::ShellExecuteExW(&mut info) }?;
+    if info.hProcess.0.is_null() {
+        bail!("Windows did not return an elevated process handle");
+    }
+    let process = ProcessHandle(info.hProcess);
+    let wait_result = unsafe { Threading::WaitForSingleObject(process.0, Threading::INFINITE) };
+    if wait_result == Foundation::WAIT_FAILED {
+        return Err(io::Error::last_os_error().into());
+    }
+    if wait_result != Foundation::WAIT_OBJECT_0 {
+        bail!("Unexpected elevated process wait result: {}", wait_result.0);
+    }
+    let mut exit_code = 0;
+    unsafe { Threading::GetExitCodeProcess(process.0, &mut exit_code) }?;
+    Ok(exit_code)
+}
+
+// Escape `^` before using it to escape `&` so both survive nested cmd.exe parsing.
+// https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc754250(v=ws.11)
+pub(super) fn escape_nested_cmd_ampersands(value: &str) -> String {
+    value.replace('^', "^^").replace('&', "^&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_values_enforce_command_safety() {
+        assert!(validate_install_value(r"C:\safe ! path").is_ok());
+        assert!(validate_install_value(r"C:\Program Files (x86)\RustDesk").is_ok());
+        assert!(validate_install_value(r"C:\Users\R&D\RustDesk.exe").is_ok());
+        assert!(validate_install_value(r"C:\A&^ B\RustDesk.exe").is_ok());
+        for character in ['\0', '"', '%', '\r', '\n', '|', '<', '>'] {
+            let value = format!(r"C:\unsafe{character}path");
+            assert!(
+                validate_install_value(&value).is_err(),
+                "cmd.exe control character was accepted: {character:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn nested_cmd_values_escape_ampersands_and_carets() {
+        assert_eq!(
+            escape_nested_cmd_ampersands(r"C:\A&^ B\RustDesk.exe"),
+            r"C:\A^&^^ B\RustDesk.exe"
+        );
+    }
+}


### PR DESCRIPTION
This PR hardens the Windows installer command flow against local temporary-file replacement.

The previous flow wrote a predictable batch file to the current user's writable `%TEMP%` directory and later executed it through an elevated `cmd.exe`. A local medium-integrity process could replace that file after the user started the official installer but before elevated execution, gaining high-integrity command execution after the user approved the legitimate RustDesk UAC prompt.

This is a UAC-assisted installer elevation hijack, not a silent UAC bypass.

## Changes

- Create the source batch file with a random UUID name and `create_new` semantics.
- Hash the exact batch contents before elevation.
- Start the absolute system `cmd.exe` through `ShellExecuteExW`, using the existing `windows` crate, and remove the now-unused `runas` dependency.
- After elevation, copy the batch to a unique runner in the Windows system directory, verify the protected copy with SHA-256, and execute it only when the hash matches.
- Resolve bootstrap tools from the Windows system directory and reset command-sensitive environment values before running installer commands.
- Return explicit exit codes for copy, hash, output-directory, and shortcut-decoding failures.
- Validate values interpolated into installer commands and escape carets before ampersands at the nested `cmd.exe` boundary.
- Isolate the new handoff and Shell helper logic in private `installer_handoff` and `installer_shell` modules.

A random temporary filename alone is insufficient: an attacker can monitor `%TEMP%` and replace the file after it is created. Verification must happen on the protected post-elevation copy immediately before execution.

## Shortcut handling

Installer shortcuts are serialized with the Windows Shell Link COM interfaces and embedded in the verified batch. The elevated runner decodes them into `%RUSTDESK_OUTPUT_DIR%`, which expands to `%~f0.dir` beside the protected runner, rather than staging privileged shortcut artifacts in the user-writable `%TEMP%` directory.

This avoids PowerShell and preserves non-ASCII shortcut targets on Windows 7.

The remaining non-installer VBS shortcut helper writes a UTF-16LE BOM before the normalized CRLF script contents.

## Testing

1. Install dir contains non-ASCII characters: `C:\µû ^ & !RUSTDESK_HANDOFF_EXPAND! \`, `RUSTDESK_HANDOFF_EXPAND` is an environment variable of another string.
2. Install, auto/manually update, uninstall.
3. Shortcuts are correctly created.
4. Uninstall via the shortcut and Control Panel.

- [x] Win7 & Win11, sciter, flutter exe, msi.
- [x] Win11, custom client, flutter exe, msi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer reliability across paths, command-line arguments, and custom icons.
  * Fixed quoting/escaping for installer, uninstall, service, and URL/open commands.
  * Added an added safeguard that verifies installer command scripts before elevated execution to prevent tampering.

* **Improvements**
  * Updated shortcut and tray-shortcut creation to be more robust and consistent.
  * Improved Windows compatibility for encoding and line endings used in generated installer scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the previous predictable-filename temp-batch elevation flow with a hardened handoff: a UUID-named source batch is written to `%TEMP%`, its SHA-256 hash is captured before `ShellExecuteExW` raises privileges, the elevated bootstrap copies the file into `System32`, re-hashes the protected copy with `certutil`, confirms the match with `findstr`, and only then executes it. Installer shortcuts are now serialized via `IShellLink` COM and embedded as base64 in the verified batch rather than staged as VBS scripts in the user-writable temp directory.

- **Hardened elevation handoff** (`installer_handoff.rs`): UUID source path, `create_new` exclusive open, pre-elevation SHA-256 hash, post-copy re-verification in System32 before execution.
- **Trusted environment construction** (`installer_shell.rs`): resolves `cmd.exe`, `certutil.exe`, `findstr.exe`, `chcp.com` from the absolute system directory; resets `PATH`, `ComSpec`, `SystemRoot`, `WINDIR`, `ProgramData`, and `PUBLIC` inside the protected batch.
- **Input sanitisation**: `validate_install_value` and `escape_nested_cmd_ampersands` applied at all cmd interpolation sites; `validate_install_app_name` enforces `[a-zA-Z0-9-]+`; `path_for_cmd_assignment` escapes `^` and `!` for the delayed-expansion bootstrap.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core hardening logic is well-structured and covered by native tests; the three findings are confined to cleanup behaviour, a silent fallback, and an inconsistent return value.

The elevation handoff, hash verification, trusted-environment reset, and input validation are all correctly implemented and tested. The findings are limited to a Drop ordering issue that can leave a partial temp file on write failure, a silent unwrap_or("") in get_import_config that violates the project Rust rules, and an inconsistent bool return from install_service across two error paths — none affect the cryptographic verification or elevation boundary.

**Files Needing Attention:** src/platform/windows.rs (get_import_config and install_service error paths) and src/platform/windows/installer_handoff.rs (write_install_script Drop ordering).
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/platform/windows/installer_handoff.rs | New module implementing the hardened install handoff: UUID-named source batch in %TEMP%, SHA-256 hash captured before elevation, protected copy made to System32 by the elevated bootstrap, hash re-verified from the protected copy before execution. Drop ordering on write failure leaves a partial temp file (P2). |
| src/platform/windows/installer_shell.rs | New module: shortcut serialization via IShellLink COM, base64-encoded embed in the protected batch, trusted environment construction, path validators, cmd-ampersand escaping, and ShellExecuteExW elevation helper. Logic is sound; all external inputs are validated before interpolation. |
| src/platform/windows.rs | Significant restructuring: removes runas dependency, introduces validate_install_value and escape_nested_cmd_ampersands at call sites, migrates shortcut creation from VBS+cscript to COM-embedded batch, refactors install_service. Two P2 issues: unwrap_or("") in get_import_config and inconsistent return value in install_service error path. |
| Cargo.toml | Removes runas dependency; adds Win32_System_Com, Win32_System_Registry, Win32_System_SystemInformation, and Win32_UI_WindowsAndMessaging feature flags for the new COM and shell integration. |
| Cargo.lock | Lock file updated to remove the runas 1.2.0 package and its transitive dependencies. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant RD as RustDesk (medium IL)
    participant TEMP as %TEMP% (user-writable)
    participant S32 as System32 (admin-writable)
    participant UAC as UAC / ShellExecuteExW
    participant ECMD as Elevated cmd.exe (high IL)

    RD->>TEMP: write UUID-named batch (create_new)
    RD->>RD: SHA-256 hash of batch contents
    RD->>UAC: ShellExecuteExW runas cmd.exe /C bootstrap
    UAC-->>RD: UAC prompt shown to user
    RD->>UAC: user approves
    UAC->>ECMD: elevated bootstrap executes

    ECMD->>TEMP: copy /Y source to S32/UUID.bat
    ECMD->>S32: certutil -hashfile UUID.bat SHA256 to UUID.bat.hash
    ECMD->>S32: findstr /R /I pattern UUID.bat.hash
    alt hash matches
        ECMD->>S32: cmd.exe /C UUID.bat (trusted env)
        S32-->>ECMD: exit code
    else hash mismatch
        ECMD-->>RD: exit INSTALL_HANDOFF_HASH_MISMATCH
    end
    ECMD->>S32: "del UUID.bat UUID.bat.* rd UUID.bat.dir"
    ECMD-->>RD: final exit code
    RD->>TEMP: Drop InstallCommandScript deletes source
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/platform/windows.rs`, line 3479-3480 ([link](https://github.com/rustdesk/rustdesk/blob/25259c6cfdc8d15f8eb1bc69541a7717b2cfe099/src/platform/windows.rs#L3479-L3480)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`unwrap_or("")` on config path violates Rust rules**

   `config_path.to_str().unwrap_or("")` silently replaces a non-UTF-8 config path with an empty string, which would embed an empty `sc config` `binpath` into the elevated batch without any error. The project's Rust rules explicitly require avoiding `unwrap()` / `expect()` in production code and not silently ignoring errors. Since callers of `get_import_config` already have access to `exe` as a `&str`, this function should return `ResultType<String>` so the error can propagate.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/rustdesk/github/rustdesk/rustdesk/-/custom-context?memory=f7c8a0b7-52cb-4813-8d03-0dc35dfcbc0b))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/platform/windows.rs
   Line: 3479-3480
   
   Comment:
   **`unwrap_or("")` on config path violates Rust rules**
   
   `config_path.to_str().unwrap_or("")` silently replaces a non-UTF-8 config path with an empty string, which would embed an empty `sc config` `binpath` into the elevated batch without any error. The project's Rust rules explicitly require avoiding `unwrap()` / `expect()` in production code and not silently ignoring errors. Since callers of `get_import_config` already have access to `exe` as a `&str`, this function should return `ResultType<String>` so the error can propagate.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/rustdesk/github/rustdesk/rustdesk/-/custom-context?memory=f7c8a0b7-52cb-4813-8d03-0dc35dfcbc0b))
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fplatform%2Fwindows.rs%0ALine%3A%203479-3480%0A%0AComment%3A%0A**%60unwrap_or%28%22%22%29%60%20on%20config%20path%20violates%20Rust%20rules**%0A%0A%60config_path.to_str%28%29.unwrap_or%28%22%22%29%60%20silently%20replaces%20a%20non-UTF-8%20config%20path%20with%20an%20empty%20string%2C%20which%20would%20embed%20an%20empty%20%60sc%20config%60%20%60binpath%60%20into%20the%20elevated%20batch%20without%20any%20error.%20The%20project's%20Rust%20rules%20explicitly%20require%20avoiding%20%60unwrap%28%29%60%20%2F%20%60expect%28%29%60%20in%20production%20code%20and%20not%20silently%20ignoring%20errors.%20Since%20callers%20of%20%60get_import_config%60%20already%20have%20access%20to%20%60exe%60%20as%20a%20%60%26str%60%2C%20this%20function%20should%20return%20%60ResultType%3CString%3E%60%20so%20the%20error%20can%20propagate.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Frustdesk%2Fgithub%2Frustdesk%2Frustdesk%2F-%2Fcustom-context%3Fmemory%3Df7c8a0b7-52cb-4813-8d03-0dc35dfcbc0b%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15634&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix%2Fwindows-installer-temp-script-hijack-re%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fwindows-installer-temp-script-hijack-re%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fplatform%2Fwindows.rs%0ALine%3A%203479-3480%0A%0AComment%3A%0A**%60unwrap_or%28%22%22%29%60%20on%20config%20path%20violates%20Rust%20rules**%0A%0A%60config_path.to_str%28%29.unwrap_or%28%22%22%29%60%20silently%20replaces%20a%20non-UTF-8%20config%20path%20with%20an%20empty%20string%2C%20which%20would%20embed%20an%20empty%20%60sc%20config%60%20%60binpath%60%20into%20the%20elevated%20batch%20without%20any%20error.%20The%20project's%20Rust%20rules%20explicitly%20require%20avoiding%20%60unwrap%28%29%60%20%2F%20%60expect%28%29%60%20in%20production%20code%20and%20not%20silently%20ignoring%20errors.%20Since%20callers%20of%20%60get_import_config%60%20already%20have%20access%20to%20%60exe%60%20as%20a%20%60%26str%60%2C%20this%20function%20should%20return%20%60ResultType%3CString%3E%60%20so%20the%20error%20can%20propagate.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Frustdesk%2Fgithub%2Frustdesk%2Frustdesk%2F-%2Fcustom-context%3Fmemory%3Df7c8a0b7-52cb-4813-8d03-0dc35dfcbc0b%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15634&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

2. `src/platform/windows.rs`, line 3428-3436 ([link](https://github.com/rustdesk/rustdesk/blob/25259c6cfdc8d15f8eb1bc69541a7717b2cfe099/src/platform/windows.rs#L3428-L3436)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inconsistent return value on command-preparation failure**

   When `get_install_service_commands` fails the function returns `true`, but when `run_cmds` fails the existing path returns `false`. In `ui_interface.rs` the caller uses `if install_service() { return; }`, meaning `true` causes the caller to stop and `false` lets it continue. Returning `true` (stop) on an error that prevents the batch from even being built, while returning `false` (continue) on an elevated-execution error, is backwards — both are fatal installation failures and should signal the caller in the same way.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/platform/windows.rs
   Line: 3428-3436

   Comment:
   **Inconsistent return value on command-preparation failure**

   When `get_install_service_commands` fails the function returns `true`, but when `run_cmds` fails the existing path returns `false`. In `ui_interface.rs` the caller uses `if install_service() { return; }`, meaning `true` causes the caller to stop and `false` lets it continue. Returning `true` (stop) on an error that prevents the batch from even being built, while returning `false` (continue) on an elevated-execution error, is backwards — both are fatal installation failures and should signal the caller in the same way.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fplatform%2Fwindows.rs%0ALine%3A%203428-3436%0A%0AComment%3A%0A**Inconsistent%20return%20value%20on%20command-preparation%20failure**%0A%0AWhen%20%60get_install_service_commands%60%20fails%20the%20function%20returns%20%60true%60%2C%20but%20when%20%60run_cmds%60%20fails%20the%20existing%20path%20returns%20%60false%60.%20In%20%60ui_interface.rs%60%20the%20caller%20uses%20%60if%20install_service%28%29%20%7B%20return%3B%20%7D%60%2C%20meaning%20%60true%60%20causes%20the%20caller%20to%20stop%20and%20%60false%60%20lets%20it%20continue.%20Returning%20%60true%60%20%28stop%29%20on%20an%20error%20that%20prevents%20the%20batch%20from%20even%20being%20built%2C%20while%20returning%20%60false%60%20%28continue%29%20on%20an%20elevated-execution%20error%2C%20is%20backwards%20%E2%80%94%20both%20are%20fatal%20installation%20failures%20and%20should%20signal%20the%20caller%20in%20the%20same%20way.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15634&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix%2Fwindows-installer-temp-script-hijack-re%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fwindows-installer-temp-script-hijack-re%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fplatform%2Fwindows.rs%0ALine%3A%203428-3436%0A%0AComment%3A%0A**Inconsistent%20return%20value%20on%20command-preparation%20failure**%0A%0AWhen%20%60get_install_service_commands%60%20fails%20the%20function%20returns%20%60true%60%2C%20but%20when%20%60run_cmds%60%20fails%20the%20existing%20path%20returns%20%60false%60.%20In%20%60ui_interface.rs%60%20the%20caller%20uses%20%60if%20install_service%28%29%20%7B%20return%3B%20%7D%60%2C%20meaning%20%60true%60%20causes%20the%20caller%20to%20stop%20and%20%60false%60%20lets%20it%20continue.%20Returning%20%60true%60%20%28stop%29%20on%20an%20error%20that%20prevents%20the%20batch%20from%20even%20being%20built%2C%20while%20returning%20%60false%60%20%28continue%29%20on%20an%20elevated-execution%20error%2C%20is%20backwards%20%E2%80%94%20both%20are%20fatal%20installation%20failures%20and%20should%20signal%20the%20caller%20in%20the%20same%20way.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15634&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fplatform%2Fwindows.rs%3A3479-3480%0A**%60unwrap_or%28%22%22%29%60%20on%20config%20path%20violates%20Rust%20rules**%0A%0A%60config_path.to_str%28%29.unwrap_or%28%22%22%29%60%20silently%20replaces%20a%20non-UTF-8%20config%20path%20with%20an%20empty%20string%2C%20which%20would%20embed%20an%20empty%20%60sc%20config%60%20%60binpath%60%20into%20the%20elevated%20batch%20without%20any%20error.%20The%20project's%20Rust%20rules%20explicitly%20require%20avoiding%20%60unwrap%28%29%60%20%2F%20%60expect%28%29%60%20in%20production%20code%20and%20not%20silently%20ignoring%20errors.%20Since%20callers%20of%20%60get_import_config%60%20already%20have%20access%20to%20%60exe%60%20as%20a%20%60%26str%60%2C%20this%20function%20should%20return%20%60ResultType%3CString%3E%60%20so%20the%20error%20can%20propagate.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fplatform%2Fwindows%2Finstaller_handoff.rs%3A77-87%0A**Drop%20ordering%20leaves%20partial%20file%20on%20write%20failure**%0A%0A%60InstallCommandScript%60%20takes%20ownership%20of%20%60path%60%20at%20line%2081%E2%80%9384%2C%20before%20%60file.write_all%28%29%60%20is%20called.%20In%20Rust%2C%20locals%20are%20dropped%20in%20reverse%20declaration%20order%2C%20so%20on%20a%20%60write_all%60%20or%20%60sync_all%60%20error%20the%20%60script%60%20struct%20is%20dropped%20%28triggering%20%60fs%3A%3Aremove_file%60%29%20while%20%60file%60%20is%20still%20open.%20On%20Windows%2C%20deleting%20an%20open%20file%20without%20%60FILE_SHARE_DELETE%60%20fails%20with%20a%20sharing-violation%20error%3B%20the%20Drop%20logs%20a%20warning%20and%20continues%2C%20leaving%20a%20partial%20zero-%20or%20partially-written%20batch%20file%20in%20%60%25TEMP%25%60.%20Declaring%20%60script%60%20after%20both%20writes%20%28and%20closing%20the%20file%20first%20by%20dropping%20%60file%60%29%20would%20ensure%20cleanup%20succeeds.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fplatform%2Fwindows.rs%3A3428-3436%0A**Inconsistent%20return%20value%20on%20command-preparation%20failure**%0A%0AWhen%20%60get_install_service_commands%60%20fails%20the%20function%20returns%20%60true%60%2C%20but%20when%20%60run_cmds%60%20fails%20the%20existing%20path%20returns%20%60false%60.%20In%20%60ui_interface.rs%60%20the%20caller%20uses%20%60if%20install_service%28%29%20%7B%20return%3B%20%7D%60%2C%20meaning%20%60true%60%20causes%20the%20caller%20to%20stop%20and%20%60false%60%20lets%20it%20continue.%20Returning%20%60true%60%20%28stop%29%20on%20an%20error%20that%20prevents%20the%20batch%20from%20even%20being%20built%2C%20while%20returning%20%60false%60%20%28continue%29%20on%20an%20elevated-execution%20error%2C%20is%20backwards%20%E2%80%94%20both%20are%20fatal%20installation%20failures%20and%20should%20signal%20the%20caller%20in%20the%20same%20way.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15634&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix%2Fwindows-installer-temp-script-hijack-re%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fwindows-installer-temp-script-hijack-re%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fplatform%2Fwindows.rs%3A3479-3480%0A**%60unwrap_or%28%22%22%29%60%20on%20config%20path%20violates%20Rust%20rules**%0A%0A%60config_path.to_str%28%29.unwrap_or%28%22%22%29%60%20silently%20replaces%20a%20non-UTF-8%20config%20path%20with%20an%20empty%20string%2C%20which%20would%20embed%20an%20empty%20%60sc%20config%60%20%60binpath%60%20into%20the%20elevated%20batch%20without%20any%20error.%20The%20project's%20Rust%20rules%20explicitly%20require%20avoiding%20%60unwrap%28%29%60%20%2F%20%60expect%28%29%60%20in%20production%20code%20and%20not%20silently%20ignoring%20errors.%20Since%20callers%20of%20%60get_import_config%60%20already%20have%20access%20to%20%60exe%60%20as%20a%20%60%26str%60%2C%20this%20function%20should%20return%20%60ResultType%3CString%3E%60%20so%20the%20error%20can%20propagate.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fplatform%2Fwindows%2Finstaller_handoff.rs%3A77-87%0A**Drop%20ordering%20leaves%20partial%20file%20on%20write%20failure**%0A%0A%60InstallCommandScript%60%20takes%20ownership%20of%20%60path%60%20at%20line%2081%E2%80%9384%2C%20before%20%60file.write_all%28%29%60%20is%20called.%20In%20Rust%2C%20locals%20are%20dropped%20in%20reverse%20declaration%20order%2C%20so%20on%20a%20%60write_all%60%20or%20%60sync_all%60%20error%20the%20%60script%60%20struct%20is%20dropped%20%28triggering%20%60fs%3A%3Aremove_file%60%29%20while%20%60file%60%20is%20still%20open.%20On%20Windows%2C%20deleting%20an%20open%20file%20without%20%60FILE_SHARE_DELETE%60%20fails%20with%20a%20sharing-violation%20error%3B%20the%20Drop%20logs%20a%20warning%20and%20continues%2C%20leaving%20a%20partial%20zero-%20or%20partially-written%20batch%20file%20in%20%60%25TEMP%25%60.%20Declaring%20%60script%60%20after%20both%20writes%20%28and%20closing%20the%20file%20first%20by%20dropping%20%60file%60%29%20would%20ensure%20cleanup%20succeeds.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fplatform%2Fwindows.rs%3A3428-3436%0A**Inconsistent%20return%20value%20on%20command-preparation%20failure**%0A%0AWhen%20%60get_install_service_commands%60%20fails%20the%20function%20returns%20%60true%60%2C%20but%20when%20%60run_cmds%60%20fails%20the%20existing%20path%20returns%20%60false%60.%20In%20%60ui_interface.rs%60%20the%20caller%20uses%20%60if%20install_service%28%29%20%7B%20return%3B%20%7D%60%2C%20meaning%20%60true%60%20causes%20the%20caller%20to%20stop%20and%20%60false%60%20lets%20it%20continue.%20Returning%20%60true%60%20%28stop%29%20on%20an%20error%20that%20prevents%20the%20batch%20from%20even%20being%20built%2C%20while%20returning%20%60false%60%20%28continue%29%20on%20an%20elevated-execution%20error%2C%20is%20backwards%20%E2%80%94%20both%20are%20fatal%20installation%20failures%20and%20should%20signal%20the%20caller%20in%20the%20same%20way.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15634&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/platform/windows.rs:3479-3480
**`unwrap_or("")` on config path violates Rust rules**

`config_path.to_str().unwrap_or("")` silently replaces a non-UTF-8 config path with an empty string, which would embed an empty `sc config` `binpath` into the elevated batch without any error. The project's Rust rules explicitly require avoiding `unwrap()` / `expect()` in production code and not silently ignoring errors. Since callers of `get_import_config` already have access to `exe` as a `&str`, this function should return `ResultType<String>` so the error can propagate.

### Issue 2
src/platform/windows/installer_handoff.rs:77-87
**Drop ordering leaves partial file on write failure**

`InstallCommandScript` takes ownership of `path` at line 81–84, before `file.write_all()` is called. In Rust, locals are dropped in reverse declaration order, so on a `write_all` or `sync_all` error the `script` struct is dropped (triggering `fs::remove_file`) while `file` is still open. On Windows, deleting an open file without `FILE_SHARE_DELETE` fails with a sharing-violation error; the Drop logs a warning and continues, leaving a partial zero- or partially-written batch file in `%TEMP%`. Declaring `script` after both writes (and closing the file first by dropping `file`) would ensure cleanup succeeds.

### Issue 3
src/platform/windows.rs:3428-3436
**Inconsistent return value on command-preparation failure**

When `get_install_service_commands` fails the function returns `true`, but when `run_cmds` fails the existing path returns `false`. In `ui_interface.rs` the caller uses `if install_service() { return; }`, meaning `true` causes the caller to stop and `false` lets it continue. Returning `true` (stop) on an error that prevents the batch from even being built, while returning `false` (continue) on an elevated-execution error, is backwards — both are fatal installation failures and should signal the caller in the same way.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Simple refactor"](https://github.com/rustdesk/rustdesk/commit/25259c6cfdc8d15f8eb1bc69541a7717b2cfe099) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47862159)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/rustdesk/github/rustdesk/rustdesk/-/custom-context?memory=f7c8a0b7-52cb-4813-8d03-0dc35dfcbc0b))

<!-- /greptile_comment -->