### PR TITLE
security: remove hardcoded fallback signing key, require SECRET_KEY env var

### DIFF
--- a/res/job.py
+++ b/res/job.py
@@ -2,6 +2,7 @@
 
 import requests
 import os
+import sys
 import time
 import argparse
 import logging
@@ -18,7 +19,11 @@ logging.basicConfig(
 BASE_URL = os.getenv("BASE_URL") or "http://localhost:5000"
 
 # The secret key for API authentication
-SECRET_KEY = os.getenv("SECRET_KEY") or "worldpeace2024"
+SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    print("ERROR: SECRET_KEY environment variable is required for signing.", file=sys.stderr)
+    print("Set it via: export SECRET_KEY=<your-signing-key>", file=sys.stderr)
+    sys.exit(1)
 
 # The headers for API requests
 HEADERS = {"Authorization": f"Bearer {SECRET_KEY}"}


### PR DESCRIPTION
Fixes #15649

Removes the hardcoded fallback signing key `worldpeace2024` from `res/job.py` and replaces it with an explicit error exit when `SECRET_KEY` is not set, preventing accidental use of a known key during manual builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup validation for request authentication.
  * The application now stops with a clear error when `SECRET_KEY` is missing instead of using a default signing key.
  * Authentication behavior remains unchanged when a valid `SECRET_KEY` is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->