### PR TITLE
fix: validate RGBA clipboard dimensions

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -37,6 +37,17 @@ const CLIPBOARD_GET_MAX_RETRY: usize = 3;
 const CLIPBOARD_GET_RETRY_INTERVAL_DUR: Duration = Duration::from_millis(33);
 
 #[cfg(not(target_os = "android"))]
+fn valid_rgba_dimensions(width: i32, height: i32, data_len: usize) -> Option<(usize, usize)> {
+    let width = usize::try_from(width).ok()?;
+    let height = usize::try_from(height).ok()?;
+    if width == 0 || height == 0 {
+        return None;
+    }
+    let expected_len = width.checked_mul(height)?.checked_mul(4)?;
+    (data_len == expected_len).then_some((width, height))
+}
+
+#[cfg(not(target_os = "android"))]
 const SUPPORTED_FORMATS: &[ClipboardFormat] = &[
     ClipboardFormat::Text,
     ClipboardFormat::Html,
@@ -722,11 +733,15 @@ mod proto {
             Ok(ClipboardFormat::Text) => String::from_utf8(data).ok().map(ClipboardData::Text),
             Ok(ClipboardFormat::Rtf) => String::from_utf8(data).ok().map(ClipboardData::Rtf),
             Ok(ClipboardFormat::Html) => String::from_utf8(data).ok().map(ClipboardData::Html),
-            Ok(ClipboardFormat::ImageRgba) => Some(ClipboardData::Image(arboard::ImageData::rgba(
-                clipboard.width as _,
-                clipboard.height as _,
-                data.into(),
-            ))),
+            Ok(ClipboardFormat::ImageRgba) => {
+                let (width, height) =
+                    super::valid_rgba_dimensions(clipboard.width, clipboard.height, data.len())?;
+                Some(ClipboardData::Image(arboard::ImageData::rgba(
+                    width,
+                    height,
+                    data.into(),
+                )))
+            }
             Ok(ClipboardFormat::ImagePng) => {
                 Some(ClipboardData::Image(arboard::ImageData::png(data.into())))
             }
@@ -767,6 +782,22 @@ mod proto {
                 msg.set_clipboard(c.clone());
                 msg
             })
+    }
+}
+
+#[cfg(all(test, not(target_os = "android")))]
+mod rgba_tests {
+    use super::valid_rgba_dimensions;
+
+    #[test]
+    fn validates_dimensions_against_content_length() {
+        assert_eq!(valid_rgba_dimensions(1, 1, 4), Some((1, 1)));
+        assert_eq!(valid_rgba_dimensions(1, 1, 3), None);
+        assert_eq!(valid_rgba_dimensions(-1, 1, 4), None);
+        assert_eq!(valid_rgba_dimensions(0, 1, 0), None);
+        assert_eq!(valid_rgba_dimensions(i32::MAX, i32::MAX, 4), None);
+        #[cfg(target_pointer_width = "32")]
+        assert_eq!(valid_rgba_dimensions(i32::MAX, 2, 0), None);
     }
 }
 


### PR DESCRIPTION
## Summary

Validate peer-provided RGBA clipboard dimensions before constructing `arboard::ImageData`.

Previously, signed width and height fields were cast directly to `usize` and were not checked against the content length. A malformed clipboard message could therefore describe a very large image backed by only a few bytes, allowing downstream consumers to read beyond the supplied buffer.

## Changes

- reject non-positive dimensions
- use checked multiplication for `width * height * 4`
- require the computed RGBA length to exactly match the content length
- cover valid, truncated, negative, zero, and overflowing inputs

## Testing

`cargo test --lib --features linux-pkg-config rgba_tests::validates_dimensions_against_content_length`

The regression test passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard image validation for RGBA images by rejecting invalid or zero dimensions.
  * Ensures the clipboard payload size exactly matches the expected RGBA byte length before conversion.
  * Prevents malformed or oversized clipboard images from being converted incorrectly.
* **Tests**
  * Added non-Android unit tests covering valid cases, mismatched payload lengths, zero/negative dimensions, and overflow edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->