### PR TITLE
fix(linux): avoid Xwayland environment fork storm

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1703,6 +1703,17 @@ mod desktop {
                 && self.has_required_session_envs()
         }
 
+        fn set_session_id(&mut self, sid: String) {
+            if self.sid != sid {
+                self.display.clear();
+                self.xauth.clear();
+                self.wl_display.clear();
+                self.dbus.clear();
+                self.xwayland_env_session = None;
+            }
+            self.sid = sid;
+        }
+
         fn get_display_xauth_wayland(&mut self) {
             // Re-run the optional X11 lookup if Xwayland is started again later.
             self.xwayland_env_session = None;
@@ -1733,10 +1744,10 @@ mod desktop {
             }
 
             self.xwayland_env_session = None;
+            // A session change clears every value in set_session_id(). Within the same
+            // session, keep the required Wayland values while refreshing optional X11 ones.
             self.display.clear();
             self.xauth.clear();
-            self.wl_display.clear();
-            self.dbus.clear();
 
             let tray = format!("{} +--tray", crate::get_app_name().to_lowercase());
             let fallback_proc = format!(
@@ -1983,7 +1994,7 @@ mod desktop {
                 return;
             }
 
-            self.sid = seat0_values[0].clone();
+            self.set_session_id(seat0_values[0].clone());
             self.uid = seat0_values[1].clone();
             self.username = seat0_values[2].clone();
             self.protocol = get_display_server_of_session(&self.sid).into();
@@ -2092,6 +2103,33 @@ mod desktop {
             assert!(d.has_cached_xwayland_envs());
             d.sid = "3".to_owned();
             assert!(!d.has_cached_xwayland_envs());
+        }
+
+        #[test]
+        fn session_change_clears_discovered_envs() {
+            let mut d = Desktop {
+                sid: "2".to_owned(),
+                display: ":0".to_owned(),
+                xauth: "/tmp/xauth".to_owned(),
+                wl_display: "wayland-0".to_owned(),
+                dbus: "unix:path=/run/user/1000/bus".to_owned(),
+                xwayland_env_session: Some("2".to_owned()),
+                ..Default::default()
+            };
+
+            d.set_session_id("2".to_owned());
+            assert_eq!(d.display, ":0");
+            assert_eq!(d.xauth, "/tmp/xauth");
+            assert_eq!(d.wl_display, "wayland-0");
+            assert_eq!(d.dbus, "unix:path=/run/user/1000/bus");
+            assert_eq!(d.xwayland_env_session.as_deref(), Some("2"));
+
+            d.set_session_id("3".to_owned());
+            assert!(d.display.is_empty());
+            assert!(d.xauth.is_empty());
+            assert!(d.wl_display.is_empty());
+            assert!(d.dbus.is_empty());
+            assert!(d.xwayland_env_session.is_none());
         }
     }
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1631,6 +1631,13 @@ mod desktop {
     const ENV_KEY_XAUTHORITY: &str = "XAUTHORITY";
     const ENV_KEY_WAYLAND_DISPLAY: &str = "WAYLAND_DISPLAY";
     const ENV_KEY_DBUS_SESSION_BUS_ADDRESS: &str = "DBUS_SESSION_BUS_ADDRESS";
+    const WAYLAND_ENV_KEYS: [&str; 4] = [
+        ENV_KEY_WAYLAND_DISPLAY,
+        ENV_KEY_DBUS_SESSION_BUS_ADDRESS,
+        ENV_KEY_DISPLAY,
+        ENV_KEY_XAUTHORITY,
+    ];
+    const X11_ENV_KEYS: [&str; 2] = [ENV_KEY_DISPLAY, ENV_KEY_XAUTHORITY];
 
     #[derive(Debug, Clone, Default)]
     pub struct Desktop {
@@ -1644,6 +1651,8 @@ mod desktop {
         pub dbus: String,
         pub is_rustdesk_subprocess: bool,
         pub wl_display: String,
+        // Session whose required Xwayland-path environment has been discovered.
+        xwayland_env_session: Option<String>,
     }
 
     impl Desktop {
@@ -1662,19 +1671,44 @@ mod desktop {
             self.sid.is_empty() || self.is_rustdesk_subprocess
         }
 
+        fn fill_missing_env(
+            target: &mut String,
+            envs: &std::collections::HashMap<&str, String>,
+            name: &str,
+        ) {
+            if target.is_empty() {
+                if let Some(value) = envs.get(name).filter(|value| !value.is_empty()) {
+                    target.clone_from(value);
+                }
+            }
+        }
+
+        fn fill_missing_session_envs(&mut self, envs: &std::collections::HashMap<&str, String>) {
+            Self::fill_missing_env(&mut self.display, envs, ENV_KEY_DISPLAY);
+            Self::fill_missing_env(&mut self.xauth, envs, ENV_KEY_XAUTHORITY);
+            Self::fill_missing_env(&mut self.wl_display, envs, ENV_KEY_WAYLAND_DISPLAY);
+            Self::fill_missing_env(&mut self.dbus, envs, ENV_KEY_DBUS_SESSION_BUS_ADDRESS);
+        }
+
+        fn has_required_session_envs(&self) -> bool {
+            if self.is_wayland() {
+                !self.wl_display.is_empty() && !self.dbus.is_empty()
+            } else {
+                !self.display.is_empty() && !self.xauth.is_empty()
+            }
+        }
+
+        fn has_cached_xwayland_envs(&self) -> bool {
+            self.xwayland_env_session.as_deref() == Some(self.sid.as_str())
+                && self.has_required_session_envs()
+        }
+
         fn get_display_xauth_wayland(&mut self) {
+            // Re-run the optional X11 lookup if Xwayland is started again later.
+            self.xwayland_env_session = None;
             for _ in 1..=10 {
                 // Prefer Wayland-related variables first when multiple portal processes match.
-                let mut envs = get_envs(
-                    &self.uid,
-                    XDG_DESKTOP_PORTAL,
-                    &[
-                        ENV_KEY_WAYLAND_DISPLAY,
-                        ENV_KEY_DBUS_SESSION_BUS_ADDRESS,
-                        ENV_KEY_DISPLAY,
-                        ENV_KEY_XAUTHORITY,
-                    ],
-                );
+                let mut envs = get_envs(&self.uid, XDG_DESKTOP_PORTAL, &WAYLAND_ENV_KEYS);
                 self.display = envs.remove(ENV_KEY_DISPLAY).unwrap_or_default();
                 self.xauth = envs.remove(ENV_KEY_XAUTHORITY).unwrap_or_default();
                 self.wl_display = envs.remove(ENV_KEY_WAYLAND_DISPLAY).unwrap_or_default();
@@ -1694,24 +1728,38 @@ mod desktop {
         }
 
         fn get_display_xauth_xwayland(&mut self) {
+            if self.has_cached_xwayland_envs() {
+                return;
+            }
+
+            self.xwayland_env_session = None;
+            self.display.clear();
+            self.xauth.clear();
+            self.wl_display.clear();
+            self.dbus.clear();
+
             let tray = format!("{} +--tray", crate::get_app_name().to_lowercase());
+            let fallback_proc = format!(
+                "{}|{}|{}|{}|{}",
+                XWAYLAND,
+                IBUS_DAEMON,
+                GNOME_GOA_DAEMON,
+                PLASMA_KDED,
+                regex::escape(&tray),
+            );
             for _ in 1..=10 {
-                let display_proc = vec![
-                    XDG_DESKTOP_PORTAL,
-                    XWAYLAND,
-                    IBUS_DAEMON,
-                    GNOME_GOA_DAEMON,
-                    PLASMA_KDED,
-                    tray.as_str(),
-                ];
-                for proc in display_proc {
-                    self.display = get_env(ENV_KEY_DISPLAY, &self.uid, proc);
-                    self.xauth = get_env(ENV_KEY_XAUTHORITY, &self.uid, proc);
-                    self.wl_display = get_env(ENV_KEY_WAYLAND_DISPLAY, &self.uid, proc);
-                    self.dbus = get_env(ENV_KEY_DBUS_SESSION_BUS_ADDRESS, &self.uid, proc);
-                    if !self.display.is_empty() && !self.xauth.is_empty() {
-                        return;
-                    }
+                let portal_envs = get_envs(&self.uid, XDG_DESKTOP_PORTAL, &WAYLAND_ENV_KEYS);
+                self.fill_missing_session_envs(&portal_envs);
+
+                // Keep the controlled-side Xwayland fallback from #5935, but only
+                // supplement values that the portal process did not provide.
+                let fallback_envs = get_envs(&self.uid, &fallback_proc, &X11_ENV_KEYS);
+                self.fill_missing_session_envs(&fallback_envs);
+
+                if self.has_required_session_envs() {
+                    // Optional X11 values must not keep rootless Xwayland sessions retrying.
+                    self.xwayland_env_session = Some(self.sid.clone());
+                    return;
                 }
                 sleep_millis(300);
             }
@@ -1914,8 +1962,12 @@ mod desktop {
 
         pub fn refresh(&mut self) {
             if !self.sid.is_empty() && is_active_and_seat0(&self.sid) {
+                if self.is_login_wayland() {
+                    self.is_rustdesk_subprocess = false;
+                    return;
+                }
                 // Xwayland display and xauth may not be available in a short time after login.
-                if is_xwayland_running() && !self.is_login_wayland() {
+                if is_xwayland_running() {
                     self.get_display_xauth_xwayland();
                     self.is_rustdesk_subprocess = false;
                 } else if self.is_wayland() {
@@ -1978,6 +2030,68 @@ mod desktop {
                     }
                 }
             }
+        }
+
+        #[test]
+        fn required_session_envs_follow_protocol() {
+            let wayland = Desktop {
+                protocol: DISPLAY_SERVER_WAYLAND.to_owned(),
+                wl_display: "wayland-0".to_owned(),
+                dbus: "unix:path=/run/user/1000/bus".to_owned(),
+                ..Default::default()
+            };
+
+            assert!(wayland.has_required_session_envs());
+            assert!(wayland.display.is_empty());
+            assert!(wayland.xauth.is_empty());
+
+            let mut x11 = Desktop {
+                display: ":0".to_owned(),
+                ..Default::default()
+            };
+            assert!(!x11.has_required_session_envs());
+            x11.xauth = "/tmp/xauth".to_owned();
+            assert!(x11.has_required_session_envs());
+        }
+
+        #[test]
+        fn session_envs_fill_only_missing_values() {
+            let mut d = Desktop {
+                display: ":portal".to_owned(),
+                ..Default::default()
+            };
+            let envs = std::collections::HashMap::from([
+                (ENV_KEY_DISPLAY, ":fallback".to_owned()),
+                (ENV_KEY_XAUTHORITY, "/tmp/xauth".to_owned()),
+                (ENV_KEY_WAYLAND_DISPLAY, "wayland-0".to_owned()),
+                (
+                    ENV_KEY_DBUS_SESSION_BUS_ADDRESS,
+                    "unix:path=/run/user/1000/bus".to_owned(),
+                ),
+            ]);
+
+            d.fill_missing_session_envs(&envs);
+
+            assert_eq!(d.display, ":portal");
+            assert_eq!(d.xauth, "/tmp/xauth");
+            assert_eq!(d.wl_display, "wayland-0");
+            assert_eq!(d.dbus, "unix:path=/run/user/1000/bus");
+        }
+
+        #[test]
+        fn xwayland_env_cache_is_scoped_to_session() {
+            let mut d = Desktop {
+                sid: "2".to_owned(),
+                protocol: DISPLAY_SERVER_WAYLAND.to_owned(),
+                wl_display: "wayland-0".to_owned(),
+                dbus: "unix:path=/run/user/1000/bus".to_owned(),
+                xwayland_env_session: Some("2".to_owned()),
+                ..Default::default()
+            };
+
+            assert!(d.has_cached_xwayland_envs());
+            d.sid = "3".to_owned();
+            assert!(!d.has_cached_xwayland_envs());
         }
     }
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1638,6 +1638,7 @@ mod desktop {
         ENV_KEY_XAUTHORITY,
     ];
     const X11_ENV_KEYS: [&str; 2] = [ENV_KEY_DISPLAY, ENV_KEY_XAUTHORITY];
+    const XWAYLAND_X11_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
     #[derive(Debug, Clone, Default)]
     pub struct Desktop {
@@ -1653,6 +1654,8 @@ mod desktop {
         pub wl_display: String,
         // Session whose required Xwayland-path environment has been discovered.
         xwayland_env_session: Option<String>,
+        // Throttle optional X11 discovery when DISPLAY is not available yet.
+        xwayland_x11_retry_at: Option<Instant>,
     }
 
     impl Desktop {
@@ -1698,9 +1701,41 @@ mod desktop {
             }
         }
 
+        fn has_cached_xwayland_envs_at(&self, now: Instant) -> bool {
+            if self.xwayland_env_session.as_deref() != Some(self.sid.as_str())
+                || !self.has_required_session_envs()
+            {
+                return false;
+            }
+
+            if !self.is_wayland() || !self.display.is_empty() {
+                return true;
+            }
+
+            match self.xwayland_x11_retry_at {
+                Some(retry_at) => now < retry_at,
+                None => false,
+            }
+        }
+
         fn has_cached_xwayland_envs(&self) -> bool {
-            self.xwayland_env_session.as_deref() == Some(self.sid.as_str())
-                && self.has_required_session_envs()
+            self.has_cached_xwayland_envs_at(Instant::now())
+        }
+
+        fn cache_xwayland_envs(&mut self, now: Instant) {
+            self.xwayland_env_session = Some(self.sid.clone());
+            self.xwayland_x11_retry_at = if self.is_wayland() && self.display.is_empty() {
+                Some(now + XWAYLAND_X11_RETRY_INTERVAL)
+            } else {
+                None
+            };
+        }
+
+        fn prepare_xwayland_env_refresh(&mut self) {
+            self.xwayland_env_session = None;
+            self.xwayland_x11_retry_at = None;
+            self.display.clear();
+            self.xauth.clear();
         }
 
         fn set_session_id(&mut self, sid: String) {
@@ -1710,6 +1745,7 @@ mod desktop {
                 self.wl_display.clear();
                 self.dbus.clear();
                 self.xwayland_env_session = None;
+                self.xwayland_x11_retry_at = None;
             }
             self.sid = sid;
         }
@@ -1717,6 +1753,7 @@ mod desktop {
         fn get_display_xauth_wayland(&mut self) {
             // Re-run the optional X11 lookup if Xwayland is started again later.
             self.xwayland_env_session = None;
+            self.xwayland_x11_retry_at = None;
             for _ in 1..=10 {
                 // Prefer Wayland-related variables first when multiple portal processes match.
                 let mut envs = get_envs(&self.uid, XDG_DESKTOP_PORTAL, &WAYLAND_ENV_KEYS);
@@ -1743,11 +1780,9 @@ mod desktop {
                 return;
             }
 
-            self.xwayland_env_session = None;
             // A session change clears every value in set_session_id(). Within the same
             // session, keep the required Wayland values while refreshing optional X11 ones.
-            self.display.clear();
-            self.xauth.clear();
+            self.prepare_xwayland_env_refresh();
 
             let tray = format!("{} +--tray", crate::get_app_name().to_lowercase());
             let fallback_proc = format!(
@@ -1768,8 +1803,9 @@ mod desktop {
                 self.fill_missing_session_envs(&fallback_envs);
 
                 if self.has_required_session_envs() {
-                    // Optional X11 values must not keep rootless Xwayland sessions retrying.
-                    self.xwayland_env_session = Some(self.sid.clone());
+                    // Optional X11 values must not block rootless Xwayland sessions. If
+                    // DISPLAY is late, retry one native scan after a short cooldown.
+                    self.cache_xwayland_envs(Instant::now());
                     return;
                 }
                 sleep_millis(300);
@@ -2094,6 +2130,7 @@ mod desktop {
             let mut d = Desktop {
                 sid: "2".to_owned(),
                 protocol: DISPLAY_SERVER_WAYLAND.to_owned(),
+                display: ":0".to_owned(),
                 wl_display: "wayland-0".to_owned(),
                 dbus: "unix:path=/run/user/1000/bus".to_owned(),
                 xwayland_env_session: Some("2".to_owned()),
@@ -2106,6 +2143,51 @@ mod desktop {
         }
 
         #[test]
+        fn xwayland_env_cache_retries_late_display_after_cooldown() {
+            let now = Instant::now();
+            let retry_at = now + XWAYLAND_X11_RETRY_INTERVAL;
+            let mut d = Desktop {
+                sid: "2".to_owned(),
+                protocol: DISPLAY_SERVER_WAYLAND.to_owned(),
+                wl_display: "wayland-0".to_owned(),
+                dbus: "unix:path=/run/user/1000/bus".to_owned(),
+                ..Default::default()
+            };
+
+            d.cache_xwayland_envs(now);
+            assert_eq!(d.xwayland_x11_retry_at, Some(retry_at));
+            assert!(d.has_cached_xwayland_envs_at(now));
+            assert!(!d.has_cached_xwayland_envs_at(retry_at));
+
+            d.display = ":0".to_owned();
+            d.cache_xwayland_envs(retry_at);
+            assert!(d.xwayland_x11_retry_at.is_none());
+            assert!(d.has_cached_xwayland_envs_at(retry_at + XWAYLAND_X11_RETRY_INTERVAL));
+        }
+
+        #[test]
+        fn same_session_xwayland_refresh_preserves_wayland_envs() {
+            let mut d = Desktop {
+                sid: "2".to_owned(),
+                display: ":0".to_owned(),
+                xauth: "/tmp/xauth".to_owned(),
+                wl_display: "wayland-0".to_owned(),
+                dbus: "unix:path=/run/user/1000/bus".to_owned(),
+                xwayland_env_session: Some("2".to_owned()),
+                xwayland_x11_retry_at: Some(Instant::now()),
+                ..Default::default()
+            };
+
+            d.prepare_xwayland_env_refresh();
+            assert!(d.display.is_empty());
+            assert!(d.xauth.is_empty());
+            assert_eq!(d.wl_display, "wayland-0");
+            assert_eq!(d.dbus, "unix:path=/run/user/1000/bus");
+            assert!(d.xwayland_env_session.is_none());
+            assert!(d.xwayland_x11_retry_at.is_none());
+        }
+
+        #[test]
         fn session_change_clears_discovered_envs() {
             let mut d = Desktop {
                 sid: "2".to_owned(),
@@ -2114,6 +2196,7 @@ mod desktop {
                 wl_display: "wayland-0".to_owned(),
                 dbus: "unix:path=/run/user/1000/bus".to_owned(),
                 xwayland_env_session: Some("2".to_owned()),
+                xwayland_x11_retry_at: Some(Instant::now()),
                 ..Default::default()
             };
 
@@ -2123,6 +2206,7 @@ mod desktop {
             assert_eq!(d.wl_display, "wayland-0");
             assert_eq!(d.dbus, "unix:path=/run/user/1000/bus");
             assert_eq!(d.xwayland_env_session.as_deref(), Some("2"));
+            assert!(d.xwayland_x11_retry_at.is_some());
 
             d.set_session_id("3".to_owned());
             assert!(d.display.is_empty());
@@ -2130,6 +2214,7 @@ mod desktop {
             assert!(d.wl_display.is_empty());
             assert!(d.dbus.is_empty());
             assert!(d.xwayland_env_session.is_none());
+            assert!(d.xwayland_x11_retry_at.is_none());
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace the repeated per-variable `get_env()` shell pipelines in Xwayland environment discovery with native `/proc` scans through `get_envs()`
- keep portal-discovered values and supplement only missing `DISPLAY` / `XAUTHORITY` values from the existing Xwayland fallback processes
- require `WAYLAND_DISPLAY` and `DBUS_SESSION_BUS_ADDRESS` for Wayland sessions while keeping the X11 success condition unchanged
- cache successful Xwayland-path discovery per logind session
- explicitly skip user-session discovery for active GDM Wayland login sessions

## Background

This addresses the fork storm reported in #15554. A rootless Xwayland process can export `DISPLAY` without `XAUTHORITY`; the old `DISPLAY && XAUTHORITY` success condition then runs the full 10 retries × 6 process patterns × 4 variables, spawning up to 240 shell pipelines on every refresh.

#15561 fixed the symptom by changing refresh routing, but review identified regressions in the GDM login-screen protection from #8111 and the controlled-side Xwayland fallback from #5935. This patch follows the compatible direction requested in that review without reordering those protocol branches.

For a Wayland session, each retry now performs one native portal scan for all session variables and one native scan across the combined fallback process pattern for the two optional X11 variables. Once the required Wayland values are present, missing optional X11 values do not keep the retry loop alive.

## Validation

- `git diff --check`
- `cargo metadata --no-deps --format-version 1`
- focused Rust logic harness: 3 passed
  - Wayland success does not require X11 variables
  - fallback values do not overwrite portal values
  - the cache is scoped to the logind session
- live reproduction on Arch Linux / Hyprland / RustDesk 1.4.9:
  - `xdg-desktop-portal` exports `WAYLAND_DISPLAY`, D-Bus, and `DISPLAY`, but no `XAUTHORITY`
  - the installed service previously consumed about 64% of one core while idle
  - forcing the existing native Wayland discovery path reduced it to about 2.94% of one core

`cargo test --lib platform::linux::desktop::tests --no-default-features` was attempted, but dependency resolution stalled while fetching the pinned `rustdesk-org/wezterm` Git dependency. A full upstream build result is therefore still pending.

Addresses #15554.
Follow-up to #15561.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux desktop-session detection across Wayland, X11, and Xwayland environments.
  * Preserved valid session settings while filling in missing display and authentication details.
  * Improved handling when sessions change, including refreshed environment discovery and retries.
  * Fixed login Wayland session processing to avoid unnecessary follow-up actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Xwayland environment fork storm (#15554) by replacing per-variable shell pipeline spawns (up to 240 `get_env()` calls per refresh cycle) with native `/proc` scans via `get_envs()`, and adds per-logind-session caching to avoid redundant re-discovery. It also moves the GDM Wayland early-return guard into the fast path so it is consistently applied in both the initial and repeated refresh branches.

- **Fork storm eliminated**: `get_display_xauth_xwayland` now performs at most two `/proc` scans per retry (portal + fallback) instead of spawning 6 × 4 shell pipelines. The `has_cached_xwayland_envs()` short-circuit skips the retry loop entirely when the session's required environment is already known.
- **Wayland/X11 split success conditions**: `WAYLAND_DISPLAY` + `DBUS_SESSION_BUS_ADDRESS` are required for Wayland sessions; `DISPLAY` + `XAUTHORITY` remain required for X11. `XAUTHORITY` is now explicitly optional for Wayland.
- **Session-scoped cache with late-X11 cooldown**: `prepare_xwayland_env_refresh` preserves `wl_display`/`dbus` while clearing only the X11 fields on re-entry, and a 5-second retry interval gates re-scans for a missing `DISPLAY`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change eliminates a well-documented fork storm without altering any externally observable session detection outcomes for normal Wayland, Xwayland, or X11 sessions.

The reworked discovery path is mechanically sound: get_envs reads /proc once per call and returns a single consistent process snapshot, fill_missing_session_envs never overwrites a value already set, and has_cached_xwayland_envs_at correctly gates re-scans per logind session. Five targeted unit tests cover the cache hit/miss, late-DISPLAY cooldown, same-session preservation, and cross-session clearing scenarios.

**Files Needing Attention:** No files require special attention. src/platform/linux.rs is the only changed file and the new cache fields and helper methods are well isolated from unrelated discovery paths.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/platform/linux.rs | Replaces shell-spawning get_env() loop with native /proc scans, adds per-session Xwayland environment caching with a late-DISPLAY retry interval, fixes GDM Wayland fast-path guard, and adds 5 unit tests covering the new cache logic. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(linux): retry late Xwayland display ..."](https://github.com/rustdesk/rustdesk/commit/5b0b45c452d74d6cb6b150d4d6b5f18ac2d44d21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47878515)</sub>

<!-- /greptile_comment -->