### PR TITLE
fix(macOS): use modern Flutter to avoid semantics crash

### DIFF
--- a/.github/patches/apply_flutter_3.44_source_patches.sh
+++ b/.github/patches/apply_flutter_3.44_source_patches.sh
@@ -2,13 +2,13 @@
 # Applies the Flutter 3.44-only source/pubspec changes on the fly, in CI only.
 #
 # Windows arm64 needs Flutter >= 3.44 (the first stable release shipping an arm64 Dart SDK +
-# engine), which renamed DialogTheme/TabBarTheme -> *Data and needs newer extended_text/
-# google_fonts. Every other platform is still on Flutter 3.24.5, where the old names/versions
-# are required, so these changes are kept OUT of the committed sources and applied here instead.
+# engine), and macOS needs a newer engine to avoid flutter/flutter#148279. Flutter 3.44 renamed
+# DialogTheme/TabBarTheme -> *Data and needs newer extended_text/google_fonts. Other platforms
+# are still on Flutter 3.24.5, so these changes stay OUT of committed sources and are applied here.
 #
-# Used by BOTH the Windows arm64 build (flutter-build.yml) and its dedicated bridge artifact
-# (bridge.yml) so they share an identical 3.44 source state -- the generated *.freezed.dart must
-# compile against the same Flutter/freezed version the arm64 build resolves.
+# Used by the Windows arm64 and macOS builds (flutter-build.yml) and their dedicated bridge
+# artifact (bridge.yml) so they share an identical 3.44 source state -- generated *.freezed.dart
+# must compile against the same Flutter/freezed version those builds resolve.
 #
 # Remove this script (and commit the changes) once upstream bumps Flutter across the board.
 #
@@ -17,16 +17,21 @@
 # therefore CRLF-safe.
 set -euo pipefail
 
+sed_in_place() {
+  sed -i.bak "$@"
+}
+
 # ThemeData API renames (Flutter 3.27+):
-sed -i 's/dialogTheme: DialogTheme(/dialogTheme: DialogThemeData(/g' flutter/lib/common.dart
-sed -i 's/tabBarTheme: const TabBarTheme(/tabBarTheme: const TabBarThemeData(/g' flutter/lib/common.dart
-sed -i '/static ThemeData lightTheme = ThemeData(/,/static ThemeData darkTheme = ThemeData(/s/dialogTheme: DialogThemeData(/dialogTheme: DialogThemeData(\
+sed_in_place 's/dialogTheme: DialogTheme(/dialogTheme: DialogThemeData(/g' flutter/lib/common.dart
+sed_in_place 's/tabBarTheme: const TabBarTheme(/tabBarTheme: const TabBarThemeData(/g' flutter/lib/common.dart
+sed_in_place '/static ThemeData lightTheme = ThemeData(/,/static ThemeData darkTheme = ThemeData(/s/dialogTheme: DialogThemeData(/dialogTheme: DialogThemeData(\
       backgroundColor: Colors.white,/' flutter/lib/common.dart
-sed -i '/static ThemeData darkTheme = ThemeData(/,/scrollbarTheme: scrollbarThemeDark,/s/dialogTheme: DialogThemeData(/dialogTheme: DialogThemeData(\
+sed_in_place '/static ThemeData darkTheme = ThemeData(/,/scrollbarTheme: scrollbarThemeDark,/s/dialogTheme: DialogThemeData(/dialogTheme: DialogThemeData(\
       backgroundColor: Color(0xFF18191E),/' flutter/lib/common.dart
 # Dependency bumps required by the newer Dart/Flutter:
-sed -i 's/extended_text: 14.0.0/extended_text: 15.0.2/' flutter/pubspec.yaml
-sed -i 's/google_fonts: \^6.2.1/google_fonts: ^8.1.0/' flutter/pubspec.yaml
+sed_in_place 's/extended_text: 14.0.0/extended_text: 15.0.2/' flutter/pubspec.yaml
+sed_in_place 's/google_fonts: \^6.2.1/google_fonts: ^8.1.0/' flutter/pubspec.yaml
+rm -f flutter/lib/common.dart.bak flutter/pubspec.yaml.bak
 
 # Fail loudly if any expected string drifted, so we never silently build unpatched:
 grep -qF 'dialogTheme: DialogThemeData(' flutter/lib/common.dart

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -25,12 +25,12 @@ jobs:
               flutter-version: "3.22.3",
               artifact-name: "bridge-artifact",
             }
-          # Dedicated bridge for the Windows arm64 build (Flutter 3.44); runs in parallel.
+          # Dedicated bridge for Windows arm64 and macOS (Flutter 3.44); runs in parallel.
           - {
               target: x86_64-unknown-linux-gnu,
               os: ubuntu-22.04,
               extra-build-args: "",
-              flutter-version: "3.44.0",
+              flutter-version: "3.44.8",
               artifact-name: "bridge-artifact-flutter-3.44",
             }
     steps:
@@ -92,8 +92,8 @@ jobs:
             # Default Flutter 3.22.3: extended_text 14 needs a newer Dart, so downgrade for resolution.
             sed -i -e 's/extended_text: 14.0.0/extended_text: 13.0.0/g' flutter/pubspec.yaml
           else
-            # Flutter 3.44 bridge for Windows arm64: match that build's source/pubspec state so the
-            # generated *.freezed.dart compiles against the same Flutter/freezed it resolves.
+            # Flutter 3.44 bridge for Windows arm64 and macOS: match those builds' source/pubspec
+            # state so generated *.freezed.dart compiles against the same Flutter/freezed version.
             bash .github/patches/apply_flutter_3.44_source_patches.sh
           fi
           pushd flutter && flutter pub get && popd

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -27,11 +27,11 @@ env:
   LLVM_VERSION: "15.0.6"
   FLUTTER_VERSION: "3.24.5"
   ANDROID_FLUTTER_VERSION: "3.24.5"
-  # Windows arm64 only: the first stable Flutter to ship a native arm64 Windows Dart SDK +
-  # engine is 3.44. Every other platform stays on FLUTTER_VERSION (3.24.5) until Windows 7
-  # support is restored after the upstream-wide Flutter bump. The arm64 job patches the few
-  # 3.44-only source/pubspec changes on the fly (see "Patch RustDesk sources for Flutter 3.44").
-  FLUTTER_WINDOWS_ARM_VERSION: "3.44.0"
+  # Windows arm64 needs Flutter >=3.44 for a native arm64 Dart SDK and engine. macOS also uses
+  # this version because Flutter 3.24.5 can crash when a queued semantics update arrives after
+  # semantics are disabled (https://github.com/flutter/flutter/issues/148279). Other platforms
+  # stay on FLUTTER_VERSION until Windows 7 support is restored after the upstream-wide bump.
+  FLUTTER_MODERN_VERSION: "3.44.8"
   # for arm64 linux because official Dart SDK does not work
   FLUTTER_ELINUX_VERSION: "3.16.9"
   TAG_NAME: "${{ inputs.upload-tag }}"
@@ -134,14 +134,14 @@ jobs:
 
       - name: Install flutter
         id: flutter
-        # arm64 builds with FLUTTER_WINDOWS_ARM_VERSION (>=3.44); x64 stays on FLUTTER_VERSION.
+        # arm64 builds with FLUTTER_MODERN_VERSION (>=3.44); x64 stays on FLUTTER_VERSION.
         # subosito only ships an x64 Windows SDK (Flutter's release manifest lists x64 only),
         # so it installs x64 on both arches. The arm64 runner re-bootstraps Dart to arm64 in
         # the next step.
         uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225  # v2.12.0; https://github.com/subosito/flutter-action/issues/277
         with:
           channel: "stable"
-          flutter-version: ${{ matrix.job.arch == 'aarch64' && env.FLUTTER_WINDOWS_ARM_VERSION || env.FLUTTER_VERSION }}
+          flutter-version: ${{ matrix.job.arch == 'aarch64' && env.FLUTTER_MODERN_VERSION || env.FLUTTER_VERSION }}
           architecture: x64
 
       - name: Force arm64 Dart SDK + engine
@@ -741,12 +741,11 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: "stable"
-          flutter-version: ${{ env.FLUTTER_VERSION }}
+          flutter-version: ${{ env.FLUTTER_MODERN_VERSION }}
 
-      - name: Patch flutter
-        run: |
-          cd $(dirname $(dirname $(which flutter)))
-          [[ "3.24.5" == ${{env.FLUTTER_VERSION}} ]] && git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+      - name: Patch RustDesk sources for Flutter 3.44
+        shell: bash
+        run: bash .github/patches/apply_flutter_3.44_source_patches.sh
 
       - name: Workaround for flutter issue
         shell: bash
@@ -770,7 +769,7 @@ jobs:
       - name: Restore bridge files
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: bridge-artifact
+          name: bridge-artifact-flutter-3.44
           path: ./
 
       - name: Setup vcpkg with Github Actions binary cache


### PR DESCRIPTION
## Summary

- build macOS with Flutter 3.44.8 instead of 3.24.5
- reuse the existing modern-Flutter source patch and matching bridge artifact
- keep legacy platforms on Flutter 3.24.5
- make the shared patch script portable to BSD `sed` on macOS

## Root cause

RustDesk 1.4.9's Flutter 3.24.5 engine asserts in
`FlutterViewController::updateSemantics` when a queued semantics update arrives
one run-loop turn after semantics are disabled. This is the exact crash reported
in [flutter/flutter#148279](https://github.com/flutter/flutter/issues/148279).
Flutter removed the assertion in
[flutter/engine#54364](https://github.com/flutter-team-archive/engine/pull/54364)
because this event ordering is expected.

Flutter 3.44.8 contains that fix. The Flutter 3.24.5 macOS framework contains
the `Semantics must be enabled.` assertion; the 3.44.8 framework does not.

## Scope

Windows ARM64 already uses the modern Flutter path. This change shares that path
with macOS. iOS, Android, Linux, Windows x64, and web remain unchanged.

This is deliberately narrower than the earlier repo-wide upgrade attempted in
[rustdesk/rustdesk#15141](https://github.com/rustdesk/rustdesk/pull/15141).

## Validation

- Flutter 3.44.8 `flutter pub get`
- restored the matching `bridge-artifact-flutter-3.44` from a successful
  upstream nightly build
- Flutter analyzer: zero errors (existing warnings remain)
- `flutter test --no-pub`: 19 passed
- patch script: `bash -n`, ShellCheck, and execution with macOS BSD `sed`
- `git diff --check`
