### PR TITLE
Translate 'Continue' to 'Kontynuuj' in Polish

### DIFF
--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -332,7 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Połączenie przez bramkę"),
         ("Secure Connection", "Połączenie szyfrowane"),
         ("Insecure Connection", "Połączenie nieszyfrowane"),
-        ("Continue", ""),
+        ("Continue", "Kontynuuj"),
         ("Scale original", "Skalowanie oryginalne"),
         ("Scale adaptive", "Dopasuj do wyświetlacza"),
         ("General", "Ogólne"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added the missing Polish translation for the “Continue” action, displayed as “Kontynuuj.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->