### PR TITLE
fix: validate remote audio channel count

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1401,6 +1401,10 @@ impl AudioHandler {
 
     /// Handle audio format and create an audio decoder.
     pub fn handle_format(&mut self, f: AudioFormat) {
+        if !is_supported_audio_channel_count(f.channels) {
+            log::error!("Unsupported audio channel count: {}", f.channels);
+            return;
+        }
         match AudioDecoder::new(f.sample_rate, if f.channels > 1 { Stereo } else { Mono }) {
             Ok(d) => {
                 let buffer = vec![0.; f.sample_rate as usize * f.channels as usize];
@@ -1537,6 +1541,23 @@ impl AudioHandler {
         stream.play()?;
         self.audio_stream = Some(Box::new(stream));
         Ok(())
+    }
+}
+
+fn is_supported_audio_channel_count(channels: u32) -> bool {
+    (1..=2).contains(&channels)
+}
+
+#[cfg(test)]
+mod audio_format_tests {
+    use super::is_supported_audio_channel_count;
+
+    #[test]
+    fn only_mono_and_stereo_are_supported() {
+        assert!(is_supported_audio_channel_count(1));
+        assert!(is_supported_audio_channel_count(2));
+        assert!(!is_supported_audio_channel_count(0));
+        assert!(!is_supported_audio_channel_count(u32::MAX));
     }
 }
 


### PR DESCRIPTION
## Summary

Reject audio formats whose peer-provided channel count is not mono or stereo before constructing the decoder buffer.

The channel field is an untrusted `u32` and was used directly in:

`sample_rate * channels`

A maximal channel value could therefore request an allocation on the order of hundreds of terabytes and abort the client process.

## Changes

- accept only the channel counts supported by the Opus decoder path (1 or 2)
- return before decoder/buffer/audio-device setup for invalid formats
- add boundary coverage for zero, mono, stereo, and `u32::MAX`

## Testing

`cargo test --lib --features linux-pkg-config audio_format_tests::only_mono_and_stereo_are_supported`

The regression test passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio format validation by supporting only mono and stereo channel configurations.
  * Unsupported audio formats are now rejected gracefully with an error instead of causing decoder setup to proceed.

* **Tests**
  * Added coverage for supported and unsupported audio channel counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->