### PR TITLE
feat(recording): add visibility and service storage options

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libs/hbb_common"]
 	path = libs/hbb_common
-	url = https://github.com/rustdesk/hbb_common
+	url = https://github.com/21pages/hbb_common
+	branch = recording

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "libs/hbb_common"]
 	path = libs/hbb_common
-	url = https://github.com/21pages/hbb_common
-	branch = recording
+	url = https://github.com/rustdesk/hbb_common

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -583,6 +583,7 @@ List<TTextMenu> toolbarControls(BuildContext context, String id, FFI ffi) {
   }
   // record
   if (!(isDesktop || isWeb) &&
+      bind.mainGetLocalOption(key: kOptionHideRecordingButton) != 'Y' &&
       (ffi.recordingModel.start || (perms["recording"] != false))) {
     v.add(TTextMenu(
         child: Row(

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -104,6 +104,7 @@ const String kOptionAutoDisconnectTimeout = "auto-disconnect-timeout";
 const String kOptionEnableHwcodec = "enable-hwcodec";
 const String kOptionAllowAutoRecordIncoming = "allow-auto-record-incoming";
 const String kOptionAllowAutoRecordOutgoing = "allow-auto-record-outgoing";
+const String kOptionHideRecordingButton = "hide-recording-button";
 const String kOptionVideoSaveDirectory = "video-save-directory";
 const String kOptionAccessMode = "access-mode";
 const String kOptionEnableKeyboard = "enable-keyboard";

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -2740,7 +2740,9 @@ class _RecordMenu extends StatelessWidget {
   Widget build(BuildContext context) {
     var ffi = Provider.of<FfiModel>(context);
     var recordingModel = Provider.of<RecordingModel>(context);
-    final visible =
+    final hideRecordingButton =
+        bind.mainGetLocalOption(key: kOptionHideRecordingButton) == 'Y';
+    final visible = !hideRecordingButton &&
         (recordingModel.start || ffi.permissions['recording'] != false);
     if (!visible) return Offstage();
     return _IconMenuButton(

--- a/libs/scrap/src/common/record.rs
+++ b/libs/scrap/src/common/record.rs
@@ -20,6 +20,22 @@ use webm::mux::{self, Segment, Track, VideoTrack, Writer};
 
 const MIN_SECS: u64 = 1;
 
+// Use a Windows-safe filename on all platforms so recordings remain portable.
+// Control characters are also replaced because they can make filenames invalid
+// on Windows or invisible and difficult to handle on Linux and macOS.
+fn sanitize_filename_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_control() || matches!(c, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*') {
+                '_'
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone)]
 pub struct RecorderContext {
     pub server: bool,
@@ -45,7 +61,7 @@ impl RecorderContext2 {
         }
         let file = if ctx.server { "incoming" } else { "outgoing" }.to_string()
             + "_"
-            + &ctx.id.clone()
+            + &sanitize_filename_component(&ctx.id)
             + &chrono::Local::now().format("_%Y%m%d%H%M%S%3f_").to_string()
             + &format!(
                 "{}{}_",
@@ -419,5 +435,26 @@ impl Drop for HwRecorder {
             state = RecordState::RemoveFile;
         }
         self.ctx.tx.as_ref().map(|tx| tx.send(state));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_filename_component;
+
+    #[test]
+    fn sanitize_recording_filename_component() {
+        assert_eq!(
+            sanitize_filename_component("192.168.1.2:21118"),
+            "192.168.1.2_21118"
+        );
+        assert_eq!(
+            sanitize_filename_component("[2001:db8::1]:21118"),
+            "[2001_db8__1]_21118"
+        );
+        assert_eq!(
+            sanitize_filename_component("peer/name\\with?bad\nchars"),
+            "peer_name_with_bad_chars"
+        );
     }
 }

--- a/libs/scrap/src/common/record.rs
+++ b/libs/scrap/src/common/record.rs
@@ -20,7 +20,7 @@ use webm::mux::{self, Segment, Track, VideoTrack, Writer};
 
 const MIN_SECS: u64 = 1;
 
-// Use a Windows-safe filename on all platforms so recordings remain portable.
+// Replace characters that are invalid in Windows filename components so recordings remain portable.
 // Control characters are also replaced because they can make filenames invalid
 // on Windows or invisible and difficult to handle on Linux and macOS.
 fn sanitize_filename_component(value: &str) -> String {

--- a/src/ui/header.tis
+++ b/src/ui/header.tis
@@ -151,7 +151,7 @@ class Header: Reactor.Component {
             <span #action>{svg_action}</span>
             <span #display>{svg_display}</span>
             <span #keyboard>{svg_keyboard}</span>
-            {recording_enabled ? <span #recording>{recording ? svg_recording_on : svg_recording_off}</span> : ""}
+            {recording_enabled && show_recording_button ? <span #recording>{recording ? svg_recording_on : svg_recording_off}</span> : ""}
             {this.renderKeyboardPop()}
             {this.renderDisplayPop()}
             {this.renderActionPop()}

--- a/src/ui/remote.rs
+++ b/src/ui/remote.rs
@@ -504,6 +504,7 @@ impl sciter::EventHandler for SciterSession {
         fn get_id();
         fn get_default_pi();
         fn get_option(String);
+        fn get_local_option(String);
         fn t(String);
         fn set_option(String, String);
         fn input_os_password(String, bool);
@@ -636,6 +637,10 @@ impl SciterSession {
 
     pub fn t(&self, name: String) -> String {
         crate::client::translate(name)
+    }
+
+    pub fn get_local_option(&self, key: String) -> String {
+        crate::ui_interface::get_local_option(key)
     }
 
     pub fn get_icon(&self) -> String {

--- a/src/ui/remote.tis
+++ b/src/ui/remote.tis
@@ -17,6 +17,7 @@ var audio_enabled = true; // server side
 var file_enabled = true; // server side
 var restart_enabled = true; // server side
 var recording_enabled = true; // server side
+var show_recording_button = handler.get_local_option("hide-recording-button") != "Y";
 var privacy_mode_enabled = true; // server side
 var scroll_body = $(body);
 var peer_platform = "";

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -930,6 +930,10 @@ pub fn video_save_directory(root: bool) -> String {
         // Currently, only installed windows run as root
         #[cfg(windows)]
         {
+            let dir = Config::get_option(OPTION_WINDOWS_SERVICE_VIDEO_SAVE_DIRECTORY);
+            if !dir.is_empty() {
+                return dir;
+            }
             let drive = std::env::var("SystemDrive").unwrap_or("C:".to_owned());
             let dir =
                 std::path::PathBuf::from(format!("{drive}\\ProgramData\\{appname}\\recording",));

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -911,9 +911,23 @@ pub fn get_langs() -> String {
     json!(x).to_string()
 }
 
-fn validate_video_save_directory(value: &str) -> Option<&str> {
+// Preserve relative paths for existing configurations and only remove accidental
+// surrounding whitespace. Config values are not shell-expanded (for example, `~`).
+fn trim_video_save_directory(value: &str) -> Option<&str> {
     let value = value.trim();
-    if !value.is_empty() && std::path::Path::new(value).is_absolute() {
+    if !value.is_empty() {
+        Some(value)
+    } else {
+        None
+    }
+}
+
+// A Windows service typically runs with System32 as its working directory, so
+// require an absolute path to avoid resolving recordings there unexpectedly.
+#[cfg(any(windows, test))]
+fn validate_windows_service_video_save_directory(value: &str) -> Option<&str> {
+    let value = trim_video_save_directory(value)?;
+    if std::path::Path::new(value).is_absolute() {
         Some(value)
     } else {
         None
@@ -940,7 +954,7 @@ pub fn video_save_directory(root: bool) -> String {
         #[cfg(windows)]
         {
             let dir = Config::get_option(OPTION_WINDOWS_SERVICE_VIDEO_SAVE_DIRECTORY);
-            if let Some(dir) = validate_video_save_directory(&dir) {
+            if let Some(dir) = validate_windows_service_video_save_directory(&dir) {
                 return dir.to_owned();
             }
             if !dir.trim().is_empty() {
@@ -959,11 +973,8 @@ pub fn video_save_directory(root: bool) -> String {
     let dir = LocalConfig::get_option_from_file(OPTION_VIDEO_SAVE_DIRECTORY);
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     let dir = LocalConfig::get_option(OPTION_VIDEO_SAVE_DIRECTORY);
-    if let Some(dir) = validate_video_save_directory(&dir) {
+    if let Some(dir) = trim_video_save_directory(&dir) {
         return dir.to_owned();
-    }
-    if !dir.trim().is_empty() {
-        log::warn!("Ignoring {OPTION_VIDEO_SAVE_DIRECTORY}: path must be absolute");
     }
     #[cfg(any(target_os = "android", target_os = "ios"))]
     if let Ok(home) = config::APP_HOME_DIR.read() {
@@ -1729,10 +1740,19 @@ pub fn is_remote_modify_enabled_by_control_permissions() -> Option<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_video_save_directory;
+    use super::{trim_video_save_directory, validate_windows_service_video_save_directory};
 
     #[test]
-    fn validate_configured_video_save_directory() {
+    fn trim_configured_video_save_directory() {
+        assert_eq!(
+            trim_video_save_directory("  relative/recordings  "),
+            Some("relative/recordings")
+        );
+        assert_eq!(trim_video_save_directory("  "), None);
+    }
+
+    #[test]
+    fn validate_service_video_save_directory() {
         let absolute = if cfg!(windows) {
             r"C:\recordings"
         } else {
@@ -1740,12 +1760,18 @@ mod tests {
         };
         let padded = format!("  {absolute}  ");
 
-        assert_eq!(validate_video_save_directory(&padded), Some(absolute));
-        assert_eq!(validate_video_save_directory("recordings"), None);
         assert_eq!(
-            validate_video_save_directory(&format!("\"{absolute}\"")),
+            validate_windows_service_video_save_directory(&padded),
+            Some(absolute)
+        );
+        assert_eq!(
+            validate_windows_service_video_save_directory("recordings"),
             None
         );
-        assert_eq!(validate_video_save_directory("  "), None);
+        assert_eq!(
+            validate_windows_service_video_save_directory(&format!("\"{absolute}\"")),
+            None
+        );
+        assert_eq!(validate_windows_service_video_save_directory("  "), None);
     }
 }

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -911,6 +911,15 @@ pub fn get_langs() -> String {
     json!(x).to_string()
 }
 
+fn validate_video_save_directory(value: &str) -> Option<&str> {
+    let value = value.trim();
+    if !value.is_empty() && std::path::Path::new(value).is_absolute() {
+        Some(value)
+    } else {
+        None
+    }
+}
+
 #[inline]
 pub fn video_save_directory(root: bool) -> String {
     let appname = crate::get_app_name();
@@ -931,8 +940,13 @@ pub fn video_save_directory(root: bool) -> String {
         #[cfg(windows)]
         {
             let dir = Config::get_option(OPTION_WINDOWS_SERVICE_VIDEO_SAVE_DIRECTORY);
-            if !dir.is_empty() {
-                return dir;
+            if let Some(dir) = validate_video_save_directory(&dir) {
+                return dir.to_owned();
+            }
+            if !dir.trim().is_empty() {
+                log::warn!(
+                    "Ignoring {OPTION_WINDOWS_SERVICE_VIDEO_SAVE_DIRECTORY}: path must be absolute"
+                );
             }
             let drive = std::env::var("SystemDrive").unwrap_or("C:".to_owned());
             let dir =
@@ -945,8 +959,11 @@ pub fn video_save_directory(root: bool) -> String {
     let dir = LocalConfig::get_option_from_file(OPTION_VIDEO_SAVE_DIRECTORY);
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     let dir = LocalConfig::get_option(OPTION_VIDEO_SAVE_DIRECTORY);
-    if !dir.is_empty() {
-        return dir;
+    if let Some(dir) = validate_video_save_directory(&dir) {
+        return dir.to_owned();
+    }
+    if !dir.trim().is_empty() {
+        log::warn!("Ignoring {OPTION_VIDEO_SAVE_DIRECTORY}: path must be absolute");
     }
     #[cfg(any(target_os = "android", target_os = "ios"))]
     if let Ok(home) = config::APP_HOME_DIR.read() {
@@ -1708,4 +1725,27 @@ pub fn is_remote_modify_enabled_by_control_permissions() -> Option<bool> {
     *IS_REMOTE_MODIFY_ENABLED_BY_CONTROL_PERMISSIONS
         .lock()
         .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_video_save_directory;
+
+    #[test]
+    fn validate_configured_video_save_directory() {
+        let absolute = if cfg!(windows) {
+            r"C:\recordings"
+        } else {
+            "/recordings"
+        };
+        let padded = format!("  {absolute}  ");
+
+        assert_eq!(validate_video_save_directory(&padded), Some(absolute));
+        assert_eq!(validate_video_save_directory("recordings"), None);
+        assert_eq!(
+            validate_video_save_directory(&format!("\"{absolute}\"")),
+            None
+        );
+        assert_eq!(validate_video_save_directory("  "), None);
+    }
 }


### PR DESCRIPTION
https://github.com/rustdesk/hbb_common/pull/572
  
  - support `hide-recording-button` in Flutter and Sciter
  - allow a custom save directory for Windows service recordings
  - sanitize peer IDs used in recording filenames

  Tested:
  - with `hide-recording-button=Y` and `allow-auto-record-outgoing=Y`, outgoing sessions are recorded automatically while the recording button remains hidden and cannot be stopped from the UI; verified on Flutter desktop, Sciter, and Android
  - `windows-service-video-save-directory` takes effect when the Windows client runs as an installed service
  - the Windows controlling side can save recordings for direct `IP:port` connections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new option to hide the session recording button consistently across desktop toolbars and the remote UI.
  - Enhanced recording save directory handling, including trimming and stricter Windows path validation.

- **Bug Fixes**
  - Recording filenames are now sanitized to improve portability and prevent invalid/special characters on different platforms.
  - Recording indicators/controls now display only when recording is enabled *and* the button is allowed by the visibility option.

- **Tests**
  - Added unit tests covering filename sanitization and directory trimming/validation.

- **Chores**
  - Updated a shared library dependency pointer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->