### PR TITLE
fix(windows): prevent ghost and duplicate tray icons (#15689)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,12 @@
 * Do not make formatting-only changes.
 * Keep naming/style consistent with nearby code.
 
+### Be minimally invasive
+
+* Prefer purely additive changes: layer new (`#[cfg]`-gated) blocks or new functions around existing code instead of restructuring it. The ideal diff for a fix adds lines and modifies/deletes none.
+* Do not extract or reshape existing code just to enable your new code; look for a mechanism that leaves existing lines untouched (e.g. hide/show an existing object instead of refactoring its construction into a helper for rebuilding).
+* Put new logic in self-contained functions in the module it belongs to (platform-specific logic in `src/platform/`, with `use` inside the function body to avoid churning shared import blocks). Call sites in shared files (`src/tray.rs`, `src/core_main.rs`, `src/server/connection.rs`, …) should be thin one-line hooks.
+
 ## Localization (`src/lang/*.rs`)
 
 Each file is a `HashMap<key, translation>`. Layout:

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3314,6 +3314,18 @@ pub fn update_me(debug: bool) -> ResultType<()> {
     }
 
     let app_exe_name = &format!("{}.exe", &app_name);
+    // NOTE: The pids below are matched by command line, which can silently come
+    // back empty even while the processes are running:
+    // - a 32-bit build cannot read the command line of a 64-bit process, so it
+    //   shells out to `wmic` instead (#11638), and `wmic` is no longer installed
+    //   by default since Windows 11 24H2;
+    // - a non-elevated process cannot read the command line of an elevated one.
+    // The `taskkill` in the commands below matches by image name and is not
+    // affected, but `*_sessions` are then empty, so `_restore_session_guard`
+    // silently restores nothing and the update leaves the user without a tray
+    // icon and main window until the app is launched again. Reading the command
+    // line through `NtQueryInformationProcess` instead would fix the queries for
+    // every caller.
     let main_window_pids =
         crate::platform::get_pids_of_process_with_args::<_, &str>(&app_exe_name, &[]);
     let main_window_sessions = main_window_pids

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3162,12 +3162,24 @@ impl Drop for WakeLock {
     }
 }
 
-// `check_process("--tray", ..)` can miss an already running tray process: it
-// cannot read the command line of an elevated process from a non-elevated one,
-// and wmic (used by 32-bit builds, #11638) is gone from newer Windows 11. Each
-// missed check spawns one more tray icon, and `connection.rs` checks once per
-// incoming connection, so the icons kept piling up (#6692, #15689). Hold a named
-// mutex as the authoritative single instance guard instead.
+// `check_process("--tray", ..)` can miss a tray process that is already running,
+// and every miss spawns one more tray icon.
+//
+// The case confirmed in #15689: `run_after_run_cmds()` spawns the tray in the
+// caller's own context, so installing or toggling the service from a RustDesk
+// that was itself started elevated leaves a high integrity tray behind. A main
+// window started normally afterwards runs at medium integrity and cannot open
+// that process with `PROCESS_QUERY_INFORMATION | PROCESS_VM_READ`. sysinfo then
+// falls back to `PROCESS_QUERY_LIMITED_INFORMATION`, which is not enough for
+// `GetModuleFileNameExW`, so the executable path comes back empty and the tray
+// is skipped before its command line is ever looked at.
+//
+// A second blind spot: 32-bit builds read the command line through `wmic`
+// (#11638), which is no longer installed by default since Windows 11 24H2.
+//
+// Both are cases of one process failing to inspect another, and patching the
+// inspection has regressed twice already (#6692), so use a named mutex instead:
+// the kernel answers without us needing any access to the other process.
 //
 // Returns `false` if another tray process is already running in this session.
 pub fn try_lock_tray_single_instance() -> bool {
@@ -3193,9 +3205,9 @@ pub fn try_lock_tray_single_instance() -> bool {
             return true;
         }
         if last_error == ERROR_ACCESS_DENIED {
-            // The mutex exists but belongs to a tray process we may not touch,
-            // i.e. one spawned by the elevated installer. Defer to it instead of
-            // adding a second icon.
+            // The mutex exists but was created by a tray running at a higher
+            // integrity level, which is exactly the elevated tray described
+            // above. Defer to it instead of adding a second icon.
             return false;
         }
         // Unexpected: show the tray icon anyway, a duplicated icon is better

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3162,6 +3162,52 @@ impl Drop for WakeLock {
     }
 }
 
+// `check_process("--tray", ..)` can miss an already running tray process: it
+// cannot read the command line of an elevated process from a non-elevated one,
+// and wmic (used by 32-bit builds, #11638) is gone from newer Windows 11. Each
+// missed check spawns one more tray icon, and `connection.rs` checks once per
+// incoming connection, so the icons kept piling up (#6692, #15689). Hold a named
+// mutex as the authoritative single instance guard instead.
+//
+// Returns `false` if another tray process is already running in this session.
+pub fn try_lock_tray_single_instance() -> bool {
+    use winapi::um::{
+        errhandlingapi::{GetLastError, SetLastError},
+        synchapi::CreateMutexW,
+    };
+    // `Local\` is the per session namespace, so the name is scoped to this
+    // session already and cannot be squatted by another user.
+    let name = wide_string(&format!("Local\\{}_tray", crate::get_app_name()));
+    unsafe {
+        // A successful `CreateMutexW` doesn't clear the last error, clear it to
+        // reliably detect `ERROR_ALREADY_EXISTS`.
+        SetLastError(0);
+        // The handle is deliberately kept open for the lifetime of the process.
+        let handle = CreateMutexW(null_mut(), FALSE, name.as_ptr());
+        let last_error = GetLastError();
+        if !handle.is_null() {
+            if last_error == ERROR_ALREADY_EXISTS {
+                CloseHandle(handle);
+                return false;
+            }
+            return true;
+        }
+        if last_error == ERROR_ACCESS_DENIED {
+            // The mutex exists but belongs to a tray process we may not touch,
+            // i.e. one spawned by the elevated installer. Defer to it instead of
+            // adding a second icon.
+            return false;
+        }
+        // Unexpected: show the tray icon anyway, a duplicated icon is better
+        // than never showing the tray icon at all.
+        log::warn!(
+            "Failed to create the tray single instance mutex: {}",
+            io::Error::from_raw_os_error(last_error as _)
+        );
+        true
+    }
+}
+
 pub fn uninstall_service(show_new_window: bool, _: bool) -> bool {
     log::info!("Uninstalling service...");
     let filter = format!(" /FI \"PID ne {}\"", get_current_pid());

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -30,6 +30,15 @@ fn make_tray() -> hbb_common::ResultType<()> {
         menu::{Menu, MenuEvent, MenuItem},
         TrayIcon, TrayIconBuilder, TrayIconEvent as TrayEvent,
     };
+
+    // Duplicated tray icons kept piling up through the blind spots of
+    // `check_process("--tray", ..)`. https://github.com/rustdesk/rustdesk/issues/15689
+    #[cfg(windows)]
+    if !crate::platform::windows::try_lock_tray_single_instance() {
+        log::info!("Another tray process is already running in this session, exit");
+        return Ok(());
+    }
+
     let icon;
     #[cfg(target_os = "macos")]
     {
@@ -185,9 +194,26 @@ fn make_tray() -> hbb_common::ResultType<()> {
                         return;
                     }
                     */
+                    // Remove the icon first: on success `uninstall_service()` ends
+                    // this process with `std::process::exit`, which skips the
+                    // destructor that would remove it, leaving a ghost icon behind.
+                    #[cfg(windows)]
+                    let _ = _tray_icon
+                        .lock()
+                        .unwrap()
+                        .as_mut()
+                        .map(|t| t.set_visible(false));
                     if !crate::platform::uninstall_service(false, false) {
                         *control_flow = ControlFlow::Exit;
                     }
+                    // Still alive, so stopping the service failed or was cancelled
+                    // in the UAC prompt. Show the icon again.
+                    #[cfg(windows)]
+                    let _ = _tray_icon
+                        .lock()
+                        .unwrap()
+                        .as_mut()
+                        .map(|t| t.set_visible(true));
                 } else if event.id == open_i.id() {
                     open_func();
                 }


### PR DESCRIPTION
## Problem

`check_process("--tray", ..)` decides whether a tray process still needs to be
spawned, but it can fail to see one that is already running:

- it cannot read the command line of an elevated process from a non-elevated one,
  and the installer spawns the tray elevated (`run_after_run_cmds`);
- wmic, used by 32-bit builds since #11638, is gone from newer Windows 11.

`connection.rs` runs that check once per incoming connection, so every miss adds
another tray icon — which is why the icons keep piling up while opening the main
window and connecting/disconnecting sessions. This is the same blind spot behind
#6692, which was patched twice before (2023 `cmd[0]` → `exe()`, 2025 wmic
fallback) and regressed each time a new blind spot appeared.

## Changes

- Hold a named mutex (`Local\<AppName>_tray`) as the authoritative single
  instance guard, so a redundant tray process exits before it creates an icon.
  A kernel object is immune to all of the detection blind spots above.
  `Local\` is the per-session namespace, which is the scope we want anyway and
  cannot be squatted by another user. `ERROR_ACCESS_DENIED` also counts as
  "already running", since it means the mutex belongs to a tray we may not
  touch; any other failure shows the icon anyway, because a duplicated icon is
  better than no tray icon at all.
- Remove the icon before the tray menu's "Stop service" calls
  `uninstall_service()`. On success that function ends the process with
  `std::process::exit`, which skips the destructor that calls
  `Shell_NotifyIcon(NIM_DELETE)`, so every click left a ghost icon behind. Th
  icon is shown again if stopping the service failed or was cancelled in the
  UAC prompt.

Windows only; both hooks are `#[cfg(windows)]` and no existing lines change
behaviour on other platforms.

## Not covered

Ghost icons left by the `taskkill /F` in the install / update / service-toggle
flows are deliberately out of scope. Those need cross-process coordination an
are a separate, unreported issue.

## Testing

Not yet verified on Windows — needs a Windows build. Worth checking on the
reporter's machine whether `tasklist /FI "IMAGENAME eq rustdesk.exe" /V` show
several `--tray` processes (live duplicates, which this fixes) or just one
(then the icons are ghosts and the cause is elsewhere).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes duplicate and ghost tray icons on Windows by replacing the fragile `check_process("--tray", ..)` detection (which fails for elevated processes and on Windows 11 24H2 where `wmic` was removed) with a `Local\<AppName>_tray` named mutex as the authoritative single-instance guard, and by hiding the tray icon before `uninstall_service()` to prevent the ghost icon left when `std::process::exit` skips the `Shell_NotifyIcon(NIM_DELETE)` destructor.

- **`src/platform/windows.rs`**: Adds `try_lock_tray_single_instance()` — calls `CreateMutexW` in the `Local\` (per-session) namespace; returns `false` on `ERROR_ALREADY_EXISTS` or `ERROR_ACCESS_DENIED` (elevated tray), `true` otherwise. Also adds a comment in `update_me()` documenting the command-line-reading blind spots.
- **`src/tray.rs`**: Guards `make_tray()` with the new mutex check, and wraps the "Stop service" handler with `set_visible(false)` / `set_visible(true)` to manage ghost icons across `uninstall_service()`'s `exit(0)` fast path.
- **`AGENTS.md`**: Codifies the "be minimally invasive" conventions demonstrated by this PR itself.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge on Windows; the mutex guard and hide/show logic are correct and well-scoped under #[cfg(windows)].

The core mutex logic is sound — ERROR_ALREADY_EXISTS and ERROR_ACCESS_DENIED are handled correctly, the Local\ namespace scopes detection to the right session, and the hide/show around uninstall_service() cleanly closes the ghost-icon path. The one thing worth a follow-up is that the successful HANDLE is silently leaked (no static, no ManuallyDrop) — future callers of try_lock_tray_single_instance from within the same process would unexpectedly see ERROR_ALREADY_EXISTS on their own mutex.

**Files Needing Attention:** src/platform/windows.rs — the intentionally leaked HANDLE in try_lock_tray_single_instance.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/platform/windows.rs | Adds try_lock_tray_single_instance() using a Local\<AppName>_tray named mutex to prevent duplicate tray processes; also adds a diagnostic comment in update_me(). The mutex logic is correct but the successful HANDLE is intentionally leaked (not stored anywhere) — relies on OS cleanup at process exit. |
| src/tray.rs | Calls the new single-instance guard at make_tray() entry and hides the tray icon before uninstall_service() to prevent ghost icons; shows it again if stopping the service fails. Logic is correct and follows the existing codebase patterns. |
| AGENTS.md | Adds a 'Be minimally invasive' section documenting the additive-diff, thin-hook, and module-placement conventions that this PR itself follows. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Tray as tray process (new)
    participant WinAPI as Windows kernel
    participant ExistingTray as tray process (existing)

    Tray->>Tray: make_tray() called
    Tray->>+WinAPI: CreateMutexW("Local\\RustDesk_tray")

    alt Mutex does not exist yet
        WinAPI-->>Tray: "HANDLE non-null, last_error=0"
        Note over Tray: Store handle in static OnceLock,<br/>keep mutex alive for process lifetime
        Tray->>Tray: try_lock_tray_single_instance() → true
        Tray->>Tray: Proceed to create tray icon
    else Mutex already held by ExistingTray
        WinAPI-->>Tray: "HANDLE non-null, last_error=ERROR_ALREADY_EXISTS"
        Tray->>WinAPI: CloseHandle(handle)
        Tray->>Tray: try_lock_tray_single_instance() → false
        Tray->>Tray: log::info! + return Ok(())
    else Mutex held by elevated ExistingTray
        WinAPI-->>-Tray: "NULL, last_error=ERROR_ACCESS_DENIED"
        Tray->>Tray: try_lock_tray_single_instance() → false
        Tray->>Tray: log::info! + return Ok(())
    end

    Note over ExistingTray,Tray: Stop service menu item clicked

    ExistingTray->>ExistingTray: set_visible(false)
    ExistingTray->>ExistingTray: uninstall_service(false, false)

    alt Service stopped successfully
        ExistingTray->>ExistingTray: std::process::exit(0)
        Note over ExistingTray: OS closes mutex handle
    else UAC cancelled or run_cmds error
        ExistingTray->>ExistingTray: returns true
        ExistingTray->>ExistingTray: set_visible(true)
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fplatform%2Fwindows.rs%3A3200-3206%0AThe%20Win32%20HANDLE%20obtained%20from%20a%20successful%20%60CreateMutexW%60%20call%20is%20deliberately%20kept%20open%20but%20is%20never%20stored%20anywhere%20%E2%80%94%20the%20function%20simply%20returns%20%60true%60%20and%20the%20raw%20integer%20walks%20off%20the%20stack.%20The%20kernel%20object%20stays%20alive%20because%20Windows%20reference-counts%20it%2C%20and%20the%20OS%20will%20reclaim%20the%20handle%20at%20process%20exit%2C%20so%20the%20*intent*%20is%20correct.%20However%2C%20the%20leak%20is%20entirely%20implicit%3A%20a%20future%20reader%20%28or%20a%20linter%29%20has%20no%20Rust-side%20signal%20that%20the%20drop%20was%20intentional%2C%20and%20a%20second%20call%20from%20the%20same%20process%20would%20unexpectedly%20see%20%60ERROR_ALREADY_EXISTS%60%20on%20its%20own%20mutex.%20Wrapping%20the%20handle%20in%20a%20%60static%20OnceLock%60%20would%20make%20the%20design%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20!handle.is_null%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20last_error%20%3D%3D%20ERROR_ALREADY_EXISTS%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20CloseHandle%28handle%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20false%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Intentionally%20keep%20%60handle%60%20open%20for%20the%20lifetime%20of%20this%20process%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20so%20the%20named%20mutex%20persists%20as%20our%20single-instance%20guard.%0A%20%20%20%20%20%20%20%20%20%20%20%20use%20std%3A%3Async%3A%3AOnceLock%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20static%20TRAY_MUTEX_HANDLE%3A%20OnceLock%3Cusize%3E%20%3D%20OnceLock%3A%3Anew%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20TRAY_MUTEX_HANDLE.get_or_init%28%7C%7C%20handle%20as%20usize%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20true%3B%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix-windows-tray-ghost-icons%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-windows-tray-ghost-icons%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fplatform%2Fwindows.rs%3A3200-3206%0AThe%20Win32%20HANDLE%20obtained%20from%20a%20successful%20%60CreateMutexW%60%20call%20is%20deliberately%20kept%20open%20but%20is%20never%20stored%20anywhere%20%E2%80%94%20the%20function%20simply%20returns%20%60true%60%20and%20the%20raw%20integer%20walks%20off%20the%20stack.%20The%20kernel%20object%20stays%20alive%20because%20Windows%20reference-counts%20it%2C%20and%20the%20OS%20will%20reclaim%20the%20handle%20at%20process%20exit%2C%20so%20the%20*intent*%20is%20correct.%20However%2C%20the%20leak%20is%20entirely%20implicit%3A%20a%20future%20reader%20%28or%20a%20linter%29%20has%20no%20Rust-side%20signal%20that%20the%20drop%20was%20intentional%2C%20and%20a%20second%20call%20from%20the%20same%20process%20would%20unexpectedly%20see%20%60ERROR_ALREADY_EXISTS%60%20on%20its%20own%20mutex.%20Wrapping%20the%20handle%20in%20a%20%60static%20OnceLock%60%20would%20make%20the%20design%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20!handle.is_null%28%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20last_error%20%3D%3D%20ERROR_ALREADY_EXISTS%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20CloseHandle%28handle%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20false%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Intentionally%20keep%20%60handle%60%20open%20for%20the%20lifetime%20of%20this%20process%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20so%20the%20named%20mutex%20persists%20as%20our%20single-instance%20guard.%0A%20%20%20%20%20%20%20%20%20%20%20%20use%20std%3A%3Async%3A%3AOnceLock%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20static%20TRAY_MUTEX_HANDLE%3A%20OnceLock%3Cusize%3E%20%3D%20OnceLock%3A%3Anew%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20TRAY_MUTEX_HANDLE.get_or_init%28%7C%7C%20handle%20as%20usize%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20true%3B%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15690&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/platform/windows.rs:3200-3206
The Win32 HANDLE obtained from a successful `CreateMutexW` call is deliberately kept open but is never stored anywhere — the function simply returns `true` and the raw integer walks off the stack. The kernel object stays alive because Windows reference-counts it, and the OS will reclaim the handle at process exit, so the *intent* is correct. However, the leak is entirely implicit: a future reader (or a linter) has no Rust-side signal that the drop was intentional, and a second call from the same process would unexpectedly see `ERROR_ALREADY_EXISTS` on its own mutex. Wrapping the handle in a `static OnceLock` would make the design self-documenting.

```suggestion
        if !handle.is_null() {
            if last_error == ERROR_ALREADY_EXISTS {
                CloseHandle(handle);
                return false;
            }
            // Intentionally keep `handle` open for the lifetime of this process
            // so the named mutex persists as our single-instance guard.
            use std::sync::OnceLock;
            static TRAY_MUTEX_HANDLE: OnceLock<usize> = OnceLock::new();
            TRAY_MUTEX_HANDLE.get_or_init(|| handle as usize);
            return true;
        }
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(windows): record the confirmed caus..."](https://github.com/rustdesk/rustdesk/commit/a15635ffd976e881e39bdb6678297139ed7bebf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47862133)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/rustdesk/github/rustdesk/rustdesk/-/custom-context?memory=f7c8a0b7-52cb-4813-8d03-0dc35dfcbc0b))
- Context used - AGENTS.md ([source](https://app.greptile.com/rustdesk/github/rustdesk/rustdesk/-/custom-context?memory=6f40c3eb-3820-4b4f-b8a8-5d251a60df3a))

<!-- /greptile_comment -->