### PR TITLE
fix(uinput): limit virtual keyboard keycodes to the X11/XKB range

### DIFF
--- a/src/server/uinput.rs
+++ b/src/server/uinput.rs
@@ -533,7 +533,12 @@ pub mod service {
     fn create_uinput_keyboard() -> ResultType<VirtualDevice> {
         // TODO: ensure keys here
         let mut keys = AttributeSet::<evdev::Key>::new();
-        for i in evdev::Key::KEY_ESC.code()..(evdev::Key::BTN_TRIGGER_HAPPY40.code() + 1) {
+        // X11/XKB only supports keycodes up to 255 (X11 keycode = evdev code + 8).
+        // Declaring codes beyond that yields an oversized keymap which makes some
+        // Wayland compositors (e.g. mutter) crash while recompiling the keymap.
+        // Codes above this range are gamepad/joystick buttons, not keyboard keys.
+        for i in evdev::Key::KEY_ESC.code()..=247 {
+
             let key = evdev::Key::new(i);
             if !format!("{:?}", &key).contains("unknown key") {
                 keys.insert(key);


### PR DESCRIPTION
### Problem

On a Wayland GNOME session, `rustdesk --service` creates a virtual keyboard
(`RustDesk UInput Keyboard`) that declares evdev key codes all the way up to
`BTN_TRIGGER_HAPPY40` (0x2E7 = 743) — i.e. including gamepad/joystick buttons.

X11/XKB only supports keycodes up to 255 (X11 keycode = evdev code + 8). On
Ubuntu 26.04 (GNOME 50, mutter 50.1) this oversized key range made gnome-shell
crash with SIGSEGV in `clutter_seat_get_keymap()` from
`pick_keycode_for_keyval_in_current_group_in_impl()` whenever the keymap was
recompiled. The whole session went down — every application was killed and the
user was dropped back to the login screen.

Two things make this hard to diagnose:

- The uinput device **outlives the RustDesk process**. In our case
  `rustdesk.service` was SIGKILLed at 13:10:46 and the session still crashed at
  16:27:41, over three hours later, because the device was still registered and
  a later keymap recompilation hit it.
- The crash can be triggered by *anything* that recompiles the keymap (another
  remote desktop tool connecting, a keyboard layout change, …), so it is easy to
  blame the wrong component.

Related: Ubuntu bug #2101814, GNOME/mutter issue #3950 (same crash signature).

### Fix

Limit the declared range to what X11/XKB can actually represent. Codes above
this range are gamepad/joystick buttons, which a virtual *keyboard* has no
reason to advertise.

```rust
for i in evdev::Key::KEY_ESC.code()..=247 {
```

(The existing `// TODO: ensure keys here` comment right above the loop suggests
this range was provisional to begin with.)

### Verification

Built 1.4.9 with this patch on Ubuntu 26.04 / GNOME 50 / mutter 50.1 / Wayland
and ran it as the system service:

| | before | after |
|---|---|---|
| max evdev keycode of `RustDesk UInput Keyboard` | 743 | **247** |
| gnome-shell crashes | **12** (Jun 08 – Jul 15) | **0** |

All ordinary keyboard keys (letters, function keys, multimedia keys) are
preserved — only gamepad/joystick button codes are dropped, so remote keyboard
input is unaffected. Remote control, including multi-monitor Wayland sessions,
works normally with the patched build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual keyboard compatibility on Wayland by limiting registered key codes to the supported range.
  * Prevented unsupported input codes from being included in the virtual keyboard configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->