### PR TITLE
Webrtc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,30 +1163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if 1.0.0",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "chacha20poly1305"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
-dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
- "zeroize",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,7 +1211,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -2329,7 +2304,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.4",
 ]
 
 [[package]]
@@ -2445,42 +2420,6 @@ checksum = "fd39dde40b6e196c2e8763f23d119ddb1a8714534bf7d77fa97a65b0feda3986"
 dependencies = [
  "libc",
  "linux-raw-sys 0.6.5",
-]
-
-[[package]]
-name = "dtls"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f531dd7c181beaf3cebab3716afa4d0d41ab888be85232583f56bbaf07ca208a"
-dependencies = [
- "aes",
- "aes-gcm",
- "async-trait",
- "bincode",
- "byteorder",
- "cbc",
- "ccm",
- "chacha20poly1305",
- "der-parser",
- "hmac",
- "log",
- "p256",
- "p384",
- "portable-atomic",
- "rand 0.9.2",
- "rand_core 0.6.4",
- "rcgen",
- "ring",
- "rustls",
- "sec1",
- "serde 1.0.228",
- "sha1",
- "sha2",
- "thiserror 1.0.61",
- "tokio",
- "webrtc-util",
- "x25519-dalek",
- "x509-parser",
 ]
 
 [[package]]
@@ -2694,7 +2633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4183,16 +4122,15 @@ dependencies = [
 
 [[package]]
 name = "interceptor"
-version = "0.15.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea51375727680dc15f06e8ad90fa31df75d79dd030100e8ad60eef1c27fe2c98"
+checksum = "1ac0781c825d602095113772e389ef0607afcb869ae0e68a590d8e0799cdcef8"
 dependencies = [
  "async-trait",
  "bytes",
- "futures",
  "log",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "rtcp",
  "rtp",
  "thiserror 1.0.61",
@@ -4494,7 +4432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6338,17 +6276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
-dependencies = [
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7154,9 +7081,9 @@ dependencies = [
 
 [[package]]
 name = "rtcp"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d30d1c4091644431c22acf9f8be6191b56805e0e977f15ca7104b4a6d6eaec"
+checksum = "e9689528bf3a9eb311fd938d05516dd546412f9ce4fffc8acfc1db27cc3dbf72"
 dependencies = [
  "bytes",
  "thiserror 1.0.61",
@@ -7165,14 +7092,14 @@ dependencies = [
 
 [[package]]
 name = "rtp"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f126f38ea84c02480e32e547c1459a939052f74fb92117ac3eef23fdac6b023"
+checksum = "c54733451a67d76caf9caa07a7a2cec6871ea9dda92a7847f98063d459200f4b"
 dependencies = [
  "bytes",
  "memchr",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "serde 1.0.228",
  "thiserror 1.0.61",
  "webrtc-util",
@@ -7434,7 +7361,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7491,7 +7418,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7622,11 +7549,11 @@ dependencies = [
 
 [[package]]
 name = "sdp"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c374dceda16965d541c8800ce9cc4e1c14acfd661ddf7952feeedc3411e5c6"
+checksum = "4cd277015eada44a0bb810a4b84d3bf6e810573fa62fb442f457edf6a1087a69"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.8.5",
  "substring",
  "thiserror 1.0.61",
  "url",
@@ -8204,15 +8131,15 @@ dependencies = [
 
 [[package]]
 name = "stun"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a512c5d501e3e3b5a4bb3e8e31462d56d54a66b95a28b8596e14422bf21c32b"
+checksum = "7dbc2bab375524093c143dc362a03fb6a1fb79e938391cdb21665688f88a088a"
 dependencies = [
  "base64 0.22.1",
  "crc",
  "lazy_static",
  "md-5",
- "rand 0.9.2",
+ "rand 0.8.5",
  "ring",
  "subtle",
  "thiserror 1.0.61",
@@ -9123,9 +9050,9 @@ dependencies = [
 
 [[package]]
 name = "turn"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed995882f66ab94238de77c62e5e778389698ab700afa4696f4754da8f457cb"
+checksum = "3f5aea1116456e1da71c45586b87c72e3b43164fbf435eb93ff6aa475416a9a4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9133,7 +9060,7 @@ dependencies = [
  "log",
  "md-5",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "ring",
  "stun",
  "thiserror 1.0.61",
@@ -9258,12 +9185,6 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"
@@ -9809,25 +9730,26 @@ dependencies = [
 
 [[package]]
 name = "webrtc"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08fd686c0920ac08f3a57eacc48e31f0e4ca1ffefba4478784606f78c14e83ad"
+checksum = "24bab7195998d605c862772f90a452ba655b90a2f463c850ac032038890e367a"
 dependencies = [
  "arc-swap",
  "async-trait",
  "bytes",
- "dtls",
+ "cfg-if 1.0.0",
  "hex",
  "interceptor",
  "lazy_static",
  "log",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "rcgen",
  "regex",
  "ring",
  "rtcp",
  "rtp",
+ "rustls",
  "sdp",
  "serde 1.0.228",
  "serde_json 1.0.118",
@@ -9835,12 +9757,13 @@ dependencies = [
  "smol_str",
  "stun",
  "thiserror 1.0.61",
+ "time 0.3.36",
  "tokio",
  "turn",
- "unicase",
  "url",
  "waitgroup",
  "webrtc-data",
+ "webrtc-dtls",
  "webrtc-ice",
  "webrtc-mdns",
  "webrtc-media",
@@ -9851,9 +9774,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-data"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062a5438d63bb0756a221693d76cc0dd6119affee1dfdfe57abe3a2a8c8b3eea"
+checksum = "4e97b932854da633a767eff0cc805425a2222fc6481e96f463e57b015d949d1d"
 dependencies = [
  "bytes",
  "log",
@@ -9865,17 +9788,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "webrtc-ice"
-version = "0.14.0"
+name = "webrtc-dtls"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cb13fd1a373e68addc4bba0c8ca058627518e54342583d024bdcbb8ae5d97d"
+checksum = "5ccbe4d9049390ab52695c3646c1395c877e16c15fb05d3bda8eee0c7351711c"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "bincode",
+ "byteorder",
+ "cbc",
+ "ccm",
+ "der-parser",
+ "hkdf",
+ "hmac",
+ "log",
+ "p256",
+ "p384",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring",
+ "rustls",
+ "sec1",
+ "serde 1.0.228",
+ "sha1",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.61",
+ "tokio",
+ "webrtc-util",
+ "x25519-dalek",
+ "x509-parser",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb51bde0d790f109a15bfe4d04f1b56fb51d567da231643cb3f21bb74d678997"
 dependencies = [
  "arc-swap",
  "async-trait",
  "crc",
  "log",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "serde 1.0.228",
  "serde_json 1.0.118",
  "stun",
@@ -9891,9 +9851,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-mdns"
-version = "0.10.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17279a067e75df72ce923fdeb7f04cd808f6f5aa4910dc6bcb4fbe66b396ace"
+checksum = "979cc85259c53b7b620803509d10d35e2546fa505d228850cbe3f08765ea6ea8"
 dependencies = [
  "log",
  "socket2 0.5.10",
@@ -9904,22 +9864,22 @@ dependencies = [
 
 [[package]]
 name = "webrtc-media"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a84c910fec0848fd5a0d8a5651e0ddbdedaf25a7d3ae3f0b15f71ac73a1773"
+checksum = "80041211deccda758a3e19aa93d6b10bc1d37c9183b519054b40a83691d13810"
 dependencies = [
  "byteorder",
  "bytes",
- "rand 0.9.2",
+ "rand 0.8.5",
  "rtp",
  "thiserror 1.0.61",
 ]
 
 [[package]]
 name = "webrtc-sctp"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f985465467d8910c1f8ac4382cd64f83b1f6a1a75021a82b221546f6fb3b856f"
+checksum = "07439c134425d51d2f10907aaf2f815fdfb587dce19fe94a4ae8b5faf2aae5ae"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9927,7 +9887,7 @@ dependencies = [
  "crc",
  "log",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "thiserror 1.0.61",
  "tokio",
  "webrtc-util",
@@ -9935,9 +9895,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-srtp"
-version = "0.16.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d8cdc33413f1d0192670a80ce93d17cb78d57fe3a2414be30d6f6dff121123"
+checksum = "01e773f79b09b057ffbda6b03fe7b43403b012a240cf8d05d630674c3723b5bb"
 dependencies = [
  "aead",
  "aes",
@@ -9958,19 +9918,20 @@ dependencies = [
 
 [[package]]
 name = "webrtc-util"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c0c7e0c8f280f2bbfae442701465777ac07adaf46ce0c5863cd58e13fe472a"
+checksum = "64bfb10dbe6d762f80169ae07cf252bafa1f764b9594d140008a0231c0cdce58"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "bytes",
  "ipnet",
  "lazy_static",
+ "libc",
  "log",
  "nix 0.26.4",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "thiserror 1.0.61",
  "tokio",
  "winapi 0.3.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,30 +1162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if 1.0.0",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "chacha20poly1305"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
-dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
- "zeroize",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,7 +1210,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -2440,42 +2415,6 @@ checksum = "fd39dde40b6e196c2e8763f23d119ddb1a8714534bf7d77fa97a65b0feda3986"
 dependencies = [
  "libc",
  "linux-raw-sys 0.6.5",
-]
-
-[[package]]
-name = "dtls"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f531dd7c181beaf3cebab3716afa4d0d41ab888be85232583f56bbaf07ca208a"
-dependencies = [
- "aes",
- "aes-gcm",
- "async-trait",
- "bincode",
- "byteorder",
- "cbc",
- "ccm",
- "chacha20poly1305",
- "der-parser",
- "hmac",
- "log",
- "p256",
- "p384",
- "portable-atomic",
- "rand 0.9.2",
- "rand_core 0.6.4",
- "rcgen",
- "ring",
- "rustls",
- "sec1",
- "serde 1.0.228",
- "sha1",
- "sha2",
- "thiserror 1.0.61",
- "tokio",
- "webrtc-util",
- "x25519-dalek",
- "x509-parser",
 ]
 
 [[package]]
@@ -4177,16 +4116,15 @@ dependencies = [
 
 [[package]]
 name = "interceptor"
-version = "0.15.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea51375727680dc15f06e8ad90fa31df75d79dd030100e8ad60eef1c27fe2c98"
+checksum = "1ac0781c825d602095113772e389ef0607afcb869ae0e68a590d8e0799cdcef8"
 dependencies = [
  "async-trait",
  "bytes",
- "futures",
  "log",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "rtcp",
  "rtp",
  "thiserror 1.0.61",
@@ -6278,17 +6216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
-dependencies = [
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7094,9 +7021,9 @@ dependencies = [
 
 [[package]]
 name = "rtcp"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d30d1c4091644431c22acf9f8be6191b56805e0e977f15ca7104b4a6d6eaec"
+checksum = "e9689528bf3a9eb311fd938d05516dd546412f9ce4fffc8acfc1db27cc3dbf72"
 dependencies = [
  "bytes",
  "thiserror 1.0.61",
@@ -7105,14 +7032,14 @@ dependencies = [
 
 [[package]]
 name = "rtp"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f126f38ea84c02480e32e547c1459a939052f74fb92117ac3eef23fdac6b023"
+checksum = "c54733451a67d76caf9caa07a7a2cec6871ea9dda92a7847f98063d459200f4b"
 dependencies = [
  "bytes",
  "memchr",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "serde 1.0.228",
  "thiserror 1.0.61",
  "webrtc-util",
@@ -7547,11 +7474,11 @@ dependencies = [
 
 [[package]]
 name = "sdp"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c374dceda16965d541c8800ce9cc4e1c14acfd661ddf7952feeedc3411e5c6"
+checksum = "4cd277015eada44a0bb810a4b84d3bf6e810573fa62fb442f457edf6a1087a69"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.8.5",
  "substring",
  "thiserror 1.0.61",
  "url",
@@ -8129,15 +8056,15 @@ dependencies = [
 
 [[package]]
 name = "stun"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a512c5d501e3e3b5a4bb3e8e31462d56d54a66b95a28b8596e14422bf21c32b"
+checksum = "7dbc2bab375524093c143dc362a03fb6a1fb79e938391cdb21665688f88a088a"
 dependencies = [
  "base64 0.22.1",
  "crc",
  "lazy_static",
  "md-5",
- "rand 0.9.2",
+ "rand 0.8.5",
  "ring",
  "subtle",
  "thiserror 1.0.61",
@@ -9048,9 +8975,9 @@ dependencies = [
 
 [[package]]
 name = "turn"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed995882f66ab94238de77c62e5e778389698ab700afa4696f4754da8f457cb"
+checksum = "3f5aea1116456e1da71c45586b87c72e3b43164fbf435eb93ff6aa475416a9a4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9058,7 +8985,7 @@ dependencies = [
  "log",
  "md-5",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "ring",
  "stun",
  "thiserror 1.0.61",
@@ -9183,12 +9110,6 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"
@@ -9724,25 +9645,26 @@ dependencies = [
 
 [[package]]
 name = "webrtc"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08fd686c0920ac08f3a57eacc48e31f0e4ca1ffefba4478784606f78c14e83ad"
+checksum = "24bab7195998d605c862772f90a452ba655b90a2f463c850ac032038890e367a"
 dependencies = [
  "arc-swap",
  "async-trait",
  "bytes",
- "dtls",
+ "cfg-if 1.0.0",
  "hex",
  "interceptor",
  "lazy_static",
  "log",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "rcgen",
  "regex",
  "ring",
  "rtcp",
  "rtp",
+ "rustls",
  "sdp",
  "serde 1.0.228",
  "serde_json 1.0.118",
@@ -9750,12 +9672,13 @@ dependencies = [
  "smol_str",
  "stun",
  "thiserror 1.0.61",
+ "time 0.3.36",
  "tokio",
  "turn",
- "unicase",
  "url",
  "waitgroup",
  "webrtc-data",
+ "webrtc-dtls",
  "webrtc-ice",
  "webrtc-mdns",
  "webrtc-media",
@@ -9766,9 +9689,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-data"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062a5438d63bb0756a221693d76cc0dd6119affee1dfdfe57abe3a2a8c8b3eea"
+checksum = "4e97b932854da633a767eff0cc805425a2222fc6481e96f463e57b015d949d1d"
 dependencies = [
  "bytes",
  "log",
@@ -9780,17 +9703,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "webrtc-ice"
-version = "0.14.0"
+name = "webrtc-dtls"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cb13fd1a373e68addc4bba0c8ca058627518e54342583d024bdcbb8ae5d97d"
+checksum = "5ccbe4d9049390ab52695c3646c1395c877e16c15fb05d3bda8eee0c7351711c"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "bincode",
+ "byteorder",
+ "cbc",
+ "ccm",
+ "der-parser",
+ "hkdf",
+ "hmac",
+ "log",
+ "p256",
+ "p384",
+ "portable-atomic",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring",
+ "rustls",
+ "sec1",
+ "serde 1.0.228",
+ "sha1",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.61",
+ "tokio",
+ "webrtc-util",
+ "x25519-dalek",
+ "x509-parser",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb51bde0d790f109a15bfe4d04f1b56fb51d567da231643cb3f21bb74d678997"
 dependencies = [
  "arc-swap",
  "async-trait",
  "crc",
  "log",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "serde 1.0.228",
  "serde_json 1.0.118",
  "stun",
@@ -9806,9 +9766,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-mdns"
-version = "0.10.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17279a067e75df72ce923fdeb7f04cd808f6f5aa4910dc6bcb4fbe66b396ace"
+checksum = "979cc85259c53b7b620803509d10d35e2546fa505d228850cbe3f08765ea6ea8"
 dependencies = [
  "log",
  "socket2 0.5.10",
@@ -9819,22 +9779,22 @@ dependencies = [
 
 [[package]]
 name = "webrtc-media"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a84c910fec0848fd5a0d8a5651e0ddbdedaf25a7d3ae3f0b15f71ac73a1773"
+checksum = "80041211deccda758a3e19aa93d6b10bc1d37c9183b519054b40a83691d13810"
 dependencies = [
  "byteorder",
  "bytes",
- "rand 0.9.2",
+ "rand 0.8.5",
  "rtp",
  "thiserror 1.0.61",
 ]
 
 [[package]]
 name = "webrtc-sctp"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f985465467d8910c1f8ac4382cd64f83b1f6a1a75021a82b221546f6fb3b856f"
+checksum = "07439c134425d51d2f10907aaf2f815fdfb587dce19fe94a4ae8b5faf2aae5ae"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9842,7 +9802,7 @@ dependencies = [
  "crc",
  "log",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "thiserror 1.0.61",
  "tokio",
  "webrtc-util",
@@ -9850,9 +9810,9 @@ dependencies = [
 
 [[package]]
 name = "webrtc-srtp"
-version = "0.16.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d8cdc33413f1d0192670a80ce93d17cb78d57fe3a2414be30d6f6dff121123"
+checksum = "01e773f79b09b057ffbda6b03fe7b43403b012a240cf8d05d630674c3723b5bb"
 dependencies = [
  "aead",
  "aes",
@@ -9873,19 +9833,20 @@ dependencies = [
 
 [[package]]
 name = "webrtc-util"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c0c7e0c8f280f2bbfae442701465777ac07adaf46ce0c5863cd58e13fe472a"
+checksum = "64bfb10dbe6d762f80169ae07cf252bafa1f764b9594d140008a0231c0cdce58"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "bytes",
  "ipnet",
  "lazy_static",
+ "libc",
  "log",
  "nix 0.26.4",
  "portable-atomic",
- "rand 0.9.2",
+ "rand 0.8.5",
  "thiserror 1.0.61",
  "tokio",
  "winapi 0.3.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,6 +3687,7 @@ dependencies = [
  "mac_address",
  "machine-uid",
  "osascript",
+ "percent-encoding",
  "protobuf",
  "protobuf-codegen",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9747,8 +9747,7 @@ dependencies = [
 [[package]]
 name = "webrtc-util"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bfb10dbe6d762f80169ae07cf252bafa1f764b9594d140008a0231c0cdce58"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=ac9e74ec2dc502d9afce8d5fc3c9644f2139aee7#ac9e74ec2dc502d9afce8d5fc3c9644f2139aee7"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "kcp-sys"
 version = "0.1.0"
-source = "git+https://github.com/rustdesk-org/kcp-sys?branch=rustdesk-patches#fa51c1574318c6d8938697223c147a1a446f7ef1"
+source = "git+https://github.com/rustdesk-org/kcp-sys?branch=rustdesk-patches#023a0065398968989f2ddfcf5cc72bb886d02675"
 dependencies = [
  "anyhow",
  "auto_impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.9.1",
  "cexpr",
@@ -4276,11 +4276,11 @@ dependencies = [
 [[package]]
 name = "kcp-sys"
 version = "0.1.0"
-source = "git+https://github.com/rustdesk-org/kcp-sys#32a6c09fc6223f54aea83981a6aa8995931d29be"
+source = "git+https://github.com/rustdesk-org/kcp-sys?branch=rustdesk-patches#acd13bad5248c7ea0f4c0595a627c308af210fb1"
 dependencies = [
  "anyhow",
  "auto_impl",
- "bindgen 0.71.1",
+ "bindgen 0.72.1",
  "bitflags 2.9.1",
  "bytes",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,24 +763,6 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
- "proc-macro2 1.0.93",
- "quote 1.0.36",
- "regex",
- "rustc-hash 2.1.1",
- "shlex",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.9.1",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2 1.0.93",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,7 +2281,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.4",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -2784,7 +2784,7 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "log",
- "nu-ansi-term 0.49.0",
+ "nu-ansi-term",
  "regex",
  "thiserror 1.0.61",
 ]
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "kcp-sys"
 version = "0.1.0"
-source = "git+https://github.com/rustdesk-org/kcp-sys?branch=rustdesk-patches#acd13bad5248c7ea0f4c0595a627c308af210fb1"
+source = "git+https://github.com/rustdesk-org/kcp-sys?branch=rustdesk-patches#fa51c1574318c6d8938697223c147a1a446f7ef1"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -4273,8 +4273,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",
- "tracing",
- "tracing-subscriber",
  "zerocopy 0.7.34",
 ]
 
@@ -4408,7 +4406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5132,16 +5130,6 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "nu-ansi-term"
 version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
@@ -5802,12 +5790,6 @@ dependencies = [
  "serde_derive",
  "serde_json 1.0.118",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -7691,15 +7673,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8429,16 +8402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if 1.0.0",
- "once_cell",
-]
-
-[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8817,32 +8780,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
-dependencies = [
- "nu-ansi-term 0.46.0",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -9237,12 +9174,6 @@ checksum = "6779878362b9bacadc7893eac76abe69612e8837ef746573c4a5239daf11990b"
 dependencies = [
  "bindgen 0.65.1",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9706,8 +9706,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sctp"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07439c134425d51d2f10907aaf2f815fdfb587dce19fe94a4ae8b5faf2aae5ae"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833#56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9747,7 +9746,7 @@ dependencies = [
 [[package]]
 name = "webrtc-util"
 version = "0.11.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=ac9e74ec2dc502d9afce8d5fc3c9644f2139aee7#ac9e74ec2dc502d9afce8d5fc3c9644f2139aee7"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833#56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sctp"
 version = "0.12.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833#56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=0a84ba37fbca940b82f230fb469d1b3a3172abf6#0a84ba37fbca940b82f230fb469d1b3a3172abf6"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9746,7 +9746,7 @@ dependencies = [
 [[package]]
 name = "webrtc-util"
 version = "0.11.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833#56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=0a84ba37fbca940b82f230fb469d1b3a3172abf6#0a84ba37fbca940b82f230fb469d1b3a3172abf6"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sctp"
 version = "0.12.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=65fbe090326bf3abe8480d159b6bb07b5f509c22#65fbe090326bf3abe8480d159b6bb07b5f509c22"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=825a0a4862818f74406d8e1cc25be72259228235#825a0a4862818f74406d8e1cc25be72259228235"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9747,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "webrtc-util"
 version = "0.11.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=65fbe090326bf3abe8480d159b6bb07b5f509c22#65fbe090326bf3abe8480d159b6bb07b5f509c22"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=825a0a4862818f74406d8e1cc25be72259228235#825a0a4862818f74406d8e1cc25be72259228235"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sctp"
 version = "0.12.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=0a84ba37fbca940b82f230fb469d1b3a3172abf6#0a84ba37fbca940b82f230fb469d1b3a3172abf6"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=65fbe090326bf3abe8480d159b6bb07b5f509c22#65fbe090326bf3abe8480d159b6bb07b5f509c22"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9747,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "webrtc-util"
 version = "0.11.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=0a84ba37fbca940b82f230fb469d1b3a3172abf6#0a84ba37fbca940b82f230fb469d1b3a3172abf6"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=65fbe090326bf3abe8480d159b6bb07b5f509c22#65fbe090326bf3abe8480d159b6bb07b5f509c22"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7158,6 +7158,7 @@ dependencies = [
  "terminfo",
  "termios 0.3.3",
  "tiny-skia",
+ "tokio",
  "totp-rs",
  "tray-icon",
  "ttf-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sctp"
 version = "0.12.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=cc6633bc240936b4973a3a30b12dad02d9a57f3f#cc6633bc240936b4973a3a30b12dad02d9a57f3f"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956#2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "webrtc-util"
 version = "0.11.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=cc6633bc240936b4973a3a30b12dad02d9a57f3f#cc6633bc240936b4973a3a30b12dad02d9a57f3f"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956#2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sctp"
 version = "0.12.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=825a0a4862818f74406d8e1cc25be72259228235#825a0a4862818f74406d8e1cc25be72259228235"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=cc6633bc240936b4973a3a30b12dad02d9a57f3f#cc6633bc240936b4973a3a30b12dad02d9a57f3f"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "webrtc-util"
 version = "0.11.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=825a0a4862818f74406d8e1cc25be72259228235#825a0a4862818f74406d8e1cc25be72259228235"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=cc6633bc240936b4973a3a30b12dad02d9a57f3f#cc6633bc240936b4973a3a30b12dad02d9a57f3f"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sctp"
 version = "0.12.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956#2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=48100bf13e694d7e5bbb49b9a753dbad1c359d0c#48100bf13e694d7e5bbb49b9a753dbad1c359d0c"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -9748,7 +9748,7 @@ dependencies = [
 [[package]]
 name = "webrtc-util"
 version = "0.11.0"
-source = "git+https://github.com/rustdesk-org/webrtc?rev=2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956#2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956"
+source = "git+https://github.com/rustdesk-org/webrtc?rev=48100bf13e694d7e5bbb49b9a753dbad1c359d0c#48100bf13e694d7e5bbb49b9a753dbad1c359d0c"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.9.1",
  "cexpr",
@@ -4282,11 +4282,11 @@ dependencies = [
 [[package]]
 name = "kcp-sys"
 version = "0.1.0"
-source = "git+https://github.com/rustdesk-org/kcp-sys#32a6c09fc6223f54aea83981a6aa8995931d29be"
+source = "git+https://github.com/rustdesk-org/kcp-sys?branch=rustdesk-patches#acd13bad5248c7ea0f4c0595a627c308af210fb1"
 dependencies = [
  "anyhow",
  "auto_impl",
- "bindgen 0.71.1",
+ "bindgen 0.72.1",
  "bitflags 2.9.1",
  "bytes",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ screencapturekit = ["cpal/screencapturekit"]
 [dependencies]
 async-trait = "0.1"
 scrap = { path = "libs/scrap", features = ["wayland"] }
-hbb_common = { path = "libs/hbb_common" }
+hbb_common = { path = "libs/hbb_common", features = ["webrtc"] }
 serde_derive = "1.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,8 +223,8 @@ libxdo-sys = { path = "libs/libxdo-sys-stub" }
 # IPv6; and its AIMD pins a lossy long-haul link to MSS/(RTT*sqrt(p)), so a switch sends without
 # a congestion window, as KCP does - on by default, `allow-webrtc-congestion-control` opts back in.
 # Pinned by rev, not branch: a fork branch can be rewritten out from under the lockfile.
-webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "65fbe090326bf3abe8480d159b6bb07b5f509c22" }
-webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "65fbe090326bf3abe8480d159b6bb07b5f509c22" }
+webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "825a0a4862818f74406d8e1cc25be72259228235" }
+webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "825a0a4862818f74406d8e1cc25be72259228235" }
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,10 +220,11 @@ libxdo-sys = { path = "libs/libxdo-sys-stub" }
 # one comes out byte-swapped, fails to bind, and ICE gathers no IPv6 host candidate on Windows.
 # webrtc-sctp: RFC 4960's 1s RTO floor makes a single loss cost 1-3s on a link whose RTT is 24-64ms,
 # and fast retransmit cannot cover a request/response exchange; INITIAL_MTU 1228 also fragments on
-# IPv6. The fork commit carries the arithmetic.
+# IPv6; and its AIMD pins a lossy long-haul link to MSS/(RTT*sqrt(p)), so a switch sends without
+# a congestion window, as KCP does - on by default, `allow-webrtc-congestion-control` opts back in.
 # Pinned by rev, not branch: a fork branch can be rewritten out from under the lockfile.
-webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "0a84ba37fbca940b82f230fb469d1b3a3172abf6" }
-webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "0a84ba37fbca940b82f230fb469d1b3a3172abf6" }
+webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "65fbe090326bf3abe8480d159b6bb07b5f509c22" }
+webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "65fbe090326bf3abe8480d159b6bb07b5f509c22" }
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ fon = "0.6"
 shutdown_hooks = "0.1"
 totp-rs = { version = "5.4", default-features = false, features = ["gen_secret", "otpauth"] }
 stunclient = "0.4"
-kcp-sys= { git = "https://github.com/rustdesk-org/kcp-sys"}
+kcp-sys= { git = "https://github.com/rustdesk-org/kcp-sys", branch = "rustdesk-patches" }
 reqwest = { version = "0.12", features = ["blocking", "socks", "json", "native-tls", "rustls-tls", "rustls-tls-native-roots", "gzip", "zstd"], default-features=false }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,8 @@ libxdo-sys = { path = "libs/libxdo-sys-stub" }
 # and fast retransmit cannot cover a request/response exchange; INITIAL_MTU 1228 also fragments on
 # IPv6. The fork commit carries the arithmetic.
 # Pinned by rev, not branch: a fork branch can be rewritten out from under the lockfile.
-webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833" }
-webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833" }
+webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "0a84ba37fbca940b82f230fb469d1b3a3172abf6" }
+webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "0a84ba37fbca940b82f230fb469d1b3a3172abf6" }
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ screencapturekit = ["cpal/screencapturekit"]
 [dependencies]
 async-trait = "0.1"
 scrap = { path = "libs/scrap", features = ["wayland"] }
-hbb_common = { path = "libs/hbb_common" }
+hbb_common = { path = "libs/hbb_common", features = ["webrtc"] }
 serde_derive = "1.0"
 serde = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,10 +215,15 @@ exclude = ["vdi/host"]
 # This allows building and running on systems without libxdo installed (e.g., Wayland-only)
 [patch.crates-io]
 libxdo-sys = { path = "libs/libxdo-sys-stub" }
-# webrtc-util reads the Windows adapter list's IPv6 addresses as host-order u16 groups, so every
+# One branch off upstream v0.13.0, the tag whose crate versions match this stack.
+# webrtc-util: reads the Windows adapter list's IPv6 addresses as host-order u16 groups, so every
 # one comes out byte-swapped, fails to bind, and ICE gathers no IPv6 host candidate on Windows.
+# webrtc-sctp: RFC 4960's 1s RTO floor makes a single loss cost 1-3s on a link whose RTT is 24-64ms,
+# and fast retransmit cannot cover a request/response exchange; INITIAL_MTU 1228 also fragments on
+# IPv6. The fork commit carries the arithmetic.
 # Pinned by rev, not branch: a fork branch can be rewritten out from under the lockfile.
-webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "ac9e74ec2dc502d9afce8d5fc3c9644f2139aee7" }
+webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833" }
+webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "56d097c54f9ea1e48c0dfbeb6ce7e66d2e66e833" }
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,6 +215,10 @@ exclude = ["vdi/host"]
 # This allows building and running on systems without libxdo installed (e.g., Wayland-only)
 [patch.crates-io]
 libxdo-sys = { path = "libs/libxdo-sys-stub" }
+# webrtc-util reads the Windows adapter list's IPv6 addresses as host-order u16 groups, so every
+# one comes out byte-swapped, fails to bind, and ICE gathers no IPv6 host candidate on Windows.
+# Pinned by rev, not branch: a fork branch can be rewritten out from under the lockfile.
+webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "ac9e74ec2dc502d9afce8d5fc3c9644f2139aee7" }
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,6 +243,7 @@ os-version = "0.2"
 [dev-dependencies]
 hound = "3.5"
 docopt = "1.1"
+tokio = { version = "1.44", features = ["test-util"] }
 
 [package.metadata.bundle]
 name = "RustDesk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,8 +226,8 @@ libxdo-sys = { path = "libs/libxdo-sys-stub" }
 # path that jitters, every DATA chunk asks for its SACK at once so a lost tail is back within an
 # RTT at KCP's RTO floors, and bundles of small chunks stay within the MTU.
 # Pinned by rev, not branch: a fork branch can be rewritten out from under the lockfile.
-webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "cc6633bc240936b4973a3a30b12dad02d9a57f3f" }
-webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "cc6633bc240936b4973a3a30b12dad02d9a57f3f" }
+webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956" }
+webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956" }
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,8 +226,8 @@ libxdo-sys = { path = "libs/libxdo-sys-stub" }
 # path that jitters, every DATA chunk asks for its SACK at once so a lost tail is back within an
 # RTT at KCP's RTO floors, and bundles of small chunks stay within the MTU.
 # Pinned by rev, not branch: a fork branch can be rewritten out from under the lockfile.
-webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956" }
-webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "2b8e55bcbf0ebfd465d6c34d698d4ccc5315a956" }
+webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "48100bf13e694d7e5bbb49b9a753dbad1c359d0c" }
+webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "48100bf13e694d7e5bbb49b9a753dbad1c359d0c" }
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,9 +222,12 @@ libxdo-sys = { path = "libs/libxdo-sys-stub" }
 # and fast retransmit cannot cover a request/response exchange; INITIAL_MTU 1228 also fragments on
 # IPv6; and its AIMD pins a lossy long-haul link to MSS/(RTT*sqrt(p)), so a switch sends without
 # a congestion window, as KCP does - on by default, `allow-webrtc-congestion-control` opts back in.
+# Sending that way, a reordering window keeps a chunk that is merely late from being resent on a
+# path that jitters, every DATA chunk asks for its SACK at once so a lost tail is back within an
+# RTT at KCP's RTO floors, and bundles of small chunks stay within the MTU.
 # Pinned by rev, not branch: a fork branch can be rewritten out from under the lockfile.
-webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "825a0a4862818f74406d8e1cc25be72259228235" }
-webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "825a0a4862818f74406d8e1cc25be72259228235" }
+webrtc-util = { git = "https://github.com/rustdesk-org/webrtc", rev = "cc6633bc240936b4973a3a30b12dad02d9a57f3f" }
+webrtc-sctp = { git = "https://github.com/rustdesk-org/webrtc", rev = "cc6633bc240936b4973a3a30b12dad02d9a57f3f" }
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ zip = "0.6"
 shutdown_hooks = "0.1"
 totp-rs = { version = "5.4", default-features = false, features = ["gen_secret", "otpauth"] }
 stunclient = "0.4"
-kcp-sys= { git = "https://github.com/rustdesk-org/kcp-sys"}
+kcp-sys= { git = "https://github.com/rustdesk-org/kcp-sys", branch = "rustdesk-patches" }
 reqwest = { version = "0.12", features = ["blocking", "socks", "json", "native-tls", "rustls-tls", "rustls-tls-native-roots", "gzip"], default-features=false }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]

--- a/build.rs
+++ b/build.rs
@@ -43,6 +43,15 @@ fn build_manifest() {
     }
 }
 
+// bionic only exports getifaddrs()/freeifaddrs() from API 24, while the jniLibs
+// are built against the API 21 sysroot (flutter/ndk_*.sh). webrtc-util calls
+// them, so without this the android link fails on undefined symbols.
+fn build_android_ifaddrs() {
+    let file = "src/platform/android_ifaddrs.c";
+    cc::Build::new().file(file).compile("android_ifaddrs");
+    println!("cargo:rerun-if-changed={}", file);
+}
+
 fn install_android_deps() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     if target_os != "android" {
@@ -88,6 +97,9 @@ fn main() {
         #[cfg(target_os = "macos")]
         build_mac();
         println!("cargo:rustc-link-lib=framework=ApplicationServices");
+    }
+    if target_os == "android" {
+        build_android_ifaddrs();
     }
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -1633,7 +1633,8 @@ String bool2option(String option, bool b) {
   String res;
   if (option.startsWith('enable-') &&
       option != kOptionEnableUdpPunch &&
-      option != kOptionEnableIpv6Punch) {
+      option != kOptionEnableIpv6Punch &&
+      option != kOptionEnableWebrtc) {
     res = b ? defaultOptionYes : 'N';
   } else if (option.startsWith('allow-') ||
       option == kOptionStopService ||

--- a/flutter/lib/common/widgets/overlay.dart
+++ b/flutter/lib/common/widgets/overlay.dart
@@ -606,6 +606,9 @@ class QualityMonitor extends StatelessWidget {
                       _row(
                           "Codec", qualityMonitorModel.data.codecFormat ?? '-'),
                       _row("Chroma", qualityMonitorModel.data.chroma ?? '-'),
+                      if (qualityMonitorModel.webrtcTransport != null)
+                        _row("Transport",
+                            qualityMonitorModel.webrtcTransport!),
                     ],
                   ),
                 )

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -172,6 +172,7 @@ const String kOptionAllowRemoveWallpaper = "allow-remove-wallpaper";
 const String kOptionStopService = "stop-service";
 const String kOptionDirectxCapture = "enable-directx-capture";
 const String kOptionAllowRemoteCmModification = "allow-remote-cm-modification";
+const String kOptionEnableTcpPunch = "enable-tcp-punch";
 const String kOptionEnableUdpPunch = "enable-udp-punch";
 const String kOptionEnableIpv6Punch = "enable-ipv6-punch";
 const String kOptionAllowSyncClipboardBetweenSessions =

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -176,6 +176,7 @@ const String kOptionEnableUdpPunch = "enable-udp-punch";
 const String kOptionEnableIpv6Punch = "enable-ipv6-punch";
 const String kOptionAllowSyncClipboardBetweenSessions =
     "allow-sync-clipboard-between-sessions";
+const String kOptionEnableWebrtc = "enable-webrtc";
 const String kOptionEnableTrustedDevices = "enable-trusted-devices";
 const String kOptionShowVirtualMouse = "show-virtual-mouse";
 const String kOptionVirtualMouseScale = "virtual-mouse-scale";

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -584,6 +584,12 @@ class _GeneralState extends State<_General> {
           kOptionEnableIpv6Punch,
           isServer: false,
         ),
+        _OptionCheckBox(
+          context,
+          'Enable WebRTC P2P connection',
+          kOptionEnableWebrtc,
+          isServer: false,
+        ),
         Tooltip(
           message: translate('sync-clipboard-between-sessions-tip'),
           child: _OptionCheckBox(

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -590,12 +590,15 @@ class _GeneralState extends State<_General> {
           kOptionEnableIpv6Punch,
           isServer: false,
         ),
+      ],
+      if (!incomingOnly)
         _OptionCheckBox(
           context,
           'Enable WebRTC P2P connection',
           kOptionEnableWebrtc,
           isServer: false,
         ),
+      if (!isWeb && !incomingOnly)
         Tooltip(
           message: translate('sync-clipboard-between-sessions-tip'),
           child: _OptionCheckBox(
@@ -605,7 +608,6 @@ class _GeneralState extends State<_General> {
             isServer: false,
           ),
         ),
-      ],
     ];
 
     // Add client-side wakelock option for desktop platforms

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -574,6 +574,12 @@ class _GeneralState extends State<_General> {
       if (!isWeb && !incomingOnly) ...[
         _OptionCheckBox(
           context,
+          'Enable TCP hole punching',
+          kOptionEnableTcpPunch,
+          isServer: false,
+        ),
+        _OptionCheckBox(
+          context,
           'Enable UDP hole punching',
           kOptionEnableUdpPunch,
           isServer: false,

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -101,6 +101,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
   var _allowInsecureTlsFallback = false;
   var _disableUdp = false;
   var _enableIpv6Punch = false;
+  var _enableWebrtc = false;
   var _isUsingPublicServer = false;
   var _allowAskForNoteAtEndOfConnection = false;
   var _preventSleepWhileConnected = true;
@@ -143,6 +144,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
     _enableTrustedDevices = mainGetBoolOptionSync(kOptionEnableTrustedDevices);
     _enableUdpPunch = mainGetLocalBoolOptionSync(kOptionEnableUdpPunch);
     _enableIpv6Punch = mainGetLocalBoolOptionSync(kOptionEnableIpv6Punch);
+    _enableWebrtc = mainGetLocalBoolOptionSync(kOptionEnableWebrtc);
     _allowAskForNoteAtEndOfConnection =
         mainGetLocalBoolOptionSync(kOptionAllowAskForNoteAtEndOfConnection);
     _preventSleepWhileConnected =
@@ -838,6 +840,18 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
                     mainGetLocalBoolOptionSync(kOptionEnableIpv6Punch);
                 setState(() {
                   _enableIpv6Punch = newValue;
+                });
+              },
+            ),
+          if (!incomingOnly)
+            SettingsTile.switchTile(
+              title: Text(translate('Enable WebRTC P2P connection')),
+              initialValue: _enableWebrtc,
+              onToggle: (v) async {
+                await mainSetLocalBoolOption(kOptionEnableWebrtc, v);
+                final newValue = mainGetLocalBoolOptionSync(kOptionEnableWebrtc);
+                setState(() {
+                  _enableWebrtc = newValue;
                 });
               },
             ),

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -97,6 +97,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
   var _hideNetwork = false;
   var _hideWebSocket = false;
   var _enableTrustedDevices = false;
+  var _enableTcpPunch = false;
   var _enableUdpPunch = false;
   var _allowInsecureTlsFallback = false;
   var _disableUdp = false;
@@ -142,6 +143,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
         bind.mainGetBuildinOption(key: kOptionHideWebSocketSetting) == 'Y' ||
             isWeb;
     _enableTrustedDevices = mainGetBoolOptionSync(kOptionEnableTrustedDevices);
+    _enableTcpPunch = mainGetLocalBoolOptionSync(kOptionEnableTcpPunch);
     _enableUdpPunch = mainGetLocalBoolOptionSync(kOptionEnableUdpPunch);
     _enableIpv6Punch = mainGetLocalBoolOptionSync(kOptionEnableIpv6Punch);
     _enableWebrtc = mainGetLocalBoolOptionSync(kOptionEnableWebrtc);
@@ -819,41 +821,63 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
             ),
           if (!incomingOnly)
             SettingsTile.switchTile(
+              title: Text(translate('Enable TCP hole punching')),
+              initialValue: _enableTcpPunch,
+              onToggle: isOptionFixed(kOptionEnableTcpPunch)
+                  ? null
+                  : (v) async {
+                      await mainSetLocalBoolOption(kOptionEnableTcpPunch, v);
+                      final newValue =
+                          mainGetLocalBoolOptionSync(kOptionEnableTcpPunch);
+                      setState(() {
+                        _enableTcpPunch = newValue;
+                      });
+                    },
+            ),
+          if (!incomingOnly)
+            SettingsTile.switchTile(
               title: Text(translate('Enable UDP hole punching')),
               initialValue: _enableUdpPunch,
-              onToggle: (v) async {
-                await mainSetLocalBoolOption(kOptionEnableUdpPunch, v);
-                final newValue =
-                    mainGetLocalBoolOptionSync(kOptionEnableUdpPunch);
-                setState(() {
-                  _enableUdpPunch = newValue;
-                });
-              },
+              onToggle: isOptionFixed(kOptionEnableUdpPunch)
+                  ? null
+                  : (v) async {
+                      await mainSetLocalBoolOption(kOptionEnableUdpPunch, v);
+                      final newValue =
+                          mainGetLocalBoolOptionSync(kOptionEnableUdpPunch);
+                      setState(() {
+                        _enableUdpPunch = newValue;
+                      });
+                    },
             ),
           if (!incomingOnly)
             SettingsTile.switchTile(
               title: Text(translate('Enable IPv6 P2P connection')),
               initialValue: _enableIpv6Punch,
-              onToggle: (v) async {
-                await mainSetLocalBoolOption(kOptionEnableIpv6Punch, v);
-                final newValue =
-                    mainGetLocalBoolOptionSync(kOptionEnableIpv6Punch);
-                setState(() {
-                  _enableIpv6Punch = newValue;
-                });
-              },
+              onToggle: isOptionFixed(kOptionEnableIpv6Punch)
+                  ? null
+                  : (v) async {
+                      await mainSetLocalBoolOption(kOptionEnableIpv6Punch, v);
+                      final newValue =
+                          mainGetLocalBoolOptionSync(kOptionEnableIpv6Punch);
+                      setState(() {
+                        _enableIpv6Punch = newValue;
+                      });
+                    },
             ),
           if (!incomingOnly)
             SettingsTile.switchTile(
               title: Text(translate('Enable WebRTC P2P connection')),
               initialValue: _enableWebrtc,
-              onToggle: (v) async {
-                await mainSetLocalBoolOption(kOptionEnableWebrtc, v);
-                final newValue = mainGetLocalBoolOptionSync(kOptionEnableWebrtc);
-                setState(() {
-                  _enableWebrtc = newValue;
-                });
-              },
+              onToggle: isOptionFixed(kOptionEnableWebrtc)
+                  ? null
+                  : (v) async {
+                      await mainSetLocalBoolOption(kOptionEnableWebrtc, v);
+                      final newValue =
+                          mainGetLocalBoolOptionSync(kOptionEnableWebrtc);
+                      setState(() {
+                        _enableWebrtc = newValue;
+                      });
+                    },
             ),
           SettingsTile(
               title: Text(translate('Language')),

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -3597,6 +3597,16 @@ class QualityMonitorModel with ChangeNotifier {
   bool get show => _show;
   QualityMonitorData get data => _data;
 
+  // Only a WebRTC session names its transport here: web has no session tab
+  // to show it on, and WebRTC is the one path that can be direct or TURN.
+  String? get webrtcTransport {
+    final ffiModel = parent.target?.ffiModel;
+    if (ffiModel == null) return null;
+    final streamType = ffiModel.cachedPeerData.streamType;
+    if (!streamType.startsWith('WebRTC')) return null;
+    return ffiModel.direct == false ? '$streamType (TURN)' : streamType;
+  }
+
   checkShowQualityMonitor(SessionID sessionId) async {
     final show = await bind.sessionGetToggleOption(
             sessionId: sessionId, arg: 'show-quality-monitor') ==

--- a/libs/scrap/examples/benchmark.rs
+++ b/libs/scrap/examples/benchmark.rs
@@ -143,7 +143,7 @@ fn test_vpx(
     println!(
         "{:?} encode: {:?}, {} byte",
         codec_id,
-        time_sum / yuv_count as _,
+        time_sum / yuv_count as u32,
         size / yuv_count
     );
 
@@ -156,7 +156,7 @@ fn test_vpx(
     println!(
         "{:?} decode: {:?}",
         codec_id,
-        start.elapsed() / yuv_count as _
+        start.elapsed() / yuv_count as u32
     );
 }
 
@@ -212,7 +212,7 @@ fn test_av1(
     assert_eq!(av1s.len(), yuv_count);
     println!(
         "AV1 encode: {:?}, {} byte",
-        time_sum / yuv_count as _,
+        time_sum / yuv_count as u32,
         size / yuv_count
     );
     let mut decoder = AomDecoder::new().unwrap();
@@ -221,7 +221,7 @@ fn test_av1(
         let _ = decoder.decode(&av1);
         let _ = decoder.flush();
     }
-    println!("AV1 decode: {:?}", start.elapsed() / yuv_count as _);
+    println!("AV1 decode: {:?}", start.elapsed() / yuv_count as u32);
 }
 
 #[cfg(feature = "hwcodec")]

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,11 +65,12 @@ use hbb_common::{
         self,
         net::UdpSocket,
         sync::{
-            mpsc::{unbounded_channel, UnboundedReceiver},
+            mpsc::{error::TryRecvError, unbounded_channel, UnboundedReceiver},
             oneshot,
         },
         time::{interval, Duration, Instant},
     },
+    webrtc::WebRTCStream,
     AddrMangle, ResultType, Stream,
 };
 pub use helper::*;
@@ -332,6 +333,19 @@ impl Client {
         } else {
             (None, None)
         };
+        let ipv6 = if crate::get_ipv6_punch_enabled() {
+            crate::get_ipv6_socket().await
+        } else {
+            None
+        };
+        let webrtc_offerer =
+            match WebRTCStream::new("", interface.is_force_relay(), CONNECT_TIMEOUT).await {
+                Ok(stream) => Some(stream),
+                Err(err) => {
+                    log::warn!("webrtc offerer setup failed: {}", err);
+                    None
+                }
+            };
         let fut = Self::_start_inner(
             peer.to_owned(),
             key.to_owned(),
@@ -340,6 +354,8 @@ impl Client {
             interface.clone(),
             udp.clone(),
             Some(stop_udp_tx),
+            ipv6,
+            webrtc_offerer,
             rendezvous_server.clone(),
             servers.clone(),
             contained,
@@ -357,6 +373,8 @@ impl Client {
             interface,
             (None, None),
             None,
+            None,
+            None,
             rendezvous_server,
             servers,
             contained,
@@ -368,6 +386,68 @@ impl Client {
         }
     }
 
+    fn spawn_webrtc_ice_bridge(
+        mut socket: Stream,
+        mut local_ice_rx: Option<UnboundedReceiver<String>>,
+        webrtc: WebRTCStream,
+        peer: String,
+        session_key: String,
+    ) -> oneshot::Sender<()> {
+        let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+        let my_id = Config::get_id();
+        tokio::spawn(async move {
+            loop {
+                match stop_rx.try_recv() {
+                    Ok(_) | Err(tokio::sync::oneshot::error::TryRecvError::Closed) => break,
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {}
+                }
+
+                if let Some(rx) = local_ice_rx.as_mut() {
+                    loop {
+                        match rx.try_recv() {
+                            Ok(candidate) => {
+                                let mut msg = RendezvousMessage::new();
+                                msg.set_ice_candidate(IceCandidate {
+                                    from_id: my_id.clone(),
+                                    to_id: peer.clone(),
+                                    session_key: session_key.clone(),
+                                    candidate,
+                                    ..Default::default()
+                                });
+                                if let Err(err) = socket.send(&msg).await {
+                                    log::warn!("failed to send WebRTC ICE candidate: {}", err);
+                                    return;
+                                }
+                            }
+                            Err(TryRecvError::Empty) => break,
+                            Err(TryRecvError::Disconnected) => {
+                                local_ice_rx = None;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if let Some(msg_in) =
+                    crate::get_next_nonkeyexchange_msg(&mut socket, Some(100)).await
+                {
+                    if let Some(rendezvous_message::Union::IceCandidate(ice)) = msg_in.union {
+                        if ice.from_id == peer
+                            && ice.to_id == my_id
+                            && ice.session_key == session_key
+                        {
+                            if let Err(err) = webrtc.add_remote_ice_candidate(&ice.candidate).await
+                            {
+                                log::warn!("failed to add WebRTC ICE candidate: {}", err);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        stop_tx
+    }
+
     async fn _start_inner(
         peer: String,
         key: String,
@@ -376,6 +456,8 @@ impl Client {
         interface: impl Interface,
         mut udp: (Option<Arc<UdpSocket>>, Option<Arc<Mutex<u16>>>),
         stop_udp_tx: Option<oneshot::Sender<()>>,
+        mut ipv6: Option<(Arc<UdpSocket>, bytes::Bytes)>,
+        mut webrtc_offerer: Option<WebRTCStream>,
         mut rendezvous_server: String,
         servers: Vec<String>,
         contained: bool,
@@ -448,14 +530,20 @@ impl Client {
         // Stop UDP NAT test task if still running
         stop_udp_tx.map(|tx| tx.send(()));
         let mut msg_out = RendezvousMessage::new();
-        let mut ipv6 = if crate::get_ipv6_punch_enabled() {
-            if let Some((socket, addr)) = crate::get_ipv6_socket().await {
-                (Some(socket), Some(addr))
-            } else {
-                (None, None)
+        let mut ipv6 = ipv6
+            .take()
+            .map(|(socket, addr)| (Some(socket), Some(addr)))
+            .unwrap_or((None, None));
+        let webrtc_sdp_offer = if let Some(webrtc) = webrtc_offerer.as_ref() {
+            match webrtc.get_local_endpoint().await {
+                Ok(endpoint) => endpoint,
+                Err(err) => {
+                    log::warn!("failed to read local WebRTC offer: {}", err);
+                    String::new()
+                }
             }
         } else {
-            (None, None)
+            String::new()
         };
         let udp_nat_port = udp.1.map(|x| *x.lock().unwrap()).unwrap_or(0);
         let punch_type = if udp_nat_port > 0 { "UDP" } else { "TCP" };
@@ -469,8 +557,15 @@ impl Client {
             udp_port: udp_nat_port as _,
             force_relay: interface.is_force_relay(),
             socket_addr_v6: ipv6.1.unwrap_or_default(),
+            webrtc_sdp_offer: webrtc_sdp_offer.clone(),
             ..Default::default()
         });
+        let webrtc_session_key = webrtc_offerer
+            .as_ref()
+            .map(|webrtc| webrtc.session_key().to_owned())
+            .unwrap_or_default();
+        let mut webrtc_sdp_answer = String::new();
+        let mut pending_webrtc_ice = Vec::<String>::new();
         for i in 1..=3 {
             log::info!(
                 "#{} {} punch attempt with {}, id: {}",
@@ -512,6 +607,7 @@ impl Client {
                             relay_server = ph.relay_server;
                             peer_addr = AddrMangle::decode(&ph.socket_addr);
                             feedback = ph.feedback;
+                            webrtc_sdp_answer = ph.webrtc_sdp_answer;
                             let s = udp.0.take();
                             if ph.is_udp && s.is_some() {
                                 if let Some(s) = s {
@@ -551,6 +647,38 @@ impl Client {
                             }
                         }
                         signed_id_pk = rr.pk().into();
+                        let mut webrtc_bridge_stop = None;
+                        let mut webrtc_for_connect = None;
+                        if !rr.webrtc_sdp_answer.is_empty() {
+                            if let Some(webrtc) = webrtc_offerer.take() {
+                                if let Err(err) =
+                                    webrtc.set_remote_endpoint(&rr.webrtc_sdp_answer).await
+                                {
+                                    log::warn!("failed to set WebRTC relay answer: {}", err);
+                                } else {
+                                    for candidate in pending_webrtc_ice.drain(..) {
+                                        if let Err(err) =
+                                            webrtc.add_remote_ice_candidate(&candidate).await
+                                        {
+                                            log::warn!(
+                                                "failed to add buffered WebRTC ICE candidate: {}",
+                                                err
+                                            );
+                                        }
+                                    }
+                                    let session_key = webrtc.session_key().to_owned();
+                                    let local_ice_rx = webrtc.take_local_ice_rx();
+                                    webrtc_bridge_stop = Some(Self::spawn_webrtc_ice_bridge(
+                                        socket,
+                                        local_ice_rx,
+                                        webrtc.clone(),
+                                        peer.clone(),
+                                        session_key,
+                                    ));
+                                    webrtc_for_connect = Some(webrtc);
+                                }
+                            }
+                        }
                         let fut = Self::create_relay(
                             &peer,
                             rr.uuid,
@@ -566,22 +694,49 @@ impl Client {
                             }
                             .boxed(),
                         );
+                        if let Some(mut webrtc) = webrtc_for_connect {
+                            connect_futures.push(
+                                async move {
+                                    webrtc.wait_connected(CONNECT_TIMEOUT).await?;
+                                    Ok((Stream::WebRTC(webrtc), None, "WebRTC"))
+                                }
+                                .boxed(),
+                            );
+                        }
                         // Run all connection attempts concurrently, return the first successful one
                         let (conn, kcp, typ) = match select_ok(connect_futures).await {
                             Ok(conn) => (Ok(conn.0 .0), conn.0 .1, conn.0 .2),
 
                             Err(e) => (Err(e), None, ""),
                         };
+                        if let Some(stop) = webrtc_bridge_stop {
+                            let _ = stop.send(());
+                        }
                         let mut conn = conn?;
                         feedback = rr.feedback;
                         log::info!("{:?} used to establish {typ} connection", start.elapsed());
                         let pk =
                             Self::secure_connection(&peer, signed_id_pk, &key, &mut conn).await?;
                         return Ok((
-                            (conn, typ == "IPv6", pk, kcp, typ),
+                            (conn, typ == "IPv6" || typ == "WebRTC", pk, kcp, typ),
                             (feedback, rendezvous_server),
                             false,
                         ));
+                    }
+                    Some(rendezvous_message::Union::IceCandidate(ice)) => {
+                        if !webrtc_session_key.is_empty()
+                            && ice.from_id == peer
+                            && ice.to_id == Config::get_id()
+                            && ice.session_key == webrtc_session_key
+                        {
+                            pending_webrtc_ice.push(ice.candidate);
+                        } else {
+                            log::debug!(
+                                "dropping ICE candidate for unexpected WebRTC session from {} key {}",
+                                ice.from_id,
+                                ice.session_key
+                            );
+                        }
                     }
                     _ => {
                         log::error!("Unexpected protobuf msg received: {:?}", msg_in);
@@ -589,7 +744,36 @@ impl Client {
                 }
             }
         }
-        drop(socket);
+        let mut webrtc_bridge_stop = None;
+        let mut webrtc_for_connect = None;
+        if !webrtc_sdp_answer.is_empty() {
+            if let Some(webrtc) = webrtc_offerer.take() {
+                if let Err(err) = webrtc.set_remote_endpoint(&webrtc_sdp_answer).await {
+                    log::warn!("failed to set WebRTC answer: {}", err);
+                    drop(socket);
+                } else {
+                    for candidate in pending_webrtc_ice.drain(..) {
+                        if let Err(err) = webrtc.add_remote_ice_candidate(&candidate).await {
+                            log::warn!("failed to add buffered WebRTC ICE candidate: {}", err);
+                        }
+                    }
+                    let session_key = webrtc.session_key().to_owned();
+                    let local_ice_rx = webrtc.take_local_ice_rx();
+                    webrtc_bridge_stop = Some(Self::spawn_webrtc_ice_bridge(
+                        socket,
+                        local_ice_rx,
+                        webrtc.clone(),
+                        peer.clone(),
+                        session_key,
+                    ));
+                    webrtc_for_connect = Some(webrtc);
+                }
+            } else {
+                drop(socket);
+            }
+        } else {
+            drop(socket);
+        }
         if peer_addr.port() == 0 {
             bail!("Failed to connect via rendezvous server");
         }
@@ -623,6 +807,8 @@ impl Client {
                 interface,
                 udp.0,
                 ipv6.0,
+                webrtc_for_connect,
+                webrtc_bridge_stop,
                 punch_type,
             )
             .await?,
@@ -649,6 +835,8 @@ impl Client {
         interface: impl Interface,
         udp_socket_nat: Option<Arc<UdpSocket>>,
         udp_socket_v6: Option<Arc<UdpSocket>>,
+        webrtc_offerer: Option<WebRTCStream>,
+        webrtc_bridge_stop: Option<oneshot::Sender<()>>,
         punch_type: &str,
     ) -> ResultType<(
         Stream,
@@ -707,11 +895,23 @@ impl Client {
         if let Some(udp_socket_v6) = udp_socket_v6 {
             connect_futures.push(udp_nat_connect(udp_socket_v6, "IPv6", connect_timeout).boxed());
         }
+        if let Some(mut webrtc) = webrtc_offerer {
+            connect_futures.push(
+                async move {
+                    webrtc.wait_connected(connect_timeout).await?;
+                    Ok((Stream::WebRTC(webrtc), None, "WebRTC"))
+                }
+                .boxed(),
+            );
+        }
         // Run all connection attempts concurrently, return the first successful one
         let (mut conn, kcp, mut typ) = match select_ok(connect_futures).await {
             Ok(conn) => (Ok(conn.0 .0), conn.0 .1, conn.0 .2),
             Err(e) => (Err(e), None, ""),
         };
+        if let Some(stop) = webrtc_bridge_stop {
+            let _ = stop.send(());
+        }
 
         let mut direct = !conn.is_err();
         if interface.is_force_relay() || conn.is_err() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 use crate::{
     check_port,
     common::input::{MOUSE_BUTTON_LEFT, MOUSE_BUTTON_RIGHT, MOUSE_TYPE_DOWN, MOUSE_TYPE_UP},
-    create_symmetric_key_msg, decode_id_pk, get_rs_pk, is_keyboard_mode_supported,
+    create_symmetric_key_msg, decode_id_pk, decode_id_pk_dtls, get_rs_pk, is_keyboard_mode_supported,
     kcp_stream::KcpStream,
     secure_tcp,
     ui_interface::{get_builtin_option, resolve_avatar_url, use_texture_render},
@@ -51,7 +51,7 @@ use hbb_common::{
         CONNECT_TIMEOUT, READ_TIMEOUT, RELAY_PORT, RENDEZVOUS_PORT, RENDEZVOUS_SERVERS,
     },
     fs::JobType,
-    futures::future::{select_ok, FutureExt},
+    futures::future::{select_ok, BoxFuture, FutureExt},
     get_version_number, log,
     message_proto::{option_message::BoolOption, *},
     protobuf::{Message as _, MessageField},
@@ -185,6 +185,118 @@ pub fn get_key_state(key: enigo::Key) -> bool {
         return true;
     }
     ENIGO.lock().unwrap().get_key_state(key)
+}
+
+/// RAII guard for a WebRTC offerer that has not yet been adopted into a connection.
+///
+/// The offerer's `RTCPeerConnection` is created eagerly in `Client::start` and inserted into the
+/// global `SESSIONS` map; if it never receives a remote answer it stays in ICE state `New`
+/// forever, so its state-change handler never fires and it never self-removes. This guard closes
+/// the pc on drop, covering the paths that would otherwise leak it: early `?`/`bail!` returns in
+/// `_start_inner`, and `select_ok` cancelling the racing attempt that holds the offerer. Call
+/// [`OffererGuard::into_inner`] to disarm when the stream is adopted into a live connection.
+struct OffererGuard(Option<WebRTCStream>);
+
+impl OffererGuard {
+    fn new(stream: WebRTCStream) -> Self {
+        Self(Some(stream))
+    }
+
+    fn stream(&self) -> Option<&WebRTCStream> {
+        self.0.as_ref()
+    }
+
+    fn into_inner(mut self) -> Option<WebRTCStream> {
+        self.0.take()
+    }
+}
+
+impl Drop for OffererGuard {
+    fn drop(&mut self) {
+        if let Some(stream) = self.0.take() {
+            Client::spawn_close_webrtc(stream);
+        }
+    }
+}
+
+/// Race the WebRTC connect attempt against the other transport futures, preferring P2P.
+///
+/// A plain `select_ok` would almost always pick the relay: its TCP connect completes in one
+/// round trip while WebRTC needs candidate trickle + ICE checks + DTLS + SCTP. Instead:
+/// - a WebRTC success is committed immediately;
+/// - an `is_p2p` result from `others` (e.g. IPv6 direct) is committed immediately;
+/// - a relayed result inside the preference window is *held*, giving WebRTC until the window
+///   expires to connect and take priority, while unfinished `others` keep racing so a slower
+///   direct transport can still win; when the window ends (or WebRTC fails) the held connection
+///   is committed;
+/// - a failure on one side commits the survivor as soon as it succeeds; two failures compose
+///   into one error.
+///
+/// `others` must be non-empty (`select_ok` requires it).
+async fn race_transports_prefer_webrtc<'a, T: 'a>(
+    webrtc_fut: BoxFuture<'a, ResultType<T>>,
+    others: Vec<BoxFuture<'a, ResultType<T>>>,
+    window_ms: u64,
+    is_p2p: impl Fn(&T) -> bool,
+) -> ResultType<T> {
+    let mut webrtc_fut = Some(webrtc_fut);
+    let mut others_fut = Some(select_ok(others));
+    let mut held: Option<T> = None;
+    let mut webrtc_err: Option<hbb_common::anyhow::Error> = None;
+    let mut others_err: Option<hbb_common::anyhow::Error> = None;
+    let window = tokio::time::sleep(Duration::from_millis(window_ms));
+    tokio::pin!(window);
+    let mut window_over = false;
+    loop {
+        tokio::select! {
+            res = async { webrtc_fut.as_mut().unwrap().await }, if webrtc_fut.is_some() => {
+                webrtc_fut = None;
+                match res {
+                    // WebRTC connected: preferred outright; a held relay conn just drops.
+                    Ok(conn) => return Ok(conn),
+                    Err(e) => {
+                        if let Some(conn) = held.take() {
+                            return Ok(conn);
+                        }
+                        match others_err.take() {
+                            Some(oe) => bail!("WebRTC failed: {}; fallback failed: {}", e, oe),
+                            None if others_fut.is_none() => bail!("WebRTC failed: {}", e),
+                            None => webrtc_err = Some(e),
+                        }
+                    }
+                }
+            }
+            res = async { others_fut.as_mut().unwrap().await }, if others_fut.is_some() => {
+                others_fut = None;
+                match res {
+                    Ok((conn, unfinished)) => {
+                        if is_p2p(&conn) || window_over || webrtc_fut.is_none() {
+                            return Ok(conn);
+                        }
+                        // Hold the first relay, but keep polling unfinished alternatives: an IPv6
+                        // direct attempt may complete inside the same WebRTC preference window.
+                        if held.is_none() {
+                            held = Some(conn);
+                        }
+                        if !unfinished.is_empty() {
+                            others_fut = Some(select_ok(unfinished));
+                        }
+                    }
+                    Err(e) => match webrtc_err.take() {
+                        Some(we) => bail!("WebRTC failed: {}; fallback failed: {}", we, e),
+                        None if webrtc_fut.is_none() => return Err(e),
+                        None => others_err = Some(e),
+                    },
+                }
+            }
+            _ = &mut window, if !window_over => {
+                window_over = true;
+                if let Some(conn) = held.take() {
+                    return Ok(conn);
+                }
+            }
+        }
+    }
 }
 
 impl Client {
@@ -338,14 +450,17 @@ impl Client {
         } else {
             None
         };
-        let webrtc_offerer =
+        let webrtc_offerer = if Self::should_create_webrtc_offerer(&interface) {
             match WebRTCStream::new("", interface.is_force_relay(), CONNECT_TIMEOUT).await {
                 Ok(stream) => Some(stream),
                 Err(err) => {
                     log::warn!("webrtc offerer setup failed: {}", err);
                     None
                 }
-            };
+            }
+        } else {
+            None
+        };
         let fut = Self::_start_inner(
             peer.to_owned(),
             key.to_owned(),
@@ -390,6 +505,70 @@ impl Client {
         !session_key.is_empty() && ice.session_key == session_key && !ice.candidate.is_empty()
     }
 
+    /// Tear down an abandoned WebRTC offerer off the connection hot path.
+    ///
+    /// The pc must be closed explicitly (a dropped handle leaves the `SESSIONS` clone alive),
+    /// but `close()` awaits internal ICE/DTLS shutdown and the result is pure cleanup with no
+    /// downstream dependency, so it must not block session establishment.
+    fn spawn_close_webrtc(webrtc: WebRTCStream) {
+        // Use the current runtime handle explicitly: this is also called from OffererGuard::drop,
+        // which can run during runtime teardown where a bare tokio::spawn would panic. If no
+        // runtime is available the pc cannot be closed here (it is released at process exit).
+        // Handle::spawn can also panic when the runtime is shutting down; catch that so Drop
+        // never panics (prefer a brief leak until process exit over aborting the process).
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                let spawn_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    handle.spawn(async move {
+                        webrtc.close().await;
+                    });
+                }));
+                if spawn_result.is_err() {
+                    log::warn!("failed to spawn WebRTC close (runtime shutting down)");
+                }
+            }
+            Err(_) => {
+                log::warn!("no tokio runtime available to close WebRTC peer connection");
+            }
+        }
+    }
+
+    /// Whether to build a WebRTC offerer for this connection.
+    ///
+    /// Skips it when UDP punching is disabled or a SOCKS proxy/websocket transport is configured:
+    /// WebRTC's ICE binds its own UDP sockets and speaks STUN directly, which would bypass either
+    /// policy (and can leak the real IP through a proxy). Under force_relay the pc uses Relay-only
+    /// ICE, which gathers nothing and can never connect unless a TURN server is configured, so
+    /// skip building a guaranteed-dead pc + STUN/TURN gathering + answerer signaling in that case
+    /// too.
+    /// When force_relay *and* TURN are configured, WebRTC via TURN is a valid "relayed" path:
+    /// `connect` keeps a WebRTC win instead of replacing it with the RustDesk relay, and the
+    /// RelayResponse path prefers it within the WebRTC preference window.
+    fn should_create_webrtc_offerer(interface: &impl Interface) -> bool {
+        if !crate::get_udp_punch_enabled() || use_ws() || Config::is_proxy() {
+            return false;
+        }
+        if interface.is_force_relay() && !WebRTCStream::has_turn_server() {
+            return false;
+        }
+        true
+    }
+
+    /// Max ICE candidates buffered during the punch window before the answer is applied.
+    /// Bounds memory if a misbehaving rendezvous floods candidates.
+    const MAX_PENDING_WEBRTC_ICE: usize = 64;
+
+    /// Prefer-P2P window: how long a WebRTC attempt outranks an already-established relay
+    /// result, and the floor for a punch-path WebRTC attempt whose race timeout is tuned for a
+    /// raw TCP SYN. Long enough for candidate trickle + ICE checks + DTLS on high-latency
+    /// links; short enough that UDP-blocked networks settle on relay without a noticeable wait.
+    const WEBRTC_PREFER_WINDOW_MS: u64 = 2500;
+
+    /// Delay before re-sending an ICE candidate over the rendezvous route once. The hop to the
+    /// peer can be UDP (the controlled side's mediator channel), so a candidate can be lost in
+    /// flight; the remote ICE agent dedups repeats, so the second copy is free.
+    const WEBRTC_ICE_RESEND_DELAY: Duration = Duration::from_millis(400);
+
     fn spawn_webrtc_ice_bridge(
         mut socket: Stream,
         mut local_ice_rx: Option<UnboundedReceiver<String>>,
@@ -399,6 +578,7 @@ impl Client {
     ) -> oneshot::Sender<()> {
         let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
         tokio::spawn(async move {
+            let mut pending_resend: Vec<(Instant, RendezvousMessage)> = Vec::new();
             loop {
                 match stop_rx.try_recv() {
                     Ok(_) | Err(tokio::sync::oneshot::error::TryRecvError::Closed) => break,
@@ -416,10 +596,20 @@ impl Client {
                                     candidate,
                                     ..Default::default()
                                 });
-                                if let Err(err) = socket.send(&msg).await {
-                                    log::warn!("failed to send WebRTC ICE candidate: {}", err);
-                                    return;
+                                // Bound the send so a stalled rendezvous socket cannot block the
+                                // bridge past its stop signal.
+                                match timeout(3000, socket.send(&msg)).await {
+                                    Ok(Ok(())) => {}
+                                    Ok(Err(err)) => {
+                                        log::warn!("failed to send WebRTC ICE candidate: {}", err);
+                                        return;
+                                    }
+                                    Err(_) => {
+                                        log::warn!("WebRTC ICE candidate send timed out");
+                                        return;
+                                    }
                                 }
+                                pending_resend.push((Instant::now(), msg));
                             }
                             Err(TryRecvError::Empty) => break,
                             Err(TryRecvError::Disconnected) => {
@@ -430,16 +620,53 @@ impl Client {
                     }
                 }
 
-                if let Some(msg_in) =
-                    crate::get_next_nonkeyexchange_msg(&mut socket, Some(100)).await
-                {
-                    if let Some(rendezvous_message::Union::IceCandidate(ice)) = msg_in.union {
-                        if Self::is_expected_webrtc_ice_candidate(&ice, &session_key) {
-                            if let Err(err) = webrtc.add_remote_ice_candidate(&ice.candidate).await
-                            {
-                                log::warn!("failed to add WebRTC ICE candidate: {}", err);
+                // Re-send each candidate once after a short delay: the rendezvous hop to the peer
+                // can be UDP, so the first copy may be lost; the remote ICE agent dedups repeats.
+                let mut i = 0;
+                while i < pending_resend.len() {
+                    if pending_resend[i].0.elapsed() >= Self::WEBRTC_ICE_RESEND_DELAY {
+                        let (_, msg) = pending_resend.swap_remove(i);
+                        match timeout(3000, socket.send(&msg)).await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(err)) => {
+                                log::warn!("failed to re-send WebRTC ICE candidate: {}", err);
+                                return;
+                            }
+                            Err(_) => {
+                                log::warn!("WebRTC ICE candidate re-send timed out");
+                                return;
                             }
                         }
+                    } else {
+                        i += 1;
+                    }
+                }
+
+                // Read one incoming message, blocking up to the poll window. Distinguish a real
+                // timeout (keep looping to drain outbound candidates) from stream EOF/error: the
+                // rendezvous server closes the punch connection after the response, and an
+                // unrecognized-message server closes it on the first candidate we send. Without
+                // this, the collapsed None-on-EOF made the loop hot-spin a core until stop.
+                match timeout(100, socket.next()).await {
+                    Err(_) => {}
+                    Ok(None) => break,
+                    Ok(Some(Ok(bytes))) => {
+                        if let Ok(msg_in) = RendezvousMessage::parse_from_bytes(&bytes) {
+                            if let Some(rendezvous_message::Union::IceCandidate(ice)) = msg_in.union
+                            {
+                                if Self::is_expected_webrtc_ice_candidate(&ice, &session_key) {
+                                    if let Err(err) =
+                                        webrtc.add_remote_ice_candidate(&ice.candidate).await
+                                    {
+                                        log::warn!("failed to add WebRTC ICE candidate: {}", err);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Ok(Some(Err(err))) => {
+                        log::debug!("WebRTC ICE bridge socket read ended: {}", err);
+                        break;
                     }
                 }
             }
@@ -456,7 +683,7 @@ impl Client {
         mut udp: (Option<Arc<UdpSocket>>, Option<Arc<Mutex<u16>>>),
         stop_udp_tx: Option<oneshot::Sender<()>>,
         mut ipv6: Option<(Arc<UdpSocket>, bytes::Bytes)>,
-        mut webrtc_offerer: Option<WebRTCStream>,
+        webrtc_offerer: Option<WebRTCStream>,
         mut rendezvous_server: String,
         servers: Vec<String>,
         contained: bool,
@@ -471,6 +698,10 @@ impl Client {
         (i32, String),
         bool,
     )> {
+        // Wrap the offerer so any early return below (?/bail) or cancellation of this future by
+        // the outer select_ok closes its pc instead of leaking it in SESSIONS. Disarmed via
+        // into_inner() once the stream is adopted into a connection attempt.
+        let mut webrtc_offerer = webrtc_offerer.map(OffererGuard::new);
         let mut start = Instant::now();
         let mut socket = connect_tcp(&*rendezvous_server, CONNECT_TIMEOUT).await;
         debug_assert!(!servers.contains(&rendezvous_server));
@@ -533,8 +764,10 @@ impl Client {
             .take()
             .map(|(socket, addr)| (Some(socket), Some(addr)))
             .unwrap_or((None, None));
-        let webrtc_sdp_offer = if let Some(webrtc) = webrtc_offerer.as_ref() {
-            match webrtc.get_local_endpoint().await {
+        let webrtc_sdp_offer = if let Some(stream) =
+            webrtc_offerer.as_ref().and_then(|g| g.stream())
+        {
+            match stream.get_local_endpoint().await {
                 Ok(endpoint) => endpoint,
                 Err(err) => {
                     log::warn!("failed to read local WebRTC offer: {}", err);
@@ -561,7 +794,8 @@ impl Client {
         });
         let webrtc_session_key = webrtc_offerer
             .as_ref()
-            .map(|webrtc| webrtc.session_key().to_owned())
+            .and_then(|guard| guard.stream())
+            .map(|stream| stream.session_key().to_owned())
             .unwrap_or_default();
         let mut webrtc_sdp_answer = String::new();
         let mut pending_webrtc_ice = Vec::<String>::new();
@@ -660,22 +894,34 @@ impl Client {
                         let mut webrtc_bridge_stop = None;
                         let mut webrtc_for_connect = None;
                         if !rr.webrtc_sdp_answer.is_empty() {
-                            if let Some(webrtc) = webrtc_offerer.take() {
-                                if let Err(err) =
-                                    webrtc.set_remote_endpoint(&rr.webrtc_sdp_answer).await
-                                {
-                                    log::warn!("failed to set WebRTC relay answer: {}", err);
-                                } else {
-                                    for candidate in pending_webrtc_ice.drain(..) {
-                                        if let Err(err) =
-                                            webrtc.add_remote_ice_candidate(&candidate).await
-                                        {
-                                            log::warn!(
-                                                "failed to add buffered WebRTC ICE candidate: {}",
-                                                err
-                                            );
+                            if let Some(guard) = webrtc_offerer.take() {
+                                // Run the awaited setup on the guard's borrowed stream so a
+                                // cancellation during these awaits still closes the pc via the
+                                // guard's drop; take ownership only at the synchronous handoff.
+                                let setup_ok = if let Some(webrtc) = guard.stream() {
+                                    if let Err(err) =
+                                        webrtc.set_remote_endpoint(&rr.webrtc_sdp_answer).await
+                                    {
+                                        log::warn!("failed to set WebRTC relay answer: {}", err);
+                                        false
+                                    } else {
+                                        for candidate in pending_webrtc_ice.drain(..) {
+                                            if let Err(err) =
+                                                webrtc.add_remote_ice_candidate(&candidate).await
+                                            {
+                                                log::warn!(
+                                                    "failed to add buffered WebRTC ICE candidate: {}",
+                                                    err
+                                                );
+                                            }
                                         }
+                                        true
                                     }
+                                } else {
+                                    false
+                                };
+                                if let Some(webrtc) = setup_ok.then(|| guard.into_inner()).flatten()
+                                {
                                     let session_key = webrtc.session_key().to_owned();
                                     let local_ice_rx = webrtc.take_local_ice_rx();
                                     webrtc_bridge_stop = Some(Self::spawn_webrtc_ice_bridge(
@@ -687,8 +933,16 @@ impl Client {
                                     ));
                                     webrtc_for_connect = Some(webrtc);
                                 }
+                                // If setup failed, `guard` drops here and closes the pc.
                             }
                         }
+                        // An offerer not adopted into the relay race (empty answer) is closed by
+                        // the guard's drop here.
+                        drop(webrtc_offerer.take());
+                        // Keep relay_server for a WebRTC secure-failure fallback: request_relay
+                        // coordinates a FRESH uuid via the rendezvous server, so it works even if
+                        // the raced create_relay already consumed the original uuid pairing.
+                        let relay_server_rr = rr.relay_server.clone();
                         let fut = Self::create_relay(
                             &peer,
                             rr.uuid,
@@ -704,38 +958,122 @@ impl Client {
                             }
                             .boxed(),
                         );
-                        if let Some(mut webrtc) = webrtc_for_connect {
-                            connect_futures.push(
-                                async move {
-                                    webrtc.wait_connected(CONNECT_TIMEOUT).await?;
-                                    Ok((Stream::WebRTC(webrtc), None, "WebRTC"))
-                                }
-                                .boxed(),
-                            );
-                        }
-                        // Run all connection attempts concurrently, return the first successful one
-                        let (conn, kcp, typ) = match select_ok(connect_futures).await {
-                            Ok(conn) => (Ok(conn.0 .0), conn.0 .1, conn.0 .2),
-
-                            Err(e) => (Err(e), None, ""),
+                        // Keep the adopted offerer in a guard that stays armed across the race AND
+                        // secure_connection, so cancellation of this future by the outer race (or a
+                        // secure-handshake failure) closes the pc instead of leaking it. It is
+                        // disarmed only once WebRTC is confirmed the winning, secured transport.
+                        let mut webrtc_guard = None;
+                        let race_result = if let Some(webrtc) = webrtc_for_connect {
+                            webrtc_guard = Some(OffererGuard::new(webrtc.clone()));
+                            let mut raced = webrtc;
+                            let webrtc_fut = async move {
+                                raced.wait_connected(CONNECT_TIMEOUT).await?;
+                                Ok((Stream::WebRTC(raced), None, "WebRTC"))
+                            }
+                            .boxed();
+                            // The peer answered WebRTC: prefer P2P. The relay result is held for
+                            // the preference window so WebRTC can win even though a relay TCP
+                            // connect completes much faster than ICE + DTLS setup.
+                            race_transports_prefer_webrtc(
+                                webrtc_fut,
+                                connect_futures,
+                                Self::WEBRTC_PREFER_WINDOW_MS,
+                                |result| result.2 == "IPv6",
+                            )
+                            .await
+                        } else {
+                            // Run all connection attempts concurrently, take the first success.
+                            select_ok(connect_futures).await.map(|r| r.0)
                         };
                         if let Some(stop) = webrtc_bridge_stop {
                             let _ = stop.send(());
                         }
-                        let mut conn = conn?;
+                        // The ? / secure_connection failures below return early; webrtc_guard stays
+                        // in scope and closes the offerer on any such exit (loss, error, cancellation).
+                        let (mut conn, kcp, mut typ) = race_result?;
                         feedback = rr.feedback;
                         log::info!("{:?} used to establish {typ} connection", start.elapsed());
-                        let pk =
-                            Self::secure_connection(&peer, signed_id_pk, &key, &mut conn).await?;
+                        let pk = match Self::secure_connection(
+                            &peer,
+                            signed_id_pk.clone(),
+                            &key,
+                            &mut conn,
+                        )
+                        .await
+                        {
+                            Ok(pk) => pk,
+                            Err(e) if typ == "WebRTC" => {
+                                // WebRTC won the race but identity/DTLS binding failed. Fall back
+                                // to a freshly-coordinated relay (request_relay negotiates a new
+                                // uuid, immune to the raced create_relay having consumed the
+                                // original pairing) so a bad WebRTC handshake does not kill the
+                                // whole session when relay is available.
+                                log::warn!(
+                                    "WebRTC secure handshake failed ({}), falling back to relay",
+                                    e
+                                );
+                                drop(webrtc_guard.take());
+                                let mut relay_conn = Self::request_relay(
+                                    &peer,
+                                    relay_server_rr,
+                                    &rendezvous_server,
+                                    !signed_id_pk.is_empty(),
+                                    &key,
+                                    &token,
+                                    conn_type,
+                                )
+                                .await
+                                .map_err(|relay_e| {
+                                    anyhow!(
+                                        "WebRTC secure failed ({}); relay fallback also failed: {}",
+                                        e,
+                                        relay_e
+                                    )
+                                })?;
+                                let pk = Self::secure_connection(
+                                    &peer,
+                                    signed_id_pk,
+                                    &key,
+                                    &mut relay_conn,
+                                )
+                                .await?;
+                                conn = relay_conn;
+                                typ = if use_ws() { "WebSocket" } else { "Relay" };
+                                pk
+                            }
+                            Err(e) => return Err(e),
+                        };
+                        // Compute the direct/relayed flag (an await) BEFORE disarming the guard, so
+                        // a cancellation of this future during webrtc_relayed() still closes the pc
+                        // via the guard's drop. Matches connect()'s ordering.
+                        let direct = match typ {
+                            "IPv6" => true,
+                            // WebRTC through a TURN server is relayed traffic; report it as such.
+                            "WebRTC" => !conn.webrtc_relayed().await.unwrap_or(false),
+                            _ => false,
+                        };
+                        // Secured and WebRTC won: disarm so the returned conn keeps the pc alive.
+                        if typ == "WebRTC" {
+                            if let Some(guard) = webrtc_guard.take() {
+                                let _ = guard.into_inner();
+                            }
+                        }
                         return Ok((
-                            (conn, typ == "IPv6" || typ == "WebRTC", pk, kcp, typ),
+                            (conn, direct, pk, kcp, typ),
                             (feedback, rendezvous_server),
                             false,
                         ));
                     }
                     Some(rendezvous_message::Union::IceCandidate(ice)) => {
                         if Self::is_expected_webrtc_ice_candidate(&ice, &webrtc_session_key) {
-                            pending_webrtc_ice.push(ice.candidate);
+                            if pending_webrtc_ice.len() < Self::MAX_PENDING_WEBRTC_ICE {
+                                pending_webrtc_ice.push(ice.candidate);
+                            } else {
+                                log::warn!(
+                                    "dropping WebRTC ICE candidate: pending buffer full ({})",
+                                    Self::MAX_PENDING_WEBRTC_ICE
+                                );
+                            }
                         } else {
                             log::debug!(
                                 "dropping ICE candidate for unexpected WebRTC session key {}",
@@ -752,16 +1090,26 @@ impl Client {
         let mut webrtc_bridge_stop = None;
         let mut webrtc_for_connect = None;
         if !webrtc_sdp_answer.is_empty() {
-            if let Some(webrtc) = webrtc_offerer.take() {
-                if let Err(err) = webrtc.set_remote_endpoint(&webrtc_sdp_answer).await {
-                    log::warn!("failed to set WebRTC answer: {}", err);
-                    drop(socket);
-                } else {
-                    for candidate in pending_webrtc_ice.drain(..) {
-                        if let Err(err) = webrtc.add_remote_ice_candidate(&candidate).await {
-                            log::warn!("failed to add buffered WebRTC ICE candidate: {}", err);
+            if let Some(guard) = webrtc_offerer.take() {
+                // Run the awaited setup on the guard's borrowed stream so a cancellation during
+                // these awaits still closes the pc via the guard's drop; take ownership only at
+                // the synchronous handoff below.
+                let setup_ok = if let Some(webrtc) = guard.stream() {
+                    if let Err(err) = webrtc.set_remote_endpoint(&webrtc_sdp_answer).await {
+                        log::warn!("failed to set WebRTC answer: {}", err);
+                        false
+                    } else {
+                        for candidate in pending_webrtc_ice.drain(..) {
+                            if let Err(err) = webrtc.add_remote_ice_candidate(&candidate).await {
+                                log::warn!("failed to add buffered WebRTC ICE candidate: {}", err);
+                            }
                         }
+                        true
                     }
+                } else {
+                    false
+                };
+                if let Some(webrtc) = setup_ok.then(|| guard.into_inner()).flatten() {
                     let session_key = webrtc.session_key().to_owned();
                     let local_ice_rx = webrtc.take_local_ice_rx();
                     webrtc_bridge_stop = Some(Self::spawn_webrtc_ice_bridge(
@@ -772,6 +1120,9 @@ impl Client {
                         session_key,
                     ));
                     webrtc_for_connect = Some(webrtc);
+                } else {
+                    // setup failed (guard dropped -> pc closed) or no stream: release the socket.
+                    drop(socket);
                 }
             } else {
                 drop(socket);
@@ -779,7 +1130,18 @@ impl Client {
         } else {
             drop(socket);
         }
+        // An offerer never adopted into a connection attempt (e.g. the peer returned no WebRTC
+        // answer) is closed by the guard's drop here, so its pc does not linger in SESSIONS.
+        drop(webrtc_offerer.take());
         if peer_addr.port() == 0 {
+            // Bailing before connect(): an offerer already adopted into webrtc_for_connect was
+            // disarmed out of its guard, so close it (and stop its bridge) explicitly here.
+            if let Some(webrtc) = webrtc_for_connect.take() {
+                Self::spawn_close_webrtc(webrtc);
+            }
+            if let Some(stop) = webrtc_bridge_stop.take() {
+                let _ = stop.send(());
+            }
             bail!("Failed to connect via rendezvous server");
         }
         let time_used = start.elapsed().as_millis() as u64;
@@ -850,6 +1212,10 @@ impl Client {
         Option<KcpStream>,
         &'static str,
     )> {
+        // Guard the offerer for the whole of connect(): any early return — cancellation during the
+        // awaits below, the relay override, or a secure_connection failure — closes its pc via the
+        // guard's drop. Disarmed only once WebRTC is the confirmed winning, secured transport.
+        let mut webrtc_guard = webrtc_offerer.map(OffererGuard::new);
         let direct_failures = interface.get_lch().read().unwrap().direct_failures;
         let mut connect_timeout = 0;
         const MIN: u64 = 1000;
@@ -900,11 +1266,20 @@ impl Client {
         if let Some(udp_socket_v6) = udp_socket_v6 {
             connect_futures.push(udp_nat_connect(udp_socket_v6, "IPv6", connect_timeout).boxed());
         }
-        if let Some(mut webrtc) = webrtc_offerer {
+        // Race a clone of the offerer; the guard retains its own clone so a losing/cancelled race
+        // still closes the pc (select_ok drops the future's clone without closing).
+        if let Some(stream) = webrtc_guard.as_ref().and_then(|g| g.stream()) {
+            let mut raced = stream.clone();
+            // The punch-tuned timeout can be as low as 1s — enough for a raw TCP SYN but not for
+            // candidate trickle + ICE checks + DTLS. Give WebRTC its own floor (prefer-P2P) so a
+            // viable P2P path is not abandoned before it can complete; TCP/UDP keep the tighter
+            // timeout, so a working direct connection still wins the race immediately, and the
+            // relay fallback below only waits the extra time when direct attempts all failed.
+            let webrtc_timeout = connect_timeout.max(Self::WEBRTC_PREFER_WINDOW_MS);
             connect_futures.push(
                 async move {
-                    webrtc.wait_connected(connect_timeout).await?;
-                    Ok((Stream::WebRTC(webrtc), None, "WebRTC"))
+                    raced.wait_connected(webrtc_timeout).await?;
+                    Ok((Stream::WebRTC(raced), None, "WebRTC"))
                 }
                 .boxed(),
             );
@@ -917,9 +1292,14 @@ impl Client {
         if let Some(stop) = webrtc_bridge_stop {
             let _ = stop.send(());
         }
+        // webrtc_guard stays armed across the relay override and secure_connection below; it is
+        // disarmed only at the successful return when WebRTC is the kept transport.
 
         let mut direct = !conn.is_err();
-        if interface.is_force_relay() || conn.is_err() {
+        // A WebRTC win under force_relay only happens when the pc was built with Relay-only ICE
+        // (TURN configured), which already honors the relay requirement — keep it instead of
+        // replacing it with the RustDesk relay.
+        if (interface.is_force_relay() && typ != "WebRTC") || conn.is_err() {
             if !relay_server.is_empty() {
                 conn = Self::request_relay(
                     peer_id,
@@ -948,15 +1328,71 @@ impl Client {
             start.elapsed(),
             punch_type
         );
-        let res = Self::secure_connection(peer_id, signed_id_pk, key, &mut conn).await;
+        let res = Self::secure_connection(peer_id, signed_id_pk.clone(), key, &mut conn).await;
         let pk: Option<Vec<u8>> = match res {
             Ok(pk) => pk,
+            Err(e) if typ == "WebRTC" && !relay_server.is_empty() => {
+                // WebRTC won the race but identity/DTLS binding failed; fall back to a freshly
+                // coordinated relay instead of failing the whole attempt. The guard is dropped
+                // first so the bad pc is closed promptly.
+                log::warn!("WebRTC secure handshake failed ({}), falling back to relay", e);
+                drop(webrtc_guard.take());
+                match Self::request_relay(
+                    peer_id,
+                    relay_server.to_owned(),
+                    rendezvous_server,
+                    !signed_id_pk.is_empty(),
+                    key,
+                    token,
+                    conn_type,
+                )
+                .await
+                {
+                    Ok(mut relay_conn) => {
+                        match Self::secure_connection(peer_id, signed_id_pk, key, &mut relay_conn)
+                            .await
+                        {
+                            Ok(pk) => {
+                                conn = relay_conn;
+                                typ = "Relay";
+                                direct = false;
+                                pk
+                            }
+                            Err(e) => {
+                                interface.update_direct(Some(false));
+                                bail!(e);
+                            }
+                        }
+                    }
+                    Err(relay_e) => {
+                        interface.update_direct(Some(direct));
+                        bail!(
+                            "WebRTC secure failed ({}); relay fallback also failed: {}",
+                            e,
+                            relay_e
+                        );
+                    }
+                }
+            }
             Err(e) => {
                 // this direct is mainly used by on_establish_connection_error, so we update it here before bail
                 interface.update_direct(Some(direct));
+                // webrtc_guard is still armed here, so a WebRTC winner whose secure handshake
+                // failed is closed by the guard's drop as we bail (no explicit close needed).
                 bail!(e);
             }
         };
+        if typ == "WebRTC" {
+            // WebRTC through a TURN server (force_relay, or a TURN pair winning under All
+            // policy) is relayed traffic; report the direct flag accordingly.
+            if conn.webrtc_relayed().await.unwrap_or(false) {
+                direct = false;
+            }
+            // Secured: disarm so the returned conn keeps the pc alive.
+            if let Some(guard) = webrtc_guard.take() {
+                let _ = guard.into_inner();
+            }
+        }
         log::debug!("{} punch secure_connection ok", punch_type);
         Ok((conn, direct, pk, kcp, typ))
     }
@@ -973,6 +1409,15 @@ impl Client {
         } else {
             key
         });
+        // A WebRTC channel is peer-authenticated only once its DTLS fingerprint is bound to the
+        // verified peer identity below. Once a trusted identity IS established, every binding
+        // failure fails closed: any peer able to answer WebRTC also signs its fingerprint, so a
+        // mismatch is concrete evidence of a rendezvous/relay MITM (not a legacy peer), and
+        // callers fall back to a fresh relay connection rather than proceeding on that channel.
+        // Without a trusted identity (absent, or unverifiable under our configured root) no
+        // binding is possible at all; WebRTC then proceeds like TCP's non-secure fallback —
+        // DTLS-encrypted but reported unsecured. TCP/UDP/relay keep their existing behavior.
+        let is_webrtc = conn.is_webrtc();
         let mut sign_pk = None;
         let mut option_pk = None;
         if !signed_id_pk.is_empty() {
@@ -991,6 +1436,17 @@ impl Client {
         let sign_pk = match sign_pk {
             Some(v) => v,
             None => {
+                // No trusted peer identity: either the deployment provides none (empty
+                // signed_id_pk, key-less) or the blob does not verify under our configured root
+                // (typical benign cause: self-hosted server with the client not configured with
+                // its key, so verification runs against the built-in RS_PUB_KEY). Either way no
+                // fingerprint binding is possible, which is the same cryptographic state as
+                // key-less: DTLS-encrypted to an unauthenticated peer. Proceed like TCP's
+                // non-secure fallback with is_secured() left false. Bailing here instead would
+                // only push the session onto a relay where the same blob fails verification
+                // again and the payload then runs in plaintext — strictly worse than
+                // unauthenticated DTLS, while an active attacker reaches the same warned,
+                // unauthenticated endpoint either way.
                 // send an empty message out in case server is setting up secure and waiting for first message
                 conn.send(&Message::new()).await?;
                 return Ok(option_pk);
@@ -1001,8 +1457,22 @@ impl Client {
                 let bytes = res?;
                 if let Ok(msg_in) = Message::parse_from_bytes(&bytes) {
                     if let Some(message::Union::SignedId(si)) = msg_in.union {
-                        if let Ok((id, their_pk_b)) = decode_id_pk(&si.id, &sign_pk) {
+                        if let Ok((id, their_pk_b, signed_fp)) = decode_id_pk_dtls(&si.id, &sign_pk) {
                             if id == peer_id {
+                                // WebRTC only: bind the DTLS channel to the verified peer identity.
+                                // webrtc-rs already verified the peer certificate matches the remote
+                                // SDP fingerprint, so requiring the peer to have signed that same
+                                // fingerprint defeats a rendezvous/relay MITM that swaps SDPs. Fail
+                                // closed: an unreadable/empty/mismatched fingerprint aborts the
+                                // WebRTC connection rather than silently accepting it.
+                                if is_webrtc {
+                                    let actual_fp = conn.dtls_fingerprint(false).await.ok_or_else(
+                                        || anyhow!("WebRTC DTLS fingerprint unavailable"),
+                                    )?;
+                                    if signed_fp.is_empty() || signed_fp != actual_fp {
+                                        bail!("WebRTC DTLS fingerprint not bound to peer identity (possible MITM)");
+                                    }
+                                }
                                 let (asymmetric_value, symmetric_value, key) =
                                     create_symmetric_key_msg(their_pk_b);
                                 let mut msg_out = Message::new();
@@ -1014,10 +1484,16 @@ impl Client {
                                 timeout(CONNECT_TIMEOUT, conn.send(&msg_out)).await??;
                                 conn.set_key(key);
                             } else {
+                                if is_webrtc {
+                                    bail!("WebRTC handshake id mismatch (possible MITM)");
+                                }
                                 log::error!("Handshake failed: sign failure");
                                 conn.send(&Message::new()).await?;
                             }
                         } else {
+                            if is_webrtc {
+                                bail!("WebRTC peer identity could not be verified (refusing unbound channel)");
+                            }
                             // fall back to non-secure connection in case pk mismatch
                             log::info!("pk mismatch, fall back to non-secure");
                             let mut msg_out = Message::new();
@@ -1025,10 +1501,16 @@ impl Client {
                             conn.send(&msg_out).await?;
                         }
                     } else {
+                        if is_webrtc {
+                            bail!("WebRTC handshake received an unexpected message type");
+                        }
                         log::error!("Handshake failed: invalid message type");
                         conn.send(&Message::new()).await?;
                     }
                 } else {
+                    if is_webrtc {
+                        bail!("WebRTC handshake received a malformed message");
+                    }
                     log::error!("Handshake failed: invalid message format");
                     conn.send(&Message::new()).await?;
                 }
@@ -4543,4 +5025,147 @@ async fn udp_nat_connect(
             anyhow!(err)
         })?;
     Ok((res.1, Some(res.0), typ))
+}
+
+#[cfg(test)]
+mod webrtc_race_tests {
+    use super::race_transports_prefer_webrtc;
+    use hbb_common::{
+        anyhow::anyhow,
+        futures::future::{BoxFuture, FutureExt},
+        tokio,
+        tokio::time::{sleep, Duration, Instant},
+        ResultType,
+    };
+
+    fn ok_after(ms: u64, tag: &'static str) -> BoxFuture<'static, ResultType<&'static str>> {
+        async move {
+            sleep(Duration::from_millis(ms)).await;
+            Ok(tag)
+        }
+        .boxed()
+    }
+
+    fn err_after(ms: u64, what: &'static str) -> BoxFuture<'static, ResultType<&'static str>> {
+        async move {
+            sleep(Duration::from_millis(ms)).await;
+            Err(anyhow!(what))
+        }
+        .boxed()
+    }
+
+    const NOT_P2P: fn(&&'static str) -> bool = |_| false;
+
+    #[tokio::test]
+    async fn webrtc_preferred_over_faster_relay_within_window() {
+        let got = race_transports_prefer_webrtc(
+            ok_after(120, "webrtc"),
+            vec![ok_after(10, "relay")],
+            60_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "webrtc");
+    }
+
+    #[tokio::test]
+    async fn unfinished_ipv6_still_beats_held_relay() {
+        let start = Instant::now();
+        let got = race_transports_prefer_webrtc(
+            ok_after(60_000, "webrtc"),
+            vec![ok_after(10, "relay"), ok_after(100, "ipv6")],
+            1_000,
+            |t| *t == "ipv6",
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "ipv6");
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn held_relay_committed_when_window_expires() {
+        let start = Instant::now();
+        let got = race_transports_prefer_webrtc(
+            ok_after(60_000, "webrtc"),
+            vec![ok_after(10, "relay")],
+            150,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "relay");
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn held_relay_committed_when_webrtc_fails() {
+        let start = Instant::now();
+        let got = race_transports_prefer_webrtc(
+            err_after(50, "webrtc dead"),
+            vec![ok_after(10, "relay")],
+            60_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "relay");
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn relay_committed_directly_after_webrtc_failed() {
+        let got = race_transports_prefer_webrtc(
+            err_after(5, "webrtc dead"),
+            vec![ok_after(100, "relay")],
+            60_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "relay");
+    }
+
+    #[tokio::test]
+    async fn webrtc_still_wins_past_window_when_relay_dead() {
+        let got = race_transports_prefer_webrtc(
+            ok_after(300, "webrtc"),
+            vec![err_after(10, "relay dead")],
+            50,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "webrtc");
+    }
+
+    #[tokio::test]
+    async fn p2p_transport_committed_immediately() {
+        let start = Instant::now();
+        let got = race_transports_prefer_webrtc(
+            ok_after(60_000, "webrtc"),
+            vec![ok_after(10, "ipv6")],
+            60_000,
+            |t| *t == "ipv6",
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "ipv6");
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn both_failing_compose_error() {
+        let err = race_transports_prefer_webrtc(
+            err_after(10, "webrtc dead"),
+            vec![err_after(20, "relay dead")],
+            1_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("webrtc dead") && err.contains("relay dead"), "{}", err);
+    }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -226,9 +226,10 @@ impl Drop for OffererGuard {
 /// - a WebRTC success is committed immediately;
 /// - an `is_p2p` result from `others` (e.g. IPv6 direct) is committed immediately;
 /// - a relayed result inside the preference window is *held*, giving WebRTC until the window
-///   expires to connect and take priority, while unfinished `others` keep racing so a slower
-///   direct transport can still win; when the window ends (or WebRTC fails) the held connection
-///   is committed;
+///   expires to connect and take priority. The window starts when the first relay is ready, not
+///   when setup begins, so rendezvous latency cannot consume the preference budget. Unfinished
+///   `others` keep racing so a slower direct transport can still win; when the window ends (or
+///   WebRTC fails) the held connection is committed;
 /// - a failure on one side commits the survivor as soon as it succeeds; two failures compose
 ///   into one error.
 ///
@@ -246,10 +247,15 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
     let mut others_err: Option<hbb_common::anyhow::Error> = None;
     let window = tokio::time::sleep(Duration::from_millis(window_ms));
     tokio::pin!(window);
-    let mut window_over = false;
+    let mut window_started = false;
     loop {
         tokio::select! {
-            res = async { webrtc_fut.as_mut().unwrap().await }, if webrtc_fut.is_some() => {
+            res = async {
+                match webrtc_fut.as_mut() {
+                    Some(fut) => fut.await,
+                    None => std::future::pending().await,
+                }
+            }, if webrtc_fut.is_some() => {
                 webrtc_fut = None;
                 match res {
                     // WebRTC connected: preferred outright; a held relay conn just drops.
@@ -266,17 +272,26 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
                     }
                 }
             }
-            res = async { others_fut.as_mut().unwrap().await }, if others_fut.is_some() => {
+            res = async {
+                match others_fut.as_mut() {
+                    Some(fut) => fut.await,
+                    None => std::future::pending().await,
+                }
+            }, if others_fut.is_some() => {
                 others_fut = None;
                 match res {
                     Ok((conn, unfinished)) => {
-                        if is_p2p(&conn) || window_over || webrtc_fut.is_none() {
+                        if is_p2p(&conn) || webrtc_fut.is_none() {
                             return Ok(conn);
                         }
                         // Hold the first relay, but keep polling unfinished alternatives: an IPv6
                         // direct attempt may complete inside the same WebRTC preference window.
                         if held.is_none() {
                             held = Some(conn);
+                            window.as_mut().reset(
+                                Instant::now() + Duration::from_millis(window_ms),
+                            );
+                            window_started = true;
                         }
                         if !unfinished.is_empty() {
                             others_fut = Some(select_ok(unfinished));
@@ -289,14 +304,22 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
                     },
                 }
             }
-            _ = &mut window, if !window_over => {
-                window_over = true;
+            _ = &mut window, if window_started => {
                 if let Some(conn) = held.take() {
                     return Ok(conn);
                 }
+                window_started = false;
             }
         }
     }
+}
+
+fn request_can_carry_webrtc(udp_port: u16, force_relay: bool) -> bool {
+    // A normal TCP punch request must close its rendezvous socket before reusing that local
+    // address, while WebRTC trickle ICE retains the socket as its signaling bridge. Therefore a
+    // request with udp_port=0 must never carry WebRTC. UDP requests can carry it because their
+    // punch socket is separate; force-relay requests can too because they never enter TCP punching.
+    udp_port > 0 || force_relay
 }
 
 impl Client {
@@ -450,7 +473,13 @@ impl Client {
         } else {
             None
         };
-        let webrtc_offerer = if Self::should_create_webrtc_offerer(&interface) {
+        // Prepare WebRTC only for a possible UDP request, or for force-relay where TURN is the
+        // only WebRTC path. `_start_inner` applies the stricter wire invariant after the UDP NAT
+        // test: an actual request with udp_port=0 never includes the offer.
+        let may_prepare_webrtc = udp.0.is_some() || interface.is_force_relay();
+        let webrtc_offerer = if may_prepare_webrtc
+            && Self::should_create_webrtc_offerer(&interface)
+        {
             match WebRTCStream::new("", interface.is_force_relay(), CONNECT_TIMEOUT).await {
                 Ok(stream) => Some(stream),
                 Err(err) => {
@@ -461,6 +490,7 @@ impl Client {
         } else {
             None
         };
+        let has_webrtc_offerer = webrtc_offerer.is_some();
         let fut = Self::_start_inner(
             peer.to_owned(),
             key.to_owned(),
@@ -478,9 +508,12 @@ impl Client {
         if udp.0.is_none() {
             return fut.await;
         }
-        let mut connect_futures = Vec::new();
-        connect_futures.push(fut.boxed());
-        let fut = Self::_start_inner(
+        let preferred_fut = fut.boxed();
+        // This is deliberately a pure TCP punch request: its WebRTC argument must stay `None`.
+        // TCP punching closes the rendezvous socket before binding a new connection to the same
+        // local address; a WebRTC ICE bridge would retain that socket and break the port reuse.
+        // The preferred request above may carry WebRTC only because it owns a separate UDP socket.
+        let fallback_fut = Self::_start_inner(
             peer.to_owned(),
             key.to_owned(),
             token.to_owned(),
@@ -493,8 +526,18 @@ impl Client {
             rendezvous_server,
             servers,
             contained,
-        );
-        connect_futures.push(fut.boxed());
+        )
+        .boxed();
+        if has_webrtc_offerer {
+            return race_transports_prefer_webrtc(
+                preferred_fut,
+                vec![fallback_fut],
+                Self::WEBRTC_PREFER_WINDOW_MS,
+                |result| result.0 .1,
+            )
+            .await;
+        }
+        let connect_futures = vec![preferred_fut, fallback_fut];
         match select_ok(connect_futures).await {
             Ok(conn) => Ok((conn.0 .0, conn.0 .1, conn.0 .2)),
             Err(e) => Err(e),
@@ -543,7 +586,9 @@ impl Client {
     /// too.
     /// When force_relay *and* TURN are configured, WebRTC via TURN is a valid "relayed" path:
     /// `connect` keeps a WebRTC win instead of replacing it with the RustDesk relay, and the
-    /// RelayResponse path prefers it within the WebRTC preference window.
+    /// RelayResponse path races it without a P2P preference delay. The caller additionally
+    /// requires either a usable UDP request or force_relay; a normal TCP punch request must never
+    /// carry a WebRTC offer because trickle ICE retains the socket TCP punching needs to reuse.
     fn should_create_webrtc_offerer(interface: &impl Interface) -> bool {
         if !crate::get_udp_punch_enabled() || use_ws() || Config::is_proxy() {
             return false;
@@ -764,20 +809,26 @@ impl Client {
             .take()
             .map(|(socket, addr)| (Some(socket), Some(addr)))
             .unwrap_or((None, None));
-        let webrtc_sdp_offer = if let Some(stream) =
-            webrtc_offerer.as_ref().and_then(|g| g.stream())
-        {
-            match stream.get_local_endpoint().await {
-                Ok(endpoint) => endpoint,
-                Err(err) => {
-                    log::warn!("failed to read local WebRTC offer: {}", err);
+        let udp_nat_port = udp.1.map(|x| *x.lock().unwrap()).unwrap_or(0);
+        let webrtc_sdp_offer =
+            if request_can_carry_webrtc(udp_nat_port, interface.is_force_relay()) {
+                if let Some(stream) = webrtc_offerer.as_ref().and_then(|g| g.stream()) {
+                    match stream.get_local_endpoint_trickle().await {
+                        Ok(endpoint) => endpoint,
+                        Err(err) => {
+                            log::warn!("failed to read local WebRTC offer: {}", err);
+                            String::new()
+                        }
+                    }
+                } else {
                     String::new()
                 }
-            }
-        } else {
-            String::new()
-        };
-        let udp_nat_port = udp.1.map(|x| *x.lock().unwrap()).unwrap_or(0);
+            } else {
+                // Hard protocol invariant: a normal request with udp_port=0 is a TCP punch
+                // request. It must not start WebRTC trickle on the rendezvous socket that TCP
+                // punching needs to close and reuse by local address.
+                String::new()
+            };
         let punch_type = if udp_nat_port > 0 { "UDP" } else { "TCP" };
         msg_out.set_punch_hole_request(PunchHoleRequest {
             id: peer.to_owned(),
@@ -971,16 +1022,24 @@ impl Client {
                                 Ok((Stream::WebRTC(raced), None, "WebRTC"))
                             }
                             .boxed();
-                            // The peer answered WebRTC: prefer P2P. The relay result is held for
-                            // the preference window so WebRTC can win even though a relay TCP
-                            // connect completes much faster than ICE + DTLS setup.
-                            race_transports_prefer_webrtc(
-                                webrtc_fut,
-                                connect_futures,
-                                Self::WEBRTC_PREFER_WINDOW_MS,
-                                |result| result.2 == "IPv6",
-                            )
-                            .await
+                            if interface.is_force_relay() {
+                                // Relay-only WebRTC can use only TURN, so it has no P2P advantage
+                                // over the RustDesk relay. Take the first successful relay instead
+                                // of delaying an already-ready result for the preference window.
+                                connect_futures.push(webrtc_fut);
+                                select_ok(connect_futures).await.map(|r| r.0)
+                            } else {
+                                // The peer answered WebRTC: prefer P2P. The relay result is held
+                                // for the preference window so WebRTC can win even though a relay
+                                // TCP connect completes much faster than ICE + DTLS setup.
+                                race_transports_prefer_webrtc(
+                                    webrtc_fut,
+                                    connect_futures,
+                                    Self::WEBRTC_PREFER_WINDOW_MS,
+                                    |result| result.2 == "IPv6",
+                                )
+                                .await
+                            }
                         } else {
                             // Run all connection attempts concurrently, take the first success.
                             select_ok(connect_futures).await.map(|r| r.0)
@@ -5029,7 +5088,7 @@ async fn udp_nat_connect(
 
 #[cfg(test)]
 mod webrtc_race_tests {
-    use super::race_transports_prefer_webrtc;
+    use super::{race_transports_prefer_webrtc, request_can_carry_webrtc};
     use hbb_common::{
         anyhow::anyhow,
         futures::future::{BoxFuture, FutureExt},
@@ -5056,12 +5115,32 @@ mod webrtc_race_tests {
 
     const NOT_P2P: fn(&&'static str) -> bool = |_| false;
 
+    #[test]
+    fn tcp_punch_request_never_carries_webrtc() {
+        assert!(!request_can_carry_webrtc(0, false));
+        assert!(request_can_carry_webrtc(1, false));
+        assert!(request_can_carry_webrtc(0, true));
+    }
+
     #[tokio::test]
     async fn webrtc_preferred_over_faster_relay_within_window() {
         let got = race_transports_prefer_webrtc(
             ok_after(120, "webrtc"),
             vec![ok_after(10, "relay")],
             60_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "webrtc");
+    }
+
+    #[tokio::test]
+    async fn preference_window_starts_when_relay_is_ready() {
+        let got = race_transports_prefer_webrtc(
+            ok_after(350, "webrtc"),
+            vec![ok_after(250, "relay")],
+            200,
             NOT_P2P,
         )
         .await

--- a/src/client.rs
+++ b/src/client.rs
@@ -386,6 +386,10 @@ impl Client {
         }
     }
 
+    fn is_expected_webrtc_ice_candidate(ice: &IceCandidate, session_key: &str) -> bool {
+        !session_key.is_empty() && ice.session_key == session_key && !ice.candidate.is_empty()
+    }
+
     fn spawn_webrtc_ice_bridge(
         mut socket: Stream,
         mut local_ice_rx: Option<UnboundedReceiver<String>>,
@@ -394,7 +398,6 @@ impl Client {
         session_key: String,
     ) -> oneshot::Sender<()> {
         let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
-        let my_id = Config::get_id();
         tokio::spawn(async move {
             loop {
                 match stop_rx.try_recv() {
@@ -408,8 +411,7 @@ impl Client {
                             Ok(candidate) => {
                                 let mut msg = RendezvousMessage::new();
                                 msg.set_ice_candidate(IceCandidate {
-                                    from_id: my_id.clone(),
-                                    to_id: peer.clone(),
+                                    id: peer.clone(),
                                     session_key: session_key.clone(),
                                     candidate,
                                     ..Default::default()
@@ -432,10 +434,7 @@ impl Client {
                     crate::get_next_nonkeyexchange_msg(&mut socket, Some(100)).await
                 {
                     if let Some(rendezvous_message::Union::IceCandidate(ice)) = msg_in.union {
-                        if ice.from_id == peer
-                            && ice.to_id == my_id
-                            && ice.session_key == session_key
-                        {
+                        if Self::is_expected_webrtc_ice_candidate(&ice, &session_key) {
                             if let Err(err) = webrtc.add_remote_ice_candidate(&ice.candidate).await
                             {
                                 log::warn!("failed to add WebRTC ICE candidate: {}", err);
@@ -566,7 +565,7 @@ impl Client {
             .unwrap_or_default();
         let mut webrtc_sdp_answer = String::new();
         let mut pending_webrtc_ice = Vec::<String>::new();
-        for i in 1..=3 {
+        'punch_attempts: for i in 1..=3 {
             log::info!(
                 "#{} {} punch attempt with {}, id: {}",
                 i,
@@ -576,9 +575,20 @@ impl Client {
             );
             socket.send(&msg_out).await?;
             // below timeout should not bigger than hbbs's connection timeout.
-            if let Some(msg_in) =
-                crate::get_next_nonkeyexchange_msg(&mut socket, Some(i * 3000)).await
-            {
+            let attempt_deadline = Instant::now() + Duration::from_millis((i * 3000) as u64);
+            loop {
+                let remaining = attempt_deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                let timeout_ms = remaining
+                    .as_millis()
+                    .clamp(1, u64::MAX as u128) as u64;
+                let Some(msg_in) =
+                    crate::get_next_nonkeyexchange_msg(&mut socket, Some(timeout_ms)).await
+                else {
+                    break;
+                };
                 match msg_in.union {
                     Some(rendezvous_message::Union::PunchHoleResponse(ph)) => {
                         if ph.socket_addr.is_empty() {
@@ -626,7 +636,7 @@ impl Client {
                                 }
                             }
                             log::info!("{} Hole Punched {} = {}", punch_type, peer, peer_addr);
-                            break;
+                            break 'punch_attempts;
                         }
                     }
                     Some(rendezvous_message::Union::RelayResponse(rr)) => {
@@ -724,17 +734,12 @@ impl Client {
                         ));
                     }
                     Some(rendezvous_message::Union::IceCandidate(ice)) => {
-                        if !webrtc_session_key.is_empty()
-                            && ice.from_id == peer
-                            && ice.to_id == Config::get_id()
-                            && ice.session_key == webrtc_session_key
-                        {
+                        if Self::is_expected_webrtc_ice_candidate(&ice, &webrtc_session_key) {
                             pending_webrtc_ice.push(ice.candidate);
                         } else {
                             log::debug!(
-                                "dropping ICE candidate for unexpected WebRTC session from {} key {}",
-                                ice.from_id,
-                                ice.session_key
+                                "dropping ICE candidate for unexpected WebRTC session key {}",
+                                ice.session_key,
                             );
                         }
                     }
@@ -4383,7 +4388,21 @@ pub mod peer_online {
 
     #[cfg(test)]
     mod tests {
+        use crate::client::Client;
+        use hbb_common::rendezvous_proto::IceCandidate;
         use hbb_common::tokio;
+
+        #[test]
+        fn accepts_webrtc_ice_by_session_key_only() {
+            let ice = IceCandidate {
+                session_key: "session-a".to_owned(),
+                candidate: "candidate-json".to_owned(),
+                ..Default::default()
+            };
+
+            assert!(Client::is_expected_webrtc_ice_candidate(&ice, "session-a"));
+            assert!(!Client::is_expected_webrtc_ice_candidate(&ice, "session-b"));
+        }
 
         #[tokio::test]
         async fn test_query_onlines() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -464,7 +464,9 @@ impl Client {
             }
         };
 
-        if crate::get_ipv6_punch_enabled() {
+        // Same relay gate as the v6 socket below: under any forced relay the v6 punch cannot
+        // be used, so probing v6 reachability is wasted work on every such connection.
+        if crate::get_ipv6_punch_enabled() && !interface.is_force_relay() {
             crate::test_ipv6().await;
         }
 
@@ -600,6 +602,9 @@ impl Client {
 
     /// Whether to build a WebRTC offerer for this connection.
     ///
+    /// Off by default against a private rendezvous server, like the UDP/IPv6 punch options:
+    /// a self-hosted deployment opts in once its server (and TURN, if any) is ready.
+    ///
     /// Skips it when a SOCKS proxy is configured: WebRTC's ICE binds its own UDP sockets and
     /// speaks STUN directly, which would bypass the proxy policy and can leak the real IP.
     /// WebSocket mode does NOT skip it: ws only tunnels the signaling/relay legs to the server
@@ -620,6 +625,9 @@ impl Client {
     /// keeps its rendezvous socket for trickle signaling and never reuses it for TCP punching; a
     /// separate offer-less request provides the TCP fallback when force-relay is not requested.
     fn should_create_webrtc_offerer(interface: &impl Interface) -> bool {
+        if !crate::get_webrtc_enabled() {
+            return false;
+        }
         if Config::is_proxy() {
             return false;
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -326,6 +326,15 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
     }
 }
 
+// A peer decides how many ICE candidates it sends, and the rendezvous route that carries them is
+// reachable without a prior punch, so these sites would otherwise let someone else set how much
+// this machine writes to its log file. One line a minute each, carrying the suppressed count.
+use hbb_common::log_throttle::LogThrottle;
+const ICE_LOG_INTERVAL: Duration = Duration::from_secs(60);
+static REJECTED_ICE_LOG: LogThrottle = LogThrottle::new(ICE_LOG_INTERVAL);
+static UNEXPECTED_ICE_LOG: LogThrottle = LogThrottle::new(ICE_LOG_INTERVAL);
+static PENDING_ICE_FULL_LOG: LogThrottle = LogThrottle::new(ICE_LOG_INTERVAL);
+
 fn request_allows_tcp_punch(webrtc_sdp_offer: &str) -> bool {
     // WebRTC trickle ICE retains the rendezvous socket as its signaling bridge. Only a request
     // without an offer may close that socket and reuse its local address for TCP punching.
@@ -728,7 +737,13 @@ impl Client {
                                     if let Err(err) =
                                         webrtc.add_remote_ice_candidate(&ice.candidate).await
                                     {
-                                        log::warn!("failed to add WebRTC ICE candidate: {}", err);
+                                        if let Some(n) = REJECTED_ICE_LOG.due() {
+                                            log::warn!(
+                                                "failed to add {} WebRTC ICE candidate(s), last: {}",
+                                                n,
+                                                err
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -1157,16 +1172,20 @@ impl Client {
                             // would discard exactly the ones that traverse NAT and keep the
                             // host ones that only work on a shared LAN.
                             if pending_webrtc_ice.len() >= Self::MAX_PENDING_WEBRTC_ICE {
-                                log::warn!(
-                                    "WebRTC ICE pending buffer full ({}), dropping oldest candidate",
-                                    Self::MAX_PENDING_WEBRTC_ICE
-                                );
+                                if let Some(n) = PENDING_ICE_FULL_LOG.due() {
+                                    log::warn!(
+                                        "WebRTC ICE pending buffer full ({}), evicted {} oldest",
+                                        Self::MAX_PENDING_WEBRTC_ICE,
+                                        n
+                                    );
+                                }
                                 pending_webrtc_ice.remove(0);
                             }
                             pending_webrtc_ice.push(ice.candidate);
-                        } else {
+                        } else if let Some(n) = UNEXPECTED_ICE_LOG.due() {
                             log::debug!(
-                                "dropping ICE candidate for unexpected WebRTC session key {}",
+                                "dropped {} ICE candidate(s) for unexpected WebRTC session key, last: {}",
+                                n,
                                 ice.session_key,
                             );
                         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -613,7 +613,9 @@ impl Client {
     }
 
     /// Max ICE candidates buffered during the punch window before the answer is applied.
-    /// Bounds memory if a misbehaving rendezvous floods candidates.
+    /// Bounds memory if a misbehaving rendezvous floods candidates. On overflow the oldest is
+    /// evicted: gathering order is host, then srflx, then relay, so the newest arrivals are the
+    /// ones that traverse NAT.
     const MAX_PENDING_WEBRTC_ICE: usize = 64;
 
     /// Prefer-P2P window: how long a WebRTC attempt outranks an already-established relay
@@ -627,6 +629,16 @@ impl Client {
     /// flight; the remote ICE agent dedups repeats, so the second copy is free.
     const WEBRTC_ICE_RESEND_DELAY: Duration = Duration::from_millis(400);
 
+    /// Bridge local ICE candidates to the peer over the punch socket, and feed the peer's back
+    /// into the pc.
+    ///
+    /// This socket must not be reconnected on error, unlike the controlled side's sender which
+    /// dials a fresh connection per candidate. Its address *is* the return route: the server
+    /// mangles it into `PunchHole.socket_addr`, the peer echoes it back as
+    /// `IceCandidate.socket_addr`, and the server resolves it through `tcp_punch`. A reconnect
+    /// would arrive from a new address that no route points at, and the server drops the old
+    /// entry when this connection closes — so once it dies, both directions are dead and
+    /// abandoning WebRTC for another transport is the correct response, not retrying.
     fn spawn_webrtc_ice_bridge(
         mut socket: Stream,
         mut local_ice_rx: Option<UnboundedReceiver<String>>,
@@ -1140,14 +1152,18 @@ impl Client {
                     }
                     Some(rendezvous_message::Union::IceCandidate(ice)) => {
                         if Self::is_expected_webrtc_ice_candidate(&ice, &webrtc_session_key) {
-                            if pending_webrtc_ice.len() < Self::MAX_PENDING_WEBRTC_ICE {
-                                pending_webrtc_ice.push(ice.candidate);
-                            } else {
+                            // Evict the oldest, not the newest. Candidates arrive in gathering
+                            // order — host first, then srflx, then relay — so dropping arrivals
+                            // would discard exactly the ones that traverse NAT and keep the
+                            // host ones that only work on a shared LAN.
+                            if pending_webrtc_ice.len() >= Self::MAX_PENDING_WEBRTC_ICE {
                                 log::warn!(
-                                    "dropping WebRTC ICE candidate: pending buffer full ({})",
+                                    "WebRTC ICE pending buffer full ({}), dropping oldest candidate",
                                     Self::MAX_PENDING_WEBRTC_ICE
                                 );
+                                pending_webrtc_ice.remove(0);
                             }
+                            pending_webrtc_ice.push(ice.candidate);
                         } else {
                             log::debug!(
                                 "dropping ICE candidate for unexpected WebRTC session key {}",

--- a/src/client.rs
+++ b/src/client.rs
@@ -595,6 +595,28 @@ impl Client {
     /// links; short enough that UDP-blocked networks settle on relay without a noticeable wait.
     const WEBRTC_PREFER_WINDOW_MS: u64 = 2500;
 
+    /// UDP-NAT-test wait when the TCP clock is implausible (see TCP_RTT_PLAUSIBLE_MIN). The
+    /// normal bound is `rtt / 2`: the test has been running since before the TCP connect, so on
+    /// a network where TCP RTT ~ UDP RTT its response has already landed. A transparent TCP
+    /// proxy — a TUN-mode VPN on the host, or a redirect-mode proxy on the LAN gateway (soft
+    /// router), which fakes the handshake for every device behind it — breaks that by answering
+    /// in ~3ms while the real UDP round trip is hundreds of ms: the window collapsed to ~1.5ms,
+    /// udp_port stayed 0, and UDP punch never ran on such networks. The wait still exits the instant the port
+    /// arrives, so a genuinely nearby server (LAN hbbs) pays nothing; only UDP-dead networks
+    /// wait out the full grace, and only on this round — the pure-TCP fallback round never
+    /// waits. Sized as a ceiling on real-world rendezvous RTTs plus one 20ms retransmit
+    /// (intercontinental ~300ms); paths slower than that lose UDP punch under a proxy, which
+    /// is today's behavior, not a regression.
+    const UDP_NAT_TEST_GRACE: Duration = Duration::from_millis(400);
+
+    /// Below this, the measured TCP connect time is not a believable WAN round trip — it was
+    /// answered inside the LAN (host TUN proxy, gateway transparent proxy, or a genuinely local
+    /// server) — and must not be used to size the UDP window.
+    /// Generous on purpose: over-triggering costs nothing (the wait exits on arrival, and a
+    /// UDP-dead round loses to the racing fallback anyway), while a tight bound would let a
+    /// busy proxy's occasional ~80ms handshake slip through and silently drop UDP punch.
+    const TCP_RTT_PLAUSIBLE_MIN: Duration = Duration::from_millis(100);
+
     /// Delay before re-sending an ICE candidate over the rendezvous route once. The hop to the
     /// peer can be UDP (the controlled side's mediator channel), so a candidate can be lost in
     /// flight; the remote ICE agent dedups repeats, so the second copy is free.
@@ -788,13 +810,20 @@ impl Client {
                 .map_err(|e| anyhow!("Failed to secure tcp: {}", e))?;
         } else if let Some(udp) = udp.1.as_ref() {
             let tm = Instant::now();
+            // rtt is the TCP connect time. When it is too short to be a real WAN round trip it
+            // says nothing about the UDP path (a TUN VPN or the LAN gateway answered the
+            // handshake, not the server), so fall back to the flat grace; otherwise trust it.
+            let udp_nat_wait = if rtt < Self::TCP_RTT_PLAUSIBLE_MIN {
+                Self::UDP_NAT_TEST_GRACE
+            } else {
+                rtt / 2
+            };
             loop {
                 let port = *udp.lock().unwrap();
                 if port > 0 {
                     break;
                 }
-                // await for 0.5 RTT
-                if tm.elapsed() > rtt / 2 {
+                if tm.elapsed() > udp_nat_wait {
                     break;
                 }
                 hbb_common::sleep(0.001).await;

--- a/src/client.rs
+++ b/src/client.rs
@@ -334,6 +334,18 @@ fn request_allows_tcp_punch(webrtc_sdp_offer: &str) -> bool {
     webrtc_sdp_offer.is_empty()
 }
 
+/// TCP punch is a user option like the other direct transports, but it is also the backstop:
+/// with every direct transport switched off there would be nothing left to punch with, so it
+/// runs regardless. Only the switches decide that — a transport that is enabled but fails to
+/// materialize (no public v6 address, offerer setup error) leaves this alone, because the
+/// relay fallback already covers a round that ends up with no usable direct transport.
+fn tcp_punch_allowed() -> bool {
+    crate::get_tcp_punch_enabled()
+        || !(crate::get_udp_punch_enabled()
+            || crate::get_ipv6_punch_enabled()
+            || crate::get_webrtc_enabled())
+}
+
 impl Client {
     const CLIENT_CLIPBOARD_NAME: &'static str = "client-clipboard";
 
@@ -521,7 +533,13 @@ impl Client {
             servers.clone(),
             contained,
         );
-        if interface.is_force_relay() || (udp.0.is_none() && !has_webrtc_offerer) {
+        // The fallback request exists only to carry a TCP punch, so it is pointless once TCP
+        // punch is off — it would reach `connect()` with nothing to try and just open a second
+        // relay.
+        if interface.is_force_relay()
+            || (udp.0.is_none() && !has_webrtc_offerer)
+            || !tcp_punch_allowed()
+        {
             return fut.await;
         }
         let preferred_fut = fut.boxed();
@@ -849,7 +867,7 @@ impl Client {
             } else {
                 String::new()
             };
-        let allow_tcp_punch = request_allows_tcp_punch(&webrtc_sdp_offer);
+        let allow_tcp_punch = tcp_punch_allowed() && request_allows_tcp_punch(&webrtc_sdp_offer);
         let punch_type = if udp_nat_port > 0 {
             "UDP"
         } else if allow_tcp_punch {

--- a/src/client.rs
+++ b/src/client.rs
@@ -202,7 +202,7 @@ impl OffererGuard {
 impl Drop for OffererGuard {
     fn drop(&mut self) {
         if let Some(stream) = self.0.take() {
-            Client::spawn_close_webrtc(stream);
+            stream.close_detached();
         }
     }
 }
@@ -579,34 +579,6 @@ impl Client {
 
     fn is_expected_webrtc_ice_candidate(ice: &IceCandidate, session_key: &str) -> bool {
         !session_key.is_empty() && ice.session_key == session_key && !ice.candidate.is_empty()
-    }
-
-    /// Tear down an abandoned WebRTC offerer off the connection hot path.
-    ///
-    /// The pc must be closed explicitly (a dropped handle leaves the `SESSIONS` clone alive),
-    /// but `close()` awaits internal ICE/DTLS shutdown and the result is pure cleanup with no
-    /// downstream dependency, so it must not block session establishment.
-    fn spawn_close_webrtc(webrtc: WebRTCStream) {
-        // Use the current runtime handle explicitly: this is also called from OffererGuard::drop,
-        // which can run during runtime teardown where a bare tokio::spawn would panic. If no
-        // runtime is available the pc cannot be closed here (it is released at process exit).
-        // Handle::spawn can also panic when the runtime is shutting down; catch that so Drop
-        // never panics (prefer a brief leak until process exit over aborting the process).
-        match tokio::runtime::Handle::try_current() {
-            Ok(handle) => {
-                let spawn_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    handle.spawn(async move {
-                        webrtc.close().await;
-                    });
-                }));
-                if spawn_result.is_err() {
-                    log::warn!("failed to spawn WebRTC close (runtime shutting down)");
-                }
-            }
-            Err(_) => {
-                log::warn!("no tokio runtime available to close WebRTC peer connection");
-            }
-        }
     }
 
     /// Whether to build a WebRTC offerer for this connection.
@@ -1180,7 +1152,10 @@ impl Client {
                         let direct = match typ {
                             "IPv6" => true,
                             // WebRTC through a TURN server is relayed traffic; report it as such.
-                            "WebRTC" => !conn.webrtc_relayed().await.unwrap_or(false),
+                            // An unknown answer (no selected pair yet, or the pc closed under a
+                            // concurrent teardown) must not be read as "direct": claiming a P2P
+                            // path needs evidence of one.
+                            "WebRTC" => !conn.webrtc_relayed().await.unwrap_or(true),
                             _ => false,
                         };
                         // Secured and WebRTC won: disarm so the returned conn keeps the pc alive.
@@ -1276,7 +1251,7 @@ impl Client {
             // Bailing before connect(): an offerer already adopted into webrtc_for_connect was
             // disarmed out of its guard, so close it (and stop its bridge) explicitly here.
             if let Some(webrtc) = webrtc_for_connect.take() {
-                Self::spawn_close_webrtc(webrtc);
+                webrtc.close_detached();
             }
             if let Some(stop) = webrtc_bridge_stop.take() {
                 let _ = stop.send(());
@@ -1536,8 +1511,9 @@ impl Client {
         };
         if typ == "WebRTC" {
             // WebRTC through a TURN server (force_relay, or a TURN pair winning under All
-            // policy) is relayed traffic; report the direct flag accordingly.
-            if conn.webrtc_relayed().await.unwrap_or(false) {
+            // policy) is relayed traffic; report the direct flag accordingly. An unknown answer
+            // counts as relayed — claiming a P2P path needs evidence of one.
+            if conn.webrtc_relayed().await.unwrap_or(true) {
                 direct = false;
             }
             // Secured: disarm so the returned conn keeps the pc alive.

--- a/src/client.rs
+++ b/src/client.rs
@@ -855,25 +855,33 @@ impl Client {
             .map(|(socket, addr)| (Some(socket), Some(addr)))
             .unwrap_or((None, None));
         let udp_nat_port = udp.1.map(|x| *x.lock().unwrap()).unwrap_or(0);
-        let webrtc_sdp_offer =
-            if let Some(stream) = webrtc_offerer.as_ref().and_then(|g| g.stream()) {
-                match stream.get_local_endpoint_trickle().await {
-                    Ok(endpoint) => endpoint,
-                    Err(err) => {
-                        log::warn!("failed to read local WebRTC offer: {}", err);
-                        String::new()
-                    }
-                }
-            } else {
-                String::new()
-            };
+        let webrtc_sdp_offer = webrtc_offerer
+            .as_ref()
+            .and_then(|g| g.stream())
+            .map(|stream| stream.local_endpoint().to_owned())
+            .unwrap_or_default();
         let allow_tcp_punch = tcp_punch_allowed() && request_allows_tcp_punch(&webrtc_sdp_offer);
-        let punch_type = if udp_nat_port > 0 {
-            "UDP"
-        } else if allow_tcp_punch {
-            "TCP"
+        // Every direct transport this round carries, not one of them: a round can carry several
+        // at once (a NAT port and an offer and a v6 address), and since the TCP punch became a
+        // switch it can carry none — a single name had to misreport both. `relay` is not a punch,
+        // it is what a round with nothing to punch with can still end as.
+        let mut transports = Vec::new();
+        if udp_nat_port > 0 {
+            transports.push("UDP");
+        }
+        if allow_tcp_punch {
+            transports.push("TCP");
+        }
+        if ipv6.1.is_some() {
+            transports.push("IPv6");
+        }
+        if !webrtc_sdp_offer.is_empty() {
+            transports.push("WebRTC");
+        }
+        let punch_type = if transports.is_empty() {
+            "Relay".to_owned()
         } else {
-            "WebRTC"
+            transports.join("+")
         };
         msg_out.set_punch_hole_request(PunchHoleRequest {
             id: peer.to_owned(),
@@ -889,7 +897,7 @@ impl Client {
             // The offer's envelope itself declares its ICE policy (`ice_policy: "all"` under
             // pure ws), telling the controlled side its answer may gather every candidate
             // type despite force_relay instead of requiring TURN.
-            webrtc_sdp_offer: webrtc_sdp_offer.clone(),
+            webrtc_sdp_offer,
             ..Default::default()
         });
         let webrtc_session_key = webrtc_offerer
@@ -1310,7 +1318,7 @@ impl Client {
                 webrtc_for_connect,
                 webrtc_bridge_stop,
                 allow_tcp_punch,
-                punch_type,
+                &punch_type,
             )
             .await?,
             (feedback, rendezvous_server),

--- a/src/client.rs
+++ b/src/client.rs
@@ -612,7 +612,8 @@ impl Client {
     /// is configured, so skip building a guaranteed-dead pc + STUN/TURN gathering + answerer
     /// signaling in that case. WebSocket-forced relay is deliberately NOT policy: ws only
     /// tunnels the signaling/relay legs, so the offer keeps full ICE and may land a direct
-    /// connection - the flagship path for ws deployments (`webrtc_all_ice` tells the peer).
+    /// connection - the flagship path for ws deployments (the offer envelope's `ice_policy`
+    /// key tells the peer).
     /// When policy relay *and* TURN are configured, WebRTC via TURN is a valid "relayed" path:
     /// `connect` keeps a WebRTC win instead of replacing it with the RustDesk relay, and the
     /// RelayResponse path races it without a P2P preference delay. Any request carrying an offer
@@ -888,10 +889,10 @@ impl Client {
             force_relay: interface.is_force_relay(),
             socket_addr_v6: ipv6.1.unwrap_or_default(),
             switch_code,
+            // The offer's envelope itself declares its ICE policy (`ice_policy: "all"` under
+            // pure ws), telling the controlled side its answer may gather every candidate
+            // type despite force_relay instead of requiring TURN.
             webrtc_sdp_offer: webrtc_sdp_offer.clone(),
-            // Full-ICE offer despite force_relay (ws transport): tells the controlled side
-            // its answer may gather every candidate type instead of requiring TURN.
-            webrtc_all_ice: !webrtc_sdp_offer.is_empty() && !interface.is_policy_relay(),
             ..Default::default()
         });
         let webrtc_session_key = webrtc_offerer

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,11 +65,12 @@ use hbb_common::{
         self,
         net::UdpSocket,
         sync::{
-            mpsc::{unbounded_channel, UnboundedReceiver},
+            mpsc::{error::TryRecvError, unbounded_channel, UnboundedReceiver},
             oneshot,
         },
         time::{interval, Duration, Instant},
     },
+    webrtc::WebRTCStream,
     AddrMangle, ResultType, Stream,
 };
 pub use helper::*;
@@ -320,6 +321,19 @@ impl Client {
         } else {
             (None, None)
         };
+        let ipv6 = if crate::get_ipv6_punch_enabled() {
+            crate::get_ipv6_socket().await
+        } else {
+            None
+        };
+        let webrtc_offerer =
+            match WebRTCStream::new("", interface.is_force_relay(), CONNECT_TIMEOUT).await {
+                Ok(stream) => Some(stream),
+                Err(err) => {
+                    log::warn!("webrtc offerer setup failed: {}", err);
+                    None
+                }
+            };
         let fut = Self::_start_inner(
             peer.to_owned(),
             key.to_owned(),
@@ -328,6 +342,8 @@ impl Client {
             interface.clone(),
             udp.clone(),
             Some(stop_udp_tx),
+            ipv6,
+            webrtc_offerer,
             rendezvous_server.clone(),
             servers.clone(),
             contained,
@@ -345,6 +361,8 @@ impl Client {
             interface,
             (None, None),
             None,
+            None,
+            None,
             rendezvous_server,
             servers,
             contained,
@@ -356,6 +374,68 @@ impl Client {
         }
     }
 
+    fn spawn_webrtc_ice_bridge(
+        mut socket: Stream,
+        mut local_ice_rx: Option<UnboundedReceiver<String>>,
+        webrtc: WebRTCStream,
+        peer: String,
+        session_key: String,
+    ) -> oneshot::Sender<()> {
+        let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
+        let my_id = Config::get_id();
+        tokio::spawn(async move {
+            loop {
+                match stop_rx.try_recv() {
+                    Ok(_) | Err(tokio::sync::oneshot::error::TryRecvError::Closed) => break,
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {}
+                }
+
+                if let Some(rx) = local_ice_rx.as_mut() {
+                    loop {
+                        match rx.try_recv() {
+                            Ok(candidate) => {
+                                let mut msg = RendezvousMessage::new();
+                                msg.set_ice_candidate(IceCandidate {
+                                    from_id: my_id.clone(),
+                                    to_id: peer.clone(),
+                                    session_key: session_key.clone(),
+                                    candidate,
+                                    ..Default::default()
+                                });
+                                if let Err(err) = socket.send(&msg).await {
+                                    log::warn!("failed to send WebRTC ICE candidate: {}", err);
+                                    return;
+                                }
+                            }
+                            Err(TryRecvError::Empty) => break,
+                            Err(TryRecvError::Disconnected) => {
+                                local_ice_rx = None;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if let Some(msg_in) =
+                    crate::get_next_nonkeyexchange_msg(&mut socket, Some(100)).await
+                {
+                    if let Some(rendezvous_message::Union::IceCandidate(ice)) = msg_in.union {
+                        if ice.from_id == peer
+                            && ice.to_id == my_id
+                            && ice.session_key == session_key
+                        {
+                            if let Err(err) = webrtc.add_remote_ice_candidate(&ice.candidate).await
+                            {
+                                log::warn!("failed to add WebRTC ICE candidate: {}", err);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        stop_tx
+    }
+
     async fn _start_inner(
         peer: String,
         key: String,
@@ -364,6 +444,8 @@ impl Client {
         interface: impl Interface,
         mut udp: (Option<Arc<UdpSocket>>, Option<Arc<Mutex<u16>>>),
         stop_udp_tx: Option<oneshot::Sender<()>>,
+        mut ipv6: Option<(Arc<UdpSocket>, bytes::Bytes)>,
+        mut webrtc_offerer: Option<WebRTCStream>,
         mut rendezvous_server: String,
         servers: Vec<String>,
         contained: bool,
@@ -436,14 +518,20 @@ impl Client {
         // Stop UDP NAT test task if still running
         stop_udp_tx.map(|tx| tx.send(()));
         let mut msg_out = RendezvousMessage::new();
-        let mut ipv6 = if crate::get_ipv6_punch_enabled() {
-            if let Some((socket, addr)) = crate::get_ipv6_socket().await {
-                (Some(socket), Some(addr))
-            } else {
-                (None, None)
+        let mut ipv6 = ipv6
+            .take()
+            .map(|(socket, addr)| (Some(socket), Some(addr)))
+            .unwrap_or((None, None));
+        let webrtc_sdp_offer = if let Some(webrtc) = webrtc_offerer.as_ref() {
+            match webrtc.get_local_endpoint().await {
+                Ok(endpoint) => endpoint,
+                Err(err) => {
+                    log::warn!("failed to read local WebRTC offer: {}", err);
+                    String::new()
+                }
             }
         } else {
-            (None, None)
+            String::new()
         };
         let udp_nat_port = udp.1.map(|x| *x.lock().unwrap()).unwrap_or(0);
         let punch_type = if udp_nat_port > 0 { "UDP" } else { "TCP" };
@@ -458,8 +546,15 @@ impl Client {
             force_relay: interface.is_force_relay(),
             socket_addr_v6: ipv6.1.unwrap_or_default(),
             switch_code,
+            webrtc_sdp_offer: webrtc_sdp_offer.clone(),
             ..Default::default()
         });
+        let webrtc_session_key = webrtc_offerer
+            .as_ref()
+            .map(|webrtc| webrtc.session_key().to_owned())
+            .unwrap_or_default();
+        let mut webrtc_sdp_answer = String::new();
+        let mut pending_webrtc_ice = Vec::<String>::new();
         for i in 1..=3 {
             log::info!(
                 "#{} {} punch attempt with {}, id: {}",
@@ -501,6 +596,7 @@ impl Client {
                             relay_server = ph.relay_server;
                             peer_addr = AddrMangle::decode(&ph.socket_addr);
                             feedback = ph.feedback;
+                            webrtc_sdp_answer = ph.webrtc_sdp_answer;
                             let s = udp.0.take();
                             if ph.is_udp && s.is_some() {
                                 if let Some(s) = s {
@@ -540,6 +636,38 @@ impl Client {
                             }
                         }
                         signed_id_pk = rr.pk().into();
+                        let mut webrtc_bridge_stop = None;
+                        let mut webrtc_for_connect = None;
+                        if !rr.webrtc_sdp_answer.is_empty() {
+                            if let Some(webrtc) = webrtc_offerer.take() {
+                                if let Err(err) =
+                                    webrtc.set_remote_endpoint(&rr.webrtc_sdp_answer).await
+                                {
+                                    log::warn!("failed to set WebRTC relay answer: {}", err);
+                                } else {
+                                    for candidate in pending_webrtc_ice.drain(..) {
+                                        if let Err(err) =
+                                            webrtc.add_remote_ice_candidate(&candidate).await
+                                        {
+                                            log::warn!(
+                                                "failed to add buffered WebRTC ICE candidate: {}",
+                                                err
+                                            );
+                                        }
+                                    }
+                                    let session_key = webrtc.session_key().to_owned();
+                                    let local_ice_rx = webrtc.take_local_ice_rx();
+                                    webrtc_bridge_stop = Some(Self::spawn_webrtc_ice_bridge(
+                                        socket,
+                                        local_ice_rx,
+                                        webrtc.clone(),
+                                        peer.clone(),
+                                        session_key,
+                                    ));
+                                    webrtc_for_connect = Some(webrtc);
+                                }
+                            }
+                        }
                         let fut = Self::create_relay(
                             &peer,
                             rr.uuid,
@@ -555,22 +683,49 @@ impl Client {
                             }
                             .boxed(),
                         );
+                        if let Some(mut webrtc) = webrtc_for_connect {
+                            connect_futures.push(
+                                async move {
+                                    webrtc.wait_connected(CONNECT_TIMEOUT).await?;
+                                    Ok((Stream::WebRTC(webrtc), None, "WebRTC"))
+                                }
+                                .boxed(),
+                            );
+                        }
                         // Run all connection attempts concurrently, return the first successful one
                         let (conn, kcp, typ) = match select_ok(connect_futures).await {
                             Ok(conn) => (Ok(conn.0 .0), conn.0 .1, conn.0 .2),
 
                             Err(e) => (Err(e), None, ""),
                         };
+                        if let Some(stop) = webrtc_bridge_stop {
+                            let _ = stop.send(());
+                        }
                         let mut conn = conn?;
                         feedback = rr.feedback;
                         log::info!("{:?} used to establish {typ} connection", start.elapsed());
                         let pk =
                             Self::secure_connection(&peer, signed_id_pk, &key, &mut conn).await?;
                         return Ok((
-                            (conn, typ == "IPv6", pk, kcp, typ),
+                            (conn, typ == "IPv6" || typ == "WebRTC", pk, kcp, typ),
                             (feedback, rendezvous_server),
                             false,
                         ));
+                    }
+                    Some(rendezvous_message::Union::IceCandidate(ice)) => {
+                        if !webrtc_session_key.is_empty()
+                            && ice.from_id == peer
+                            && ice.to_id == Config::get_id()
+                            && ice.session_key == webrtc_session_key
+                        {
+                            pending_webrtc_ice.push(ice.candidate);
+                        } else {
+                            log::debug!(
+                                "dropping ICE candidate for unexpected WebRTC session from {} key {}",
+                                ice.from_id,
+                                ice.session_key
+                            );
+                        }
                     }
                     _ => {
                         log::error!("Unexpected protobuf msg received: {:?}", msg_in);
@@ -578,7 +733,36 @@ impl Client {
                 }
             }
         }
-        drop(socket);
+        let mut webrtc_bridge_stop = None;
+        let mut webrtc_for_connect = None;
+        if !webrtc_sdp_answer.is_empty() {
+            if let Some(webrtc) = webrtc_offerer.take() {
+                if let Err(err) = webrtc.set_remote_endpoint(&webrtc_sdp_answer).await {
+                    log::warn!("failed to set WebRTC answer: {}", err);
+                    drop(socket);
+                } else {
+                    for candidate in pending_webrtc_ice.drain(..) {
+                        if let Err(err) = webrtc.add_remote_ice_candidate(&candidate).await {
+                            log::warn!("failed to add buffered WebRTC ICE candidate: {}", err);
+                        }
+                    }
+                    let session_key = webrtc.session_key().to_owned();
+                    let local_ice_rx = webrtc.take_local_ice_rx();
+                    webrtc_bridge_stop = Some(Self::spawn_webrtc_ice_bridge(
+                        socket,
+                        local_ice_rx,
+                        webrtc.clone(),
+                        peer.clone(),
+                        session_key,
+                    ));
+                    webrtc_for_connect = Some(webrtc);
+                }
+            } else {
+                drop(socket);
+            }
+        } else {
+            drop(socket);
+        }
         if peer_addr.port() == 0 {
             bail!("Failed to connect via rendezvous server");
         }
@@ -612,6 +796,8 @@ impl Client {
                 interface,
                 udp.0,
                 ipv6.0,
+                webrtc_for_connect,
+                webrtc_bridge_stop,
                 punch_type,
             )
             .await?,
@@ -638,6 +824,8 @@ impl Client {
         interface: impl Interface,
         udp_socket_nat: Option<Arc<UdpSocket>>,
         udp_socket_v6: Option<Arc<UdpSocket>>,
+        webrtc_offerer: Option<WebRTCStream>,
+        webrtc_bridge_stop: Option<oneshot::Sender<()>>,
         punch_type: &str,
     ) -> ResultType<(
         Stream,
@@ -696,11 +884,23 @@ impl Client {
         if let Some(udp_socket_v6) = udp_socket_v6 {
             connect_futures.push(udp_nat_connect(udp_socket_v6, "IPv6", connect_timeout).boxed());
         }
+        if let Some(mut webrtc) = webrtc_offerer {
+            connect_futures.push(
+                async move {
+                    webrtc.wait_connected(connect_timeout).await?;
+                    Ok((Stream::WebRTC(webrtc), None, "WebRTC"))
+                }
+                .boxed(),
+            );
+        }
         // Run all connection attempts concurrently, return the first successful one
         let (mut conn, kcp, mut typ) = match select_ok(connect_futures).await {
             Ok(conn) => (Ok(conn.0 .0), conn.0 .1, conn.0 .2),
             Err(e) => (Err(e), None, ""),
         };
+        if let Some(stop) = webrtc_bridge_stop {
+            let _ = stop.send(());
+        }
 
         let mut direct = !conn.is_err();
         if interface.is_force_relay() || conn.is_err() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1070,6 +1070,7 @@ impl Client {
                                     &key,
                                     &token,
                                     conn_type,
+                                    &interface.get_switch_code(),
                                 )
                                 .await
                                 .map_err(|relay_e| {
@@ -1405,6 +1406,7 @@ impl Client {
                     key,
                     token,
                     conn_type,
+                    &interface.get_switch_code(),
                 )
                 .await
                 {

--- a/src/client.rs
+++ b/src/client.rs
@@ -214,9 +214,10 @@ impl Drop for OffererGuard {
 /// - a WebRTC success is committed immediately;
 /// - an `is_p2p` result from `others` (e.g. IPv6 direct) is committed immediately;
 /// - a relayed result inside the preference window is *held*, giving WebRTC until the window
-///   expires to connect and take priority, while unfinished `others` keep racing so a slower
-///   direct transport can still win; when the window ends (or WebRTC fails) the held connection
-///   is committed;
+///   expires to connect and take priority. The window starts when the first relay is ready, not
+///   when setup begins, so rendezvous latency cannot consume the preference budget. Unfinished
+///   `others` keep racing so a slower direct transport can still win; when the window ends (or
+///   WebRTC fails) the held connection is committed;
 /// - a failure on one side commits the survivor as soon as it succeeds; two failures compose
 ///   into one error.
 ///
@@ -234,10 +235,15 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
     let mut others_err: Option<hbb_common::anyhow::Error> = None;
     let window = tokio::time::sleep(Duration::from_millis(window_ms));
     tokio::pin!(window);
-    let mut window_over = false;
+    let mut window_started = false;
     loop {
         tokio::select! {
-            res = async { webrtc_fut.as_mut().unwrap().await }, if webrtc_fut.is_some() => {
+            res = async {
+                match webrtc_fut.as_mut() {
+                    Some(fut) => fut.await,
+                    None => std::future::pending().await,
+                }
+            }, if webrtc_fut.is_some() => {
                 webrtc_fut = None;
                 match res {
                     // WebRTC connected: preferred outright; a held relay conn just drops.
@@ -254,17 +260,26 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
                     }
                 }
             }
-            res = async { others_fut.as_mut().unwrap().await }, if others_fut.is_some() => {
+            res = async {
+                match others_fut.as_mut() {
+                    Some(fut) => fut.await,
+                    None => std::future::pending().await,
+                }
+            }, if others_fut.is_some() => {
                 others_fut = None;
                 match res {
                     Ok((conn, unfinished)) => {
-                        if is_p2p(&conn) || window_over || webrtc_fut.is_none() {
+                        if is_p2p(&conn) || webrtc_fut.is_none() {
                             return Ok(conn);
                         }
                         // Hold the first relay, but keep polling unfinished alternatives: an IPv6
                         // direct attempt may complete inside the same WebRTC preference window.
                         if held.is_none() {
                             held = Some(conn);
+                            window.as_mut().reset(
+                                Instant::now() + Duration::from_millis(window_ms),
+                            );
+                            window_started = true;
                         }
                         if !unfinished.is_empty() {
                             others_fut = Some(select_ok(unfinished));
@@ -277,14 +292,22 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
                     },
                 }
             }
-            _ = &mut window, if !window_over => {
-                window_over = true;
+            _ = &mut window, if window_started => {
                 if let Some(conn) = held.take() {
                     return Ok(conn);
                 }
+                window_started = false;
             }
         }
     }
+}
+
+fn request_can_carry_webrtc(udp_port: u16, force_relay: bool) -> bool {
+    // A normal TCP punch request must close its rendezvous socket before reusing that local
+    // address, while WebRTC trickle ICE retains the socket as its signaling bridge. Therefore a
+    // request with udp_port=0 must never carry WebRTC. UDP requests can carry it because their
+    // punch socket is separate; force-relay requests can too because they never enter TCP punching.
+    udp_port > 0 || force_relay
 }
 
 impl Client {
@@ -438,7 +461,13 @@ impl Client {
         } else {
             None
         };
-        let webrtc_offerer = if Self::should_create_webrtc_offerer(&interface) {
+        // Prepare WebRTC only for a possible UDP request, or for force-relay where TURN is the
+        // only WebRTC path. `_start_inner` applies the stricter wire invariant after the UDP NAT
+        // test: an actual request with udp_port=0 never includes the offer.
+        let may_prepare_webrtc = udp.0.is_some() || interface.is_force_relay();
+        let webrtc_offerer = if may_prepare_webrtc
+            && Self::should_create_webrtc_offerer(&interface)
+        {
             match WebRTCStream::new("", interface.is_force_relay(), CONNECT_TIMEOUT).await {
                 Ok(stream) => Some(stream),
                 Err(err) => {
@@ -449,6 +478,7 @@ impl Client {
         } else {
             None
         };
+        let has_webrtc_offerer = webrtc_offerer.is_some();
         let fut = Self::_start_inner(
             peer.to_owned(),
             key.to_owned(),
@@ -466,9 +496,12 @@ impl Client {
         if udp.0.is_none() {
             return fut.await;
         }
-        let mut connect_futures = Vec::new();
-        connect_futures.push(fut.boxed());
-        let fut = Self::_start_inner(
+        let preferred_fut = fut.boxed();
+        // This is deliberately a pure TCP punch request: its WebRTC argument must stay `None`.
+        // TCP punching closes the rendezvous socket before binding a new connection to the same
+        // local address; a WebRTC ICE bridge would retain that socket and break the port reuse.
+        // The preferred request above may carry WebRTC only because it owns a separate UDP socket.
+        let fallback_fut = Self::_start_inner(
             peer.to_owned(),
             key.to_owned(),
             token.to_owned(),
@@ -481,8 +514,18 @@ impl Client {
             rendezvous_server,
             servers,
             contained,
-        );
-        connect_futures.push(fut.boxed());
+        )
+        .boxed();
+        if has_webrtc_offerer {
+            return race_transports_prefer_webrtc(
+                preferred_fut,
+                vec![fallback_fut],
+                Self::WEBRTC_PREFER_WINDOW_MS,
+                |result| result.0 .1,
+            )
+            .await;
+        }
+        let connect_futures = vec![preferred_fut, fallback_fut];
         match select_ok(connect_futures).await {
             Ok(conn) => Ok((conn.0 .0, conn.0 .1, conn.0 .2)),
             Err(e) => Err(e),
@@ -531,7 +574,9 @@ impl Client {
     /// too.
     /// When force_relay *and* TURN are configured, WebRTC via TURN is a valid "relayed" path:
     /// `connect` keeps a WebRTC win instead of replacing it with the RustDesk relay, and the
-    /// RelayResponse path prefers it within the WebRTC preference window.
+    /// RelayResponse path races it without a P2P preference delay. The caller additionally
+    /// requires either a usable UDP request or force_relay; a normal TCP punch request must never
+    /// carry a WebRTC offer because trickle ICE retains the socket TCP punching needs to reuse.
     fn should_create_webrtc_offerer(interface: &impl Interface) -> bool {
         if !crate::get_udp_punch_enabled() || use_ws() || Config::is_proxy() {
             return false;
@@ -752,20 +797,26 @@ impl Client {
             .take()
             .map(|(socket, addr)| (Some(socket), Some(addr)))
             .unwrap_or((None, None));
-        let webrtc_sdp_offer = if let Some(stream) =
-            webrtc_offerer.as_ref().and_then(|g| g.stream())
-        {
-            match stream.get_local_endpoint().await {
-                Ok(endpoint) => endpoint,
-                Err(err) => {
-                    log::warn!("failed to read local WebRTC offer: {}", err);
+        let udp_nat_port = udp.1.map(|x| *x.lock().unwrap()).unwrap_or(0);
+        let webrtc_sdp_offer =
+            if request_can_carry_webrtc(udp_nat_port, interface.is_force_relay()) {
+                if let Some(stream) = webrtc_offerer.as_ref().and_then(|g| g.stream()) {
+                    match stream.get_local_endpoint_trickle().await {
+                        Ok(endpoint) => endpoint,
+                        Err(err) => {
+                            log::warn!("failed to read local WebRTC offer: {}", err);
+                            String::new()
+                        }
+                    }
+                } else {
                     String::new()
                 }
-            }
-        } else {
-            String::new()
-        };
-        let udp_nat_port = udp.1.map(|x| *x.lock().unwrap()).unwrap_or(0);
+            } else {
+                // Hard protocol invariant: a normal request with udp_port=0 is a TCP punch
+                // request. It must not start WebRTC trickle on the rendezvous socket that TCP
+                // punching needs to close and reuse by local address.
+                String::new()
+            };
         let punch_type = if udp_nat_port > 0 { "UDP" } else { "TCP" };
         msg_out.set_punch_hole_request(PunchHoleRequest {
             id: peer.to_owned(),
@@ -960,16 +1011,24 @@ impl Client {
                                 Ok((Stream::WebRTC(raced), None, "WebRTC"))
                             }
                             .boxed();
-                            // The peer answered WebRTC: prefer P2P. The relay result is held for
-                            // the preference window so WebRTC can win even though a relay TCP
-                            // connect completes much faster than ICE + DTLS setup.
-                            race_transports_prefer_webrtc(
-                                webrtc_fut,
-                                connect_futures,
-                                Self::WEBRTC_PREFER_WINDOW_MS,
-                                |result| result.2 == "IPv6",
-                            )
-                            .await
+                            if interface.is_force_relay() {
+                                // Relay-only WebRTC can use only TURN, so it has no P2P advantage
+                                // over the RustDesk relay. Take the first successful relay instead
+                                // of delaying an already-ready result for the preference window.
+                                connect_futures.push(webrtc_fut);
+                                select_ok(connect_futures).await.map(|r| r.0)
+                            } else {
+                                // The peer answered WebRTC: prefer P2P. The relay result is held
+                                // for the preference window so WebRTC can win even though a relay
+                                // TCP connect completes much faster than ICE + DTLS setup.
+                                race_transports_prefer_webrtc(
+                                    webrtc_fut,
+                                    connect_futures,
+                                    Self::WEBRTC_PREFER_WINDOW_MS,
+                                    |result| result.2 == "IPv6",
+                                )
+                                .await
+                            }
                         } else {
                             // Run all connection attempts concurrently, take the first success.
                             select_ok(connect_futures).await.map(|r| r.0)
@@ -5122,7 +5181,7 @@ async fn udp_nat_connect(
 
 #[cfg(test)]
 mod webrtc_race_tests {
-    use super::race_transports_prefer_webrtc;
+    use super::{race_transports_prefer_webrtc, request_can_carry_webrtc};
     use hbb_common::{
         anyhow::anyhow,
         futures::future::{BoxFuture, FutureExt},
@@ -5149,12 +5208,32 @@ mod webrtc_race_tests {
 
     const NOT_P2P: fn(&&'static str) -> bool = |_| false;
 
+    #[test]
+    fn tcp_punch_request_never_carries_webrtc() {
+        assert!(!request_can_carry_webrtc(0, false));
+        assert!(request_can_carry_webrtc(1, false));
+        assert!(request_can_carry_webrtc(0, true));
+    }
+
     #[tokio::test]
     async fn webrtc_preferred_over_faster_relay_within_window() {
         let got = race_transports_prefer_webrtc(
             ok_after(120, "webrtc"),
             vec![ok_after(10, "relay")],
             60_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "webrtc");
+    }
+
+    #[tokio::test]
+    async fn preference_window_starts_when_relay_is_ready() {
+        let got = race_transports_prefer_webrtc(
+            ok_after(350, "webrtc"),
+            vec![ok_after(250, "relay")],
+            200,
             NOT_P2P,
         )
         .await

--- a/src/client.rs
+++ b/src/client.rs
@@ -207,33 +207,12 @@ impl Drop for OffererGuard {
     }
 }
 
-/// Race the WebRTC connect attempt against the other transport futures, preferring P2P.
-///
-/// A plain `select_ok` would almost always pick the relay: its TCP connect completes in one
-/// round trip while WebRTC needs candidate trickle + ICE checks + DTLS + SCTP. Instead:
-/// - an `is_p2p` result from either side (WebRTC, or e.g. IPv6 direct from `others`) is committed
-///   immediately;
-/// - a relayed result from *either* side inside the preference window is *held*, giving the other
-///   side until the window expires to land something direct. `webrtc_fut` is a whole punch
-///   attempt, not just the WebRTC connect, so it too can end in a relay, and committing that
-///   immediately would preempt a direct punch still in flight on the other branch. The window
-///   starts when the first relay is ready, not when setup begins, so rendezvous latency cannot
-///   consume the preference budget. Unfinished `others` keep racing so a slower direct transport
-///   can still win; when the window ends (or the other side fails) the held connection is
-///   committed;
-/// - a failure on one side commits the survivor as soon as it succeeds; two failures compose
-///   into one error.
+/// Race WebRTC against the other transports, preferring P2P: `select_ok` would always pick the
+/// relay, whose TCP connect beats ICE + DTLS + SCTP by an order of magnitude. An `is_p2p` result
+/// wins outright; a relayed one — from either side, since `webrtc_fut` is a whole punch attempt
+/// that can also end in a relay — is held for `window_ms` to give the other side a chance.
 ///
 /// `others` must be non-empty (`select_ok` requires it).
-/// Whether a transport label names a peer-to-peer path rather than the RustDesk relay.
-///
-/// The preference window exists to let one of these beat a relay that connects sooner, so a
-/// label misclassified here inverts the race: a direct connection is parked as if it were a
-/// relay, and the relay is then committed the moment it arrives.
-fn is_direct_transport(typ: &str) -> bool {
-    !matches!(typ, "Relay" | "WebSocket")
-}
-
 async fn race_transports_prefer_webrtc<'a, T: 'a>(
     webrtc_fut: BoxFuture<'a, ResultType<T>>,
     others: Vec<BoxFuture<'a, ResultType<T>>>,
@@ -583,28 +562,10 @@ impl Client {
 
     /// Whether to build a WebRTC offerer for this connection.
     ///
-    /// Off by default against a private rendezvous server, like the UDP/IPv6 punch options:
-    /// a self-hosted deployment opts in once its server (and TURN, if any) is ready.
-    ///
-    /// Skips it when a SOCKS proxy is configured: WebRTC's ICE binds its own UDP sockets and
-    /// speaks STUN directly, which would bypass the proxy policy and can leak the real IP.
-    /// WebSocket mode does NOT skip it: ws only tunnels the signaling/relay legs to the server
-    /// (and `connect_tcp` is ws-aware for them), while ICE remains the only viable P2P path in
-    /// ws deployments where classic punching is forced to relay. Independent of the udp-punch
-    /// option too — the offer rides any request, and a server or peer without WebRTC support
-    /// drops the field, so the race simply proceeds without it.
-    /// Under relay-by-POLICY (force-always-relay option or an explicit relay request) the pc
-    /// uses Relay-only ICE, which gathers nothing and can never connect unless a TURN server
-    /// is configured, so skip building a guaranteed-dead pc + STUN/TURN gathering + answerer
-    /// signaling in that case. WebSocket-forced relay is deliberately NOT policy: ws only
-    /// tunnels the signaling/relay legs, so the offer keeps full ICE and may land a direct
-    /// connection - the flagship path for ws deployments (the offer envelope's `ice_policy`
-    /// key tells the peer).
-    /// When policy relay *and* TURN are configured, WebRTC via TURN is a valid "relayed" path:
-    /// `connect` keeps a WebRTC win instead of replacing it with the RustDesk relay, and the
-    /// RelayResponse path races it without a P2P preference delay. Any request carrying an offer
-    /// keeps its rendezvous socket for trickle signaling and never reuses it for TCP punching; a
-    /// separate offer-less request provides the TCP fallback when force-relay is not requested.
+    /// A SOCKS proxy rules it out: ICE binds its own UDP sockets and speaks STUN directly, past
+    /// the proxy and with the real IP. Relay-by-policy without TURN rules it out too, since
+    /// Relay-only ICE can then gather nothing. WebSocket does not: it tunnels only the signaling
+    /// and relay legs, so the offer keeps full ICE and direct is exactly what it is there for.
     fn should_create_webrtc_offerer(interface: &impl Interface) -> bool {
         if !crate::get_webrtc_enabled() {
             return false;
@@ -638,13 +599,9 @@ impl Client {
     /// Bridge local ICE candidates to the peer over the punch socket, and feed the peer's back
     /// into the pc.
     ///
-    /// This socket must not be reconnected on error, unlike the controlled side's sender which
-    /// dials a fresh connection per candidate. Its address *is* the return route: the server
-    /// mangles it into `PunchHole.socket_addr`, the peer echoes it back as
-    /// `IceCandidate.socket_addr`, and the server resolves it through `tcp_punch`. A reconnect
-    /// would arrive from a new address that no route points at, and the server drops the old
-    /// entry when this connection closes — so once it dies, both directions are dead and
-    /// abandoning WebRTC for another transport is the correct response, not retrying.
+    /// Never reconnect this socket: its address *is* the return route (the server mangles it into
+    /// `PunchHole.socket_addr` and resolves the echo through `tcp_punch`), so a new address is one
+    /// nothing points at. Once it dies, both directions are dead — abandon WebRTC, do not retry.
     fn spawn_webrtc_ice_bridge(
         mut socket: Stream,
         mut local_ice_rx: Option<UnboundedReceiver<String>>,
@@ -1571,17 +1528,10 @@ impl Client {
         let sign_pk = match sign_pk {
             Some(v) => v,
             None => {
-                // No trusted peer identity: either the deployment provides none (empty
-                // signed_id_pk, key-less) or the blob does not verify under our configured root
-                // (typical benign cause: self-hosted server with the client not configured with
-                // its key, so verification runs against the built-in RS_PUB_KEY). Either way no
-                // fingerprint binding is possible, which is the same cryptographic state as
-                // key-less: DTLS-encrypted to an unauthenticated peer. Proceed like TCP's
-                // non-secure fallback with is_secured() left false. Bailing here instead would
-                // only push the session onto a relay where the same blob fails verification
-                // again and the payload then runs in plaintext — strictly worse than
-                // unauthenticated DTLS, while an active attacker reaches the same warned,
-                // unauthenticated endpoint either way.
+                // No trusted peer identity (key-less deployment, or a blob that does not verify
+                // under our root), so no fingerprint binding is possible. Fall through like TCP's
+                // non-secure path with is_secured() false: bailing would only move the session to
+                // a relay that fails the same check and then runs in plaintext.
                 // send an empty message out in case server is setting up secure and waiting for first message
                 conn.send(&Message::new()).await?;
                 return Ok(option_pk);
@@ -1595,11 +1545,9 @@ impl Client {
                         if let Ok((id, their_pk_b, signed_fp)) = decode_id_pk_dtls(&si.id, &sign_pk) {
                             if id == peer_id {
                                 // WebRTC only: bind the DTLS channel to the verified peer identity.
-                                // webrtc-rs already verified the peer certificate matches the remote
-                                // SDP fingerprint, so requiring the peer to have signed that same
-                                // fingerprint defeats a rendezvous/relay MITM that swaps SDPs. Fail
-                                // closed: an unreadable/empty/mismatched fingerprint aborts the
-                                // WebRTC connection rather than silently accepting it.
+                                // webrtc-rs already bound the certificate to the remote SDP, so
+                                // requiring the peer to have SIGNED that fingerprint defeats a
+                                // rendezvous/relay MITM that swaps SDPs. Fail closed.
                                 if is_webrtc {
                                     let actual_fp = conn.dtls_fingerprint(false).await.ok_or_else(
                                         || anyhow!("WebRTC DTLS fingerprint unavailable"),
@@ -2605,14 +2553,11 @@ pub struct LoginConfigHandler {
     // reconnect before the real reboot disconnect.
     restart_remote_device_at: Option<Instant>,
     pub force_relay: bool,
-    // The policy component of force_relay: peer_relay plus proxy, WITHOUT the WebSocket
-    // transport. ws kills classic TCP/UDP punching (force_relay stays set for those paths)
-    // but says nothing about ICE, so the WebRTC decisions - offer ICE policy, prefer-P2P
-    // racing - key off this instead: relay-by-policy must stay Relay-only ICE, while
-    // relay-by-transport may still go direct over full ICE.
+    // force_relay minus the WebSocket transport. ws forces relay for classic punching but says
+    // nothing about ICE, so every WebRTC decision keys off this: policy means Relay-only ICE,
+    // transport may still go direct.
     pub policy_relay: bool,
-    // The peer-scoped component: this peer's saved force-always-relay option, or an explicit
-    // relay request for it. The only part that may be written back into the peer's config.
+    // The peer-scoped part of it, and the only part that may be written back to the peer.
     pub peer_relay: bool,
     pub direct: Option<bool>,
     pub received: bool,
@@ -2726,12 +2671,9 @@ impl LoginConfigHandler {
         self.session_id = sid;
         self.supported_encoding = Default::default();
         self.clear_restarting_remote_device();
-        // Three scopes, and only the first belongs in the peer's saved config: what was decided
-        // about THIS PEER (its saved option, or an explicit relay request such as an `/r` id or
-        // a retry-via-relay), versus what is true of this client right now (a proxy, WebSocket).
-        // Persisting either of the latter turns a transient local setup into a permanent property
-        // of the peer — and relay-by-policy means Relay-only ICE, so WebRTC never goes direct to
-        // it again.
+        // Three scopes: what was decided about this PEER, what this CLIENT is set up as (proxy),
+        // and what its TRANSPORT forces (ws). Only the first may be written back to the peer's
+        // config — persisting the others would make a local setup a permanent peer property.
         self.peer_relay =
             config::option2bool("force-always-relay", &self.get_option("force-always-relay"))
                 || force_relay;
@@ -5284,7 +5226,7 @@ async fn udp_nat_connect(
 
 #[cfg(test)]
 mod webrtc_race_tests {
-    use super::{is_direct_transport, race_transports_prefer_webrtc, request_allows_tcp_punch};
+    use super::{race_transports_prefer_webrtc, request_allows_tcp_punch};
     use hbb_common::{
         anyhow::anyhow,
         futures::future::{BoxFuture, FutureExt},
@@ -5317,35 +5259,19 @@ mod webrtc_race_tests {
         assert!(!request_allows_tcp_punch("webrtc://offer"));
     }
 
-    // The transport labels the RelayResponse race actually runs on. Its predicate has to
-    // recognise the WebRTC branch's own label as direct, or a WebRTC connection that completes
-    // BEFORE the relay is parked as if it were a relay and the relay is committed on arrival —
-    // inverting the race exactly on the fast networks where ICE beats a TCP relay connect.
-    #[test]
-    fn transport_labels_are_classified_as_direct_or_relayed() {
-        for direct in ["WebRTC", "TCP", "UDP", "IPv6"] {
-            assert!(is_direct_transport(direct), "{direct} is a direct path");
-        }
-        for relayed in ["Relay", "WebSocket"] {
-            assert!(
-                !is_direct_transport(relayed),
-                "{relayed} goes via the relay"
-            );
-        }
-    }
-
+    // A direct result must win even when it lands first — the LAN ordering, where ICE beats the
+    // relay's TCP connect. Parking it as if it were a relay commits the relay on arrival.
     #[tokio::test]
     async fn direct_result_wins_even_when_it_arrives_first() {
-        // Same ordering as a LAN: the preferred branch connects before the relay does.
         let got = race_transports_prefer_webrtc(
-            ok_after(10, "WebRTC"),
-            vec![ok_after(120, "Relay")],
+            ok_after(10, "direct"),
+            vec![ok_after(120, "relay")],
             60_000,
-            |result| is_direct_transport(result),
+            |result| *result == "direct",
         )
         .await
         .unwrap();
-        assert_eq!(got, "WebRTC");
+        assert_eq!(got, "direct");
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -175,14 +175,9 @@ pub fn get_key_state(key: enigo::Key) -> bool {
     ENIGO.lock().unwrap().get_key_state(key)
 }
 
-/// RAII guard for a WebRTC offerer that has not yet been adopted into a connection.
-///
-/// The offerer's `RTCPeerConnection` is created eagerly in `Client::start` and inserted into the
-/// global `SESSIONS` map; if it never receives a remote answer it stays in ICE state `New`
-/// forever, so its state-change handler never fires and it never self-removes. This guard closes
-/// the pc on drop, covering the paths that would otherwise leak it: early `?`/`bail!` returns in
-/// `_start_inner`, and `select_ok` cancelling the racing attempt that holds the offerer. Call
-/// [`OffererGuard::into_inner`] to disarm when the stream is adopted into a live connection.
+/// Closes an unadopted WebRTC offerer's pc on drop. Without an answer it stays in ICE `New`
+/// forever, so its state handler never fires to self-remove it from `SESSIONS`; this covers the
+/// early returns and cancelled races that would leak it. `into_inner` disarms on adoption.
 struct OffererGuard(Option<WebRTCStream>);
 
 impl OffererGuard {
@@ -254,8 +249,12 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
                         }
                     }
                     Err(e) => {
-                        if let Some(conn) = held.take() {
-                            return Ok(conn);
+                        // Commit a held relay only when nothing direct is still racing; otherwise
+                        // keep it and let the survivor (or the window) decide.
+                        if others_fut.is_none() {
+                            if let Some(conn) = held.take() {
+                                return Ok(conn);
+                            }
                         }
                         match others_err.take() {
                             Some(oe) => bail!("WebRTC failed: {}; fallback failed: {}", e, oe),
@@ -274,11 +273,15 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
                 others_fut = None;
                 match res {
                     Ok((conn, unfinished)) => {
-                        if is_p2p(&conn) || webrtc_fut.is_none() {
+                        if is_p2p(&conn) {
                             return Ok(conn);
                         }
-                        // Hold the first relay, but keep polling unfinished alternatives: an IPv6
-                        // direct attempt may complete inside the same WebRTC preference window.
+                        // Relayed: commit now only if nothing direct can still arrive. If a
+                        // direct attempt is still in flight (here or in `unfinished`), hold it
+                        // and keep racing for the preference window instead of discarding them.
+                        if webrtc_fut.is_none() && unfinished.is_empty() {
+                            return Ok(conn);
+                        }
                         if held.is_none() {
                             held = Some(conn);
                             window.as_mut().reset(
@@ -291,15 +294,16 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
                         }
                     }
                     Err(e) => match webrtc_err.take() {
-                        Some(we) => bail!("WebRTC failed: {}; fallback failed: {}", we, e),
-                        None if webrtc_fut.is_none() => {
-                            // The preferred branch may have parked a relay here; nothing else can
-                            // win now, so commit it rather than failing the connection.
-                            match held.take() {
-                                Some(conn) => return Ok(conn),
-                                None => return Err(e),
-                            }
-                        }
+                        // Nothing more can win, but a parked relay is still a valid outcome — take
+                        // it before failing the connection.
+                        Some(we) => match held.take() {
+                            Some(conn) => return Ok(conn),
+                            None => bail!("WebRTC failed: {}; fallback failed: {}", we, e),
+                        },
+                        None if webrtc_fut.is_none() => match held.take() {
+                            Some(conn) => return Ok(conn),
+                            None => return Err(e),
+                        },
                         None => others_err = Some(e),
                     },
                 }
@@ -1066,7 +1070,7 @@ impl Client {
                         }
                         // The ? / secure_connection failures below return early; webrtc_guard stays
                         // in scope and closes the offerer on any such exit (loss, error, cancellation).
-                        let (mut conn, kcp, mut typ, direct) = race_result?;
+                        let (mut conn, kcp, mut typ, mut direct) = race_result?;
                         feedback = rr.feedback;
                         log::info!("{:?} used to establish {typ} connection", start.elapsed());
                         let pk = match Self::secure_connection(
@@ -1116,6 +1120,10 @@ impl Client {
                                 .await?;
                                 conn = relay_conn;
                                 typ = if use_ws() { "WebSocket" } else { "Relay" };
+                                // The transport is now a relay: the WebRTC win it replaced must
+                                // not carry its direct flag into the return, or the relay is
+                                // reported P2P and the outer race treats it as one.
+                                direct = false;
                                 pk
                             }
                             Err(e) => return Err(e),
@@ -1331,50 +1339,81 @@ impl Client {
         log::info!("peer address: {}, timeout: {}", peer, connect_timeout);
         let start = std::time::Instant::now();
 
-        let mut connect_futures = Vec::new();
+        // Each attempt carries whether its path is direct (4th field). TCP/UDP/IPv6 punch are
+        // always direct; WebRTC is direct only when ICE nominated a non-TURN pair.
+        let mut direct_futures = Vec::new();
         if allow_tcp_punch {
             let fut = connect_tcp_local(peer, Some(local_addr), connect_timeout);
-            connect_futures.push(
+            direct_futures.push(
                 async move {
                     let conn = fut.await?;
-                    Ok((conn, None, "TCP"))
+                    Ok((conn, None, "TCP", true))
                 }
                 .boxed(),
             );
         }
         if let Some(udp_socket_nat) = udp_socket_nat {
-            connect_futures.push(udp_nat_connect(udp_socket_nat, "UDP", connect_timeout).boxed());
-        }
-        if let Some(udp_socket_v6) = udp_socket_v6 {
-            connect_futures.push(udp_nat_connect(udp_socket_v6, "IPv6", connect_timeout).boxed());
-        }
-        // Race a clone of the offerer; the guard retains its own clone so a losing/cancelled race
-        // still closes the pc (select_ok drops the future's clone without closing).
-        if let Some(stream) = webrtc_guard.as_ref().and_then(|g| g.stream()) {
-            let mut raced = stream.clone();
-            // The punch-tuned timeout can be as low as 1s — enough for a raw TCP SYN but not for
-            // candidate trickle + ICE checks + DTLS. Give WebRTC its own floor (prefer-P2P) so a
-            // viable P2P path is not abandoned before it can complete; TCP/UDP keep the tighter
-            // timeout, so a working direct connection still wins the race immediately, and the
-            // relay fallback below only waits the extra time when direct attempts all failed.
-            let webrtc_timeout = connect_timeout.max(Self::WEBRTC_PREFER_WINDOW_MS);
-            connect_futures.push(
+            direct_futures.push(
                 async move {
-                    raced.wait_connected(webrtc_timeout).await?;
-                    Ok((Stream::WebRTC(raced), None, "WebRTC"))
+                    let (conn, kcp, typ) =
+                        udp_nat_connect(udp_socket_nat, "UDP", connect_timeout).await?;
+                    Ok((conn, kcp, typ, true))
                 }
                 .boxed(),
             );
         }
-        // Run all connection attempts concurrently, return the first successful one
-        let direct_result = if connect_futures.is_empty() {
-            Err(anyhow!("No direct transport available"))
-        } else {
-            select_ok(connect_futures).await.map(|conn| conn.0)
+        if let Some(udp_socket_v6) = udp_socket_v6 {
+            direct_futures.push(
+                async move {
+                    let (conn, kcp, typ) =
+                        udp_nat_connect(udp_socket_v6, "IPv6", connect_timeout).await?;
+                    Ok((conn, kcp, typ, true))
+                }
+                .boxed(),
+            );
+        }
+        // Race a clone of the offerer; the guard retains its own clone so a losing/cancelled race
+        // still closes the pc (select_ok drops the future's clone without closing).
+        let webrtc_fut = webrtc_guard
+            .as_ref()
+            .and_then(|g| g.stream())
+            .map(|stream| {
+                let mut raced = stream.clone();
+                // The punch-tuned timeout can be as low as 1s — enough for a raw TCP SYN but not
+                // for candidate trickle + ICE checks + DTLS. Give WebRTC its own floor (prefer-P2P)
+                // so a viable P2P path is not abandoned before it can complete; TCP/UDP keep the
+                // tighter timeout, so a working direct connection still wins immediately, and the
+                // relay fallback only waits the extra time when direct attempts all failed.
+                let webrtc_timeout = connect_timeout.max(Self::WEBRTC_PREFER_WINDOW_MS);
+                async move {
+                    raced.wait_connected(webrtc_timeout).await?;
+                    // Resolve the pair here: a TURN win is relayed, not direct, and must be held
+                    // behind still-racing direct attempts rather than committed as P2P.
+                    let relayed = raced.is_relayed().await.unwrap_or(true);
+                    Ok((Stream::WebRTC(raced), None, "WebRTC", !relayed))
+                }
+                .boxed()
+            });
+        // Prefer P2P: a direct result wins outright, a relayed WebRTC (TURN) is held for the
+        // window so a direct punch can still land. Falls back to plain select_ok when only one
+        // kind is present.
+        let direct_result = match (webrtc_fut, direct_futures.is_empty()) {
+            (Some(webrtc_fut), false) => {
+                race_transports_prefer_webrtc(
+                    webrtc_fut,
+                    direct_futures,
+                    Self::WEBRTC_PREFER_WINDOW_MS,
+                    |r| r.3,
+                )
+                .await
+            }
+            (Some(webrtc_fut), true) => webrtc_fut.await,
+            (None, false) => select_ok(direct_futures).await.map(|c| c.0),
+            (None, true) => Err(anyhow!("No direct transport available")),
         };
-        let (mut conn, kcp, mut typ) = match direct_result {
-            Ok(conn) => (Ok(conn.0), conn.1, conn.2),
-            Err(e) => (Err(e), None, ""),
+        let (mut conn, kcp, mut typ, mut direct) = match direct_result {
+            Ok((conn, kcp, typ, direct)) => (Ok(conn), kcp, typ, direct),
+            Err(e) => (Err(e), None, "", false),
         };
         if let Some(stop) = webrtc_bridge_stop {
             let _ = stop.send(());
@@ -1382,7 +1421,6 @@ impl Client {
         // webrtc_guard stays armed across the relay override and secure_connection below; it is
         // disarmed only at the successful return when WebRTC is the kept transport.
 
-        let mut direct = !conn.is_err();
         // Keep a WebRTC win instead of replacing it with the RustDesk relay: under relay-by-
         // policy the pc was built with Relay-only ICE (TURN configured), which already honors
         // the relay requirement, and under ws-forced relay a direct full-ICE connection is the
@@ -5355,6 +5393,51 @@ mod webrtc_race_tests {
         .unwrap();
         assert_eq!(got, "ipv6");
         assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    // WebRTC fails first (others still racing), then a relay arrives with a direct attempt still
+    // unfinished behind it. The relay must not be committed while that direct attempt can win.
+    #[tokio::test]
+    async fn relay_does_not_preempt_unfinished_direct_after_webrtc_fails() {
+        let got = race_transports_prefer_webrtc(
+            err_after(5, "webrtc dead"),
+            vec![ok_after(10, "relay"), ok_after(100, "ipv6")],
+            60_000,
+            |t| *t == "ipv6",
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "ipv6");
+    }
+
+    // A relay is held with a direct attempt racing behind it, then WebRTC fails. The held relay
+    // must not be committed while the direct attempt is still in flight.
+    #[tokio::test]
+    async fn held_relay_waits_for_racing_direct_when_webrtc_fails() {
+        let got = race_transports_prefer_webrtc(
+            err_after(50, "webrtc dead"),
+            vec![ok_after(10, "relay"), ok_after(100, "ipv6")],
+            60_000,
+            |t| *t == "ipv6",
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "ipv6");
+    }
+
+    // Both attempts error, but a relay was parked before they did — it is the outcome, not a
+    // composed error.
+    #[tokio::test]
+    async fn held_relay_survives_both_errors() {
+        let got = race_transports_prefer_webrtc(
+            err_after(50, "webrtc dead"),
+            vec![ok_after(10, "relay"), err_after(100, "ipv6 dead")],
+            60_000,
+            |t| *t == "ipv6",
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "relay");
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -499,7 +499,10 @@ impl Client {
         // When this request carries an offer, `_start_inner` keeps its rendezvous socket solely
         // for trickle signaling; a separate offer-less request owns any TCP punch attempt.
         let webrtc_offerer = if Self::should_create_webrtc_offerer(&interface) {
-            match WebRTCStream::new("", interface.is_force_relay(), CONNECT_TIMEOUT).await {
+            // ICE policy follows relay-by-POLICY, not force_relay: under WebSocket the
+            // latter is set for the classic paths, but ICE opens its own sockets and may
+            // still go direct - that is the only P2P path ws deployments have.
+            match WebRTCStream::new("", interface.is_policy_relay(), CONNECT_TIMEOUT).await {
                 Ok(stream) => Some(stream),
                 Err(err) => {
                     log::warn!("webrtc offerer setup failed: {}", err);
@@ -604,10 +607,13 @@ impl Client {
     /// ws deployments where classic punching is forced to relay. Independent of the udp-punch
     /// option too — the offer rides any request, and a server or peer without WebRTC support
     /// drops the field, so the race simply proceeds without it.
-    /// Under force_relay the pc uses Relay-only ICE, which gathers nothing and can never connect
-    /// unless a TURN server is configured, so skip building a guaranteed-dead pc + STUN/TURN
-    /// gathering + answerer signaling in that case too.
-    /// When force_relay *and* TURN are configured, WebRTC via TURN is a valid "relayed" path:
+    /// Under relay-by-POLICY (force-always-relay option or an explicit relay request) the pc
+    /// uses Relay-only ICE, which gathers nothing and can never connect unless a TURN server
+    /// is configured, so skip building a guaranteed-dead pc + STUN/TURN gathering + answerer
+    /// signaling in that case. WebSocket-forced relay is deliberately NOT policy: ws only
+    /// tunnels the signaling/relay legs, so the offer keeps full ICE and may land a direct
+    /// connection - the flagship path for ws deployments (`webrtc_all_ice` tells the peer).
+    /// When policy relay *and* TURN are configured, WebRTC via TURN is a valid "relayed" path:
     /// `connect` keeps a WebRTC win instead of replacing it with the RustDesk relay, and the
     /// RelayResponse path races it without a P2P preference delay. Any request carrying an offer
     /// keeps its rendezvous socket for trickle signaling and never reuses it for TCP punching; a
@@ -616,7 +622,7 @@ impl Client {
         if Config::is_proxy() {
             return false;
         }
-        if interface.is_force_relay() && !WebRTCStream::has_turn_server() {
+        if interface.is_policy_relay() && !WebRTCStream::has_turn_server() {
             return false;
         }
         true
@@ -883,6 +889,9 @@ impl Client {
             socket_addr_v6: ipv6.1.unwrap_or_default(),
             switch_code,
             webrtc_sdp_offer: webrtc_sdp_offer.clone(),
+            // Full-ICE offer despite force_relay (ws transport): tells the controlled side
+            // its answer may gather every candidate type instead of requiring TURN.
+            webrtc_all_ice: !webrtc_sdp_offer.is_empty() && !interface.is_policy_relay(),
             ..Default::default()
         });
         let webrtc_session_key = webrtc_offerer
@@ -1064,10 +1073,12 @@ impl Client {
                                 Ok((Stream::WebRTC(raced), None, "WebRTC"))
                             }
                             .boxed();
-                            if interface.is_force_relay() {
+                            if interface.is_policy_relay() {
                                 // Relay-only WebRTC can use only TURN, so it has no P2P advantage
                                 // over the RustDesk relay. Take the first successful relay instead
                                 // of delaying an already-ready result for the preference window.
+                                // Policy, not force_relay: under ws the offer is full ICE and a
+                                // direct path is exactly what the preference window exists for.
                                 connect_futures.push(webrtc_fut);
                                 select_ok(connect_futures).await.map(|r| r.0)
                             } else {
@@ -1415,9 +1426,10 @@ impl Client {
         // disarmed only at the successful return when WebRTC is the kept transport.
 
         let mut direct = !conn.is_err();
-        // A WebRTC win under force_relay only happens when the pc was built with Relay-only ICE
-        // (TURN configured), which already honors the relay requirement — keep it instead of
-        // replacing it with the RustDesk relay.
+        // Keep a WebRTC win instead of replacing it with the RustDesk relay: under relay-by-
+        // policy the pc was built with Relay-only ICE (TURN configured), which already honors
+        // the relay requirement, and under ws-forced relay a direct full-ICE connection is the
+        // preferred outcome, not a violation.
         if (interface.is_force_relay() && typ != "WebRTC") || conn.is_err() {
             if !relay_server.is_empty() {
                 let switch_code = interface.get_switch_code();
@@ -2592,6 +2604,13 @@ pub struct LoginConfigHandler {
     // reconnect before the real reboot disconnect.
     restart_remote_device_at: Option<Instant>,
     pub force_relay: bool,
+    // The policy component of force_relay: the user's relay choice (option or explicit
+    // request) plus proxy, WITHOUT the WebSocket-transport component. ws kills classic
+    // TCP/UDP punching (force_relay stays set for those paths) but says nothing about
+    // ICE, so WebRTC decisions - offer ICE policy, prefer-P2P racing - key off this
+    // instead: relay-by-policy must stay Relay-only ICE, relay-by-transport may go
+    // direct over full ICE.
+    pub policy_relay: bool,
     pub direct: Option<bool>,
     pub received: bool,
     switch_uuid: Option<String>,
@@ -2704,11 +2723,11 @@ impl LoginConfigHandler {
         self.session_id = sid;
         self.supported_encoding = Default::default();
         self.clear_restarting_remote_device();
-        self.force_relay =
+        self.policy_relay =
             config::option2bool("force-always-relay", &self.get_option("force-always-relay"))
                 || force_relay
-                || use_ws()
                 || Config::is_proxy();
+        self.force_relay = self.policy_relay || use_ws();
         if let Some((real_id, server, key)) = &self.other_server {
             let other_server_key = self.get_option("other-server-key");
             if !other_server_key.is_empty() && key.is_empty() {
@@ -4599,6 +4618,10 @@ pub trait Interface: Send + Clone + 'static + Sized {
 
     fn is_force_relay(&self) -> bool {
         self.get_lch().read().unwrap().force_relay
+    }
+
+    fn is_policy_relay(&self) -> bool {
+        self.get_lch().read().unwrap().policy_relay
     }
 
     fn get_switch_code(&self) -> String {

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 use crate::{
     check_port,
     common::input::{MOUSE_BUTTON_LEFT, MOUSE_BUTTON_RIGHT, MOUSE_TYPE_DOWN, MOUSE_TYPE_UP},
-    create_symmetric_key_msg, decode_id_pk, get_rs_pk, is_keyboard_mode_supported,
+    create_symmetric_key_msg, decode_id_pk, decode_id_pk_dtls, get_rs_pk, is_keyboard_mode_supported,
     kcp_stream::KcpStream,
     secure_tcp,
     ui_interface::{get_builtin_option, resolve_avatar_url, use_texture_render},
@@ -51,7 +51,7 @@ use hbb_common::{
         CONNECT_TIMEOUT, READ_TIMEOUT, RELAY_PORT, RENDEZVOUS_PORT, RENDEZVOUS_SERVERS,
     },
     fs::JobType,
-    futures::future::{select_ok, FutureExt},
+    futures::future::{select_ok, BoxFuture, FutureExt},
     get_version_number, log,
     message_proto::{option_message::BoolOption, *},
     protobuf::{Message as _, MessageField},
@@ -173,6 +173,118 @@ pub fn get_key_state(key: enigo::Key) -> bool {
         return true;
     }
     ENIGO.lock().unwrap().get_key_state(key)
+}
+
+/// RAII guard for a WebRTC offerer that has not yet been adopted into a connection.
+///
+/// The offerer's `RTCPeerConnection` is created eagerly in `Client::start` and inserted into the
+/// global `SESSIONS` map; if it never receives a remote answer it stays in ICE state `New`
+/// forever, so its state-change handler never fires and it never self-removes. This guard closes
+/// the pc on drop, covering the paths that would otherwise leak it: early `?`/`bail!` returns in
+/// `_start_inner`, and `select_ok` cancelling the racing attempt that holds the offerer. Call
+/// [`OffererGuard::into_inner`] to disarm when the stream is adopted into a live connection.
+struct OffererGuard(Option<WebRTCStream>);
+
+impl OffererGuard {
+    fn new(stream: WebRTCStream) -> Self {
+        Self(Some(stream))
+    }
+
+    fn stream(&self) -> Option<&WebRTCStream> {
+        self.0.as_ref()
+    }
+
+    fn into_inner(mut self) -> Option<WebRTCStream> {
+        self.0.take()
+    }
+}
+
+impl Drop for OffererGuard {
+    fn drop(&mut self) {
+        if let Some(stream) = self.0.take() {
+            Client::spawn_close_webrtc(stream);
+        }
+    }
+}
+
+/// Race the WebRTC connect attempt against the other transport futures, preferring P2P.
+///
+/// A plain `select_ok` would almost always pick the relay: its TCP connect completes in one
+/// round trip while WebRTC needs candidate trickle + ICE checks + DTLS + SCTP. Instead:
+/// - a WebRTC success is committed immediately;
+/// - an `is_p2p` result from `others` (e.g. IPv6 direct) is committed immediately;
+/// - a relayed result inside the preference window is *held*, giving WebRTC until the window
+///   expires to connect and take priority, while unfinished `others` keep racing so a slower
+///   direct transport can still win; when the window ends (or WebRTC fails) the held connection
+///   is committed;
+/// - a failure on one side commits the survivor as soon as it succeeds; two failures compose
+///   into one error.
+///
+/// `others` must be non-empty (`select_ok` requires it).
+async fn race_transports_prefer_webrtc<'a, T: 'a>(
+    webrtc_fut: BoxFuture<'a, ResultType<T>>,
+    others: Vec<BoxFuture<'a, ResultType<T>>>,
+    window_ms: u64,
+    is_p2p: impl Fn(&T) -> bool,
+) -> ResultType<T> {
+    let mut webrtc_fut = Some(webrtc_fut);
+    let mut others_fut = Some(select_ok(others));
+    let mut held: Option<T> = None;
+    let mut webrtc_err: Option<hbb_common::anyhow::Error> = None;
+    let mut others_err: Option<hbb_common::anyhow::Error> = None;
+    let window = tokio::time::sleep(Duration::from_millis(window_ms));
+    tokio::pin!(window);
+    let mut window_over = false;
+    loop {
+        tokio::select! {
+            res = async { webrtc_fut.as_mut().unwrap().await }, if webrtc_fut.is_some() => {
+                webrtc_fut = None;
+                match res {
+                    // WebRTC connected: preferred outright; a held relay conn just drops.
+                    Ok(conn) => return Ok(conn),
+                    Err(e) => {
+                        if let Some(conn) = held.take() {
+                            return Ok(conn);
+                        }
+                        match others_err.take() {
+                            Some(oe) => bail!("WebRTC failed: {}; fallback failed: {}", e, oe),
+                            None if others_fut.is_none() => bail!("WebRTC failed: {}", e),
+                            None => webrtc_err = Some(e),
+                        }
+                    }
+                }
+            }
+            res = async { others_fut.as_mut().unwrap().await }, if others_fut.is_some() => {
+                others_fut = None;
+                match res {
+                    Ok((conn, unfinished)) => {
+                        if is_p2p(&conn) || window_over || webrtc_fut.is_none() {
+                            return Ok(conn);
+                        }
+                        // Hold the first relay, but keep polling unfinished alternatives: an IPv6
+                        // direct attempt may complete inside the same WebRTC preference window.
+                        if held.is_none() {
+                            held = Some(conn);
+                        }
+                        if !unfinished.is_empty() {
+                            others_fut = Some(select_ok(unfinished));
+                        }
+                    }
+                    Err(e) => match webrtc_err.take() {
+                        Some(we) => bail!("WebRTC failed: {}; fallback failed: {}", we, e),
+                        None if webrtc_fut.is_none() => return Err(e),
+                        None => others_err = Some(e),
+                    },
+                }
+            }
+            _ = &mut window, if !window_over => {
+                window_over = true;
+                if let Some(conn) = held.take() {
+                    return Ok(conn);
+                }
+            }
+        }
+    }
 }
 
 impl Client {
@@ -326,14 +438,17 @@ impl Client {
         } else {
             None
         };
-        let webrtc_offerer =
+        let webrtc_offerer = if Self::should_create_webrtc_offerer(&interface) {
             match WebRTCStream::new("", interface.is_force_relay(), CONNECT_TIMEOUT).await {
                 Ok(stream) => Some(stream),
                 Err(err) => {
                     log::warn!("webrtc offerer setup failed: {}", err);
                     None
                 }
-            };
+            }
+        } else {
+            None
+        };
         let fut = Self::_start_inner(
             peer.to_owned(),
             key.to_owned(),
@@ -378,6 +493,70 @@ impl Client {
         !session_key.is_empty() && ice.session_key == session_key && !ice.candidate.is_empty()
     }
 
+    /// Tear down an abandoned WebRTC offerer off the connection hot path.
+    ///
+    /// The pc must be closed explicitly (a dropped handle leaves the `SESSIONS` clone alive),
+    /// but `close()` awaits internal ICE/DTLS shutdown and the result is pure cleanup with no
+    /// downstream dependency, so it must not block session establishment.
+    fn spawn_close_webrtc(webrtc: WebRTCStream) {
+        // Use the current runtime handle explicitly: this is also called from OffererGuard::drop,
+        // which can run during runtime teardown where a bare tokio::spawn would panic. If no
+        // runtime is available the pc cannot be closed here (it is released at process exit).
+        // Handle::spawn can also panic when the runtime is shutting down; catch that so Drop
+        // never panics (prefer a brief leak until process exit over aborting the process).
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                let spawn_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    handle.spawn(async move {
+                        webrtc.close().await;
+                    });
+                }));
+                if spawn_result.is_err() {
+                    log::warn!("failed to spawn WebRTC close (runtime shutting down)");
+                }
+            }
+            Err(_) => {
+                log::warn!("no tokio runtime available to close WebRTC peer connection");
+            }
+        }
+    }
+
+    /// Whether to build a WebRTC offerer for this connection.
+    ///
+    /// Skips it when UDP punching is disabled or a SOCKS proxy/websocket transport is configured:
+    /// WebRTC's ICE binds its own UDP sockets and speaks STUN directly, which would bypass either
+    /// policy (and can leak the real IP through a proxy). Under force_relay the pc uses Relay-only
+    /// ICE, which gathers nothing and can never connect unless a TURN server is configured, so
+    /// skip building a guaranteed-dead pc + STUN/TURN gathering + answerer signaling in that case
+    /// too.
+    /// When force_relay *and* TURN are configured, WebRTC via TURN is a valid "relayed" path:
+    /// `connect` keeps a WebRTC win instead of replacing it with the RustDesk relay, and the
+    /// RelayResponse path prefers it within the WebRTC preference window.
+    fn should_create_webrtc_offerer(interface: &impl Interface) -> bool {
+        if !crate::get_udp_punch_enabled() || use_ws() || Config::is_proxy() {
+            return false;
+        }
+        if interface.is_force_relay() && !WebRTCStream::has_turn_server() {
+            return false;
+        }
+        true
+    }
+
+    /// Max ICE candidates buffered during the punch window before the answer is applied.
+    /// Bounds memory if a misbehaving rendezvous floods candidates.
+    const MAX_PENDING_WEBRTC_ICE: usize = 64;
+
+    /// Prefer-P2P window: how long a WebRTC attempt outranks an already-established relay
+    /// result, and the floor for a punch-path WebRTC attempt whose race timeout is tuned for a
+    /// raw TCP SYN. Long enough for candidate trickle + ICE checks + DTLS on high-latency
+    /// links; short enough that UDP-blocked networks settle on relay without a noticeable wait.
+    const WEBRTC_PREFER_WINDOW_MS: u64 = 2500;
+
+    /// Delay before re-sending an ICE candidate over the rendezvous route once. The hop to the
+    /// peer can be UDP (the controlled side's mediator channel), so a candidate can be lost in
+    /// flight; the remote ICE agent dedups repeats, so the second copy is free.
+    const WEBRTC_ICE_RESEND_DELAY: Duration = Duration::from_millis(400);
+
     fn spawn_webrtc_ice_bridge(
         mut socket: Stream,
         mut local_ice_rx: Option<UnboundedReceiver<String>>,
@@ -387,6 +566,7 @@ impl Client {
     ) -> oneshot::Sender<()> {
         let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
         tokio::spawn(async move {
+            let mut pending_resend: Vec<(Instant, RendezvousMessage)> = Vec::new();
             loop {
                 match stop_rx.try_recv() {
                     Ok(_) | Err(tokio::sync::oneshot::error::TryRecvError::Closed) => break,
@@ -404,10 +584,20 @@ impl Client {
                                     candidate,
                                     ..Default::default()
                                 });
-                                if let Err(err) = socket.send(&msg).await {
-                                    log::warn!("failed to send WebRTC ICE candidate: {}", err);
-                                    return;
+                                // Bound the send so a stalled rendezvous socket cannot block the
+                                // bridge past its stop signal.
+                                match timeout(3000, socket.send(&msg)).await {
+                                    Ok(Ok(())) => {}
+                                    Ok(Err(err)) => {
+                                        log::warn!("failed to send WebRTC ICE candidate: {}", err);
+                                        return;
+                                    }
+                                    Err(_) => {
+                                        log::warn!("WebRTC ICE candidate send timed out");
+                                        return;
+                                    }
                                 }
+                                pending_resend.push((Instant::now(), msg));
                             }
                             Err(TryRecvError::Empty) => break,
                             Err(TryRecvError::Disconnected) => {
@@ -418,16 +608,53 @@ impl Client {
                     }
                 }
 
-                if let Some(msg_in) =
-                    crate::get_next_nonkeyexchange_msg(&mut socket, Some(100)).await
-                {
-                    if let Some(rendezvous_message::Union::IceCandidate(ice)) = msg_in.union {
-                        if Self::is_expected_webrtc_ice_candidate(&ice, &session_key) {
-                            if let Err(err) = webrtc.add_remote_ice_candidate(&ice.candidate).await
-                            {
-                                log::warn!("failed to add WebRTC ICE candidate: {}", err);
+                // Re-send each candidate once after a short delay: the rendezvous hop to the peer
+                // can be UDP, so the first copy may be lost; the remote ICE agent dedups repeats.
+                let mut i = 0;
+                while i < pending_resend.len() {
+                    if pending_resend[i].0.elapsed() >= Self::WEBRTC_ICE_RESEND_DELAY {
+                        let (_, msg) = pending_resend.swap_remove(i);
+                        match timeout(3000, socket.send(&msg)).await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(err)) => {
+                                log::warn!("failed to re-send WebRTC ICE candidate: {}", err);
+                                return;
+                            }
+                            Err(_) => {
+                                log::warn!("WebRTC ICE candidate re-send timed out");
+                                return;
                             }
                         }
+                    } else {
+                        i += 1;
+                    }
+                }
+
+                // Read one incoming message, blocking up to the poll window. Distinguish a real
+                // timeout (keep looping to drain outbound candidates) from stream EOF/error: the
+                // rendezvous server closes the punch connection after the response, and an
+                // unrecognized-message server closes it on the first candidate we send. Without
+                // this, the collapsed None-on-EOF made the loop hot-spin a core until stop.
+                match timeout(100, socket.next()).await {
+                    Err(_) => {}
+                    Ok(None) => break,
+                    Ok(Some(Ok(bytes))) => {
+                        if let Ok(msg_in) = RendezvousMessage::parse_from_bytes(&bytes) {
+                            if let Some(rendezvous_message::Union::IceCandidate(ice)) = msg_in.union
+                            {
+                                if Self::is_expected_webrtc_ice_candidate(&ice, &session_key) {
+                                    if let Err(err) =
+                                        webrtc.add_remote_ice_candidate(&ice.candidate).await
+                                    {
+                                        log::warn!("failed to add WebRTC ICE candidate: {}", err);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Ok(Some(Err(err))) => {
+                        log::debug!("WebRTC ICE bridge socket read ended: {}", err);
+                        break;
                     }
                 }
             }
@@ -444,7 +671,7 @@ impl Client {
         mut udp: (Option<Arc<UdpSocket>>, Option<Arc<Mutex<u16>>>),
         stop_udp_tx: Option<oneshot::Sender<()>>,
         mut ipv6: Option<(Arc<UdpSocket>, bytes::Bytes)>,
-        mut webrtc_offerer: Option<WebRTCStream>,
+        webrtc_offerer: Option<WebRTCStream>,
         mut rendezvous_server: String,
         servers: Vec<String>,
         contained: bool,
@@ -459,6 +686,10 @@ impl Client {
         (i32, String),
         bool,
     )> {
+        // Wrap the offerer so any early return below (?/bail) or cancellation of this future by
+        // the outer select_ok closes its pc instead of leaking it in SESSIONS. Disarmed via
+        // into_inner() once the stream is adopted into a connection attempt.
+        let mut webrtc_offerer = webrtc_offerer.map(OffererGuard::new);
         let mut start = Instant::now();
         let mut socket = connect_tcp(&*rendezvous_server, CONNECT_TIMEOUT).await;
         debug_assert!(!servers.contains(&rendezvous_server));
@@ -521,8 +752,10 @@ impl Client {
             .take()
             .map(|(socket, addr)| (Some(socket), Some(addr)))
             .unwrap_or((None, None));
-        let webrtc_sdp_offer = if let Some(webrtc) = webrtc_offerer.as_ref() {
-            match webrtc.get_local_endpoint().await {
+        let webrtc_sdp_offer = if let Some(stream) =
+            webrtc_offerer.as_ref().and_then(|g| g.stream())
+        {
+            match stream.get_local_endpoint().await {
                 Ok(endpoint) => endpoint,
                 Err(err) => {
                     log::warn!("failed to read local WebRTC offer: {}", err);
@@ -550,7 +783,8 @@ impl Client {
         });
         let webrtc_session_key = webrtc_offerer
             .as_ref()
-            .map(|webrtc| webrtc.session_key().to_owned())
+            .and_then(|guard| guard.stream())
+            .map(|stream| stream.session_key().to_owned())
             .unwrap_or_default();
         let mut webrtc_sdp_answer = String::new();
         let mut pending_webrtc_ice = Vec::<String>::new();
@@ -649,22 +883,34 @@ impl Client {
                         let mut webrtc_bridge_stop = None;
                         let mut webrtc_for_connect = None;
                         if !rr.webrtc_sdp_answer.is_empty() {
-                            if let Some(webrtc) = webrtc_offerer.take() {
-                                if let Err(err) =
-                                    webrtc.set_remote_endpoint(&rr.webrtc_sdp_answer).await
-                                {
-                                    log::warn!("failed to set WebRTC relay answer: {}", err);
-                                } else {
-                                    for candidate in pending_webrtc_ice.drain(..) {
-                                        if let Err(err) =
-                                            webrtc.add_remote_ice_candidate(&candidate).await
-                                        {
-                                            log::warn!(
-                                                "failed to add buffered WebRTC ICE candidate: {}",
-                                                err
-                                            );
+                            if let Some(guard) = webrtc_offerer.take() {
+                                // Run the awaited setup on the guard's borrowed stream so a
+                                // cancellation during these awaits still closes the pc via the
+                                // guard's drop; take ownership only at the synchronous handoff.
+                                let setup_ok = if let Some(webrtc) = guard.stream() {
+                                    if let Err(err) =
+                                        webrtc.set_remote_endpoint(&rr.webrtc_sdp_answer).await
+                                    {
+                                        log::warn!("failed to set WebRTC relay answer: {}", err);
+                                        false
+                                    } else {
+                                        for candidate in pending_webrtc_ice.drain(..) {
+                                            if let Err(err) =
+                                                webrtc.add_remote_ice_candidate(&candidate).await
+                                            {
+                                                log::warn!(
+                                                    "failed to add buffered WebRTC ICE candidate: {}",
+                                                    err
+                                                );
+                                            }
                                         }
+                                        true
                                     }
+                                } else {
+                                    false
+                                };
+                                if let Some(webrtc) = setup_ok.then(|| guard.into_inner()).flatten()
+                                {
                                     let session_key = webrtc.session_key().to_owned();
                                     let local_ice_rx = webrtc.take_local_ice_rx();
                                     webrtc_bridge_stop = Some(Self::spawn_webrtc_ice_bridge(
@@ -676,8 +922,16 @@ impl Client {
                                     ));
                                     webrtc_for_connect = Some(webrtc);
                                 }
+                                // If setup failed, `guard` drops here and closes the pc.
                             }
                         }
+                        // An offerer not adopted into the relay race (empty answer) is closed by
+                        // the guard's drop here.
+                        drop(webrtc_offerer.take());
+                        // Keep relay_server for a WebRTC secure-failure fallback: request_relay
+                        // coordinates a FRESH uuid via the rendezvous server, so it works even if
+                        // the raced create_relay already consumed the original uuid pairing.
+                        let relay_server_rr = rr.relay_server.clone();
                         let fut = Self::create_relay(
                             &peer,
                             rr.uuid,
@@ -693,38 +947,122 @@ impl Client {
                             }
                             .boxed(),
                         );
-                        if let Some(mut webrtc) = webrtc_for_connect {
-                            connect_futures.push(
-                                async move {
-                                    webrtc.wait_connected(CONNECT_TIMEOUT).await?;
-                                    Ok((Stream::WebRTC(webrtc), None, "WebRTC"))
-                                }
-                                .boxed(),
-                            );
-                        }
-                        // Run all connection attempts concurrently, return the first successful one
-                        let (conn, kcp, typ) = match select_ok(connect_futures).await {
-                            Ok(conn) => (Ok(conn.0 .0), conn.0 .1, conn.0 .2),
-
-                            Err(e) => (Err(e), None, ""),
+                        // Keep the adopted offerer in a guard that stays armed across the race AND
+                        // secure_connection, so cancellation of this future by the outer race (or a
+                        // secure-handshake failure) closes the pc instead of leaking it. It is
+                        // disarmed only once WebRTC is confirmed the winning, secured transport.
+                        let mut webrtc_guard = None;
+                        let race_result = if let Some(webrtc) = webrtc_for_connect {
+                            webrtc_guard = Some(OffererGuard::new(webrtc.clone()));
+                            let mut raced = webrtc;
+                            let webrtc_fut = async move {
+                                raced.wait_connected(CONNECT_TIMEOUT).await?;
+                                Ok((Stream::WebRTC(raced), None, "WebRTC"))
+                            }
+                            .boxed();
+                            // The peer answered WebRTC: prefer P2P. The relay result is held for
+                            // the preference window so WebRTC can win even though a relay TCP
+                            // connect completes much faster than ICE + DTLS setup.
+                            race_transports_prefer_webrtc(
+                                webrtc_fut,
+                                connect_futures,
+                                Self::WEBRTC_PREFER_WINDOW_MS,
+                                |result| result.2 == "IPv6",
+                            )
+                            .await
+                        } else {
+                            // Run all connection attempts concurrently, take the first success.
+                            select_ok(connect_futures).await.map(|r| r.0)
                         };
                         if let Some(stop) = webrtc_bridge_stop {
                             let _ = stop.send(());
                         }
-                        let mut conn = conn?;
+                        // The ? / secure_connection failures below return early; webrtc_guard stays
+                        // in scope and closes the offerer on any such exit (loss, error, cancellation).
+                        let (mut conn, kcp, mut typ) = race_result?;
                         feedback = rr.feedback;
                         log::info!("{:?} used to establish {typ} connection", start.elapsed());
-                        let pk =
-                            Self::secure_connection(&peer, signed_id_pk, &key, &mut conn).await?;
+                        let pk = match Self::secure_connection(
+                            &peer,
+                            signed_id_pk.clone(),
+                            &key,
+                            &mut conn,
+                        )
+                        .await
+                        {
+                            Ok(pk) => pk,
+                            Err(e) if typ == "WebRTC" => {
+                                // WebRTC won the race but identity/DTLS binding failed. Fall back
+                                // to a freshly-coordinated relay (request_relay negotiates a new
+                                // uuid, immune to the raced create_relay having consumed the
+                                // original pairing) so a bad WebRTC handshake does not kill the
+                                // whole session when relay is available.
+                                log::warn!(
+                                    "WebRTC secure handshake failed ({}), falling back to relay",
+                                    e
+                                );
+                                drop(webrtc_guard.take());
+                                let mut relay_conn = Self::request_relay(
+                                    &peer,
+                                    relay_server_rr,
+                                    &rendezvous_server,
+                                    !signed_id_pk.is_empty(),
+                                    &key,
+                                    &token,
+                                    conn_type,
+                                )
+                                .await
+                                .map_err(|relay_e| {
+                                    anyhow!(
+                                        "WebRTC secure failed ({}); relay fallback also failed: {}",
+                                        e,
+                                        relay_e
+                                    )
+                                })?;
+                                let pk = Self::secure_connection(
+                                    &peer,
+                                    signed_id_pk,
+                                    &key,
+                                    &mut relay_conn,
+                                )
+                                .await?;
+                                conn = relay_conn;
+                                typ = if use_ws() { "WebSocket" } else { "Relay" };
+                                pk
+                            }
+                            Err(e) => return Err(e),
+                        };
+                        // Compute the direct/relayed flag (an await) BEFORE disarming the guard, so
+                        // a cancellation of this future during webrtc_relayed() still closes the pc
+                        // via the guard's drop. Matches connect()'s ordering.
+                        let direct = match typ {
+                            "IPv6" => true,
+                            // WebRTC through a TURN server is relayed traffic; report it as such.
+                            "WebRTC" => !conn.webrtc_relayed().await.unwrap_or(false),
+                            _ => false,
+                        };
+                        // Secured and WebRTC won: disarm so the returned conn keeps the pc alive.
+                        if typ == "WebRTC" {
+                            if let Some(guard) = webrtc_guard.take() {
+                                let _ = guard.into_inner();
+                            }
+                        }
                         return Ok((
-                            (conn, typ == "IPv6" || typ == "WebRTC", pk, kcp, typ),
+                            (conn, direct, pk, kcp, typ),
                             (feedback, rendezvous_server),
                             false,
                         ));
                     }
                     Some(rendezvous_message::Union::IceCandidate(ice)) => {
                         if Self::is_expected_webrtc_ice_candidate(&ice, &webrtc_session_key) {
-                            pending_webrtc_ice.push(ice.candidate);
+                            if pending_webrtc_ice.len() < Self::MAX_PENDING_WEBRTC_ICE {
+                                pending_webrtc_ice.push(ice.candidate);
+                            } else {
+                                log::warn!(
+                                    "dropping WebRTC ICE candidate: pending buffer full ({})",
+                                    Self::MAX_PENDING_WEBRTC_ICE
+                                );
+                            }
                         } else {
                             log::debug!(
                                 "dropping ICE candidate for unexpected WebRTC session key {}",
@@ -741,16 +1079,26 @@ impl Client {
         let mut webrtc_bridge_stop = None;
         let mut webrtc_for_connect = None;
         if !webrtc_sdp_answer.is_empty() {
-            if let Some(webrtc) = webrtc_offerer.take() {
-                if let Err(err) = webrtc.set_remote_endpoint(&webrtc_sdp_answer).await {
-                    log::warn!("failed to set WebRTC answer: {}", err);
-                    drop(socket);
-                } else {
-                    for candidate in pending_webrtc_ice.drain(..) {
-                        if let Err(err) = webrtc.add_remote_ice_candidate(&candidate).await {
-                            log::warn!("failed to add buffered WebRTC ICE candidate: {}", err);
+            if let Some(guard) = webrtc_offerer.take() {
+                // Run the awaited setup on the guard's borrowed stream so a cancellation during
+                // these awaits still closes the pc via the guard's drop; take ownership only at
+                // the synchronous handoff below.
+                let setup_ok = if let Some(webrtc) = guard.stream() {
+                    if let Err(err) = webrtc.set_remote_endpoint(&webrtc_sdp_answer).await {
+                        log::warn!("failed to set WebRTC answer: {}", err);
+                        false
+                    } else {
+                        for candidate in pending_webrtc_ice.drain(..) {
+                            if let Err(err) = webrtc.add_remote_ice_candidate(&candidate).await {
+                                log::warn!("failed to add buffered WebRTC ICE candidate: {}", err);
+                            }
                         }
+                        true
                     }
+                } else {
+                    false
+                };
+                if let Some(webrtc) = setup_ok.then(|| guard.into_inner()).flatten() {
                     let session_key = webrtc.session_key().to_owned();
                     let local_ice_rx = webrtc.take_local_ice_rx();
                     webrtc_bridge_stop = Some(Self::spawn_webrtc_ice_bridge(
@@ -761,6 +1109,9 @@ impl Client {
                         session_key,
                     ));
                     webrtc_for_connect = Some(webrtc);
+                } else {
+                    // setup failed (guard dropped -> pc closed) or no stream: release the socket.
+                    drop(socket);
                 }
             } else {
                 drop(socket);
@@ -768,7 +1119,18 @@ impl Client {
         } else {
             drop(socket);
         }
+        // An offerer never adopted into a connection attempt (e.g. the peer returned no WebRTC
+        // answer) is closed by the guard's drop here, so its pc does not linger in SESSIONS.
+        drop(webrtc_offerer.take());
         if peer_addr.port() == 0 {
+            // Bailing before connect(): an offerer already adopted into webrtc_for_connect was
+            // disarmed out of its guard, so close it (and stop its bridge) explicitly here.
+            if let Some(webrtc) = webrtc_for_connect.take() {
+                Self::spawn_close_webrtc(webrtc);
+            }
+            if let Some(stop) = webrtc_bridge_stop.take() {
+                let _ = stop.send(());
+            }
             bail!("Failed to connect via rendezvous server");
         }
         let time_used = start.elapsed().as_millis() as u64;
@@ -839,6 +1201,10 @@ impl Client {
         Option<KcpStream>,
         &'static str,
     )> {
+        // Guard the offerer for the whole of connect(): any early return — cancellation during the
+        // awaits below, the relay override, or a secure_connection failure — closes its pc via the
+        // guard's drop. Disarmed only once WebRTC is the confirmed winning, secured transport.
+        let mut webrtc_guard = webrtc_offerer.map(OffererGuard::new);
         let direct_failures = interface.get_lch().read().unwrap().direct_failures;
         let mut connect_timeout = 0;
         const MIN: u64 = 1000;
@@ -889,11 +1255,20 @@ impl Client {
         if let Some(udp_socket_v6) = udp_socket_v6 {
             connect_futures.push(udp_nat_connect(udp_socket_v6, "IPv6", connect_timeout).boxed());
         }
-        if let Some(mut webrtc) = webrtc_offerer {
+        // Race a clone of the offerer; the guard retains its own clone so a losing/cancelled race
+        // still closes the pc (select_ok drops the future's clone without closing).
+        if let Some(stream) = webrtc_guard.as_ref().and_then(|g| g.stream()) {
+            let mut raced = stream.clone();
+            // The punch-tuned timeout can be as low as 1s — enough for a raw TCP SYN but not for
+            // candidate trickle + ICE checks + DTLS. Give WebRTC its own floor (prefer-P2P) so a
+            // viable P2P path is not abandoned before it can complete; TCP/UDP keep the tighter
+            // timeout, so a working direct connection still wins the race immediately, and the
+            // relay fallback below only waits the extra time when direct attempts all failed.
+            let webrtc_timeout = connect_timeout.max(Self::WEBRTC_PREFER_WINDOW_MS);
             connect_futures.push(
                 async move {
-                    webrtc.wait_connected(connect_timeout).await?;
-                    Ok((Stream::WebRTC(webrtc), None, "WebRTC"))
+                    raced.wait_connected(webrtc_timeout).await?;
+                    Ok((Stream::WebRTC(raced), None, "WebRTC"))
                 }
                 .boxed(),
             );
@@ -906,9 +1281,14 @@ impl Client {
         if let Some(stop) = webrtc_bridge_stop {
             let _ = stop.send(());
         }
+        // webrtc_guard stays armed across the relay override and secure_connection below; it is
+        // disarmed only at the successful return when WebRTC is the kept transport.
 
         let mut direct = !conn.is_err();
-        if interface.is_force_relay() || conn.is_err() {
+        // A WebRTC win under force_relay only happens when the pc was built with Relay-only ICE
+        // (TURN configured), which already honors the relay requirement — keep it instead of
+        // replacing it with the RustDesk relay.
+        if (interface.is_force_relay() && typ != "WebRTC") || conn.is_err() {
             if !relay_server.is_empty() {
                 let switch_code = interface.get_switch_code();
                 conn = Self::request_relay(
@@ -939,15 +1319,71 @@ impl Client {
             start.elapsed(),
             punch_type
         );
-        let res = Self::secure_connection(peer_id, signed_id_pk, key, &mut conn).await;
+        let res = Self::secure_connection(peer_id, signed_id_pk.clone(), key, &mut conn).await;
         let pk: Option<Vec<u8>> = match res {
             Ok(pk) => pk,
+            Err(e) if typ == "WebRTC" && !relay_server.is_empty() => {
+                // WebRTC won the race but identity/DTLS binding failed; fall back to a freshly
+                // coordinated relay instead of failing the whole attempt. The guard is dropped
+                // first so the bad pc is closed promptly.
+                log::warn!("WebRTC secure handshake failed ({}), falling back to relay", e);
+                drop(webrtc_guard.take());
+                match Self::request_relay(
+                    peer_id,
+                    relay_server.to_owned(),
+                    rendezvous_server,
+                    !signed_id_pk.is_empty(),
+                    key,
+                    token,
+                    conn_type,
+                )
+                .await
+                {
+                    Ok(mut relay_conn) => {
+                        match Self::secure_connection(peer_id, signed_id_pk, key, &mut relay_conn)
+                            .await
+                        {
+                            Ok(pk) => {
+                                conn = relay_conn;
+                                typ = "Relay";
+                                direct = false;
+                                pk
+                            }
+                            Err(e) => {
+                                interface.update_direct(Some(false));
+                                bail!(e);
+                            }
+                        }
+                    }
+                    Err(relay_e) => {
+                        interface.update_direct(Some(direct));
+                        bail!(
+                            "WebRTC secure failed ({}); relay fallback also failed: {}",
+                            e,
+                            relay_e
+                        );
+                    }
+                }
+            }
             Err(e) => {
                 // this direct is mainly used by on_establish_connection_error, so we update it here before bail
                 interface.update_direct(Some(direct));
+                // webrtc_guard is still armed here, so a WebRTC winner whose secure handshake
+                // failed is closed by the guard's drop as we bail (no explicit close needed).
                 bail!(e);
             }
         };
+        if typ == "WebRTC" {
+            // WebRTC through a TURN server (force_relay, or a TURN pair winning under All
+            // policy) is relayed traffic; report the direct flag accordingly.
+            if conn.webrtc_relayed().await.unwrap_or(false) {
+                direct = false;
+            }
+            // Secured: disarm so the returned conn keeps the pc alive.
+            if let Some(guard) = webrtc_guard.take() {
+                let _ = guard.into_inner();
+            }
+        }
         log::debug!("{} punch secure_connection ok", punch_type);
         Ok((conn, direct, pk, kcp, typ))
     }
@@ -964,6 +1400,15 @@ impl Client {
         } else {
             key
         });
+        // A WebRTC channel is peer-authenticated only once its DTLS fingerprint is bound to the
+        // verified peer identity below. Once a trusted identity IS established, every binding
+        // failure fails closed: any peer able to answer WebRTC also signs its fingerprint, so a
+        // mismatch is concrete evidence of a rendezvous/relay MITM (not a legacy peer), and
+        // callers fall back to a fresh relay connection rather than proceeding on that channel.
+        // Without a trusted identity (absent, or unverifiable under our configured root) no
+        // binding is possible at all; WebRTC then proceeds like TCP's non-secure fallback —
+        // DTLS-encrypted but reported unsecured. TCP/UDP/relay keep their existing behavior.
+        let is_webrtc = conn.is_webrtc();
         let mut sign_pk = None;
         let mut option_pk = None;
         if !signed_id_pk.is_empty() {
@@ -982,6 +1427,17 @@ impl Client {
         let sign_pk = match sign_pk {
             Some(v) => v,
             None => {
+                // No trusted peer identity: either the deployment provides none (empty
+                // signed_id_pk, key-less) or the blob does not verify under our configured root
+                // (typical benign cause: self-hosted server with the client not configured with
+                // its key, so verification runs against the built-in RS_PUB_KEY). Either way no
+                // fingerprint binding is possible, which is the same cryptographic state as
+                // key-less: DTLS-encrypted to an unauthenticated peer. Proceed like TCP's
+                // non-secure fallback with is_secured() left false. Bailing here instead would
+                // only push the session onto a relay where the same blob fails verification
+                // again and the payload then runs in plaintext — strictly worse than
+                // unauthenticated DTLS, while an active attacker reaches the same warned,
+                // unauthenticated endpoint either way.
                 // send an empty message out in case server is setting up secure and waiting for first message
                 conn.send(&Message::new()).await?;
                 return Ok(option_pk);
@@ -992,8 +1448,22 @@ impl Client {
                 let bytes = res?;
                 if let Ok(msg_in) = Message::parse_from_bytes(&bytes) {
                     if let Some(message::Union::SignedId(si)) = msg_in.union {
-                        if let Ok((id, their_pk_b)) = decode_id_pk(&si.id, &sign_pk) {
+                        if let Ok((id, their_pk_b, signed_fp)) = decode_id_pk_dtls(&si.id, &sign_pk) {
                             if id == peer_id {
+                                // WebRTC only: bind the DTLS channel to the verified peer identity.
+                                // webrtc-rs already verified the peer certificate matches the remote
+                                // SDP fingerprint, so requiring the peer to have signed that same
+                                // fingerprint defeats a rendezvous/relay MITM that swaps SDPs. Fail
+                                // closed: an unreadable/empty/mismatched fingerprint aborts the
+                                // WebRTC connection rather than silently accepting it.
+                                if is_webrtc {
+                                    let actual_fp = conn.dtls_fingerprint(false).await.ok_or_else(
+                                        || anyhow!("WebRTC DTLS fingerprint unavailable"),
+                                    )?;
+                                    if signed_fp.is_empty() || signed_fp != actual_fp {
+                                        bail!("WebRTC DTLS fingerprint not bound to peer identity (possible MITM)");
+                                    }
+                                }
                                 let (asymmetric_value, symmetric_value, key) =
                                     create_symmetric_key_msg(their_pk_b);
                                 let mut msg_out = Message::new();
@@ -1005,10 +1475,16 @@ impl Client {
                                 timeout(CONNECT_TIMEOUT, conn.send(&msg_out)).await??;
                                 conn.set_key(key);
                             } else {
+                                if is_webrtc {
+                                    bail!("WebRTC handshake id mismatch (possible MITM)");
+                                }
                                 log::error!("Handshake failed: sign failure");
                                 conn.send(&Message::new()).await?;
                             }
                         } else {
+                            if is_webrtc {
+                                bail!("WebRTC peer identity could not be verified (refusing unbound channel)");
+                            }
                             // fall back to non-secure connection in case pk mismatch
                             log::info!("pk mismatch, fall back to non-secure");
                             let mut msg_out = Message::new();
@@ -1016,10 +1492,16 @@ impl Client {
                             conn.send(&msg_out).await?;
                         }
                     } else {
+                        if is_webrtc {
+                            bail!("WebRTC handshake received an unexpected message type");
+                        }
                         log::error!("Handshake failed: invalid message type");
                         conn.send(&Message::new()).await?;
                     }
                 } else {
+                    if is_webrtc {
+                        bail!("WebRTC handshake received a malformed message");
+                    }
                     log::error!("Handshake failed: invalid message format");
                     conn.send(&Message::new()).await?;
                 }
@@ -4636,4 +5118,147 @@ async fn udp_nat_connect(
             anyhow!(err)
         })?;
     Ok((res.1, Some(res.0), typ))
+}
+
+#[cfg(test)]
+mod webrtc_race_tests {
+    use super::race_transports_prefer_webrtc;
+    use hbb_common::{
+        anyhow::anyhow,
+        futures::future::{BoxFuture, FutureExt},
+        tokio,
+        tokio::time::{sleep, Duration, Instant},
+        ResultType,
+    };
+
+    fn ok_after(ms: u64, tag: &'static str) -> BoxFuture<'static, ResultType<&'static str>> {
+        async move {
+            sleep(Duration::from_millis(ms)).await;
+            Ok(tag)
+        }
+        .boxed()
+    }
+
+    fn err_after(ms: u64, what: &'static str) -> BoxFuture<'static, ResultType<&'static str>> {
+        async move {
+            sleep(Duration::from_millis(ms)).await;
+            Err(anyhow!(what))
+        }
+        .boxed()
+    }
+
+    const NOT_P2P: fn(&&'static str) -> bool = |_| false;
+
+    #[tokio::test]
+    async fn webrtc_preferred_over_faster_relay_within_window() {
+        let got = race_transports_prefer_webrtc(
+            ok_after(120, "webrtc"),
+            vec![ok_after(10, "relay")],
+            60_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "webrtc");
+    }
+
+    #[tokio::test]
+    async fn unfinished_ipv6_still_beats_held_relay() {
+        let start = Instant::now();
+        let got = race_transports_prefer_webrtc(
+            ok_after(60_000, "webrtc"),
+            vec![ok_after(10, "relay"), ok_after(100, "ipv6")],
+            1_000,
+            |t| *t == "ipv6",
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "ipv6");
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn held_relay_committed_when_window_expires() {
+        let start = Instant::now();
+        let got = race_transports_prefer_webrtc(
+            ok_after(60_000, "webrtc"),
+            vec![ok_after(10, "relay")],
+            150,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "relay");
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn held_relay_committed_when_webrtc_fails() {
+        let start = Instant::now();
+        let got = race_transports_prefer_webrtc(
+            err_after(50, "webrtc dead"),
+            vec![ok_after(10, "relay")],
+            60_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "relay");
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn relay_committed_directly_after_webrtc_failed() {
+        let got = race_transports_prefer_webrtc(
+            err_after(5, "webrtc dead"),
+            vec![ok_after(100, "relay")],
+            60_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "relay");
+    }
+
+    #[tokio::test]
+    async fn webrtc_still_wins_past_window_when_relay_dead() {
+        let got = race_transports_prefer_webrtc(
+            ok_after(300, "webrtc"),
+            vec![err_after(10, "relay dead")],
+            50,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "webrtc");
+    }
+
+    #[tokio::test]
+    async fn p2p_transport_committed_immediately() {
+        let start = Instant::now();
+        let got = race_transports_prefer_webrtc(
+            ok_after(60_000, "webrtc"),
+            vec![ok_after(10, "ipv6")],
+            60_000,
+            |t| *t == "ipv6",
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "ipv6");
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn both_failing_compose_error() {
+        let err = race_transports_prefer_webrtc(
+            err_after(10, "webrtc dead"),
+            vec![err_after(20, "relay dead")],
+            1_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("webrtc dead") && err.contains("relay dead"), "{}", err);
+    }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -225,6 +225,15 @@ impl Drop for OffererGuard {
 ///   into one error.
 ///
 /// `others` must be non-empty (`select_ok` requires it).
+/// Whether a transport label names a peer-to-peer path rather than the RustDesk relay.
+///
+/// The preference window exists to let one of these beat a relay that connects sooner, so a
+/// label misclassified here inverts the race: a direct connection is parked as if it were a
+/// relay, and the relay is then committed the moment it arrives.
+fn is_direct_transport(typ: &str) -> bool {
+    !matches!(typ, "Relay" | "WebSocket")
+}
+
 async fn race_transports_prefer_webrtc<'a, T: 'a>(
     webrtc_fut: BoxFuture<'a, ResultType<T>>,
     others: Vec<BoxFuture<'a, ResultType<T>>>,
@@ -1098,7 +1107,7 @@ impl Client {
                                     webrtc_fut,
                                     connect_futures,
                                     Self::WEBRTC_PREFER_WINDOW_MS,
-                                    |result| result.2 == "IPv6",
+                                    |result| is_direct_transport(result.2),
                                 )
                                 .await
                             }
@@ -3453,7 +3462,12 @@ impl LoginConfigHandler {
                     .insert("other-server-key".to_owned(), c.clone());
             }
         }
-        if self.force_relay {
+        // policy_relay, not force_relay: this writes the user's relay CHOICE back into the peer's
+        // saved config, and force_relay also carries the WebSocket transport, which is a property
+        // of this client's current setup rather than of the peer. Persisting that turned one ws
+        // session into a permanent relay-by-policy peer — and since relay-by-policy means
+        // Relay-only ICE, WebRTC could never go direct to it again.
+        if self.policy_relay {
             config
                 .options
                 .insert("force-always-relay".to_owned(), "Y".to_owned());
@@ -5282,7 +5296,7 @@ async fn udp_nat_connect(
 
 #[cfg(test)]
 mod webrtc_race_tests {
-    use super::{race_transports_prefer_webrtc, request_allows_tcp_punch};
+    use super::{is_direct_transport, race_transports_prefer_webrtc, request_allows_tcp_punch};
     use hbb_common::{
         anyhow::anyhow,
         futures::future::{BoxFuture, FutureExt},
@@ -5313,6 +5327,37 @@ mod webrtc_race_tests {
     fn webrtc_request_never_reuses_its_signaling_socket_for_tcp_punch() {
         assert!(request_allows_tcp_punch(""));
         assert!(!request_allows_tcp_punch("webrtc://offer"));
+    }
+
+    // The transport labels the RelayResponse race actually runs on. Its predicate has to
+    // recognise the WebRTC branch's own label as direct, or a WebRTC connection that completes
+    // BEFORE the relay is parked as if it were a relay and the relay is committed on arrival —
+    // inverting the race exactly on the fast networks where ICE beats a TCP relay connect.
+    #[test]
+    fn transport_labels_are_classified_as_direct_or_relayed() {
+        for direct in ["WebRTC", "TCP", "UDP", "IPv6"] {
+            assert!(is_direct_transport(direct), "{direct} is a direct path");
+        }
+        for relayed in ["Relay", "WebSocket"] {
+            assert!(
+                !is_direct_transport(relayed),
+                "{relayed} goes via the relay"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn direct_result_wins_even_when_it_arrives_first() {
+        // Same ordering as a LAN: the preferred branch connects before the relay does.
+        let got = race_transports_prefer_webrtc(
+            ok_after(10, "WebRTC"),
+            vec![ok_after(120, "Relay")],
+            60_000,
+            |result| is_direct_transport(result),
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "WebRTC");
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -302,12 +302,10 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
     }
 }
 
-fn request_can_carry_webrtc(udp_port: u16, force_relay: bool) -> bool {
-    // A normal TCP punch request must close its rendezvous socket before reusing that local
-    // address, while WebRTC trickle ICE retains the socket as its signaling bridge. Therefore a
-    // request with udp_port=0 must never carry WebRTC. UDP requests can carry it because their
-    // punch socket is separate; force-relay requests can too because they never enter TCP punching.
-    udp_port > 0 || force_relay
+fn request_allows_tcp_punch(webrtc_sdp_offer: &str) -> bool {
+    // WebRTC trickle ICE retains the rendezvous socket as its signaling bridge. Only a request
+    // without an offer may close that socket and reuse its local address for TCP punching.
+    webrtc_sdp_offer.is_empty()
 }
 
 impl Client {
@@ -456,18 +454,17 @@ impl Client {
         } else {
             (None, None)
         };
-        let ipv6 = if crate::get_ipv6_punch_enabled() {
+        // Under force-relay a direct IPv6 path is not allowed, so don't bind the v6 socket;
+        // the controlled side likewise skips v6 when relaying.
+        let ipv6 = if crate::get_ipv6_punch_enabled() && !interface.is_force_relay() {
             crate::get_ipv6_socket().await
         } else {
             None
         };
-        // Prepare WebRTC only for a possible UDP request, or for force-relay where TURN is the
-        // only WebRTC path. `_start_inner` applies the stricter wire invariant after the UDP NAT
-        // test: an actual request with udp_port=0 never includes the offer.
-        let may_prepare_webrtc = udp.0.is_some() || interface.is_force_relay();
-        let webrtc_offerer = if may_prepare_webrtc
-            && Self::should_create_webrtc_offerer(&interface)
-        {
+        // WebRTC uses its own ICE sockets and does not depend on the legacy UDP punch socket.
+        // When this request carries an offer, `_start_inner` keeps its rendezvous socket solely
+        // for trickle signaling; a separate offer-less request owns any TCP punch attempt.
+        let webrtc_offerer = if Self::should_create_webrtc_offerer(&interface) {
             match WebRTCStream::new("", interface.is_force_relay(), CONNECT_TIMEOUT).await {
                 Ok(stream) => Some(stream),
                 Err(err) => {
@@ -493,14 +490,14 @@ impl Client {
             servers.clone(),
             contained,
         );
-        if udp.0.is_none() {
+        if interface.is_force_relay() || (udp.0.is_none() && !has_webrtc_offerer) {
             return fut.await;
         }
         let preferred_fut = fut.boxed();
         // This is deliberately a pure TCP punch request: its WebRTC argument must stay `None`.
         // TCP punching closes the rendezvous socket before binding a new connection to the same
         // local address; a WebRTC ICE bridge would retain that socket and break the port reuse.
-        // The preferred request above may carry WebRTC only because it owns a separate UDP socket.
+        // The preferred request retains its own socket for WebRTC signaling.
         let fallback_fut = Self::_start_inner(
             peer.to_owned(),
             key.to_owned(),
@@ -566,19 +563,23 @@ impl Client {
 
     /// Whether to build a WebRTC offerer for this connection.
     ///
-    /// Skips it when UDP punching is disabled or a SOCKS proxy/websocket transport is configured:
-    /// WebRTC's ICE binds its own UDP sockets and speaks STUN directly, which would bypass either
-    /// policy (and can leak the real IP through a proxy). Under force_relay the pc uses Relay-only
-    /// ICE, which gathers nothing and can never connect unless a TURN server is configured, so
-    /// skip building a guaranteed-dead pc + STUN/TURN gathering + answerer signaling in that case
-    /// too.
+    /// Skips it when a SOCKS proxy is configured: WebRTC's ICE binds its own UDP sockets and
+    /// speaks STUN directly, which would bypass the proxy policy and can leak the real IP.
+    /// WebSocket mode does NOT skip it: ws only tunnels the signaling/relay legs to the server
+    /// (and `connect_tcp` is ws-aware for them), while ICE remains the only viable P2P path in
+    /// ws deployments where classic punching is forced to relay. Independent of the udp-punch
+    /// option too — the offer rides any request, and a server or peer without WebRTC support
+    /// drops the field, so the race simply proceeds without it.
+    /// Under force_relay the pc uses Relay-only ICE, which gathers nothing and can never connect
+    /// unless a TURN server is configured, so skip building a guaranteed-dead pc + STUN/TURN
+    /// gathering + answerer signaling in that case too.
     /// When force_relay *and* TURN are configured, WebRTC via TURN is a valid "relayed" path:
     /// `connect` keeps a WebRTC win instead of replacing it with the RustDesk relay, and the
-    /// RelayResponse path races it without a P2P preference delay. The caller additionally
-    /// requires either a usable UDP request or force_relay; a normal TCP punch request must never
-    /// carry a WebRTC offer because trickle ICE retains the socket TCP punching needs to reuse.
+    /// RelayResponse path races it without a P2P preference delay. Any request carrying an offer
+    /// keeps its rendezvous socket for trickle signaling and never reuses it for TCP punching; a
+    /// separate offer-less request provides the TCP fallback when force-relay is not requested.
     fn should_create_webrtc_offerer(interface: &impl Interface) -> bool {
-        if !crate::get_udp_punch_enabled() || use_ws() || Config::is_proxy() {
+        if Config::is_proxy() {
             return false;
         }
         if interface.is_force_relay() && !WebRTCStream::has_turn_server() {
@@ -799,25 +800,25 @@ impl Client {
             .unwrap_or((None, None));
         let udp_nat_port = udp.1.map(|x| *x.lock().unwrap()).unwrap_or(0);
         let webrtc_sdp_offer =
-            if request_can_carry_webrtc(udp_nat_port, interface.is_force_relay()) {
-                if let Some(stream) = webrtc_offerer.as_ref().and_then(|g| g.stream()) {
-                    match stream.get_local_endpoint_trickle().await {
-                        Ok(endpoint) => endpoint,
-                        Err(err) => {
-                            log::warn!("failed to read local WebRTC offer: {}", err);
-                            String::new()
-                        }
+            if let Some(stream) = webrtc_offerer.as_ref().and_then(|g| g.stream()) {
+                match stream.get_local_endpoint_trickle().await {
+                    Ok(endpoint) => endpoint,
+                    Err(err) => {
+                        log::warn!("failed to read local WebRTC offer: {}", err);
+                        String::new()
                     }
-                } else {
-                    String::new()
                 }
             } else {
-                // Hard protocol invariant: a normal request with udp_port=0 is a TCP punch
-                // request. It must not start WebRTC trickle on the rendezvous socket that TCP
-                // punching needs to close and reuse by local address.
                 String::new()
             };
-        let punch_type = if udp_nat_port > 0 { "UDP" } else { "TCP" };
+        let allow_tcp_punch = request_allows_tcp_punch(&webrtc_sdp_offer);
+        let punch_type = if udp_nat_port > 0 {
+            "UDP"
+        } else if allow_tcp_punch {
+            "TCP"
+        } else {
+            "WebRTC"
+        };
         msg_out.set_punch_hole_request(PunchHoleRequest {
             id: peer.to_owned(),
             token: token.to_owned(),
@@ -893,7 +894,7 @@ impl Client {
                             feedback = ph.feedback;
                             webrtc_sdp_answer = ph.webrtc_sdp_answer;
                             let s = udp.0.take();
-                            if ph.is_udp && s.is_some() {
+                            if udp_nat_port > 0 && ph.is_udp && s.is_some() {
                                 if let Some(s) = s {
                                     allow_err!(s.connect(peer_addr).await);
                                     udp.0 = Some(s);
@@ -1224,6 +1225,7 @@ impl Client {
                 ipv6.0,
                 webrtc_for_connect,
                 webrtc_bridge_stop,
+                allow_tcp_punch,
                 punch_type,
             )
             .await?,
@@ -1252,6 +1254,7 @@ impl Client {
         udp_socket_v6: Option<Arc<UdpSocket>>,
         webrtc_offerer: Option<WebRTCStream>,
         webrtc_bridge_stop: Option<oneshot::Sender<()>>,
+        allow_tcp_punch: bool,
         punch_type: &str,
     ) -> ResultType<(
         Stream,
@@ -1300,14 +1303,16 @@ impl Client {
         let start = std::time::Instant::now();
 
         let mut connect_futures = Vec::new();
-        let fut = connect_tcp_local(peer, Some(local_addr), connect_timeout);
-        connect_futures.push(
-            async move {
-                let conn = fut.await?;
-                Ok((conn, None, "TCP"))
-            }
-            .boxed(),
-        );
+        if allow_tcp_punch {
+            let fut = connect_tcp_local(peer, Some(local_addr), connect_timeout);
+            connect_futures.push(
+                async move {
+                    let conn = fut.await?;
+                    Ok((conn, None, "TCP"))
+                }
+                .boxed(),
+            );
+        }
         if let Some(udp_socket_nat) = udp_socket_nat {
             connect_futures.push(udp_nat_connect(udp_socket_nat, "UDP", connect_timeout).boxed());
         }
@@ -1333,8 +1338,13 @@ impl Client {
             );
         }
         // Run all connection attempts concurrently, return the first successful one
-        let (mut conn, kcp, mut typ) = match select_ok(connect_futures).await {
-            Ok(conn) => (Ok(conn.0 .0), conn.0 .1, conn.0 .2),
+        let direct_result = if connect_futures.is_empty() {
+            Err(anyhow!("No direct transport available"))
+        } else {
+            select_ok(connect_futures).await.map(|conn| conn.0)
+        };
+        let (mut conn, kcp, mut typ) = match direct_result {
+            Ok(conn) => (Ok(conn.0), conn.1, conn.2),
             Err(e) => (Err(e), None, ""),
         };
         if let Some(stop) = webrtc_bridge_stop {
@@ -5062,13 +5072,10 @@ async fn test_udp_uat(
     udp_port: Arc<Mutex<u16>>,
     mut stop_udp_rx: oneshot::Receiver<()>,
 ) -> ResultType<()> {
-    let (tx, mut rx) = oneshot::channel::<_>();
-    tokio::spawn(async {
-        if let Ok(v) = crate::test_nat_ipv4().await {
-            tx.send(v).ok();
-        }
-    });
-
+    // The punch port must come only from the rendezvous server's TestNatResponse, which
+    // observes THIS socket's public mapping. A STUN probe binds a different socket and reports
+    // a different NAT mapping, so racing it here could advertise a port the peer can never
+    // reach (and, on symmetric NAT, silently poison the whole UDP punch).
     let start = Instant::now();
     let mut msg_out = RendezvousMessage::new();
     msg_out.set_test_nat_request(TestNatRequest {
@@ -5094,11 +5101,6 @@ async fn test_udp_uat(
 
     loop {
         tokio::select! {
-            Ok((addr, server)) = &mut rx => {
-                *udp_port.lock().unwrap() = addr.port();
-                log::debug!("UDP NAT test received response from {}: {}", addr, server);
-                break;
-            }
             _ = &mut stop_udp_rx => {
                 log::debug!("UDP NAT test received stop signal after {} packets", packets_sent);
                 break;
@@ -5181,7 +5183,7 @@ async fn udp_nat_connect(
 
 #[cfg(test)]
 mod webrtc_race_tests {
-    use super::{race_transports_prefer_webrtc, request_can_carry_webrtc};
+    use super::{race_transports_prefer_webrtc, request_allows_tcp_punch};
     use hbb_common::{
         anyhow::anyhow,
         futures::future::{BoxFuture, FutureExt},
@@ -5209,10 +5211,9 @@ mod webrtc_race_tests {
     const NOT_P2P: fn(&&'static str) -> bool = |_| false;
 
     #[test]
-    fn tcp_punch_request_never_carries_webrtc() {
-        assert!(!request_can_carry_webrtc(0, false));
-        assert!(request_can_carry_webrtc(1, false));
-        assert!(request_can_carry_webrtc(0, true));
+    fn webrtc_request_never_reuses_its_signaling_socket_for_tcp_punch() {
+        assert!(request_allows_tcp_punch(""));
+        assert!(!request_allows_tcp_punch("webrtc://offer"));
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -211,13 +211,16 @@ impl Drop for OffererGuard {
 ///
 /// A plain `select_ok` would almost always pick the relay: its TCP connect completes in one
 /// round trip while WebRTC needs candidate trickle + ICE checks + DTLS + SCTP. Instead:
-/// - a WebRTC success is committed immediately;
-/// - an `is_p2p` result from `others` (e.g. IPv6 direct) is committed immediately;
-/// - a relayed result inside the preference window is *held*, giving WebRTC until the window
-///   expires to connect and take priority. The window starts when the first relay is ready, not
-///   when setup begins, so rendezvous latency cannot consume the preference budget. Unfinished
-///   `others` keep racing so a slower direct transport can still win; when the window ends (or
-///   WebRTC fails) the held connection is committed;
+/// - an `is_p2p` result from either side (WebRTC, or e.g. IPv6 direct from `others`) is committed
+///   immediately;
+/// - a relayed result from *either* side inside the preference window is *held*, giving the other
+///   side until the window expires to land something direct. `webrtc_fut` is a whole punch
+///   attempt, not just the WebRTC connect, so it too can end in a relay, and committing that
+///   immediately would preempt a direct punch still in flight on the other branch. The window
+///   starts when the first relay is ready, not when setup begins, so rendezvous latency cannot
+///   consume the preference budget. Unfinished `others` keep racing so a slower direct transport
+///   can still win; when the window ends (or the other side fails) the held connection is
+///   committed;
 /// - a failure on one side commits the survivor as soon as it succeeds; two failures compose
 ///   into one error.
 ///
@@ -246,8 +249,22 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
             }, if webrtc_fut.is_some() => {
                 webrtc_fut = None;
                 match res {
-                    // WebRTC connected: preferred outright; a held relay conn just drops.
-                    Ok(conn) => return Ok(conn),
+                    // A direct connection is the outcome this race exists to protect: commit it
+                    // outright, and a held relay conn just drops.
+                    Ok(conn) if is_p2p(&conn) || others_fut.is_none() => return Ok(conn),
+                    // `webrtc_fut` is a whole punch attempt, not just the WebRTC connect, so it
+                    // can end in a relay of its own. Committing that immediately would preempt a
+                    // direct punch still in flight on the other branch — the exact inversion this
+                    // function exists to prevent — so hold it on the same terms as any relay.
+                    Ok(conn) => {
+                        if held.is_none() {
+                            held = Some(conn);
+                            window.as_mut().reset(
+                                Instant::now() + Duration::from_millis(window_ms),
+                            );
+                            window_started = true;
+                        }
+                    }
                     Err(e) => {
                         if let Some(conn) = held.take() {
                             return Ok(conn);
@@ -287,7 +304,14 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
                     }
                     Err(e) => match webrtc_err.take() {
                         Some(we) => bail!("WebRTC failed: {}; fallback failed: {}", we, e),
-                        None if webrtc_fut.is_none() => return Err(e),
+                        None if webrtc_fut.is_none() => {
+                            // The preferred branch may have parked a relay here; nothing else can
+                            // win now, so commit it rather than failing the connection.
+                            match held.take() {
+                                Some(conn) => return Ok(conn),
+                                None => return Err(e),
+                            }
+                        }
                         None => others_err = Some(e),
                     },
                 }
@@ -5229,6 +5253,48 @@ mod webrtc_race_tests {
         .await
         .unwrap();
         assert_eq!(got, "webrtc");
+    }
+
+    // The preferred branch runs a whole punch attempt, so it can itself end in a relay. That must
+    // not preempt a direct punch still in flight on the fallback branch.
+    #[tokio::test]
+    async fn relay_from_preferred_branch_does_not_preempt_a_direct_fallback() {
+        let got = race_transports_prefer_webrtc(
+            ok_after(10, "preferred-relay"),
+            vec![ok_after(120, "direct")],
+            60_000,
+            |tag| *tag == "direct",
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "direct");
+    }
+
+    // ...but it is still committed once nothing direct can arrive.
+    #[tokio::test]
+    async fn relay_from_preferred_branch_committed_when_fallback_fails() {
+        let got = race_transports_prefer_webrtc(
+            ok_after(10, "preferred-relay"),
+            vec![err_after(50, "punch failed")],
+            60_000,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "preferred-relay");
+    }
+
+    #[tokio::test]
+    async fn relay_from_preferred_branch_committed_when_window_expires() {
+        let got = race_transports_prefer_webrtc(
+            ok_after(10, "preferred-relay"),
+            vec![ok_after(60_000, "too-slow")],
+            100,
+            NOT_P2P,
+        )
+        .await
+        .unwrap();
+        assert_eq!(got, "preferred-relay");
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -332,6 +332,7 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
 use hbb_common::log_throttle::LogThrottle;
 const ICE_LOG_INTERVAL: Duration = Duration::from_secs(60);
 static REJECTED_ICE_LOG: LogThrottle = LogThrottle::new(ICE_LOG_INTERVAL);
+static UDP_UAT_ERR_LOG: LogThrottle = LogThrottle::new(ICE_LOG_INTERVAL);
 static UNEXPECTED_ICE_LOG: LogThrottle = LogThrottle::new(ICE_LOG_INTERVAL);
 static PENDING_ICE_FULL_LOG: LogThrottle = LogThrottle::new(ICE_LOG_INTERVAL);
 
@@ -5202,7 +5203,12 @@ async fn test_udp_uat(
                         }
                     }
                     Err(e) => {
-                        log::warn!("UDP NAT test socket error: {}", e);
+                        // Same ICMP-driven errors as punch_udp sees. Without a pause this arm
+                        // re-arms recv immediately and spins the loop at CPU speed.
+                        if let Some(n) = UDP_UAT_ERR_LOG.due() {
+                            log::warn!("UDP NAT test socket error x{n}, last: {e}");
+                        }
+                        hbb_common::sleep(0.01).await;
                     }
                 }
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -977,8 +977,14 @@ impl Client {
                             let addr = AddrMangle::decode(&rr.socket_addr_v6);
                             if addr.port() > 0 {
                                 if s.connect(addr).await.is_ok() {
-                                    connect_futures
-                                        .push(udp_nat_connect(s, "IPv6", CONNECT_TIMEOUT).boxed());
+                                    connect_futures.push(
+                                        async move {
+                                            let (conn, kcp, typ) =
+                                                udp_nat_connect(s, "IPv6", CONNECT_TIMEOUT).await?;
+                                            Ok((conn, kcp, typ, true))
+                                        }
+                                        .boxed(),
+                                    );
                                 }
                             }
                         }
@@ -1046,7 +1052,12 @@ impl Client {
                         connect_futures.push(
                             async move {
                                 let conn = fut.await?;
-                                Ok((conn, None, if use_ws() { "WebSocket" } else { "Relay" }))
+                                Ok((
+                                    conn,
+                                    None,
+                                    if use_ws() { "WebSocket" } else { "Relay" },
+                                    false,
+                                ))
                             }
                             .boxed(),
                         );
@@ -1060,7 +1071,13 @@ impl Client {
                             let mut raced = webrtc;
                             let webrtc_fut = async move {
                                 raced.wait_connected(CONNECT_TIMEOUT).await?;
-                                Ok((Stream::WebRTC(raced), None, "WebRTC"))
+                                // Resolve relayed-ness here, not from the label: WebRTC is only a
+                                // P2P path when ICE nominated a non-TURN pair, and the race has to
+                                // know which it got. Committing a TURN pair as if it were direct
+                                // cancels a genuine direct attempt still in flight — the same
+                                // inversion the preference window exists to prevent, one level up.
+                                let relayed = raced.is_relayed().await.unwrap_or(true);
+                                Ok((Stream::WebRTC(raced), None, "WebRTC", !relayed))
                             }
                             .boxed();
                             if interface.is_policy_relay() {
@@ -1079,7 +1096,7 @@ impl Client {
                                     webrtc_fut,
                                     connect_futures,
                                     Self::WEBRTC_PREFER_WINDOW_MS,
-                                    |result| is_direct_transport(result.2),
+                                    |result| result.3,
                                 )
                                 .await
                             }
@@ -1092,7 +1109,7 @@ impl Client {
                         }
                         // The ? / secure_connection failures below return early; webrtc_guard stays
                         // in scope and closes the offerer on any such exit (loss, error, cancellation).
-                        let (mut conn, kcp, mut typ) = race_result?;
+                        let (mut conn, kcp, mut typ, direct) = race_result?;
                         feedback = rr.feedback;
                         log::info!("{:?} used to establish {typ} connection", start.elapsed());
                         let pk = match Self::secure_connection(
@@ -1146,18 +1163,8 @@ impl Client {
                             }
                             Err(e) => return Err(e),
                         };
-                        // Compute the direct/relayed flag (an await) BEFORE disarming the guard, so
-                        // a cancellation of this future during webrtc_relayed() still closes the pc
-                        // via the guard's drop. Matches connect()'s ordering.
-                        let direct = match typ {
-                            "IPv6" => true,
-                            // WebRTC through a TURN server is relayed traffic; report it as such.
-                            // An unknown answer (no selected pair yet, or the pc closed under a
-                            // concurrent teardown) must not be read as "direct": claiming a P2P
-                            // path needs evidence of one.
-                            "WebRTC" => !conn.webrtc_relayed().await.unwrap_or(true),
-                            _ => false,
-                        };
+                        // `direct` came from the winning future, which resolved it while the pc was
+                        // definitely alive — the race needed it to pick a winner at all.
                         // Secured and WebRTC won: disarm so the returned conn keeps the pc alive.
                         if typ == "WebRTC" {
                             if let Some(guard) = webrtc_guard.take() {
@@ -2598,13 +2605,15 @@ pub struct LoginConfigHandler {
     // reconnect before the real reboot disconnect.
     restart_remote_device_at: Option<Instant>,
     pub force_relay: bool,
-    // The policy component of force_relay: the user's relay choice (option or explicit
-    // request) plus proxy, WITHOUT the WebSocket-transport component. ws kills classic
-    // TCP/UDP punching (force_relay stays set for those paths) but says nothing about
-    // ICE, so WebRTC decisions - offer ICE policy, prefer-P2P racing - key off this
-    // instead: relay-by-policy must stay Relay-only ICE, relay-by-transport may go
-    // direct over full ICE.
+    // The policy component of force_relay: peer_relay plus proxy, WITHOUT the WebSocket
+    // transport. ws kills classic TCP/UDP punching (force_relay stays set for those paths)
+    // but says nothing about ICE, so the WebRTC decisions - offer ICE policy, prefer-P2P
+    // racing - key off this instead: relay-by-policy must stay Relay-only ICE, while
+    // relay-by-transport may still go direct over full ICE.
     pub policy_relay: bool,
+    // The peer-scoped component: this peer's saved force-always-relay option, or an explicit
+    // relay request for it. The only part that may be written back into the peer's config.
+    pub peer_relay: bool,
     pub direct: Option<bool>,
     pub received: bool,
     switch_uuid: Option<String>,
@@ -2717,10 +2726,16 @@ impl LoginConfigHandler {
         self.session_id = sid;
         self.supported_encoding = Default::default();
         self.clear_restarting_remote_device();
-        self.policy_relay =
+        // Three scopes, and only the first belongs in the peer's saved config: what was decided
+        // about THIS PEER (its saved option, or an explicit relay request such as an `/r` id or
+        // a retry-via-relay), versus what is true of this client right now (a proxy, WebSocket).
+        // Persisting either of the latter turns a transient local setup into a permanent property
+        // of the peer — and relay-by-policy means Relay-only ICE, so WebRTC never goes direct to
+        // it again.
+        self.peer_relay =
             config::option2bool("force-always-relay", &self.get_option("force-always-relay"))
-                || force_relay
-                || Config::is_proxy();
+                || force_relay;
+        self.policy_relay = self.peer_relay || Config::is_proxy();
         self.force_relay = self.policy_relay || use_ws();
         if let Some((real_id, server, key)) = &self.other_server {
             let other_server_key = self.get_option("other-server-key");
@@ -3438,12 +3453,9 @@ impl LoginConfigHandler {
                     .insert("other-server-key".to_owned(), c.clone());
             }
         }
-        // policy_relay, not force_relay: this writes the user's relay CHOICE back into the peer's
-        // saved config, and force_relay also carries the WebSocket transport, which is a property
-        // of this client's current setup rather than of the peer. Persisting that turned one ws
-        // session into a permanent relay-by-policy peer — and since relay-by-policy means
-        // Relay-only ICE, WebRTC could never go direct to it again.
-        if self.policy_relay {
+        // peer_relay only — see `initialize`: neither the proxy nor the WebSocket transport is a
+        // fact about this peer, and writing one here makes it permanent.
+        if self.peer_relay {
             config
                 .options
                 .insert("force-always-relay".to_owned(), "Y".to_owned());

--- a/src/client.rs
+++ b/src/client.rs
@@ -374,6 +374,10 @@ impl Client {
         }
     }
 
+    fn is_expected_webrtc_ice_candidate(ice: &IceCandidate, session_key: &str) -> bool {
+        !session_key.is_empty() && ice.session_key == session_key && !ice.candidate.is_empty()
+    }
+
     fn spawn_webrtc_ice_bridge(
         mut socket: Stream,
         mut local_ice_rx: Option<UnboundedReceiver<String>>,
@@ -382,7 +386,6 @@ impl Client {
         session_key: String,
     ) -> oneshot::Sender<()> {
         let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
-        let my_id = Config::get_id();
         tokio::spawn(async move {
             loop {
                 match stop_rx.try_recv() {
@@ -396,8 +399,7 @@ impl Client {
                             Ok(candidate) => {
                                 let mut msg = RendezvousMessage::new();
                                 msg.set_ice_candidate(IceCandidate {
-                                    from_id: my_id.clone(),
-                                    to_id: peer.clone(),
+                                    id: peer.clone(),
                                     session_key: session_key.clone(),
                                     candidate,
                                     ..Default::default()
@@ -420,10 +422,7 @@ impl Client {
                     crate::get_next_nonkeyexchange_msg(&mut socket, Some(100)).await
                 {
                     if let Some(rendezvous_message::Union::IceCandidate(ice)) = msg_in.union {
-                        if ice.from_id == peer
-                            && ice.to_id == my_id
-                            && ice.session_key == session_key
-                        {
+                        if Self::is_expected_webrtc_ice_candidate(&ice, &session_key) {
                             if let Err(err) = webrtc.add_remote_ice_candidate(&ice.candidate).await
                             {
                                 log::warn!("failed to add WebRTC ICE candidate: {}", err);
@@ -555,7 +554,7 @@ impl Client {
             .unwrap_or_default();
         let mut webrtc_sdp_answer = String::new();
         let mut pending_webrtc_ice = Vec::<String>::new();
-        for i in 1..=3 {
+        'punch_attempts: for i in 1..=3 {
             log::info!(
                 "#{} {} punch attempt with {}, id: {}",
                 i,
@@ -565,9 +564,20 @@ impl Client {
             );
             socket.send(&msg_out).await?;
             // below timeout should not bigger than hbbs's connection timeout.
-            if let Some(msg_in) =
-                crate::get_next_nonkeyexchange_msg(&mut socket, Some(i * 3000)).await
-            {
+            let attempt_deadline = Instant::now() + Duration::from_millis((i * 3000) as u64);
+            loop {
+                let remaining = attempt_deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                let timeout_ms = remaining
+                    .as_millis()
+                    .clamp(1, u64::MAX as u128) as u64;
+                let Some(msg_in) =
+                    crate::get_next_nonkeyexchange_msg(&mut socket, Some(timeout_ms)).await
+                else {
+                    break;
+                };
                 match msg_in.union {
                     Some(rendezvous_message::Union::PunchHoleResponse(ph)) => {
                         if ph.socket_addr.is_empty() {
@@ -615,7 +625,7 @@ impl Client {
                                 }
                             }
                             log::info!("{} Hole Punched {} = {}", punch_type, peer, peer_addr);
-                            break;
+                            break 'punch_attempts;
                         }
                     }
                     Some(rendezvous_message::Union::RelayResponse(rr)) => {
@@ -713,17 +723,12 @@ impl Client {
                         ));
                     }
                     Some(rendezvous_message::Union::IceCandidate(ice)) => {
-                        if !webrtc_session_key.is_empty()
-                            && ice.from_id == peer
-                            && ice.to_id == Config::get_id()
-                            && ice.session_key == webrtc_session_key
-                        {
+                        if Self::is_expected_webrtc_ice_candidate(&ice, &webrtc_session_key) {
                             pending_webrtc_ice.push(ice.candidate);
                         } else {
                             log::debug!(
-                                "dropping ICE candidate for unexpected WebRTC session from {} key {}",
-                                ice.from_id,
-                                ice.session_key
+                                "dropping ICE candidate for unexpected WebRTC session key {}",
+                                ice.session_key,
                             );
                         }
                     }
@@ -4476,7 +4481,21 @@ pub mod peer_online {
 
     #[cfg(test)]
     mod tests {
+        use crate::client::Client;
+        use hbb_common::rendezvous_proto::IceCandidate;
         use hbb_common::tokio;
+
+        #[test]
+        fn accepts_webrtc_ice_by_session_key_only() {
+            let ice = IceCandidate {
+                session_key: "session-a".to_owned(),
+                candidate: "candidate-json".to_owned(),
+                ..Default::default()
+            };
+
+            assert!(Client::is_expected_webrtc_ice_candidate(&ice, "session-a"));
+            assert!(!Client::is_expected_webrtc_ice_candidate(&ice, "session-b"));
+        }
 
         #[tokio::test]
         async fn test_query_onlines() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -314,12 +314,10 @@ async fn race_transports_prefer_webrtc<'a, T: 'a>(
     }
 }
 
-fn request_can_carry_webrtc(udp_port: u16, force_relay: bool) -> bool {
-    // A normal TCP punch request must close its rendezvous socket before reusing that local
-    // address, while WebRTC trickle ICE retains the socket as its signaling bridge. Therefore a
-    // request with udp_port=0 must never carry WebRTC. UDP requests can carry it because their
-    // punch socket is separate; force-relay requests can too because they never enter TCP punching.
-    udp_port > 0 || force_relay
+fn request_allows_tcp_punch(webrtc_sdp_offer: &str) -> bool {
+    // WebRTC trickle ICE retains the rendezvous socket as its signaling bridge. Only a request
+    // without an offer may close that socket and reuse its local address for TCP punching.
+    webrtc_sdp_offer.is_empty()
 }
 
 impl Client {
@@ -468,18 +466,17 @@ impl Client {
         } else {
             (None, None)
         };
-        let ipv6 = if crate::get_ipv6_punch_enabled() {
+        // Under force-relay a direct IPv6 path is not allowed, so don't bind the v6 socket;
+        // the controlled side likewise skips v6 when relaying.
+        let ipv6 = if crate::get_ipv6_punch_enabled() && !interface.is_force_relay() {
             crate::get_ipv6_socket().await
         } else {
             None
         };
-        // Prepare WebRTC only for a possible UDP request, or for force-relay where TURN is the
-        // only WebRTC path. `_start_inner` applies the stricter wire invariant after the UDP NAT
-        // test: an actual request with udp_port=0 never includes the offer.
-        let may_prepare_webrtc = udp.0.is_some() || interface.is_force_relay();
-        let webrtc_offerer = if may_prepare_webrtc
-            && Self::should_create_webrtc_offerer(&interface)
-        {
+        // WebRTC uses its own ICE sockets and does not depend on the legacy UDP punch socket.
+        // When this request carries an offer, `_start_inner` keeps its rendezvous socket solely
+        // for trickle signaling; a separate offer-less request owns any TCP punch attempt.
+        let webrtc_offerer = if Self::should_create_webrtc_offerer(&interface) {
             match WebRTCStream::new("", interface.is_force_relay(), CONNECT_TIMEOUT).await {
                 Ok(stream) => Some(stream),
                 Err(err) => {
@@ -505,14 +502,14 @@ impl Client {
             servers.clone(),
             contained,
         );
-        if udp.0.is_none() {
+        if interface.is_force_relay() || (udp.0.is_none() && !has_webrtc_offerer) {
             return fut.await;
         }
         let preferred_fut = fut.boxed();
         // This is deliberately a pure TCP punch request: its WebRTC argument must stay `None`.
         // TCP punching closes the rendezvous socket before binding a new connection to the same
         // local address; a WebRTC ICE bridge would retain that socket and break the port reuse.
-        // The preferred request above may carry WebRTC only because it owns a separate UDP socket.
+        // The preferred request retains its own socket for WebRTC signaling.
         let fallback_fut = Self::_start_inner(
             peer.to_owned(),
             key.to_owned(),
@@ -578,19 +575,23 @@ impl Client {
 
     /// Whether to build a WebRTC offerer for this connection.
     ///
-    /// Skips it when UDP punching is disabled or a SOCKS proxy/websocket transport is configured:
-    /// WebRTC's ICE binds its own UDP sockets and speaks STUN directly, which would bypass either
-    /// policy (and can leak the real IP through a proxy). Under force_relay the pc uses Relay-only
-    /// ICE, which gathers nothing and can never connect unless a TURN server is configured, so
-    /// skip building a guaranteed-dead pc + STUN/TURN gathering + answerer signaling in that case
-    /// too.
+    /// Skips it when a SOCKS proxy is configured: WebRTC's ICE binds its own UDP sockets and
+    /// speaks STUN directly, which would bypass the proxy policy and can leak the real IP.
+    /// WebSocket mode does NOT skip it: ws only tunnels the signaling/relay legs to the server
+    /// (and `connect_tcp` is ws-aware for them), while ICE remains the only viable P2P path in
+    /// ws deployments where classic punching is forced to relay. Independent of the udp-punch
+    /// option too — the offer rides any request, and a server or peer without WebRTC support
+    /// drops the field, so the race simply proceeds without it.
+    /// Under force_relay the pc uses Relay-only ICE, which gathers nothing and can never connect
+    /// unless a TURN server is configured, so skip building a guaranteed-dead pc + STUN/TURN
+    /// gathering + answerer signaling in that case too.
     /// When force_relay *and* TURN are configured, WebRTC via TURN is a valid "relayed" path:
     /// `connect` keeps a WebRTC win instead of replacing it with the RustDesk relay, and the
-    /// RelayResponse path races it without a P2P preference delay. The caller additionally
-    /// requires either a usable UDP request or force_relay; a normal TCP punch request must never
-    /// carry a WebRTC offer because trickle ICE retains the socket TCP punching needs to reuse.
+    /// RelayResponse path races it without a P2P preference delay. Any request carrying an offer
+    /// keeps its rendezvous socket for trickle signaling and never reuses it for TCP punching; a
+    /// separate offer-less request provides the TCP fallback when force-relay is not requested.
     fn should_create_webrtc_offerer(interface: &impl Interface) -> bool {
-        if !crate::get_udp_punch_enabled() || use_ws() || Config::is_proxy() {
+        if Config::is_proxy() {
             return false;
         }
         if interface.is_force_relay() && !WebRTCStream::has_turn_server() {
@@ -811,25 +812,25 @@ impl Client {
             .unwrap_or((None, None));
         let udp_nat_port = udp.1.map(|x| *x.lock().unwrap()).unwrap_or(0);
         let webrtc_sdp_offer =
-            if request_can_carry_webrtc(udp_nat_port, interface.is_force_relay()) {
-                if let Some(stream) = webrtc_offerer.as_ref().and_then(|g| g.stream()) {
-                    match stream.get_local_endpoint_trickle().await {
-                        Ok(endpoint) => endpoint,
-                        Err(err) => {
-                            log::warn!("failed to read local WebRTC offer: {}", err);
-                            String::new()
-                        }
+            if let Some(stream) = webrtc_offerer.as_ref().and_then(|g| g.stream()) {
+                match stream.get_local_endpoint_trickle().await {
+                    Ok(endpoint) => endpoint,
+                    Err(err) => {
+                        log::warn!("failed to read local WebRTC offer: {}", err);
+                        String::new()
                     }
-                } else {
-                    String::new()
                 }
             } else {
-                // Hard protocol invariant: a normal request with udp_port=0 is a TCP punch
-                // request. It must not start WebRTC trickle on the rendezvous socket that TCP
-                // punching needs to close and reuse by local address.
                 String::new()
             };
-        let punch_type = if udp_nat_port > 0 { "UDP" } else { "TCP" };
+        let allow_tcp_punch = request_allows_tcp_punch(&webrtc_sdp_offer);
+        let punch_type = if udp_nat_port > 0 {
+            "UDP"
+        } else if allow_tcp_punch {
+            "TCP"
+        } else {
+            "WebRTC"
+        };
         msg_out.set_punch_hole_request(PunchHoleRequest {
             id: peer.to_owned(),
             token: token.to_owned(),
@@ -904,7 +905,7 @@ impl Client {
                             feedback = ph.feedback;
                             webrtc_sdp_answer = ph.webrtc_sdp_answer;
                             let s = udp.0.take();
-                            if ph.is_udp && s.is_some() {
+                            if udp_nat_port > 0 && ph.is_udp && s.is_some() {
                                 if let Some(s) = s {
                                     allow_err!(s.connect(peer_addr).await);
                                     udp.0 = Some(s);
@@ -1235,6 +1236,7 @@ impl Client {
                 ipv6.0,
                 webrtc_for_connect,
                 webrtc_bridge_stop,
+                allow_tcp_punch,
                 punch_type,
             )
             .await?,
@@ -1263,6 +1265,7 @@ impl Client {
         udp_socket_v6: Option<Arc<UdpSocket>>,
         webrtc_offerer: Option<WebRTCStream>,
         webrtc_bridge_stop: Option<oneshot::Sender<()>>,
+        allow_tcp_punch: bool,
         punch_type: &str,
     ) -> ResultType<(
         Stream,
@@ -1311,14 +1314,16 @@ impl Client {
         let start = std::time::Instant::now();
 
         let mut connect_futures = Vec::new();
-        let fut = connect_tcp_local(peer, Some(local_addr), connect_timeout);
-        connect_futures.push(
-            async move {
-                let conn = fut.await?;
-                Ok((conn, None, "TCP"))
-            }
-            .boxed(),
-        );
+        if allow_tcp_punch {
+            let fut = connect_tcp_local(peer, Some(local_addr), connect_timeout);
+            connect_futures.push(
+                async move {
+                    let conn = fut.await?;
+                    Ok((conn, None, "TCP"))
+                }
+                .boxed(),
+            );
+        }
         if let Some(udp_socket_nat) = udp_socket_nat {
             connect_futures.push(udp_nat_connect(udp_socket_nat, "UDP", connect_timeout).boxed());
         }
@@ -1344,8 +1349,13 @@ impl Client {
             );
         }
         // Run all connection attempts concurrently, return the first successful one
-        let (mut conn, kcp, mut typ) = match select_ok(connect_futures).await {
-            Ok(conn) => (Ok(conn.0 .0), conn.0 .1, conn.0 .2),
+        let direct_result = if connect_futures.is_empty() {
+            Err(anyhow!("No direct transport available"))
+        } else {
+            select_ok(connect_futures).await.map(|conn| conn.0)
+        };
+        let (mut conn, kcp, mut typ) = match direct_result {
+            Ok(conn) => (Ok(conn.0), conn.1, conn.2),
             Err(e) => (Err(e), None, ""),
         };
         if let Some(stop) = webrtc_bridge_stop {
@@ -4969,13 +4979,10 @@ async fn test_udp_uat(
     udp_port: Arc<Mutex<u16>>,
     mut stop_udp_rx: oneshot::Receiver<()>,
 ) -> ResultType<()> {
-    let (tx, mut rx) = oneshot::channel::<_>();
-    tokio::spawn(async {
-        if let Ok(v) = crate::test_nat_ipv4().await {
-            tx.send(v).ok();
-        }
-    });
-
+    // The punch port must come only from the rendezvous server's TestNatResponse, which
+    // observes THIS socket's public mapping. A STUN probe binds a different socket and reports
+    // a different NAT mapping, so racing it here could advertise a port the peer can never
+    // reach (and, on symmetric NAT, silently poison the whole UDP punch).
     let start = Instant::now();
     let mut msg_out = RendezvousMessage::new();
     msg_out.set_test_nat_request(TestNatRequest {
@@ -5001,11 +5008,6 @@ async fn test_udp_uat(
 
     loop {
         tokio::select! {
-            Ok((addr, server)) = &mut rx => {
-                *udp_port.lock().unwrap() = addr.port();
-                log::debug!("UDP NAT test received response from {}: {}", addr, server);
-                break;
-            }
             _ = &mut stop_udp_rx => {
                 log::debug!("UDP NAT test received stop signal after {} packets", packets_sent);
                 break;
@@ -5088,7 +5090,7 @@ async fn udp_nat_connect(
 
 #[cfg(test)]
 mod webrtc_race_tests {
-    use super::{race_transports_prefer_webrtc, request_can_carry_webrtc};
+    use super::{race_transports_prefer_webrtc, request_allows_tcp_punch};
     use hbb_common::{
         anyhow::anyhow,
         futures::future::{BoxFuture, FutureExt},
@@ -5116,10 +5118,9 @@ mod webrtc_race_tests {
     const NOT_P2P: fn(&&'static str) -> bool = |_| false;
 
     #[test]
-    fn tcp_punch_request_never_carries_webrtc() {
-        assert!(!request_can_carry_webrtc(0, false));
-        assert!(request_can_carry_webrtc(1, false));
-        assert!(request_can_carry_webrtc(0, true));
+    fn webrtc_request_never_reuses_its_signaling_socket_for_tcp_punch() {
+        assert!(request_allows_tcp_punch(""));
+        assert!(!request_allows_tcp_punch("webrtc://offer"));
     }
 
     #[tokio::test]

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -196,6 +196,9 @@ impl<T: InvokeUiSession> Remote<T> {
                         tokio::time::sleep(KCP_CLOSE_REASON_FLUSH_DELAY).await;
                     }
                     self.handle_disconnected(round);
+                    // Close the WebRTC pc on this decline path too (no-op for TCP/WS); otherwise its
+                    // pc lingers in the global session cache until ICE decays on its own.
+                    peer.close_webrtc().await;
                     return;
                 }
                 self.handler.update_direct(Some(direct));
@@ -342,6 +345,10 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                 }
                 log::debug!("Exit io_loop of id={}", self.handler.get_id());
+                // Close the WebRTC peer connection (if this session used it) so its pc is not left
+                // lingering in the global session cache after the session ends; dropping `peer`
+                // alone does not release it. No-op for TCP/WebSocket transports.
+                peer.close_webrtc().await;
                 // Stop client audio server.
                 if let Some(s) = self.stop_voice_call_sender.take() {
                     s.send(()).ok();

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -185,6 +185,14 @@ impl<T: InvokeUiSession> Remote<T> {
                     .unwrap()
                     .set_connected();
                 let is_secured = peer.is_secured();
+                // Only WebRTC needs refining: its label names the transport that won the race,
+                // not the family ICE ended up nominating, and it is the one path where the two
+                // can disagree with the address the rendezvous observed.
+                let stream_type = if peer.webrtc_remote_ipv6().await.unwrap_or(false) {
+                    "WebRTC/IPv6"
+                } else {
+                    stream_type
+                };
                 self.handler
                     .set_connection_type(is_secured, direct, stream_type); // flutter -> connection_ready
                 if !is_secured

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -197,7 +197,9 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                     self.handle_disconnected(round);
                     // Close the WebRTC pc on this decline path too (no-op for TCP/WS); otherwise its
-                    // pc lingers in the global session cache until ICE decays on its own.
+                    // pc lingers in the global session cache until ICE decays on its own. The pc
+                    // and its teardown live on hbb_common's WebRTC I/O runtime, so this session
+                    // runtime's death on return affects neither.
                     peer.close_webrtc();
                     return;
                 }
@@ -347,7 +349,11 @@ impl<T: InvokeUiSession> Remote<T> {
                 log::debug!("Exit io_loop of id={}", self.handler.get_id());
                 // Close the WebRTC peer connection (if this session used it) so its pc is not left
                 // lingering in the global session cache after the session ends; dropping `peer`
-                // alone does not release it. No-op for TCP/WebSocket transports.
+                // alone does not release it. No-op for TCP/WebSocket transports. The pc, its
+                // sockets and pump tasks, and this close all live on hbb_common's WebRTC I/O
+                // runtime — nothing may run them on this session runtime, which is dropped the
+                // moment io_loop returns and would kill the teardown (or, if awaited under a
+                // timeout, cancel it after `close()` latches `is_closed`, stranding the pc).
                 peer.close_webrtc();
                 // Stop client audio server.
                 if let Some(s) = self.stop_voice_call_sender.take() {

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -198,7 +198,7 @@ impl<T: InvokeUiSession> Remote<T> {
                     self.handle_disconnected(round);
                     // Close the WebRTC pc on this decline path too (no-op for TCP/WS); otherwise its
                     // pc lingers in the global session cache until ICE decays on its own.
-                    peer.close_webrtc().await;
+                    peer.close_webrtc();
                     return;
                 }
                 self.handler.update_direct(Some(direct));
@@ -348,7 +348,7 @@ impl<T: InvokeUiSession> Remote<T> {
                 // Close the WebRTC peer connection (if this session used it) so its pc is not left
                 // lingering in the global session cache after the session ends; dropping `peer`
                 // alone does not release it. No-op for TCP/WebSocket transports.
-                peer.close_webrtc().await;
+                peer.close_webrtc();
                 // Stop client audio server.
                 if let Some(s) = self.stop_voice_call_sender.take() {
                     s.send(()).ok();

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -204,11 +204,6 @@ impl<T: InvokeUiSession> Remote<T> {
                         tokio::time::sleep(KCP_CLOSE_REASON_FLUSH_DELAY).await;
                     }
                     self.handle_disconnected(round);
-                    // Close the WebRTC pc on this decline path too (no-op for TCP/WS); otherwise its
-                    // pc lingers in the global session cache until ICE decays on its own. The pc
-                    // and its teardown live on hbb_common's WebRTC I/O runtime, so this session
-                    // runtime's death on return affects neither.
-                    peer.close_webrtc();
                     return;
                 }
                 self.handler.update_direct(Some(direct));
@@ -355,14 +350,6 @@ impl<T: InvokeUiSession> Remote<T> {
                     }
                 }
                 log::debug!("Exit io_loop of id={}", self.handler.get_id());
-                // Close the WebRTC peer connection (if this session used it) so its pc is not left
-                // lingering in the global session cache after the session ends; dropping `peer`
-                // alone does not release it. No-op for TCP/WebSocket transports. The pc, its
-                // sockets and pump tasks, and this close all live on hbb_common's WebRTC I/O
-                // runtime — nothing may run them on this session runtime, which is dropped the
-                // moment io_loop returns and would kill the teardown (or, if awaited under a
-                // timeout, cancel it after `close()` latches `is_closed`, stranding the pc).
-                peer.close_webrtc();
                 // Stop client audio server.
                 if let Some(s) = self.stop_voice_call_sender.take() {
                     s.send(()).ok();

--- a/src/common.rs
+++ b/src/common.rs
@@ -2010,11 +2010,21 @@ pub fn get_rs_pk(str_base64: &str) -> Option<sign::PublicKey> {
 }
 
 pub fn decode_id_pk(signed: &[u8], key: &sign::PublicKey) -> ResultType<(String, [u8; 32])> {
+    let (id, pk, _) = decode_id_pk_dtls(signed, key)?;
+    Ok((id, pk))
+}
+
+/// Like [`decode_id_pk`] but also returns the signed DTLS certificate fingerprint (empty string
+/// for non-WebRTC peers), used to bind a WebRTC DTLS channel to the verified peer identity.
+pub fn decode_id_pk_dtls(
+    signed: &[u8],
+    key: &sign::PublicKey,
+) -> ResultType<(String, [u8; 32], String)> {
     let res = IdPk::parse_from_bytes(
         &sign::verify(signed, key).map_err(|_| anyhow!("Signature mismatch"))?,
     )?;
     if let Some(pk) = get_pk(&res.pk) {
-        Ok((res.id, pk))
+        Ok((res.id, pk, res.dtls_fingerprint))
     } else {
         bail!("Wrong their public length");
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -2607,50 +2607,87 @@ pub async fn test_ipv6() -> Option<tokio::task::JoinHandle<()>> {
     }))
 }
 
+// A punch packet carries a magic and a transaction id so a reply can be *proven* to answer this
+// probe. The punch it replaces sent a zero-length datagram and called the hole open on whatever
+// arrived next - which the rendezvous NAT test's own leftover replies satisfied instantly, so the
+// retry loop below never actually ran and its success meant nothing.
+const PUNCH_PROBE: [u8; 4] = *b"RDP?";
+const PUNCH_ACK: [u8; 4] = *b"RDP!";
+const PUNCH_PACKET_LEN: usize = 12;
+
+fn punch_packet(tag: &[u8; 4], tid: u64) -> [u8; PUNCH_PACKET_LEN] {
+    let mut packet = [0u8; PUNCH_PACKET_LEN];
+    packet[..4].copy_from_slice(tag);
+    packet[4..].copy_from_slice(&tid.to_le_bytes());
+    packet
+}
+
+fn punch_tid(packet: &[u8], tag: &[u8; 4]) -> Option<u64> {
+    if packet.len() != PUNCH_PACKET_LEN || packet[..4] != tag[..] {
+        return None;
+    }
+    packet[4..].try_into().ok().map(u64::from_le_bytes)
+}
+
+/// Punch until one of our own probes is acknowledged. Both ends run this identically - each
+/// probes, each answers the other's probes - and each returns only once a reply carrying its own
+/// transaction id comes back, the one thing that proves the pair carries traffic both ways.
+///
+/// Returning is therefore a fact rather than a guess, which is what lets the caller stop instead
+/// of handing a dead socket to a transport whose only way to discover the truth is to time out.
+///
+/// A datagram that is neither probe nor acknowledgement is returned rather than dropped: it means
+/// the peer finished first and is already speaking KCP, whose SYN is never retransmitted.
+///
+/// Only the connector stops on its own acknowledgement, because only it has something to send
+/// next. An acknowledgement proves our probe came back, not that the peer's probe was answered -
+/// and after this returns nothing answers probes any more, since KCP's io loop drops anything
+/// shorter than its header. A listener that stopped here would go mute while a peer whose own
+/// probe or answer was lost - the normal state of a hole that is still opening - kept probing an
+/// endpoint that works, until it timed out. So the listener stops on the peer's first real packet.
 pub async fn punch_udp(
     socket: Arc<UdpSocket>,
     listen: bool,
 ) -> ResultType<Option<bytes::BytesMut>> {
+    let tid = ((hbb_common::time_based_rand() as u64) << 32) | hbb_common::time_based_rand() as u64;
+    let probe = punch_packet(&PUNCH_PROBE, tid);
+    let mut data = [0u8; 1500];
+    // `connect` does not flush the receive queue, so the NAT test's extra replies are still in it.
+    while socket.try_recv(&mut data).is_ok() {}
+
     let mut retry_interval = Duration::from_millis(20);
     const MAX_INTERVAL: Duration = Duration::from_millis(200);
-    const MAX_TIME: Duration = Duration::from_secs(20);
-    let mut packets_sent = 0;
+    // Both ends start within one rendezvous round trip of each other and the acknowledgement is
+    // one peer round trip, so a pair that has not answered in this long is not going to. The old
+    // 20s came from having no way to tell "not yet" from "never".
+    const MAX_TIME: Duration = Duration::from_secs(3);
+    let mut probes_sent = 0u32;
+    let mut probes_seen = 0u32;
+    let mut acked = false;
     let mut recv_errors = 0u32;
-    socket.send(&[]).await.ok();
-    packets_sent += 1;
+    socket.send(&probe).await.ok();
+    probes_sent += 1;
     let mut last_send_time = Instant::now();
     let tm = Instant::now();
-    let mut data = [0u8; 1500];
 
     loop {
         tokio::select! {
             _ = hbb_common::sleep(retry_interval.as_secs_f32()) => {
                 if tm.elapsed() > MAX_TIME {
-                    bail!("UDP punch is timed out, stop sending packets after {:?} packets, {} recv errors absorbed", packets_sent, recv_errors);
+                    bail!("UDP punch is timed out, {probes_sent} probes sent, {probes_seen} probes received, acked: {acked}, {recv_errors} recv errors absorbed");
                 }
-                let elapsed = last_send_time.elapsed();
-
-                if elapsed >= retry_interval {
-                    socket.send(&[]).await.ok();
-                    packets_sent += 1;
-
-                    // Exponentially increase interval to reduce network pressure
-                    retry_interval = std::cmp::min(
-                        Duration::from_millis((retry_interval.as_millis() as f64 * 1.5) as u64),
-                        MAX_INTERVAL
-                    );
+                if last_send_time.elapsed() >= retry_interval {
+                    socket.send(&probe).await.ok();
+                    probes_sent += 1;
+                    retry_interval = std::cmp::min(retry_interval.mul_f64(1.5), MAX_INTERVAL);
                     last_send_time = Instant::now();
                 }
             }
             res = socket.recv(&mut data) => match res {
                 Err(e) => {
-                    // While the hole is still forming, ICMP unreachable from the peer's NAT
-                    // is expected and surfaces as ConnectionReset/Refused on a connected
-                    // socket (notably 10054 on Windows). Treat it as loss and keep punching;
-                    // MAX_TIME above still bounds the whole attempt.
-                    // Log only the first: this retries every 10ms for up to MAX_TIME, so one
-                    // line per occurrence would write thousands into the log file per punch.
-                    // The count is reported once at the end.
+                    // ICMP unreachable from the peer's NAT is expected while the hole forms and
+                    // surfaces here as ConnectionReset/Refused; treat it as loss, MAX_TIME bounds
+                    // the attempt. Log only the first - this retries every 10ms.
                     recv_errors += 1;
                     if recv_errors == 1 {
                         log::debug!("UDP punch recv error (treated as loss): {e}");
@@ -2658,14 +2695,26 @@ pub async fn punch_udp(
                     hbb_common::sleep(0.01).await;
                 }
                 Ok(n) => {
-                    // log::debug!("UDP punch succeeded after sending {} packets after {:?}", packets_sent, tm.elapsed());
-                    if listen {
-                        if n == 0 {
-                            continue;
+                    let ack = punch_tid(&data[..n], &PUNCH_ACK);
+                    if ack == Some(tid) {
+                        if !listen {
+                            log::debug!(
+                                "UDP punch confirmed in {:?}, {probes_sent} probes sent, {probes_seen} received",
+                                tm.elapsed()
+                            );
+                            return Ok(None);
                         }
+                        acked = true;
+                    } else if let Some(peer_tid) = punch_tid(&data[..n], &PUNCH_PROBE) {
+                        probes_seen += 1;
+                        socket.send(&punch_packet(&PUNCH_ACK, peer_tid)).await.ok();
+                    } else if ack.is_none() && n > 0 {
+                        log::debug!(
+                            "UDP punch confirmed by {n} bytes of peer data in {:?}, {probes_sent} probes sent",
+                            tm.elapsed()
+                        );
                         return Ok(Some(bytes::BytesMut::from(&data[..n])));
                     }
-                    return Ok(None);
                 }
             }
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -2126,11 +2126,21 @@ pub fn get_rs_pk(str_base64: &str) -> Option<sign::PublicKey> {
 }
 
 pub fn decode_id_pk(signed: &[u8], key: &sign::PublicKey) -> ResultType<(String, [u8; 32])> {
+    let (id, pk, _) = decode_id_pk_dtls(signed, key)?;
+    Ok((id, pk))
+}
+
+/// Like [`decode_id_pk`] but also returns the signed DTLS certificate fingerprint (empty string
+/// for non-WebRTC peers), used to bind a WebRTC DTLS channel to the verified peer identity.
+pub fn decode_id_pk_dtls(
+    signed: &[u8],
+    key: &sign::PublicKey,
+) -> ResultType<(String, [u8; 32], String)> {
     let res = IdPk::parse_from_bytes(
         &sign::verify(signed, key).map_err(|_| anyhow!("Signature mismatch"))?,
     )?;
     if let Some(pk) = get_pk(&res.pk) {
-        Ok((res.id, pk))
+        Ok((res.id, pk, res.dtls_fingerprint))
     } else {
         bail!("Wrong their public length");
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -2642,6 +2642,7 @@ pub async fn punch_udp(
     const MAX_INTERVAL: Duration = Duration::from_millis(200);
     const MAX_TIME: Duration = Duration::from_secs(20);
     let mut packets_sent = 0;
+    let mut recv_errors = 0u32;
     socket.send(&[]).await.ok();
     packets_sent += 1;
     let mut last_send_time = Instant::now();
@@ -2652,7 +2653,7 @@ pub async fn punch_udp(
         tokio::select! {
             _ = hbb_common::sleep(retry_interval.as_secs_f32()) => {
                 if tm.elapsed() > MAX_TIME {
-                    bail!("UDP punch is timed out, stop sending packets after {:?} packets", packets_sent);
+                    bail!("UDP punch is timed out, stop sending packets after {packets_sent:?} packets, {recv_errors} recv errors absorbed");
                 }
                 let elapsed = last_send_time.elapsed();
 
@@ -2674,7 +2675,13 @@ pub async fn punch_udp(
                     // is expected and surfaces as ConnectionReset/Refused on a connected
                     // socket (notably 10054 on Windows). Treat it as loss and keep punching;
                     // MAX_TIME above still bounds the whole attempt.
-                    log::debug!("UDP punch recv error (treated as loss): {e}");
+                    // Log only the first: this retries every 10ms for up to MAX_TIME, so one
+                    // line per occurrence would write thousands into the log file per punch.
+                    // The count is reported once at the end.
+                    recv_errors += 1;
+                    if recv_errors == 1 {
+                        log::debug!("UDP punch recv error (treated as loss): {e}");
+                    }
                     hbb_common::sleep(0.01).await;
                 }
                 Ok(n) => {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     future::Future,
-    net::{SocketAddr, ToSocketAddrs},
+    net::SocketAddr,
     sync::{Arc, Mutex, RwLock},
     task::Poll,
 };
@@ -2326,16 +2326,27 @@ pub fn is_udp_disabled() -> bool {
     Config::get_option(keys::OPTION_DISABLE_UDP) == "Y"
 }
 
+pub const OPTION_ENABLE_KCP_CC: &str = "enable-kcp-congestion-control";
+
+// Default ON ("enable-" option2bool semantics); set "N" to fall back to the pure
+// turbo profile (nc=1, no congestion window).
+#[inline]
+pub fn get_kcp_cc_enabled() -> bool {
+    config::option2bool(
+        OPTION_ENABLE_KCP_CC,
+        &Config::get_option(OPTION_ENABLE_KCP_CC),
+    )
+}
+
 // this crate https://github.com/yoshd/stun-client supports nat type
 async fn stun_ipv6_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
-    use std::net::ToSocketAddrs;
     use stunclient::StunClient;
     let local_addr = SocketAddr::from(([0u16; 8], 0)); // [::]:0
     let socket = UdpSocket::bind(&local_addr).await?;
-    let Some(stun_addr) = stun_server
-        .to_socket_addrs()?
-        .filter(|x| x.is_ipv6())
-        .next()
+    // Resolve via tokio so DNS never blocks the async runtime worker.
+    let Some(stun_addr) = tokio::net::lookup_host(stun_server)
+        .await?
+        .find(|x| x.is_ipv6())
     else {
         bail!(
             "Failed to resolve STUN ipv6 server address: {}",
@@ -2352,14 +2363,13 @@ async fn stun_ipv6_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
 }
 
 async fn stun_ipv4_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
-    use std::net::ToSocketAddrs;
     use stunclient::StunClient;
     let local_addr = SocketAddr::from(([0u8; 4], 0));
     let socket = UdpSocket::bind(&local_addr).await?;
-    let Some(stun_addr) = stun_server
-        .to_socket_addrs()?
-        .filter(|x| x.is_ipv4())
-        .next()
+    // Resolve via tokio so DNS never blocks the async runtime worker.
+    let Some(stun_addr) = tokio::net::lookup_host(stun_server)
+        .await?
+        .find(|x| x.is_ipv4())
     else {
         bail!(
             "Failed to resolve STUN ipv4 server address: {}",
@@ -2371,7 +2381,7 @@ async fn stun_ipv4_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
     Ok(if addr.ip().is_ipv4() {
         (addr, stun_server.to_owned())
     } else {
-        bail!("STUN server returned non-IPv6 address: {}", addr)
+        bail!("STUN server returned non-IPv4 address: {}", addr)
     })
 }
 
@@ -2410,10 +2420,9 @@ pub async fn test_nat_ipv4() -> ResultType<(SocketAddr, String)> {
 async fn test_bind_ipv6() -> ResultType<SocketAddr> {
     let local_addr = SocketAddr::from(([0u16; 8], 0)); // [::]:0
     let socket = UdpSocket::bind(local_addr).await?;
-    let addr = STUNS_V6[0]
-        .to_socket_addrs()?
-        .filter(|x| x.is_ipv6())
-        .next()
+    let addr = tokio::net::lookup_host(STUNS_V6[0])
+        .await?
+        .find(|x| x.is_ipv6())
         .ok_or_else(|| {
             anyhow!(
                 "Failed to resolve STUN ipv6 server address: {}",
@@ -2544,7 +2553,14 @@ pub async fn punch_udp(
                 }
             }
             res = socket.recv(&mut data) => match res {
-                Err(e) => bail!("UDP punch failed, {packets_sent} packets sent: {e}"),
+                Err(e) => {
+                    // While the hole is still forming, ICMP unreachable from the peer's NAT
+                    // is expected and surfaces as ConnectionReset/Refused on a connected
+                    // socket (notably 10054 on Windows). Treat it as loss and keep punching;
+                    // MAX_TIME above still bounds the whole attempt.
+                    log::debug!("UDP punch recv error (treated as loss): {e}");
+                    hbb_common::sleep(0.01).await;
+                }
                 Ok(n) => {
                     // log::debug!("UDP punch succeeded after sending {} packets after {:?}", packets_sent, tm.elapsed());
                     if listen {

--- a/src/common.rs
+++ b/src/common.rs
@@ -2454,14 +2454,26 @@ pub fn is_udp_disabled() -> bool {
 
 pub const OPTION_ENABLE_KCP_CC: &str = "enable-kcp-congestion-control";
 
-// Default ON ("enable-" option2bool semantics); set "N" to fall back to the pure
-// turbo profile (nc=1, no congestion window).
+/// Whether to run KCP with its built-in congestion window (nc=0) instead of the pure turbo
+/// profile (nc=1) it has always shipped with.
+///
+/// Opt-in, deliberately: switching it on is a transport-behavior change for every session, and
+/// which profile wins depends on why packets are being lost.
+///
+/// - nc=1 never shrinks the send window. On a link that is genuinely congested it keeps pushing,
+///   deepening the loss it is reacting to and crowding out other traffic on the same uplink.
+/// - nc=0 adds KCP's congestion window, whose backoff is blunt: a fast retransmit halves it, but
+///   an RTO sets `cwnd = 1` outright (ikcp.c) and the recovery slow-starts from one packet. On a
+///   link with random loss but no congestion — Wi-Fi interference, a long-haul path — that reads
+///   loss as congestion and can stall an interactive video stream for seconds.
+///
+/// Neither is safely decidable from reasoning, and a loopback benchmark cannot settle it: with
+/// no bottleneck queue there is no congestion to control, so it would flatter nc=1 by
+/// construction. Until there is evidence from a shaped link or the field, keep the profile users
+/// already run and let anyone who wants the other one ask for it.
 #[inline]
 pub fn get_kcp_cc_enabled() -> bool {
-    config::option2bool(
-        OPTION_ENABLE_KCP_CC,
-        &Config::get_option(OPTION_ENABLE_KCP_CC),
-    )
+    Config::get_option(OPTION_ENABLE_KCP_CC) == "Y"
 }
 
 // this crate https://github.com/yoshd/stun-client supports nat type

--- a/src/common.rs
+++ b/src/common.rs
@@ -2653,7 +2653,7 @@ pub async fn punch_udp(
         tokio::select! {
             _ = hbb_common::sleep(retry_interval.as_secs_f32()) => {
                 if tm.elapsed() > MAX_TIME {
-                    bail!("UDP punch is timed out, stop sending packets after {packets_sent:?} packets, {recv_errors} recv errors absorbed");
+                    bail!("UDP punch is timed out, stop sending packets after {:?} packets, {} recv errors absorbed", packets_sent, recv_errors);
                 }
                 let elapsed = last_send_time.elapsed();
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1167,9 +1167,19 @@ pub fn get_ipv6_punch_enabled() -> bool {
     )
 }
 
+pub fn get_webrtc_enabled() -> bool {
+    config::option2bool(
+        keys::OPTION_ENABLE_WEBRTC,
+        &get_local_option(keys::OPTION_ENABLE_WEBRTC),
+    )
+}
+
 pub fn get_local_option(key: &str) -> String {
     let v = LocalConfig::get_option(key);
-    if key == keys::OPTION_ENABLE_UDP_PUNCH || key == keys::OPTION_ENABLE_IPV6_PUNCH {
+    if key == keys::OPTION_ENABLE_UDP_PUNCH
+        || key == keys::OPTION_ENABLE_IPV6_PUNCH
+        || key == keys::OPTION_ENABLE_WEBRTC
+    {
         if v.is_empty() {
             if !is_public(&Config::get_rendezvous_server()) {
                 return "N".to_owned();

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     future::Future,
-    net::{SocketAddr, ToSocketAddrs},
+    net::SocketAddr,
     sync::{Arc, Mutex, RwLock},
     task::Poll,
 };
@@ -2442,16 +2442,27 @@ pub fn is_udp_disabled() -> bool {
     Config::get_option(keys::OPTION_DISABLE_UDP) == "Y"
 }
 
+pub const OPTION_ENABLE_KCP_CC: &str = "enable-kcp-congestion-control";
+
+// Default ON ("enable-" option2bool semantics); set "N" to fall back to the pure
+// turbo profile (nc=1, no congestion window).
+#[inline]
+pub fn get_kcp_cc_enabled() -> bool {
+    config::option2bool(
+        OPTION_ENABLE_KCP_CC,
+        &Config::get_option(OPTION_ENABLE_KCP_CC),
+    )
+}
+
 // this crate https://github.com/yoshd/stun-client supports nat type
 async fn stun_ipv6_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
-    use std::net::ToSocketAddrs;
     use stunclient::StunClient;
     let local_addr = SocketAddr::from(([0u16; 8], 0)); // [::]:0
     let socket = UdpSocket::bind(&local_addr).await?;
-    let Some(stun_addr) = stun_server
-        .to_socket_addrs()?
-        .filter(|x| x.is_ipv6())
-        .next()
+    // Resolve via tokio so DNS never blocks the async runtime worker.
+    let Some(stun_addr) = tokio::net::lookup_host(stun_server)
+        .await?
+        .find(|x| x.is_ipv6())
     else {
         bail!(
             "Failed to resolve STUN ipv6 server address: {}",
@@ -2468,14 +2479,13 @@ async fn stun_ipv6_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
 }
 
 async fn stun_ipv4_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
-    use std::net::ToSocketAddrs;
     use stunclient::StunClient;
     let local_addr = SocketAddr::from(([0u8; 4], 0));
     let socket = UdpSocket::bind(&local_addr).await?;
-    let Some(stun_addr) = stun_server
-        .to_socket_addrs()?
-        .filter(|x| x.is_ipv4())
-        .next()
+    // Resolve via tokio so DNS never blocks the async runtime worker.
+    let Some(stun_addr) = tokio::net::lookup_host(stun_server)
+        .await?
+        .find(|x| x.is_ipv4())
     else {
         bail!(
             "Failed to resolve STUN ipv4 server address: {}",
@@ -2487,7 +2497,7 @@ async fn stun_ipv4_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
     Ok(if addr.ip().is_ipv4() {
         (addr, stun_server.to_owned())
     } else {
-        bail!("STUN server returned non-IPv6 address: {}", addr)
+        bail!("STUN server returned non-IPv4 address: {}", addr)
     })
 }
 
@@ -2526,10 +2536,9 @@ pub async fn test_nat_ipv4() -> ResultType<(SocketAddr, String)> {
 async fn test_bind_ipv6() -> ResultType<SocketAddr> {
     let local_addr = SocketAddr::from(([0u16; 8], 0)); // [::]:0
     let socket = UdpSocket::bind(local_addr).await?;
-    let addr = STUNS_V6[0]
-        .to_socket_addrs()?
-        .filter(|x| x.is_ipv6())
-        .next()
+    let addr = tokio::net::lookup_host(STUNS_V6[0])
+        .await?
+        .find(|x| x.is_ipv6())
         .ok_or_else(|| {
             anyhow!(
                 "Failed to resolve STUN ipv6 server address: {}",
@@ -2660,7 +2669,14 @@ pub async fn punch_udp(
                 }
             }
             res = socket.recv(&mut data) => match res {
-                Err(e) => bail!("UDP punch failed, {packets_sent} packets sent: {e}"),
+                Err(e) => {
+                    // While the hole is still forming, ICMP unreachable from the peer's NAT
+                    // is expected and surfaces as ConnectionReset/Refused on a connected
+                    // socket (notably 10054 on Windows). Treat it as loss and keep punching;
+                    // MAX_TIME above still bounds the whole attempt.
+                    log::debug!("UDP punch recv error (treated as loss): {e}");
+                    hbb_common::sleep(0.01).await;
+                }
                 Ok(n) => {
                     // log::debug!("UDP punch succeeded after sending {} packets after {:?}", packets_sent, tm.elapsed());
                     if listen {

--- a/src/common.rs
+++ b/src/common.rs
@@ -2454,23 +2454,11 @@ pub fn is_udp_disabled() -> bool {
 
 pub const OPTION_ENABLE_KCP_CC: &str = "enable-kcp-congestion-control";
 
-/// Whether to run KCP with its built-in congestion window (nc=0) instead of the pure turbo
-/// profile (nc=1) it has always shipped with.
+/// Run KCP with its congestion window (nc=0) instead of the turbo profile it has always shipped.
 ///
-/// Opt-in, deliberately: switching it on is a transport-behavior change for every session, and
-/// which profile wins depends on why packets are being lost.
-///
-/// - nc=1 never shrinks the send window. On a link that is genuinely congested it keeps pushing,
-///   deepening the loss it is reacting to and crowding out other traffic on the same uplink.
-/// - nc=0 adds KCP's congestion window, whose backoff is blunt: a fast retransmit halves it, but
-///   an RTO sets `cwnd = 1` outright (ikcp.c) and the recovery slow-starts from one packet. On a
-///   link with random loss but no congestion — Wi-Fi interference, a long-haul path — that reads
-///   loss as congestion and can stall an interactive video stream for seconds.
-///
-/// Neither is safely decidable from reasoning, and a loopback benchmark cannot settle it: with
-/// no bottleneck queue there is no congestion to control, so it would flatter nc=1 by
-/// construction. Until there is evidence from a shaped link or the field, keep the profile users
-/// already run and let anyone who wants the other one ask for it.
+/// Opt-in: which profile wins depends on why packets are lost — nc=1 deepens real congestion,
+/// while nc=0 reads random loss as congestion and its RTO backoff drops cwnd to 1. Undecidable
+/// without a shaped link, so keep what users run today.
 #[inline]
 pub fn get_kcp_cc_enabled() -> bool {
     Config::get_option(OPTION_ENABLE_KCP_CC) == "Y"

--- a/src/common.rs
+++ b/src/common.rs
@@ -2452,8 +2452,6 @@ pub fn is_udp_disabled() -> bool {
     Config::get_option(keys::OPTION_DISABLE_UDP) == "Y"
 }
 
-pub const OPTION_ENABLE_KCP_CC: &str = "enable-kcp-congestion-control";
-
 /// Run KCP with its congestion window (nc=0) instead of the turbo profile it has always shipped.
 ///
 /// Opt-in: which profile wins depends on why packets are lost — nc=1 deepens real congestion,
@@ -2461,7 +2459,7 @@ pub const OPTION_ENABLE_KCP_CC: &str = "enable-kcp-congestion-control";
 /// without a shaped link, so keep what users run today.
 #[inline]
 pub fn get_kcp_cc_enabled() -> bool {
-    Config::get_option(OPTION_ENABLE_KCP_CC) == "Y"
+    Config::get_option(keys::OPTION_ENABLE_KCP_CC) == "Y"
 }
 
 // this crate https://github.com/yoshd/stun-client supports nat type

--- a/src/common.rs
+++ b/src/common.rs
@@ -1153,6 +1153,13 @@ pub fn is_public(url: &str) -> bool {
     host == "rustdesk.com" || host.ends_with(".rustdesk.com")
 }
 
+pub fn get_tcp_punch_enabled() -> bool {
+    config::option2bool(
+        keys::OPTION_ENABLE_TCP_PUNCH,
+        &get_local_option(keys::OPTION_ENABLE_TCP_PUNCH),
+    )
+}
+
 pub fn get_udp_punch_enabled() -> bool {
     config::option2bool(
         keys::OPTION_ENABLE_UDP_PUNCH,

--- a/src/common.rs
+++ b/src/common.rs
@@ -2466,16 +2466,17 @@ pub fn is_udp_disabled() -> bool {
 /// without a shaped link, so keep what users run today.
 #[inline]
 pub fn get_kcp_cc_enabled() -> bool {
-    Config::get_option(keys::OPTION_ENABLE_KCP_CC) == "Y"
+    let k = keys::OPTION_ALLOW_KCP_CC;
+    config::option2bool(k, &Config::get_option(k))
 }
 
 // this crate https://github.com/yoshd/stun-client supports nat type
-async fn stun_ipv6_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
+async fn stun_ipv6_test(stun_server: String) -> ResultType<(SocketAddr, String)> {
     use stunclient::StunClient;
     let local_addr = SocketAddr::from(([0u16; 8], 0)); // [::]:0
     let socket = UdpSocket::bind(&local_addr).await?;
     // Resolve via tokio so DNS never blocks the async runtime worker.
-    let Some(stun_addr) = tokio::net::lookup_host(stun_server)
+    let Some(stun_addr) = tokio::net::lookup_host(&stun_server)
         .await?
         .find(|x| x.is_ipv6())
     else {
@@ -2487,79 +2488,36 @@ async fn stun_ipv6_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
     let client = StunClient::new(stun_addr);
     let addr = client.query_external_address_async(&socket).await?;
     Ok(if addr.ip().is_ipv6() {
-        (addr, stun_server.to_owned())
+        (addr, stun_server)
     } else {
         bail!("STUN server returned non-IPv6 address: {}", addr)
     })
 }
 
-async fn stun_ipv4_test(stun_server: &str) -> ResultType<(SocketAddr, String)> {
-    use stunclient::StunClient;
-    let local_addr = SocketAddr::from(([0u8; 4], 0));
-    let socket = UdpSocket::bind(&local_addr).await?;
-    // Resolve via tokio so DNS never blocks the async runtime worker.
-    let Some(stun_addr) = tokio::net::lookup_host(stun_server)
-        .await?
-        .find(|x| x.is_ipv4())
-    else {
-        bail!(
-            "Failed to resolve STUN ipv4 server address: {}",
-            stun_server
-        );
-    };
-    let client = StunClient::new(stun_addr);
-    let addr = client.query_external_address_async(&socket).await?;
-    Ok(if addr.ip().is_ipv4() {
-        (addr, stun_server.to_owned())
-    } else {
-        bail!("STUN server returned non-IPv4 address: {}", addr)
-    })
-}
-
-static STUNS_V4: [&str; 3] = [
-    "stun.l.google.com:19302",
-    "stun.cloudflare.com:3478",
-    "stun.nextcloud.com:3478",
-];
-
-static STUNS_V6: [&str; 3] = [
-    "stun.l.google.com:19302",
-    "stun.cloudflare.com:3478",
-    "stun.nextcloud.com:3478",
-];
-
-pub async fn test_nat_ipv4() -> ResultType<(SocketAddr, String)> {
-    use hbb_common::futures::future::{select_ok, FutureExt};
-    let tests = STUNS_V4
-        .iter()
-        .map(|&stun| stun_ipv4_test(stun).boxed())
-        .collect::<Vec<_>>();
-
-    match select_ok(tests).await {
-        Ok(res) => {
-            return Ok(res.0);
-        }
-        Err(e) => {
-            bail!(
-                "Failed to get public IPv4 address via public STUN servers: {}",
-                e
-            );
-        }
-    };
-}
-
 async fn test_bind_ipv6() -> ResultType<SocketAddr> {
+    use hbb_common::futures::future::FutureExt;
     let local_addr = SocketAddr::from(([0u16; 8], 0)); // [::]:0
     let socket = UdpSocket::bind(local_addr).await?;
-    let addr = tokio::net::lookup_host(STUNS_V6[0])
-        .await?
-        .find(|x| x.is_ipv6())
-        .ok_or_else(|| {
-            anyhow!(
-                "Failed to resolve STUN ipv6 server address: {}",
-                STUNS_V6[0]
-            )
-        })?;
+    // Nothing is sent - `connect` only makes the kernel pick a route and a source address - so any
+    // resolvable target answers equally and the whole cost is DNS. Race the lookups rather than
+    // walk them: this is awaited inline on the connection path, not every STUN host publishes a
+    // AAAA, and one resolver that hangs must not decide whether this host has v6.
+    let lookups = hbb_common::webrtc::WebRTCStream::default_stun_servers()
+        .into_iter()
+        .map(|stun| {
+            (async move {
+                let addr = tokio::net::lookup_host(&stun)
+                    .await?
+                    .find(|x| x.is_ipv6())
+                    .ok_or_else(|| {
+                        anyhow!("Failed to resolve STUN ipv6 server address: {}", stun)
+                    })?;
+                Ok::<SocketAddr, hbb_common::anyhow::Error>(addr)
+            })
+            .boxed()
+        })
+        .collect::<Vec<_>>();
+    let (addr, _) = hbb_common::futures::future::select_ok(lookups).await?;
     socket.connect(addr).await?;
     Ok(socket.local_addr()?)
 }
@@ -2626,9 +2584,9 @@ pub async fn test_ipv6() -> Option<tokio::task::JoinHandle<()>> {
 
     Some(tokio::spawn(async {
         use hbb_common::futures::future::{select_ok, FutureExt};
-        let tests = STUNS_V6
-            .iter()
-            .map(|&stun| stun_ipv6_test(stun).boxed())
+        let tests = hbb_common::webrtc::WebRTCStream::default_stun_servers()
+            .into_iter()
+            .map(|stun| stun_ipv6_test(stun).boxed())
             .collect::<Vec<_>>();
 
         match select_ok(tests).await {

--- a/src/common.rs
+++ b/src/common.rs
@@ -2667,21 +2667,24 @@ pub async fn punch_udp(
     let mut recv_errors = 0u32;
     socket.send(&probe).await.ok();
     probes_sent += 1;
-    let mut last_send_time = Instant::now();
     let tm = Instant::now();
+    // Absolute instants, not relative sleeps: `select!` rebuilds every arm each iteration, so a
+    // peer that keeps the receive side ready restarts a relative timer before it can fire. That
+    // both defeats MAX_TIME and starves the retransmit, and the peer decides the rate - an
+    // old-build peer's empty datagrams match no arm below and loop without even a pause.
+    let deadline = tm + MAX_TIME;
+    let mut next_probe = tm + retry_interval;
 
     loop {
         tokio::select! {
-            _ = hbb_common::sleep(retry_interval.as_secs_f32()) => {
-                if tm.elapsed() > MAX_TIME {
-                    bail!("UDP punch is timed out, {probes_sent} probes sent, {probes_seen} probes received, acked: {acked}, {recv_errors} recv errors absorbed");
-                }
-                if last_send_time.elapsed() >= retry_interval {
-                    socket.send(&probe).await.ok();
-                    probes_sent += 1;
-                    retry_interval = std::cmp::min(retry_interval.mul_f64(1.5), MAX_INTERVAL);
-                    last_send_time = Instant::now();
-                }
+            _ = tokio::time::sleep_until(deadline) => {
+                bail!("UDP punch is timed out, {probes_sent} probes sent, {probes_seen} probes received, acked: {acked}, {recv_errors} recv errors absorbed");
+            }
+            _ = tokio::time::sleep_until(next_probe) => {
+                socket.send(&probe).await.ok();
+                probes_sent += 1;
+                retry_interval = std::cmp::min(retry_interval.mul_f64(1.5), MAX_INTERVAL);
+                next_probe = Instant::now() + retry_interval;
             }
             res = socket.recv(&mut data) => match res {
                 Err(e) => {
@@ -2836,6 +2839,38 @@ mod tests {
             Instant::now() + Duration::from_secs(1),
             Duration::from_secs(1),
         )
+    }
+
+    // The deadline must hold against a peer that keeps the receive side ready. `select!` rebuilds
+    // its arms every iteration, so a relative sleep would be restarted by every datagram and the
+    // punch would run for as long as the peer keeps talking, with no outer timeout to stop it.
+    #[tokio::test]
+    async fn test_udp_punch_deadline_survives_a_talkative_peer() {
+        let a = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let (a_addr, b_addr) = (a.local_addr().unwrap(), b.local_addr().unwrap());
+        a.connect(b_addr).await.unwrap();
+        b.connect(a_addr).await.unwrap();
+        // Empty datagrams answer no probe and match no return branch, so they only feed the loop.
+        // Sent well past the punch deadline so a restarted timer would show up as a long run.
+        let flooder = tokio::spawn(async move {
+            let end = Instant::now() + Duration::from_secs(12);
+            while Instant::now() < end {
+                if b.send(&[]).await.is_err() {
+                    break;
+                }
+                sleep(Duration::from_millis(5)).await;
+            }
+        });
+        let start = Instant::now();
+        let res = punch_udp(Arc::new(a), false).await;
+        let elapsed = start.elapsed();
+        flooder.abort();
+        assert!(res.is_err(), "the punch should have timed out");
+        assert!(
+            elapsed < Duration::from_secs(6),
+            "the punch ran for {elapsed:?}; its deadline did not hold"
+        );
     }
 
     #[test]

--- a/src/ipc/auth.rs
+++ b/src/ipc/auth.rs
@@ -24,7 +24,6 @@ use std::os::windows::io::AsRawHandle;
 use std::{
     fs,
     path::{Path, PathBuf},
-    sync::{Mutex, OnceLock},
 };
 #[cfg(windows)]
 use windows::Win32::{Foundation::HANDLE, System::Pipes::GetNamedPipeClientProcessId};
@@ -520,66 +519,17 @@ pub(crate) fn ensure_peer_executable_matches_current_by_fd(
 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
 const UNAUTHORIZED_IPC_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
-#[derive(Default)]
-struct UnauthorizedIpcLogThrottle {
-    last_log_at: Option<std::time::Instant>,
-    suppressed: u64,
-}
-
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
-impl UnauthorizedIpcLogThrottle {
-    #[inline]
-    fn on_reject(&mut self, now: std::time::Instant) -> Option<u64> {
-        if let Some(last) = self.last_log_at {
-            if now.saturating_duration_since(last) < UNAUTHORIZED_IPC_LOG_INTERVAL {
-                self.suppressed += 1;
-                return None;
-            }
-        }
-        self.last_log_at = Some(now);
-        Some(std::mem::take(&mut self.suppressed))
-    }
-}
-
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
-#[inline]
-fn throttled_unauthorized_ipc_log(
-    throttle_cell: &OnceLock<Mutex<UnauthorizedIpcLogThrottle>>,
-    emit: impl FnOnce(u64),
-) {
-    let throttle = throttle_cell.get_or_init(|| Mutex::new(UnauthorizedIpcLogThrottle::default()));
-    let should_log = match throttle.lock() {
-        Ok(mut throttle) => throttle.on_reject(std::time::Instant::now()),
-        Err(_) => Some(0),
-    };
-    if let Some(suppressed) = should_log {
-        emit(suppressed);
-    }
-}
-
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[inline]
 fn log_rejected_service_connection(postfix: &str, peer_uid: Option<u32>, active_uid: Option<u32>) {
-    static LOG_THROTTLE: OnceLock<Mutex<UnauthorizedIpcLogThrottle>> = OnceLock::new();
-    throttled_unauthorized_ipc_log(&LOG_THROTTLE, |suppressed| {
-        if suppressed > 0 {
-            log::warn!(
-                "Rejected unauthorized connection on protected service-scoped IPC channel: postfix={}, peer_uid={:?}, active_uid={:?} (suppressed {} similar events)",
-                postfix,
-                peer_uid,
-                active_uid,
-                suppressed
-            );
-        } else {
-            log::warn!(
-                "Rejected unauthorized connection on protected service-scoped IPC channel: postfix={}, peer_uid={:?}, active_uid={:?}",
-                postfix,
-                peer_uid,
-                active_uid
-            );
-        }
-    });
+    hbb_common::throttled_log!(
+        UNAUTHORIZED_IPC_LOG_INTERVAL,
+        warn,
+        "Rejected unauthorized connection on protected service-scoped IPC channel: postfix={}, peer_uid={:?}, active_uid={:?}",
+        postfix,
+        peer_uid,
+        active_uid
+    );
 }
 
 #[cfg(target_os = "linux")]
@@ -589,25 +539,14 @@ pub(crate) fn log_rejected_uinput_connection(
     peer_uid: Option<u32>,
     active_uid: Option<u32>,
 ) {
-    static LOG_THROTTLE: OnceLock<Mutex<UnauthorizedIpcLogThrottle>> = OnceLock::new();
-    throttled_unauthorized_ipc_log(&LOG_THROTTLE, |suppressed| {
-        if suppressed > 0 {
-            log::warn!(
-                "Rejected unauthorized connection on uinput ipc channel: postfix={}, peer_uid={:?}, active_uid={:?} (suppressed {} similar events)",
-                postfix,
-                peer_uid,
-                active_uid,
-                suppressed
-            );
-        } else {
-            log::warn!(
-                "Rejected unauthorized connection on uinput ipc channel: postfix={}, peer_uid={:?}, active_uid={:?}",
-                postfix,
-                peer_uid,
-                active_uid
-            );
-        }
-    });
+    hbb_common::throttled_log!(
+        UNAUTHORIZED_IPC_LOG_INTERVAL,
+        warn,
+        "Rejected unauthorized connection on uinput ipc channel: postfix={}, peer_uid={:?}, active_uid={:?}",
+        postfix,
+        peer_uid,
+        active_uid
+    );
 }
 
 #[cfg(windows)]
@@ -620,31 +559,17 @@ pub(crate) fn log_rejected_windows_ipc_connection(
     peer_is_system: Option<bool>,
     peer_is_elevated: Option<bool>,
 ) {
-    static LOG_THROTTLE: OnceLock<Mutex<UnauthorizedIpcLogThrottle>> = OnceLock::new();
-    throttled_unauthorized_ipc_log(&LOG_THROTTLE, |suppressed| {
-        if suppressed > 0 {
-            log::warn!(
-                "Rejected unauthorized connection on ipc channel: postfix={}, peer_pid={:?}, peer_session_id={:?}, expected_session_id={:?}, peer_is_system={:?}, peer_is_elevated={:?} (suppressed {} similar events)",
-                postfix,
-                peer_pid,
-                peer_session_id,
-                expected_session_id,
-                peer_is_system,
-                peer_is_elevated,
-                suppressed
-            );
-        } else {
-            log::warn!(
-                "Rejected unauthorized connection on ipc channel: postfix={}, peer_pid={:?}, peer_session_id={:?}, expected_session_id={:?}, peer_is_system={:?}, peer_is_elevated={:?}",
-                postfix,
-                peer_pid,
-                peer_session_id,
-                expected_session_id,
-                peer_is_system,
-                peer_is_elevated
-            );
-        }
-    });
+    hbb_common::throttled_log!(
+        UNAUTHORIZED_IPC_LOG_INTERVAL,
+        warn,
+        "Rejected unauthorized connection on ipc channel: postfix={}, peer_pid={:?}, peer_session_id={:?}, expected_session_id={:?}, peer_is_system={:?}, peer_is_elevated={:?}",
+        postfix,
+        peer_pid,
+        peer_session_id,
+        expected_session_id,
+        peer_is_system,
+        peer_is_elevated
+    );
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/src/kcp_stream.rs
+++ b/src/kcp_stream.rs
@@ -26,12 +26,11 @@ static KCP_RECV_ERR_LOG: hbb_common::log_throttle::LogThrottle =
     hbb_common::log_throttle::LogThrottle::new(KCP_IO_ERR_LOG_INTERVAL);
 
 impl KcpStream {
-    // Engage KCP's built-in congestion control (nc=0) unless disabled by option: pure turbo
-    // (nc=1) keeps blasting a full 1024-segment window through loss, which on constrained
-    // links amplifies brief loss into a spiral users experience as stalls or drops. This is
-    // sender-side only, so no wire negotiation is needed and either peer may run either
-    // profile. Requires kcp-sys from the `rustdesk-patches` branch, which wires the config
-    // factory into connection setup (on older revs the factory was stored but never consulted).
+    // Opt in to KCP's built-in congestion window (nc=0) instead of the pure turbo profile
+    // (nc=1) that has always shipped; see `get_kcp_cc_enabled` for why this is not the default.
+    // Sender-side only, so no wire negotiation is needed and either peer may run either profile.
+    // Requires kcp-sys from the `rustdesk-patches` branch, which wires the config factory into
+    // connection setup (on older revs the factory was stored but never consulted).
     fn apply_kcp_config(endpoint: &mut KcpEndpoint) {
         if crate::get_kcp_cc_enabled() {
             endpoint.set_kcp_config_factory(Box::new(|conv| {

--- a/src/kcp_stream.rs
+++ b/src/kcp_stream.rs
@@ -20,6 +20,22 @@ pub struct KcpStream {
 }
 
 impl KcpStream {
+    // Engage KCP's built-in congestion control (nc=0) unless disabled by option: pure turbo
+    // (nc=1) keeps blasting a full 1024-segment window through loss, which on constrained
+    // links amplifies brief loss into a spiral users experience as stalls or drops. This is
+    // sender-side only, so no wire negotiation is needed and either peer may run either
+    // profile. Requires kcp-sys from the `rustdesk-patches` branch, which wires the config
+    // factory into connection setup (on older revs the factory was stored but never consulted).
+    fn apply_kcp_config(endpoint: &mut KcpEndpoint) {
+        if crate::get_kcp_cc_enabled() {
+            endpoint.set_kcp_config_factory(Box::new(|conv| {
+                let mut config = kcp_sys::ffi_safe::KcpConfig::new_turbo(conv);
+                config.nc = Some(0);
+                config
+            }));
+        }
+    }
+
     fn create_framed(stream: stream::KcpStream, local_addr: Option<SocketAddr>) -> Stream {
         Stream::Tcp(FramedStream(
             tokio_util::codec::Framed::new(DynTcpStream(Box::new(stream)), BytesCodec::new()),
@@ -35,6 +51,7 @@ impl KcpStream {
         init_packet: Option<BytesMut>,
     ) -> ResultType<(Self, Stream)> {
         let mut endpoint = KcpEndpoint::new();
+        Self::apply_kcp_config(&mut endpoint);
         endpoint.run().await;
 
         let (input, output) = (
@@ -70,6 +87,7 @@ impl KcpStream {
         timeout: std::time::Duration,
     ) -> ResultType<(Self, Stream)> {
         let mut endpoint = KcpEndpoint::new();
+        Self::apply_kcp_config(&mut endpoint);
         endpoint.run().await;
 
         let (input, output) = (
@@ -104,6 +122,13 @@ impl KcpStream {
         let udp = udp_socket.clone();
         tokio::spawn(async move {
             let mut buf = vec![0; 1500];
+            // A connected UDP socket surfaces ICMP port-unreachable as an error on
+            // send/recv (WSAECONNRESET 10054 on Windows, ECONNREFUSED on Linux). For UDP
+            // these are advisory: a stray ICMP from a NAT rebind glitch or a momentary
+            // peer hiccup does not mean the path is dead, and KCP retransmits through it.
+            // Treat socket errors as packet loss instead of tearing the session down;
+            // a truly dead link is reaped by the KCP pong timeout / app-level timeouts.
+            // The short sleep prevents a persistently failing socket from busy-spinning.
             loop {
                 tokio::select! {
                     _ = &mut stop_receiver => {
@@ -112,8 +137,8 @@ impl KcpStream {
                     }
                     Some(data) = output.recv() => {
                         if let Err(e) = udp.send(&data.inner()).await {
-                            log::debug!("KCP send error: {:?}", e);
-                            break;
+                            log::debug!("KCP send error (treated as loss): {:?}", e);
+                            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                         }
                     }
                     result = udp.recv_from(&mut buf) => {
@@ -127,8 +152,8 @@ impl KcpStream {
                                     .await.ok();
                             }
                             Err(e) => {
-                                log::debug!("KCP recv_from error: {:?}", e);
-                                break;
+                                log::debug!("KCP recv_from error (treated as loss): {:?}", e);
+                                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                             }
                         }
                     }

--- a/src/kcp_stream.rs
+++ b/src/kcp_stream.rs
@@ -190,3 +190,124 @@ impl Drop for KcpStream {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    async fn connected_pair() -> (Arc<UdpSocket>, Arc<UdpSocket>) {
+        let a = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let b = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        a.connect(b.local_addr().unwrap()).await.unwrap();
+        b.connect(a.local_addr().unwrap()).await.unwrap();
+        (Arc::new(a), Arc::new(b))
+    }
+
+    async fn establish() -> ((KcpStream, Stream), (KcpStream, Stream)) {
+        let (a, b) = connected_pair().await;
+        let (accept_res, connect_res) = tokio::join!(
+            KcpStream::accept(b, Duration::from_secs(5), None),
+            KcpStream::connect(a, Duration::from_secs(5))
+        );
+        (
+            connect_res.expect("connect over loopback"),
+            accept_res.expect("accept over loopback"),
+        )
+    }
+
+    // The full client path over real loopback sockets: handshake through the kcp_io
+    // pumps, framed data both ways, then a graceful close. The endpoint guard stays
+    // alive across the stream drop so the FIN can go out, and the peer's framed
+    // stream must end (BrokenPipe from the kcp reader) instead of hanging.
+    #[tokio::test]
+    async fn test_kcp_stream_loopback_roundtrip_and_close() {
+        let ((_guard_a, mut stream_a), (_guard_b, mut stream_b)) = establish().await;
+
+        stream_a
+            .send_bytes(Bytes::from_static(b"ping"))
+            .await
+            .unwrap();
+        let got = stream_b.next_timeout(5000).await.unwrap().unwrap();
+        assert_eq!(&got[..], b"ping");
+
+        stream_b
+            .send_bytes(Bytes::from_static(b"pong"))
+            .await
+            .unwrap();
+        let got = stream_a.next_timeout(5000).await.unwrap().unwrap();
+        assert_eq!(&got[..], b"pong");
+
+        drop(stream_a);
+        match stream_b.next_timeout(10_000).await {
+            None | Some(Err(_)) => {}
+            Some(Ok(data)) => panic!("unexpected data after close: {:?}", data),
+        }
+    }
+
+    // A writer that queues many frames and closes immediately must not cost the
+    // reader any of them: every frame arrives intact, in order, before end-of-stream.
+    // This is the client-side pin for the kcp-sys close-tail-drain semantics, through
+    // the real BytesCodec framing rustdesk sessions use.
+    #[tokio::test]
+    async fn test_kcp_stream_close_delivers_all_frames() {
+        let ((_guard_a, mut tx), (_guard_b, mut rx)) = establish().await;
+
+        const N: usize = 50;
+        let payload = vec![7u8; 32 * 1024];
+        for _ in 0..N {
+            tx.send_bytes(Bytes::from(payload.clone())).await.unwrap();
+        }
+        drop(tx);
+
+        let mut got = 0usize;
+        loop {
+            match rx.next_timeout(10_000).await {
+                Some(Ok(data)) => {
+                    assert_eq!(data.len(), payload.len(), "frame boundary broken");
+                    assert!(data.iter().all(|&b| b == 7), "frame content corrupted");
+                    got += 1;
+                }
+                // BrokenPipe (kcp reader end) or timeout-None both end the stream.
+                None | Some(Err(_)) => break,
+            }
+        }
+        assert_eq!(got, N, "graceful close lost frames");
+    }
+
+    // Socket errors on the connected UDP socket (ICMP unreachable after the peer
+    // vanishes) are advisory: the io loop must treat them as loss - keep accepting
+    // writes, keep running - rather than tearing the session down. Whether the OS
+    // actually surfaces ECONNREFUSED here is platform-dependent; either way the
+    // session must stay alive for this window.
+    #[tokio::test]
+    async fn test_kcp_io_treats_socket_errors_as_loss() {
+        let ((_guard_a, mut stream_a), (guard_b, stream_b)) = establish().await;
+
+        // Kill the peer entirely: endpoint stops, socket closes.
+        drop(stream_b);
+        drop(guard_b);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        for _ in 0..10 {
+            stream_a
+                .send_bytes(Bytes::from_static(b"into the void"))
+                .await
+                .expect("socket errors must be treated as loss, not stream failure");
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    // The connect deadline must hold when nothing answers: no hang, prompt error.
+    #[tokio::test]
+    async fn test_kcp_connect_timeout_without_peer() {
+        let (a, _b) = connected_pair().await;
+        let start = tokio::time::Instant::now();
+        let res = KcpStream::connect(a, Duration::from_millis(600)).await;
+        assert!(res.is_err(), "connect must fail with no peer endpoint");
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "connect did not honor its deadline"
+        );
+    }
+}

--- a/src/kcp_stream.rs
+++ b/src/kcp_stream.rs
@@ -19,6 +19,12 @@ pub struct KcpStream {
     stop_sender: Option<oneshot::Sender<()>>,
 }
 
+const KCP_IO_ERR_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+static KCP_SEND_ERR_LOG: hbb_common::log_throttle::LogThrottle =
+    hbb_common::log_throttle::LogThrottle::new(KCP_IO_ERR_LOG_INTERVAL);
+static KCP_RECV_ERR_LOG: hbb_common::log_throttle::LogThrottle =
+    hbb_common::log_throttle::LogThrottle::new(KCP_IO_ERR_LOG_INTERVAL);
+
 impl KcpStream {
     // Engage KCP's built-in congestion control (nc=0) unless disabled by option: pure turbo
     // (nc=1) keeps blasting a full 1024-segment window through loss, which on constrained
@@ -34,33 +40,6 @@ impl KcpStream {
                 config
             }));
         }
-    }
-
-    // One line per run of socket failures rather than per failure: these are absorbed as packet
-    // loss and can repeat every 10ms, and debug output is written to the log file.
-    const KCP_IO_FAIL_PERSIST: u64 = 500; // ~5s at the 10ms retry interval
-
-    fn note_io_err(fail_run: &mut u64, what: &str, e: &std::io::Error) {
-        *fail_run += 1;
-        if *fail_run == 1 {
-            log::debug!("KCP {} error (treated as loss): {:?}", what, e);
-        } else if *fail_run % Self::KCP_IO_FAIL_PERSIST == 0 {
-            // Still failing well past a transient ICMP: say so once per run length, else a
-            // socket that never recovers is silent until KCP reaps it 60s later.
-            log::warn!(
-                "KCP {} failing persistently: {} consecutive errors, last: {:?}",
-                what,
-                fail_run,
-                e
-            );
-        }
-    }
-
-    fn note_io_ok(fail_run: &mut u64) {
-        if *fail_run >= Self::KCP_IO_FAIL_PERSIST {
-            log::info!("KCP socket recovered after {} failed operations", fail_run);
-        }
-        *fail_run = 0;
     }
 
     fn create_framed(stream: stream::KcpStream, local_addr: Option<SocketAddr>) -> Stream {
@@ -157,12 +136,11 @@ impl KcpStream {
             // a truly dead link is reaped by the KCP pong timeout / app-level timeouts.
             // The short sleep prevents a persistently failing socket from busy-spinning.
             //
-            // Log by run, not per occurrence: the 10ms sleep means a persistently failing
-            // socket would otherwise write ~100 lines a second into the log file. One line
-            // when a run starts, one per PERSIST run length so a stuck socket stays visible
-            // (the pong timeout takes 60s to reap it, and the session is frozen meanwhile),
-            // and one when it recovers carrying the total.
-            let mut fail_run = 0u64;
+            // These repeat every 10ms while the socket stays broken, so throttle the line —
+            // debug output is written to the log file. One throttle per direction: an ICMP
+            // error on a connected socket is reported once and cleared, so the steady state is
+            // an alternation (send succeeds, the next recv reports the error), and a shared
+            // counter would be reset by the succeeding direction on every cycle.
             loop {
                 tokio::select! {
                     _ = &mut stop_receiver => {
@@ -170,18 +148,16 @@ impl KcpStream {
                         break;
                     }
                     Some(data) = output.recv() => {
-                        match udp.send(&data.inner()).await {
-                            Ok(_) => Self::note_io_ok(&mut fail_run),
-                            Err(e) => {
-                                Self::note_io_err(&mut fail_run, "send", &e);
-                                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                        if let Err(e) = udp.send(&data.inner()).await {
+                            if let Some(n) = KCP_SEND_ERR_LOG.due() {
+                                log::debug!("KCP send error x{n} (treated as loss), last: {e}");
                             }
+                            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                         }
                     }
                     result = udp.recv_from(&mut buf) => {
                         match result {
                             Ok((size, _)) => {
-                                Self::note_io_ok(&mut fail_run);
                                 if size < std::mem::size_of::<KcpPacketHeader>() {
                                     continue;
                                 }
@@ -190,7 +166,9 @@ impl KcpStream {
                                     .await.ok();
                             }
                             Err(e) => {
-                                Self::note_io_err(&mut fail_run, "recv", &e);
+                                if let Some(n) = KCP_RECV_ERR_LOG.due() {
+                                    log::debug!("KCP recv error x{n} (treated as loss), last: {e}");
+                                }
                                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                             }
                         }

--- a/src/kcp_stream.rs
+++ b/src/kcp_stream.rs
@@ -36,6 +36,33 @@ impl KcpStream {
         }
     }
 
+    // One line per run of socket failures rather than per failure: these are absorbed as packet
+    // loss and can repeat every 10ms, and debug output is written to the log file.
+    const KCP_IO_FAIL_PERSIST: u64 = 500; // ~5s at the 10ms retry interval
+
+    fn note_io_err(fail_run: &mut u64, what: &str, e: &std::io::Error) {
+        *fail_run += 1;
+        if *fail_run == 1 {
+            log::debug!("KCP {} error (treated as loss): {:?}", what, e);
+        } else if *fail_run % Self::KCP_IO_FAIL_PERSIST == 0 {
+            // Still failing well past a transient ICMP: say so once per run length, else a
+            // socket that never recovers is silent until KCP reaps it 60s later.
+            log::warn!(
+                "KCP {} failing persistently: {} consecutive errors, last: {:?}",
+                what,
+                fail_run,
+                e
+            );
+        }
+    }
+
+    fn note_io_ok(fail_run: &mut u64) {
+        if *fail_run >= Self::KCP_IO_FAIL_PERSIST {
+            log::info!("KCP socket recovered after {} failed operations", fail_run);
+        }
+        *fail_run = 0;
+    }
+
     fn create_framed(stream: stream::KcpStream, local_addr: Option<SocketAddr>) -> Stream {
         Stream::Tcp(FramedStream(
             tokio_util::codec::Framed::new(DynTcpStream(Box::new(stream)), BytesCodec::new()),
@@ -129,6 +156,13 @@ impl KcpStream {
             // Treat socket errors as packet loss instead of tearing the session down;
             // a truly dead link is reaped by the KCP pong timeout / app-level timeouts.
             // The short sleep prevents a persistently failing socket from busy-spinning.
+            //
+            // Log by run, not per occurrence: the 10ms sleep means a persistently failing
+            // socket would otherwise write ~100 lines a second into the log file. One line
+            // when a run starts, one per PERSIST run length so a stuck socket stays visible
+            // (the pong timeout takes 60s to reap it, and the session is frozen meanwhile),
+            // and one when it recovers carrying the total.
+            let mut fail_run = 0u64;
             loop {
                 tokio::select! {
                     _ = &mut stop_receiver => {
@@ -136,14 +170,18 @@ impl KcpStream {
                         break;
                     }
                     Some(data) = output.recv() => {
-                        if let Err(e) = udp.send(&data.inner()).await {
-                            log::debug!("KCP send error (treated as loss): {:?}", e);
-                            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                        match udp.send(&data.inner()).await {
+                            Ok(_) => Self::note_io_ok(&mut fail_run),
+                            Err(e) => {
+                                Self::note_io_err(&mut fail_run, "send", &e);
+                                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                            }
                         }
                     }
                     result = udp.recv_from(&mut buf) => {
                         match result {
                             Ok((size, _)) => {
+                                Self::note_io_ok(&mut fail_run);
                                 if size < std::mem::size_of::<KcpPacketHeader>() {
                                     continue;
                                 }
@@ -152,7 +190,7 @@ impl KcpStream {
                                     .await.ok();
                             }
                             Err(e) => {
-                                log::debug!("KCP recv_from error (treated as loss): {:?}", e);
+                                Self::note_io_err(&mut fail_run, "recv", &e);
                                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                             }
                         }

--- a/src/kcp_stream.rs
+++ b/src/kcp_stream.rs
@@ -127,19 +127,10 @@ impl KcpStream {
         let udp = udp_socket.clone();
         tokio::spawn(async move {
             let mut buf = vec![0; 1500];
-            // A connected UDP socket surfaces ICMP port-unreachable as an error on
-            // send/recv (WSAECONNRESET 10054 on Windows, ECONNREFUSED on Linux). For UDP
-            // these are advisory: a stray ICMP from a NAT rebind glitch or a momentary
-            // peer hiccup does not mean the path is dead, and KCP retransmits through it.
-            // Treat socket errors as packet loss instead of tearing the session down;
-            // a truly dead link is reaped by the KCP pong timeout / app-level timeouts.
-            // The short sleep prevents a persistently failing socket from busy-spinning.
-            //
-            // These repeat every 10ms while the socket stays broken, so throttle the line —
-            // debug output is written to the log file. One throttle per direction: an ICMP
-            // error on a connected socket is reported once and cleared, so the steady state is
-            // an alternation (send succeeds, the next recv reports the error), and a shared
-            // counter would be reset by the succeeding direction on every cycle.
+            // Socket errors are ICMP unreachable on a connected UDP socket — advisory, and
+            // routine while a hole forms — so treat them as loss and let KCP's pong timeout reap
+            // a link that is really dead. One throttle PER DIRECTION: the error is reported once
+            // and cleared, so send-ok/recv-err alternates and a shared counter never fires.
             loop {
                 tokio::select! {
                     _ = &mut stop_receiver => {

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "سرعة لوحة التتبع الافتراضية"),
         ("Numeric one-time password", "كلمة مرور رقمية لمرة واحدة"),
         ("Enable IPv6 P2P connection", "تمكين اتصال نظير إلى نظير عبر IPv6"),
+        ("Enable WebRTC P2P connection", "تمكين اتصال نظير إلى نظير عبر WebRTC"),
         ("Enable UDP hole punching", "تمكين تقنية حفر الثغرات عبر UDP"),
         ("View camera", "عرض الكاميرا"),
         ("Enable camera", "تمكين الكاميرا"),

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "سرعة لوحة التتبع الافتراضية"),
         ("Numeric one-time password", "كلمة مرور رقمية لمرة واحدة"),
         ("Enable IPv6 P2P connection", "تمكين اتصال نظير إلى نظير عبر IPv6"),
-        ("Enable WebRTC P2P connection", "تمكين اتصال نظير إلى نظير عبر WebRTC"),
         ("Enable UDP hole punching", "تمكين تقنية حفر الثغرات عبر UDP"),
         ("View camera", "عرض الكاميرا"),
         ("Enable camera", "تمكين الكاميرا"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "تفعيل"),
         ("Reuse one connection for port forwarding", "إعادة استخدام اتصال واحد لإعادة توجيه المنافذ"),
         ("port-forward-mux-tip", "تمرير جميع اتصالات إعادة توجيه المنافذ عبر اتصال واحد بالجهاز الآخر، بدلاً من الاتصال وتسجيل الدخول من جديد لكل اتصال."),
+        ("Enable WebRTC P2P connection", "تمكين اتصال نظير إلى نظير عبر WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "إعادة استخدام اتصال واحد لإعادة توجيه المنافذ"),
         ("port-forward-mux-tip", "تمرير جميع اتصالات إعادة توجيه المنافذ عبر اتصال واحد بالجهاز الآخر، بدلاً من الاتصال وتسجيل الدخول من جديد لكل اتصال."),
         ("Enable WebRTC P2P connection", "تمكين اتصال نظير إلى نظير عبر WebRTC"),
+        ("Enable TCP hole punching", "تمكين تقنية حفر الثغرات عبر TCP"),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Стандартная хуткасць трэкпада"),
         ("Numeric one-time password", "Лічбавы аднаразовы пароль"),
         ("Enable IPv6 P2P connection", "Выкарыстоўваць падключэнне IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Выкарыстоўваць падключэнне WebRTC P2P"),
         ("Enable UDP hole punching", "Выкарыстоўваць UDP hole punching"),
         ("View camera", "Рэжым камеры"),
         ("Enable camera", "Уключыць камеру"),

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Выкарыстоўваць адно злучэнне для перанакіравання партоў"),
         ("port-forward-mux-tip", "Перадаваць усе злучэнні аднаго перанакіравання партоў праз адно злучэнне з аддаленай прыладай замест паўторнага падлучэння і ўваходу для кожнага з іх."),
         ("Enable WebRTC P2P connection", "Выкарыстоўваць падключэнне WebRTC P2P"),
+        ("Enable TCP hole punching", "Выкарыстоўваць TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Стандартная хуткасць трэкпада"),
         ("Numeric one-time password", "Лічбавы аднаразовы пароль"),
         ("Enable IPv6 P2P connection", "Выкарыстоўваць падключэнне IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Выкарыстоўваць падключэнне WebRTC P2P"),
         ("Enable UDP hole punching", "Выкарыстоўваць UDP hole punching"),
         ("View camera", "Рэжым камеры"),
         ("Enable camera", "Уключыць камеру"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Уключыць"),
         ("Reuse one connection for port forwarding", "Выкарыстоўваць адно злучэнне для перанакіравання партоў"),
         ("port-forward-mux-tip", "Перадаваць усе злучэнні аднаго перанакіравання партоў праз адно злучэнне з аддаленай прыладай замест паўторнага падлучэння і ўваходу для кожнага з іх."),
+        ("Enable WebRTC P2P connection", "Выкарыстоўваць падключэнне WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Скорост на тъчпада по подразбиране"),
         ("Numeric one-time password", "Цифрова еднократна парола"),
         ("Enable IPv6 P2P connection", "Позволяване на IPv6 P2P връзка"),
+        ("Enable WebRTC P2P connection", "Позволяване на WebRTC P2P връзка"),
         ("Enable UDP hole punching", "Позволяване на UDP hole punching"),
         ("View camera", "Преглед на камерата"),
         ("Enable camera", "Позволяване на камерата"),

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Използване на една връзка за пренасочване на портове"),
         ("port-forward-mux-tip", "Всички връзки на едно пренасочване на портове минават през една връзка към отсрещния компютър, вместо да се свързвате и влизате отново за всяка от тях."),
         ("Enable WebRTC P2P connection", "Позволяване на WebRTC P2P връзка"),
+        ("Enable TCP hole punching", "Позволяване на TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Скорост на тъчпада по подразбиране"),
         ("Numeric one-time password", "Цифрова еднократна парола"),
         ("Enable IPv6 P2P connection", "Позволяване на IPv6 P2P връзка"),
-        ("Enable WebRTC P2P connection", "Позволяване на WebRTC P2P връзка"),
         ("Enable UDP hole punching", "Позволяване на UDP hole punching"),
         ("View camera", "Преглед на камерата"),
         ("Enable camera", "Позволяване на камерата"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Активирай"),
         ("Reuse one connection for port forwarding", "Използване на една връзка за пренасочване на портове"),
         ("port-forward-mux-tip", "Всички връзки на едно пренасочване на портове минават през една връзка към отсрещния компютър, вместо да се свързвате и влизате отново за всяка от тях."),
+        ("Enable WebRTC P2P connection", "Позволяване на WebRTC P2P връзка"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velocitat per defecte del trackpad"),
         ("Numeric one-time password", "Contrasenya numèrica d'un sol ús"),
         ("Enable IPv6 P2P connection", "Habilita la connexió IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Habilita la connexió WebRTC P2P"),
         ("Enable UDP hole punching", "Activa la perforació UDP"),
         ("View camera", "Mostra la càmera"),
         ("Enable camera", "Habilita la càmera"),

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velocitat per defecte del trackpad"),
         ("Numeric one-time password", "Contrasenya numèrica d'un sol ús"),
         ("Enable IPv6 P2P connection", "Habilita la connexió IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Habilita la connexió WebRTC P2P"),
         ("Enable UDP hole punching", "Activa la perforació UDP"),
         ("View camera", "Mostra la càmera"),
         ("Enable camera", "Habilita la càmera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Habilita"),
         ("Reuse one connection for port forwarding", "Reutilitza una connexió per a la redirecció de ports"),
         ("port-forward-mux-tip", "Fa passar totes les connexions d'una redirecció de ports per una única connexió amb l'altre equip, en lloc de connectar i iniciar la sessió de nou per a cadascuna."),
+        ("Enable WebRTC P2P connection", "Habilita la connexió WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Reutilitza una connexió per a la redirecció de ports"),
         ("port-forward-mux-tip", "Fa passar totes les connexions d'una redirecció de ports per una única connexió amb l'altre equip, en lloc de connectar i iniciar la sessió de nou per a cadascuna."),
         ("Enable WebRTC P2P connection", "Habilita la connexió WebRTC P2P"),
+        ("Enable TCP hole punching", "Activa la perforació TCP"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "默认触控板速度"),
         ("Numeric one-time password", "一次性密码为数字"),
         ("Enable IPv6 P2P connection", "启用 IPv6 P2P 连接"),
+        ("Enable WebRTC P2P connection", "启用 WebRTC P2P 连接"),
         ("Enable UDP hole punching", "启用 UDP 打洞"),
         ("View camera", "查看摄像头"),
         ("Enable camera", "允许查看摄像头"),

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "默认触控板速度"),
         ("Numeric one-time password", "一次性密码为数字"),
         ("Enable IPv6 P2P connection", "启用 IPv6 P2P 连接"),
-        ("Enable WebRTC P2P connection", "启用 WebRTC P2P 连接"),
         ("Enable UDP hole punching", "启用 UDP 打洞"),
         ("View camera", "查看摄像头"),
         ("Enable camera", "允许查看摄像头"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "启用"),
         ("Reuse one connection for port forwarding", "端口转发复用同一条连接"),
         ("port-forward-mux-tip", "同一条端口转发规则上的所有连接共用一条到对方的连接，而不是每条连接都重新连接并登录一次。"),
+        ("Enable WebRTC P2P connection", "启用 WebRTC P2P 连接"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "端口转发复用同一条连接"),
         ("port-forward-mux-tip", "同一条端口转发规则上的所有连接共用一条到对方的连接，而不是每条连接都重新连接并登录一次。"),
         ("Enable WebRTC P2P connection", "启用 WebRTC P2P 连接"),
+        ("Enable TCP hole punching", "启用 TCP 打洞"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Výchozí rychlost trackpadu"),
         ("Numeric one-time password", "Číselné jednorázové heslo"),
         ("Enable IPv6 P2P connection", "Povolit připojení IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Povolit připojení WebRTC P2P"),
         ("Enable UDP hole punching", "Povolit UDP hole punching"),
         ("View camera", "Zobrazit kameru"),
         ("Enable camera", "Povolit kameru"),

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Znovu použít jedno připojení pro přesměrování portů"),
         ("port-forward-mux-tip", "Vede všechna připojení jednoho přesměrování portů přes jediné připojení k protějšku místo opakovaného připojování a přihlašování pro každé z nich."),
         ("Enable WebRTC P2P connection", "Povolit připojení WebRTC P2P"),
+        ("Enable TCP hole punching", "Povolit TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Výchozí rychlost trackpadu"),
         ("Numeric one-time password", "Číselné jednorázové heslo"),
         ("Enable IPv6 P2P connection", "Povolit připojení IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Povolit připojení WebRTC P2P"),
         ("Enable UDP hole punching", "Povolit UDP hole punching"),
         ("View camera", "Zobrazit kameru"),
         ("Enable camera", "Povolit kameru"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Povolit"),
         ("Reuse one connection for port forwarding", "Znovu použít jedno připojení pro přesměrování portů"),
         ("port-forward-mux-tip", "Vede všechna připojení jednoho přesměrování portů přes jediné připojení k protějšku místo opakovaného připojování a přihlašování pro každé z nich."),
+        ("Enable WebRTC P2P connection", "Povolit připojení WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Standard pegefeltshastighed"),
         ("Numeric one-time password", "Numerisk engangskode"),
         ("Enable IPv6 P2P connection", "Aktivér IPv6 P2P-forbindelse"),
+        ("Enable WebRTC P2P connection", "Aktivér WebRTC P2P-forbindelse"),
         ("Enable UDP hole punching", "Aktivér UDP hole punching"),
         ("View camera", "Se kamera"),
         ("Enable camera", "Aktivér kamera"),

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Standard pegefeltshastighed"),
         ("Numeric one-time password", "Numerisk engangskode"),
         ("Enable IPv6 P2P connection", "Aktivér IPv6 P2P-forbindelse"),
-        ("Enable WebRTC P2P connection", "Aktivér WebRTC P2P-forbindelse"),
         ("Enable UDP hole punching", "Aktivér UDP hole punching"),
         ("View camera", "Se kamera"),
         ("Enable camera", "Aktivér kamera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Aktivér"),
         ("Reuse one connection for port forwarding", "Genbrug én forbindelse til portvideresendelse"),
         ("port-forward-mux-tip", "Fører alle forbindelser i en portvideresendelse gennem én enkelt forbindelse til modparten i stedet for at forbinde og logge ind igen for hver enkelt."),
+        ("Enable WebRTC P2P connection", "Aktivér WebRTC P2P-forbindelse"),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Genbrug én forbindelse til portvideresendelse"),
         ("port-forward-mux-tip", "Fører alle forbindelser i en portvideresendelse gennem én enkelt forbindelse til modparten i stedet for at forbinde og logge ind igen for hver enkelt."),
         ("Enable WebRTC P2P connection", "Aktivér WebRTC P2P-forbindelse"),
+        ("Enable TCP hole punching", "Aktivér TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Standardgeschwindigkeit des Trackpads"),
         ("Numeric one-time password", "Numerisches Einmalpasswort"),
         ("Enable IPv6 P2P connection", "IPv6-P2P-Verbindung aktivieren"),
+        ("Enable WebRTC P2P connection", "WebRTC-P2P-Verbindung aktivieren"),
         ("Enable UDP hole punching", "UDP-Hole-Punching aktivieren"),
         ("View camera", "Kamera anzeigen"),
         ("Enable camera", "Kamera zulassen"),

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Standardgeschwindigkeit des Trackpads"),
         ("Numeric one-time password", "Numerisches Einmalpasswort"),
         ("Enable IPv6 P2P connection", "IPv6-P2P-Verbindung aktivieren"),
-        ("Enable WebRTC P2P connection", "WebRTC-P2P-Verbindung aktivieren"),
         ("Enable UDP hole punching", "UDP-Hole-Punching aktivieren"),
         ("View camera", "Kamera anzeigen"),
         ("Enable camera", "Kamera zulassen"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Aktivieren"),
         ("Reuse one connection for port forwarding", "Eine Verbindung für die Portweiterleitung wiederverwenden"),
         ("port-forward-mux-tip", "Alle Verbindungen einer Portweiterleitung über eine einzige Verbindung zur Gegenstelle führen, statt sich für jede einzelne neu zu verbinden und anzumelden."),
+        ("Enable WebRTC P2P connection", "WebRTC-P2P-Verbindung aktivieren"),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Eine Verbindung für die Portweiterleitung wiederverwenden"),
         ("port-forward-mux-tip", "Alle Verbindungen einer Portweiterleitung über eine einzige Verbindung zur Gegenstelle führen, statt sich für jede einzelne neu zu verbinden und anzumelden."),
         ("Enable WebRTC P2P connection", "WebRTC-P2P-Verbindung aktivieren"),
+        ("Enable TCP hole punching", "TCP-Hole-Punching aktivieren"),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Προεπιλεγμένη ταχύτητα trackpad"),
         ("Numeric one-time password", "Αριθμητικός κωδικός πρόσβασης μίας χρήσης"),
         ("Enable IPv6 P2P connection", "Ενεργοποίηση σύνδεσης IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Ενεργοποίηση σύνδεσης WebRTC P2P"),
         ("Enable UDP hole punching", "Ενεργοποίηση διάτρησης οπών UDP"),
         ("View camera", "Προβολή κάμερας"),
         ("Enable camera", "Ενεργοποίηση κάμερας"),

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Προεπιλεγμένη ταχύτητα trackpad"),
         ("Numeric one-time password", "Αριθμητικός κωδικός πρόσβασης μίας χρήσης"),
         ("Enable IPv6 P2P connection", "Ενεργοποίηση σύνδεσης IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Ενεργοποίηση σύνδεσης WebRTC P2P"),
         ("Enable UDP hole punching", "Ενεργοποίηση διάτρησης οπών UDP"),
         ("View camera", "Προβολή κάμερας"),
         ("Enable camera", "Ενεργοποίηση κάμερας"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Ενεργοποίηση"),
         ("Reuse one connection for port forwarding", "Επαναχρησιμοποίηση μίας σύνδεσης για την προώθηση θυρών"),
         ("port-forward-mux-tip", "Όλες οι συνδέσεις μιας προώθησης θυρών περνούν από μία μόνο σύνδεση προς τον απομακρυσμένο υπολογιστή, αντί να πραγματοποιείται νέα σύνδεση και ταυτοποίηση για κάθε μία."),
+        ("Enable WebRTC P2P connection", "Ενεργοποίηση σύνδεσης WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Επαναχρησιμοποίηση μίας σύνδεσης για την προώθηση θυρών"),
         ("port-forward-mux-tip", "Όλες οι συνδέσεις μιας προώθησης θυρών περνούν από μία μόνο σύνδεση προς τον απομακρυσμένο υπολογιστή, αντί να πραγματοποιείται νέα σύνδεση και ταυτοποίηση για κάθε μία."),
         ("Enable WebRTC P2P connection", "Ενεργοποίηση σύνδεσης WebRTC P2P"),
+        ("Enable TCP hole punching", "Ενεργοποίηση διάτρησης οπών TCP"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Implicita rapideco de tuŝplato"),
         ("Numeric one-time password", "Numera unufoja pasvorto"),
         ("Enable IPv6 P2P connection", "Ebligi IPv6 P2P-konekton"),
+        ("Enable WebRTC P2P connection", "Ebligi WebRTC P2P-konekton"),
         ("Enable UDP hole punching", "Ebligi UDP-trapikadon"),
         ("View camera", "Rigardi kameron"),
         ("Enable camera", "Ebligi kameron"),

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Implicita rapideco de tuŝplato"),
         ("Numeric one-time password", "Numera unufoja pasvorto"),
         ("Enable IPv6 P2P connection", "Ebligi IPv6 P2P-konekton"),
-        ("Enable WebRTC P2P connection", "Ebligi WebRTC P2P-konekton"),
         ("Enable UDP hole punching", "Ebligi UDP-trapikadon"),
         ("View camera", "Rigardi kameron"),
         ("Enable camera", "Ebligi kameron"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Ebligi"),
         ("Reuse one connection for port forwarding", "Reuzi unu konekton por pordo-plusendado"),
         ("port-forward-mux-tip", "Ĉiuj konektoj de unu pordo-plusendado iras tra unu sola konekto al la alia komputilo, anstataŭ konekti kaj ensaluti denove por ĉiu el ili."),
+        ("Enable WebRTC P2P connection", "Ebligi WebRTC P2P-konekton"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Reuzi unu konekton por pordo-plusendado"),
         ("port-forward-mux-tip", "Ĉiuj konektoj de unu pordo-plusendado iras tra unu sola konekto al la alia komputilo, anstataŭ konekti kaj ensaluti denove por ĉiu el ili."),
         ("Enable WebRTC P2P connection", "Ebligi WebRTC P2P-konekton"),
+        ("Enable TCP hole punching", "Ebligi TCP-trapikadon"),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velocidad predeterminada de trackpad"),
         ("Numeric one-time password", "Contraseña numérica de un solo uso"),
         ("Enable IPv6 P2P connection", "Habilitar conexión IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Habilitar conexión WebRTC P2P"),
         ("Enable UDP hole punching", "Habilitar perforación de agujero UDP"),
         ("View camera", "Ver cámara"),
         ("Enable camera", "Habilitar cámara"),

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Reutilizar una conexión para la redirección de puertos"),
         ("port-forward-mux-tip", "Llevar todas las conexiones de una redirección de puertos por una única conexión con el otro equipo, en lugar de conectar e iniciar sesión de nuevo para cada una."),
         ("Enable WebRTC P2P connection", "Habilitar conexión WebRTC P2P"),
+        ("Enable TCP hole punching", "Habilitar perforación de agujero TCP"),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velocidad predeterminada de trackpad"),
         ("Numeric one-time password", "Contraseña numérica de un solo uso"),
         ("Enable IPv6 P2P connection", "Habilitar conexión IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Habilitar conexión WebRTC P2P"),
         ("Enable UDP hole punching", "Habilitar perforación de agujero UDP"),
         ("View camera", "Ver cámara"),
         ("Enable camera", "Habilitar cámara"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Habilitar"),
         ("Reuse one connection for port forwarding", "Reutilizar una conexión para la redirección de puertos"),
         ("port-forward-mux-tip", "Llevar todas las conexiones de una redirección de puertos por una única conexión con el otro equipo, en lugar de conectar e iniciar sesión de nuevo para cada una."),
+        ("Enable WebRTC P2P connection", "Habilitar conexión WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Vaikimisi puuteplaadi kiirus"),
         ("Numeric one-time password", "Numbriline ühekordne parool"),
         ("Enable IPv6 P2P connection", "Luba IPv6 P2P-ühendus"),
+        ("Enable WebRTC P2P connection", "Luba WebRTC P2P-ühendus"),
         ("Enable UDP hole punching", "Luba UDP-augustamine"),
         ("View camera", "Vaata kaamerat"),
         ("Enable camera", "Luba kaamera"),

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Vaikimisi puuteplaadi kiirus"),
         ("Numeric one-time password", "Numbriline ühekordne parool"),
         ("Enable IPv6 P2P connection", "Luba IPv6 P2P-ühendus"),
-        ("Enable WebRTC P2P connection", "Luba WebRTC P2P-ühendus"),
         ("Enable UDP hole punching", "Luba UDP-augustamine"),
         ("View camera", "Vaata kaamerat"),
         ("Enable camera", "Luba kaamera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Luba"),
         ("Reuse one connection for port forwarding", "Kasuta pordi suunamiseks üht ühendust"),
         ("port-forward-mux-tip", "Juhib ühe pordisuunamise kõik ühendused ühe teise arvutiga loodud ühenduse kaudu, selle asemel et iga ühenduse jaoks uuesti ühenduda ja sisse logida."),
+        ("Enable WebRTC P2P connection", "Luba WebRTC P2P-ühendus"),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Kasuta pordi suunamiseks üht ühendust"),
         ("port-forward-mux-tip", "Juhib ühe pordisuunamise kõik ühendused ühe teise arvutiga loodud ühenduse kaudu, selle asemel et iga ühenduse jaoks uuesti ühenduda ja sisse logida."),
         ("Enable WebRTC P2P connection", "Luba WebRTC P2P-ühendus"),
+        ("Enable TCP hole punching", "Luba TCP-augustamine"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Trackpad-aren abiadura lehenetsia"),
         ("Numeric one-time password", "Behin-behineko pasahitz numerikoa"),
         ("Enable IPv6 P2P connection", "Gaitu IPv6 P2P konexioa"),
+        ("Enable WebRTC P2P connection", "Gaitu WebRTC P2P konexioa"),
         ("Enable UDP hole punching", "Gaitu UDP zulo-egitea"),
         ("View camera", "Ikusi kamera"),
         ("Enable camera", "Gaitu kamera"),

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Berrerabili konexio bakarra portuen birbideratzerako"),
         ("port-forward-mux-tip", "Portu-birbideratze baten konexio guztiak beste ordenagailurako konexio bakar batetik eramaten ditu, bakoitzerako berriro konektatu eta saioa hasi beharrean."),
         ("Enable WebRTC P2P connection", "Gaitu WebRTC P2P konexioa"),
+        ("Enable TCP hole punching", "Gaitu TCP zulo-egitea"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Trackpad-aren abiadura lehenetsia"),
         ("Numeric one-time password", "Behin-behineko pasahitz numerikoa"),
         ("Enable IPv6 P2P connection", "Gaitu IPv6 P2P konexioa"),
-        ("Enable WebRTC P2P connection", "Gaitu WebRTC P2P konexioa"),
         ("Enable UDP hole punching", "Gaitu UDP zulo-egitea"),
         ("View camera", "Ikusi kamera"),
         ("Enable camera", "Gaitu kamera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Gaitu"),
         ("Reuse one connection for port forwarding", "Berrerabili konexio bakarra portuen birbideratzerako"),
         ("port-forward-mux-tip", "Portu-birbideratze baten konexio guztiak beste ordenagailurako konexio bakar batetik eramaten ditu, bakoitzerako berriro konektatu eta saioa hasi beharrean."),
+        ("Enable WebRTC P2P connection", "Gaitu WebRTC P2P konexioa"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "سرعت پیش‌فرض ترک‌پد"),
         ("Numeric one-time password", "رمز عبور یک‌بار مصرف عددی"),
         ("Enable IPv6 P2P connection", "فعال‌سازی اتصال همتا‌به‌همتای IPv6"),
+        ("Enable WebRTC P2P connection", "فعال‌سازی اتصال همتا‌به‌همتای WebRTC"),
         ("Enable UDP hole punching", "فعال‌سازی تکنیک UDP hole punching"),
         ("View camera", "نمایش دوربین"),
         ("Enable camera", "فعال کردن دوربین"),

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "سرعت پیش‌فرض ترک‌پد"),
         ("Numeric one-time password", "رمز عبور یک‌بار مصرف عددی"),
         ("Enable IPv6 P2P connection", "فعال‌سازی اتصال همتا‌به‌همتای IPv6"),
-        ("Enable WebRTC P2P connection", "فعال‌سازی اتصال همتا‌به‌همتای WebRTC"),
         ("Enable UDP hole punching", "فعال‌سازی تکنیک UDP hole punching"),
         ("View camera", "نمایش دوربین"),
         ("Enable camera", "فعال کردن دوربین"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "فعال‌سازی"),
         ("Reuse one connection for port forwarding", "استفاده مجدد از یک اتصال برای هدایت پورت"),
         ("port-forward-mux-tip", "همه اتصال‌های یک هدایت پورت از یک اتصال واحد به دستگاه مقابل عبور می‌کنند، به‌جای اتصال و ورود دوباره برای هر کدام."),
+        ("Enable WebRTC P2P connection", "فعال‌سازی اتصال همتا‌به‌همتای WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "استفاده مجدد از یک اتصال برای هدایت پورت"),
         ("port-forward-mux-tip", "همه اتصال‌های یک هدایت پورت از یک اتصال واحد به دستگاه مقابل عبور می‌کنند، به‌جای اتصال و ورود دوباره برای هر کدام."),
         ("Enable WebRTC P2P connection", "فعال‌سازی اتصال همتا‌به‌همتای WebRTC"),
+        ("Enable TCP hole punching", "فعال‌سازی تکنیک TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Oletusnopeus kosketuslevylle"),
         ("Numeric one-time password", "Numeerinen kertakäyttösalasana"),
         ("Enable IPv6 P2P connection", "Ota IPv6 P2P yhteys käyttöön"),
+        ("Enable WebRTC P2P connection", "Ota WebRTC P2P yhteys käyttöön"),
         ("Enable UDP hole punching", "Ota käyttöön UDP hole punching  tekniikka"),
         ("View camera", "Näytä kamera"),
         ("Enable camera", "Ota kamera käyttöön"),

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Käytä yhtä yhteyttä portin edelleenohjaukseen"),
         ("port-forward-mux-tip", "Välittää kaikki yhden portin edelleenohjauksen yhteydet yhden vastapuoleen avatun yhteyden kautta sen sijaan, että jokaista varten muodostettaisiin yhteys ja kirjauduttaisiin uudelleen."),
         ("Enable WebRTC P2P connection", "Ota WebRTC P2P yhteys käyttöön"),
+        ("Enable TCP hole punching", "Ota käyttöön TCP hole punching  tekniikka"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Oletusnopeus kosketuslevylle"),
         ("Numeric one-time password", "Numeerinen kertakäyttösalasana"),
         ("Enable IPv6 P2P connection", "Ota IPv6 P2P yhteys käyttöön"),
-        ("Enable WebRTC P2P connection", "Ota WebRTC P2P yhteys käyttöön"),
         ("Enable UDP hole punching", "Ota käyttöön UDP hole punching  tekniikka"),
         ("View camera", "Näytä kamera"),
         ("Enable camera", "Ota kamera käyttöön"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Ota käyttöön"),
         ("Reuse one connection for port forwarding", "Käytä yhtä yhteyttä portin edelleenohjaukseen"),
         ("port-forward-mux-tip", "Välittää kaikki yhden portin edelleenohjauksen yhteydet yhden vastapuoleen avatun yhteyden kautta sen sijaan, että jokaista varten muodostettaisiin yhteys ja kirjauduttaisiin uudelleen."),
+        ("Enable WebRTC P2P connection", "Ota WebRTC P2P yhteys käyttöön"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Vitesse par défaut du pavé tactile"),
         ("Numeric one-time password", "Mot de passe à usage unique numérique"),
         ("Enable IPv6 P2P connection", "Activer la connexion P2P IPv6"),
+        ("Enable WebRTC P2P connection", "Activer la connexion P2P WebRTC"),
         ("Enable UDP hole punching", "Activer le « hole punching » UDP"),
         ("View camera", "Afficher la caméra"),
         ("Enable camera", "Activer la caméra"),

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Vitesse par défaut du pavé tactile"),
         ("Numeric one-time password", "Mot de passe à usage unique numérique"),
         ("Enable IPv6 P2P connection", "Activer la connexion P2P IPv6"),
-        ("Enable WebRTC P2P connection", "Activer la connexion P2P WebRTC"),
         ("Enable UDP hole punching", "Activer le « hole punching » UDP"),
         ("View camera", "Afficher la caméra"),
         ("Enable camera", "Activer la caméra"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Activer"),
         ("Reuse one connection for port forwarding", "Réutiliser une seule connexion pour la redirection de ports"),
         ("port-forward-mux-tip", "Faire passer toutes les connexions d'une redirection de ports par une seule connexion vers le pair, au lieu de se connecter et de s'authentifier à nouveau pour chacune."),
+        ("Enable WebRTC P2P connection", "Activer la connexion P2P WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Réutiliser une seule connexion pour la redirection de ports"),
         ("port-forward-mux-tip", "Faire passer toutes les connexions d'une redirection de ports par une seule connexion vers le pair, au lieu de se connecter et de s'authentifier à nouveau pour chacune."),
         ("Enable WebRTC P2P connection", "Activer la connexion P2P WebRTC"),
+        ("Enable TCP hole punching", "Activer le « hole punching » TCP"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "ტაჩპადის ნაგულისხმევი სიჩქარე"),
         ("Numeric one-time password", "ციფრული ერთჯერადი პაროლი"),
         ("Enable IPv6 P2P connection", "IPv6 P2P კავშირის ჩართვა"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P კავშირის ჩართვა"),
         ("Enable UDP hole punching", "UDP hole punching-ის ჩართვა"),
         ("View camera", "კამერის ნახვა"),
         ("Enable camera", "კამერის ჩართვა"),

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "პორტის გადამისამართებისთვის ერთი კავშირის ხელახლა გამოყენება"),
         ("port-forward-mux-tip", "ერთი პორტის გადამისამართების ყველა კავშირი გადის მეორე კომპიუტერთან დამყარებული ერთი კავშირით, ნაცვლად იმისა, რომ თითოეულისთვის თავიდან დაუკავშირდეს და შევიდეს სისტემაში."),
         ("Enable WebRTC P2P connection", "WebRTC P2P კავშირის ჩართვა"),
+        ("Enable TCP hole punching", "TCP hole punching-ის ჩართვა"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "ტაჩპადის ნაგულისხმევი სიჩქარე"),
         ("Numeric one-time password", "ციფრული ერთჯერადი პაროლი"),
         ("Enable IPv6 P2P connection", "IPv6 P2P კავშირის ჩართვა"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P კავშირის ჩართვა"),
         ("Enable UDP hole punching", "UDP hole punching-ის ჩართვა"),
         ("View camera", "კამერის ნახვა"),
         ("Enable camera", "კამერის ჩართვა"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "ჩართვა"),
         ("Reuse one connection for port forwarding", "პორტის გადამისამართებისთვის ერთი კავშირის ხელახლა გამოყენება"),
         ("port-forward-mux-tip", "ერთი პორტის გადამისამართების ყველა კავშირი გადის მეორე კომპიუტერთან დამყარებული ერთი კავშირით, ნაცვლად იმისა, რომ თითოეულისთვის თავიდან დაუკავშირდეს და შევიდეს სისტემაში."),
+        ("Enable WebRTC P2P connection", "WebRTC P2P კავშირის ჩართვა"),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "ડિફોલ્ટ ટ્રેકપેડ સ્પીડ"),
         ("Numeric one-time password", "ન્યુમેરિક OTP"),
         ("Enable IPv6 P2P connection", "IPv6 P2P કનેક્શન સક્ષમ કરો"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P કનેક્શન સક્ષમ કરો"),
         ("Enable UDP hole punching", "UDP હોલ પંચિંગ સક્ષમ કરો"),
         ("View camera", "કેમેરા જુઓ"),
         ("Enable camera", "કેમેરા સક્ષમ કરો"),

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "ડિફોલ્ટ ટ્રેકપેડ સ્પીડ"),
         ("Numeric one-time password", "ન્યુમેરિક OTP"),
         ("Enable IPv6 P2P connection", "IPv6 P2P કનેક્શન સક્ષમ કરો"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P કનેક્શન સક્ષમ કરો"),
         ("Enable UDP hole punching", "UDP હોલ પંચિંગ સક્ષમ કરો"),
         ("View camera", "કેમેરા જુઓ"),
         ("Enable camera", "કેમેરા સક્ષમ કરો"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "સક્ષમ કરો"),
         ("Reuse one connection for port forwarding", "પોર્ટ ફોરવર્ડિંગ માટે એક જ કનેક્શન ફરી વાપરો"),
         ("port-forward-mux-tip", "એક પોર્ટ ફોરવર્ડિંગનાં બધાં કનેક્શન સામેના કમ્પ્યુટર સાથેના એક જ કનેક્શન મારફતે જાય છે, દરેક માટે ફરીથી કનેક્ટ અને લોગિન કરવાને બદલે."),
+        ("Enable WebRTC P2P connection", "WebRTC P2P કનેક્શન સક્ષમ કરો"),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "પોર્ટ ફોરવર્ડિંગ માટે એક જ કનેક્શન ફરી વાપરો"),
         ("port-forward-mux-tip", "એક પોર્ટ ફોરવર્ડિંગનાં બધાં કનેક્શન સામેના કમ્પ્યુટર સાથેના એક જ કનેક્શન મારફતે જાય છે, દરેક માટે ફરીથી કનેક્ટ અને લોગિન કરવાને બદલે."),
         ("Enable WebRTC P2P connection", "WebRTC P2P કનેક્શન સક્ષમ કરો"),
+        ("Enable TCP hole punching", "TCP હોલ પંચિંગ સક્ષમ કરો"),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "מהירות ברירת מחדל של משטח מגע"),
         ("Numeric one-time password", "סיסמה חד-פעמית מספרית"),
         ("Enable IPv6 P2P connection", "אפשר חיבור IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "אפשר חיבור WebRTC P2P"),
         ("Enable UDP hole punching", "אפשר UDP hole punching"),
         ("View camera", "הצג מצלמה"),
         ("Enable camera", "הפעל מצלמה"),

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "מהירות ברירת מחדל של משטח מגע"),
         ("Numeric one-time password", "סיסמה חד-פעמית מספרית"),
         ("Enable IPv6 P2P connection", "אפשר חיבור IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "אפשר חיבור WebRTC P2P"),
         ("Enable UDP hole punching", "אפשר UDP hole punching"),
         ("View camera", "הצג מצלמה"),
         ("Enable camera", "הפעל מצלמה"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "הפעל"),
         ("Reuse one connection for port forwarding", "שימוש חוזר בחיבור אחד להעברת פורטים"),
         ("port-forward-mux-tip", "כל החיבורים של העברת פורטים אחת עוברים דרך חיבור יחיד למחשב המרוחק, במקום ליצור חיבור חדש ולהיכנס מחדש עבור כל אחד מהם."),
+        ("Enable WebRTC P2P connection", "אפשר חיבור WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "שימוש חוזר בחיבור אחד להעברת פורטים"),
         ("port-forward-mux-tip", "כל החיבורים של העברת פורטים אחת עוברים דרך חיבור יחיד למחשב המרוחק, במקום ליצור חיבור חדש ולהיכנס מחדש עבור כל אחד מהם."),
         ("Enable WebRTC P2P connection", "אפשר חיבור WebRTC P2P"),
+        ("Enable TCP hole punching", "אפשר TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "डिफ़ॉल्ट ट्रैकपैड गति"),
         ("Numeric one-time password", "संख्यात्मक वन-टाइम पासवर्ड"),
         ("Enable IPv6 P2P connection", "IPv6 P2P कनेक्शन सक्षम करें"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P कनेक्शन सक्षम करें"),
         ("Enable UDP hole punching", "UDP होल पंचिंग सक्षम करें"),
         ("View camera", "कैमरा देखें"),
         ("Enable camera", "कैमरा सक्षम करें"),

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "पोर्ट फ़ॉरवर्डिंग के लिए एक ही कनेक्शन दोबारा उपयोग करें"),
         ("port-forward-mux-tip", "एक पोर्ट फ़ॉरवर्डिंग के सभी कनेक्शन दूसरे कंप्यूटर से बने एक ही कनेक्शन से होकर जाते हैं, हर एक के लिए दोबारा कनेक्ट और लॉगिन करने के बजाय।"),
         ("Enable WebRTC P2P connection", "WebRTC P2P कनेक्शन सक्षम करें"),
+        ("Enable TCP hole punching", "TCP होल पंचिंग सक्षम करें"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "डिफ़ॉल्ट ट्रैकपैड गति"),
         ("Numeric one-time password", "संख्यात्मक वन-टाइम पासवर्ड"),
         ("Enable IPv6 P2P connection", "IPv6 P2P कनेक्शन सक्षम करें"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P कनेक्शन सक्षम करें"),
         ("Enable UDP hole punching", "UDP होल पंचिंग सक्षम करें"),
         ("View camera", "कैमरा देखें"),
         ("Enable camera", "कैमरा सक्षम करें"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "सक्षम करें"),
         ("Reuse one connection for port forwarding", "पोर्ट फ़ॉरवर्डिंग के लिए एक ही कनेक्शन दोबारा उपयोग करें"),
         ("port-forward-mux-tip", "एक पोर्ट फ़ॉरवर्डिंग के सभी कनेक्शन दूसरे कंप्यूटर से बने एक ही कनेक्शन से होकर जाते हैं, हर एक के लिए दोबारा कनेक्ट और लॉगिन करने के बजाय।"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P कनेक्शन सक्षम करें"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Zadana brzina dodirne ploče"),
         ("Numeric one-time password", "Numerička jednokratna lozinka"),
         ("Enable IPv6 P2P connection", "Omogući IPv6 P2P vezu"),
+        ("Enable WebRTC P2P connection", "Omogući WebRTC P2P vezu"),
         ("Enable UDP hole punching", "Omogući UDP hole punching"),
         ("View camera", "Pregled kamere"),
         ("Enable camera", "Omogući kameru"),

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Ponovno koristi jednu vezu za prosljeđivanje portova"),
         ("port-forward-mux-tip", "Sve veze jednog prosljeđivanja portova idu kroz jednu vezu prema drugoj strani, umjesto ponovnog povezivanja i prijave za svaku od njih."),
         ("Enable WebRTC P2P connection", "Omogući WebRTC P2P vezu"),
+        ("Enable TCP hole punching", "Omogući TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Zadana brzina dodirne ploče"),
         ("Numeric one-time password", "Numerička jednokratna lozinka"),
         ("Enable IPv6 P2P connection", "Omogući IPv6 P2P vezu"),
-        ("Enable WebRTC P2P connection", "Omogući WebRTC P2P vezu"),
         ("Enable UDP hole punching", "Omogući UDP hole punching"),
         ("View camera", "Pregled kamere"),
         ("Enable camera", "Omogući kameru"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Omogući"),
         ("Reuse one connection for port forwarding", "Ponovno koristi jednu vezu za prosljeđivanje portova"),
         ("port-forward-mux-tip", "Sve veze jednog prosljeđivanja portova idu kroz jednu vezu prema drugoj strani, umjesto ponovnog povezivanja i prijave za svaku od njih."),
+        ("Enable WebRTC P2P connection", "Omogući WebRTC P2P vezu"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Alapértelmezett érintőpad sebessége"),
         ("Numeric one-time password", "Numerikus, egyszer használatos jelszó"),
         ("Enable IPv6 P2P connection", "IPv6 P2P kapcsolat engedélyezése"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P kapcsolat engedélyezése"),
         ("Enable UDP hole punching", "UDP résszűrés engedélyezése"),
         ("View camera", "Kamera nézet"),
         ("Enable camera", "Kamera engedélyezése"),

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Egyetlen kapcsolat újrafelhasználása a portátirányításhoz"),
         ("port-forward-mux-tip", "Egy portátirányítás összes kapcsolatát egyetlen, a másik géppel létesített kapcsolaton vezeti át, ahelyett hogy mindegyikhez újra csatlakozna és bejelentkezne."),
         ("Enable WebRTC P2P connection", "WebRTC P2P kapcsolat engedélyezése"),
+        ("Enable TCP hole punching", "TCP résszűrés engedélyezése"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Alapértelmezett érintőpad sebessége"),
         ("Numeric one-time password", "Numerikus, egyszer használatos jelszó"),
         ("Enable IPv6 P2P connection", "IPv6 P2P kapcsolat engedélyezése"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P kapcsolat engedélyezése"),
         ("Enable UDP hole punching", "UDP résszűrés engedélyezése"),
         ("View camera", "Kamera nézet"),
         ("Enable camera", "Kamera engedélyezése"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Engedélyezés"),
         ("Reuse one connection for port forwarding", "Egyetlen kapcsolat újrafelhasználása a portátirányításhoz"),
         ("port-forward-mux-tip", "Egy portátirányítás összes kapcsolatát egyetlen, a másik géppel létesített kapcsolaton vezeti át, ahelyett hogy mindegyikhez újra csatlakozna és bejelentkezne."),
+        ("Enable WebRTC P2P connection", "WebRTC P2P kapcsolat engedélyezése"),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Kecepatan default trackpad"),
         ("Numeric one-time password", "Kata sandi sekali pakai numerik"),
         ("Enable IPv6 P2P connection", "Aktifkan koneksi P2P IPv6"),
+        ("Enable WebRTC P2P connection", "Aktifkan koneksi P2P WebRTC"),
         ("Enable UDP hole punching", "Aktifkan UDP hole punching"),
         ("View camera", "Lihat Kamera"),
         ("Enable camera", "Aktifkan kamera"),

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Gunakan ulang satu koneksi untuk penerusan port"),
         ("port-forward-mux-tip", "Menyalurkan semua koneksi dari satu penerusan port melalui satu koneksi ke perangkat lain, alih-alih menyambung dan masuk lagi untuk setiap koneksi."),
         ("Enable WebRTC P2P connection", "Aktifkan koneksi P2P WebRTC"),
+        ("Enable TCP hole punching", "Aktifkan TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Kecepatan default trackpad"),
         ("Numeric one-time password", "Kata sandi sekali pakai numerik"),
         ("Enable IPv6 P2P connection", "Aktifkan koneksi P2P IPv6"),
-        ("Enable WebRTC P2P connection", "Aktifkan koneksi P2P WebRTC"),
         ("Enable UDP hole punching", "Aktifkan UDP hole punching"),
         ("View camera", "Lihat Kamera"),
         ("Enable camera", "Aktifkan kamera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Aktifkan"),
         ("Reuse one connection for port forwarding", "Gunakan ulang satu koneksi untuk penerusan port"),
         ("port-forward-mux-tip", "Menyalurkan semua koneksi dari satu penerusan port melalui satu koneksi ke perangkat lain, alih-alih menyambung dan masuk lagi untuk setiap koneksi."),
+        ("Enable WebRTC P2P connection", "Aktifkan koneksi P2P WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velocità predefinita trackpad"),
         ("Numeric one-time password", "Password numerica monouso"),
         ("Enable IPv6 P2P connection", "Abilita connessione P2P IPv6"),
+        ("Enable WebRTC P2P connection", "Abilita connessione P2P WebRTC"),
         ("Enable UDP hole punching", "Abilita  hole punching UDP"),
         ("View camera", "Visualizza telecamera"),
         ("Enable camera", "Abilita camera"),

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Riutilizza una sola connessione per l'inoltro delle porte"),
         ("port-forward-mux-tip", "Fa passare tutte le connessioni di un inoltro di porte su un'unica connessione verso il dispositivo remoto, invece di connettersi e autenticarsi di nuovo per ognuna."),
         ("Enable WebRTC P2P connection", "Abilita connessione P2P WebRTC"),
+        ("Enable TCP hole punching", "Abilita  hole punching TCP"),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velocità predefinita trackpad"),
         ("Numeric one-time password", "Password numerica monouso"),
         ("Enable IPv6 P2P connection", "Abilita connessione P2P IPv6"),
-        ("Enable WebRTC P2P connection", "Abilita connessione P2P WebRTC"),
         ("Enable UDP hole punching", "Abilita  hole punching UDP"),
         ("View camera", "Visualizza telecamera"),
         ("Enable camera", "Abilita camera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Abilita"),
         ("Reuse one connection for port forwarding", "Riutilizza una sola connessione per l'inoltro delle porte"),
         ("port-forward-mux-tip", "Fa passare tutte le connessioni di un inoltro di porte su un'unica connessione verso il dispositivo remoto, invece di connettersi e autenticarsi di nuovo per ognuna."),
+        ("Enable WebRTC P2P connection", "Abilita connessione P2P WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "既定のトラックパッドの速度"),
         ("Numeric one-time password", "数字のワンタイムパスワード"),
         ("Enable IPv6 P2P connection", "IPv6 P2P 接続を有効化する"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P 接続を有効化する"),
         ("Enable UDP hole punching", "UDP ホールパンチを有効化する"),
         ("View camera", "カメラを表示"),
         ("Enable camera", "カメラを有効化する"),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "既定のトラックパッドの速度"),
         ("Numeric one-time password", "数字のワンタイムパスワード"),
         ("Enable IPv6 P2P connection", "IPv6 P2P 接続を有効化する"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P 接続を有効化する"),
         ("Enable UDP hole punching", "UDP ホールパンチを有効化する"),
         ("View camera", "カメラを表示"),
         ("Enable camera", "カメラを有効化する"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "有効にする"),
         ("Reuse one connection for port forwarding", "ポート転送で 1 つの接続を再利用する"),
         ("port-forward-mux-tip", "1 つのポート転送のすべての接続を、相手への 1 本の接続にまとめます。接続ごとに接続とログインをやり直しません。"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P 接続を有効化する"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "ポート転送で 1 つの接続を再利用する"),
         ("port-forward-mux-tip", "1 つのポート転送のすべての接続を、相手への 1 本の接続にまとめます。接続ごとに接続とログインをやり直しません。"),
         ("Enable WebRTC P2P connection", "WebRTC P2P 接続を有効化する"),
+        ("Enable TCP hole punching", "TCP ホールパンチを有効化する"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "기본 트랙패드 속도"),
         ("Numeric one-time password", "숫자 일회용 비밀번호"),
         ("Enable IPv6 P2P connection", "IPv6 P2P 연결 사용"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P 연결 사용"),
         ("Enable UDP hole punching", "UDP 홀 펀칭 사용"),
         ("View camera", "카메라 보기"),
         ("Enable camera", "카메라 허용"),

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "포트 포워딩에 연결 하나를 재사용"),
         ("port-forward-mux-tip", "포트 포워딩 하나의 모든 연결을 상대방과의 단일 연결로 전달합니다. 연결마다 다시 접속하고 로그인하지 않습니다."),
         ("Enable WebRTC P2P connection", "WebRTC P2P 연결 사용"),
+        ("Enable TCP hole punching", "TCP 홀 펀칭 사용"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "기본 트랙패드 속도"),
         ("Numeric one-time password", "숫자 일회용 비밀번호"),
         ("Enable IPv6 P2P connection", "IPv6 P2P 연결 사용"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P 연결 사용"),
         ("Enable UDP hole punching", "UDP 홀 펀칭 사용"),
         ("View camera", "카메라 보기"),
         ("Enable camera", "카메라 허용"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "활성화"),
         ("Reuse one connection for port forwarding", "포트 포워딩에 연결 하나를 재사용"),
         ("port-forward-mux-tip", "포트 포워딩 하나의 모든 연결을 상대방과의 단일 연결로 전달합니다. 연결마다 다시 접속하고 로그인하지 않습니다."),
+        ("Enable WebRTC P2P connection", "WebRTC P2P 연결 사용"),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Әдепкі трекпад жылдамдығы"),
         ("Numeric one-time password", "Сандық бір-реттік құпия сөз"),
         ("Enable IPv6 P2P connection", "IPv6 P2P қосылымын іске қосу"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P қосылымын іске қосу"),
         ("Enable UDP hole punching", "UDP hole punching'ті іске қосу"),
         ("View camera", "Камераны Көру"),
         ("Enable camera", "Камераны қосу"),

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Әдепкі трекпад жылдамдығы"),
         ("Numeric one-time password", "Сандық бір-реттік құпия сөз"),
         ("Enable IPv6 P2P connection", "IPv6 P2P қосылымын іске қосу"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P қосылымын іске қосу"),
         ("Enable UDP hole punching", "UDP hole punching'ті іске қосу"),
         ("View camera", "Камераны Көру"),
         ("Enable camera", "Камераны қосу"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Қосу"),
         ("Reuse one connection for port forwarding", "Порт бағыттау үшін бір қосылымды қайта пайдалану"),
         ("port-forward-mux-tip", "Бір порт бағыттаудың барлық қосылымдары әрқайсысы үшін қайта қосылып кірудің орнына қарсы құрылғымен орнатылған бір қосылым арқылы өтеді."),
+        ("Enable WebRTC P2P connection", "WebRTC P2P қосылымын іске қосу"),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Порт бағыттау үшін бір қосылымды қайта пайдалану"),
         ("port-forward-mux-tip", "Бір порт бағыттаудың барлық қосылымдары әрқайсысы үшін қайта қосылып кірудің орнына қарсы құрылғымен орнатылған бір қосылым арқылы өтеді."),
         ("Enable WebRTC P2P connection", "WebRTC P2P қосылымын іске қосу"),
+        ("Enable TCP hole punching", "TCP hole punching'ті іске қосу"),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Numatytasis jutiklinės dalies greitis"),
         ("Numeric one-time password", "Skaitmeninis vienkartinis slaptažodis"),
         ("Enable IPv6 P2P connection", "Įgalinti IPv6 P2P ryšį"),
+        ("Enable WebRTC P2P connection", "Įgalinti WebRTC P2P ryšį"),
         ("Enable UDP hole punching", "Įgalinti UDP gręžimą (hole punching)"),
         ("View camera", "Peržiūrėti kamerą"),
         ("Enable camera", "Įgalinti kamerą"),

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Numatytasis jutiklinės dalies greitis"),
         ("Numeric one-time password", "Skaitmeninis vienkartinis slaptažodis"),
         ("Enable IPv6 P2P connection", "Įgalinti IPv6 P2P ryšį"),
-        ("Enable WebRTC P2P connection", "Įgalinti WebRTC P2P ryšį"),
         ("Enable UDP hole punching", "Įgalinti UDP gręžimą (hole punching)"),
         ("View camera", "Peržiūrėti kamerą"),
         ("Enable camera", "Įgalinti kamerą"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Įgalinti"),
         ("Reuse one connection for port forwarding", "Prievadų peradresavimui naudoti vieną ryšį"),
         ("port-forward-mux-tip", "Visi vieno prievadų peradresavimo ryšiai eina per vieną ryšį su kitu kompiuteriu, užuot kiekvienam iš jų jungiantis ir prisijungiant iš naujo."),
+        ("Enable WebRTC P2P connection", "Įgalinti WebRTC P2P ryšį"),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Prievadų peradresavimui naudoti vieną ryšį"),
         ("port-forward-mux-tip", "Visi vieno prievadų peradresavimo ryšiai eina per vieną ryšį su kitu kompiuteriu, užuot kiekvienam iš jų jungiantis ir prisijungiant iš naujo."),
         ("Enable WebRTC P2P connection", "Įgalinti WebRTC P2P ryšį"),
+        ("Enable TCP hole punching", "Įgalinti TCP gręžimą (hole punching)"),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Noklusējuma skārienpaliktņa ātrums"),
         ("Numeric one-time password", "Vienreiz lietojama ciparu parole"),
         ("Enable IPv6 P2P connection", "Iespējot IPv6 P2P savienojumu"),
+        ("Enable WebRTC P2P connection", "Iespējot WebRTC P2P savienojumu"),
         ("Enable UDP hole punching", "Iespējot UDP caurumu veidošanu"),
         ("View camera", "Skatīt kameru"),
         ("Enable camera", "Iespējot kameru"),

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Atkārtoti izmantot vienu savienojumu portu pārsūtīšanai"),
         ("port-forward-mux-tip", "Visi viena portu pārsūtījuma savienojumi tiek novadīti pa vienu savienojumu ar otru datoru, nevis katram no tiem izveidojot jaunu savienojumu un pieteikšanos."),
         ("Enable WebRTC P2P connection", "Iespējot WebRTC P2P savienojumu"),
+        ("Enable TCP hole punching", "Iespējot TCP caurumu veidošanu"),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Noklusējuma skārienpaliktņa ātrums"),
         ("Numeric one-time password", "Vienreiz lietojama ciparu parole"),
         ("Enable IPv6 P2P connection", "Iespējot IPv6 P2P savienojumu"),
-        ("Enable WebRTC P2P connection", "Iespējot WebRTC P2P savienojumu"),
         ("Enable UDP hole punching", "Iespējot UDP caurumu veidošanu"),
         ("View camera", "Skatīt kameru"),
         ("Enable camera", "Iespējot kameru"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Iespējot"),
         ("Reuse one connection for port forwarding", "Atkārtoti izmantot vienu savienojumu portu pārsūtīšanai"),
         ("port-forward-mux-tip", "Visi viena portu pārsūtījuma savienojumi tiek novadīti pa vienu savienojumu ar otru datoru, nevis katram no tiem izveidojot jaunu savienojumu un pieteikšanos."),
+        ("Enable WebRTC P2P connection", "Iespējot WebRTC P2P savienojumu"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "സാധാരണ ട്രാക്ക്പാഡ് വേഗത"),
         ("Numeric one-time password", "അക്കങ്ങൾ മാത്രമുള്ള OTP"),
         ("Enable IPv6 P2P connection", "IPv6 P2P കണക്ഷൻ അനുവദിക്കുക"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P കണക്ഷൻ അനുവദിക്കുക"),
         ("Enable UDP hole punching", "UDP ഹോൾ പഞ്ചിംഗ് അനുവദിക്കുക"),
         ("View camera", "ക്യാമറ കാണുക"),
         ("Enable camera", "ക്യാമറ ഓൺ ചെയ്യുക"),

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "സാധാരണ ട്രാക്ക്പാഡ് വേഗത"),
         ("Numeric one-time password", "അക്കങ്ങൾ മാത്രമുള്ള OTP"),
         ("Enable IPv6 P2P connection", "IPv6 P2P കണക്ഷൻ അനുവദിക്കുക"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P കണക്ഷൻ അനുവദിക്കുക"),
         ("Enable UDP hole punching", "UDP ഹോൾ പഞ്ചിംഗ് അനുവദിക്കുക"),
         ("View camera", "ക്യാമറ കാണുക"),
         ("Enable camera", "ക്യാമറ ഓൺ ചെയ്യുക"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "അനുവദിക്കുക"),
         ("Reuse one connection for port forwarding", "പോർട്ട് ഫോർവേഡിംഗിന് ഒരേ കണക്ഷൻ വീണ്ടും ഉപയോഗിക്കുക"),
         ("port-forward-mux-tip", "ഒരു പോർട്ട് ഫോർവേഡിംഗിന്റെ എല്ലാ കണക്ഷനുകളും മറ്റേ കമ്പ്യൂട്ടറിലേക്കുള്ള ഒരൊറ്റ കണക്ഷനിലൂടെ കടന്നുപോകുന്നു, ഓരോന്നിനും വീണ്ടും കണക്റ്റ് ചെയ്ത് ലോഗിൻ ചെയ്യുന്നതിനു പകരം."),
+        ("Enable WebRTC P2P connection", "WebRTC P2P കണക്ഷൻ അനുവദിക്കുക"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "പോർട്ട് ഫോർവേഡിംഗിന് ഒരേ കണക്ഷൻ വീണ്ടും ഉപയോഗിക്കുക"),
         ("port-forward-mux-tip", "ഒരു പോർട്ട് ഫോർവേഡിംഗിന്റെ എല്ലാ കണക്ഷനുകളും മറ്റേ കമ്പ്യൂട്ടറിലേക്കുള്ള ഒരൊറ്റ കണക്ഷനിലൂടെ കടന്നുപോകുന്നു, ഓരോന്നിനും വീണ്ടും കണക്റ്റ് ചെയ്ത് ലോഗിൻ ചെയ്യുന്നതിനു പകരം."),
         ("Enable WebRTC P2P connection", "WebRTC P2P കണക്ഷൻ അനുവദിക്കുക"),
+        ("Enable TCP hole punching", "TCP ഹോൾ പഞ്ചിംഗ് അനുവദിക്കുക"),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Standard styreplatehastighet"),
         ("Numeric one-time password", "Numerisk engangspassord"),
         ("Enable IPv6 P2P connection", "Aktiver IPv6 P2P-tilkobling"),
+        ("Enable WebRTC P2P connection", "Aktiver WebRTC P2P-tilkobling"),
         ("Enable UDP hole punching", "Aktiver UDP hole punching"),
         ("View camera", "Vis kamera"),
         ("Enable camera", "Aktiver kamera"),

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Standard styreplatehastighet"),
         ("Numeric one-time password", "Numerisk engangspassord"),
         ("Enable IPv6 P2P connection", "Aktiver IPv6 P2P-tilkobling"),
-        ("Enable WebRTC P2P connection", "Aktiver WebRTC P2P-tilkobling"),
         ("Enable UDP hole punching", "Aktiver UDP hole punching"),
         ("View camera", "Vis kamera"),
         ("Enable camera", "Aktiver kamera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Aktiver"),
         ("Reuse one connection for port forwarding", "Gjenbruk én tilkobling for portvideresending"),
         ("port-forward-mux-tip", "Fører alle tilkoblinger i en portvideresending gjennom én enkelt tilkobling til motparten i stedet for å koble til og logge inn på nytt for hver enkelt."),
+        ("Enable WebRTC P2P connection", "Aktiver WebRTC P2P-tilkobling"),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Gjenbruk én tilkobling for portvideresending"),
         ("port-forward-mux-tip", "Fører alle tilkoblinger i en portvideresending gjennom én enkelt tilkobling til motparten i stedet for å koble til og logge inn på nytt for hver enkelt."),
         ("Enable WebRTC P2P connection", "Aktiver WebRTC P2P-tilkobling"),
+        ("Enable TCP hole punching", "Aktiver TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Standaardsnelheid Trackpad"),
         ("Numeric one-time password", "Eenmalig numeriek wachtwoord"),
         ("Enable IPv6 P2P connection", "IPv6 P2P-verbinding inschakelen"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P-verbinding inschakelen"),
         ("Enable UDP hole punching", "UDP-hole punching inschakelen"),
         ("View camera", "Camera weergeven"),
         ("Enable camera", "Camera inschakelen"),

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Eén verbinding hergebruiken voor poortdoorschakeling"),
         ("port-forward-mux-tip", "Alle verbindingen van een poortdoorschakeling via één enkele verbinding met de andere computer laten lopen, in plaats van voor elke verbinding opnieuw verbinding te maken en in te loggen."),
         ("Enable WebRTC P2P connection", "WebRTC P2P-verbinding inschakelen"),
+        ("Enable TCP hole punching", "TCP-hole punching inschakelen"),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Standaardsnelheid Trackpad"),
         ("Numeric one-time password", "Eenmalig numeriek wachtwoord"),
         ("Enable IPv6 P2P connection", "IPv6 P2P-verbinding inschakelen"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P-verbinding inschakelen"),
         ("Enable UDP hole punching", "UDP-hole punching inschakelen"),
         ("View camera", "Camera weergeven"),
         ("Enable camera", "Camera inschakelen"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Inschakelen"),
         ("Reuse one connection for port forwarding", "Eén verbinding hergebruiken voor poortdoorschakeling"),
         ("port-forward-mux-tip", "Alle verbindingen van een poortdoorschakeling via één enkele verbinding met de andere computer laten lopen, in plaats van voor elke verbinding opnieuw verbinding te maken en in te loggen."),
+        ("Enable WebRTC P2P connection", "WebRTC P2P-verbinding inschakelen"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Domyślna szybkość gładzika"),
         ("Numeric one-time password", "Jednorazowe hasło cyfrowe"),
         ("Enable IPv6 P2P connection", "Włącz połączenie P2P IPv6"),
+        ("Enable WebRTC P2P connection", "Włącz połączenie P2P WebRTC"),
         ("Enable UDP hole punching", "Włącz tworzenie tunelu UDP"),
         ("View camera", "Podgląd kamery"),
         ("Enable camera", "Włącz kamerę"),

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Użyj ponownie jednego połączenia do przekierowania portów"),
         ("port-forward-mux-tip", "Przekazuj wszystkie połączenia jednego przekierowania portów przez jedno połączenie ze zdalnym komputerem, zamiast łączyć się i logować od nowa dla każdego z nich."),
         ("Enable WebRTC P2P connection", "Włącz połączenie P2P WebRTC"),
+        ("Enable TCP hole punching", "Włącz tworzenie tunelu TCP"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Domyślna szybkość gładzika"),
         ("Numeric one-time password", "Jednorazowe hasło cyfrowe"),
         ("Enable IPv6 P2P connection", "Włącz połączenie P2P IPv6"),
-        ("Enable WebRTC P2P connection", "Włącz połączenie P2P WebRTC"),
         ("Enable UDP hole punching", "Włącz tworzenie tunelu UDP"),
         ("View camera", "Podgląd kamery"),
         ("Enable camera", "Włącz kamerę"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Włącz"),
         ("Reuse one connection for port forwarding", "Użyj ponownie jednego połączenia do przekierowania portów"),
         ("port-forward-mux-tip", "Przekazuj wszystkie połączenia jednego przekierowania portów przez jedno połączenie ze zdalnym komputerem, zamiast łączyć się i logować od nowa dla każdego z nich."),
+        ("Enable WebRTC P2P connection", "Włącz połączenie P2P WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velocidade predefinida do trackpad"),
         ("Numeric one-time password", "Palavra-passe de uso único numérica"),
         ("Enable IPv6 P2P connection", "Ativar ligação P2P por IPv6"),
+        ("Enable WebRTC P2P connection", "Ativar ligação P2P por WebRTC"),
         ("Enable UDP hole punching", "Ativar UDP hole punching"),
         ("View camera", "Ver câmara"),
         ("Enable camera", "Ativar câmara"),

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velocidade predefinida do trackpad"),
         ("Numeric one-time password", "Palavra-passe de uso único numérica"),
         ("Enable IPv6 P2P connection", "Ativar ligação P2P por IPv6"),
-        ("Enable WebRTC P2P connection", "Ativar ligação P2P por WebRTC"),
         ("Enable UDP hole punching", "Ativar UDP hole punching"),
         ("View camera", "Ver câmara"),
         ("Enable camera", "Ativar câmara"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Ativar"),
         ("Reuse one connection for port forwarding", "Reutilizar uma ligação para o reencaminhamento de portas"),
         ("port-forward-mux-tip", "Encaminhar todas as ligações de um reencaminhamento de portas por uma única ligação ao outro computador, em vez de ligar e iniciar sessão novamente para cada uma."),
+        ("Enable WebRTC P2P connection", "Ativar ligação P2P por WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Reutilizar uma ligação para o reencaminhamento de portas"),
         ("port-forward-mux-tip", "Encaminhar todas as ligações de um reencaminhamento de portas por uma única ligação ao outro computador, em vez de ligar e iniciar sessão novamente para cada uma."),
         ("Enable WebRTC P2P connection", "Ativar ligação P2P por WebRTC"),
+        ("Enable TCP hole punching", "Ativar TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velocidade padrão do trackpad"),
         ("Numeric one-time password", "Senha numérica de uso único"),
         ("Enable IPv6 P2P connection", "Habilitar conexão IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Habilitar conexão WebRTC P2P"),
         ("Enable UDP hole punching", "Habilitar UDP hole punching"),
         ("View camera", "Visualizar câmera"),
         ("Enable camera", "Habilitar câmera"),

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Reutilizar uma conexão para encaminhamento de portas"),
         ("port-forward-mux-tip", "Levar todas as conexões de um encaminhamento de portas por uma única conexão com o outro computador, em vez de conectar e fazer login novamente para cada uma."),
         ("Enable WebRTC P2P connection", "Habilitar conexão WebRTC P2P"),
+        ("Enable TCP hole punching", "Habilitar TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velocidade padrão do trackpad"),
         ("Numeric one-time password", "Senha numérica de uso único"),
         ("Enable IPv6 P2P connection", "Habilitar conexão IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Habilitar conexão WebRTC P2P"),
         ("Enable UDP hole punching", "Habilitar UDP hole punching"),
         ("View camera", "Visualizar câmera"),
         ("Enable camera", "Habilitar câmera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Habilitar"),
         ("Reuse one connection for port forwarding", "Reutilizar uma conexão para encaminhamento de portas"),
         ("port-forward-mux-tip", "Levar todas as conexões de um encaminhamento de portas por uma única conexão com o outro computador, em vez de conectar e fazer login novamente para cada uma."),
+        ("Enable WebRTC P2P connection", "Habilitar conexão WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Viteza implicită a touchpad-ului"),
         ("Numeric one-time password", "Parolă unică numerică"),
         ("Enable IPv6 P2P connection", "Activează conexiunea P2P prin IPv6"),
+        ("Enable WebRTC P2P connection", "Activează conexiunea P2P prin WebRTC"),
         ("Enable UDP hole punching", "Activează traversarea UDP (hole punching)"),
         ("View camera", "Vezi camera"),
         ("Enable camera", "Activează camera"),

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Reutilizează o singură conexiune pentru redirecționarea porturilor"),
         ("port-forward-mux-tip", "Trece toate conexiunile unei redirecționări de porturi printr-o singură conexiune către celălalt calculator, în loc să se conecteze și să se autentifice din nou pentru fiecare."),
         ("Enable WebRTC P2P connection", "Activează conexiunea P2P prin WebRTC"),
+        ("Enable TCP hole punching", "Activează traversarea TCP (hole punching)"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Viteza implicită a touchpad-ului"),
         ("Numeric one-time password", "Parolă unică numerică"),
         ("Enable IPv6 P2P connection", "Activează conexiunea P2P prin IPv6"),
-        ("Enable WebRTC P2P connection", "Activează conexiunea P2P prin WebRTC"),
         ("Enable UDP hole punching", "Activează traversarea UDP (hole punching)"),
         ("View camera", "Vezi camera"),
         ("Enable camera", "Activează camera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Activează"),
         ("Reuse one connection for port forwarding", "Reutilizează o singură conexiune pentru redirecționarea porturilor"),
         ("port-forward-mux-tip", "Trece toate conexiunile unei redirecționări de porturi printr-o singură conexiune către celălalt calculator, în loc să se conecteze și să se autentifice din nou pentru fiecare."),
+        ("Enable WebRTC P2P connection", "Activează conexiunea P2P prin WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Скорость трекпада по умолчанию"),
         ("Numeric one-time password", "Цифровой одноразовый пароль"),
         ("Enable IPv6 P2P connection", "Использовать подключение IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Использовать подключение WebRTC P2P"),
         ("Enable UDP hole punching", "Использовать UDP hole punching"),
         ("View camera", "Просмотр камеры"),
         ("Enable camera", "Включить камеру"),

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Скорость трекпада по умолчанию"),
         ("Numeric one-time password", "Цифровой одноразовый пароль"),
         ("Enable IPv6 P2P connection", "Использовать подключение IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Использовать подключение WebRTC P2P"),
         ("Enable UDP hole punching", "Использовать UDP hole punching"),
         ("View camera", "Просмотр камеры"),
         ("Enable camera", "Включить камеру"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Включить"),
         ("Reuse one connection for port forwarding", "Использовать одно подключение для перенаправления портов"),
         ("port-forward-mux-tip", "Передавать все соединения одного перенаправления портов через одно подключение к удалённому устройству вместо повторного подключения и входа для каждого из них."),
+        ("Enable WebRTC P2P connection", "Использовать подключение WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Использовать одно подключение для перенаправления портов"),
         ("port-forward-mux-tip", "Передавать все соединения одного перенаправления портов через одно подключение к удалённому устройству вместо повторного подключения и входа для каждого из них."),
         ("Enable WebRTC P2P connection", "Использовать подключение WebRTC P2P"),
+        ("Enable TCP hole punching", "Использовать TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velotzidade predefinida de su pannellu tàtile"),
         ("Numeric one-time password", "Crae numèrica monoimpreu"),
         ("Enable IPv6 P2P connection", "Abìlita connessione P2P IPv6"),
+        ("Enable WebRTC P2P connection", "Abìlita connessione P2P WebRTC"),
         ("Enable UDP hole punching", "Abìlita s'istampadura UDP"),
         ("View camera", "Mustra sa càmera"),
         ("Enable camera", "Abìlita sa càmera"),

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Torra a impreare una connessione pro s'imbiu de is portas"),
         ("port-forward-mux-tip", "Totu is connessiones de un'imbiu de portas passant in una connessione ebbia a s'àteru computadore, in logu de si connètere e intrare torra pro dontzi una."),
         ("Enable WebRTC P2P connection", "Abìlita connessione P2P WebRTC"),
+        ("Enable TCP hole punching", "Abìlita s'istampadura TCP"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Velotzidade predefinida de su pannellu tàtile"),
         ("Numeric one-time password", "Crae numèrica monoimpreu"),
         ("Enable IPv6 P2P connection", "Abìlita connessione P2P IPv6"),
-        ("Enable WebRTC P2P connection", "Abìlita connessione P2P WebRTC"),
         ("Enable UDP hole punching", "Abìlita s'istampadura UDP"),
         ("View camera", "Mustra sa càmera"),
         ("Enable camera", "Abìlita sa càmera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Abìlita"),
         ("Reuse one connection for port forwarding", "Torra a impreare una connessione pro s'imbiu de is portas"),
         ("port-forward-mux-tip", "Totu is connessiones de un'imbiu de portas passant in una connessione ebbia a s'àteru computadore, in logu de si connètere e intrare torra pro dontzi una."),
+        ("Enable WebRTC P2P connection", "Abìlita connessione P2P WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Predvolená rýchlosť touchpadu"),
         ("Numeric one-time password", "Číselné jednorazové heslo"),
         ("Enable IPv6 P2P connection", "Povoliť pripojenie IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Povoliť pripojenie WebRTC P2P"),
         ("Enable UDP hole punching", "Povoliť UDP hole punching"),
         ("View camera", "Zobraziť kameru"),
         ("Enable camera", "Povoliť kameru"),

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Predvolená rýchlosť touchpadu"),
         ("Numeric one-time password", "Číselné jednorazové heslo"),
         ("Enable IPv6 P2P connection", "Povoliť pripojenie IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Povoliť pripojenie WebRTC P2P"),
         ("Enable UDP hole punching", "Povoliť UDP hole punching"),
         ("View camera", "Zobraziť kameru"),
         ("Enable camera", "Povoliť kameru"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Povoliť"),
         ("Reuse one connection for port forwarding", "Znovu použiť jedno pripojenie na presmerovanie portov"),
         ("port-forward-mux-tip", "Vedie všetky pripojenia jedného presmerovania portov cez jediné pripojenie k druhej strane namiesto opakovaného pripájania a prihlasovania pre každé z nich."),
+        ("Enable WebRTC P2P connection", "Povoliť pripojenie WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Znovu použiť jedno pripojenie na presmerovanie portov"),
         ("port-forward-mux-tip", "Vedie všetky pripojenia jedného presmerovania portov cez jediné pripojenie k druhej strane namiesto opakovaného pripájania a prihlasovania pre každé z nich."),
         ("Enable WebRTC P2P connection", "Povoliť pripojenie WebRTC P2P"),
+        ("Enable TCP hole punching", "Povoliť TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Privzeta hitrost sledilne ploščice"),
         ("Numeric one-time password", "Numerično enkratno geslo"),
         ("Enable IPv6 P2P connection", "Omogoči povezavo IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Omogoči povezavo WebRTC P2P"),
         ("Enable UDP hole punching", "Omogoči preboj lukenj UDP"),
         ("View camera", "Pogled kamere"),
         ("Enable camera", "Omogoči kamero"),

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Ponovno uporabi eno povezavo za posredovanje vrat"),
         ("port-forward-mux-tip", "Vse povezave enega posredovanja vrat potekajo prek ene same povezave do druge strani, namesto ponovnega povezovanja in prijave za vsako od njih."),
         ("Enable WebRTC P2P connection", "Omogoči povezavo WebRTC P2P"),
+        ("Enable TCP hole punching", "Omogoči preboj lukenj TCP"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Privzeta hitrost sledilne ploščice"),
         ("Numeric one-time password", "Numerično enkratno geslo"),
         ("Enable IPv6 P2P connection", "Omogoči povezavo IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Omogoči povezavo WebRTC P2P"),
         ("Enable UDP hole punching", "Omogoči preboj lukenj UDP"),
         ("View camera", "Pogled kamere"),
         ("Enable camera", "Omogoči kamero"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Omogoči"),
         ("Reuse one connection for port forwarding", "Ponovno uporabi eno povezavo za posredovanje vrat"),
         ("port-forward-mux-tip", "Vse povezave enega posredovanja vrat potekajo prek ene same povezave do druge strani, namesto ponovnega povezovanja in prijave za vsako od njih."),
+        ("Enable WebRTC P2P connection", "Omogoči povezavo WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Shpejtësia e parazgjedhur e trackpad-it"),
         ("Numeric one-time password", "Fjalëkalim numerik një-herë"),
         ("Enable IPv6 P2P connection", "Aktivizo lidhjen IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Aktivizo lidhjen WebRTC P2P"),
         ("Enable UDP hole punching", "Aktivizo UDP hole punching"),
         ("View camera", "Shiko kamerën"),
         ("Enable camera", "Aktivizo kamerën"),

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Ripërdor një lidhje për përcjelljen e porteve"),
         ("port-forward-mux-tip", "Të gjitha lidhjet e një përcjelljeje portesh kalojnë përmes një lidhjeje të vetme me kompjuterin tjetër, në vend që të lidhet dhe të hyjë sërish për secilën prej tyre."),
         ("Enable WebRTC P2P connection", "Aktivizo lidhjen WebRTC P2P"),
+        ("Enable TCP hole punching", "Aktivizo TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Shpejtësia e parazgjedhur e trackpad-it"),
         ("Numeric one-time password", "Fjalëkalim numerik një-herë"),
         ("Enable IPv6 P2P connection", "Aktivizo lidhjen IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Aktivizo lidhjen WebRTC P2P"),
         ("Enable UDP hole punching", "Aktivizo UDP hole punching"),
         ("View camera", "Shiko kamerën"),
         ("Enable camera", "Aktivizo kamerën"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Aktivizo"),
         ("Reuse one connection for port forwarding", "Ripërdor një lidhje për përcjelljen e porteve"),
         ("port-forward-mux-tip", "Të gjitha lidhjet e një përcjelljeje portesh kalojnë përmes një lidhjeje të vetme me kompjuterin tjetër, në vend që të lidhet dhe të hyjë sërish për secilën prej tyre."),
+        ("Enable WebRTC P2P connection", "Aktivizo lidhjen WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Podrazumevana brzina dodirne table"),
         ("Numeric one-time password", "Numerička jednokratna lozinka"),
         ("Enable IPv6 P2P connection", "Omogući IPv6 P2P konekciju"),
+        ("Enable WebRTC P2P connection", "Omogući WebRTC P2P konekciju"),
         ("Enable UDP hole punching", "Omogući UDP hole punching"),
         ("View camera", "Pregled kamere"),
         ("Enable camera", "Omogući kameru"),

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Podrazumevana brzina dodirne table"),
         ("Numeric one-time password", "Numerička jednokratna lozinka"),
         ("Enable IPv6 P2P connection", "Omogući IPv6 P2P konekciju"),
-        ("Enable WebRTC P2P connection", "Omogući WebRTC P2P konekciju"),
         ("Enable UDP hole punching", "Omogući UDP hole punching"),
         ("View camera", "Pregled kamere"),
         ("Enable camera", "Omogući kameru"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Omogući"),
         ("Reuse one connection for port forwarding", "Ponovo koristi jednu vezu za prosleđivanje portova"),
         ("port-forward-mux-tip", "Sve veze jednog prosleđivanja portova idu kroz jednu vezu ka drugoj strani, umesto povezivanja i prijavljivanja iznova za svaku od njih."),
+        ("Enable WebRTC P2P connection", "Omogući WebRTC P2P konekciju"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Ponovo koristi jednu vezu za prosleđivanje portova"),
         ("port-forward-mux-tip", "Sve veze jednog prosleđivanja portova idu kroz jednu vezu ka drugoj strani, umesto povezivanja i prijavljivanja iznova za svaku od njih."),
         ("Enable WebRTC P2P connection", "Omogući WebRTC P2P konekciju"),
+        ("Enable TCP hole punching", "Omogući TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Standardhastighet för styrplattan"),
         ("Numeric one-time password", "Numeriskt engångslösenord"),
         ("Enable IPv6 P2P connection", "Aktivera IPv6 P2P anslutning"),
+        ("Enable WebRTC P2P connection", "Aktivera WebRTC P2P anslutning"),
         ("Enable UDP hole punching", "Aktivera UDP hålslagning"),
         ("View camera", "Visa kamera"),
         ("Enable camera", "Aktivera kamera"),

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Återanvänd en anslutning för portvidarebefordran"),
         ("port-forward-mux-tip", "Låt alla anslutningar i en portvidarebefordran gå via en enda anslutning till motparten, i stället för att ansluta och logga in på nytt för varje anslutning."),
         ("Enable WebRTC P2P connection", "Aktivera WebRTC P2P anslutning"),
+        ("Enable TCP hole punching", "Aktivera TCP hålslagning"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Standardhastighet för styrplattan"),
         ("Numeric one-time password", "Numeriskt engångslösenord"),
         ("Enable IPv6 P2P connection", "Aktivera IPv6 P2P anslutning"),
-        ("Enable WebRTC P2P connection", "Aktivera WebRTC P2P anslutning"),
         ("Enable UDP hole punching", "Aktivera UDP hålslagning"),
         ("View camera", "Visa kamera"),
         ("Enable camera", "Aktivera kamera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Aktivera"),
         ("Reuse one connection for port forwarding", "Återanvänd en anslutning för portvidarebefordran"),
         ("port-forward-mux-tip", "Låt alla anslutningar i en portvidarebefordran gå via en enda anslutning till motparten, i stället för att ansluta och logga in på nytt för varje anslutning."),
+        ("Enable WebRTC P2P connection", "Aktivera WebRTC P2P anslutning"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "இயல்புநிலை டிராக்பேட் வேகம்"),
         ("Numeric one-time password", "எண் ஒருமுறை கடவுச்சொல்"),
         ("Enable IPv6 P2P connection", "IPv6 P2P இணைப்பு இயக்கு"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P இணைப்பு இயக்கு"),
         ("Enable UDP hole punching", "UDP hole punching இயக்கு"),
         ("View camera", "கேமரா பார்"),
         ("Enable camera", "கேமரா இயக்கு"),

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "போர்ட் ஃபார்வேர்டிங்கிற்கு ஒரே இணைப்பை மீண்டும் பயன்படுத்து"),
         ("port-forward-mux-tip", "ஒரு போர்ட் ஃபார்வேர்டிங்கின் அனைத்து இணைப்புகளும் மறுமுனைக்கான ஒரே இணைப்பின் வழியாகச் செல்லும், ஒவ்வொன்றுக்கும் மீண்டும் இணைந்து உள்நுழைவதற்குப் பதிலாக."),
         ("Enable WebRTC P2P connection", "WebRTC P2P இணைப்பு இயக்கு"),
+        ("Enable TCP hole punching", "TCP hole punching இயக்கு"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "இயல்புநிலை டிராக்பேட் வேகம்"),
         ("Numeric one-time password", "எண் ஒருமுறை கடவுச்சொல்"),
         ("Enable IPv6 P2P connection", "IPv6 P2P இணைப்பு இயக்கு"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P இணைப்பு இயக்கு"),
         ("Enable UDP hole punching", "UDP hole punching இயக்கு"),
         ("View camera", "கேமரா பார்"),
         ("Enable camera", "கேமரா இயக்கு"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "இயக்கு"),
         ("Reuse one connection for port forwarding", "போர்ட் ஃபார்வேர்டிங்கிற்கு ஒரே இணைப்பை மீண்டும் பயன்படுத்து"),
         ("port-forward-mux-tip", "ஒரு போர்ட் ஃபார்வேர்டிங்கின் அனைத்து இணைப்புகளும் மறுமுனைக்கான ஒரே இணைப்பின் வழியாகச் செல்லும், ஒவ்வொன்றுக்கும் மீண்டும் இணைந்து உள்நுழைவதற்குப் பதிலாக."),
+        ("Enable WebRTC P2P connection", "WebRTC P2P இணைப்பு இயக்கு"),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", ""),
         ("Numeric one-time password", ""),
         ("Enable IPv6 P2P connection", ""),
+        ("Enable WebRTC P2P connection", ""),
         ("Enable UDP hole punching", ""),
         ("View camera", ""),
         ("Enable camera", ""),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", ""),
         ("port-forward-mux-tip", ""),
         ("Enable WebRTC P2P connection", ""),
+        ("Enable TCP hole punching", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", ""),
         ("Numeric one-time password", ""),
         ("Enable IPv6 P2P connection", ""),
-        ("Enable WebRTC P2P connection", ""),
         ("Enable UDP hole punching", ""),
         ("View camera", ""),
         ("Enable camera", ""),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", ""),
         ("Reuse one connection for port forwarding", ""),
         ("port-forward-mux-tip", ""),
+        ("Enable WebRTC P2P connection", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "ความเร็วแทร็กแพดเริ่มต้น"),
         ("Numeric one-time password", "รหัสผ่านครั้งเดียวแบบตัวเลข"),
         ("Enable IPv6 P2P connection", "เปิดใช้งานการเชื่อมต่อ P2P แบบ IPv6"),
+        ("Enable WebRTC P2P connection", "เปิดใช้งานการเชื่อมต่อ P2P แบบ WebRTC"),
         ("Enable UDP hole punching", "เปิดใช้งาน UDP hole punching"),
         ("View camera", "ดูกล้อง"),
         ("Enable camera", "เปิดใช้งานกล้อง"),

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "ใช้การเชื่อมต่อเดียวร่วมกันสำหรับการส่งต่อพอร์ต"),
         ("port-forward-mux-tip", "ส่งการเชื่อมต่อทั้งหมดของการส่งต่อพอร์ตหนึ่งรายการผ่านการเชื่อมต่อเดียวไปยังอีกฝ่าย แทนการเชื่อมต่อและเข้าสู่ระบบใหม่ทุกครั้ง"),
         ("Enable WebRTC P2P connection", "เปิดใช้งานการเชื่อมต่อ P2P แบบ WebRTC"),
+        ("Enable TCP hole punching", "เปิดใช้งาน TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "ความเร็วแทร็กแพดเริ่มต้น"),
         ("Numeric one-time password", "รหัสผ่านครั้งเดียวแบบตัวเลข"),
         ("Enable IPv6 P2P connection", "เปิดใช้งานการเชื่อมต่อ P2P แบบ IPv6"),
-        ("Enable WebRTC P2P connection", "เปิดใช้งานการเชื่อมต่อ P2P แบบ WebRTC"),
         ("Enable UDP hole punching", "เปิดใช้งาน UDP hole punching"),
         ("View camera", "ดูกล้อง"),
         ("Enable camera", "เปิดใช้งานกล้อง"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "เปิดใช้งาน"),
         ("Reuse one connection for port forwarding", "ใช้การเชื่อมต่อเดียวร่วมกันสำหรับการส่งต่อพอร์ต"),
         ("port-forward-mux-tip", "ส่งการเชื่อมต่อทั้งหมดของการส่งต่อพอร์ตหนึ่งรายการผ่านการเชื่อมต่อเดียวไปยังอีกฝ่าย แทนการเชื่อมต่อและเข้าสู่ระบบใหม่ทุกครั้ง"),
+        ("Enable WebRTC P2P connection", "เปิดใช้งานการเชื่อมต่อ P2P แบบ WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Varsayılan izleme paneli hızı"),
         ("Numeric one-time password", "Sayısal tek seferlik parola"),
         ("Enable IPv6 P2P connection", "IPv6 P2P bağlantısını etkinleştir"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P bağlantısını etkinleştir"),
         ("Enable UDP hole punching", "UDP delik açmayı etkinleştir"),
         ("View camera", "Kamerayı görüntüle"),
         ("Enable camera", "Kamerayı etkinleştir"),

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Port yönlendirme için tek bağlantıyı yeniden kullan"),
         ("port-forward-mux-tip", "Bir port yönlendirmesindeki tüm bağlantıları, her biri için yeniden bağlanıp oturum açmak yerine karşı tarafa açılan tek bir bağlantı üzerinden taşır."),
         ("Enable WebRTC P2P connection", "WebRTC P2P bağlantısını etkinleştir"),
+        ("Enable TCP hole punching", "TCP delik açmayı etkinleştir"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Varsayılan izleme paneli hızı"),
         ("Numeric one-time password", "Sayısal tek seferlik parola"),
         ("Enable IPv6 P2P connection", "IPv6 P2P bağlantısını etkinleştir"),
-        ("Enable WebRTC P2P connection", "WebRTC P2P bağlantısını etkinleştir"),
         ("Enable UDP hole punching", "UDP delik açmayı etkinleştir"),
         ("View camera", "Kamerayı görüntüle"),
         ("Enable camera", "Kamerayı etkinleştir"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Etkinleştir"),
         ("Reuse one connection for port forwarding", "Port yönlendirme için tek bağlantıyı yeniden kullan"),
         ("port-forward-mux-tip", "Bir port yönlendirmesindeki tüm bağlantıları, her biri için yeniden bağlanıp oturum açmak yerine karşı tarafa açılan tek bir bağlantı üzerinden taşır."),
+        ("Enable WebRTC P2P connection", "WebRTC P2P bağlantısını etkinleştir"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "預設觸控板速度"),
         ("Numeric one-time password", "數字一次性密碼"),
         ("Enable IPv6 P2P connection", "啟用 IPv6 P2P 連線"),
+        ("Enable WebRTC P2P connection", "啟用 WebRTC P2P 連線"),
         ("Enable UDP hole punching", "啟用 UDP 打洞"),
         ("View camera", "檢視相機"),
         ("Enable camera", "允許查看鏡頭"),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "連接埠轉送重複使用同一條連線"),
         ("port-forward-mux-tip", "同一條連接埠轉送規則上的所有連線共用一條到對方的連線，而不是每條連線都重新連線並登入一次。"),
         ("Enable WebRTC P2P connection", "啟用 WebRTC P2P 連線"),
+        ("Enable TCP hole punching", "啟用 TCP 打洞"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "預設觸控板速度"),
         ("Numeric one-time password", "數字一次性密碼"),
         ("Enable IPv6 P2P connection", "啟用 IPv6 P2P 連線"),
-        ("Enable WebRTC P2P connection", "啟用 WebRTC P2P 連線"),
         ("Enable UDP hole punching", "啟用 UDP 打洞"),
         ("View camera", "檢視相機"),
         ("Enable camera", "允許查看鏡頭"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "啟用"),
         ("Reuse one connection for port forwarding", "連接埠轉送重複使用同一條連線"),
         ("port-forward-mux-tip", "同一條連接埠轉送規則上的所有連線共用一條到對方的連線，而不是每條連線都重新連線並登入一次。"),
+        ("Enable WebRTC P2P connection", "啟用 WebRTC P2P 連線"),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Швидкість тачпада за замовчуванням"),
         ("Numeric one-time password", "Числовий одноразовий пароль"),
         ("Enable IPv6 P2P connection", "Увімкнути P2P-підключення через IPv6"),
+        ("Enable WebRTC P2P connection", "Увімкнути P2P-підключення через WebRTC"),
         ("Enable UDP hole punching", "Увімкнути UDP hole punching"),
         ("View camera", "Перегляд камери"),
         ("Enable camera", "Увімкнути камеру"),

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Використовувати одне з'єднання для перенаправлення портів"),
         ("port-forward-mux-tip", "Передавати всі з'єднання одного перенаправлення портів через одне з'єднання з віддаленим пристроєм замість повторного під'єднання та входу для кожного з них."),
         ("Enable WebRTC P2P connection", "Увімкнути P2P-підключення через WebRTC"),
+        ("Enable TCP hole punching", "Увімкнути TCP hole punching"),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Швидкість тачпада за замовчуванням"),
         ("Numeric one-time password", "Числовий одноразовий пароль"),
         ("Enable IPv6 P2P connection", "Увімкнути P2P-підключення через IPv6"),
-        ("Enable WebRTC P2P connection", "Увімкнути P2P-підключення через WebRTC"),
         ("Enable UDP hole punching", "Увімкнути UDP hole punching"),
         ("View camera", "Перегляд камери"),
         ("Enable camera", "Увімкнути камеру"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Увімкнути"),
         ("Reuse one connection for port forwarding", "Використовувати одне з'єднання для перенаправлення портів"),
         ("port-forward-mux-tip", "Передавати всі з'єднання одного перенаправлення портів через одне з'єднання з віддаленим пристроєм замість повторного під'єднання та входу для кожного з них."),
+        ("Enable WebRTC P2P connection", "Увімкнути P2P-підключення через WebRTC"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ur.rs
+++ b/src/lang/ur.rs
@@ -768,6 +768,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("sync-clipboard-between-sessions-tip", "ایک ریموٹ سیشن میں کاپی کیا گیا متن یا تصاویر آپ کے دیگر منسلک سیشنز کے کلپ بورڈ پر بھی بھیجی جاتی ہیں۔"),
         ("Reuse one connection for port forwarding", "پورٹ فارورڈنگ کے لیے ایک ہی کنکشن دوبارہ استعمال کریں"),
         ("port-forward-mux-tip", "ایک پورٹ فارورڈنگ کے تمام کنکشن دوسرے کمپیوٹر کے ساتھ بنے ایک ہی کنکشن سے گزرتے ہیں، ہر ایک کے لیے دوبارہ منسلک ہو کر لاگ اِن کرنے کے بجائے۔"),
+        ("Enable WebRTC P2P connection", "WebRTC P2P کنکشن کو فعال کریں"),
+        ("Enable TCP hole punching", "TCP ہول پنچنگ کو فعال کریں"),
     ].iter().cloned().collect();
 }
 

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -676,6 +676,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Tốc độ Trackpad mặc định"),
         ("Numeric one-time password", "Mật khẩu số dùng một lần"),
         ("Enable IPv6 P2P connection", "Cho phép kết nối IPv6 P2P"),
+        ("Enable WebRTC P2P connection", "Cho phép kết nối WebRTC P2P"),
         ("Enable UDP hole punching", "Bật UDP Hole Punching"),
         ("View camera", "Xem Camera"),
         ("Enable camera", "Bật Camera"),

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -676,7 +676,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Default trackpad speed", "Tốc độ Trackpad mặc định"),
         ("Numeric one-time password", "Mật khẩu số dùng một lần"),
         ("Enable IPv6 P2P connection", "Cho phép kết nối IPv6 P2P"),
-        ("Enable WebRTC P2P connection", "Cho phép kết nối WebRTC P2P"),
         ("Enable UDP hole punching", "Bật UDP Hole Punching"),
         ("View camera", "Xem Camera"),
         ("Enable camera", "Bật Camera"),
@@ -769,5 +768,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable", "Bật"),
         ("Reuse one connection for port forwarding", "Dùng chung một kết nối cho chuyển tiếp cổng"),
         ("port-forward-mux-tip", "Chuyển toàn bộ kết nối của một quy tắc chuyển tiếp cổng qua một kết nối duy nhất tới máy đối phương, thay vì kết nối và đăng nhập lại cho từng kết nối."),
+        ("Enable WebRTC P2P connection", "Cho phép kết nối WebRTC P2P"),
     ].iter().cloned().collect();
 }

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -769,5 +769,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Reuse one connection for port forwarding", "Dùng chung một kết nối cho chuyển tiếp cổng"),
         ("port-forward-mux-tip", "Chuyển toàn bộ kết nối của một quy tắc chuyển tiếp cổng qua một kết nối duy nhất tới máy đối phương, thay vì kết nối và đăng nhập lại cho từng kết nối."),
         ("Enable WebRTC P2P connection", "Cho phép kết nối WebRTC P2P"),
+        ("Enable TCP hole punching", "Bật TCP Hole Punching"),
     ].iter().cloned().collect();
 }

--- a/src/platform/android_ifaddrs.c
+++ b/src/platform/android_ifaddrs.c
@@ -1,0 +1,404 @@
+/*
+ * getifaddrs()/freeifaddrs() for Android: bionic only exports them from API 24,
+ * while the jniLibs are built against the API 21 sysroot (flutter/ndk_*.sh) and
+ * webrtc-util calls them whenever WebRTC gathers ICE candidates.
+ *
+ * Only AF_INET and AF_INET6 entries are reported; the AF_PACKET ones the real
+ * getifaddrs() also returns have no reader in this build.
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+
+/* Refuse a single netlink datagram larger than this rather than grow forever. */
+#define RD_NL_MAX_BUF (1024 * 1024)
+/* A dump that never terminates must not hang the caller. */
+#define RD_NL_MAX_DATAGRAMS 4096
+
+typedef int (*rd_nl_cb)(struct nlmsghdr *nlh, void *ctx);
+
+struct rd_link_info {
+    unsigned int index;
+    unsigned int flags;
+    char name[IFNAMSIZ + 1];
+};
+
+struct rd_link_table {
+    struct rd_link_info *items;
+    size_t len;
+    size_t cap;
+};
+
+/* One allocation per reported address; `ifa` first so freeifaddrs() can free
+ * the node it is handed. */
+struct rd_ifaddrs_storage {
+    struct ifaddrs ifa;
+    struct sockaddr_storage addr;
+    struct sockaddr_storage netmask;
+    struct sockaddr_storage ifu;
+    char name[IFNAMSIZ + 1];
+};
+
+struct rd_addr_ctx {
+    const struct rd_link_table *links;
+    struct ifaddrs *head;
+    struct ifaddrs *tail;
+};
+
+static void rd_parse_rtattr(struct rtattr *rta, int len, struct rtattr **tb, int max)
+{
+    memset(tb, 0, sizeof(*tb) * ((size_t)max + 1));
+    for (; RTA_OK(rta, len); rta = RTA_NEXT(rta, len)) {
+        if (rta->rta_type <= (unsigned short)max && tb[rta->rta_type] == NULL)
+            tb[rta->rta_type] = rta;
+    }
+}
+
+/* `len` must stay signed: NLMSG_NEXT subtracts the *aligned* length, which
+ * overshoots on an unaligned trailing message, and only a negative remainder
+ * stops NLMSG_OK from reading past the buffer. */
+static int rd_nl_parse(char *buf, int len, unsigned short reply_type, unsigned int seq,
+                       rd_nl_cb cb, void *ctx, int *done)
+{
+    struct nlmsghdr *nlh = (struct nlmsghdr *)buf;
+
+    for (; NLMSG_OK(nlh, len); nlh = NLMSG_NEXT(nlh, len)) {
+        if (nlh->nlmsg_seq != seq)
+            continue;
+        if (nlh->nlmsg_type == NLMSG_DONE) {
+            *done = 1;
+            return 0;
+        }
+        if (nlh->nlmsg_type == NLMSG_ERROR) {
+            struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(nlh);
+            if (nlh->nlmsg_len >= NLMSG_LENGTH(sizeof(*err)) && err->error != 0)
+                errno = -err->error;
+            else
+                errno = EIO;
+            return -1;
+        }
+        if (nlh->nlmsg_type != reply_type)
+            continue;
+        if (cb(nlh, ctx) != 0)
+            return -1;
+        /* A non-multipart reply is the whole answer; nothing follows it. */
+        if ((nlh->nlmsg_flags & NLM_F_MULTI) == 0) {
+            *done = 1;
+            return 0;
+        }
+    }
+    return 0;
+}
+
+static int rd_nl_dump(int fd, unsigned short request_type, unsigned short reply_type,
+                      unsigned int seq, rd_nl_cb cb, void *ctx)
+{
+    struct {
+        struct nlmsghdr nlh;
+        struct rtgenmsg gen;
+    } req;
+    struct sockaddr_nl kernel;
+    char *buf;
+    size_t cap = 8192;
+    int datagrams = 0;
+    int done = 0;
+    int rc = -1;
+    int saved;
+
+    memset(&req, 0, sizeof(req));
+    req.nlh.nlmsg_len = NLMSG_LENGTH(sizeof(req.gen));
+    req.nlh.nlmsg_type = request_type;
+    req.nlh.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    req.nlh.nlmsg_seq = seq;
+    req.gen.rtgen_family = AF_UNSPEC;
+
+    memset(&kernel, 0, sizeof(kernel));
+    kernel.nl_family = AF_NETLINK;
+
+    for (;;) {
+        if (sendto(fd, &req, req.nlh.nlmsg_len, 0, (struct sockaddr *)&kernel,
+                   sizeof(kernel)) >= 0)
+            break;
+        if (errno != EINTR)
+            return -1;
+    }
+
+    buf = (char *)malloc(cap);
+    if (buf == NULL) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    while (!done) {
+        /* MSG_PEEK|MSG_TRUNC reports the datagram's real size, so an
+         * undersized buffer costs a resize instead of a silent truncation. */
+        ssize_t n = recv(fd, buf, cap, MSG_PEEK | MSG_TRUNC);
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            goto out;
+        }
+        if ((size_t)n > cap) {
+            char *grown;
+            if ((size_t)n > RD_NL_MAX_BUF) {
+                errno = EMSGSIZE;
+                goto out;
+            }
+            grown = (char *)realloc(buf, (size_t)n);
+            if (grown == NULL) {
+                errno = ENOMEM;
+                goto out;
+            }
+            buf = grown;
+            cap = (size_t)n;
+            continue;
+        }
+        n = recv(fd, buf, cap, 0);
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            goto out;
+        }
+        if (n == 0 || ++datagrams > RD_NL_MAX_DATAGRAMS) {
+            errno = EIO;
+            goto out;
+        }
+        if (rd_nl_parse(buf, (int)n, reply_type, seq, cb, ctx, &done) != 0)
+            goto out;
+    }
+    rc = 0;
+
+out:
+    saved = errno;
+    free(buf);
+    errno = saved;
+    return rc;
+}
+
+static int rd_link_cb(struct nlmsghdr *nlh, void *ctx)
+{
+    struct rd_link_table *t = (struct rd_link_table *)ctx;
+    struct ifinfomsg *ifi;
+    struct rtattr *tb[IFLA_IFNAME + 1];
+    struct rd_link_info *slot;
+    int payload;
+    int namelen;
+
+    if (nlh->nlmsg_len < NLMSG_LENGTH(sizeof(*ifi)))
+        return 0;
+    ifi = (struct ifinfomsg *)NLMSG_DATA(nlh);
+    payload = (int)nlh->nlmsg_len - (int)NLMSG_SPACE(sizeof(*ifi));
+    if (payload < 0)
+        payload = 0;
+    rd_parse_rtattr(IFLA_RTA(ifi), payload, tb, IFLA_IFNAME);
+
+    /* An interface we cannot name is of no use: callers dereference ifa_name. */
+    if (tb[IFLA_IFNAME] == NULL || (int)RTA_PAYLOAD(tb[IFLA_IFNAME]) <= 0)
+        return 0;
+
+    if (t->len == t->cap) {
+        size_t ncap = t->cap ? t->cap * 2 : 16;
+        struct rd_link_info *items =
+            (struct rd_link_info *)realloc(t->items, ncap * sizeof(*items));
+        if (items == NULL) {
+            errno = ENOMEM;
+            return -1;
+        }
+        t->items = items;
+        t->cap = ncap;
+    }
+
+    slot = &t->items[t->len];
+    memset(slot, 0, sizeof(*slot));
+    slot->index = (unsigned int)ifi->ifi_index;
+    slot->flags = ifi->ifi_flags;
+    namelen = (int)RTA_PAYLOAD(tb[IFLA_IFNAME]);
+    if (namelen > IFNAMSIZ)
+        namelen = IFNAMSIZ;
+    memcpy(slot->name, RTA_DATA(tb[IFLA_IFNAME]), (size_t)namelen);
+    slot->name[namelen] = '\0';
+    t->len++;
+    return 0;
+}
+
+static const struct rd_link_info *rd_link_find(const struct rd_link_table *t,
+                                               unsigned int index)
+{
+    size_t i;
+    for (i = 0; i < t->len; i++) {
+        if (t->items[i].index == index)
+            return &t->items[i];
+    }
+    return NULL;
+}
+
+static void rd_fill_mask(unsigned char *out, int len, unsigned int prefix)
+{
+    int i;
+    if (prefix > (unsigned int)len * 8)
+        prefix = (unsigned int)len * 8;
+    for (i = 0; i < len; i++) {
+        if (prefix >= 8) {
+            out[i] = 0xff;
+            prefix -= 8;
+        } else if (prefix > 0) {
+            out[i] = (unsigned char)(0xff << (8 - prefix));
+            prefix = 0;
+        } else {
+            out[i] = 0;
+        }
+    }
+}
+
+static void rd_set_in(struct sockaddr_storage *ss, const void *addr)
+{
+    struct sockaddr_in *sin = (struct sockaddr_in *)ss;
+    sin->sin_family = AF_INET;
+    memcpy(&sin->sin_addr, addr, 4);
+}
+
+static int rd_addr_cb(struct nlmsghdr *nlh, void *ctx)
+{
+    struct rd_addr_ctx *c = (struct rd_addr_ctx *)ctx;
+    struct ifaddrmsg *ifa;
+    struct rtattr *tb[IFA_BROADCAST + 1];
+    struct rtattr *ra;
+    const struct rd_link_info *link;
+    struct rd_ifaddrs_storage *st;
+    int payload;
+
+    if (nlh->nlmsg_len < NLMSG_LENGTH(sizeof(*ifa)))
+        return 0;
+    ifa = (struct ifaddrmsg *)NLMSG_DATA(nlh);
+    if (ifa->ifa_family != AF_INET && ifa->ifa_family != AF_INET6)
+        return 0;
+
+    /* Without the link entry there is no name, and callers deref ifa_name. */
+    link = rd_link_find(c->links, ifa->ifa_index);
+    if (link == NULL)
+        return 0;
+
+    payload = (int)nlh->nlmsg_len - (int)NLMSG_SPACE(sizeof(*ifa));
+    if (payload < 0)
+        payload = 0;
+    rd_parse_rtattr(IFA_RTA(ifa), payload, tb, IFA_BROADCAST);
+
+    /* On a point-to-point link IFA_ADDRESS holds the peer and IFA_LOCAL the
+     * local address; ipv6 only ever sets IFA_ADDRESS. */
+    if (ifa->ifa_family == AF_INET)
+        ra = tb[IFA_LOCAL] ? tb[IFA_LOCAL] : tb[IFA_ADDRESS];
+    else
+        ra = tb[IFA_ADDRESS] ? tb[IFA_ADDRESS] : tb[IFA_LOCAL];
+    if (ra == NULL)
+        return 0;
+    if ((int)RTA_PAYLOAD(ra) < (ifa->ifa_family == AF_INET ? 4 : 16))
+        return 0;
+
+    st = (struct rd_ifaddrs_storage *)calloc(1, sizeof(*st));
+    if (st == NULL) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    memcpy(st->name, link->name, sizeof(st->name));
+    st->ifa.ifa_name = st->name;
+    st->ifa.ifa_flags = link->flags;
+    st->ifa.ifa_addr = (struct sockaddr *)&st->addr;
+    st->ifa.ifa_netmask = (struct sockaddr *)&st->netmask;
+
+    if (ifa->ifa_family == AF_INET) {
+        struct sockaddr_in *mask = (struct sockaddr_in *)&st->netmask;
+
+        rd_set_in(&st->addr, RTA_DATA(ra));
+        mask->sin_family = AF_INET;
+        rd_fill_mask((unsigned char *)&mask->sin_addr, 4, ifa->ifa_prefixlen);
+
+        if ((link->flags & IFF_POINTOPOINT) && tb[IFA_ADDRESS] && tb[IFA_LOCAL] &&
+            (int)RTA_PAYLOAD(tb[IFA_ADDRESS]) >= 4 &&
+            memcmp(RTA_DATA(tb[IFA_ADDRESS]), RTA_DATA(tb[IFA_LOCAL]), 4) != 0) {
+            rd_set_in(&st->ifu, RTA_DATA(tb[IFA_ADDRESS]));
+            st->ifa.ifa_dstaddr = (struct sockaddr *)&st->ifu;
+        } else if (tb[IFA_BROADCAST] && (int)RTA_PAYLOAD(tb[IFA_BROADCAST]) >= 4) {
+            rd_set_in(&st->ifu, RTA_DATA(tb[IFA_BROADCAST]));
+            st->ifa.ifa_broadaddr = (struct sockaddr *)&st->ifu;
+        }
+    } else {
+        struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&st->addr;
+        struct sockaddr_in6 *mask = (struct sockaddr_in6 *)&st->netmask;
+
+        sin6->sin6_family = AF_INET6;
+        memcpy(&sin6->sin6_addr, RTA_DATA(ra), 16);
+        /* A link-local address is not routable without its scope id. */
+        if (IN6_IS_ADDR_LINKLOCAL(&sin6->sin6_addr) ||
+            IN6_IS_ADDR_MC_LINKLOCAL(&sin6->sin6_addr))
+            sin6->sin6_scope_id = ifa->ifa_index;
+        mask->sin6_family = AF_INET6;
+        rd_fill_mask((unsigned char *)&mask->sin6_addr, 16, ifa->ifa_prefixlen);
+    }
+
+    if (c->tail != NULL)
+        c->tail->ifa_next = &st->ifa;
+    else
+        c->head = &st->ifa;
+    c->tail = &st->ifa;
+    return 0;
+}
+
+void freeifaddrs(struct ifaddrs *ifa)
+{
+    while (ifa != NULL) {
+        struct ifaddrs *next = ifa->ifa_next;
+        free(ifa);
+        ifa = next;
+    }
+}
+
+int getifaddrs(struct ifaddrs **ifap)
+{
+    struct rd_link_table links;
+    struct rd_addr_ctx ctx;
+    int fd;
+    int saved;
+
+    if (ifap == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    *ifap = NULL;
+
+    memset(&links, 0, sizeof(links));
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.links = &links;
+
+    fd = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, NETLINK_ROUTE);
+    if (fd < 0)
+        return -1;
+
+    if (rd_nl_dump(fd, RTM_GETLINK, RTM_NEWLINK, 1, rd_link_cb, &links) != 0)
+        goto fail;
+    if (rd_nl_dump(fd, RTM_GETADDR, RTM_NEWADDR, 2, rd_addr_cb, &ctx) != 0)
+        goto fail;
+
+    close(fd);
+    free(links.items);
+    *ifap = ctx.head;
+    return 0;
+
+fail:
+    saved = errno;
+    close(fd);
+    free(links.items);
+    freeifaddrs(ctx.head);
+    errno = saved;
+    return -1;
+}

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -128,6 +128,9 @@ async fn connect_and_login(
     if !stream.is_secured() && !crate::common::is_direct_ip_access(id) {
         if !confirm_insecure_connection(&interface, ui_receiver).await {
             *close_port_forward = true;
+            // Close the WebRTC pc on this decline path too (no-op for TCP/WS), matching every
+            // other exit in this function; a bare drop leaks it in the global session cache.
+            stream.close_webrtc().await;
             return Ok(None);
         }
     }
@@ -140,6 +143,7 @@ async fn connect_and_login(
         tokio::select! {
             res = timeout(READ_TIMEOUT, stream.next()) => match res {
                 Err(_) => {
+                    stream.close_webrtc().await;
                     bail!("Timeout");
                 }
                 Ok(Some(Ok(bytes))) => {
@@ -147,7 +151,13 @@ async fn connect_and_login(
                         received = true;
                         interface.update_received(true);
                     }
-                    let msg_in = Message::parse_from_bytes(&bytes)?;
+                    let msg_in = match Message::parse_from_bytes(&bytes) {
+                        Ok(msg) => msg,
+                        Err(err) => {
+                            stream.close_webrtc().await;
+                            return Err(err.into());
+                        }
+                    };
                     match msg_in.union {
                         Some(message::Union::Hash(hash)) => {
                             interface.handle_hash(password, hash, &mut stream).await;
@@ -155,6 +165,7 @@ async fn connect_and_login(
                         Some(message::Union::LoginResponse(lr)) => match lr.union {
                             Some(login_response::Union::Error(err)) => {
                                 if !interface.handle_login_error(&err) {
+                                    stream.close_webrtc().await;
                                     return Ok(None);
                                 }
                             }
@@ -171,9 +182,11 @@ async fn connect_and_login(
                     }
                 }
                 Ok(Some(Err(err))) => {
+                    stream.close_webrtc().await;
                     bail!("Connection closed: {}", err);
                 }
                 _ => {
+                    stream.close_webrtc().await;
                     bail!("Reset by the peer");
                 }
             },
@@ -192,6 +205,7 @@ async fn connect_and_login(
                 if let Some(Ok(bytes)) = res {
                     buffer.extend(bytes);
                 } else {
+                    stream.close_webrtc().await;
                     return Ok(None);
                 }
             },
@@ -226,5 +240,6 @@ async fn run_forward(forward: Framed<TcpStream, BytesCodec>, stream: Stream) -> 
             },
         }
     }
+    stream.close_webrtc().await;
     Ok(())
 }

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -180,6 +180,9 @@ async fn connect_and_login(
     if !stream.is_secured() && !crate::common::is_direct_ip_access(id) {
         if !confirm_insecure_connection(&interface, ui_receiver).await {
             *close_port_forward = true;
+            // Close the WebRTC pc on this decline path too (no-op for TCP/WS), matching every
+            // other exit in this function; a bare drop leaks it in the global session cache.
+            stream.close_webrtc().await;
             return Ok(None);
         }
     }
@@ -194,6 +197,7 @@ async fn connect_and_login(
         tokio::select! {
             res = timeout(READ_TIMEOUT, stream.next()) => match res {
                 Err(_) => {
+                    stream.close_webrtc().await;
                     bail!("Timeout");
                 }
                 Ok(Some(Ok(bytes))) => {
@@ -201,7 +205,13 @@ async fn connect_and_login(
                         received = true;
                         interface.update_received(true);
                     }
-                    let msg_in = Message::parse_from_bytes(&bytes)?;
+                    let msg_in = match Message::parse_from_bytes(&bytes) {
+                        Ok(msg) => msg,
+                        Err(err) => {
+                            stream.close_webrtc().await;
+                            return Err(err.into());
+                        }
+                    };
                     match msg_in.union {
                         Some(message::Union::Hash(hash)) => {
                             challenge = Some(hash.clone());
@@ -212,6 +222,7 @@ async fn connect_and_login(
                         Some(message::Union::LoginResponse(lr)) => match lr.union {
                             Some(login_response::Union::Error(err)) => {
                                 if !interface.handle_login_error(&err) {
+                                    stream.close_webrtc().await;
                                     return Ok(None);
                                 }
                             }
@@ -228,9 +239,11 @@ async fn connect_and_login(
                     }
                 }
                 Ok(Some(Err(err))) => {
+                    stream.close_webrtc().await;
                     bail!("Connection closed: {}", err);
                 }
                 _ => {
+                    stream.close_webrtc().await;
                     bail!("Reset by the peer");
                 }
             },
@@ -250,6 +263,7 @@ async fn connect_and_login(
                 if let Some(Ok(bytes)) = res {
                     buffer.extend(bytes);
                 } else {
+                    stream.close_webrtc().await;
                     return Ok(None);
                 }
             },
@@ -580,6 +594,7 @@ async fn run_forward(forward: Framed<TcpStream, BytesCodec>, stream: Stream) -> 
             },
         }
     }
+    stream.close_webrtc().await;
     Ok(())
 }
 

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -201,12 +201,7 @@ async fn connect_and_login(
                         received = true;
                         interface.update_received(true);
                     }
-                    let msg_in = match Message::parse_from_bytes(&bytes) {
-                        Ok(msg) => msg,
-                        Err(err) => {
-                            return Err(err.into());
-                        }
-                    };
+                    let msg_in = Message::parse_from_bytes(&bytes)?;
                     match msg_in.union {
                         Some(message::Union::Hash(hash)) => {
                             challenge = Some(hash.clone());

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -182,7 +182,7 @@ async fn connect_and_login(
             *close_port_forward = true;
             // Close the WebRTC pc on this decline path too (no-op for TCP/WS), matching every
             // other exit in this function; a bare drop leaks it in the global session cache.
-            stream.close_webrtc().await;
+            stream.close_webrtc();
             return Ok(None);
         }
     }
@@ -197,7 +197,7 @@ async fn connect_and_login(
         tokio::select! {
             res = timeout(READ_TIMEOUT, stream.next()) => match res {
                 Err(_) => {
-                    stream.close_webrtc().await;
+                    stream.close_webrtc();
                     bail!("Timeout");
                 }
                 Ok(Some(Ok(bytes))) => {
@@ -208,7 +208,7 @@ async fn connect_and_login(
                     let msg_in = match Message::parse_from_bytes(&bytes) {
                         Ok(msg) => msg,
                         Err(err) => {
-                            stream.close_webrtc().await;
+                            stream.close_webrtc();
                             return Err(err.into());
                         }
                     };
@@ -222,7 +222,7 @@ async fn connect_and_login(
                         Some(message::Union::LoginResponse(lr)) => match lr.union {
                             Some(login_response::Union::Error(err)) => {
                                 if !interface.handle_login_error(&err) {
-                                    stream.close_webrtc().await;
+                                    stream.close_webrtc();
                                     return Ok(None);
                                 }
                             }
@@ -239,11 +239,11 @@ async fn connect_and_login(
                     }
                 }
                 Ok(Some(Err(err))) => {
-                    stream.close_webrtc().await;
+                    stream.close_webrtc();
                     bail!("Connection closed: {}", err);
                 }
                 _ => {
-                    stream.close_webrtc().await;
+                    stream.close_webrtc();
                     bail!("Reset by the peer");
                 }
             },
@@ -263,7 +263,7 @@ async fn connect_and_login(
                 if let Some(Ok(bytes)) = res {
                     buffer.extend(bytes);
                 } else {
-                    stream.close_webrtc().await;
+                    stream.close_webrtc();
                     return Ok(None);
                 }
             },
@@ -594,7 +594,7 @@ async fn run_forward(forward: Framed<TcpStream, BytesCodec>, stream: Stream) -> 
             },
         }
     }
-    stream.close_webrtc().await;
+    stream.close_webrtc();
     Ok(())
 }
 

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -180,9 +180,6 @@ async fn connect_and_login(
     if !stream.is_secured() && !crate::common::is_direct_ip_access(id) {
         if !confirm_insecure_connection(&interface, ui_receiver).await {
             *close_port_forward = true;
-            // Close the WebRTC pc on this decline path too (no-op for TCP/WS), matching every
-            // other exit in this function; a bare drop leaks it in the global session cache.
-            stream.close_webrtc();
             return Ok(None);
         }
     }
@@ -197,7 +194,6 @@ async fn connect_and_login(
         tokio::select! {
             res = timeout(READ_TIMEOUT, stream.next()) => match res {
                 Err(_) => {
-                    stream.close_webrtc();
                     bail!("Timeout");
                 }
                 Ok(Some(Ok(bytes))) => {
@@ -208,7 +204,6 @@ async fn connect_and_login(
                     let msg_in = match Message::parse_from_bytes(&bytes) {
                         Ok(msg) => msg,
                         Err(err) => {
-                            stream.close_webrtc();
                             return Err(err.into());
                         }
                     };
@@ -222,7 +217,6 @@ async fn connect_and_login(
                         Some(message::Union::LoginResponse(lr)) => match lr.union {
                             Some(login_response::Union::Error(err)) => {
                                 if !interface.handle_login_error(&err) {
-                                    stream.close_webrtc();
                                     return Ok(None);
                                 }
                             }
@@ -239,11 +233,9 @@ async fn connect_and_login(
                     }
                 }
                 Ok(Some(Err(err))) => {
-                    stream.close_webrtc();
                     bail!("Connection closed: {}", err);
                 }
                 _ => {
-                    stream.close_webrtc();
                     bail!("Reset by the peer");
                 }
             },
@@ -263,7 +255,6 @@ async fn connect_and_login(
                 if let Some(Ok(bytes)) = res {
                     buffer.extend(bytes);
                 } else {
-                    stream.close_webrtc();
                     return Ok(None);
                 }
             },
@@ -594,7 +585,6 @@ async fn run_forward(forward: Framed<TcpStream, BytesCodec>, stream: Stream) -> 
             },
         }
     }
-    stream.close_webrtc();
     Ok(())
 }
 

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -40,10 +40,6 @@ use crate::{
 type Message = RendezvousMessage;
 type RendezvousSender = mpsc::UnboundedSender<Message>;
 
-fn webrtc_ice_key(peer_id: &str, session_key: &str) -> String {
-    format!("{}\n{}", peer_id, session_key)
-}
-
 fn connection_meta(
     control_permissions: Option<ControlPermissions>,
     controlled_context: Option<ControlledContext>,
@@ -423,17 +419,12 @@ impl RendezvousMediator {
                 });
             }
             Some(rendezvous_message::Union::IceCandidate(ice)) => {
-                if ice.to_id != Config::get_id() {
-                    return Ok(());
-                }
-                let key = webrtc_ice_key(&ice.from_id, &ice.session_key);
-                let tx = WEBRTC_ICE_TXS.lock().await.get(&key).cloned();
+                let tx = WEBRTC_ICE_TXS.lock().await.get(&ice.session_key).cloned();
                 if let Some(tx) = tx {
                     let _ = tx.send(ice.candidate);
                 } else {
                     log::debug!(
-                        "dropping ICE candidate for unknown WebRTC session from {} key {}",
-                        ice.from_id,
+                        "dropping ICE candidate for unknown WebRTC session key {}",
                         ice.session_key
                     );
                 }
@@ -693,26 +684,22 @@ impl RendezvousMediator {
     async fn spawn_webrtc_answerer(
         &self,
         ph: &PunchHole,
+        force_relay: bool,
         server: ServerPtr,
         peer_addr: SocketAddr,
         meta: ConnectionMeta,
     ) -> ResultType<String> {
-        if ph.requester_id.is_empty() {
-            log::warn!("WebRTC offer missing requester_id; falling back to existing transports");
-            return Ok(String::new());
-        }
-
         let mut stream =
-            WebRTCStream::new(&ph.webrtc_sdp_offer, ph.force_relay, CONNECT_TIMEOUT).await?;
+            WebRTCStream::new(&ph.webrtc_sdp_offer, force_relay, CONNECT_TIMEOUT).await?;
         let answer = stream.get_local_endpoint().await?;
         let session_key = stream.session_key().to_owned();
-        let peer_id = ph.requester_id.clone();
+        let return_route = ph.socket_addr.clone();
 
         let (remote_ice_tx, mut remote_ice_rx) = mpsc::unbounded_channel::<String>();
         WEBRTC_ICE_TXS
             .lock()
             .await
-            .insert(webrtc_ice_key(&peer_id, &session_key), remote_ice_tx);
+            .insert(session_key.clone(), remote_ice_tx);
 
         let stream_for_remote_ice = stream.clone();
         tokio::spawn(async move {
@@ -726,15 +713,13 @@ impl RendezvousMediator {
 
         if let Some(mut local_ice_rx) = stream.take_local_ice_rx() {
             let sender = self.rz_sender.clone();
-            let my_id = Config::get_id();
-            let target_id = peer_id.clone();
+            let socket_addr = return_route.clone();
             let session_key_for_ice = session_key.clone();
             tokio::spawn(async move {
                 while let Some(candidate) = local_ice_rx.recv().await {
                     let mut msg = Message::new();
                     msg.set_ice_candidate(IceCandidate {
-                        from_id: my_id.clone(),
-                        to_id: target_id.clone(),
+                        socket_addr: socket_addr.clone(),
                         session_key: session_key_for_ice.clone(),
                         candidate,
                         ..Default::default()
@@ -744,17 +729,13 @@ impl RendezvousMediator {
             });
         }
 
-        let peer_id_for_cleanup = peer_id.clone();
         let session_key_for_cleanup = session_key.clone();
         tokio::spawn(async move {
             let result = stream.wait_connected(CONNECT_TIMEOUT).await;
             WEBRTC_ICE_TXS
                 .lock()
                 .await
-                .remove(&webrtc_ice_key(
-                    &peer_id_for_cleanup,
-                    &session_key_for_cleanup,
-                ));
+                .remove(&session_key_for_cleanup);
             if let Err(err) = result {
                 log::warn!("webrtc wait_connected failed: {}", err);
                 return;
@@ -791,7 +772,7 @@ impl RendezvousMediator {
             ph.controlled_context.clone().into_option(),
         );
         let webrtc_sdp_answer = if !ph.webrtc_sdp_offer.is_empty() {
-            self.spawn_webrtc_answerer(&ph, server.clone(), peer_addr, meta.clone())
+            self.spawn_webrtc_answerer(&ph, relay, server.clone(), peer_addr, meta.clone())
                 .await
                 .unwrap_or_else(|err| {
                     log::warn!("failed to create WebRTC answer: {}", err);

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     net::SocketAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -21,8 +22,13 @@ use hbb_common::{
     rendezvous_proto::*,
     sleep,
     socket_client::{self, connect_tcp, is_ipv4, new_direct_udp_for, new_udp_for},
-    tokio::{self, select, sync::Mutex, time::interval},
+    tokio::{
+        self, select,
+        sync::{mpsc, Mutex},
+        time::interval,
+    },
     udp::FramedSocket,
+    webrtc::WebRTCStream,
     AddrMangle, IntoTargetAddr, ResultType, Stream, TargetAddr,
 };
 
@@ -32,6 +38,11 @@ use crate::{
 };
 
 type Message = RendezvousMessage;
+type RendezvousSender = mpsc::UnboundedSender<Message>;
+
+fn webrtc_ice_key(peer_id: &str, session_key: &str) -> String {
+    format!("{}\n{}", peer_id, session_key)
+}
 
 fn connection_meta(
     control_permissions: Option<ControlPermissions>,
@@ -47,6 +58,7 @@ lazy_static::lazy_static! {
     static ref SOLVING_PK_MISMATCH: Mutex<String> = Default::default();
     static ref LAST_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
     static ref LAST_RELAY_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
+    static ref WEBRTC_ICE_TXS: Mutex<HashMap<String, mpsc::UnboundedSender<String>>> = Default::default();
 }
 static SHOULD_EXIT: AtomicBool = AtomicBool::new(false);
 static MANUAL_RESTARTED: AtomicBool = AtomicBool::new(false);
@@ -104,6 +116,7 @@ pub struct RendezvousMediator {
     host: String,
     host_prefix: String,
     keep_alive: i32,
+    rz_sender: RendezvousSender,
 }
 
 impl RendezvousMediator {
@@ -215,11 +228,13 @@ impl RendezvousMediator {
         let host = check_port(&host, RENDEZVOUS_PORT);
         log::info!("start udp: {host}");
         let (mut socket, mut addr) = new_udp_for(&host, CONNECT_TIMEOUT).await?;
+        let (rz_sender, mut rz_out_rx) = mpsc::unbounded_channel::<Message>();
         let mut rz = Self {
             addr: addr.clone(),
             host: host.clone(),
             host_prefix: Self::get_host_prefix(&host),
             keep_alive: crate::DEFAULT_KEEP_ALIVE,
+            rz_sender,
         };
 
         let mut timer = crate::rustdesk_interval(interval(crate::TIMER_OUT));
@@ -278,6 +293,9 @@ impl RendezvousMediator {
                             bail!("Socket receive none. Maybe socks5 server is down.");
                         },
                     }
+                },
+                Some(msg_out) = rz_out_rx.recv() => {
+                    Sink::Framed(&mut socket, &addr).send(&msg_out).await?;
                 },
                 _ = timer.tick() => {
                     if SHOULD_EXIT.load(Ordering::SeqCst) {
@@ -404,6 +422,22 @@ impl RendezvousMediator {
                     allow_err!(rz.handle_intranet(fla, server).await);
                 });
             }
+            Some(rendezvous_message::Union::IceCandidate(ice)) => {
+                if ice.to_id != Config::get_id() {
+                    return Ok(());
+                }
+                let key = webrtc_ice_key(&ice.from_id, &ice.session_key);
+                let tx = WEBRTC_ICE_TXS.lock().await.get(&key).cloned();
+                if let Some(tx) = tx {
+                    let _ = tx.send(ice.candidate);
+                } else {
+                    log::debug!(
+                        "dropping ICE candidate for unknown WebRTC session from {} key {}",
+                        ice.from_id,
+                        ice.session_key
+                    );
+                }
+            }
             Some(rendezvous_message::Union::ConfigureUpdate(cu)) => {
                 let v0 = Config::get_rendezvous_servers();
                 Config::set_option(
@@ -426,11 +460,13 @@ impl RendezvousMediator {
         let mut conn = connect_tcp(host.clone(), CONNECT_TIMEOUT).await?;
         let key = crate::get_key(true).await;
         crate::secure_tcp(&mut conn, &key).await?;
+        let (rz_sender, mut rz_out_rx) = mpsc::unbounded_channel::<Message>();
         let mut rz = Self {
             addr: conn.local_addr().into_target_addr()?,
             host: host.clone(),
             host_prefix: Self::get_host_prefix(&host),
             keep_alive: crate::DEFAULT_KEEP_ALIVE,
+            rz_sender,
         };
         let mut timer = crate::rustdesk_interval(interval(crate::TIMER_OUT));
         let mut last_register_sent: Option<Instant> = None;
@@ -457,6 +493,9 @@ impl RendezvousMediator {
                     }
                     let msg = Message::parse_from_bytes(&bytes)?;
                     rz.handle_resp(msg.union, Sink::Stream(&mut conn), &server, &mut update_latency).await?
+                }
+                Some(msg_out) = rz_out_rx.recv() => {
+                    Sink::Stream(&mut conn).send(&msg_out).await?;
                 }
                 _ = timer.tick() => {
                     if SHOULD_EXIT.load(Ordering::SeqCst) {
@@ -513,6 +552,7 @@ impl RendezvousMediator {
             rr.secure,
             false,
             Default::default(),
+            String::new(),
             meta,
         )
         .await
@@ -527,6 +567,7 @@ impl RendezvousMediator {
         secure: bool,
         initiate: bool,
         socket_addr_v6: bytes::Bytes,
+        webrtc_sdp_answer: String,
         meta: ConnectionMeta,
     ) -> ResultType<()> {
         let peer_addr = AddrMangle::decode(&socket_addr);
@@ -545,6 +586,7 @@ impl RendezvousMediator {
             socket_addr: socket_addr.into(),
             version: crate::VERSION.to_owned(),
             socket_addr_v6,
+            webrtc_sdp_answer,
             ..Default::default()
         };
         if initiate {
@@ -611,6 +653,7 @@ impl RendezvousMediator {
             true,
             true,
             socket_addr_v6,
+            String::new(),
             meta,
         )
         .await
@@ -647,6 +690,91 @@ impl RendezvousMediator {
         Ok(())
     }
 
+    async fn spawn_webrtc_answerer(
+        &self,
+        ph: &PunchHole,
+        server: ServerPtr,
+        peer_addr: SocketAddr,
+        meta: ConnectionMeta,
+    ) -> ResultType<String> {
+        if ph.requester_id.is_empty() {
+            log::warn!("WebRTC offer missing requester_id; falling back to existing transports");
+            return Ok(String::new());
+        }
+
+        let mut stream =
+            WebRTCStream::new(&ph.webrtc_sdp_offer, ph.force_relay, CONNECT_TIMEOUT).await?;
+        let answer = stream.get_local_endpoint().await?;
+        let session_key = stream.session_key().to_owned();
+        let peer_id = ph.requester_id.clone();
+
+        let (remote_ice_tx, mut remote_ice_rx) = mpsc::unbounded_channel::<String>();
+        WEBRTC_ICE_TXS
+            .lock()
+            .await
+            .insert(webrtc_ice_key(&peer_id, &session_key), remote_ice_tx);
+
+        let stream_for_remote_ice = stream.clone();
+        tokio::spawn(async move {
+            while let Some(candidate) = remote_ice_rx.recv().await {
+                if let Err(err) = stream_for_remote_ice.add_remote_ice_candidate(&candidate).await
+                {
+                    log::warn!("failed to add remote WebRTC ICE candidate: {}", err);
+                }
+            }
+        });
+
+        if let Some(mut local_ice_rx) = stream.take_local_ice_rx() {
+            let sender = self.rz_sender.clone();
+            let my_id = Config::get_id();
+            let target_id = peer_id.clone();
+            let session_key_for_ice = session_key.clone();
+            tokio::spawn(async move {
+                while let Some(candidate) = local_ice_rx.recv().await {
+                    let mut msg = Message::new();
+                    msg.set_ice_candidate(IceCandidate {
+                        from_id: my_id.clone(),
+                        to_id: target_id.clone(),
+                        session_key: session_key_for_ice.clone(),
+                        candidate,
+                        ..Default::default()
+                    });
+                    let _ = sender.send(msg);
+                }
+            });
+        }
+
+        let peer_id_for_cleanup = peer_id.clone();
+        let session_key_for_cleanup = session_key.clone();
+        tokio::spawn(async move {
+            let result = stream.wait_connected(CONNECT_TIMEOUT).await;
+            WEBRTC_ICE_TXS
+                .lock()
+                .await
+                .remove(&webrtc_ice_key(
+                    &peer_id_for_cleanup,
+                    &session_key_for_cleanup,
+                ));
+            if let Err(err) = result {
+                log::warn!("webrtc wait_connected failed: {}", err);
+                return;
+            }
+            if let Err(err) = crate::server::create_tcp_connection(
+                server,
+                Stream::WebRTC(stream),
+                peer_addr,
+                true,
+                meta,
+            )
+            .await
+            {
+                log::warn!("failed to create WebRTC server connection: {}", err);
+            }
+        });
+
+        Ok(answer)
+    }
+
     async fn handle_punch_hole(&self, ph: PunchHole, server: ServerPtr) -> ResultType<()> {
         let mut peer_addr = AddrMangle::decode(&ph.socket_addr);
         let last = *LAST_MSG.lock().await;
@@ -659,9 +787,19 @@ impl RendezvousMediator {
         let relay = use_ws() || Config::is_proxy() || ph.force_relay;
         let mut socket_addr_v6 = Default::default();
         let meta = connection_meta(
-            ph.control_permissions.into_option(),
-            ph.controlled_context.into_option(),
+            ph.control_permissions.clone().into_option(),
+            ph.controlled_context.clone().into_option(),
         );
+        let webrtc_sdp_answer = if !ph.webrtc_sdp_offer.is_empty() {
+            self.spawn_webrtc_answerer(&ph, server.clone(), peer_addr, meta.clone())
+                .await
+                .unwrap_or_else(|err| {
+                    log::warn!("failed to create WebRTC answer: {}", err);
+                    String::new()
+                })
+        } else {
+            String::new()
+        };
         if peer_addr_v6.port() > 0 && !relay {
             socket_addr_v6 =
                 start_ipv6(peer_addr_v6, peer_addr, server.clone(), meta.clone()).await;
@@ -683,6 +821,7 @@ impl RendezvousMediator {
                     true,
                     true,
                     socket_addr_v6.clone(),
+                    webrtc_sdp_answer.clone(),
                     meta,
                 )
                 .await;
@@ -696,6 +835,7 @@ impl RendezvousMediator {
             nat_type: nat_type.into(),
             version: crate::VERSION.to_owned(),
             socket_addr_v6,
+            webrtc_sdp_answer,
             ..Default::default()
         };
         if ph.udp_port > 0 {

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -702,7 +702,7 @@ impl RendezvousMediator {
     ) -> ResultType<String> {
         let mut stream =
             WebRTCStream::new(&ph.webrtc_sdp_offer, force_relay, CONNECT_TIMEOUT).await?;
-        let answer = match stream.get_local_endpoint().await {
+        let answer = match stream.get_local_endpoint_trickle().await {
             Ok(answer) => answer,
             Err(e) => {
                 // Close the freshly-created pc so a failure here doesn't leak it in SESSIONS.

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -681,6 +681,17 @@ impl RendezvousMediator {
         Ok(())
     }
 
+    /// Build the WebRTC answerer for a punch-hole offer and return the SDP answer that rides in
+    /// the punch reply (PunchHoleSent / RelayResponse).
+    ///
+    /// This is awaited inline on the punch-reply critical path (also serializing the mediator's
+    /// message loop), which is acceptable only because everything awaited here is local-only —
+    /// pc construction + DTLS cert keygen + SDP answer, sub-millisecond in practice. Trickle ICE
+    /// makes that possible: the answer carries no candidates; STUN/TURN gathering runs afterward
+    /// and trickles via IceCandidate messages. Keep network I/O out of this path — actual
+    /// connection setup (wait_connected + create_tcp_connection) belongs in the detached task
+    /// below. On error the caller degrades to an empty answer and the punch proceeds without
+    /// WebRTC.
     async fn spawn_webrtc_answerer(
         &self,
         ph: &PunchHole,
@@ -691,9 +702,26 @@ impl RendezvousMediator {
     ) -> ResultType<String> {
         let mut stream =
             WebRTCStream::new(&ph.webrtc_sdp_offer, force_relay, CONNECT_TIMEOUT).await?;
-        let answer = stream.get_local_endpoint().await?;
+        let answer = match stream.get_local_endpoint().await {
+            Ok(answer) => answer,
+            Err(e) => {
+                // Close the freshly-created pc so a failure here doesn't leak it in SESSIONS.
+                stream.close().await;
+                return Err(e);
+            }
+        };
         let session_key = stream.session_key().to_owned();
         let return_route = ph.socket_addr.clone();
+
+        // A duplicate PunchHole (the offerer re-sends the same request across punch attempts)
+        // resolves to the SESSIONS-cached stream. `take_local_ice_rx` yields the receiver
+        // exactly once per stream instance, so `None` here means an answerer was already
+        // spawned for this offer: return the (identical) cached answer without spawning a
+        // second connect task. Otherwise two `create_tcp_connection` tasks would detach and
+        // read the same data channel, interleaving the handshake and corrupting the session.
+        let Some(mut local_ice_rx) = stream.take_local_ice_rx() else {
+            return Ok(answer);
+        };
 
         let (remote_ice_tx, mut remote_ice_rx) = mpsc::unbounded_channel::<String>();
         WEBRTC_ICE_TXS
@@ -711,7 +739,7 @@ impl RendezvousMediator {
             }
         });
 
-        if let Some(mut local_ice_rx) = stream.take_local_ice_rx() {
+        {
             let sender = self.rz_sender.clone();
             let socket_addr = return_route.clone();
             let session_key_for_ice = session_key.clone();
@@ -724,7 +752,15 @@ impl RendezvousMediator {
                         candidate,
                         ..Default::default()
                     });
-                    let _ = sender.send(msg);
+                    let _ = sender.send(msg.clone());
+                    // The mediator channel to the rendezvous server is UDP in the default setup,
+                    // so a candidate can be lost in flight; re-send once after a short delay (the
+                    // peer's ICE agent dedups repeats, so the second copy is free).
+                    let sender = sender.clone();
+                    tokio::spawn(async move {
+                        sleep(0.4).await;
+                        let _ = sender.send(msg);
+                    });
                 }
             });
         }
@@ -738,8 +774,17 @@ impl RendezvousMediator {
                 .remove(&session_key_for_cleanup);
             if let Err(err) = result {
                 log::warn!("webrtc wait_connected failed: {}", err);
+                // Release the pc now rather than waiting for the ICE agent to time out into a
+                // terminal state (~30s); this also drops the SESSIONS entry promptly.
+                stream.close().await;
                 return;
             }
+            // create_tcp_connection takes ownership of the stream; keep a handle to close the pc
+            // once the session returns. It runs the whole session and returns Ok on normal end,
+            // Err on setup failure — either way the pc must be closed, else it lingers forever in
+            // SESSIONS (its state handler only fires on a terminal ICE state, which a cleanly
+            // closed session may never reach) leaking the pc, channels, and socket fds.
+            let stream_for_cleanup = stream.clone();
             if let Err(err) = crate::server::create_tcp_connection(
                 server,
                 Stream::WebRTC(stream),
@@ -751,6 +796,7 @@ impl RendezvousMediator {
             {
                 log::warn!("failed to create WebRTC server connection: {}", err);
             }
+            stream_for_cleanup.close().await;
         });
 
         Ok(answer)
@@ -765,19 +811,32 @@ impl RendezvousMediator {
             return Ok(());
         }
         let peer_addr_v6 = hbb_common::AddrMangle::decode(&ph.socket_addr_v6);
-        let relay = use_ws() || Config::is_proxy() || ph.force_relay;
+        let local_proxy = use_ws() || Config::is_proxy();
+        let relay = local_proxy || ph.force_relay;
         let mut socket_addr_v6 = Default::default();
         let meta = connection_meta(
             ph.control_permissions.clone().into_option(),
             ph.controlled_context.clone().into_option(),
         );
-        let webrtc_sdp_answer = if !ph.webrtc_sdp_offer.is_empty() {
-            self.spawn_webrtc_answerer(&ph, relay, server.clone(), peer_addr, meta.clone())
-                .await
-                .unwrap_or_else(|err| {
-                    log::warn!("failed to create WebRTC answer: {}", err);
-                    String::new()
-                })
+        let control_permissions = ph.control_permissions.clone().into_option();
+        // WebRTC opens its own ICE sockets, so it must never be used when local traffic is routed
+        // through SOCKS/WebSocket. force_relay is different: relay-only ICE is viable with TURN.
+        let webrtc_viable = !ph.webrtc_sdp_offer.is_empty()
+            && !local_proxy
+            && (!ph.force_relay || WebRTCStream::has_turn_server());
+        let webrtc_sdp_answer = if webrtc_viable {
+            self.spawn_webrtc_answerer(
+                &ph,
+                ph.force_relay,
+                server.clone(),
+                peer_addr,
+                meta.clone(),
+            )
+            .await
+            .unwrap_or_else(|err| {
+                log::warn!("failed to create WebRTC answer: {}", err);
+                String::new()
+            })
         } else {
             String::new()
         };

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -687,15 +687,9 @@ impl RendezvousMediator {
     /// Build the WebRTC answerer for a punch-hole offer and return the SDP answer that rides in
     /// the punch reply (PunchHoleSent / RelayResponse).
     ///
-    /// This is awaited inline on the punch-reply critical path (handle_punch_hole runs as its own
-    /// spawned task, so only this reply is delayed), acceptable only because everything awaited
-    /// here is local-only —
-    /// pc construction + DTLS cert keygen + SDP answer, sub-millisecond in practice. Trickle ICE
-    /// makes that possible: the answer carries no candidates; STUN/TURN gathering runs afterward
-    /// and trickles via IceCandidate messages. Keep network I/O out of this path — actual
-    /// connection setup (wait_connected + create_tcp_connection) belongs in the detached task
-    /// below. On error the caller degrades to an empty answer and the punch proceeds without
-    /// WebRTC.
+    /// Awaited inline on the punch-reply path, which only holds because everything here is local
+    /// (pc + keygen + SDP; trickle means the answer carries no candidates). Keep network I/O out
+    /// — connection setup belongs in the detached task below.
     async fn spawn_webrtc_answerer(
         &self,
         ph: &PunchHole,
@@ -870,24 +864,15 @@ impl RendezvousMediator {
             ph.control_permissions.clone().into_option(),
             ph.controlled_context.clone().into_option(),
         );
-        // WebRTC opens its own ICE sockets, so it must not run under a SOCKS proxy: candidates
-        // and STUN bypass the proxy and leak the real IP. WebSocket mode does NOT disable it —
-        // ws only tunnels the signaling/relay legs to the server, classic punching stays forced
-        // to relay (`relay` above), and the answer rides the RelayResponse, leaving ICE as the
-        // only P2P path there. force_relay depends on why it was set, and the offer's envelope
-        // says which: an `ice_policy: "all"` declaration means the controller's relay is
-        // transport-forced (ws) and its offer carries every candidate type, so answer with
-        // full ICE and let a direct pair form; without it the offer is Relay-only ICE by
-        // policy, viable (and answerable) only through TURN.
+        // The controller's force_relay alone does not say whether ICE must be Relay-only; its
+        // offer envelope does. `ice_policy: "all"` means the relay was forced by the transport
+        // (ws), so answer with full ICE and let a direct pair form.
         let webrtc_relay_only =
             ph.force_relay && !WebRTCStream::endpoint_declares_all_ice(&ph.webrtc_sdp_offer);
-        // Like the udp/ipv6 legs, the answerer follows the request and does not consult this
-        // machine's own enable-webrtc option. That option is LocalConfig, which the UI process
-        // writes and never syncs over IPC — this code runs in the server process, which on
-        // Windows resolves LocalConfig under a different profile entirely and would read the
-        // private-server default of "N", silently refusing to answer in exactly the self-hosted
-        // deployments the transport is for. The option still gates the feature where it can:
-        // an offer only exists because a controller had it enabled.
+        // No enable-webrtc check here: it is LocalConfig, which the UI process writes and never
+        // syncs over IPC, so this (server) process would read the private-server default of "N"
+        // and refuse to answer in exactly the self-hosted deployments the transport is for.
+        // A proxy still rules it out — ICE would bypass it and leak the real IP.
         let webrtc_viable = !ph.webrtc_sdp_offer.is_empty()
             && !Config::is_proxy()
             && (!webrtc_relay_only || WebRTCStream::has_turn_server());
@@ -952,16 +937,10 @@ impl RendezvousMediator {
             return Ok(());
         }
         if !ph.webrtc_sdp_offer.is_empty() {
-            // WebRTC-only request (udp_port <= 0): return the answer over a short-lived TCP
-            // connection to the rendezvous server, like create_relay does. It must NOT ride
-            // the mediator channel: that channel is UDP in the default setup, and the answer
-            // is the largest message of the punch exchange — a single lost or fragmented
-            // datagram costs a whole 3s retry round; hbbs also applies UDP-punch semantics
-            // (source-address observation / is_udp) to PunchHoleSent received over UDP,
-            // which this request never asked for.
-            // No TCP punch connection is created or accepted; the controller retains its
-            // request socket for trickled ICE signaling. IPv6, when present, was started
-            // above and its address is carried in this same response.
+            // Return the answer over its own short-lived TCP connection rather than the mediator
+            // channel: that channel is UDP by default, and hbbs applies UDP-punch semantics
+            // (source-address observation) to a PunchHoleSent that arrives on it. No TCP punch
+            // is made — the controller keeps its request socket for trickled ICE.
             let mut msg_out = Message::new();
             msg_out.set_punch_hole_sent(msg_punch);
             let mut socket = connect_tcp(&*self.host, CONNECT_TIMEOUT).await?;

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -55,6 +55,15 @@ lazy_static::lazy_static! {
     static ref LAST_RELAY_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
     static ref WEBRTC_ICE_TXS: Mutex<HashMap<String, mpsc::UnboundedSender<String>>> = Default::default();
 }
+// The rendezvous ICE route is reachable without a prior punch and the peer decides how many
+// candidates it sends, so these sites would let someone else set how much this machine writes to
+// its log file. One line a minute each, carrying the suppressed count.
+const ICE_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+static UNKNOWN_ICE_SESSION_LOG: hbb_common::log_throttle::LogThrottle =
+    hbb_common::log_throttle::LogThrottle::new(ICE_LOG_INTERVAL);
+static REJECTED_REMOTE_ICE_LOG: hbb_common::log_throttle::LogThrottle =
+    hbb_common::log_throttle::LogThrottle::new(ICE_LOG_INTERVAL);
+
 static SHOULD_EXIT: AtomicBool = AtomicBool::new(false);
 static MANUAL_RESTARTED: AtomicBool = AtomicBool::new(false);
 static SENT_REGISTER_PK: AtomicBool = AtomicBool::new(false);
@@ -410,9 +419,10 @@ impl RendezvousMediator {
                 let tx = WEBRTC_ICE_TXS.lock().await.get(&ice.session_key).cloned();
                 if let Some(tx) = tx {
                     let _ = tx.send(ice.candidate);
-                } else {
+                } else if let Some(n) = UNKNOWN_ICE_SESSION_LOG.due() {
                     log::debug!(
-                        "dropping ICE candidate for unknown WebRTC session key {}",
+                        "dropped {} ICE candidate(s) for unknown WebRTC session key, last: {}",
+                        n,
                         ice.session_key
                     );
                 }
@@ -718,7 +728,13 @@ impl RendezvousMediator {
             while let Some(candidate) = remote_ice_rx.recv().await {
                 if let Err(err) = stream_for_remote_ice.add_remote_ice_candidate(&candidate).await
                 {
-                    log::warn!("failed to add remote WebRTC ICE candidate: {}", err);
+                    if let Some(n) = REJECTED_REMOTE_ICE_LOG.due() {
+                        log::warn!(
+                            "failed to add {} remote WebRTC ICE candidate(s), last: {}",
+                            n,
+                            err
+                        );
+                    }
                 }
             }
         });

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -38,7 +38,6 @@ use crate::{
 };
 
 type Message = RendezvousMessage;
-type RendezvousSender = mpsc::UnboundedSender<Message>;
 
 fn connection_meta(
     control_permissions: Option<ControlPermissions>,
@@ -112,7 +111,6 @@ pub struct RendezvousMediator {
     host: String,
     host_prefix: String,
     keep_alive: i32,
-    rz_sender: RendezvousSender,
 }
 
 impl RendezvousMediator {
@@ -224,13 +222,11 @@ impl RendezvousMediator {
         let host = check_port(&host, RENDEZVOUS_PORT);
         log::info!("start udp: {host}");
         let (mut socket, mut addr) = new_udp_for(&host, CONNECT_TIMEOUT).await?;
-        let (rz_sender, mut rz_out_rx) = mpsc::unbounded_channel::<Message>();
         let mut rz = Self {
             addr: addr.clone(),
             host: host.clone(),
             host_prefix: Self::get_host_prefix(&host),
             keep_alive: crate::DEFAULT_KEEP_ALIVE,
-            rz_sender,
         };
 
         let mut timer = crate::rustdesk_interval(interval(crate::TIMER_OUT));
@@ -289,9 +285,6 @@ impl RendezvousMediator {
                             bail!("Socket receive none. Maybe socks5 server is down.");
                         },
                     }
-                },
-                Some(msg_out) = rz_out_rx.recv() => {
-                    Sink::Framed(&mut socket, &addr).send(&msg_out).await?;
                 },
                 _ = timer.tick() => {
                     if SHOULD_EXIT.load(Ordering::SeqCst) {
@@ -451,13 +444,11 @@ impl RendezvousMediator {
         let mut conn = connect_tcp(host.clone(), CONNECT_TIMEOUT).await?;
         let key = crate::get_key(true).await;
         crate::secure_tcp(&mut conn, &key).await?;
-        let (rz_sender, mut rz_out_rx) = mpsc::unbounded_channel::<Message>();
         let mut rz = Self {
             addr: conn.local_addr().into_target_addr()?,
             host: host.clone(),
             host_prefix: Self::get_host_prefix(&host),
             keep_alive: crate::DEFAULT_KEEP_ALIVE,
-            rz_sender,
         };
         let mut timer = crate::rustdesk_interval(interval(crate::TIMER_OUT));
         let mut last_register_sent: Option<Instant> = None;
@@ -484,9 +475,6 @@ impl RendezvousMediator {
                     }
                     let msg = Message::parse_from_bytes(&bytes)?;
                     rz.handle_resp(msg.union, Sink::Stream(&mut conn), &server, &mut update_latency).await?
-                }
-                Some(msg_out) = rz_out_rx.recv() => {
-                    Sink::Stream(&mut conn).send(&msg_out).await?;
                 }
                 _ = timer.tick() => {
                     if SHOULD_EXIT.load(Ordering::SeqCst) {
@@ -684,8 +672,9 @@ impl RendezvousMediator {
     /// Build the WebRTC answerer for a punch-hole offer and return the SDP answer that rides in
     /// the punch reply (PunchHoleSent / RelayResponse).
     ///
-    /// This is awaited inline on the punch-reply critical path (also serializing the mediator's
-    /// message loop), which is acceptable only because everything awaited here is local-only —
+    /// This is awaited inline on the punch-reply critical path (handle_punch_hole runs as its own
+    /// spawned task, so only this reply is delayed), acceptable only because everything awaited
+    /// here is local-only —
     /// pc construction + DTLS cert keygen + SDP answer, sub-millisecond in practice. Trickle ICE
     /// makes that possible: the answer carries no candidates; STUN/TURN gathering runs afterward
     /// and trickles via IceCandidate messages. Keep network I/O out of this path — actual
@@ -740,10 +729,18 @@ impl RendezvousMediator {
         });
 
         {
-            let sender = self.rz_sender.clone();
+            let host = self.host.clone();
             let socket_addr = return_route.clone();
             let session_key_for_ice = session_key.clone();
             tokio::spawn(async move {
+                // Candidates ride a dedicated TCP connection to the rendezvous server, like
+                // the answer, NOT the mediator channel: that channel is UDP in the default
+                // setup, and target deployments front hbbs with websocket/TCP only, where
+                // its UDP port is unreachable. The server keeps candidate-carrying TCP
+                // connections open, so one lazily-opened connection serves the whole
+                // trickle, and TCP reliability replaces the old 400ms duplicate re-send
+                // (the controller keeps its own re-send for the server->peer UDP downlink).
+                let mut conn = None;
                 while let Some(candidate) = local_ice_rx.recv().await {
                     let mut msg = Message::new();
                     msg.set_ice_candidate(IceCandidate {
@@ -752,15 +749,34 @@ impl RendezvousMediator {
                         candidate,
                         ..Default::default()
                     });
-                    let _ = sender.send(msg.clone());
-                    // The mediator channel to the rendezvous server is UDP in the default setup,
-                    // so a candidate can be lost in flight; re-send once after a short delay (the
-                    // peer's ICE agent dedups repeats, so the second copy is free).
-                    let sender = sender.clone();
-                    tokio::spawn(async move {
-                        sleep(0.4).await;
-                        let _ = sender.send(msg);
-                    });
+                    // One reconnect attempt per candidate: the first send after an hbbs
+                    // restart or an idle-killed connection fails on the stale stream.
+                    for _ in 0..2 {
+                        if conn.is_none() {
+                            match connect_tcp(&*host, CONNECT_TIMEOUT).await {
+                                Ok(s) => conn = Some(s),
+                                Err(err) => {
+                                    log::warn!(
+                                        "failed to connect for WebRTC ICE candidate: {}",
+                                        err
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                        if let Some(s) = conn.as_mut() {
+                            match s.send(&msg).await {
+                                Ok(()) => break,
+                                Err(err) => {
+                                    log::debug!(
+                                        "WebRTC ICE candidate send failed, reconnecting: {}",
+                                        err
+                                    );
+                                    conn = None;
+                                }
+                            }
+                        }
+                    }
                 }
             });
         }
@@ -818,11 +834,13 @@ impl RendezvousMediator {
             ph.control_permissions.clone().into_option(),
             ph.controlled_context.clone().into_option(),
         );
-        let control_permissions = ph.control_permissions.clone().into_option();
-        // WebRTC opens its own ICE sockets, so it must never be used when local traffic is routed
-        // through SOCKS/WebSocket. force_relay is different: relay-only ICE is viable with TURN.
+        // WebRTC opens its own ICE sockets, so it must not run under a SOCKS proxy: candidates
+        // and STUN bypass the proxy and leak the real IP. WebSocket mode does NOT disable it —
+        // ws only tunnels the signaling/relay legs to the server, classic punching stays forced
+        // to relay (`relay` above), and the answer rides the RelayResponse, leaving ICE as the
+        // only P2P path there. force_relay is different: relay-only ICE is viable with TURN.
         let webrtc_viable = !ph.webrtc_sdp_offer.is_empty()
-            && !local_proxy
+            && !Config::is_proxy()
             && (!ph.force_relay || WebRTCStream::has_turn_server());
         let webrtc_sdp_answer = if webrtc_viable {
             self.spawn_webrtc_answerer(
@@ -882,6 +900,23 @@ impl RendezvousMediator {
             peer_addr.set_port(ph.udp_port as u16);
             self.punch_udp_hole(peer_addr, server, msg_punch, meta)
                 .await?;
+            return Ok(());
+        }
+        if !ph.webrtc_sdp_offer.is_empty() {
+            // WebRTC-only request (udp_port <= 0): return the answer over a short-lived TCP
+            // connection to the rendezvous server, like create_relay does. It must NOT ride
+            // the mediator channel: that channel is UDP in the default setup, and the answer
+            // is the largest message of the punch exchange — a single lost or fragmented
+            // datagram costs a whole 3s retry round; hbbs also applies UDP-punch semantics
+            // (source-address observation / is_udp) to PunchHoleSent received over UDP,
+            // which this request never asked for.
+            // No TCP punch connection is created or accepted; the controller retains its
+            // request socket for trickled ICE signaling. IPv6, when present, was started
+            // above and its address is carried in this same response.
+            let mut msg_out = Message::new();
+            msg_out.set_punch_hole_sent(msg_punch);
+            let mut socket = connect_tcp(&*self.host, CONNECT_TIMEOUT).await?;
+            socket.send(&msg_out).await?;
             return Ok(());
         }
         log::debug!("Punch tcp hole to {:?}", peer_addr);

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -849,11 +849,13 @@ impl RendezvousMediator {
         // and STUN bypass the proxy and leak the real IP. WebSocket mode does NOT disable it —
         // ws only tunnels the signaling/relay legs to the server, classic punching stays forced
         // to relay (`relay` above), and the answer rides the RelayResponse, leaving ICE as the
-        // only P2P path there. force_relay depends on why it was set: with webrtc_all_ice the
-        // controller's relay is transport-forced (ws) and its offer carries every candidate
-        // type, so answer with full ICE and let a direct pair form; without it the offer is
-        // Relay-only ICE by policy, viable (and answerable) only through TURN.
-        let webrtc_relay_only = ph.force_relay && !ph.webrtc_all_ice;
+        // only P2P path there. force_relay depends on why it was set, and the offer's envelope
+        // says which: an `ice_policy: "all"` declaration means the controller's relay is
+        // transport-forced (ws) and its offer carries every candidate type, so answer with
+        // full ICE and let a direct pair form; without it the offer is Relay-only ICE by
+        // policy, viable (and answerable) only through TURN.
+        let webrtc_relay_only = ph.force_relay
+            && !WebRTCStream::endpoint_declares_all_ice(&ph.webrtc_sdp_offer);
         let webrtc_viable = !ph.webrtc_sdp_offer.is_empty()
             && !Config::is_proxy()
             && (!webrtc_relay_only || WebRTCStream::has_turn_server());

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -1,5 +1,6 @@
 use std::{
-    collections::HashMap,
+    collections::{hash_map::RandomState, HashMap, VecDeque},
+    hash::BuildHasher,
     net::SocketAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -53,12 +54,16 @@ lazy_static::lazy_static! {
     static ref SOLVING_PK_MISMATCH: Mutex<String> = Default::default();
     static ref LAST_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
     static ref LAST_RELAY_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
-    static ref WEBRTC_ICE_TXS: Mutex<HashMap<String, mpsc::Sender<String>>> = Default::default();
+    static ref WEBRTC_ICE_TXS: Mutex<HashMap<String, IceRoute>> = Default::default();
+    static ref ICE_DIGEST_STATE: RandomState = Default::default();
 }
-/// Remote ICE candidates buffered per session while the answerer applies them. Mirrors the
-/// controller's own cap: gathering yields host, then srflx, then relay, so a real peer sends
-/// well under this, and anything past it is someone deciding how much memory this process holds.
+/// Remote ICE candidates buffered per session while the answerer applies them. Same depth as the
+/// controller's own buffer (`Client::MAX_PENDING_WEBRTC_ICE`), though that one evicts its oldest
+/// where a full channel here refuses the newest.
 const MAX_PENDING_REMOTE_ICE: usize = 64;
+/// Queued candidates remembered so the controller's re-send is skipped instead of taking a slot
+/// of its own. Far more than an honest peer gathers, at eight bytes each.
+const ICE_DEDUP_WINDOW: usize = 256;
 // The rendezvous ICE route is reachable without a prior punch and the peer decides how many
 // candidates it sends, so these sites would let someone else set how much this machine writes to
 // its log file. One line a minute each, carrying the suppressed count.
@@ -69,6 +74,45 @@ static REJECTED_REMOTE_ICE_LOG: hbb_common::log_throttle::LogThrottle =
     hbb_common::log_throttle::LogThrottle::new(ICE_LOG_INTERVAL);
 static FULL_ICE_QUEUE_LOG: hbb_common::log_throttle::LogThrottle =
     hbb_common::log_throttle::LogThrottle::new(ICE_LOG_INTERVAL);
+
+struct IceRoute {
+    tx: mpsc::Sender<String>,
+    recent: VecDeque<u64>,
+}
+
+impl IceRoute {
+    fn new(tx: mpsc::Sender<String>) -> Self {
+        Self {
+            tx,
+            recent: VecDeque::new(),
+        }
+    }
+
+    /// Keeps `queue` the only way onto the channel, so nothing reaches it unrecorded.
+    fn is_same_channel(&self, other: &mpsc::Sender<String>) -> bool {
+        self.tx.same_channel(other)
+    }
+
+    /// Skip the controller's re-send of a candidate already queued: the ICE agent that dedups
+    /// repeats is downstream of this queue, so the copy would spend a slot of its own.
+    /// False means the candidate was dropped.
+    fn queue(&mut self, candidate: String) -> bool {
+        let digest = ICE_DIGEST_STATE.hash_one(candidate.as_str());
+        if self.recent.contains(&digest) {
+            // Only honest about the drop if the route is still alive to have taken it.
+            return !self.tx.is_closed();
+        }
+        // Recorded once queued, never before: a refused candidate stays repairable by the re-send.
+        if self.tx.try_send(candidate).is_err() {
+            return false;
+        }
+        if self.recent.len() >= ICE_DEDUP_WINDOW {
+            self.recent.pop_front();
+        }
+        self.recent.push_back(digest);
+        true
+    }
+}
 
 static SHOULD_EXIT: AtomicBool = AtomicBool::new(false);
 static MANUAL_RESTARTED: AtomicBool = AtomicBool::new(false);
@@ -422,19 +466,27 @@ impl RendezvousMediator {
                 });
             }
             Some(rendezvous_message::Union::IceCandidate(ice)) => {
-                let tx = WEBRTC_ICE_TXS.lock().await.get(&ice.session_key).cloned();
-                if let Some(tx) = tx {
-                    if tx.try_send(ice.candidate).is_err() {
+                let queued = {
+                    let mut txs = WEBRTC_ICE_TXS.lock().await;
+                    txs.get_mut(&ice.session_key)
+                        .map(|route| route.queue(ice.candidate))
+                };
+                match queued {
+                    Some(false) => {
                         if let Some(n) = FULL_ICE_QUEUE_LOG.due() {
                             log::debug!("dropped {} ICE candidate(s): queue full or closed", n);
                         }
                     }
-                } else if let Some(n) = UNKNOWN_ICE_SESSION_LOG.due() {
-                    log::debug!(
-                        "dropped {} ICE candidate(s) for unknown WebRTC session key, last: {}",
-                        n,
-                        ice.session_key
-                    );
+                    None => {
+                        if let Some(n) = UNKNOWN_ICE_SESSION_LOG.due() {
+                            log::debug!(
+                                "dropped {} ICE candidate(s) for unknown WebRTC session key, last: {}",
+                                n,
+                                ice.session_key
+                            );
+                        }
+                    }
+                    _ => {}
                 }
             }
             Some(rendezvous_message::Union::ConfigureUpdate(cu)) => {
@@ -714,17 +766,17 @@ impl RendezvousMediator {
             return Ok(answer);
         };
 
-        // Bounded, like the controller's own candidate buffer: how many candidates arrive is the
-        // sender's choice, while draining one costs a JSON parse and the ICE agent's lock, so an
-        // unbounded queue lets whoever can reach this session's route grow it without limit inside
-        // a long-lived service process. A full queue drops the newest candidate, which costs at
-        // most one path; ICE keeps whatever pairs it already has.
+        // Bounded: how many candidates arrive is the sender's choice, while draining one costs a
+        // JSON parse and the ICE agent's lock, so an unbounded queue lets whoever can reach this
+        // session's route grow it without limit inside a long-lived service process. A full queue
+        // drops the newest candidate, and the controller re-sends it once — the digests beside the
+        // sender are what keep that re-send from spending a slot of its own.
         let (remote_ice_tx, mut remote_ice_rx) = mpsc::channel::<String>(MAX_PENDING_REMOTE_ICE);
         let own_ice_tx = remote_ice_tx.clone();
         WEBRTC_ICE_TXS
             .lock()
             .await
-            .insert(session_key.clone(), remote_ice_tx);
+            .insert(session_key.clone(), IceRoute::new(remote_ice_tx));
 
         let stream_for_remote_ice = stream.clone();
         tokio::spawn(async move {
@@ -806,7 +858,7 @@ impl RendezvousMediator {
                 let mut txs = WEBRTC_ICE_TXS.lock().await;
                 if txs
                     .get(&session_key_for_cleanup)
-                    .is_some_and(|tx| tx.same_channel(&own_ice_tx))
+                    .is_some_and(|route| route.is_same_channel(&own_ice_tx))
                 {
                     txs.remove(&session_key_for_cleanup);
                 }
@@ -1234,5 +1286,75 @@ impl Drop for CheckIfResendPk {
             Config::set_key_confirmed(false);
             log::info!("Set key_confirmed to false due to pk changed, will resend register_pk");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mpsc, IceRoute, ICE_DEDUP_WINDOW, MAX_PENDING_REMOTE_ICE};
+
+    fn queue(route: &mut IceRoute, candidate: &str) -> bool {
+        route.queue(candidate.to_owned())
+    }
+
+    #[test]
+    fn the_re_sent_copy_does_not_spend_a_queue_slot() {
+        // Two slots, three sends: without the dedup the re-send takes the second and "relay",
+        // the one that traverses NAT, is the one refused.
+        let (tx, mut rx) = mpsc::channel::<String>(2);
+        let mut route = IceRoute::new(tx);
+        for _ in 0..2 {
+            assert!(queue(&mut route, "host"));
+        }
+        assert!(queue(&mut route, "relay"));
+        let mut queued = Vec::new();
+        while let Ok(candidate) = rx.try_recv() {
+            queued.push(candidate);
+        }
+        assert_eq!(queued, vec!["host".to_owned(), "relay".to_owned()]);
+    }
+
+    #[test]
+    fn a_candidate_the_full_queue_refused_is_not_remembered() {
+        let (tx, mut rx) = mpsc::channel::<String>(1);
+        let mut route = IceRoute::new(tx);
+        assert!(queue(&mut route, "host"));
+        assert!(!queue(&mut route, "relay"));
+        // The re-send is the only repair for a refused candidate; remembering it would swallow it.
+        assert_eq!(rx.try_recv().ok(), Some("host".to_owned()));
+        assert!(queue(&mut route, "relay"));
+        assert_eq!(rx.try_recv().ok(), Some("relay".to_owned()));
+    }
+
+    #[test]
+    fn a_re_send_is_skipped_while_the_original_is_still_queued() {
+        let (tx, mut rx) = mpsc::channel::<String>(MAX_PENDING_REMOTE_ICE);
+        let mut route = IceRoute::new(tx);
+        for i in 0..MAX_PENDING_REMOTE_ICE {
+            assert!(queue(&mut route, &format!("candidate-{}", i)));
+        }
+        assert!(queue(&mut route, "candidate-0"));
+        let mut queued = 0;
+        while rx.try_recv().is_ok() {
+            queued += 1;
+        }
+        assert_eq!(queued, MAX_PENDING_REMOTE_ICE);
+    }
+
+    #[test]
+    fn the_window_forgets_in_arrival_order() {
+        let (tx, mut rx) = mpsc::channel::<String>(MAX_PENDING_REMOTE_ICE);
+        let mut route = IceRoute::new(tx);
+        for i in 0..=ICE_DEDUP_WINDOW {
+            assert!(queue(&mut route, &format!("candidate-{}", i)));
+            assert!(rx.try_recv().is_ok());
+        }
+        // The oldest digest made room for the newest, so its re-send is admitted again.
+        assert!(queue(&mut route, "candidate-0"));
+        assert!(rx.try_recv().is_ok());
+        // A recent one is still skipped.
+        let recent = format!("candidate-{}", ICE_DEDUP_WINDOW);
+        assert!(queue(&mut route, &recent));
+        assert!(rx.try_recv().is_err());
     }
 }

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -1192,11 +1192,11 @@ async fn udp_nat_listen(
     let socket_cloned = socket.clone();
     let func = async {
         socket.connect(peer_addr).await?;
-        let res = crate::punch_udp(socket.clone(), true).await?;
+        let init_packet = crate::punch_udp(socket.clone(), true).await?;
         let stream = crate::kcp_stream::KcpStream::accept(
             socket,
             Duration::from_millis(CONNECT_TIMEOUT as _),
-            res,
+            init_packet,
         )
         .await?;
         crate::server::create_tcp_connection(server, stream.1, peer_addr_v4, true, meta).await?;

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -40,10 +40,6 @@ use crate::{
 type Message = RendezvousMessage;
 type RendezvousSender = mpsc::UnboundedSender<Message>;
 
-fn webrtc_ice_key(peer_id: &str, session_key: &str) -> String {
-    format!("{}\n{}", peer_id, session_key)
-}
-
 fn connection_meta(
     control_permissions: Option<ControlPermissions>,
     controlled_context: Option<ControlledContext>,
@@ -418,17 +414,12 @@ impl RendezvousMediator {
                 });
             }
             Some(rendezvous_message::Union::IceCandidate(ice)) => {
-                if ice.to_id != Config::get_id() {
-                    return Ok(());
-                }
-                let key = webrtc_ice_key(&ice.from_id, &ice.session_key);
-                let tx = WEBRTC_ICE_TXS.lock().await.get(&key).cloned();
+                let tx = WEBRTC_ICE_TXS.lock().await.get(&ice.session_key).cloned();
                 if let Some(tx) = tx {
                     let _ = tx.send(ice.candidate);
                 } else {
                     log::debug!(
-                        "dropping ICE candidate for unknown WebRTC session from {} key {}",
-                        ice.from_id,
+                        "dropping ICE candidate for unknown WebRTC session key {}",
                         ice.session_key
                     );
                 }
@@ -688,26 +679,22 @@ impl RendezvousMediator {
     async fn spawn_webrtc_answerer(
         &self,
         ph: &PunchHole,
+        force_relay: bool,
         server: ServerPtr,
         peer_addr: SocketAddr,
         meta: ConnectionMeta,
     ) -> ResultType<String> {
-        if ph.requester_id.is_empty() {
-            log::warn!("WebRTC offer missing requester_id; falling back to existing transports");
-            return Ok(String::new());
-        }
-
         let mut stream =
-            WebRTCStream::new(&ph.webrtc_sdp_offer, ph.force_relay, CONNECT_TIMEOUT).await?;
+            WebRTCStream::new(&ph.webrtc_sdp_offer, force_relay, CONNECT_TIMEOUT).await?;
         let answer = stream.get_local_endpoint().await?;
         let session_key = stream.session_key().to_owned();
-        let peer_id = ph.requester_id.clone();
+        let return_route = ph.socket_addr.clone();
 
         let (remote_ice_tx, mut remote_ice_rx) = mpsc::unbounded_channel::<String>();
         WEBRTC_ICE_TXS
             .lock()
             .await
-            .insert(webrtc_ice_key(&peer_id, &session_key), remote_ice_tx);
+            .insert(session_key.clone(), remote_ice_tx);
 
         let stream_for_remote_ice = stream.clone();
         tokio::spawn(async move {
@@ -721,15 +708,13 @@ impl RendezvousMediator {
 
         if let Some(mut local_ice_rx) = stream.take_local_ice_rx() {
             let sender = self.rz_sender.clone();
-            let my_id = Config::get_id();
-            let target_id = peer_id.clone();
+            let socket_addr = return_route.clone();
             let session_key_for_ice = session_key.clone();
             tokio::spawn(async move {
                 while let Some(candidate) = local_ice_rx.recv().await {
                     let mut msg = Message::new();
                     msg.set_ice_candidate(IceCandidate {
-                        from_id: my_id.clone(),
-                        to_id: target_id.clone(),
+                        socket_addr: socket_addr.clone(),
                         session_key: session_key_for_ice.clone(),
                         candidate,
                         ..Default::default()
@@ -739,17 +724,13 @@ impl RendezvousMediator {
             });
         }
 
-        let peer_id_for_cleanup = peer_id.clone();
         let session_key_for_cleanup = session_key.clone();
         tokio::spawn(async move {
             let result = stream.wait_connected(CONNECT_TIMEOUT).await;
             WEBRTC_ICE_TXS
                 .lock()
                 .await
-                .remove(&webrtc_ice_key(
-                    &peer_id_for_cleanup,
-                    &session_key_for_cleanup,
-                ));
+                .remove(&session_key_for_cleanup);
             if let Err(err) = result {
                 log::warn!("webrtc wait_connected failed: {}", err);
                 return;
@@ -786,7 +767,7 @@ impl RendezvousMediator {
             ph.controlled_context.clone().into_option(),
         );
         let webrtc_sdp_answer = if !ph.webrtc_sdp_offer.is_empty() {
-            self.spawn_webrtc_answerer(&ph, server.clone(), peer_addr, meta.clone())
+            self.spawn_webrtc_answerer(&ph, relay, server.clone(), peer_addr, meta.clone())
                 .await
                 .unwrap_or_else(|err| {
                     log::warn!("failed to create WebRTC answer: {}", err);

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -700,14 +700,7 @@ impl RendezvousMediator {
     ) -> ResultType<String> {
         let mut stream =
             WebRTCStream::new(&ph.webrtc_sdp_offer, relay_only_ice, CONNECT_TIMEOUT).await?;
-        let answer = match stream.get_local_endpoint_trickle().await {
-            Ok(answer) => answer,
-            Err(e) => {
-                // Close the freshly-created pc so a failure here doesn't leak it in SESSIONS.
-                stream.close().await;
-                return Err(e);
-            }
-        };
+        let answer = stream.local_endpoint().to_owned();
         let session_key = stream.session_key().to_owned();
         let return_route = ph.socket_addr.clone();
 

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -697,7 +697,7 @@ impl RendezvousMediator {
     ) -> ResultType<String> {
         let mut stream =
             WebRTCStream::new(&ph.webrtc_sdp_offer, force_relay, CONNECT_TIMEOUT).await?;
-        let answer = match stream.get_local_endpoint().await {
+        let answer = match stream.get_local_endpoint_trickle().await {
             Ok(answer) => answer,
             Err(e) => {
                 // Close the freshly-created pc so a failure here doesn't leak it in SESSIONS.

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -676,6 +676,17 @@ impl RendezvousMediator {
         Ok(())
     }
 
+    /// Build the WebRTC answerer for a punch-hole offer and return the SDP answer that rides in
+    /// the punch reply (PunchHoleSent / RelayResponse).
+    ///
+    /// This is awaited inline on the punch-reply critical path (also serializing the mediator's
+    /// message loop), which is acceptable only because everything awaited here is local-only —
+    /// pc construction + DTLS cert keygen + SDP answer, sub-millisecond in practice. Trickle ICE
+    /// makes that possible: the answer carries no candidates; STUN/TURN gathering runs afterward
+    /// and trickles via IceCandidate messages. Keep network I/O out of this path — actual
+    /// connection setup (wait_connected + create_tcp_connection) belongs in the detached task
+    /// below. On error the caller degrades to an empty answer and the punch proceeds without
+    /// WebRTC.
     async fn spawn_webrtc_answerer(
         &self,
         ph: &PunchHole,
@@ -686,9 +697,26 @@ impl RendezvousMediator {
     ) -> ResultType<String> {
         let mut stream =
             WebRTCStream::new(&ph.webrtc_sdp_offer, force_relay, CONNECT_TIMEOUT).await?;
-        let answer = stream.get_local_endpoint().await?;
+        let answer = match stream.get_local_endpoint().await {
+            Ok(answer) => answer,
+            Err(e) => {
+                // Close the freshly-created pc so a failure here doesn't leak it in SESSIONS.
+                stream.close().await;
+                return Err(e);
+            }
+        };
         let session_key = stream.session_key().to_owned();
         let return_route = ph.socket_addr.clone();
+
+        // A duplicate PunchHole (the offerer re-sends the same request across punch attempts)
+        // resolves to the SESSIONS-cached stream. `take_local_ice_rx` yields the receiver
+        // exactly once per stream instance, so `None` here means an answerer was already
+        // spawned for this offer: return the (identical) cached answer without spawning a
+        // second connect task. Otherwise two `create_tcp_connection` tasks would detach and
+        // read the same data channel, interleaving the handshake and corrupting the session.
+        let Some(mut local_ice_rx) = stream.take_local_ice_rx() else {
+            return Ok(answer);
+        };
 
         let (remote_ice_tx, mut remote_ice_rx) = mpsc::unbounded_channel::<String>();
         WEBRTC_ICE_TXS
@@ -706,7 +734,7 @@ impl RendezvousMediator {
             }
         });
 
-        if let Some(mut local_ice_rx) = stream.take_local_ice_rx() {
+        {
             let sender = self.rz_sender.clone();
             let socket_addr = return_route.clone();
             let session_key_for_ice = session_key.clone();
@@ -719,7 +747,15 @@ impl RendezvousMediator {
                         candidate,
                         ..Default::default()
                     });
-                    let _ = sender.send(msg);
+                    let _ = sender.send(msg.clone());
+                    // The mediator channel to the rendezvous server is UDP in the default setup,
+                    // so a candidate can be lost in flight; re-send once after a short delay (the
+                    // peer's ICE agent dedups repeats, so the second copy is free).
+                    let sender = sender.clone();
+                    tokio::spawn(async move {
+                        sleep(0.4).await;
+                        let _ = sender.send(msg);
+                    });
                 }
             });
         }
@@ -733,8 +769,17 @@ impl RendezvousMediator {
                 .remove(&session_key_for_cleanup);
             if let Err(err) = result {
                 log::warn!("webrtc wait_connected failed: {}", err);
+                // Release the pc now rather than waiting for the ICE agent to time out into a
+                // terminal state (~30s); this also drops the SESSIONS entry promptly.
+                stream.close().await;
                 return;
             }
+            // create_tcp_connection takes ownership of the stream; keep a handle to close the pc
+            // once the session returns. It runs the whole session and returns Ok on normal end,
+            // Err on setup failure — either way the pc must be closed, else it lingers forever in
+            // SESSIONS (its state handler only fires on a terminal ICE state, which a cleanly
+            // closed session may never reach) leaking the pc, channels, and socket fds.
+            let stream_for_cleanup = stream.clone();
             if let Err(err) = crate::server::create_tcp_connection(
                 server,
                 Stream::WebRTC(stream),
@@ -746,6 +791,7 @@ impl RendezvousMediator {
             {
                 log::warn!("failed to create WebRTC server connection: {}", err);
             }
+            stream_for_cleanup.close().await;
         });
 
         Ok(answer)
@@ -760,19 +806,32 @@ impl RendezvousMediator {
             return Ok(());
         }
         let peer_addr_v6 = hbb_common::AddrMangle::decode(&ph.socket_addr_v6);
-        let relay = use_ws() || Config::is_proxy() || ph.force_relay;
+        let local_proxy = use_ws() || Config::is_proxy();
+        let relay = local_proxy || ph.force_relay;
         let mut socket_addr_v6 = Default::default();
         let meta = connection_meta(
             ph.control_permissions.clone().into_option(),
             ph.controlled_context.clone().into_option(),
         );
-        let webrtc_sdp_answer = if !ph.webrtc_sdp_offer.is_empty() {
-            self.spawn_webrtc_answerer(&ph, relay, server.clone(), peer_addr, meta.clone())
-                .await
-                .unwrap_or_else(|err| {
-                    log::warn!("failed to create WebRTC answer: {}", err);
-                    String::new()
-                })
+        let control_permissions = ph.control_permissions.clone().into_option();
+        // WebRTC opens its own ICE sockets, so it must never be used when local traffic is routed
+        // through SOCKS/WebSocket. force_relay is different: relay-only ICE is viable with TURN.
+        let webrtc_viable = !ph.webrtc_sdp_offer.is_empty()
+            && !local_proxy
+            && (!ph.force_relay || WebRTCStream::has_turn_server());
+        let webrtc_sdp_answer = if webrtc_viable {
+            self.spawn_webrtc_answerer(
+                &ph,
+                ph.force_relay,
+                server.clone(),
+                peer_addr,
+                meta.clone(),
+            )
+            .await
+            .unwrap_or_else(|err| {
+                log::warn!("failed to create WebRTC answer: {}", err);
+                String::new()
+            })
         } else {
             String::new()
         };

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -689,13 +689,13 @@ impl RendezvousMediator {
     async fn spawn_webrtc_answerer(
         &self,
         ph: &PunchHole,
-        force_relay: bool,
+        relay_only_ice: bool,
         server: ServerPtr,
         peer_addr: SocketAddr,
         meta: ConnectionMeta,
     ) -> ResultType<String> {
         let mut stream =
-            WebRTCStream::new(&ph.webrtc_sdp_offer, force_relay, CONNECT_TIMEOUT).await?;
+            WebRTCStream::new(&ph.webrtc_sdp_offer, relay_only_ice, CONNECT_TIMEOUT).await?;
         let answer = match stream.get_local_endpoint_trickle().await {
             Ok(answer) => answer,
             Err(e) => {
@@ -849,14 +849,18 @@ impl RendezvousMediator {
         // and STUN bypass the proxy and leak the real IP. WebSocket mode does NOT disable it —
         // ws only tunnels the signaling/relay legs to the server, classic punching stays forced
         // to relay (`relay` above), and the answer rides the RelayResponse, leaving ICE as the
-        // only P2P path there. force_relay is different: relay-only ICE is viable with TURN.
+        // only P2P path there. force_relay depends on why it was set: with webrtc_all_ice the
+        // controller's relay is transport-forced (ws) and its offer carries every candidate
+        // type, so answer with full ICE and let a direct pair form; without it the offer is
+        // Relay-only ICE by policy, viable (and answerable) only through TURN.
+        let webrtc_relay_only = ph.force_relay && !ph.webrtc_all_ice;
         let webrtc_viable = !ph.webrtc_sdp_offer.is_empty()
             && !Config::is_proxy()
-            && (!ph.force_relay || WebRTCStream::has_turn_server());
+            && (!webrtc_relay_only || WebRTCStream::has_turn_server());
         let webrtc_sdp_answer = if webrtc_viable {
             self.spawn_webrtc_answerer(
                 &ph,
-                ph.force_relay,
+                webrtc_relay_only,
                 server.clone(),
                 peer_addr,
                 meta.clone(),

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -854,13 +854,16 @@ impl RendezvousMediator {
         // transport-forced (ws) and its offer carries every candidate type, so answer with
         // full ICE and let a direct pair form; without it the offer is Relay-only ICE by
         // policy, viable (and answerable) only through TURN.
-        let webrtc_relay_only = ph.force_relay
-            && !WebRTCStream::endpoint_declares_all_ice(&ph.webrtc_sdp_offer);
-        // Unlike the udp/ipv6 legs - which deliberately just follow the request - WebRTC is
-        // gated on this machine's own option too: answering builds a pc that gathers ICE
-        // from this host, so a machine with WebRTC off must not be pulled into it.
+        let webrtc_relay_only =
+            ph.force_relay && !WebRTCStream::endpoint_declares_all_ice(&ph.webrtc_sdp_offer);
+        // Like the udp/ipv6 legs, the answerer follows the request and does not consult this
+        // machine's own enable-webrtc option. That option is LocalConfig, which the UI process
+        // writes and never syncs over IPC — this code runs in the server process, which on
+        // Windows resolves LocalConfig under a different profile entirely and would read the
+        // private-server default of "N", silently refusing to answer in exactly the self-hosted
+        // deployments the transport is for. The option still gates the feature where it can:
+        // an offer only exists because a controller had it enabled.
         let webrtc_viable = !ph.webrtc_sdp_offer.is_empty()
-            && crate::get_webrtc_enabled()
             && !Config::is_proxy()
             && (!webrtc_relay_only || WebRTCStream::has_turn_server());
         let webrtc_sdp_answer = if webrtc_viable {

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -38,7 +38,6 @@ use crate::{
 };
 
 type Message = RendezvousMessage;
-type RendezvousSender = mpsc::UnboundedSender<Message>;
 
 fn connection_meta(
     control_permissions: Option<ControlPermissions>,
@@ -112,7 +111,6 @@ pub struct RendezvousMediator {
     host: String,
     host_prefix: String,
     keep_alive: i32,
-    rz_sender: RendezvousSender,
 }
 
 impl RendezvousMediator {
@@ -219,13 +217,11 @@ impl RendezvousMediator {
         let host = check_port(&host, RENDEZVOUS_PORT);
         log::info!("start udp: {host}");
         let (mut socket, mut addr) = new_udp_for(&host, CONNECT_TIMEOUT).await?;
-        let (rz_sender, mut rz_out_rx) = mpsc::unbounded_channel::<Message>();
         let mut rz = Self {
             addr: addr.clone(),
             host: host.clone(),
             host_prefix: Self::get_host_prefix(&host),
             keep_alive: crate::DEFAULT_KEEP_ALIVE,
-            rz_sender,
         };
 
         let mut timer = crate::rustdesk_interval(interval(crate::TIMER_OUT));
@@ -284,9 +280,6 @@ impl RendezvousMediator {
                             bail!("Socket receive none. Maybe socks5 server is down.");
                         },
                     }
-                },
-                Some(msg_out) = rz_out_rx.recv() => {
-                    Sink::Framed(&mut socket, &addr).send(&msg_out).await?;
                 },
                 _ = timer.tick() => {
                     if SHOULD_EXIT.load(Ordering::SeqCst) {
@@ -446,13 +439,11 @@ impl RendezvousMediator {
         let mut conn = connect_tcp(host.clone(), CONNECT_TIMEOUT).await?;
         let key = crate::get_key(true).await;
         crate::secure_tcp(&mut conn, &key).await?;
-        let (rz_sender, mut rz_out_rx) = mpsc::unbounded_channel::<Message>();
         let mut rz = Self {
             addr: conn.local_addr().into_target_addr()?,
             host: host.clone(),
             host_prefix: Self::get_host_prefix(&host),
             keep_alive: crate::DEFAULT_KEEP_ALIVE,
-            rz_sender,
         };
         let mut timer = crate::rustdesk_interval(interval(crate::TIMER_OUT));
         let mut last_register_sent: Option<Instant> = None;
@@ -479,9 +470,6 @@ impl RendezvousMediator {
                     }
                     let msg = Message::parse_from_bytes(&bytes)?;
                     rz.handle_resp(msg.union, Sink::Stream(&mut conn), &server, &mut update_latency).await?
-                }
-                Some(msg_out) = rz_out_rx.recv() => {
-                    Sink::Stream(&mut conn).send(&msg_out).await?;
                 }
                 _ = timer.tick() => {
                     if SHOULD_EXIT.load(Ordering::SeqCst) {
@@ -679,8 +667,9 @@ impl RendezvousMediator {
     /// Build the WebRTC answerer for a punch-hole offer and return the SDP answer that rides in
     /// the punch reply (PunchHoleSent / RelayResponse).
     ///
-    /// This is awaited inline on the punch-reply critical path (also serializing the mediator's
-    /// message loop), which is acceptable only because everything awaited here is local-only —
+    /// This is awaited inline on the punch-reply critical path (handle_punch_hole runs as its own
+    /// spawned task, so only this reply is delayed), acceptable only because everything awaited
+    /// here is local-only —
     /// pc construction + DTLS cert keygen + SDP answer, sub-millisecond in practice. Trickle ICE
     /// makes that possible: the answer carries no candidates; STUN/TURN gathering runs afterward
     /// and trickles via IceCandidate messages. Keep network I/O out of this path — actual
@@ -735,10 +724,18 @@ impl RendezvousMediator {
         });
 
         {
-            let sender = self.rz_sender.clone();
+            let host = self.host.clone();
             let socket_addr = return_route.clone();
             let session_key_for_ice = session_key.clone();
             tokio::spawn(async move {
+                // Candidates ride a dedicated TCP connection to the rendezvous server, like
+                // the answer, NOT the mediator channel: that channel is UDP in the default
+                // setup, and target deployments front hbbs with websocket/TCP only, where
+                // its UDP port is unreachable. The server keeps candidate-carrying TCP
+                // connections open, so one lazily-opened connection serves the whole
+                // trickle, and TCP reliability replaces the old 400ms duplicate re-send
+                // (the controller keeps its own re-send for the server->peer UDP downlink).
+                let mut conn = None;
                 while let Some(candidate) = local_ice_rx.recv().await {
                     let mut msg = Message::new();
                     msg.set_ice_candidate(IceCandidate {
@@ -747,15 +744,34 @@ impl RendezvousMediator {
                         candidate,
                         ..Default::default()
                     });
-                    let _ = sender.send(msg.clone());
-                    // The mediator channel to the rendezvous server is UDP in the default setup,
-                    // so a candidate can be lost in flight; re-send once after a short delay (the
-                    // peer's ICE agent dedups repeats, so the second copy is free).
-                    let sender = sender.clone();
-                    tokio::spawn(async move {
-                        sleep(0.4).await;
-                        let _ = sender.send(msg);
-                    });
+                    // One reconnect attempt per candidate: the first send after an hbbs
+                    // restart or an idle-killed connection fails on the stale stream.
+                    for _ in 0..2 {
+                        if conn.is_none() {
+                            match connect_tcp(&*host, CONNECT_TIMEOUT).await {
+                                Ok(s) => conn = Some(s),
+                                Err(err) => {
+                                    log::warn!(
+                                        "failed to connect for WebRTC ICE candidate: {}",
+                                        err
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                        if let Some(s) = conn.as_mut() {
+                            match s.send(&msg).await {
+                                Ok(()) => break,
+                                Err(err) => {
+                                    log::debug!(
+                                        "WebRTC ICE candidate send failed, reconnecting: {}",
+                                        err
+                                    );
+                                    conn = None;
+                                }
+                            }
+                        }
+                    }
                 }
             });
         }
@@ -813,11 +829,13 @@ impl RendezvousMediator {
             ph.control_permissions.clone().into_option(),
             ph.controlled_context.clone().into_option(),
         );
-        let control_permissions = ph.control_permissions.clone().into_option();
-        // WebRTC opens its own ICE sockets, so it must never be used when local traffic is routed
-        // through SOCKS/WebSocket. force_relay is different: relay-only ICE is viable with TURN.
+        // WebRTC opens its own ICE sockets, so it must not run under a SOCKS proxy: candidates
+        // and STUN bypass the proxy and leak the real IP. WebSocket mode does NOT disable it —
+        // ws only tunnels the signaling/relay legs to the server, classic punching stays forced
+        // to relay (`relay` above), and the answer rides the RelayResponse, leaving ICE as the
+        // only P2P path there. force_relay is different: relay-only ICE is viable with TURN.
         let webrtc_viable = !ph.webrtc_sdp_offer.is_empty()
-            && !local_proxy
+            && !Config::is_proxy()
             && (!ph.force_relay || WebRTCStream::has_turn_server());
         let webrtc_sdp_answer = if webrtc_viable {
             self.spawn_webrtc_answerer(
@@ -877,6 +895,23 @@ impl RendezvousMediator {
             peer_addr.set_port(ph.udp_port as u16);
             self.punch_udp_hole(peer_addr, server, msg_punch, meta)
                 .await?;
+            return Ok(());
+        }
+        if !ph.webrtc_sdp_offer.is_empty() {
+            // WebRTC-only request (udp_port <= 0): return the answer over a short-lived TCP
+            // connection to the rendezvous server, like create_relay does. It must NOT ride
+            // the mediator channel: that channel is UDP in the default setup, and the answer
+            // is the largest message of the punch exchange — a single lost or fragmented
+            // datagram costs a whole 3s retry round; hbbs also applies UDP-punch semantics
+            // (source-address observation / is_udp) to PunchHoleSent received over UDP,
+            // which this request never asked for.
+            // No TCP punch connection is created or accepted; the controller retains its
+            // request socket for trickled ICE signaling. IPv6, when present, was started
+            // above and its address is carried in this same response.
+            let mut msg_out = Message::new();
+            msg_out.set_punch_hole_sent(msg_punch);
+            let mut socket = connect_tcp(&*self.host, CONNECT_TIMEOUT).await?;
+            socket.send(&msg_out).await?;
             return Ok(());
         }
         log::debug!("Punch tcp hole to {:?}", peer_addr);

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -856,7 +856,11 @@ impl RendezvousMediator {
         // policy, viable (and answerable) only through TURN.
         let webrtc_relay_only = ph.force_relay
             && !WebRTCStream::endpoint_declares_all_ice(&ph.webrtc_sdp_offer);
+        // Unlike the udp/ipv6 legs - which deliberately just follow the request - WebRTC is
+        // gated on this machine's own option too: answering builds a pc that gathers ICE
+        // from this host, so a machine with WebRTC off must not be pulled into it.
         let webrtc_viable = !ph.webrtc_sdp_offer.is_empty()
+            && crate::get_webrtc_enabled()
             && !Config::is_proxy()
             && (!webrtc_relay_only || WebRTCStream::has_turn_server());
         let webrtc_sdp_answer = if webrtc_viable {

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     net::SocketAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -21,8 +22,13 @@ use hbb_common::{
     rendezvous_proto::*,
     sleep,
     socket_client::{self, connect_tcp, is_ipv4, new_direct_udp_for, new_udp_for},
-    tokio::{self, select, sync::Mutex, time::interval},
+    tokio::{
+        self, select,
+        sync::{mpsc, Mutex},
+        time::interval,
+    },
     udp::FramedSocket,
+    webrtc::WebRTCStream,
     AddrMangle, IntoTargetAddr, ResultType, Stream, TargetAddr,
 };
 
@@ -32,6 +38,11 @@ use crate::{
 };
 
 type Message = RendezvousMessage;
+type RendezvousSender = mpsc::UnboundedSender<Message>;
+
+fn webrtc_ice_key(peer_id: &str, session_key: &str) -> String {
+    format!("{}\n{}", peer_id, session_key)
+}
 
 fn connection_meta(
     control_permissions: Option<ControlPermissions>,
@@ -47,6 +58,7 @@ lazy_static::lazy_static! {
     static ref SOLVING_PK_MISMATCH: Mutex<String> = Default::default();
     static ref LAST_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
     static ref LAST_RELAY_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
+    static ref WEBRTC_ICE_TXS: Mutex<HashMap<String, mpsc::UnboundedSender<String>>> = Default::default();
 }
 static SHOULD_EXIT: AtomicBool = AtomicBool::new(false);
 static MANUAL_RESTARTED: AtomicBool = AtomicBool::new(false);
@@ -104,6 +116,7 @@ pub struct RendezvousMediator {
     host: String,
     host_prefix: String,
     keep_alive: i32,
+    rz_sender: RendezvousSender,
 }
 
 impl RendezvousMediator {
@@ -210,11 +223,13 @@ impl RendezvousMediator {
         let host = check_port(&host, RENDEZVOUS_PORT);
         log::info!("start udp: {host}");
         let (mut socket, mut addr) = new_udp_for(&host, CONNECT_TIMEOUT).await?;
+        let (rz_sender, mut rz_out_rx) = mpsc::unbounded_channel::<Message>();
         let mut rz = Self {
             addr: addr.clone(),
             host: host.clone(),
             host_prefix: Self::get_host_prefix(&host),
             keep_alive: crate::DEFAULT_KEEP_ALIVE,
+            rz_sender,
         };
 
         let mut timer = crate::rustdesk_interval(interval(crate::TIMER_OUT));
@@ -273,6 +288,9 @@ impl RendezvousMediator {
                             bail!("Socket receive none. Maybe socks5 server is down.");
                         },
                     }
+                },
+                Some(msg_out) = rz_out_rx.recv() => {
+                    Sink::Framed(&mut socket, &addr).send(&msg_out).await?;
                 },
                 _ = timer.tick() => {
                     if SHOULD_EXIT.load(Ordering::SeqCst) {
@@ -399,6 +417,22 @@ impl RendezvousMediator {
                     allow_err!(rz.handle_intranet(fla, server).await);
                 });
             }
+            Some(rendezvous_message::Union::IceCandidate(ice)) => {
+                if ice.to_id != Config::get_id() {
+                    return Ok(());
+                }
+                let key = webrtc_ice_key(&ice.from_id, &ice.session_key);
+                let tx = WEBRTC_ICE_TXS.lock().await.get(&key).cloned();
+                if let Some(tx) = tx {
+                    let _ = tx.send(ice.candidate);
+                } else {
+                    log::debug!(
+                        "dropping ICE candidate for unknown WebRTC session from {} key {}",
+                        ice.from_id,
+                        ice.session_key
+                    );
+                }
+            }
             Some(rendezvous_message::Union::ConfigureUpdate(cu)) => {
                 let v0 = Config::get_rendezvous_servers();
                 Config::set_option(
@@ -421,11 +455,13 @@ impl RendezvousMediator {
         let mut conn = connect_tcp(host.clone(), CONNECT_TIMEOUT).await?;
         let key = crate::get_key(true).await;
         crate::secure_tcp(&mut conn, &key).await?;
+        let (rz_sender, mut rz_out_rx) = mpsc::unbounded_channel::<Message>();
         let mut rz = Self {
             addr: conn.local_addr().into_target_addr()?,
             host: host.clone(),
             host_prefix: Self::get_host_prefix(&host),
             keep_alive: crate::DEFAULT_KEEP_ALIVE,
+            rz_sender,
         };
         let mut timer = crate::rustdesk_interval(interval(crate::TIMER_OUT));
         let mut last_register_sent: Option<Instant> = None;
@@ -452,6 +488,9 @@ impl RendezvousMediator {
                     }
                     let msg = Message::parse_from_bytes(&bytes)?;
                     rz.handle_resp(msg.union, Sink::Stream(&mut conn), &server, &mut update_latency).await?
+                }
+                Some(msg_out) = rz_out_rx.recv() => {
+                    Sink::Stream(&mut conn).send(&msg_out).await?;
                 }
                 _ = timer.tick() => {
                     if SHOULD_EXIT.load(Ordering::SeqCst) {
@@ -508,6 +547,7 @@ impl RendezvousMediator {
             rr.secure,
             false,
             Default::default(),
+            String::new(),
             meta,
         )
         .await
@@ -522,6 +562,7 @@ impl RendezvousMediator {
         secure: bool,
         initiate: bool,
         socket_addr_v6: bytes::Bytes,
+        webrtc_sdp_answer: String,
         meta: ConnectionMeta,
     ) -> ResultType<()> {
         let peer_addr = AddrMangle::decode(&socket_addr);
@@ -540,6 +581,7 @@ impl RendezvousMediator {
             socket_addr: socket_addr.into(),
             version: crate::VERSION.to_owned(),
             socket_addr_v6,
+            webrtc_sdp_answer,
             ..Default::default()
         };
         if initiate {
@@ -606,6 +648,7 @@ impl RendezvousMediator {
             true,
             true,
             socket_addr_v6,
+            String::new(),
             meta,
         )
         .await
@@ -642,6 +685,91 @@ impl RendezvousMediator {
         Ok(())
     }
 
+    async fn spawn_webrtc_answerer(
+        &self,
+        ph: &PunchHole,
+        server: ServerPtr,
+        peer_addr: SocketAddr,
+        meta: ConnectionMeta,
+    ) -> ResultType<String> {
+        if ph.requester_id.is_empty() {
+            log::warn!("WebRTC offer missing requester_id; falling back to existing transports");
+            return Ok(String::new());
+        }
+
+        let mut stream =
+            WebRTCStream::new(&ph.webrtc_sdp_offer, ph.force_relay, CONNECT_TIMEOUT).await?;
+        let answer = stream.get_local_endpoint().await?;
+        let session_key = stream.session_key().to_owned();
+        let peer_id = ph.requester_id.clone();
+
+        let (remote_ice_tx, mut remote_ice_rx) = mpsc::unbounded_channel::<String>();
+        WEBRTC_ICE_TXS
+            .lock()
+            .await
+            .insert(webrtc_ice_key(&peer_id, &session_key), remote_ice_tx);
+
+        let stream_for_remote_ice = stream.clone();
+        tokio::spawn(async move {
+            while let Some(candidate) = remote_ice_rx.recv().await {
+                if let Err(err) = stream_for_remote_ice.add_remote_ice_candidate(&candidate).await
+                {
+                    log::warn!("failed to add remote WebRTC ICE candidate: {}", err);
+                }
+            }
+        });
+
+        if let Some(mut local_ice_rx) = stream.take_local_ice_rx() {
+            let sender = self.rz_sender.clone();
+            let my_id = Config::get_id();
+            let target_id = peer_id.clone();
+            let session_key_for_ice = session_key.clone();
+            tokio::spawn(async move {
+                while let Some(candidate) = local_ice_rx.recv().await {
+                    let mut msg = Message::new();
+                    msg.set_ice_candidate(IceCandidate {
+                        from_id: my_id.clone(),
+                        to_id: target_id.clone(),
+                        session_key: session_key_for_ice.clone(),
+                        candidate,
+                        ..Default::default()
+                    });
+                    let _ = sender.send(msg);
+                }
+            });
+        }
+
+        let peer_id_for_cleanup = peer_id.clone();
+        let session_key_for_cleanup = session_key.clone();
+        tokio::spawn(async move {
+            let result = stream.wait_connected(CONNECT_TIMEOUT).await;
+            WEBRTC_ICE_TXS
+                .lock()
+                .await
+                .remove(&webrtc_ice_key(
+                    &peer_id_for_cleanup,
+                    &session_key_for_cleanup,
+                ));
+            if let Err(err) = result {
+                log::warn!("webrtc wait_connected failed: {}", err);
+                return;
+            }
+            if let Err(err) = crate::server::create_tcp_connection(
+                server,
+                Stream::WebRTC(stream),
+                peer_addr,
+                true,
+                meta,
+            )
+            .await
+            {
+                log::warn!("failed to create WebRTC server connection: {}", err);
+            }
+        });
+
+        Ok(answer)
+    }
+
     async fn handle_punch_hole(&self, ph: PunchHole, server: ServerPtr) -> ResultType<()> {
         let mut peer_addr = AddrMangle::decode(&ph.socket_addr);
         let last = *LAST_MSG.lock().await;
@@ -654,9 +782,19 @@ impl RendezvousMediator {
         let relay = use_ws() || Config::is_proxy() || ph.force_relay;
         let mut socket_addr_v6 = Default::default();
         let meta = connection_meta(
-            ph.control_permissions.into_option(),
-            ph.controlled_context.into_option(),
+            ph.control_permissions.clone().into_option(),
+            ph.controlled_context.clone().into_option(),
         );
+        let webrtc_sdp_answer = if !ph.webrtc_sdp_offer.is_empty() {
+            self.spawn_webrtc_answerer(&ph, server.clone(), peer_addr, meta.clone())
+                .await
+                .unwrap_or_else(|err| {
+                    log::warn!("failed to create WebRTC answer: {}", err);
+                    String::new()
+                })
+        } else {
+            String::new()
+        };
         if peer_addr_v6.port() > 0 && !relay {
             socket_addr_v6 =
                 start_ipv6(peer_addr_v6, peer_addr, server.clone(), meta.clone()).await;
@@ -678,6 +816,7 @@ impl RendezvousMediator {
                     true,
                     true,
                     socket_addr_v6.clone(),
+                    webrtc_sdp_answer.clone(),
                     meta,
                 )
                 .await;
@@ -691,6 +830,7 @@ impl RendezvousMediator {
             nat_type: nat_type.into(),
             version: crate::VERSION.to_owned(),
             socket_addr_v6,
+            webrtc_sdp_answer,
             ..Default::default()
         };
         if ph.udp_port > 0 {

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -53,8 +53,12 @@ lazy_static::lazy_static! {
     static ref SOLVING_PK_MISMATCH: Mutex<String> = Default::default();
     static ref LAST_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
     static ref LAST_RELAY_MSG: Mutex<(SocketAddr, Instant)> = Mutex::new((SocketAddr::new([0; 4].into(), 0), Instant::now()));
-    static ref WEBRTC_ICE_TXS: Mutex<HashMap<String, mpsc::UnboundedSender<String>>> = Default::default();
+    static ref WEBRTC_ICE_TXS: Mutex<HashMap<String, mpsc::Sender<String>>> = Default::default();
 }
+/// Remote ICE candidates buffered per session while the answerer applies them. Mirrors the
+/// controller's own cap: gathering yields host, then srflx, then relay, so a real peer sends
+/// well under this, and anything past it is someone deciding how much memory this process holds.
+const MAX_PENDING_REMOTE_ICE: usize = 64;
 // The rendezvous ICE route is reachable without a prior punch and the peer decides how many
 // candidates it sends, so these sites would let someone else set how much this machine writes to
 // its log file. One line a minute each, carrying the suppressed count.
@@ -62,6 +66,8 @@ const ICE_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60)
 static UNKNOWN_ICE_SESSION_LOG: hbb_common::log_throttle::LogThrottle =
     hbb_common::log_throttle::LogThrottle::new(ICE_LOG_INTERVAL);
 static REJECTED_REMOTE_ICE_LOG: hbb_common::log_throttle::LogThrottle =
+    hbb_common::log_throttle::LogThrottle::new(ICE_LOG_INTERVAL);
+static FULL_ICE_QUEUE_LOG: hbb_common::log_throttle::LogThrottle =
     hbb_common::log_throttle::LogThrottle::new(ICE_LOG_INTERVAL);
 
 static SHOULD_EXIT: AtomicBool = AtomicBool::new(false);
@@ -418,7 +424,11 @@ impl RendezvousMediator {
             Some(rendezvous_message::Union::IceCandidate(ice)) => {
                 let tx = WEBRTC_ICE_TXS.lock().await.get(&ice.session_key).cloned();
                 if let Some(tx) = tx {
-                    let _ = tx.send(ice.candidate);
+                    if tx.try_send(ice.candidate).is_err() {
+                        if let Some(n) = FULL_ICE_QUEUE_LOG.due() {
+                            log::debug!("dropped {} ICE candidate(s): queue full or closed", n);
+                        }
+                    }
                 } else if let Some(n) = UNKNOWN_ICE_SESSION_LOG.due() {
                     log::debug!(
                         "dropped {} ICE candidate(s) for unknown WebRTC session key, last: {}",
@@ -717,7 +727,13 @@ impl RendezvousMediator {
             return Ok(answer);
         };
 
-        let (remote_ice_tx, mut remote_ice_rx) = mpsc::unbounded_channel::<String>();
+        // Bounded, like the controller's own candidate buffer: how many candidates arrive is the
+        // sender's choice, while draining one costs a JSON parse and the ICE agent's lock, so an
+        // unbounded queue lets whoever can reach this session's route grow it without limit inside
+        // a long-lived service process. A full queue drops the newest candidate, which costs at
+        // most one path; ICE keeps whatever pairs it already has.
+        let (remote_ice_tx, mut remote_ice_rx) = mpsc::channel::<String>(MAX_PENDING_REMOTE_ICE);
+        let own_ice_tx = remote_ice_tx.clone();
         WEBRTC_ICE_TXS
             .lock()
             .await
@@ -795,10 +811,19 @@ impl RendezvousMediator {
         let session_key_for_cleanup = session_key.clone();
         tokio::spawn(async move {
             let result = stream.wait_connected(CONNECT_TIMEOUT).await;
-            WEBRTC_ICE_TXS
-                .lock()
-                .await
-                .remove(&session_key_for_cleanup);
+            // Only evict our own route. The key is the offer's DTLS fingerprint, identical across
+            // the controller's punch retries, so a retry that built a fresh answerer has already
+            // replaced this entry — removing it blindly would delete the live session's sender and
+            // leave it receiving no candidates at all.
+            {
+                let mut txs = WEBRTC_ICE_TXS.lock().await;
+                if txs
+                    .get(&session_key_for_cleanup)
+                    .is_some_and(|tx| tx.same_channel(&own_ice_tx))
+                {
+                    txs.remove(&session_key_for_cleanup);
+                }
+            }
             if let Err(err) = result {
                 log::warn!("webrtc wait_connected failed: {}", err);
                 // Release the pc now rather than waiting for the ICE agent to time out into a

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -997,7 +997,9 @@ impl RendezvousMediator {
             let socket = connect_tcp(&*self.host, CONNECT_TIMEOUT).await?;
             let local_addr = socket.local_addr();
             // key important here for punch hole to tell my gateway incoming peer is safe.
-            // it can not be async here, because local_addr can not be reused, we must close the connection before use it again.
+            // Awaited rather than spawned so the mapping exists before `PunchHoleSent` goes out;
+            // `local_addr` itself is shared, not exclusive - every socket here binds it with the
+            // reuse flags `new_socket` sets.
             allow_err!(socket_client::connect_tcp_local(peer_addr, Some(local_addr), 30).await);
             socket
         };
@@ -1005,7 +1007,10 @@ impl RendezvousMediator {
         msg_out.set_punch_hole_sent(msg_punch);
         let bytes = msg_out.write_to_bytes()?;
         socket.send_raw(bytes).await?;
-        crate::accept_connection(server.clone(), socket, peer_addr, true, meta).await;
+        let local_addr = socket.local_addr();
+        // The listener inside takes this address over, so the mediator's socket goes first.
+        drop(socket);
+        punch_tcp_until_connected(server, peer_addr, local_addr, meta).await;
         Ok(())
     }
 
@@ -1264,6 +1269,194 @@ async fn udp_nat_listen(
     Ok(())
 }
 
+/// Where the repeats start, and the factor they slow by. The controller's SYN arrives once, at an
+/// instant we are never told, inside a window we are not told either: `Client::connect` sizes its
+/// dial only after our PunchHoleSent, from its own rendezvous time and the direct failures it has
+/// recorded for us - `CONNECT_TIMEOUT` between two known-asymmetric NATs that never failed, as
+/// little as a second once one has. So the repeats cover our own ceiling instead, `CONNECT_TIMEOUT`,
+/// which is as long as the accept below has always been willing to take a connection, and back
+/// off across it: dense at the start, where every window begins and the short ones end, sparse
+/// afterwards, which is `punch_udp`'s shape for the same reason.
+const PUNCH_INTERVAL: f32 = 0.15;
+const PUNCH_BACKOFF: f32 = 1.5;
+const PUNCH_MAX_INTERVAL: f32 = 2.0;
+/// How long a punch in flight may run past the deadline, and the only timer it runs on. A punch
+/// is cancel-safe while it is still in SYN_SENT and not once the controller's SYN has crossed it:
+/// the socket is then half way through a handshake, and dropping it there cuts the connection the
+/// controller is opening - which its `connect` has already returned, so that attempt fails
+/// outright rather than falling back to relay. A timer cannot tell the two states apart, so no
+/// punch is cut on a schedule of its own, and none needs to be. A gateway that answers with RST
+/// fails the connect at once, and the loop punches again. One that drops the SYN in silence
+/// leaves the socket in SYN_SENT, where it holds the mapping open and the kernel re-sends the
+/// SYN, and any SYN of the controller's that arrives crosses it - a second punch has nothing to
+/// add. That leaves the deadline, and this much past it lets a crossing begun just before it
+/// complete; Windows gives a SYN up at about 21s anyway.
+const PUNCH_GRACE: u64 = 3000;
+
+/// The punch above leaves before hbbs has told the controller where to dial, so it is never in
+/// flight at the same time as the controller's SYN: it opens our NAT, meets nothing, and a gateway
+/// that answers it with RST takes the mapping down with it - leaving the listener below waiting on
+/// a hole that no longer exists. Punching again across the window in which the controller dials
+/// rebuilds it, and once the controller sits in SYN_SENT one of those punches meets its SYN and
+/// completes as a simultaneous open: a second way in, which a single punch never had.
+async fn punch_tcp_until_connected(
+    server: ServerPtr,
+    peer_addr: SocketAddr,
+    local_addr: SocketAddr,
+    meta: ConnectionMeta,
+) {
+    use hbb_common::tcp::new_listener;
+    // Shadows the module's `std::time::Instant`: the deadline is held against tokio's sleeps and
+    // timeouts, so it runs on their clock.
+    use hbb_common::tokio::time::Instant;
+
+    // Not fatal on its own - the punch below can still meet the controller's SYN without it, and
+    // that half is the one a listener the OS refused to bind could not have covered anyway.
+    let listener = match new_listener(local_addr, true).await {
+        Ok(listener) => {
+            log::info!("Server listening on: {local_addr}");
+            Some(listener)
+        }
+        Err(err) => {
+            log::warn!("Failed to listen on {local_addr} after punching: {err}");
+            None
+        }
+    };
+    // Bounds both halves: the punch keeps the mapping open only while the accept is still
+    // willing to take a connection through it.
+    let until = Instant::now() + Duration::from_millis(CONNECT_TIMEOUT);
+    let punch = punch_until(until, peer_addr, |ms| {
+        socket_client::connect_tcp_local(peer_addr, Some(local_addr), ms)
+    });
+    let Some(listener) = listener else {
+        if let Some(stream) = punch.await {
+            serve_punched(server, stream, peer_addr, meta).await;
+        }
+        return;
+    };
+    // Accepting in a loop, not once: a transient `accept` error must not spend the whole window
+    // the controller still has to arrive in.
+    let accept = async {
+        loop {
+            let left = until.saturating_duration_since(Instant::now()).as_millis() as u64;
+            if left == 0 {
+                break;
+            }
+            match hbb_common::timeout(left, listener.accept()).await {
+                // Not filtered by address, as `accept_connection` never did: hbbs saw the
+                // controller through one mapping and a NAT that pools its external addresses may
+                // dial us from another, and what keeps `meta`'s control permissions from a second
+                // peer is the handshake, plus that exactly one connection is ever served.
+                Ok(Ok(accepted)) => return Some(accepted),
+                Ok(Err(err)) => {
+                    log::warn!("Failed to accept from {peer_addr}: {err}");
+                    // One that persists - EMFILE, say - would otherwise spin here for the window.
+                    sleep(1.).await;
+                }
+                Err(_) => break,
+            }
+        }
+        log::info!("Nothing connected to the hole punched to {peer_addr}");
+        None
+    };
+    // Only the accept races the punch. Racing `accept_connection` instead would race the whole
+    // session it goes on to run, so a punch landing mid-session would tear that session down.
+    //
+    // Whichever arrives first is the one connection this request produces. Serving the loser too
+    // would give a second peer the control permissions hbbs granted for this one controller, and
+    // no test on the connection itself can tell the two apart before `create_tcp_connection` has
+    // spoken to it - so the invariant is kept here, by there being no second serve.
+    let punched = select! {
+        // Both ready at once is two connections, not one seen twice - a crossing carries the
+        // punch's four-tuple, which the listener never matches - and the punch is the one kept:
+        // it is known to have met something at the address hbbs gave, where the accept takes
+        // any address, and dropping it would reset the connection the controller is opening.
+        biased;
+        Some(stream) = punch => stream,
+        Some((stream, addr)) = accept => {
+            return accept_punched_connection(server, stream, addr, meta).await;
+        }
+        else => return,
+    };
+    serve_punched(server, punched, peer_addr, meta).await;
+}
+
+/// The repeats of `punch_tcp_until_connected`, over any punch rather than `connect_tcp_local`
+/// alone, so that a test can run the schedule against a paused clock - which no socket can be.
+async fn punch_until<T, F, Fut>(
+    until: tokio::time::Instant,
+    peer_addr: SocketAddr,
+    mut punch: F,
+) -> Option<T>
+where
+    F: FnMut(u64) -> Fut,
+    Fut: std::future::Future<Output = ResultType<T>>,
+{
+    use hbb_common::tokio::time::Instant;
+
+    let mut interval = PUNCH_INTERVAL;
+    let mut round = 0;
+    loop {
+        // The deadline decides whether another punch starts, never how long one already in
+        // flight may take: that one runs to PUNCH_GRACE past it.
+        let left = until.saturating_duration_since(Instant::now());
+        if left.is_zero() {
+            log::debug!("None of {round} punches to {peer_addr} was met");
+            return None;
+        }
+        // Cut at the deadline rather than slept out past it, so the window ends on a punch and
+        // not on a gap of up to PUNCH_MAX_INTERVAL: the controller's window opened after ours,
+        // on the PunchHoleSent hbbs relayed, so one as long as ours is still open through our tail.
+        tokio::time::sleep(Duration::from_secs_f32(interval).min(left)).await;
+        interval = (interval * PUNCH_BACKOFF).min(PUNCH_MAX_INTERVAL);
+        let ms = until.saturating_duration_since(Instant::now()).as_millis() as u64 + PUNCH_GRACE;
+        match punch(ms).await {
+            // The controller's SYN crossed this punch, so the stream is the connection it
+            // dialed, not a spare one: dropping it would reset that connection.
+            Ok(stream) => return Some(stream),
+            // Not logged one by one, but the count says which gateway it was: RST fails a
+            // punch at once and fits a dozen into the window, a silent drop holds the one
+            // punch for the whole of it. `connect_tcp_local` keeps no errno anyway.
+            Err(_) => round += 1,
+        }
+    }
+}
+
+async fn serve_punched(
+    server: ServerPtr,
+    stream: Stream,
+    peer_addr: SocketAddr,
+    meta: ConnectionMeta,
+) {
+    log::info!("Punched tcp hole to {peer_addr}, connected on the punch itself");
+    if let Err(err) =
+        crate::server::create_tcp_connection(server, stream, peer_addr, true, meta).await
+    {
+        log::warn!("Failed to serve the connection punched to {peer_addr}: {err}");
+    }
+}
+
+/// The accept half of `accept_connection`, kept here because only the accept may race the punch.
+async fn accept_punched_connection(
+    server: ServerPtr,
+    stream: tokio::net::TcpStream,
+    addr: SocketAddr,
+    meta: ConnectionMeta,
+) {
+    use crate::server::create_tcp_connection;
+
+    stream.set_nodelay(true).ok();
+    match stream.local_addr() {
+        Ok(stream_addr) => {
+            let stream = Stream::from(stream, stream_addr);
+            if let Err(err) = create_tcp_connection(server, stream, addr, true, meta).await {
+                log::warn!("Failed to serve the connection from {addr}: {err}");
+            }
+        }
+        Err(err) => log::warn!("Failed to read the address accepted from {addr}: {err}"),
+    }
+}
+
 // When config is not yet synced from root, register_pk may have already been sent with a new generated pk.
 // After config sync completes, the pk may change. This struct detects pk changes and triggers
 // a re-registration by setting key_confirmed to false.
@@ -1291,7 +1484,25 @@ impl Drop for CheckIfResendPk {
 
 #[cfg(test)]
 mod tests {
-    use super::{mpsc, IceRoute, ICE_DEDUP_WINDOW, MAX_PENDING_REMOTE_ICE};
+    use super::{mpsc, socket_client, tokio, IceRoute, ICE_DEDUP_WINDOW, MAX_PENDING_REMOTE_ICE};
+    use hbb_common::tcp::new_listener;
+    use std::net::SocketAddr;
+
+    // A SOCKS proxy makes `connect_tcp_local` dial the proxy and ignore the local address, so
+    // nothing these two assert can hold. Read once, from the same global config production reads.
+    fn proxied() -> bool {
+        hbb_common::config::Config::get_socks().is_some()
+    }
+
+    /// Both held while their addresses are read, so the pair cannot be the same port - which
+    /// `SO_REUSEPORT` would let bind twice rather than refuse, leaving the tests degenerate.
+    async fn free_loopback_pair() -> (SocketAddr, SocketAddr) {
+        let (a, b) = (
+            tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap(),
+            tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap(),
+        );
+        (a.local_addr().unwrap(), b.local_addr().unwrap())
+    }
 
     fn queue(route: &mut IceRoute, candidate: &str) -> bool {
         route.queue(candidate.to_owned())
@@ -1356,5 +1567,169 @@ mod tests {
         let recent = format!("candidate-{}", ICE_DEDUP_WINDOW);
         assert!(queue(&mut route, &recent));
         assert!(rx.try_recv().is_err());
+    }
+
+    // The second way in that the repeat punch opens: a punch reaching a peer already in SYN_SENT
+    // is answered by that socket rather than reset, and the two ends come up on one connection.
+    // A punch that misses the crossing is reset outright here, loopback having no NAT to absorb
+    // it and no round trip to hide behind - so a single punch lands only by luck, and repeating
+    // is what makes it land at all. That is the premise of the repeat, asserted directly. A round
+    // that misses costs one loopback RST, so rounds are cheap and there are many.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_punch_that_meets_the_peers_syn_connects_both_ends() {
+        // The crossing needs both connects genuinely in flight at once. Loopback answers a SYN to
+        // a port nobody is listening on with an instant RST, so on one CPU the first connect runs
+        // to completion before the second is scheduled and no round can ever cross - a property of
+        // the box, which this test cannot tell apart from a broken punch.
+        if proxied() || std::thread::available_parallelism().map_or(true, |cpus| cpus.get() < 2) {
+            return;
+        }
+        for _ in 0..256 {
+            let (a, b) = free_loopback_pair().await;
+            // Held for the whole crossing, because production always has one here and the design
+            // rests on which of the two the kernel hands the connection to: the punch and the
+            // peer's SYN share a four-tuple exactly, the listener only matches the address, and
+            // the punch has to win that or every crossing would be swallowed as a plain accept.
+            let listener = new_listener(a, true).await.unwrap();
+            let to_b = tokio::spawn(socket_client::connect_tcp_local(b, Some(a), 3000));
+            let to_a = tokio::spawn(socket_client::connect_tcp_local(a, Some(b), 3000));
+            let (at_a, at_b) = tokio::join!(to_b, to_a);
+            let (Ok(Ok(mut at_a)), Ok(Ok(mut at_b))) = (at_a, at_b) else {
+                continue;
+            };
+            at_a.send_bytes(bytes::Bytes::from_static(b"punch"))
+                .await
+                .unwrap();
+            let got = at_b.next_timeout(3000).await.unwrap().unwrap();
+            assert_eq!(&got[..], b"punch", "both ends must share one connection");
+            assert!(
+                hbb_common::timeout(200, listener.accept()).await.is_err(),
+                "the crossing must reach the punch, not be accepted as an inbound connection"
+            );
+            return;
+        }
+        panic!("no punch met the peer's SYN in 256 rounds on a machine that can cross them");
+    }
+
+    // The punch binds the address the listener already holds, so it has to go through the same
+    // `connect_tcp_local` production uses - a punch built by hand here would still pass if
+    // `new_socket` ever stopped setting the reuse flags, while every real punch failed to bind.
+    // The peer's view of the source port is what proves the bind took: a fallback to an ephemeral
+    // one would connect just as happily.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_punch_binds_the_address_the_listener_holds() {
+        if proxied() {
+            return;
+        }
+        // `free_loopback_pair` hands back ports it no longer holds, so another process can take
+        // one in between; retry rather than fail for something the punch had no part in.
+        for _ in 0..8 {
+            let (local, peer_addr) = free_loopback_pair().await;
+            let (Ok(listener), Ok(peer)) = (
+                new_listener(local, true).await,
+                new_listener(peer_addr, true).await,
+            ) else {
+                continue;
+            };
+            let punch = tokio::spawn(socket_client::connect_tcp_local(
+                peer_addr,
+                Some(local),
+                1500,
+            ));
+            let (_peer_side, seen_as) = hbb_common::timeout(3000, peer.accept())
+                .await
+                .expect("the punch must reach the peer")
+                .unwrap();
+            assert_eq!(
+                seen_as.port(),
+                local.port(),
+                "the punch must leave from the address the listener holds, not an ephemeral one"
+            );
+            // Held, not asserted and dropped: the coexistence below is only exercised while this
+            // socket is still on the address, which is the state production spends its window in.
+            let _punched = punch.await.unwrap().expect("the punch must connect");
+
+            let dialed = tokio::spawn(tokio::net::TcpStream::connect(local));
+            let accepted = hbb_common::timeout(3000, listener.accept()).await;
+            assert!(
+                matches!(accepted, Ok(Ok(_))),
+                "the listener must still take connections while a punch shares its address: {accepted:?}"
+            );
+            assert!(dialed.await.unwrap().is_ok());
+            return;
+        }
+        panic!("could not hold two free loopback addresses in 8 tries");
+    }
+
+    // The schedule on its own, against a paused clock: the window is CONNECT_TIMEOUT long, and
+    // what these pin is where inside it the punches fall, which no socket could show.
+    #[tokio::test(start_paused = true)]
+    async fn the_punches_end_on_one_at_the_deadline() {
+        use super::{punch_until, PUNCH_GRACE, PUNCH_INTERVAL, PUNCH_MAX_INTERVAL};
+        use hbb_common::{anyhow::anyhow, config::CONNECT_TIMEOUT};
+        use std::time::Duration;
+        use tokio::time::Instant;
+
+        let peer: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let start = Instant::now();
+        let until = start + Duration::from_millis(CONNECT_TIMEOUT);
+        let mut punches = Vec::new();
+        // A gateway that answers with RST: every punch fails the moment it is made.
+        let met = punch_until::<(), _, _>(until, peer, |ms| {
+            punches.push((Instant::now(), ms));
+            async { Err(anyhow!("RST")) }
+        })
+        .await;
+        assert!(met.is_none());
+        assert_eq!(
+            Instant::now(),
+            until,
+            "must return the moment the window closes, not a backoff later"
+        );
+        // Tokio rounds every sleep up to the next millisecond.
+        let slack = Duration::from_millis(1);
+        assert!(punches[0].0 - start <= Duration::from_secs_f32(PUNCH_INTERVAL) + slack);
+        for pair in punches.windows(2) {
+            assert!(
+                pair[1].0 - pair[0].0 <= Duration::from_secs_f32(PUNCH_MAX_INTERVAL) + slack,
+                "no gap in the window may exceed the backoff ceiling: {pair:?}"
+            );
+        }
+        assert_eq!(
+            *punches.last().unwrap(),
+            (until, PUNCH_GRACE),
+            "the window must end on a punch, given the whole grace"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_punch_in_flight_runs_the_grace_past_the_deadline_and_no_further() {
+        use super::{punch_until, PUNCH_GRACE};
+        use hbb_common::{anyhow::anyhow, config::CONNECT_TIMEOUT};
+        use std::time::Duration;
+        use tokio::time::Instant;
+
+        let peer: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let until = Instant::now() + Duration::from_millis(CONNECT_TIMEOUT);
+        let mut punches = 0;
+        // A gateway that drops the SYN in silence: the punch sits in SYN_SENT for all it is given.
+        let met = punch_until::<(), _, _>(until, peer, |ms| {
+            punches += 1;
+            async move {
+                tokio::time::sleep(Duration::from_millis(ms)).await;
+                Err(anyhow!("timed out"))
+            }
+        })
+        .await;
+        assert!(met.is_none());
+        assert_eq!(
+            punches, 1,
+            "a punch held in SYN_SENT is the only one the window needs"
+        );
+        assert_eq!(
+            Instant::now(),
+            until + Duration::from_millis(PUNCH_GRACE),
+            "must return when the grace runs out, not a backoff later"
+        );
     }
 }

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -943,6 +943,11 @@ impl RendezvousMediator {
         }
         let relay_server = self.get_relay_server(ph.relay_server);
         // for ensure, websocket go relay directly
+        // A symmetric NAT relays the legacy transports but deliberately not WebRTC: the answer
+        // built above rides along on the relay request, and ICE probes the candidate pairs rather
+        // than trusting this classification, so a direct WebRTC pair can still form on a
+        // connection this branch has already called relay-only. Do not gate the answerer on
+        // nat_type to make the two agree.
         if ph.nat_type.enum_value() == Ok(NatType::SYMMETRIC)
             || Config::get_nat_type() == NatType::SYMMETRIC as i32
             || relay

--- a/src/server.rs
+++ b/src/server.rs
@@ -209,11 +209,21 @@ pub async fn create_tcp_connection(
         let sk = sign::SecretKey(sk_);
         let mut msg_out = Message::new();
         let (our_pk_b, our_sk_b) = box_::gen_keypair();
+        // On a WebRTC transport, bind our DTLS certificate fingerprint to our signed identity so
+        // the controller can verify the DTLS channel it negotiated actually terminates at us
+        // (not a rendezvous/relay that swapped the SDP fingerprint). Empty on other transports.
+        // Fail immediately on WebRTC if the local fingerprint is unavailable: signing "" would
+        // only make the client fail-closed after a wasted round-trip.
+        let dtls_fingerprint = stream.dtls_fingerprint(true).await.unwrap_or_default();
+        if stream.is_webrtc() && dtls_fingerprint.is_empty() {
+            bail!("WebRTC local DTLS fingerprint unavailable");
+        }
         msg_out.set_signed_id(SignedId {
             id: sign::sign(
                 &IdPk {
                     id: Config::get_id(),
                     pk: Bytes::from(our_pk_b.0.to_vec()),
+                    dtls_fingerprint,
                     ..Default::default()
                 }
                 .write_to_bytes()

--- a/src/server.rs
+++ b/src/server.rs
@@ -212,11 +212,21 @@ pub async fn create_tcp_connection(
         let sk = sign::SecretKey(sk_);
         let mut msg_out = Message::new();
         let (our_pk_b, our_sk_b) = box_::gen_keypair();
+        // On a WebRTC transport, bind our DTLS certificate fingerprint to our signed identity so
+        // the controller can verify the DTLS channel it negotiated actually terminates at us
+        // (not a rendezvous/relay that swapped the SDP fingerprint). Empty on other transports.
+        // Fail immediately on WebRTC if the local fingerprint is unavailable: signing "" would
+        // only make the client fail-closed after a wasted round-trip.
+        let dtls_fingerprint = stream.dtls_fingerprint(true).await.unwrap_or_default();
+        if stream.is_webrtc() && dtls_fingerprint.is_empty() {
+            bail!("WebRTC local DTLS fingerprint unavailable");
+        }
         msg_out.set_signed_id(SignedId {
             id: sign::sign(
                 &IdPk {
                     id: Config::get_id(),
                     pk: Bytes::from(our_pk_b.0.to_vec()),
+                    dtls_fingerprint,
                     ..Default::default()
                 }
                 .write_to_bytes()

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1296,9 +1296,11 @@ impl<T: InvokeUiSession> Session<T> {
         if true == force_relay {
             let mut lc = self.lc.write().unwrap();
             lc.force_relay = true;
-            // An explicit retry-via-relay is user policy, not transport necessity: keep
-            // WebRTC on Relay-only ICE for this round like any force-always-relay session.
+            // An explicit retry-via-relay is a decision about this peer, not transport
+            // necessity: Relay-only ICE for this round like any force-always-relay session,
+            // and it is the one kind of relay that belongs in the peer's saved config.
             lc.policy_relay = true;
+            lc.peer_relay = true;
         }
         self.lc.write().unwrap().peer_info = None;
         self.reconnect_count.fetch_add(1, Ordering::SeqCst);

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1294,7 +1294,11 @@ impl<T: InvokeUiSession> Session<T> {
 
         // override only if true
         if true == force_relay {
-            self.lc.write().unwrap().force_relay = true;
+            let mut lc = self.lc.write().unwrap();
+            lc.force_relay = true;
+            // An explicit retry-via-relay is user policy, not transport necessity: keep
+            // WebRTC on Relay-only ICE for this round like any force-always-relay session.
+            lc.policy_relay = true;
         }
         self.lc.write().unwrap().peer_info = None;
         self.reconnect_count.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
## What this does

Adds WebRTC (ICE + DTLS + SCTP data channel) as an additional **raced direct transport**, alongside the existing TCP/UDP hole punching, IPv6 and relay paths. The controller's SDP offer rides the normal punch-hole request; the controlled side answers inline in the punch reply; ICE candidates trickle through the rendezvous server. A WebRTC P2P result is preferred over an already-established relay within a 2.5 s window; everything degrades gracefully to today's transports when the peer or server has no WebRTC support (unknown protobuf fields are simply dropped).

Includes the paired `hbb_common` submodule bump (its `webrtc` branch).

## Why

NAT combinations that classic punching cannot traverse still end on relay today, and WebSocket/TCP-only deployments have no P2P path at all. ICE covers a strictly larger connectivity set (host/srflx candidates, optional TURN), and under ws it is the only viable P2P path.

## Security model

- The controlled side signs its **DTLS certificate fingerprint** into the existing signed `IdPk` (`dtls_fingerprint`, field 3). The controller verifies the signed fingerprint equals the fingerprint of the DTLS channel it actually negotiated and **fails closed** on absence/mismatch — defeating a rendezvous/relay that swaps SDP fingerprints. On failure it falls back to a freshly coordinated relay (`request_relay`, new uuid).
- `is_secured()` for WebRTC is no longer hardcoded `true`: it reports secured only after the identity binding completes, mirroring TCP's post-key-exchange meaning. Key-less deployments behave exactly like TCP's non-secure fallback (DTLS-encrypted, reported unsecured).
- WebRTC is disabled under a SOCKS proxy (ICE would bypass it and leak the real IP). WebSocket mode keeps it: ws is a server-reachability transport, not an egress policy, and classic punching stays forced to relay there.

## Key changes

**hbb_common (submodule)**
- Trickle ICE (`get_local_endpoint_trickle`, `take_local_ice_rx`, `add_remote_ice_candidate`); new rendezvous proto fields (`webrtc_sdp_offer/answer`, `IceCandidate`).
- Data plane: 1-byte-header fragmentation past the 64 KB SCTP message cap; unambiguous empty-message vs EOF; reassembly bounded by `MAX_FRAME_LENGTH`; a send gate preserving logical message boundaries across stream clones.
- Peer-connection lifecycle: weak handler captures (a strong `Arc<RTCPeerConnection>` capture leaks the pc permanently), role-prefixed session cache, close-on-error paths, explicit `close()` on every session exit.
- `is_relayed()` via candidate-pair stats feeds the UI direct/relayed flag (TURN counts as relayed).
- webrtc crate pinned to **0.13**: >=0.14 pulls sdp 0.10 / webrtc-util 0.12 which use `usize::is_multiple_of` (needs rustc >= 1.87) while CI builds with Rust 1.75 (sciter i128 ABI pin). A module-level upgrade checklist documents every version-coupled assumption (SCTP write backpressure, 64 KB cap, `detach()` semantics, handler-capture cycle, `Disconnected` transience, stats-based `is_relayed`).

**Client (controller)**
- The offer rides any punch request; only an offer-less request may close and reuse the rendezvous socket for TCP punching (trickle ICE keeps that socket as its signaling bridge); a separate offer-less request races as the TCP fallback.
- `race_transports_prefer_webrtc`: an established relay is held for the preference window while WebRTC finishes ICE + DTLS; IPv6/direct results commit immediately; failures compose into one error.
- `OffererGuard` (RAII) closes the pc on every early-return and cancellation path; WebRTC secure-handshake failure falls back to relay instead of failing the session.

**Rendezvous mediator (controlled)**
- Answerer built inline on the punch-reply critical path (local-only work; STUN/TURN gathering trickles afterwards).
- All controlled-side signaling to the server goes over **TCP** (WebRTC-only punch replies and trickled ICE candidates use dedicated connections), so ws/TCP-only hbbs deployments work; the UDP mediator channel is never used for it.

**KCP/UDP robustness (same branch)**
- ICMP-driven UDP socket errors (WSAECONNRESET 10054 on Windows, ECONNREFUSED on Linux) are treated as packet loss instead of tearing the session down; STUN DNS moved to `tokio::net::lookup_host`; removed the STUN port race in `test_udp_uat` that could advertise an unreachable port and poison the punch.
- Optional KCP congestion control (`enable-kcp-congestion-control`, default on, sender-side only); kcp-sys pinned to the `rustdesk-patches` branch (upstream main lost the RustDesk patches on the EasyTier sync; the branch also wires `set_kcp_config_factory` into connection setup, making the option effective).

## Server-side requirement

Requires the paired rustdesk-server change: forward the SDP fields, route `IceCandidate` in both directions, and keep candidate-carrying TCP connections open. Old servers/peers drop the unknown fields and clients silently fall back to today's behavior.

## Testing

- 7 loopback data-plane tests (`cargo test --features webrtc webrtc::tests`): roundtrip, empty message, 200 KB fragmentation/reassembly, concurrent large sends preserving message boundaries, EOF on peer close.
- 10 transport-race unit tests (`webrtc_race_tests`): preference window semantics, IPv6 immediate commit, failure composition.
- `cargo check` clean on the workspace; hbb_common with the webrtc feature also verified on Rust 1.75 (CI's pinned toolchain).


## Table A — Relay/transport combinations (controller's perspective)

| # | Scenario | Requests | UDP probe | IPv6 | Offerer ICE policy | Controlled-side answer | Prefer-P2P window | Possible transports (preference order) | Verdict |
|---|---|---|---|---|---|---|---|---|---|
| 1 | Normal | 2 | ✓ | ✓ | `All`, envelope marked | Full ICE | ✓ | TCP / UDP / IPv6 / WebRTC direct → relay | ✅ |
| 2 | **WebSocket** | **1** | ✗ | ✗ | `All`, envelope marked | Full ICE | ✓ | WebRTC direct → TURN → relay | ✅ target shape |
| 3 | Proxy (± ws) | 1 | ✗ | ✗ | **Not built** (ICE would bypass the proxy and leak the real IP) | — | — | Relay only | ✅ deliberate |
| 4 | `/r`, force-always-relay, retry-via-relay — no TURN configured | 1 | ✗ | ✗ | Not built (pc would be guaranteed-dead) | — | — | Relay only | ✅ |
| 5 | Same as 4, with TURN configured | 1 | ✗ | ✗ | `Relay-only`, **no marker** | Requires TURN on this side too; answers `Relay-only` | ✗ | Relay, or WebRTC-via-TURN — **never direct** | ✅ |
| 6 | ws + policy relay (4/5) together | 1 | ✗ | ✗ | Same as 4/5 | Same as 4/5 | ✗ | Policy wins over transport | ✅ tier ordering correct |
| 7 | Server-forced (hbbs `ALWAYS_USE_RELAY` / LAN asymmetry) × normal controller | 2 *(wasted)* | wasted | wasted | Built, then **offer blanked by hbbs** | Never answers (no offer arrives) | — | Relay only — not even TURN | ✅ semantics / △ overhead |
| 8 | Server-forced × ws controller | 1 | ✗ | ✗ | Offer blanked | Never answers | — | Relay only | ✅ |

**Invariant:** `proxy ≥ server-forced ≥ client policy ≥ ws-transport ≥ normal` — each tier only tightens, never loosens; no contradictory combination exists.

**Notes**
- "Envelope marked" = the offer's `webrtc://` payload carries an `ice_policy: "all"` JSON key (not a proto field), so the rendezvous server never inspects or forwards it.
- Every row's offerer is additionally gated on `enable-webrtc` (default: on for the public server, off for private ones — same pattern as UDP/IPv6 punch). If off, rows 1/2/7 lose the WebRTC leg but are otherwise unchanged; rows 3–6 are already offerer-less.
- Row 7's waste (double request + UDP probe run before hbbs suppresses them) is a known, accepted cost of the client not knowing the server's policy in advance; a pre-announced-policy optimization is on the shelf, not implemented.

## Table B — UDP / IPv6 / WebRTC option combinations (normal path, no relay forcing)

| UDP | IPv6 | WebRTC | Requests | Preferred-request race set | Fallback request | Notes |
|---|---|---|---|---|---|---|
| ✓ | ✓ | ✓ | 2 | UDP + IPv6 + WebRTC | Coordinated TCP punch | Full menu |
| ✗ | ✗ | ✓ | 2 | WebRTC only | Coordinated TCP punch | Offer is the sole signaling carrier |
| ✓ | — | ✗ | 2 | Direct TCP + UDP (+ IPv6 if on) | Coordinated TCP punch | |
| ✗ | ✓ | ✗ | **1** | Direct TCP + IPv6 | — (no offer, so the single request can still classic-punch) | |
| ✗ | ✗ | ✗ | **1** | Coordinated TCP | — | |

**Note:** the single-vs-dual-request split is exactly `request_allows_tcp_punch`: a request only skips TCP punching when it carries a WebRTC offer (the socket must stay open for trickle signaling). UDP-on and WebRTC-on independently force a second (offer-less) request; UDP-off and WebRTC-off together collapse to one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added WebRTC connectivity with ICE negotiation, intelligent transport selection, and relay fallback.
  - Added DTLS identity verification for more secure WebRTC sessions.
  - Added an option to enable KCP congestion control.

- **Bug Fixes**
  - Improved connection reliability during packet loss and temporary socket failures.
  - Prevented lingering WebRTC sessions after disconnects, declined connections, and port-forwarding errors.
  - Improved IPv4/IPv6 handling, NAT traversal, DNS probing, and UDP punching resilience.
  - Improved authentication validation and relay connection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->















































































<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds WebRTC as a raced direct transport with trickle ICE, DTLS identity binding, SCTP data channels, TURN-aware relay classification, and fallback to existing transports. It also adds transport controls and diagnostics to Flutter, updates shared protocol support through `hbb_common`, and changes KCP/UDP behavior.
- Since the previous review, only the pinned `webrtc-sctp` and `webrtc-util` fork revision changed.
- The new revision is described as extending T3 retransmission handling into SCTP shutdown states.
- No new actionable issue was established in the revision bump.
- Two previous findings remain outstanding: missing `update_direct` updates in the inline relay-response failure paths and unrelated IPC logging refactoring prohibited by repository rules.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because one connection-error path still leaves the direct-state indicator stale, and an unrelated IPC refactor still violates explicit repository requirements.

In `_start_inner`'s inline `RelayResponse` handler, failures from `request_relay`, relay `secure_connection`, or the general non-WebRTC secure error still return without updating the interface's direct state, so connection-error handling can observe the initial `None` value. The unrelated throttled-logging rewrite in `src/ipc/auth.rs` also remains despite the repository requirement to keep unrelated refactoring out of feature changes. Seven earlier threads were manually resolved without explanatory replies.

**Files Needing Attention:** src/client.rs, src/ipc/auth.rs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Pins patched `webrtc-util` and `webrtc-sctp` crates to a newer fork revision; no manifest-level compatibility issue was established. |
| Cargo.lock | Updates the two patched WebRTC crate source revisions without changing their recorded dependency sets. |
| src/client.rs | Implements WebRTC setup, transport racing, secure fallback, and relay classification; the previously reported inline RelayResponse error paths still omit `update_direct`. |
| src/ipc/auth.rs | Refactors unauthorized IPC logging through shared throttling despite the repository requirement against unrelated refactoring. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start connection] --> B{WebRTC allowed?}
    B -->|No| C[Race existing direct transports]
    B -->|Yes| D[Send SDP offer and trickle ICE]
    D --> E[Race WebRTC against TCP/UDP/IPv6]
    C --> F{Direct transport succeeds?}
    E --> F
    F -->|Yes| G[Secure connection]
    F -->|No| H[Coordinate RustDesk relay]
    G -->|WebRTC identity binding fails| H
    G -->|Success| I[Connected]
    H --> J[Secure relay]
    J -->|Success| I
    J -->|Failure| K[Connection error]
```
</details>

<sub>Reviews (66): Last reviewed commit: ["bump webrtc fork: T3-rtx restart on fast..."](https://github.com/rustdesk/rustdesk/commit/7dc127c00faf8103e973423c94eadc453d33fe85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47862136)</sub>

<!-- /greptile_comment -->