### PR TITLE
fix(wayland): scale portal pointer coordinates on niri

### DIFF
--- a/src/server/rdp_input.rs
+++ b/src/server/rdp_input.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 pub mod client {
-    use hbb_common::platform::linux::is_kde;
+    use hbb_common::platform::linux::{DISPLAY_DESKTOP_KDE, XDG_CURRENT_DESKTOP};
 
     use super::*;
 
@@ -308,11 +308,11 @@ pub mod client {
             .any(|name| name.eq_ignore_ascii_case("niri"))
     }
 
-    fn should_scale_pointer_coordinates() -> bool {
-        is_kde()
-            || std::env::var("XDG_CURRENT_DESKTOP")
-                .map(|desktop| desktop_is_niri(&desktop))
-                .unwrap_or(false)
+    lazy_static::lazy_static! {
+        static ref SHOULD_SCALE_POINTER_COORDINATES: bool =
+            std::env::var(XDG_CURRENT_DESKTOP)
+                .map(|desktop| desktop == DISPLAY_DESKTOP_KDE || desktop_is_niri(&desktop))
+                .unwrap_or(false);
     }
 
     pub struct RdpInputMouse {
@@ -340,7 +340,7 @@ pub mod client {
             // For Ubuntu 24.04(Gnome 46), (x,y) is restricted from (0,0) to (400,300), but the actual range in screen is:
             // Logic coordinate from (0,0) to (200x150).
             // Or physical coordinate from (0,0) to (400,300).
-            let scale = if should_scale_pointer_coordinates() {
+            let scale = if *SHOULD_SCALE_POINTER_COORDINATES {
                 if resolution.0 == 0 || stream.get_size().0 == 0 {
                     Some(1.0f64)
                 } else {

--- a/src/server/rdp_input.rs
+++ b/src/server/rdp_input.rs
@@ -302,6 +302,19 @@ pub mod client {
         }
     }
 
+    fn desktop_is_niri(desktop: &str) -> bool {
+        desktop
+            .split(':')
+            .any(|name| name.eq_ignore_ascii_case("niri"))
+    }
+
+    fn should_scale_pointer_coordinates() -> bool {
+        is_kde()
+            || std::env::var("XDG_CURRENT_DESKTOP")
+                .map(|desktop| desktop_is_niri(&desktop))
+                .unwrap_or(false)
+    }
+
     pub struct RdpInputMouse {
         conn: Arc<SyncConnection>,
         session: Path<'static>,
@@ -327,7 +340,7 @@ pub mod client {
             // For Ubuntu 24.04(Gnome 46), (x,y) is restricted from (0,0) to (400,300), but the actual range in screen is:
             // Logic coordinate from (0,0) to (200x150).
             // Or physical coordinate from (0,0) to (400,300).
-            let scale = if is_kde() {
+            let scale = if should_scale_pointer_coordinates() {
                 if resolution.0 == 0 || stream.get_size().0 == 0 {
                     Some(1.0f64)
                 } else {
@@ -345,6 +358,19 @@ pub mod client {
                 scale,
                 position: (pos.0 as f64, pos.1 as f64),
             })
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::desktop_is_niri;
+
+        #[test]
+        fn detects_niri_in_desktop_list() {
+            assert!(desktop_is_niri("niri"));
+            assert!(desktop_is_niri("NIRI"));
+            assert!(desktop_is_niri("GNOME:niri"));
+            assert!(!desktop_is_niri("GNOME"));
         }
     }
 


### PR DESCRIPTION
## Summary

Apply the existing Wayland portal physical-to-logical pointer scaling on niri as well as KDE.

## Problem

On a niri Wayland session with 150% output scaling:

- PipeWire capture resolution: `3840x2160`
- portal stream/compositor size: `2560x1440`
- `XDG_CURRENT_DESKTOP=niri`

`RdpInputMouse` currently computes the correct `resolution / stream.size` ratio only when `is_kde()` is true. On niri, RustDesk therefore sends physical pixel coordinates to `NotifyPointerMotionAbsolute`, whose API requires stream logical coordinates.

The visible result is that a pointer at 20% on the client moves to 30% on the host. Calls beyond 66.7% are rejected as outside the portal stream's logical bounds.

## Fix

- Detect niri in the colon-separated, case-insensitive `XDG_CURRENT_DESKTOP` value.
- Reuse the existing KDE scale calculation for niri.
- Add focused tests for desktop detection.

This keeps the GNOME exception documented in `RdpInputMouse::new` unchanged.

## Prior art

- #8524 reported the same class of fractional-scale mismatch.
- #9402 added the current physical-to-logical conversion, but limited it to KDE because those were the tested environments at the time.
- emersion/xdg-desktop-portal-wlr#325 is the currently open RemoteDesktop implementation used for the niri runtime test.

## Verification

- Reproduced on niri at 150% scale with a 3840x2160 capture and 2560x1440 portal logical size.
- Verified end-to-end that applying the 1.5 conversion restores 1:1 pointer alignment across the full output.
- `rustfmt --check src/server/rdp_input.rs` passes.
- Added a unit test for `niri`, case-insensitive matching, colon-separated desktop lists, and a non-niri value.
- A full local `cargo test` was attempted but could not complete in the current NixOS shell because the native `x11.pc` build dependency was unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pointer coordinate scaling when using the niri desktop compositor.
  * Enhanced desktop-environment detection to correctly recognize “niri”, including colon-delimited values.
* **Tests**
  * Added unit tests to validate desktop-name parsing for the new niri detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->