### PR TITLE
feat(flutter): decode clipboard server config at startup

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3656,6 +3656,25 @@ ColorFilter? svgColor(Color? color) {
   }
 }
 
+/// Try to decode clipboard text as ServerConfig.
+/// Returns the decoded config if valid (has idServer), otherwise null.
+ServerConfig? tryDecodeClipboardServerConfig(String? text) {
+  if (text == null || text.trim().isEmpty) return null;
+  try {
+    final sc = ServerConfig.decode(text.trim());
+    if (sc.idServer.isNotEmpty) {
+      // Clear relayServer on iOS and Web as the field is hidden in settings UI.
+      if (isIOS || isWeb) {
+        sc.relayServer = '';
+      }
+      return sc;
+    }
+  } catch (e) {
+    // Not a valid server config
+  }
+  return null;
+}
+
 // ignore: must_be_immutable
 class ComboBox extends StatelessWidget {
   late final List<String> keys;

--- a/flutter/lib/common/widgets/clipboard_server_config.dart
+++ b/flutter/lib/common/widgets/clipboard_server_config.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_hbb/common.dart';
+import 'package:flutter_hbb/consts.dart';
+import 'package:flutter_hbb/mobile/widgets/dialog.dart' show showServerSettingsWithValue;
+import 'package:flutter_hbb/models/platform_model.dart';
+
+/// Check clipboard for valid server config on startup and show settings dialog if found.
+///
+/// This should be called from the home page's initState.
+/// The [isMounted] callback is used to check if the widget is still mounted after async operations.
+/// The [setState] callback is passed to the dialog for UI updates.
+void checkAndShowClipboardServerConfig({
+  required bool Function() isMounted,
+  required void Function(VoidCallback) setState,
+}) {
+  final hideServer =
+      bind.mainGetBuildinOption(key: kOptionHideServerSetting) == 'Y';
+  if (hideServer) return;
+
+  WidgetsBinding.instance.addPostFrameCallback((_) async {
+    if (!isMounted()) return;
+
+    try {
+      final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+      if (!isMounted()) return;
+
+      final config = tryDecodeClipboardServerConfig(clipboardData?.text);
+      if (config != null) {
+        if (bind.mainIsInstalled()) {
+          final hasPermission = await callMainCheckSuperUserPermission();
+          if (!hasPermission || !isMounted()) return;
+        }
+        // Clear clipboard after successful parsing
+        await Clipboard.setData(const ClipboardData(text: ''));
+        if (!isMounted()) return;
+        showServerSettingsWithValue(config, gFFI.dialogManager, (fn) {
+          if (isMounted()) setState(fn);
+        });
+      }
+    } catch (e) {
+      debugPrint('checkAndShowClipboardServerConfig error: $e');
+    }
+  });
+}

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hbb/common.dart';
 import 'package:flutter_hbb/common/widgets/animated_rotation_widget.dart';
+import 'package:flutter_hbb/common/widgets/clipboard_server_config.dart';
 import 'package:flutter_hbb/common/widgets/custom_password.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/pages/connection_page.dart';
@@ -858,6 +859,12 @@ class _DesktopHomePageState extends State<DesktopHomePage>
       });
     }
     WidgetsBinding.instance.addObserver(this);
+
+    // Check clipboard for server config on startup
+    checkAndShowClipboardServerConfig(
+      isMounted: () => mounted,
+      setState: setState,
+    );
   }
 
   _updateWindowSize() {

--- a/flutter/lib/mobile/pages/home_page.dart
+++ b/flutter/lib/mobile/pages/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hbb/common/widgets/clipboard_server_config.dart';
 import 'package:flutter_hbb/mobile/pages/server_page.dart';
 import 'package:flutter_hbb/mobile/pages/settings_page.dart';
 import 'package:flutter_hbb/web/settings_page.dart';
@@ -43,6 +44,12 @@ class HomePageState extends State<HomePage> {
   void initState() {
     super.initState();
     initPages();
+    
+    // Check clipboard for server config on startup
+    checkAndShowClipboardServerConfig(
+      isMounted: () => mounted,
+      setState: setState,
+    );
   }
 
   void initPages() {


### PR DESCRIPTION
Try to decode the clipboard text as a ServerConfig when the desktop or mobile home page is initialized. If the clipboard contains a valid server config (with non-empty idServer), show the server settings dialog pre-filled with the decoded values.

This allows users to copy a server config string and have RustDesk automatically offer to apply it on startup, instead of having to manually open the server settings page and paste it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically checks the clipboard for valid server configuration data when the home screen opens (mobile and desktop).
  * If a valid configuration is found, opens the server settings dialog with the fields prefilled.
  * Safely ignores empty/invalid clipboard content, suppresses decoding errors, and clears the clipboard after a successful read.
  * Applies platform-specific adjustments to the configuration as needed and performs an elevated-permission check when required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->