### PR TITLE
feat(codec): use SVT-AV1 for AV1 encoding on 64-bit targets

### DIFF
--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -4,19 +4,48 @@ use std::{
     println,
 };
 
+/// The static library name may differ from the package name.
+fn link_lib_name(package: &str) -> &str {
+    match package {
+        "svt-av1" => "SvtAv1Enc",
+        _ => package.trim_start_matches("lib"),
+    }
+}
+
 #[cfg(all(target_os = "linux", feature = "linux-pkg-config"))]
 fn link_pkg_config(name: &str) -> Vec<PathBuf> {
     // sometimes an override is needed
     let pc_name = match name {
         "libvpx" => "vpx",
+        "svt-av1" => "SvtAv1Enc",
         _ => name,
     };
-    let lib = pkg_config::probe_library(pc_name)
+    let mut pc = pkg_config::Config::new();
+    if name == "svt-av1" {
+        // svt_av1.rs requires the 4.x API (rtc, PredStructure, on-the-fly rate events)
+        pc.atleast_version("4.2");
+    }
+    let pkg_hint = match name {
+        "svt-av1" => "libsvt-av1-dev (needs svt-av1 >= 4.2)".to_owned(),
+        _ => format!("{pc_name}-dev"),
+    };
+    let lib = pc.probe(pc_name)
         .expect(format!(
             "unable to find '{pc_name}' development headers with pkg-config (feature linux-pkg-config is enabled).
-            try installing '{pc_name}-dev' from your system package manager.").as_str());
+            try installing '{pkg_hint}' from your system package manager.").as_str());
 
-    lib.include_paths
+    let mut include_paths = lib.include_paths;
+    // SvtAv1Enc.pc's Cflags is -I${includedir}/svt-av1, but svt_av1_ffi.h uses
+    // #include <svt-av1/...>, so the parent include root is needed too.
+    if name == "svt-av1" {
+        let parents: Vec<PathBuf> = include_paths
+            .iter()
+            .filter(|p| p.ends_with("svt-av1"))
+            .filter_map(|p| p.parent().map(|p| p.to_path_buf()))
+            .collect();
+        include_paths.extend(parents);
+    }
+    include_paths
 }
 #[cfg(not(all(target_os = "linux", feature = "linux-pkg-config")))]
 fn link_pkg_config(_name: &str) -> Vec<PathBuf> {
@@ -61,10 +90,7 @@ fn link_vcpkg(mut path: PathBuf, name: &str) -> PathBuf {
         path.push("installed");
     }
     path.push(target);
-    println!(
-        "cargo:rustc-link-lib=static={}",
-        name.trim_start_matches("lib")
-    );
+    println!("cargo:rustc-link-lib=static={}", link_lib_name(name));
     println!(
         "cargo:rustc-link-search={}",
         path.join("lib").to_str().unwrap()
@@ -103,11 +129,13 @@ fn link_homebrew_m1(name: &str) -> PathBuf {
         );
     }
     path.push(directories.pop().unwrap());
-    // Link the library.
-    println!(
-        "cargo:rustc-link-lib=static={}",
-        name.trim_start_matches("lib")
-    );
+    // Link the library. Homebrew's svt-av1 bottle only ships a dylib.
+    if name == "svt-av1" {
+        println!("cargo:rustc-link-lib={}", link_lib_name(name));
+        println!("cargo:warning=svt-av1 is linked dynamically from homebrew, the binary needs homebrew's svt-av1 at runtime and is not relocatable; set VCPKG_ROOT for a static build");
+    } else {
+        println!("cargo:rustc-link-lib=static={}", link_lib_name(name));
+    }
     // Add the library path.
     println!(
         "cargo:rustc-link-search={}",
@@ -120,8 +148,9 @@ fn link_homebrew_m1(name: &str) -> PathBuf {
 }
 
 /// Find package. By default, it will try to find vcpkg first, then homebrew(currently only for Mac M1).
-/// If building for linux and feature "linux-pkg-config" is enabled, will try to use pkg-config
-/// unless check fails (e.g. NO_PKG_CONFIG_libyuv=1)
+/// If building on a linux host and feature "linux-pkg-config" is enabled, will try to use pkg-config
+/// unless check fails (e.g. NO_PKG_CONFIG_libyuv=1). Note the cfg! below sees the build host, not
+/// the target, so cross builds (e.g. linux -> android) must not enable linux-pkg-config.
 fn find_package(name: &str) -> Vec<PathBuf> {
     let no_pkg_config_var_name = format!("NO_PKG_CONFIG_{name}");
     println!("cargo:rerun-if-env-changed={no_pkg_config_var_name}");
@@ -170,9 +199,9 @@ fn gen_vcpkg_package(package: &str, ffi_header: &str, generated: &str, regex: &s
     let out_dir = Path::new(&out_dir);
 
     let ffi_header = src_dir.join("src").join("bindings").join(ffi_header);
-    println!("rerun-if-changed={}", ffi_header.display());
+    println!("cargo:rerun-if-changed={}", ffi_header.display());
     for dir in &includes {
-        println!("rerun-if-changed={}", dir.display());
+        println!("cargo:rerun-if-changed={}", dir.display());
     }
 
     let ffi_rs = out_dir.join(generated);
@@ -248,6 +277,18 @@ fn main() {
     gen_vcpkg_package("libvpx", "vpx_ffi.h", "vpx_ffi.rs", "^[vV].*");
     gen_vcpkg_package("aom", "aom_ffi.h", "aom_ffi.rs", "^(aom|AOM|OBU|AV1).*");
     gen_vcpkg_package("libyuv", "yuv_ffi.h", "yuv_ffi.rs", ".*");
+    // Skipped on 32-bit targets: svt-av1 does not support them, the vcpkg
+    // manifest does not install it there and disable_av1() never uses AV1 on
+    // them anyway. Must stay in sync with the cfg gates in
+    // mod.rs/codec.rs/video_service.rs.
+    if env::var("CARGO_CFG_TARGET_POINTER_WIDTH").as_deref() == Ok("64") {
+        gen_vcpkg_package(
+            "svt-av1",
+            "svt_av1_ffi.h",
+            "svt_av1_ffi.rs",
+            "^(svt_av1_|Svt|SVT_|Eb|EB_|PredStructure|PrivDataType).*",
+        );
+    }
     // ffmpeg();
 
     if target_os == "ios" {

--- a/libs/scrap/examples/av1_benchmark.rs
+++ b/libs/scrap/examples/av1_benchmark.rs
@@ -1,0 +1,1096 @@
+#[cfg(not(target_pointer_width = "64"))]
+fn main() {
+    eprintln!(
+        "This example requires a 64-bit target because SVT-AV1 does not support 32-bit targets."
+    );
+    std::process::exit(1);
+}
+
+// The RustDesk application normally provides this symbol from src/platform/macos.mm.
+// Standalone scrap examples need their own CoreGraphics-based implementation.
+#[cfg(all(target_pointer_width = "64", target_os = "macos"))]
+#[allow(non_snake_case)]
+#[no_mangle]
+pub extern "C" fn BackingScaleFactor(display: u32) -> f32 {
+    let pixels = unsafe { scrap::quartz::ffi::CGDisplayPixelsWide(display) } as f64;
+    let bounds = unsafe { scrap::quartz::ffi::CGDisplayBounds(display) };
+    if pixels > 0.0 && bounds.size.width > 0.0 {
+        (pixels / bounds.size.width).max(1.0) as f32
+    } else {
+        1.0
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+fn main() {
+    if let Err(error) = benchmark::run() {
+        eprintln!("AV1 benchmark failed: {error:#}");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+mod benchmark {
+    use hbb_common::{
+        anyhow::{anyhow, bail},
+        bytes::Bytes,
+        message_proto::{video_frame, Chroma, EncodedVideoFrame, EncodedVideoFrames, VideoFrame},
+        ResultType,
+    };
+    use scrap::{
+        aom::{AomDecoder, AomEncoder, AomEncoderConfig},
+        codec::{EncoderApi, EncoderCfg},
+        record::{RecordState, Recorder, RecorderContext},
+        svt_av1::{SvtAv1Encoder, SvtAv1EncoderConfig},
+        Capturer, Display as ScrapDisplay, EncodeInput, EncodeYuvFormat, GoogleImage, Pixfmt,
+        TraitCapturer, STRIDE_ALIGN,
+    };
+    use std::{
+        convert::TryFrom,
+        env,
+        fmt::Display,
+        io::ErrorKind,
+        str::FromStr,
+        sync::mpsc,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    const USAGE: &str = "\
+Compare RustDesk's AOM and SVT-AV1 encoder configurations with identical I420 frames.
+
+Usage:
+  cargo run -p scrap --release --example av1_benchmark -- [options]
+
+Options:
+  --input=TYPE    Input type: synthetic or screenshot [default: synthetic]
+  --capture-delay=N
+                  Seconds to wait before capturing the screenshot sequence [default: 0]
+  --width=N       Synthetic frame width [default: 1920]
+  --height=N      Synthetic frame height [default: 1080]
+  --frames=N      Measured frames per encoder [default: 300]
+  --warmup=N      Unmeasured warm-up frames per encoder [default: 10]
+  --fps=N         Configured frame rate [default: 30]
+  --quality=N     RustDesk quality ratio, in (0, 2] [default: 1.0]
+  --svt-preset=N  SVT-AV1 RTC preset, from 7 (slow) to 13 (fast) [default: 8]
+  --svt-first     Run SVT-AV1 before AOM to help check order/thermal bias
+  --record        Save both encoded streams under target/av1-benchmark-recordings
+  -h, --help      Show this help
+";
+
+    const SCREENSHOT_INTERVAL: Duration = Duration::from_millis(30);
+
+    #[derive(Clone, Copy)]
+    struct Args {
+        input: InputKind,
+        capture_delay: u64,
+        width: u32,
+        height: u32,
+        frames: usize,
+        warmup: usize,
+        fps: u32,
+        quality: f32,
+        svt_preset: i8,
+        svt_first: bool,
+        record: bool,
+    }
+
+    impl Default for Args {
+        fn default() -> Self {
+            Self {
+                input: InputKind::Synthetic,
+                capture_delay: 0,
+                width: 1920,
+                height: 1080,
+                frames: 300,
+                warmup: 10,
+                fps: 30,
+                quality: 1.0,
+                svt_preset: 8,
+                svt_first: false,
+                record: false,
+            }
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum InputKind {
+        Synthetic,
+        Screenshot,
+    }
+
+    impl InputKind {
+        fn name(self) -> &'static str {
+            match self {
+                Self::Synthetic => "synthetic",
+                Self::Screenshot => "screenshot",
+            }
+        }
+    }
+
+    impl FromStr for InputKind {
+        type Err = &'static str;
+
+        fn from_str(value: &str) -> Result<Self, Self::Err> {
+            match value {
+                "synthetic" => Ok(Self::Synthetic),
+                "screenshot" => Ok(Self::Screenshot),
+                _ => Err("expected synthetic or screenshot"),
+            }
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum EncoderKind {
+        Aom,
+        SvtAv1,
+    }
+
+    impl EncoderKind {
+        fn name(self) -> &'static str {
+            match self {
+                Self::Aom => "aom",
+                Self::SvtAv1 => "svt-av1",
+            }
+        }
+    }
+
+    struct BenchmarkResult {
+        encoder: &'static str,
+        initialization: Duration,
+        first_frame: Duration,
+        samples: Vec<Duration>,
+        output_frames: usize,
+        output_bytes: u64,
+        pts_mismatches: usize,
+        decoded_frames: usize,
+        quality: QualityMetrics,
+        fps: u32,
+        reference_format: EncodeYuvFormat,
+        packets: Vec<EncodedPacket>,
+    }
+
+    struct EncodedPacket {
+        input_index: usize,
+        pts: i64,
+        key: bool,
+        data: Vec<u8>,
+    }
+
+    impl BenchmarkResult {
+        fn total_encode_time(&self) -> Duration {
+            self.samples.iter().copied().sum()
+        }
+
+        fn initialization_ms(&self) -> f64 {
+            duration_ms(self.initialization)
+        }
+
+        fn first_frame_ms(&self) -> f64 {
+            duration_ms(self.first_frame)
+        }
+
+        fn mean_ms(&self) -> f64 {
+            duration_ms(self.total_encode_time()) / self.samples.len() as f64
+        }
+
+        fn percentile_ms(&self, percentile: f64) -> f64 {
+            let mut samples = self.samples.clone();
+            samples.sort_unstable();
+            let index = ((samples.len() - 1) as f64 * percentile).round() as usize;
+            duration_ms(samples[index])
+        }
+
+        fn encode_fps(&self) -> f64 {
+            self.samples.len() as f64 / self.total_encode_time().as_secs_f64()
+        }
+
+        fn average_bytes(&self) -> f64 {
+            self.output_bytes as f64 / self.output_frames as f64
+        }
+
+        fn bitrate_kbps(&self) -> f64 {
+            self.output_bytes as f64 * 8.0 * self.fps as f64 / self.samples.len() as f64 / 1000.0
+        }
+    }
+
+    #[derive(Default)]
+    struct PlaneError {
+        squared_error: u128,
+        samples: u128,
+    }
+
+    impl PlaneError {
+        fn psnr(&self) -> f64 {
+            if self.squared_error == 0 {
+                return f64::INFINITY;
+            }
+            let mse = self.squared_error as f64 / self.samples as f64;
+            10.0 * (255.0f64 * 255.0 / mse).log10()
+        }
+    }
+
+    #[derive(Default)]
+    struct QualityMetrics {
+        y: PlaneError,
+        u: PlaneError,
+        v: PlaneError,
+        ssim_y_sum: f64,
+        ssim_y_windows: u64,
+        frames: usize,
+    }
+
+    impl QualityMetrics {
+        fn add_frame(
+            &mut self,
+            reference: &[u8],
+            reference_format: &EncodeYuvFormat,
+            decoded: &scrap::aom::Image,
+        ) -> ResultType<()> {
+            if decoded.width() != reference_format.w || decoded.height() != reference_format.h {
+                bail!(
+                    "decoded dimensions {}x{} do not match reference {}x{}",
+                    decoded.width(),
+                    decoded.height(),
+                    reference_format.w,
+                    reference_format.h
+                );
+            }
+            if decoded.chroma() != Chroma::I420 {
+                bail!("decoded image is not I420: {:?}", decoded.chroma());
+            }
+            let strides = decoded.stride();
+            let planes = decoded.planes();
+            if strides.len() < 3 || planes.len() < 3 {
+                bail!("decoded image has fewer than three planes");
+            }
+            if strides[..3].iter().any(|stride| *stride <= 0)
+                || planes[..3].iter().any(|plane| plane.is_null())
+            {
+                bail!("decoded image has an invalid plane or stride");
+            }
+
+            let chroma_width = (reference_format.w + 1) / 2;
+            let chroma_height = (reference_format.h + 1) / 2;
+            accumulate_plane_error(
+                &mut self.y,
+                reference,
+                0,
+                reference_format.stride[0],
+                planes[0],
+                strides[0] as usize,
+                reference_format.w,
+                reference_format.h,
+            );
+            accumulate_plane_error(
+                &mut self.u,
+                reference,
+                reference_format.u,
+                reference_format.stride[1],
+                planes[1],
+                strides[1] as usize,
+                chroma_width,
+                chroma_height,
+            );
+            accumulate_plane_error(
+                &mut self.v,
+                reference,
+                reference_format.v,
+                reference_format.stride[2],
+                planes[2],
+                strides[2] as usize,
+                chroma_width,
+                chroma_height,
+            );
+            let (ssim_sum, windows) = calculate_ssim_y(
+                reference,
+                reference_format.stride[0],
+                planes[0],
+                strides[0] as usize,
+                reference_format.w,
+                reference_format.h,
+            );
+            self.ssim_y_sum += ssim_sum;
+            self.ssim_y_windows += windows;
+            self.frames += 1;
+            Ok(())
+        }
+
+        fn psnr_yuv(&self) -> f64 {
+            let squared_error = self.y.squared_error + self.u.squared_error + self.v.squared_error;
+            if squared_error == 0 {
+                return f64::INFINITY;
+            }
+            let samples = self.y.samples + self.u.samples + self.v.samples;
+            let mse = squared_error as f64 / samples as f64;
+            10.0 * (255.0f64 * 255.0 / mse).log10()
+        }
+
+        fn ssim_y(&self) -> f64 {
+            self.ssim_y_sum / self.ssim_y_windows as f64
+        }
+    }
+
+    struct SyntheticI420 {
+        format: EncodeYuvFormat,
+        base: Vec<u8>,
+        frame: Vec<u8>,
+    }
+
+    struct ScreenshotSequenceI420 {
+        format: EncodeYuvFormat,
+        frames: Vec<Vec<u8>>,
+    }
+
+    enum BenchmarkInput {
+        Synthetic,
+        Screenshot(ScreenshotSequenceI420),
+    }
+
+    impl BenchmarkInput {
+        fn frame_source(&self, format: EncodeYuvFormat) -> ResultType<FrameSource<'_>> {
+            match self {
+                Self::Synthetic => Ok(FrameSource::Synthetic(SyntheticI420::new(format))),
+                Self::Screenshot(screenshot) => {
+                    validate_matching_i420_layout(&screenshot.format, &format)?;
+                    Ok(FrameSource::Screenshot(&screenshot.frames))
+                }
+            }
+        }
+
+        fn description(&self) -> &'static str {
+            match self {
+                Self::Synthetic => {
+                    "Synthetic input: static checkerboard with a moving YUV rectangle (I420)"
+                }
+                Self::Screenshot(_) => {
+                    "Screenshot input: primary-display frames captured at 30 ms intervals (I420)"
+                }
+            }
+        }
+    }
+
+    enum FrameSource<'a> {
+        Synthetic(SyntheticI420),
+        Screenshot(&'a [Vec<u8>]),
+    }
+
+    impl FrameSource<'_> {
+        fn frame(&mut self, index: usize) -> ResultType<&[u8]> {
+            match self {
+                Self::Synthetic(input) => Ok(input.frame(index)),
+                Self::Screenshot(frames) => frames
+                    .get(index)
+                    .map(Vec::as_slice)
+                    .ok_or_else(|| anyhow!("screenshot frame {index} is unavailable")),
+            }
+        }
+    }
+
+    impl SyntheticI420 {
+        fn new(format: EncodeYuvFormat) -> Self {
+            let chroma_height = (format.h + 1) / 2;
+            let len = format.v + format.stride[2] * chroma_height;
+            let mut base = vec![128u8; len];
+            for y in 0..format.h {
+                let row = &mut base[y * format.stride[0]..y * format.stride[0] + format.w];
+                for (x, value) in row.iter_mut().enumerate() {
+                    *value = if (x / 32 + y / 32) % 2 == 0 { 48 } else { 192 };
+                }
+            }
+            let chroma_width = (format.w + 1) / 2;
+            for y in 0..chroma_height {
+                for x in 0..chroma_width {
+                    let first = (x / 16 + y / 16) % 2 == 0;
+                    base[format.u + y * format.stride[1] + x] = if first { 96 } else { 160 };
+                    base[format.v + y * format.stride[2] + x] = if first { 160 } else { 96 };
+                }
+            }
+            let frame = base.clone();
+            Self {
+                format,
+                base,
+                frame,
+            }
+        }
+
+        fn frame(&mut self, index: usize) -> &[u8] {
+            self.frame.copy_from_slice(&self.base);
+            let rect_width = (self.format.w / 6).max(1);
+            let rect_height = (self.format.h / 6).max(1);
+            let x_range = self.format.w - rect_width + 1;
+            let y_range = self.format.h - rect_height + 1;
+            let x = index.saturating_mul(13) % x_range;
+            let y = index.saturating_mul(7) % y_range;
+            let value = 32 + (index.saturating_mul(17) % 192) as u8;
+            for row in y..y + rect_height {
+                let begin = row * self.format.stride[0] + x;
+                self.frame[begin..begin + rect_width].fill(value);
+            }
+            let chroma_left = x / 2;
+            let chroma_top = y / 2;
+            let chroma_right = (x + rect_width + 1) / 2;
+            let chroma_bottom = (y + rect_height + 1) / 2;
+            let u_value = 64 + (index.saturating_mul(11) % 128) as u8;
+            let v_value = 192 - (index.saturating_mul(7) % 128) as u8;
+            for row in chroma_top..chroma_bottom {
+                let u_begin = self.format.u + row * self.format.stride[1] + chroma_left;
+                let v_begin = self.format.v + row * self.format.stride[2] + chroma_left;
+                self.frame[u_begin..u_begin + chroma_right - chroma_left].fill(u_value);
+                self.frame[v_begin..v_begin + chroma_right - chroma_left].fill(v_value);
+            }
+            &self.frame
+        }
+    }
+
+    fn validate_matching_i420_layout(
+        captured: &EncodeYuvFormat,
+        encoder: &EncodeYuvFormat,
+    ) -> ResultType<()> {
+        let matching_strides = captured.stride.get(..3) == encoder.stride.get(..3);
+        if captured.pixfmt != Pixfmt::I420
+            || encoder.pixfmt != Pixfmt::I420
+            || captured.w != encoder.w
+            || captured.h != encoder.h
+            || !matching_strides
+            || captured.u != encoder.u
+            || captured.v != encoder.v
+        {
+            bail!(
+                "captured I420 layout does not match encoder layout: captured={captured:?}, encoder={encoder:?}"
+            );
+        }
+        Ok(())
+    }
+
+    fn aligned_i420_format(width: usize, height: usize) -> ResultType<EncodeYuvFormat> {
+        let align = |value: usize| {
+            value
+                .checked_add(STRIDE_ALIGN - 1)
+                .map(|value| value & !(STRIDE_ALIGN - 1))
+                .ok_or_else(|| anyhow!("screen dimensions are too large"))
+        };
+        let stride_y = align(width)?;
+        let stride_uv = align((width + 1) / 2)?;
+        let u = stride_y
+            .checked_mul(height)
+            .ok_or_else(|| anyhow!("screen dimensions are too large"))?;
+        let chroma_height = (height + 1) / 2;
+        let v = stride_uv
+            .checked_mul(chroma_height)
+            .and_then(|chroma_len| u.checked_add(chroma_len))
+            .ok_or_else(|| anyhow!("screen dimensions are too large"))?;
+        Ok(EncodeYuvFormat {
+            pixfmt: Pixfmt::I420,
+            w: width,
+            h: height,
+            stride: vec![stride_y, stride_uv, stride_uv],
+            u,
+            v,
+        })
+    }
+
+    fn capture_primary_screenshots(
+        delay_seconds: u64,
+        frame_count: usize,
+    ) -> ResultType<ScreenshotSequenceI420> {
+        let mut displays = ScrapDisplay::all()?;
+        if displays.is_empty() {
+            bail!("no displays are available for screenshot input");
+        }
+        let primary_index = match displays.iter().position(ScrapDisplay::is_primary) {
+            Some(index) => index,
+            None => 0,
+        };
+        let display = displays.remove(primary_index);
+        let mut capturer = Capturer::new(display)?;
+        let width = capturer.width();
+        let height = capturer.height();
+        if width == 0 || height == 0 {
+            bail!("primary display reported an invalid size: {width}x{height}");
+        }
+        let format = aligned_i420_format(width, height)?;
+
+        for remaining in (1..=delay_seconds).rev() {
+            println!("Taking primary-display screenshot in {remaining}s...");
+            thread::sleep(Duration::from_secs(1));
+        }
+        println!(
+            "Capturing {frame_count} primary-display frames at {width}x{height} with a {} ms interval...",
+            SCREENSHOT_INTERVAL.as_millis()
+        );
+
+        let wait_limit = Duration::from_secs(10);
+        let mut wait_start = Instant::now();
+        let mut frames = Vec::with_capacity(frame_count);
+        let mut yuv = Vec::new();
+        let mut mid_data = Vec::new();
+        while frames.len() < frame_count {
+            match capturer.frame(Duration::from_millis(100)) {
+                Ok(frame) if !frame.valid() => {}
+                Ok(frame) => {
+                    let converted = frame.to(format.clone(), &mut yuv, &mut mid_data)?;
+                    if converted.yuv().is_err() {
+                        bail!("screen capturer returned a GPU texture instead of CPU pixels");
+                    }
+                    frames.push(std::mem::take(&mut yuv));
+                    wait_start = Instant::now();
+                    if frames.len() < frame_count {
+                        thread::sleep(SCREENSHOT_INTERVAL);
+                    }
+                    continue;
+                }
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {}
+                Err(error) => bail!("failed to capture primary display: {error}"),
+            }
+            if wait_start.elapsed() >= wait_limit {
+                bail!(
+                    "timed out waiting for screenshot frame {}/{}; check screen-recording permission and try again",
+                    frames.len() + 1,
+                    frame_count
+                );
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        let captured_bytes = frames.iter().map(Vec::len).sum::<usize>();
+        println!(
+            "Screenshot sequence captured ({:.1} MiB).",
+            captured_bytes as f64 / (1024.0 * 1024.0)
+        );
+        Ok(ScreenshotSequenceI420 { format, frames })
+    }
+
+    fn accumulate_plane_error(
+        error: &mut PlaneError,
+        reference: &[u8],
+        reference_offset: usize,
+        reference_stride: usize,
+        decoded: *mut u8,
+        decoded_stride: usize,
+        width: usize,
+        height: usize,
+    ) {
+        for row in 0..height {
+            let reference_begin = reference_offset + row * reference_stride;
+            let reference_row = &reference[reference_begin..reference_begin + width];
+            // The decoder-owned plane and positive stride were validated by add_frame,
+            // and width/height are the decoded image's visible dimensions.
+            let decoded_row =
+                unsafe { std::slice::from_raw_parts(decoded.add(row * decoded_stride), width) };
+            for (&original, &reconstructed) in reference_row.iter().zip(decoded_row) {
+                let difference = original as i32 - reconstructed as i32;
+                error.squared_error += (difference * difference) as u128;
+            }
+        }
+        error.samples += (width * height) as u128;
+    }
+
+    // Mean SSIM over non-overlapping 8x8 luma windows. Edge windows use their
+    // visible size, so every displayed pixel contributes to the result.
+    fn calculate_ssim_y(
+        reference: &[u8],
+        reference_stride: usize,
+        decoded: *mut u8,
+        decoded_stride: usize,
+        width: usize,
+        height: usize,
+    ) -> (f64, u64) {
+        const WINDOW: usize = 8;
+        const C1: f64 = 6.5025; // (0.01 * 255)^2
+        const C2: f64 = 58.5225; // (0.03 * 255)^2
+
+        let mut total = 0.0;
+        let mut windows = 0u64;
+        for top in (0..height).step_by(WINDOW) {
+            for left in (0..width).step_by(WINDOW) {
+                let block_width = WINDOW.min(width - left);
+                let block_height = WINDOW.min(height - top);
+                let samples = (block_width * block_height) as f64;
+                let mut original_sum = 0.0;
+                let mut decoded_sum = 0.0;
+                let mut original_square_sum = 0.0;
+                let mut decoded_square_sum = 0.0;
+                let mut product_sum = 0.0;
+
+                for row in top..top + block_height {
+                    let reference_begin = row * reference_stride + left;
+                    let reference_row = &reference[reference_begin..reference_begin + block_width];
+                    // The pointer range is covered by the validated decoded plane.
+                    let decoded_row = unsafe {
+                        std::slice::from_raw_parts(
+                            decoded.add(row * decoded_stride + left),
+                            block_width,
+                        )
+                    };
+                    for (&original, &reconstructed) in reference_row.iter().zip(decoded_row) {
+                        let original = original as f64;
+                        let reconstructed = reconstructed as f64;
+                        original_sum += original;
+                        decoded_sum += reconstructed;
+                        original_square_sum += original * original;
+                        decoded_square_sum += reconstructed * reconstructed;
+                        product_sum += original * reconstructed;
+                    }
+                }
+
+                let original_mean = original_sum / samples;
+                let decoded_mean = decoded_sum / samples;
+                let original_variance =
+                    (original_square_sum / samples - original_mean * original_mean).max(0.0);
+                let decoded_variance =
+                    (decoded_square_sum / samples - decoded_mean * decoded_mean).max(0.0);
+                let covariance = product_sum / samples - original_mean * decoded_mean;
+                total += ((2.0 * original_mean * decoded_mean + C1) * (2.0 * covariance + C2))
+                    / ((original_mean * original_mean + decoded_mean * decoded_mean + C1)
+                        * (original_variance + decoded_variance + C2));
+                windows += 1;
+            }
+        }
+        (total, windows)
+    }
+
+    pub fn run() -> ResultType<()> {
+        let Some(mut args) = parse_args()? else {
+            print!("{USAGE}");
+            return Ok(());
+        };
+        let total_frames = args
+            .warmup
+            .checked_add(args.frames)
+            .ok_or_else(|| anyhow!("--warmup + --frames is too large"))?;
+        if args.frames == 0 {
+            bail!("--frames must be greater than zero");
+        }
+        let input = match args.input {
+            InputKind::Synthetic => BenchmarkInput::Synthetic,
+            InputKind::Screenshot => {
+                let screenshot = capture_primary_screenshots(args.capture_delay, total_frames)?;
+                args.width = u32::try_from(screenshot.format.w)
+                    .map_err(|_| anyhow!("captured screen width is too large"))?;
+                args.height = u32::try_from(screenshot.format.h)
+                    .map_err(|_| anyhow!("captured screen height is too large"))?;
+                BenchmarkInput::Screenshot(screenshot)
+            }
+        };
+        validate_args(args)?;
+
+        println!(
+            "AV1 benchmark: {}x{}, input={}, quality={}, fps={}, warmup={}, measured={}",
+            args.width,
+            args.height,
+            args.input.name(),
+            args.quality,
+            args.fps,
+            args.warmup,
+            args.frames
+        );
+        println!("{}", input.description());
+        println!("Timing scope: encode_to_message only; input generation is excluded");
+        println!("Quality scope: separate decode passes after both encoders finish");
+        println!("Quality metrics: sequence PSNR and mean non-overlapping 8x8 luma SSIM\n");
+        let (svt_min_qp, svt_max_qp) = SvtAv1Encoder::quality_qp_range(args.quality);
+        println!(
+            "Comparison constraint: SVT-AV1 QP range={}..{} (matched to AOM for quality={}); preset=M{}\n",
+            svt_min_qp, svt_max_qp, args.quality, args.svt_preset
+        );
+
+        let (mut aom, mut svt) = if args.svt_first {
+            let svt = benchmark_encoder(EncoderKind::SvtAv1, args, &input)?;
+            let aom = benchmark_encoder(EncoderKind::Aom, args, &input)?;
+            (aom, svt)
+        } else {
+            let aom = benchmark_encoder(EncoderKind::Aom, args, &input)?;
+            let svt = benchmark_encoder(EncoderKind::SvtAv1, args, &input)?;
+            (aom, svt)
+        };
+
+        evaluate_quality(&mut aom, args, &input)?;
+        evaluate_quality(&mut svt, args, &input)?;
+        if args.record {
+            write_recordings([&aom, &svt], args)?;
+        }
+        print_results(&aom, &svt);
+        Ok(())
+    }
+
+    fn validate_args(args: Args) -> ResultType<()> {
+        if args.frames == 0 {
+            bail!("--frames must be greater than zero");
+        }
+        if args.fps == 0 || args.fps > 1000 {
+            bail!("--fps must be in the range 1..=1000");
+        }
+        if !args.quality.is_finite() || args.quality <= 0.0 || args.quality > 2.0 {
+            bail!("--quality must be in the range (0, 2]");
+        }
+        if !(7..=13).contains(&args.svt_preset) {
+            bail!("--svt-preset must be in the range 7..=13");
+        }
+        if !SvtAv1Encoder::support(args.width, args.height) {
+            bail!(
+                "SVT-AV1 does not support resolution {}x{}; use even dimensions between 64x64 and 16384x8704",
+                args.width,
+                args.height
+            );
+        }
+        Ok(())
+    }
+
+    fn benchmark_encoder(
+        kind: EncoderKind,
+        args: Args,
+        benchmark_input: &BenchmarkInput,
+    ) -> ResultType<BenchmarkResult> {
+        println!("Running {}...", kind.name());
+        let initialization_start = Instant::now();
+        let mut encoder: Box<dyn EncoderApi> = match kind {
+            EncoderKind::Aom => Box::new(AomEncoder::new(
+                EncoderCfg::AOM(AomEncoderConfig {
+                    width: args.width,
+                    height: args.height,
+                    quality: args.quality,
+                    keyframe_interval: None,
+                }),
+                false,
+            )?),
+            EncoderKind::SvtAv1 => Box::new(SvtAv1Encoder::new(
+                EncoderCfg::SVTAV1(SvtAv1EncoderConfig {
+                    width: args.width,
+                    height: args.height,
+                    quality: args.quality,
+                    keyframe_interval: None,
+                    qp_range: Some(SvtAv1Encoder::quality_qp_range(args.quality)),
+                    preset: Some(args.svt_preset),
+                }),
+                false,
+            )?),
+        };
+        encoder.set_fps(args.fps);
+        let initialization = initialization_start.elapsed();
+        let reference_format = encoder.yuvfmt();
+        let mut input = benchmark_input.frame_source(reference_format.clone())?;
+        let total_frames = args
+            .warmup
+            .checked_add(args.frames)
+            .ok_or_else(|| anyhow!("--warmup + --frames is too large"))?;
+        let mut first_frame = Duration::ZERO;
+        let mut samples = Vec::with_capacity(args.frames);
+        let mut output_frames = 0usize;
+        let mut output_bytes = 0u64;
+        let mut pts_mismatches = 0usize;
+        let mut packets = Vec::with_capacity(total_frames);
+
+        for index in 0..total_frames {
+            let pts = index.saturating_mul(1000) / args.fps as usize;
+            let yuv = input.frame(index)?;
+            let encode_start = Instant::now();
+            let message = encoder.encode_to_message(EncodeInput::YUV(yuv), pts as i64)?;
+            let elapsed = encode_start.elapsed();
+            if index == 0 {
+                first_frame = elapsed;
+            }
+            let measured = index >= args.warmup;
+            let frames = av1_frames(&message)?;
+            for frame in &frames.frames {
+                let pts_matches = frame.pts == pts as i64;
+                if measured {
+                    output_frames += 1;
+                    output_bytes += frame.data.len() as u64;
+                    if !pts_matches {
+                        pts_mismatches += 1;
+                    }
+                }
+                packets.push(EncodedPacket {
+                    input_index: index,
+                    pts: frame.pts,
+                    key: frame.key,
+                    data: frame.data.to_vec(),
+                });
+            }
+            if measured {
+                samples.push(elapsed);
+            }
+        }
+        drop(encoder);
+
+        Ok(BenchmarkResult {
+            encoder: kind.name(),
+            initialization,
+            first_frame,
+            samples,
+            output_frames,
+            output_bytes,
+            pts_mismatches,
+            decoded_frames: 0,
+            quality: QualityMetrics::default(),
+            fps: args.fps,
+            reference_format,
+            packets,
+        })
+    }
+
+    fn evaluate_quality(
+        result: &mut BenchmarkResult,
+        args: Args,
+        benchmark_input: &BenchmarkInput,
+    ) -> ResultType<()> {
+        println!("Evaluating {} decoded quality...", result.encoder);
+        let mut decoder = AomDecoder::new()?;
+        let mut quality_input = benchmark_input.frame_source(result.reference_format.clone())?;
+        for packet in &result.packets {
+            let expected_pts = packet.input_index.saturating_mul(1000) / args.fps as usize;
+            let measured = packet.input_index >= args.warmup;
+            let reference = quality_input.frame(packet.input_index)?;
+            let decoded = decode_packet(
+                &mut decoder,
+                &packet.data,
+                reference,
+                &result.reference_format,
+                measured && packet.pts == expected_pts as i64,
+                &mut result.quality,
+            )?;
+            if measured {
+                result.decoded_frames += decoded;
+            }
+        }
+        Ok(())
+    }
+
+    fn write_recordings(results: [&BenchmarkResult; 2], args: Args) -> ResultType<()> {
+        const RECORDING_DIR: &str = "target/av1-benchmark-recordings";
+
+        println!("Writing AV1 benchmark recordings...");
+        let mut recordings = Vec::with_capacity(results.len());
+        for result in results {
+            let (tx, rx) = mpsc::channel();
+            let mut recorder = Recorder::new(RecorderContext {
+                server: false,
+                id: format!("benchmark-{}", result.encoder),
+                dir: RECORDING_DIR.to_owned(),
+                display_idx: 0,
+                camera: false,
+                tx: Some(tx),
+            })?;
+            let frames = result
+                .packets
+                .iter()
+                .map(|packet| EncodedVideoFrame {
+                    data: Bytes::from(packet.data.clone()),
+                    key: packet.key,
+                    pts: packet.pts,
+                    ..Default::default()
+                })
+                .collect::<Vec<_>>();
+            let encoded = EncodedVideoFrames {
+                frames: frames.into(),
+                ..Default::default()
+            };
+            recorder.write_frame(
+                &video_frame::Union::Av1s(encoded),
+                args.width as usize,
+                args.height as usize,
+            )?;
+            let filename = match rx.recv() {
+                Ok(RecordState::NewFile(filename)) => filename,
+                Ok(_) => bail!("recorder did not report its output filename"),
+                Err(error) => bail!("failed to receive recorder output filename: {error}"),
+            };
+            recordings.push((recorder, filename));
+        }
+
+        // Recorder removes files whose writer exists for less than one second.
+        // Keep both muxers alive long enough for short benchmark runs as well.
+        thread::sleep(Duration::from_millis(1100));
+        for (_, filename) in &recordings {
+            println!("Recording: {filename}");
+        }
+        drop(recordings);
+        Ok(())
+    }
+
+    fn decode_packet(
+        decoder: &mut AomDecoder,
+        packet: &[u8],
+        reference: &[u8],
+        reference_format: &EncodeYuvFormat,
+        measure_quality: bool,
+        quality: &mut QualityMetrics,
+    ) -> ResultType<usize> {
+        let mut decoded_frames = 0usize;
+        for image in decoder.decode(packet)? {
+            if measure_quality {
+                quality.add_frame(reference, reference_format, &image)?;
+            }
+            decoded_frames += 1;
+        }
+        for image in decoder.flush()? {
+            if measure_quality {
+                quality.add_frame(reference, reference_format, &image)?;
+            }
+            decoded_frames += 1;
+        }
+        if decoded_frames != 1 {
+            bail!("one AV1 packet decoded to {decoded_frames} frames instead of one");
+        }
+        Ok(decoded_frames)
+    }
+
+    fn av1_frames(
+        message: &VideoFrame,
+    ) -> ResultType<&hbb_common::message_proto::EncodedVideoFrames> {
+        match message.union.as_ref() {
+            Some(video_frame::Union::Av1s(frames)) => Ok(frames),
+            _ => bail!("encoder returned a non-AV1 VideoFrame"),
+        }
+    }
+
+    fn print_results(aom: &BenchmarkResult, svt: &BenchmarkResult) {
+        println!(
+            "{:<9} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9} {:>11} {:>11} {:>9}",
+            "encoder",
+            "init ms",
+            "cold ms",
+            "mean ms",
+            "p50 ms",
+            "p95 ms",
+            "p99 ms",
+            "encode fps",
+            "avg bytes",
+            "kbps"
+        );
+        for result in [aom, svt] {
+            println!(
+                "{:<9} {:>9.3} {:>9.3} {:>9.3} {:>9.3} {:>9.3} {:>9.3} {:>11.2} {:>11.1} {:>9.1}",
+                result.encoder,
+                result.initialization_ms(),
+                result.first_frame_ms(),
+                result.mean_ms(),
+                result.percentile_ms(0.50),
+                result.percentile_ms(0.95),
+                result.percentile_ms(0.99),
+                result.encode_fps(),
+                result.average_bytes(),
+                result.bitrate_kbps()
+            );
+            println!(
+                "RESULT encoder={} init_ms={:.3} cold_ms={:.3} mean_ms={:.3} p50_ms={:.3} p95_ms={:.3} p99_ms={:.3} encode_fps={:.2} output_frames={} decoded_frames={} avg_bytes={:.1} bitrate_kbps={:.1} pts_mismatches={} quality_frames={} psnr_y={:.4} psnr_u={:.4} psnr_v={:.4} psnr_yuv={:.4} ssim_y={:.6}",
+                result.encoder,
+                result.initialization_ms(),
+                result.first_frame_ms(),
+                result.mean_ms(),
+                result.percentile_ms(0.50),
+                result.percentile_ms(0.95),
+                result.percentile_ms(0.99),
+                result.encode_fps(),
+                result.output_frames,
+                result.decoded_frames,
+                result.average_bytes(),
+                result.bitrate_kbps(),
+                result.pts_mismatches,
+                result.quality.frames,
+                result.quality.y.psnr(),
+                result.quality.u.psnr(),
+                result.quality.v.psnr(),
+                result.quality.psnr_yuv(),
+                result.quality.ssim_y()
+            );
+        }
+
+        println!(
+            "\n{:<9} {:>11} {:>11} {:>11} {:>11} {:>11}",
+            "encoder", "PSNR-Y", "PSNR-U", "PSNR-V", "PSNR-YUV", "SSIM-Y"
+        );
+        for result in [aom, svt] {
+            println!(
+                "{:<9} {:>11.4} {:>11.4} {:>11.4} {:>11.4} {:>11.6}",
+                result.encoder,
+                result.quality.y.psnr(),
+                result.quality.u.psnr(),
+                result.quality.v.psnr(),
+                result.quality.psnr_yuv(),
+                result.quality.ssim_y()
+            );
+        }
+
+        println!(
+            "\nSVT-AV1 vs AOM: throughput={:.2}x, mean_time={:.1}%, output_size={:.1}%",
+            svt.encode_fps() / aom.encode_fps(),
+            svt.mean_ms() / aom.mean_ms() * 100.0,
+            svt.average_bytes() / aom.average_bytes() * 100.0
+        );
+        println!(
+            "Quality delta (SVT-AV1 - AOM): PSNR-Y={:+.4} dB, PSNR-YUV={:+.4} dB, SSIM-Y={:+.6}",
+            svt.quality.y.psnr() - aom.quality.y.psnr(),
+            svt.quality.psnr_yuv() - aom.quality.psnr_yuv(),
+            svt.quality.ssim_y() - aom.quality.ssim_y()
+        );
+        println!(
+            "Frame mapping: AOM input/output/decoded={}/{}/{}, PTS mismatches={}; SVT-AV1 input/output/decoded={}/{}/{}, PTS mismatches={}",
+            aom.samples.len(),
+            aom.output_frames,
+            aom.decoded_frames,
+            aom.pts_mismatches,
+            svt.samples.len(),
+            svt.output_frames,
+            svt.decoded_frames,
+            svt.pts_mismatches
+        );
+        println!("Higher PSNR/SSIM and throughput are better; lower time/output_size are better.");
+    }
+
+    fn parse_args() -> ResultType<Option<Args>> {
+        let mut parsed = Args::default();
+        let mut args = env::args().skip(1);
+        while let Some(argument) = args.next() {
+            if argument == "-h" || argument == "--help" {
+                return Ok(None);
+            }
+            if argument == "--svt-first" {
+                parsed.svt_first = true;
+                continue;
+            }
+            if argument == "--record" {
+                parsed.record = true;
+                continue;
+            }
+
+            let (name, inline_value) = match argument.split_once('=') {
+                Some((name, value)) => (name, Some(value)),
+                None => (argument.as_str(), None),
+            };
+            let value = match inline_value {
+                Some(value) => value.to_owned(),
+                None => args
+                    .next()
+                    .ok_or_else(|| anyhow!("missing value for {name}"))?,
+            };
+            match name {
+                "--input" => parsed.input = parse_value(name, &value)?,
+                "--capture-delay" => parsed.capture_delay = parse_value(name, &value)?,
+                "--width" => parsed.width = parse_value(name, &value)?,
+                "--height" => parsed.height = parse_value(name, &value)?,
+                "--frames" => parsed.frames = parse_value(name, &value)?,
+                "--warmup" => parsed.warmup = parse_value(name, &value)?,
+                "--fps" => parsed.fps = parse_value(name, &value)?,
+                "--quality" => parsed.quality = parse_value(name, &value)?,
+                "--svt-preset" => parsed.svt_preset = parse_value(name, &value)?,
+                _ => bail!("unknown option {name}\n\n{USAGE}"),
+            }
+        }
+        Ok(Some(parsed))
+    }
+
+    fn parse_value<T>(name: &str, value: &str) -> ResultType<T>
+    where
+        T: FromStr,
+        T::Err: Display,
+    {
+        value
+            .parse()
+            .map_err(|error| anyhow!("invalid value for {name}: {value:?} ({error})"))
+    }
+
+    fn duration_ms(duration: Duration) -> f64 {
+        duration.as_secs_f64() * 1000.0
+    }
+}

--- a/libs/scrap/src/bindings/svt_av1_ffi.h
+++ b/libs/scrap/src/bindings/svt_av1_ffi.h
@@ -1,0 +1,5 @@
+#include <svt-av1/EbSvtAv1.h>
+#include <svt-av1/EbSvtAv1Enc.h>
+#include <svt-av1/EbSvtAv1ErrorCodes.h>
+#include <svt-av1/EbSvtAv1Formats.h>
+#include <svt-av1/EbSvtAv1Metadata.h>

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -146,17 +146,23 @@ impl Encoder {
             EncoderCfg::VPX(_) => Ok(Encoder {
                 codec: Box::new(VpxEncoder::new(config, i444)?),
             }),
-            EncoderCfg::AOM(_) => Ok(Encoder {
-                codec: Box::new(AomEncoder::new(config, i444)?),
-            }),
+            EncoderCfg::AOM(_) => {
+                log::info!("AV1 encoder: aom");
+                Ok(Encoder {
+                    codec: Box::new(AomEncoder::new(config, i444)?),
+                })
+            }
             #[cfg(target_pointer_width = "64")]
             EncoderCfg::SVTAV1(svt) => match SvtAv1Encoder::new(EncoderCfg::SVTAV1(svt), i444) {
-                Ok(codec) => Ok(Encoder {
-                    codec: Box::new(codec),
-                }),
+                Ok(codec) => {
+                    log::info!("AV1 encoder: svt-av1");
+                    Ok(Encoder {
+                        codec: Box::new(codec),
+                    })
+                }
                 Err(e) => {
                     // Same wire format, aom keeps the negotiated AV1 session alive.
-                    log::error!("new svt-av1 encoder failed: {e:?}, fallback to aom");
+                    log::error!("AV1 encoder: svt-av1 init failed ({e:?}), using aom");
                     let aom = EncoderCfg::AOM(AomEncoderConfig {
                         width: svt.width,
                         height: svt.height,

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -9,6 +9,8 @@ use std::{
 use crate::hwcodec::*;
 #[cfg(feature = "mediacodec")]
 use crate::mediacodec::{MediaCodecDecoder, H264_DECODER_SUPPORT, H265_DECODER_SUPPORT};
+#[cfg(target_pointer_width = "64")]
+use crate::svt_av1::{SvtAv1Encoder, SvtAv1EncoderConfig};
 #[cfg(feature = "vram")]
 use crate::vram::*;
 use crate::{
@@ -51,6 +53,8 @@ pub const ENCODE_NEED_SWITCH: &'static str = "ENCODE_NEED_SWITCH";
 pub enum EncoderCfg {
     VPX(VpxEncoderConfig),
     AOM(AomEncoderConfig),
+    #[cfg(target_pointer_width = "64")]
+    SVTAV1(SvtAv1EncoderConfig),
     #[cfg(feature = "hwcodec")]
     HWRAM(HwRamEncoderConfig),
     #[cfg(feature = "vram")]
@@ -70,6 +74,11 @@ pub trait EncoderApi {
     fn input_texture(&self) -> bool;
 
     fn set_quality(&mut self, ratio: f32) -> ResultType<()>;
+
+    /// Inform the encoder of the current pacing rate. Only rate controls that
+    /// budget per frame from a configured frame rate need to override the
+    /// default no-op.
+    fn set_fps(&mut self, _fps: u32) {}
 
     fn bitrate(&self) -> u32;
 
@@ -140,6 +149,25 @@ impl Encoder {
             EncoderCfg::AOM(_) => Ok(Encoder {
                 codec: Box::new(AomEncoder::new(config, i444)?),
             }),
+            #[cfg(target_pointer_width = "64")]
+            EncoderCfg::SVTAV1(svt) => match SvtAv1Encoder::new(EncoderCfg::SVTAV1(svt), i444) {
+                Ok(codec) => Ok(Encoder {
+                    codec: Box::new(codec),
+                }),
+                Err(e) => {
+                    // Same wire format, aom keeps the negotiated AV1 session alive.
+                    log::error!("new svt-av1 encoder failed: {e:?}, fallback to aom");
+                    let aom = EncoderCfg::AOM(AomEncoderConfig {
+                        width: svt.width,
+                        height: svt.height,
+                        quality: svt.quality,
+                        keyframe_interval: svt.keyframe_interval,
+                    });
+                    Ok(Encoder {
+                        codec: Box::new(AomEncoder::new(aom, i444)?),
+                    })
+                }
+            },
 
             #[cfg(feature = "hwcodec")]
             EncoderCfg::HWRAM(_) => match HwRamEncoder::new(config, i444) {
@@ -269,7 +297,10 @@ impl Encoder {
         let preference = most_frequent.enum_value_or(PreferCodec::Auto);
 
         // auto: h265 > h264 > av1/vp9/vp8
-        let av1_test = Config::get_option(hbb_common::config::keys::OPTION_AV1_TEST) != "N";
+        let av1_test = {
+            let v = Config::get_option(hbb_common::config::keys::OPTION_AV1_TEST);
+            v != "N" && v != "SVT-N"
+        };
         let mut auto_codec = if av1_useable && av1_test {
             CodecFormat::AV1
         } else {
@@ -365,6 +396,8 @@ impl Encoder {
                 VpxVideoCodecId::VP9 => CodecFormat::VP9,
             },
             EncoderCfg::AOM(_) => CodecFormat::AV1,
+            #[cfg(target_pointer_width = "64")]
+            EncoderCfg::SVTAV1(_) => CodecFormat::AV1,
             #[cfg(feature = "hwcodec")]
             EncoderCfg::HWRAM(hw) => {
                 let name = hw.name.to_lowercase();
@@ -411,6 +444,10 @@ impl Encoder {
                 VpxVideoCodecId::VP9 => decodings.iter().all(|d| d.1.i444.vp9),
             },
             EncoderCfg::AOM(_) => decodings.iter().all(|d| d.1.i444.av1),
+            // Mirrors AOM so an i444 preference change still triggers the encoder
+            // rebuild, the rebuild then selects aom for the actual i444 encoding.
+            #[cfg(target_pointer_width = "64")]
+            EncoderCfg::SVTAV1(_) => decodings.iter().all(|d| d.1.i444.av1),
             #[cfg(feature = "hwcodec")]
             EncoderCfg::HWRAM(_) => false,
             #[cfg(feature = "vram")]
@@ -1042,7 +1079,15 @@ pub fn test_av1() {
     use hbb_common::rand::Rng;
     use std::{sync::Once, time::Duration};
 
-    if disable_av1() || !Config::get_option(OPTION_AV1_TEST).is_empty() {
+    // The verdict is tied to the encoder generation that produced it, so
+    // switching the AV1 encoder (aom <-> svt-av1) re-runs the test.
+    #[cfg(target_pointer_width = "64")]
+    const AV1_TEST_RESULT: (&str, &str) = ("SVT-Y", "SVT-N");
+    #[cfg(not(target_pointer_width = "64"))]
+    const AV1_TEST_RESULT: (&str, &str) = ("Y", "N");
+
+    let cached = Config::get_option(OPTION_AV1_TEST);
+    if disable_av1() || cached == AV1_TEST_RESULT.0 || cached == AV1_TEST_RESULT.1 {
         log::info!("skip test av1");
         return;
     }
@@ -1101,15 +1146,38 @@ pub fn test_av1() {
                     }
                     Ok(dst)
                 };
-            let Ok(mut av1) = AomEncoder::new(
-                EncoderCfg::AOM(AomEncoderConfig {
+            let aom = || {
+                AomEncoder::new(
+                    EncoderCfg::AOM(AomEncoderConfig {
+                        width,
+                        height,
+                        quality,
+                        keyframe_interval,
+                    }),
+                    i444,
+                )
+                .map(|e| Box::new(e) as Box<dyn EncoderApi>)
+            };
+            // Test the encoder actually used for AV1, svt-av1 on 64-bit targets, with
+            // the same fallback to aom as Encoder::new so an svt init failure
+            // does not brand a working aom as unusable. Note that i444 (true
+            // color) sessions and svt-unsupported resolutions still run aom,
+            // whose speed is then not covered by this gate.
+            #[cfg(target_pointer_width = "64")]
+            let av1 = crate::svt_av1::SvtAv1Encoder::new(
+                EncoderCfg::SVTAV1(crate::svt_av1::SvtAv1EncoderConfig {
                     width,
                     height,
                     quality,
                     keyframe_interval,
                 }),
                 i444,
-            ) else {
+            )
+            .map(|e| Box::new(e) as Box<dyn EncoderApi>)
+            .or_else(|_| aom());
+            #[cfg(not(target_pointer_width = "64"))]
+            let av1 = aom();
+            let Ok(mut av1) = av1 else {
                 return false;
             };
             let mut key_frame_time = Duration::ZERO;
@@ -1122,7 +1190,7 @@ pub fn test_av1() {
                 };
                 let start = Instant::now();
                 if av1
-                    .encode(pts.elapsed().as_millis() as _, &yuv, super::STRIDE_ALIGN)
+                    .encode_to_message(EncodeInput::YUV(&yuv), pts.elapsed().as_millis() as _)
                     .is_err()
                 {
                     log::debug!("av1 encode failed");
@@ -1150,7 +1218,12 @@ pub fn test_av1() {
             let v = f();
             Config::set_option(
                 OPTION_AV1_TEST.to_string(),
-                if v { "Y" } else { "N" }.to_string(),
+                if v {
+                    AV1_TEST_RESULT.0
+                } else {
+                    AV1_TEST_RESULT.1
+                }
+                .to_string(),
             );
         });
     });

--- a/libs/scrap/src/common/codec.rs
+++ b/libs/scrap/src/common/codec.rs
@@ -1176,6 +1176,8 @@ pub fn test_av1() {
                     height,
                     quality,
                     keyframe_interval,
+                    qp_range: None,
+                    preset: None,
                 }),
                 i444,
             )

--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -52,6 +52,8 @@ pub mod aom;
 #[cfg(not(any(target_os = "ios")))]
 pub mod camera;
 pub mod record;
+#[cfg(target_pointer_width = "64")]
+pub mod svt_av1;
 mod vpx;
 
 #[repr(usize)]

--- a/libs/scrap/src/common/svt_av1.rs
+++ b/libs/scrap/src/common/svt_av1.rs
@@ -1,0 +1,500 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(improper_ctypes)]
+#![allow(dead_code)]
+
+include!(concat!(env!("OUT_DIR"), "/svt_av1_ffi.rs"));
+
+use crate::codec::{base_bitrate, codec_thread_num, EncoderApi, EncoderCfg};
+use crate::{EncodeInput, EncodeYuvFormat, Pixfmt, STRIDE_ALIGN};
+use hbb_common::{
+    anyhow::Context,
+    bail,
+    bytes::Bytes,
+    log,
+    message_proto::{EncodedVideoFrame, EncodedVideoFrames, VideoFrame},
+    ResultType,
+};
+use std::{mem::MaybeUninit, os::raw::c_void, ptr, slice};
+
+// SVT-AV1 rejects on-the-fly target bitrates above 100_000 kbps.
+const MAX_TARGET_BITRATE_KBPS: u32 = 100_000;
+// CBR budgets bits per frame from the configured frame rate, VideoQoS pushes
+// its authoritative pacing rate in via set_fps.
+const DEFAULT_FPS: u32 = 30;
+
+#[derive(Clone, Copy, Debug)]
+pub struct SvtAv1EncoderConfig {
+    pub width: u32,
+    pub height: u32,
+    pub quality: f32,
+    pub keyframe_interval: Option<usize>,
+}
+
+pub struct SvtAv1Encoder {
+    handle: *mut EbComponentType,
+    width: usize,
+    height: usize,
+    yuvfmt: EncodeYuvFormat,
+    // current target bitrate in kbps, same unit as aom's rc_target_bitrate
+    bitrate: u32,
+    // bitrate change (kbps) to apply with the next picture via RATE_CHANGE_EVENT
+    pending_bitrate: Option<u32>,
+    // frame rate currently configured in the encoder
+    fps: u32,
+    // frame rate change to apply with the next picture via FRAME_RATE_CHANGE_EVENT
+    pending_fps: Option<u32>,
+}
+
+// The handle is only used behind &mut self, SVT-AV1 synchronizes internally.
+unsafe impl Send for SvtAv1Encoder {}
+
+impl EncoderApi for SvtAv1Encoder {
+    fn new(cfg: EncoderCfg, i444: bool) -> ResultType<Self>
+    where
+        Self: Sized,
+    {
+        match cfg {
+            EncoderCfg::SVTAV1(config) => {
+                if i444 {
+                    // SVT-AV1 only supports 4:2:0 input, callers must fall back to aom for i444.
+                    bail!("svt-av1 encoder does not support I444");
+                }
+                if !Self::support(config.width, config.height) {
+                    bail!(
+                        "svt-av1 encoder does not support resolution {}x{}",
+                        config.width,
+                        config.height
+                    );
+                }
+                let mut handle: *mut EbComponentType = ptr::null_mut();
+                let mut c: MaybeUninit<EbSvtAv1EncConfiguration> = MaybeUninit::zeroed();
+                let res = unsafe { svt_av1_enc_init_handle(&mut handle, c.as_mut_ptr()) };
+                if res != EbErrorType::EB_ErrorNone || handle.is_null() {
+                    bail!("svt_av1_enc_init_handle failed: {res:?}");
+                }
+                // c is loaded with the library defaults now, only override what we need.
+                let mut c = unsafe { c.assume_init() };
+                let bitrate = Self::bitrate(config.width, config.height, config.quality)
+                    .min(MAX_TARGET_BITRATE_KBPS);
+                Self::apply_config(&mut c, &config, bitrate);
+                let mut res = unsafe { svt_av1_enc_set_parameter(handle, &mut c) };
+                if res == EbErrorType::EB_ErrorNone {
+                    res = unsafe { svt_av1_enc_init(handle) };
+                }
+                if res != EbErrorType::EB_ErrorNone {
+                    unsafe {
+                        svt_av1_enc_deinit_handle(handle);
+                    }
+                    bail!("failed to init svt-av1 encoder: {res:?}");
+                }
+                Ok(Self {
+                    handle,
+                    width: config.width as _,
+                    height: config.height as _,
+                    yuvfmt: Self::get_yuvfmt(config.width, config.height),
+                    bitrate,
+                    pending_bitrate: None,
+                    fps: DEFAULT_FPS,
+                    pending_fps: None,
+                })
+            }
+            _ => bail!("encoder type mismatch"),
+        }
+    }
+
+    fn encode_to_message(&mut self, input: EncodeInput, ms: i64) -> ResultType<VideoFrame> {
+        let frames = self
+            .encode(ms, input.yuv()?)
+            .with_context(|| "Failed to encode")?;
+        if frames.len() > 0 {
+            Ok(Self::create_video_frame(frames))
+        } else {
+            bail!("no valid frame");
+        }
+    }
+
+    fn yuvfmt(&self) -> EncodeYuvFormat {
+        self.yuvfmt.clone()
+    }
+
+    #[cfg(feature = "vram")]
+    fn input_texture(&self) -> bool {
+        false
+    }
+
+    fn set_quality(&mut self, ratio: f32) -> ResultType<()> {
+        let bitrate =
+            Self::bitrate(self.width as _, self.height as _, ratio).min(MAX_TARGET_BITRATE_KBPS);
+        if bitrate > 0 && bitrate != self.bitrate {
+            self.bitrate = bitrate;
+            self.pending_bitrate = Some(bitrate);
+        }
+        Ok(())
+    }
+
+    fn set_fps(&mut self, fps: u32) {
+        if fps == 0 {
+            return;
+        }
+        // also cancels a queued change that a later call made moot again
+        if fps == self.fps {
+            self.pending_fps = None;
+        } else {
+            self.pending_fps = Some(fps);
+        }
+    }
+
+    fn bitrate(&self) -> u32 {
+        self.bitrate
+    }
+
+    fn support_changing_quality(&self) -> bool {
+        true
+    }
+
+    fn latency_free(&self) -> bool {
+        true
+    }
+
+    fn is_hardware(&self) -> bool {
+        false
+    }
+
+    fn disable(&self) {}
+}
+
+impl SvtAv1Encoder {
+    pub fn support(width: u32, height: u32) -> bool {
+        width >= 64
+            && height >= 64
+            && width <= 16384
+            && height <= 8704
+            && width % 2 == 0
+            && height % 2 == 0
+    }
+
+    fn apply_config(c: &mut EbSvtAv1EncConfiguration, cfg: &SvtAv1EncoderConfig, bitrate: u32) {
+        c.enc_mode = Self::preset(cfg.width, cfg.height);
+        c.source_width = cfg.width;
+        c.source_height = cfg.height;
+        // CBR budgets bits per frame from this rate, set_fps adjusts it on the
+        // fly with FRAME_RATE_CHANGE_EVENT.
+        c.frame_rate_numerator = DEFAULT_FPS;
+        c.frame_rate_denominator = 1;
+        c.encoder_bit_depth = 8;
+        c.encoder_color_format = EbColorFormat::EB_YUV420;
+        c.profile = EbAv1SeqProfile::MAIN_PROFILE;
+        // Low delay + rtc + CBR: one packet out per picture in, svt_av1_enc_get_packet
+        // blocks until the packet for the sent picture is ready, and rate/keyframe
+        // changes on the fly are allowed.
+        c.pred_structure = PredStructure::LOW_DELAY;
+        c.rtc = true;
+        c.rate_control_mode = SvtAv1RcMode::SVT_AV1_RC_MODE_CBR as _;
+        c.target_bit_rate = bitrate.min(MAX_TARGET_BITRATE_KBPS) * 1000;
+        // Full envelope of aom's calc_q_values so later bitrate changes are not clipped.
+        c.min_qp_allowed = 5;
+        c.max_qp_allowed = 45;
+        let (q_min, q_max) = Self::calc_q_values(cfg.quality);
+        c.qp = (q_min + q_max) / 2;
+        c.look_ahead_distance = 0;
+        c.recode_loop = 0; // DISALLOW_RECODE
+        c.scene_change_detection = 0;
+        c.screen_content_mode = 1;
+        c.tune = 1; // PSNR, low delay does not support tune 0
+        c.level_of_parallelism = Self::parallelism();
+        c.intra_refresh_type = SvtAv1IntraRefreshType::SVT_AV1_KF_REFRESH; // closed GOP
+        c.intra_period_length = match cfg.keyframe_interval {
+            Some(keyframe_interval) => keyframe_interval.saturating_sub(1) as _,
+            None => -1, // no periodic intra refresh, keyframes only on demand
+        };
+        // pic_type is left to the encoder and keyframes come from encoder
+        // restarts, the force_key_frames flag must stay off for low delay CBR
+        // (the library resets it with a warning).
+        c.force_key_frames = false;
+    }
+
+    fn preset(width: u32, height: u32) -> i8 {
+        // Mirrors aom's get_cpu_speed buckets, M9-M13 are the rtc presets.
+        if width * height <= 320 * 180 {
+            9
+        } else if width * height <= 640 * 360 {
+            10
+        } else {
+            11
+        }
+    }
+
+    fn parallelism() -> u32 {
+        // level_of_parallelism is a level from 1 to 6, not a thread count.
+        match codec_thread_num(64) {
+            n if n >= 32 => 6,
+            n if n >= 16 => 5,
+            n if n >= 8 => 4,
+            n if n >= 4 => 3,
+            n if n >= 2 => 2,
+            _ => 1,
+        }
+    }
+
+    fn encode(&mut self, ms: i64, data: &[u8]) -> ResultType<Vec<EncodedVideoFrame>> {
+        let fmt = &self.yuvfmt;
+        let chroma_height = (fmt.h + 1) / 2;
+        let len = fmt.v + fmt.stride[2] * chroma_height;
+        if data.len() < len {
+            bail!("len not enough: {} < {}", data.len(), len);
+        }
+        let mut io = EbSvtIOFormat {
+            luma: data.as_ptr() as *mut u8,
+            cb: data[fmt.u..].as_ptr() as *mut u8,
+            cr: data[fmt.v..].as_ptr() as *mut u8,
+            y_stride: fmt.stride[0] as _,
+            cr_stride: fmt.stride[2] as _,
+            cb_stride: fmt.stride[1] as _,
+        };
+        let mut hdr: EbBufferHeaderType = unsafe { std::mem::zeroed() };
+        hdr.size = std::mem::size_of::<EbBufferHeaderType>() as _;
+        hdr.p_buffer = &mut io as *mut EbSvtIOFormat as *mut u8;
+        hdr.n_filled_len = len as _;
+        hdr.pts = ms;
+        hdr.pic_type = EbAv1PictureType::EB_AV1_INVALID_PICTURE; // encoder decides
+
+        // send_picture copies the private data list, stack lifetime is fine.
+        // The pending changes are only cleared after a successful send, so a
+        // failed send retries them with the next picture.
+        let pending_bitrate = self.pending_bitrate;
+        let pending_fps = self.pending_fps;
+        let mut rate_info = SvtAv1RateInfo {
+            seq_qp: 0,
+            target_bit_rate: pending_bitrate.unwrap_or(0).min(MAX_TARGET_BITRATE_KBPS) * 1000,
+        };
+        let mut fps_info = SvtAv1FrameRateInfo {
+            frame_rate_numerator: pending_fps.unwrap_or(0),
+            frame_rate_denominator: 1,
+        };
+        let mut rate_node = EbPrivDataNode {
+            node_type: PrivDataType::RATE_CHANGE_EVENT,
+            data: &mut rate_info as *mut SvtAv1RateInfo as *mut c_void,
+            size: std::mem::size_of::<SvtAv1RateInfo>() as _,
+            next: ptr::null_mut(),
+        };
+        let mut fps_node = EbPrivDataNode {
+            node_type: PrivDataType::FRAME_RATE_CHANGE_EVENT,
+            data: &mut fps_info as *mut SvtAv1FrameRateInfo as *mut c_void,
+            size: std::mem::size_of::<SvtAv1FrameRateInfo>() as _,
+            next: ptr::null_mut(),
+        };
+        let mut list: *mut EbPrivDataNode = ptr::null_mut();
+        if pending_bitrate.is_some() {
+            list = &mut rate_node;
+        }
+        if pending_fps.is_some() {
+            fps_node.next = list;
+            list = &mut fps_node;
+        }
+        hdr.p_app_private = list as *mut c_void;
+        // The input YUV planes are copied inside send_picture.
+        let res = unsafe { svt_av1_enc_send_picture(self.handle, &mut hdr) };
+        if res != EbErrorType::EB_ErrorNone {
+            bail!("svt_av1_enc_send_picture failed: {res:?}");
+        }
+        self.pending_bitrate = None;
+        self.pending_fps = None;
+        if let Some(fps) = pending_fps {
+            self.fps = fps;
+        }
+
+        // In low delay mode get_packet blocks until the packet for the picture just
+        // sent is ready, and each picture produces exactly one packet. Do not call
+        // it again without sending another picture, it would block forever.
+        let mut frames = Vec::new();
+        let mut pkt: *mut EbBufferHeaderType = ptr::null_mut();
+        let res = unsafe { svt_av1_enc_get_packet(self.handle, &mut pkt, 0) };
+        match res {
+            EbErrorType::EB_ErrorNone if !pkt.is_null() => unsafe {
+                let h = &*pkt;
+                frames.push(EncodedVideoFrame {
+                    data: Bytes::from(
+                        slice::from_raw_parts(h.p_buffer, h.n_filled_len as usize).to_vec(),
+                    ),
+                    key: h.pic_type == EbAv1PictureType::EB_AV1_KEY_PICTURE,
+                    pts: h.pts,
+                    ..Default::default()
+                });
+                svt_av1_enc_release_out_buffer(&mut pkt);
+            },
+            EbErrorType::EB_NoErrorEmptyQueue => {}
+            _ => {
+                if !pkt.is_null() {
+                    unsafe {
+                        svt_av1_enc_release_out_buffer(&mut pkt);
+                    }
+                }
+                bail!("svt_av1_enc_get_packet failed: {res:?}");
+            }
+        }
+        Ok(frames)
+    }
+
+    #[inline]
+    fn create_video_frame(frames: Vec<EncodedVideoFrame>) -> VideoFrame {
+        let mut vf = VideoFrame::new();
+        let av1s = EncodedVideoFrames {
+            frames: frames.into(),
+            ..Default::default()
+        };
+        vf.set_av1s(av1s);
+        vf
+    }
+
+    fn bitrate(width: u32, height: u32, ratio: f32) -> u32 {
+        let bitrate = base_bitrate(width, height) as f32;
+        (bitrate * ratio) as u32
+    }
+
+    // Same mapping as AomEncoder::calc_q_values, only used to seed the start qp.
+    #[inline]
+    fn calc_q_values(ratio: f32) -> (u32, u32) {
+        let b = (ratio * 100.0) as u32;
+        let b = std::cmp::min(b, 200);
+        let q_min1 = 24;
+        let q_min2 = 5;
+        let q_max1 = 45;
+        let q_max2 = 25;
+
+        let t = b as f32 / 200.0;
+
+        let mut q_min: u32 = ((1.0 - t) * q_min1 as f32 + t * q_min2 as f32).round() as u32;
+        let mut q_max = ((1.0 - t) * q_max1 as f32 + t * q_max2 as f32).round() as u32;
+
+        q_min = q_min.clamp(q_min2, q_min1);
+        q_max = q_max.clamp(q_max2, q_max1);
+
+        (q_min, q_max)
+    }
+
+    fn get_yuvfmt(width: u32, height: u32) -> EncodeYuvFormat {
+        let w = width as usize;
+        let h = height as usize;
+        let align = |x: usize| (x + STRIDE_ALIGN - 1) & !(STRIDE_ALIGN - 1);
+        let stride_y = align(w);
+        let stride_uv = align((w + 1) / 2);
+        let u = stride_y * h;
+        let v = u + stride_uv * ((h + 1) / 2);
+        EncodeYuvFormat {
+            pixfmt: Pixfmt::I420,
+            w,
+            h,
+            stride: vec![stride_y, stride_uv, stride_uv],
+            u,
+            v,
+        }
+    }
+}
+
+impl Drop for SvtAv1Encoder {
+    fn drop(&mut self) {
+        unsafe {
+            if self.handle.is_null() {
+                return;
+            }
+            // svt_av1_enc_deinit drains the pipeline itself, but logs an error
+            // when EOS was not sent first.
+            let mut hdr: EbBufferHeaderType = std::mem::zeroed();
+            hdr.size = std::mem::size_of::<EbBufferHeaderType>() as _;
+            hdr.pic_type = EbAv1PictureType::EB_AV1_INVALID_PICTURE;
+            hdr.flags = EB_BUFFERFLAG_EOS;
+            let _ = svt_av1_enc_send_picture(self.handle, &mut hdr);
+            let res = svt_av1_enc_deinit(self.handle);
+            if res != EbErrorType::EB_ErrorNone {
+                log::error!("svt_av1_enc_deinit failed: {res:?}");
+            }
+            let res = svt_av1_enc_deinit_handle(self.handle);
+            if res != EbErrorType::EB_ErrorNone {
+                log::error!("svt_av1_enc_deinit_handle failed: {res:?}");
+            }
+            self.handle = ptr::null_mut();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::GoogleImage;
+
+    fn fake_i420(fmt: &EncodeYuvFormat, index: usize) -> Vec<u8> {
+        let chroma_height = (fmt.h + 1) / 2;
+        let len = fmt.v + fmt.stride[2] * chroma_height;
+        let mut yuv = vec![128u8; len];
+        // moving gradient so every frame differs
+        for y in 0..fmt.h {
+            let row = &mut yuv[y * fmt.stride[0]..y * fmt.stride[0] + fmt.w];
+            for (x, px) in row.iter_mut().enumerate() {
+                *px = ((x + y + index * 17) % 256) as u8;
+            }
+        }
+        yuv
+    }
+
+    #[test]
+    fn test_encode_and_decode_with_aom() {
+        let (width, height) = (640u32, 480u32);
+        let mut enc = SvtAv1Encoder::new(
+            crate::codec::EncoderCfg::SVTAV1(SvtAv1EncoderConfig {
+                width,
+                height,
+                quality: 1.0,
+                keyframe_interval: None,
+            }),
+            false,
+        )
+        .unwrap();
+        let fmt = enc.yuvfmt();
+        let mut dec = crate::aom::AomDecoder::new().unwrap();
+        for i in 0..20usize {
+            if i == 5 {
+                // exercises the FRAME_RATE_CHANGE_EVENT path on the next frame
+                enc.set_fps(60);
+            }
+            if i == 10 {
+                // exercises the RATE_CHANGE_EVENT path on the next frame
+                enc.set_quality(0.5).unwrap();
+            }
+            let yuv = fake_i420(&fmt, i);
+            let frames = enc.encode(i as i64 * 33, &yuv).unwrap();
+            // one packet out per picture in, this is the low delay contract
+            assert_eq!(frames.len(), 1, "no packet for frame {i}");
+            assert_eq!(frames[0].key, i == 0, "unexpected key flag for frame {i}");
+            assert!(!frames[0].data.is_empty());
+            let mut decoded = 0;
+            for f in &frames {
+                for img in dec.decode(&f.data).unwrap() {
+                    assert_eq!(img.width(), width as usize);
+                    assert_eq!(img.height(), height as usize);
+                    decoded += 1;
+                }
+            }
+            for img in dec.flush().unwrap() {
+                assert_eq!(img.width(), width as usize);
+                decoded += 1;
+            }
+            assert!(decoded >= 1, "aom failed to decode svt-av1 frame {i}");
+        }
+    }
+
+    #[test]
+    fn test_unsupported_resolution() {
+        assert!(SvtAv1Encoder::new(
+            crate::codec::EncoderCfg::SVTAV1(SvtAv1EncoderConfig {
+                width: 62,
+                height: 62,
+                quality: 1.0,
+                keyframe_interval: None,
+            }),
+            false,
+        )
+        .is_err());
+    }
+}

--- a/libs/scrap/src/common/svt_av1.rs
+++ b/libs/scrap/src/common/svt_av1.rs
@@ -30,6 +30,13 @@ pub struct SvtAv1EncoderConfig {
     pub height: u32,
     pub quality: f32,
     pub keyframe_interval: Option<usize>,
+    // SVT cannot update min/max QP on the fly. Product callers leave this
+    // unset so dynamic quality changes retain the full project QP envelope;
+    // controlled comparisons can pin the same range used by another encoder.
+    pub qp_range: Option<(u32, u32)>,
+    // RTC supports M7 through M13. Product callers use the screen-content
+    // default; benchmarks can override it to measure the speed/quality curve.
+    pub preset: Option<i8>,
 }
 
 pub struct SvtAv1Encoder {
@@ -67,6 +74,16 @@ impl EncoderApi for SvtAv1Encoder {
                         config.width,
                         config.height
                     );
+                }
+                if let Some((min_qp, max_qp)) = config.qp_range {
+                    if min_qp > max_qp || max_qp > 63 {
+                        bail!("invalid svt-av1 QP range {min_qp}..{max_qp}");
+                    }
+                }
+                if let Some(preset) = config.preset {
+                    if !(7..=13).contains(&preset) {
+                        bail!("invalid svt-av1 RTC preset M{preset}; expected M7..M13");
+                    }
                 }
                 let mut handle: *mut EbComponentType = ptr::null_mut();
                 let mut c: MaybeUninit<EbSvtAv1EncConfiguration> = MaybeUninit::zeroed();
@@ -176,7 +193,9 @@ impl SvtAv1Encoder {
     }
 
     fn apply_config(c: &mut EbSvtAv1EncConfiguration, cfg: &SvtAv1EncoderConfig, bitrate: u32) {
-        c.enc_mode = Self::preset(cfg.width, cfg.height);
+        c.enc_mode = cfg
+            .preset
+            .unwrap_or_else(|| Self::preset(cfg.width, cfg.height));
         c.source_width = cfg.width;
         c.source_height = cfg.height;
         // CBR budgets bits per frame from this rate, set_fps adjusts it on the
@@ -190,18 +209,35 @@ impl SvtAv1Encoder {
         // blocks until the packet for the sent picture is ready, and rate/keyframe
         // changes on the fly are allowed.
         c.pred_structure = PredStructure::LOW_DELAY;
+        // A four-picture temporal hierarchy improves reference efficiency without
+        // introducing B-frame reordering. Two is also the highest hierarchy SVT
+        // validates for low-delay CBR, and still preserves one packet per input.
+        c.hierarchical_levels = 2;
         c.rtc = true;
         c.rate_control_mode = SvtAv1RcMode::SVT_AV1_RC_MODE_CBR as _;
         c.target_bit_rate = bitrate.min(MAX_TARGET_BITRATE_KBPS) * 1000;
-        // Full envelope of aom's calc_q_values so later bitrate changes are not clipped.
-        c.min_qp_allowed = 5;
-        c.max_qp_allowed = 45;
-        let (q_min, q_max) = Self::calc_q_values(cfg.quality);
-        c.qp = (q_min + q_max) / 2;
+        let initial_qp_range = Self::quality_qp_range(cfg.quality);
+        let (min_qp, max_qp) = cfg.qp_range.unwrap_or((5, 45));
+        c.min_qp_allowed = min_qp;
+        c.max_qp_allowed = max_qp;
+        c.qp = ((initial_qp_range.0 + initial_qp_range.1) / 2).clamp(min_qp, max_qp);
         c.look_ahead_distance = 0;
-        c.recode_loop = 0; // DISALLOW_RECODE
+        // SVT 4.2's RTC CBR path only re-runs mode decision once when an inter
+        // frame would overflow the virtual buffer. This keeps network bursts
+        // bounded without enabling unrestricted multi-pass re-encoding.
+        c.recode_loop = 1; // ALLOW_RECODE_KFMAXBW / one RTC VBV recode
         c.scene_change_detection = 0;
-        c.screen_content_mode = 1;
+        // Temporal filtering is primarily useful for camera/video content. It
+        // costs CPU and can soften text, while low-delay screen sharing cannot
+        // benefit from future-frame filtering.
+        c.enable_tf = 0;
+        c.enable_tf_key = false;
+        c.enable_overlays = false;
+        // Use SVT's anti-alias-aware adaptive screen detection: UI/text can use
+        // Palette and IntraBC while camera/video regions stay on the natural-
+        // content path. RTC only supports these tools at M8 or slower.
+        c.screen_content_mode = 3;
+        c.enable_intrabc = true;
         c.tune = 1; // PSNR, low delay does not support tune 0
         c.level_of_parallelism = Self::parallelism();
         c.intra_refresh_type = SvtAv1IntraRefreshType::SVT_AV1_KF_REFRESH; // closed GOP
@@ -215,15 +251,11 @@ impl SvtAv1Encoder {
         c.force_key_frames = false;
     }
 
-    fn preset(width: u32, height: u32) -> i8 {
-        // Mirrors aom's get_cpu_speed buckets, M9-M13 are the rtc presets.
-        if width * height <= 320 * 180 {
-            9
-        } else if width * height <= 640 * 360 {
-            10
-        } else {
-            11
-        }
+    fn preset(_width: u32, _height: u32) -> i8 {
+        // SVT-AV1 forces screen_content_mode to 0 for RTC presets M9 and faster,
+        // so use M8 to keep the screen-content path enabled.
+        // TODO: After benchmarking, select a quality-dependent preset in M0..=M8.
+        8
     }
 
     fn parallelism() -> u32 {
@@ -353,9 +385,9 @@ impl SvtAv1Encoder {
         (bitrate * ratio) as u32
     }
 
-    // Same mapping as AomEncoder::calc_q_values, only used to seed the start qp.
+    // Same mapping as AomEncoder::calc_q_values.
     #[inline]
-    fn calc_q_values(ratio: f32) -> (u32, u32) {
+    pub fn quality_qp_range(ratio: f32) -> (u32, u32) {
         let b = (ratio * 100.0) as u32;
         let b = std::cmp::min(b, 200);
         let q_min1 = 24;
@@ -447,6 +479,8 @@ mod tests {
                 height,
                 quality: 1.0,
                 keyframe_interval: None,
+                qp_range: None,
+                preset: None,
             }),
             false,
         )
@@ -480,7 +514,7 @@ mod tests {
                 assert_eq!(img.width(), width as usize);
                 decoded += 1;
             }
-            assert!(decoded >= 1, "aom failed to decode svt-av1 frame {i}");
+            assert!(decoded >= 1, "aom failed to decode svt-av1 frame {}", i);
         }
     }
 
@@ -492,6 +526,8 @@ mod tests {
                 height: 62,
                 quality: 1.0,
                 keyframe_interval: None,
+                qp_range: None,
+                preset: None,
             }),
             false,
         )

--- a/res/vcpkg/svt-av1/no-force-llvm.diff
+++ b/res/vcpkg/svt-av1/no-force-llvm.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c0c9767..93ec320 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -192,7 +192,7 @@ set(PC_LIBS_PRIVATE)
+ set(PC_REQUIRES_PRIVATE)
+
+ #Clang support, required to build static with LTO
+-if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND UNIX AND NOT APPLE)
++if(FALSE)
+     find_program(LLVM_LD_EXE llvm-ld)
+     find_program(LLVM_AR_EXE llvm-ar)
+     find_program(LLVM_RANLIB_EXE llvm-ranlib)

--- a/res/vcpkg/svt-av1/no-force-llvm.diff
+++ b/res/vcpkg/svt-av1/no-force-llvm.diff
@@ -1,10 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c0c9767..93ec320 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -192,7 +192,7 @@ set(PC_LIBS_PRIVATE)
- set(PC_REQUIRES_PRIVATE)
-
+@@ -194,5 +194,5 @@
  #Clang support, required to build static with LTO
 -if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND UNIX AND NOT APPLE)
 +if(FALSE)

--- a/res/vcpkg/svt-av1/no-inline-yy_unpacklo_epi128.diff
+++ b/res/vcpkg/svt-av1/no-inline-yy_unpacklo_epi128.diff
@@ -1,0 +1,19 @@
+diff --git a/Source/Lib/ASM_AVX2/synonyms_avx2.h b/Source/Lib/ASM_AVX2/synonyms_avx2.h
+index f615e2569..9a7667724 100644
+--- a/Source/Lib/ASM_AVX2/synonyms_avx2.h
++++ b/Source/Lib/ASM_AVX2/synonyms_avx2.h
+@@ -75,7 +75,13 @@ static INLINE __m256i yy_loadu2_128(const void *hi, const void *lo) {
+     return yy_set_m128i(mhi, mlo);
+ }
+ 
+-static INLINE __m256i yy_unpacklo_epi128(const __m256i in0, const __m256i in1) {
++#if defined(_MSC_VER) && _MSC_VER >= 1950
++#define MAYBE_INLINE NOINLINE
++#else
++#define MAYBE_INLINE INLINE
++#endif
++
++static MAYBE_INLINE __m256i yy_unpacklo_epi128(const __m256i in0, const __m256i in1) {
+     return _mm256_inserti128_si256(in0, _mm256_castsi256_si128(in1), 1);
+ }
+ 

--- a/res/vcpkg/svt-av1/no-inline-yy_unpacklo_epi128.diff
+++ b/res/vcpkg/svt-av1/no-inline-yy_unpacklo_epi128.diff
@@ -1,11 +1,7 @@
 diff --git a/Source/Lib/ASM_AVX2/synonyms_avx2.h b/Source/Lib/ASM_AVX2/synonyms_avx2.h
-index f615e2569..9a7667724 100644
 --- a/Source/Lib/ASM_AVX2/synonyms_avx2.h
 +++ b/Source/Lib/ASM_AVX2/synonyms_avx2.h
-@@ -75,7 +75,13 @@ static INLINE __m256i yy_loadu2_128(const void *hi, const void *lo) {
-     return yy_set_m128i(mhi, mlo);
- }
- 
+@@ -86,3 +86,9 @@
 -static INLINE __m256i yy_unpacklo_epi128(const __m256i in0, const __m256i in1) {
 +#if defined(_MSC_VER) && _MSC_VER >= 1950
 +#define MAYBE_INLINE NOINLINE
@@ -16,4 +12,3 @@ index f615e2569..9a7667724 100644
 +static MAYBE_INLINE __m256i yy_unpacklo_epi128(const __m256i in0, const __m256i in1) {
      return _mm256_inserti128_si256(in0, _mm256_castsi256_si128(in1), 1);
  }
- 

--- a/res/vcpkg/svt-av1/portfile.cmake
+++ b/res/vcpkg/svt-av1/portfile.cmake
@@ -1,0 +1,45 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.com
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO AOMediaCodec/SVT-AV1
+    REF v${VERSION}
+    SHA512 37df96559af179d28acae10cdff98c94ee2c4ee086b2446ab362b57be9adf566d6f2adc28faa30648798d9bc7d18eaeb2d0665e7292982652496b605342e1c4b
+    PATCHES
+        # upstream forces llvm-ld/llvm-ar/llvm-ranlib for clang static builds on
+        # non-Apple unix, which breaks toolchains without the llvm binutils
+        no-force-llvm.diff
+        # MSVC >= 1950 miscompiles the inlined yy_unpacklo_epi128
+        no-inline-yy_unpacklo_epi128.diff
+)
+
+if(VCPKG_TARGET_ARCHITECTURE MATCHES "^(x86|x64)$")
+    # NASM is required to build the x86/x64 assembly
+    vcpkg_find_acquire_program(NASM)
+    set(SIMD_OPTIONS -DCOMPILE_C_ONLY=OFF "-DCMAKE_ASM_NASM_COMPILER=${NASM}")
+elseif(VCPKG_TARGET_ARCHITECTURE MATCHES "^(arm64|arm64ec)$" AND NOT VCPKG_TARGET_IS_WINDOWS)
+    set(SIMD_OPTIONS -DCOMPILE_C_ONLY=OFF)
+else()
+    set(SIMD_OPTIONS -DCOMPILE_C_ONLY=ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${SIMD_OPTIONS}
+        -DBUILD_APPS=OFF
+        -DBUILD_TESTING=OFF
+        -DREPRODUCIBLE_BUILDS=ON
+        # SVT-AV1 defaults LTO to ON for gcc>=9/clang>=12, which puts LTO
+        # bitcode into the static archive and breaks linking with a different
+        # compiler version
+        -DSVT_AV1_LTO=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME SVT-AV1 CONFIG_PATH lib/cmake/SVT-AV1)
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md" "${SOURCE_PATH}/PATENTS.md")

--- a/res/vcpkg/svt-av1/vcpkg.json
+++ b/res/vcpkg/svt-av1/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "svt-av1",
+  "version-semver": "4.2.0",
+  "port-version": 0,
+  "description": "Scalable Video Technology AV1 software video encoder library",
+  "homepage": "https://gitlab.com/AOMediaCodec/SVT-AV1",
+  "license": "BSD-3-Clause-Clear",
+  "supports": "!x86 & !arm32 & !uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -1033,15 +1033,25 @@ fn get_encoder_config(
             // Prefer svt-av1 for AV1 encoding, keep aom for i444 (svt-av1 is 4:2:0
             // only) and for resolutions svt-av1 cannot handle.
             #[cfg(target_pointer_width = "64")]
-            if scrap::svt_av1::SvtAv1Encoder::support(c.width as _, c.height as _)
-                && !Encoder::use_i444(&aom)
             {
-                return EncoderCfg::SVTAV1(scrap::svt_av1::SvtAv1EncoderConfig {
-                    width: c.width as _,
-                    height: c.height as _,
-                    quality,
-                    keyframe_interval,
-                });
+                let use_i444 = Encoder::use_i444(&aom);
+                if scrap::svt_av1::SvtAv1Encoder::support(c.width as _, c.height as _) && !use_i444
+                {
+                    return EncoderCfg::SVTAV1(scrap::svt_av1::SvtAv1EncoderConfig {
+                        width: c.width as _,
+                        height: c.height as _,
+                        quality,
+                        keyframe_interval,
+                    });
+                }
+                log::info!(
+                    "AV1 uses aom instead of svt-av1: {}",
+                    if use_i444 {
+                        "i444"
+                    } else {
+                        "unsupported resolution"
+                    }
+                );
             }
             aom
         }

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -1023,12 +1023,28 @@ fn get_encoder_config(
             },
             keyframe_interval,
         }),
-        CodecFormat::AV1 => EncoderCfg::AOM(AomEncoderConfig {
-            width: c.width as _,
-            height: c.height as _,
-            quality,
-            keyframe_interval,
-        }),
+        CodecFormat::AV1 => {
+            let aom = EncoderCfg::AOM(AomEncoderConfig {
+                width: c.width as _,
+                height: c.height as _,
+                quality,
+                keyframe_interval,
+            });
+            // Prefer svt-av1 for AV1 encoding, keep aom for i444 (svt-av1 is 4:2:0
+            // only) and for resolutions svt-av1 cannot handle.
+            #[cfg(target_pointer_width = "64")]
+            if scrap::svt_av1::SvtAv1Encoder::support(c.width as _, c.height as _)
+                && !Encoder::use_i444(&aom)
+            {
+                return EncoderCfg::SVTAV1(scrap::svt_av1::SvtAv1EncoderConfig {
+                    width: c.width as _,
+                    height: c.height as _,
+                    quality,
+                    keyframe_interval,
+                });
+            }
+            aom
+        }
         _ => EncoderCfg::VPX(VpxEncoderConfig {
             width: c.width as _,
             height: c.height as _,
@@ -1326,6 +1342,9 @@ fn check_qos(
 ) -> ResultType<()> {
     let mut video_qos = VIDEO_QOS.lock().unwrap();
     *spf = video_qos.spf();
+    // encoders whose rate control budgets per frame need the real pacing rate,
+    // implementations no-op when the value is unchanged
+    encoder.set_fps(video_qos.fps());
     if *ratio != video_qos.ratio() {
         *ratio = video_qos.ratio();
         if encoder.support_changing_quality() {

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -1042,6 +1042,8 @@ fn get_encoder_config(
                         height: c.height as _,
                         quality,
                         keyframe_interval,
+                        qp_range: None,
+                        preset: None,
                     });
                 }
                 log::info!(

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,11 @@
       "host": false
     },
     {
+      "name": "svt-av1",
+      "host": false,
+      "platform": "!x86 & !arm32 & !uwp"
+    },
+    {
       "name": "cpu-features",
       "platform": "android"
     },


### PR DESCRIPTION
Encode AV1 with SVT-AV1 v4.2.0 (rtc + low delay + CBR) instead of libaom on all 64-bit targets; 32-bit targets keep aom. Decoding is unchanged and the wire format is still AV1, so old peers are unaffected.

- vcpkg overlay port pinned to v4.2.0: static build, LTO off (mixed toolchain safety), MSVC >= 1950 inline workaround, no forced llvm binutils
- low delay contract: one packet out per picture in, blocking get_packet
- bitrate and frame rate change on the fly via RATE_CHANGE_EVENT / FRAME_RATE_CHANGE_EVENT; VideoQoS pushes its pacing rate through the new EncoderApi::set_fps, applied only after a successful send
- fall back to aom for i444 (svt-av1 is 4:2:0 only), for unsupported resolutions and on encoder init failure
- test_av1 now gates auto AV1 on the encoder actually used, the cached verdict is re-keyed (SVT-Y/SVT-N) so upgrades re-measure
- unit tests: per-frame packet contract, aom cross-decode of the bitstream, on-the-fly event acceptance


Claude-Session: https://claude.ai/code/session_012Wf7v1KJM6mbhiYxWSz4PH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SVT-AV1 encoding support on compatible 64-bit systems.
  * AV1 streaming now prefers SVT-AV1 when available, with automatic fallback to the existing encoder.
  * Added configurable quality, frame rate, keyframe intervals, and encoding presets.
* **Bug Fixes**
  * Improved encoder startup, validation, and fallback behavior.
  * Enhanced native library detection and packaging for more reliable builds.
* **Performance / Quality**
  * Improved frame-rate pacing and dynamic quality updates for steadier output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces libaom with SVT-AV1 v4.2.0 for AV1 encoding on all 64-bit targets, while keeping aom for 32-bit targets, i444 sessions, and unsupported resolutions. The wire format is unchanged so old peers decode without modification.

- **New `SvtAv1Encoder`**: configures low-delay CBR with `pred_structure = LOW_DELAY + rtc`; delivers one packet per picture via linked `EbPrivDataNode` events for on-the-fly bitrate (`RATE_CHANGE_EVENT`) and frame-rate (`FRAME_RATE_CHANGE_EVENT`) changes; falls back to aom on init failure.
- **Integration**: `get_encoder_config` in `video_service.rs` now returns `EncoderCfg::SVTAV1` for AV1 on 64-bit when the resolution is in range and i444 is not needed; `check_qos` propagates the current pacing FPS to the encoder each frame via a new `set_fps` method on `EncoderApi`.
- **Build and caching**: vcpkg overlay port pins SVT-AV1 4.2.0 with two targeted patches (LLVM binutils bypass, MSVC inline workaround); `test_av1` result is re-keyed to `SVT-Y`/`SVT-N` so that upgrading from an aom-only build re-runs the performance gate.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The new encoder is correctly gated to 64-bit targets, falls back to aom on init failure, and produces the same AV1 bitstream so existing peers are unaffected.

The implementation is careful and well-tested: unit tests verify the one-packet-per-picture contract and aom cross-decode, test_av1 re-measures on encoder change, and the vcpkg overlay pins an exact version with narrow patches. The only finding is a misleading comment about get_packet blocking semantics that does not affect runtime correctness.

**Files Needing Attention:** libs/scrap/src/common/svt_av1.rs — the get_packet call comment vs. pic_out=0 semantics is worth clarifying before the comment misleads future maintainers.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/scrap/src/common/svt_av1.rs | New SVT-AV1 encoder: correct low-delay CBR setup, on-the-fly rate/fps events via linked EbPrivDataNode list, safe EOS/drain in Drop. Minor inconsistency between blocking comment and non-blocking pic_out=0 in get_packet. |
| libs/scrap/src/common/codec.rs | Adds SVTAV1 EncoderCfg variant with graceful aom fallback; new set_fps default no-op in EncoderApi trait; test cache re-keyed to SVT-Y/SVT-N so upgrades re-measure; all cfg gates consistent with build.rs. |
| src/server/video_service.rs | get_encoder_config prefers SVTAV1 for AV1 on 64-bit when resolution is supported and i444 is not in use; check_qos propagates current pacing FPS to the encoder before each encode call; changes are minimal and well-scoped. |
| libs/scrap/build.rs | Adds link_lib_name helper, SVT-AV1 pkg-config version check (>=4.2), parent include path fixup, macOS dynamic-link warning, and fixes a missing cargo: prefix on two rerun-if-changed directives. |
| res/vcpkg/svt-av1/portfile.cmake | Pins SVT-AV1 v4.2.0 with two targeted patches: disables forced LLVM binutils for Clang static builds and works around MSVC >= 1950 AVX2 inline miscompile; LTO disabled for mixed-toolchain safety. |
| libs/scrap/examples/av1_benchmark.rs | New benchmark example comparing AOM vs SVT-AV1 with PSNR/SSIM quality metrics, PTS tracking, optional recording; gated to 64-bit targets; uses real encoder APIs including aom cross-decode. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant VS as video_service
    participant QoS as VideoQoS
    participant Enc as SvtAv1Encoder
    participant SVT as SVT-AV1 lib

    VS->>QoS: check_qos()
    QoS-->>VS: fps, spf, ratio
    VS->>Enc: set_fps(fps) → pending_fps
    VS->>Enc: set_quality(ratio) → pending_bitrate
    VS->>Enc: encode_to_message(yuv, ms)
    Enc->>SVT: send_picture(hdr + FRAME_RATE_CHANGE_EVENT + RATE_CHANGE_EVENT)
    Note over Enc,SVT: pending changes cleared after successful send
    SVT-->>Enc: EB_ErrorNone
    Enc->>SVT: "get_packet(pic_out=0)"
    SVT-->>Enc: "EbBufferHeaderType* (one packet per picture)"
    Enc-->>VS: "VideoFrame { av1s }"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix svt-av1 build on windows, benchmark"](https://github.com/rustdesk/rustdesk/commit/e17efa947477f9eaf0fcb9d1cb013732fb38811a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47862149)</sub>

<!-- /greptile_comment -->