### PR TITLE
fix: reset wayland layout state per session and keep refresh from hanging the display loop

### DIFF
--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -128,10 +128,19 @@ fn refresh_wayland_uinput_rect_if_changed() {
         }
         lock.last_check = Some(std::time::Instant::now());
     }
+    // Snapshot the generation before reading the layout, so the epoch and the layout
+    // belong to the same session. Loaded after the read, an epoch could be one a reset
+    // published mid-read, and the checks below would then accept the previous
+    // session's geometry as current.
+    let epoch = WAYLAND_LAYOUT_EPOCH.load(Ordering::Relaxed);
     let Some((rect, live_rects)) = scrap::wayland::display::get_layout_for_uinput_live() else {
         return;
     };
-    let epoch = WAYLAND_LAYOUT_EPOCH.load(Ordering::Relaxed);
+    // A reset during the read means this geometry is the previous session's: bail before
+    // writing it to the device, not just before publishing it.
+    if WAYLAND_LAYOUT_EPOCH.load(Ordering::Relaxed) != epoch {
+        return;
+    }
     // Compare against the fresh layout but publish it to `live` only once the uinput
     // range below is confirmed: until then mouse threads must keep correcting against
     // the previous (layout, range) pair, which is still what the device is using.

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -60,6 +60,12 @@ struct WaylandLayout {
 #[cfg(target_os = "linux")]
 static WAYLAND_LAYOUT_DRIFTED: AtomicBool = AtomicBool::new(false);
 
+// Bumped on every session reset. A periodic poll that was blocked in the range refresh
+// across a session change must discard its snapshot instead of republishing the old
+// session's layout over the new session's state.
+#[cfg(target_os = "linux")]
+static WAYLAND_LAYOUT_EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 #[cfg(target_os = "linux")]
 pub(super) fn set_wayland_uinput_rect(rect: (i32, i32, i32, i32)) {
     WAYLAND_UINPUT_RECT.lock().unwrap().rect = Some(rect);
@@ -71,6 +77,26 @@ pub(super) fn set_wayland_layout_baseline(baseline: Vec<scrap::wayland::display:
     let mut lock = WAYLAND_LAYOUT.lock().unwrap();
     lock.baseline = baseline;
     lock.live.clear();
+}
+
+// Drop all layout state from the previous session. Called at session init before the
+// resolution refresh, so a failed refresh cannot leave a stale baseline or drift flag
+// that would remap coordinates of a client initialized to the current layout.
+#[cfg(target_os = "linux")]
+pub(super) fn reset_wayland_layout() {
+    WAYLAND_LAYOUT_EPOCH.fetch_add(1, Ordering::Relaxed);
+    WAYLAND_LAYOUT_DRIFTED.store(false, Ordering::Relaxed);
+    {
+        let mut lock = WAYLAND_LAYOUT.lock().unwrap();
+        lock.baseline.clear();
+        lock.live.clear();
+    }
+    // Drop the recorded rect too: if the init refresh fails, the periodic check must
+    // see a mismatch and retry, not trust a rect applied for the previous session.
+    // Clearing last_check lets that retry run on the first poll.
+    let mut lock = WAYLAND_UINPUT_RECT.lock().unwrap();
+    lock.rect = None;
+    lock.last_check = None;
 }
 
 // Remap an injected coordinate onto the live compositor layout when it has drifted from
@@ -105,22 +131,20 @@ fn refresh_wayland_uinput_rect_if_changed() {
     let Some((rect, live_rects)) = scrap::wayland::display::get_layout_for_uinput_live() else {
         return;
     };
-    // Refresh the per-display layout every poll: monitor origins can shift (e.g. two
-    // displays swap positions) without changing the overall desktop rect, and the mouse
-    // path needs the current per-display geometry to correct coordinates.
+    let epoch = WAYLAND_LAYOUT_EPOCH.load(Ordering::Relaxed);
+    // Compare against the fresh layout but publish it to `live` only once the uinput
+    // range below is confirmed: until then mouse threads must keep correcting against
+    // the previous (layout, range) pair, which is still what the device is using.
     let drifted = {
-        let mut layout = WAYLAND_LAYOUT.lock().unwrap();
-        let drifted = !layout.baseline.is_empty()
-            && !live_rects.is_empty()
-            && layout.baseline != live_rects;
-        layout.live = live_rects;
-        drifted
+        let layout = WAYLAND_LAYOUT.lock().unwrap();
+        !layout.baseline.is_empty() && !live_rects.is_empty() && layout.baseline != live_rects
     };
     // The remap corrects for per-display origin shifts; the uinput ABS range corrects for
     // the overall bounding box. Only enable the remap once the range matches the live
     // layout, otherwise moves would be remapped into a range the device is not yet using.
     // A drift with no bbox change (origins swapped) needs no range update and enables now.
     let mut range_ok = WAYLAND_UINPUT_RECT.lock().unwrap().rect == Some(rect);
+    let mut applied = false;
     if !range_ok {
         let (minx, maxx, miny, maxy) = rect;
         log::info!(
@@ -139,17 +163,21 @@ fn refresh_wayland_uinput_rect_if_changed() {
                 // `set_resolution()` has no timeout on the response read.
                 // timeout must be built inside the runtime, or it panics
                 // "there is no reactor running". See clipboard_service.rs.
-                match rt.block_on(async {
+                let res = rt.block_on(async {
                     timeout(
                         3_000,
                         crate::input_service::update_mouse_resolution(minx, maxx, miny, maxy),
                     )
                     .await
-                }) {
-                    // Record the rect only after a successful apply, so a transient
-                    // failure is retried on the next check.
+                });
+                // The timeout cannot cancel the spawn_blocking inside
+                // update_mouse_resolution, and dropping the runtime waits for it.
+                // Detach instead, so a refresh stuck on the enigo lock or the IPC
+                // cannot hang this loop past the timeout.
+                rt.shutdown_background();
+                match res {
                     Ok(Ok(())) => {
-                        WAYLAND_UINPUT_RECT.lock().unwrap().rect = Some(rect);
+                        applied = true;
                         range_ok = true;
                     }
                     Ok(Err(err)) => log::error!("Failed to update mouse resolution: {}", err),
@@ -160,6 +188,19 @@ fn refresh_wayland_uinput_rect_if_changed() {
                 log::error!("Failed to build tokio runtime: {}", err);
             }
         }
+    }
+    // A session reset while this poll was blocked in the refresh means the snapshot
+    // above belongs to the previous session; discard it, the next poll starts fresh.
+    if WAYLAND_LAYOUT_EPOCH.load(Ordering::Relaxed) != epoch {
+        return;
+    }
+    if applied {
+        // Record the rect only after a successful apply, so a transient failure is
+        // retried on the next check.
+        WAYLAND_UINPUT_RECT.lock().unwrap().rect = Some(rect);
+    }
+    if range_ok {
+        WAYLAND_LAYOUT.lock().unwrap().live = live_rects;
     }
     // Publish the flag last: a `true` read is always backed by a current `live` and a
     // matching uinput range. A failed range apply leaves this false and retries next poll.

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -668,23 +668,61 @@ lazy_static::lazy_static! {
 #[cfg(target_os = "linux")]
 const UINPUT_REFRESH_GIVE_UP: Duration = Duration::from_secs(60);
 
+// Ownership of the refresh slot, held across the whole update. `set_resolution()` writes
+// the resolution the uinput service recreates the mouse from, so setting the range and
+// the refresh that installs it have to be one transaction against that shared state;
+// otherwise a concurrent update's range gets installed under this caller's ack and the
+// caller caches a range the device is not using.
+//
+// Releasing on drop makes the claim cancellation-safe: if `set_resolution()` errors, or
+// the caller's timeout drops this future before the refresh starts, the slot frees. Once
+// the guard is moved into the blocking task it belongs to that task instead, so a caller
+// timeout cannot free a slot whose refresh is still running.
 #[cfg(target_os = "linux")]
-pub async fn update_mouse_resolution(minx: i32, maxx: i32, miny: i32, maxy: i32) -> ResultType<()> {
-    set_uinput_resolution(minx, maxx, miny, maxy).await?;
+struct UinputRefreshGuard(Instant);
 
-    let started = Instant::now();
-    {
+#[cfg(target_os = "linux")]
+impl UinputRefreshGuard {
+    // None while another update owns the slot and has not passed the age bound.
+    fn acquire() -> Option<Self> {
+        let started = Instant::now();
         let mut inflight = UINPUT_REFRESH_INFLIGHT_SINCE.lock().unwrap();
         if let Some(since) = *inflight {
             if since.elapsed() < UINPUT_REFRESH_GIVE_UP {
-                bail!("previous uinput refresh still in flight");
+                return None;
             }
         }
         *inflight = Some(started);
+        Some(Self(started))
     }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for UinputRefreshGuard {
+    fn drop(&mut self) {
+        // Clear only our own marker: an update that outlived the age bound must not
+        // release the slot a newer one has since claimed.
+        let mut inflight = UINPUT_REFRESH_INFLIGHT_SINCE.lock().unwrap();
+        if *inflight == Some(self.0) {
+            *inflight = None;
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub async fn update_mouse_resolution(minx: i32, maxx: i32, miny: i32, maxy: i32) -> ResultType<()> {
+    // Claimed before the range is written, so a concurrent update cannot land its own
+    // range in the shared resolution between this write and the refresh below.
+    let Some(guard) = UinputRefreshGuard::acquire() else {
+        bail!("previous uinput refresh still in flight");
+    };
+    set_uinput_resolution(minx, maxx, miny, maxy).await?;
+
     // Confirm the device adopted the new range before the caller caches it.
     // spawn_blocking because ENIGO is a std Mutex and send_refresh blocks on IPC.
     tokio::task::spawn_blocking(move || {
+        // Owned by this task now: dropped when the refresh returns, however it returns.
+        let _guard = guard;
         let res = (|| {
             if let Some(mouse) = ENIGO.lock().unwrap().get_custom_mouse() {
                 if let Some(mouse) = mouse
@@ -698,12 +736,6 @@ pub async fn update_mouse_resolution(minx: i32, maxx: i32, miny: i32, maxy: i32)
             // No custom mouse: nothing to refresh.
             Ok(())
         })();
-        // Clear only our own marker: a task that outlived the 60s bound must not
-        // release the slot a newer attempt has since claimed.
-        let mut inflight = UINPUT_REFRESH_INFLIGHT_SINCE.lock().unwrap();
-        if *inflight == Some(started) {
-            *inflight = None;
-        }
         res
     })
     .await?

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -657,24 +657,54 @@ pub async fn setup_rdp_input() -> ResultType<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+// When a refresh outlives its caller's timeout, the blocking task below keeps waiting
+// on the enigo lock or the IPC; it cannot be cancelled. Marks the launch time so
+// retries don't stack a new blocked thread on the same lock every poll: the task
+// clears the marker when it finishes, and the age bound recovers if it never runs.
+#[cfg(target_os = "linux")]
+lazy_static::lazy_static! {
+    static ref UINPUT_REFRESH_INFLIGHT_SINCE: std::sync::Mutex<Option<Instant>> = Default::default();
+}
+#[cfg(target_os = "linux")]
+const UINPUT_REFRESH_GIVE_UP: Duration = Duration::from_secs(60);
+
 #[cfg(target_os = "linux")]
 pub async fn update_mouse_resolution(minx: i32, maxx: i32, miny: i32, maxy: i32) -> ResultType<()> {
     set_uinput_resolution(minx, maxx, miny, maxy).await?;
 
+    let started = Instant::now();
+    {
+        let mut inflight = UINPUT_REFRESH_INFLIGHT_SINCE.lock().unwrap();
+        if let Some(since) = *inflight {
+            if since.elapsed() < UINPUT_REFRESH_GIVE_UP {
+                bail!("previous uinput refresh still in flight");
+            }
+        }
+        *inflight = Some(started);
+    }
     // Confirm the device adopted the new range before the caller caches it.
     // spawn_blocking because ENIGO is a std Mutex and send_refresh blocks on IPC.
     tokio::task::spawn_blocking(move || {
-        if let Some(mouse) = ENIGO.lock().unwrap().get_custom_mouse() {
-            if let Some(mouse) = mouse
-                .as_mut_any()
-                .downcast_mut::<super::uinput::client::UInputMouse>()
-            {
-                return mouse.send_refresh();
+        let res = (|| {
+            if let Some(mouse) = ENIGO.lock().unwrap().get_custom_mouse() {
+                if let Some(mouse) = mouse
+                    .as_mut_any()
+                    .downcast_mut::<super::uinput::client::UInputMouse>()
+                {
+                    return mouse.send_refresh();
+                }
+                bail!("failed to downcast custom mouse to UInputMouse");
             }
-            bail!("failed to downcast custom mouse to UInputMouse");
+            // No custom mouse: nothing to refresh.
+            Ok(())
+        })();
+        // Clear only our own marker: a task that outlived the 60s bound must not
+        // release the slot a newer attempt has since claimed.
+        let mut inflight = UINPUT_REFRESH_INFLIGHT_SINCE.lock().unwrap();
+        if *inflight == Some(started) {
+            *inflight = None;
         }
-        // No custom mouse: nothing to refresh.
-        Ok(())
+        res
     })
     .await?
 }

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -140,9 +140,22 @@ pub(super) async fn check_init() -> ResultType<()> {
                 // The cached layout may predate compositor changes made while no session
                 // was active, https://github.com/rustdesk/rustdesk/issues/15601
                 scrap::wayland::display::clear_wayland_displays_cache();
+                // Reset before the refresh, not in its success arm: if the refresh
+                // fails, the previous session's baseline and drift flag must not
+                // survive into this one.
+                super::display_service::reset_wayland_layout();
                 if let Some((minx, maxx, miny, maxy)) =
                     scrap::wayland::display::get_desktop_rect_for_uinput()
                 {
+                    // Snapshot the per-display layout the client's coordinates will be
+                    // based on, so the mouse path can correct them if the compositor
+                    // moves a monitor mid-session. Snapshotted before the refresh, not
+                    // in its success arm: the layout is local data, and a failed
+                    // refresh is retried by the periodic check, which needs this
+                    // baseline to re-enable the correction.
+                    super::display_service::set_wayland_layout_baseline(
+                        scrap::wayland::display::get_display_rects_for_uinput(),
+                    );
                     log::info!(
                         "update mouse resolution: ({}, {}), ({}, {})",
                         minx,
@@ -162,12 +175,6 @@ pub(super) async fn check_init() -> ResultType<()> {
                             super::display_service::set_wayland_uinput_rect((
                                 minx, maxx, miny, maxy,
                             ));
-                            // Snapshot the per-display layout the client's coordinates
-                            // will be based on, so the mouse path can correct them if
-                            // the compositor moves a monitor mid-session.
-                            super::display_service::set_wayland_layout_baseline(
-                                scrap::wayland::display::get_display_rects_for_uinput(),
-                            );
                         }
                         Ok(Err(err)) => log::error!("Failed to update mouse resolution: {}", err),
                         Err(err) => log::error!("Failed to update mouse resolution: {}", err),


### PR DESCRIPTION
Follow-ups to the review notes posted on #15628 after merge, plus two more holes found while fixing them.

**Stale state across sessions.** `check_init` now resets the layout state (baseline, live, drift flag, recorded rect, check timestamp) before the resolution refresh instead of relying on the success arm. A session whose init refresh fails no longer inherits the previous session's baseline, which could remap coordinates of a client that was initialized to the current layout. Clearing the recorded rect makes the periodic check retry the failed init refresh on the first poll.

**Baseline survives a failed init refresh.** The baseline snapshot moved out of the success arm to before the refresh. It is local data, and without it the periodic retry could recover the range but never re-enable drift correction for the rest of the session.

**Live layout published before the range is confirmed.** With drift already active, a second layout change used to publish the new layout to mouse threads while the device still had the old ABS range, for up to the 3s refresh bound. The fresh layout is now staged and only published together with the drift flag once the range matches, so readers always see a consistent (layout, range) pair.

**Refresh could hang the display service loop.** The 3s timeout cannot cancel the `spawn_blocking` inside `update_mouse_resolution`, and dropping the temporary runtime waits for blocking tasks, so a refresh stuck on the enigo lock or the IPC hung the loop anyway. The runtime is now detached with `shutdown_background()`. A refresh will not start while a previous one holds the slot, which also serializes the init and periodic paths against writing the device concurrently.

The slot is an RAII claim taken before `set_resolution`, so writing the range and the refresh that installs it are one transaction against the uinput service's shared `RESOLUTION`. Without that, two overlapping updates can interleave as `A set -> B set -> A claim -> B bail -> A refresh`, which installs B's range under A's ack and leaves the caller caching a range the device is not using. The claim frees on error, on caller cancellation before the refresh starts, and when the blocking refresh returns. Ownership moves into the blocking task, so a caller timeout cannot free a slot whose refresh is still running.

**Known gap, not fixed here.** The claim ages out after 60s so that one dead refresh cannot block every future one. If `ENIGO.lock()` is genuinely wedged, that admits a new blocked task once a minute rather than one per poll. It bounds the stacking rate, it does not eliminate it, and `shutdown_background()` lets the old blocking work keep running. Removing the age bound is not safe on its own; the fix is a single latest-wins refresh worker that owns the slot for its lifetime, and that touches the normal path, so it belongs in a follow-up.

**Session churn during a blocked refresh.** A poll that was blocked in the refresh across a disconnect and reconnect used to republish the old session's layout over the new session's state. The reset now bumps an epoch and the poll discards its snapshot when the epoch moved. The epoch is snapshotted before the layout is read and re-checked right after the read as well as after the refresh. Loaded after the read, it could belong to a session that started mid-read, and the poll would then write the previous session's range to the device and accept its geometry as current.

Behavior on the normal path (init succeeds, no drift) is unchanged. Builds clean, existing tests pass. The failure paths here (failed init refresh, wedged IPC, reconnect racing a blocked poll) are hard to drive on real hardware, so this one is verified by reasoning through the interleavings rather than a live rescale session like #15628 was.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wayland session handling by clearing stale display-layout data when sessions restart.
  * Prevented outdated layout refresh results from being applied after a session change.
  * Reduced the risk of overlapping or stuck mouse-resolution refresh attempts.
  * Ensured timed-out refresh operations release background resources properly.
  * Improved display-layout baseline handling during Wayland initialization and refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR resets Wayland layout state at session initialization, stages layout publication until the uinput range is confirmed, and detaches timed-out blocking refresh work.

- Adds an epoch intended to reject refresh results that cross session boundaries.
- Adds guarded serialization and age-based recovery for uinput refreshes.
- Preserves the session baseline across failed initialization refreshes.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until stale refresh state can no longer be committed after a concurrent Wayland session reset.

The final epoch check does not cover the subsequent range, layout, and drift writes, so the session-churn failure this change targets remains reachable; the age-based refresh takeover also permits slow accumulation of blocked workers.

**Files Needing Attention:** src/server/display_service.rs; src/server/input_service.rs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/display_service.rs | Adds session epochs and staged layout publication, but leaves a post-validation race that can republish stale session state. |
| src/server/input_service.rs | Adds refresh serialization and detached-task ownership, although its age takeover can periodically accumulate workers behind a permanent wedge. |
| src/server/wayland.rs | Resets layout state and records the baseline before initialization refresh so failed refreshes can recover correctly. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant P as Display poll
  participant R as Session reset
  participant S as Shared layout state
  P->>P: Read epoch E and old-session layout
  P->>P: Refresh uinput range
  P->>P: "Validate epoch == E"
  R->>S: Increment epoch and clear state
  P->>S: Publish old rect/live/drift
  Note over P,S: Publication occurs after the final validation
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2315670%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=15670&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fserver%2Fdisplay_service.rs%3A202-205%0A**Epoch%20check%20misses%20publication**%0A%0AWhen%20a%20Wayland%20session%20reset%20runs%20after%20this%20final%20epoch%20check%2C%20the%20old%20poll%20still%20writes%20its%20recorded%20range%2C%20live%20layout%2C%20and%20drift%20flag%20afterward%2C%20causing%20the%20new%20session's%20absolute%20input%20to%20be%20scaled%20or%20remapped%20using%20stale%20geometry.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fserver%2Finput_service.rs%3A689-696%0A**Expired%20guards%20stack%20workers**%0A%0AIf%20a%20refresh%20remains%20blocked%20for%20longer%20than%2060%20seconds%2C%20%60acquire%60%20replaces%20its%20still-owned%20marker%20and%20launches%20another%20non-cancellable%20blocking%20task%2C%20allowing%20one%20worker%20to%20accumulate%20every%2060%20seconds%20behind%20a%20permanently%20wedged%20ENIGO%20lock%20or%20IPC%20operation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15670&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22cody%2Fwayland-layout-state-followups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cody%2Fwayland-layout-state-followups%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fserver%2Fdisplay_service.rs%3A202-205%0A**Epoch%20check%20misses%20publication**%0A%0AWhen%20a%20Wayland%20session%20reset%20runs%20after%20this%20final%20epoch%20check%2C%20the%20old%20poll%20still%20writes%20its%20recorded%20range%2C%20live%20layout%2C%20and%20drift%20flag%20afterward%2C%20causing%20the%20new%20session's%20absolute%20input%20to%20be%20scaled%20or%20remapped%20using%20stale%20geometry.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fserver%2Finput_service.rs%3A689-696%0A**Expired%20guards%20stack%20workers**%0A%0AIf%20a%20refresh%20remains%20blocked%20for%20longer%20than%2060%20seconds%2C%20%60acquire%60%20replaces%20its%20still-owned%20marker%20and%20launches%20another%20non-cancellable%20blocking%20task%2C%20allowing%20one%20worker%20to%20accumulate%20every%2060%20seconds%20behind%20a%20permanently%20wedged%20ENIGO%20lock%20or%20IPC%20operation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15670&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/display_service.rs:202-205
**Epoch check misses publication**

When a Wayland session reset runs after this final epoch check, the old poll still writes its recorded range, live layout, and drift flag afterward, causing the new session's absolute input to be scaled or remapped using stale geometry.

### Issue 2
src/server/input_service.rs:689-696
**Expired guards stack workers**

If a refresh remains blocked for longer than 60 seconds, `acquire` replaces its still-owned marker and launches another non-cancellable blocking task, allowing one worker to accumulate every 60 seconds behind a permanently wedged ENIGO lock or IPC operation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bind the wayland layout snapshot to..."](https://github.com/rustdesk/rustdesk/commit/ce9350cff4cda13aaa1a1de735dd4f955836813a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47862143)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->