### PR TITLE
fix(macos): fall back to installed package prefixes when a vcpkg dependency is missing

### DIFF
--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -74,19 +74,62 @@ fn link_vcpkg(mut path: PathBuf, name: &str) -> PathBuf {
     include
 }
 
+fn include_dir_name(name: &str) -> &str {
+    match name {
+        "libvpx" => "vpx",
+        _ => name,
+    }
+}
+
+fn has_static_lib(lib_dir: &Path, name: &str) -> bool {
+    lib_dir
+        .join(format!("lib{}.a", name.trim_start_matches("lib")))
+        .exists()
+}
+
+fn emit_package(name: &str, lib_dir: &Path, include_dir: PathBuf) -> PathBuf {
+    println!(
+        "cargo:rustc-link-lib=static={}",
+        name.trim_start_matches("lib")
+    );
+    println!("cargo:rustc-link-search={}", lib_dir.to_str().unwrap());
+    println!("cargo:include={}", include_dir.to_str().unwrap());
+    include_dir
+}
+
+fn try_link_vcpkg(path: PathBuf, name: &str) -> Option<PathBuf> {
+    let include = link_vcpkg(path, name);
+    let lib_dir = include.parent()?.join("lib");
+    if has_static_lib(&lib_dir, name) && include.join(include_dir_name(name)).exists() {
+        Some(include)
+    } else {
+        None
+    }
+}
+
+fn try_link_macos_prefix(prefix: &Path, name: &str) -> Option<PathBuf> {
+    let lib_dir = prefix.join("lib");
+    let include = prefix.join("include");
+    if has_static_lib(&lib_dir, name) && include.join(include_dir_name(name)).exists() {
+        Some(emit_package(name, &lib_dir, include))
+    } else {
+        None
+    }
+}
+
 /// Link homebrew package(for Mac M1).
-fn link_homebrew_m1(name: &str) -> PathBuf {
+fn try_link_homebrew_m1(name: &str) -> Option<PathBuf> {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     if target_os != "macos" || target_arch != "aarch64" {
-        panic!("Couldn't find VCPKG_ROOT, also can't fallback to homebrew because it's only for macos aarch64.");
+        return None;
     }
     let mut path = PathBuf::from("/opt/homebrew/Cellar");
     path.push(name);
     let entries = if let Ok(dir) = std::fs::read_dir(&path) {
         dir
     } else {
-        panic!("Could not find package in {}. Make sure your homebrew and package {} are all installed.", path.to_str().unwrap(),&name);
+        return None;
     };
     let mut directories = entries
         .into_iter()
@@ -97,26 +140,16 @@ fn link_homebrew_m1(name: &str) -> PathBuf {
     // Find the newest version.
     directories.sort_unstable();
     if directories.is_empty() {
-        panic!(
-            "There's no installed version of {} in /opt/homebrew/Cellar",
-            name
-        );
+        return None;
     }
     path.push(directories.pop().unwrap());
-    // Link the library.
-    println!(
-        "cargo:rustc-link-lib=static={}",
-        name.trim_start_matches("lib")
-    );
-    // Add the library path.
-    println!(
-        "cargo:rustc-link-search={}",
-        path.join("lib").to_str().unwrap()
-    );
-    // Add the include path.
+    let lib_dir = path.join("lib");
     let include = path.join("include");
-    println!("cargo:include={}", include.to_str().unwrap());
-    include
+    if has_static_lib(&lib_dir, name) && include.join(include_dir_name(name)).exists() {
+        Some(emit_package(name, &lib_dir, include))
+    } else {
+        None
+    }
 }
 
 /// Find package. By default, it will try to find vcpkg first, then homebrew(currently only for Mac M1).
@@ -125,15 +158,48 @@ fn link_homebrew_m1(name: &str) -> PathBuf {
 fn find_package(name: &str) -> Vec<PathBuf> {
     let no_pkg_config_var_name = format!("NO_PKG_CONFIG_{name}");
     println!("cargo:rerun-if-env-changed={no_pkg_config_var_name}");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     if cfg!(all(target_os = "linux", feature = "linux-pkg-config"))
         && std::env::var(no_pkg_config_var_name).as_deref() != Ok("1")
     {
         link_pkg_config(name)
     } else if let Ok(vcpkg_root) = std::env::var("VCPKG_ROOT") {
-        vec![link_vcpkg(vcpkg_root.into(), name)]
+        if let Some(include) = try_link_vcpkg(vcpkg_root.into(), name) {
+            vec![include]
+        } else if target_os == "macos" {
+            if let Some(include) = try_link_macos_prefix(Path::new("/opt/local"), name) {
+                vec![include]
+            } else if let Some(include) = try_link_homebrew_m1(name) {
+                vec![include]
+            } else if let Some(include) = try_link_macos_prefix(Path::new("/usr/local"), name) {
+                vec![include]
+            } else {
+                panic!(
+                    "Could not find static package {} in VCPKG_ROOT, /opt/local, /opt/homebrew/Cellar, or /usr/local.",
+                    name
+                );
+            }
+        } else {
+            panic!("Could not find static package {} in VCPKG_ROOT.", name);
+        }
+    } else if target_os == "macos" {
+        if let Some(include) = try_link_macos_prefix(Path::new("/opt/local"), name) {
+            vec![include]
+        } else if let Some(include) = try_link_homebrew_m1(name) {
+            vec![include]
+        } else if let Some(include) = try_link_macos_prefix(Path::new("/usr/local"), name) {
+            vec![include]
+        } else {
+            panic!(
+                "Could not find static package {} in /opt/local, /opt/homebrew/Cellar, or /usr/local.",
+                name
+            );
+        }
     } else {
-        // Try using homebrew
-        vec![link_homebrew_m1(name)]
+        panic!(
+            "Could not find static package {}; set VCPKG_ROOT correctly.",
+            name
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #15653

### What changed

`libs/scrap/build.rs` now validates whether a requested package actually exists in `vcpkg` before accepting that path on macOS.

If a package is missing there, the build script falls back per package to:

1. `/opt/local`
2. `/opt/homebrew/Cellar`
3. `/usr/local`

### Why

The previous logic treated `VCPKG_ROOT` as an all-or-nothing source and otherwise only knew how to look in Homebrew's Cellar.

That breaks mixed-source macOS setups where, for example, `libvpx` and `aom` come from `vcpkg` but `libyuv` is already installed in MacPorts.

### Validation

- `rustfmt --edition 2021 --check libs/scrap/build.rs`
- `git diff --check`
- `env VCPKG_ROOT=/Users/shantanavmukherjee/Desktop/vcpkg cargo run -- --version`

Result: the branch built successfully in the reproduced mixed-source setup and `target/debug/rustdesk --version` printed `1.4.9`.
