### PR TITLE
refact(oidc): login with api domain

### DIFF
--- a/src/hbbs_http/account.rs
+++ b/src/hbbs_http/account.rs
@@ -169,6 +169,7 @@ impl OidcSession {
             "id": id,
             "uuid": uuid,
             "deviceInfo": crate::ui_interface::get_login_device_info(),
+            "apiDomain": api_server,
         })
         .to_string();
         let resp = crate::post_request_sync(format!("{}/api/oidc/auth", api_server), body, "")?;


### PR DESCRIPTION
Log in with `apiDomain` which is used to test the trusted origins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC authentication compatibility by including the API domain in authentication requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `"apiDomain": api_server` to the JSON body sent to the `/api/oidc/auth` endpoint during OIDC login. The intent is to let the server verify trusted origins by receiving the client's configured API domain alongside the auth request.

- The `api_server` string is already used to construct the request URL, so the new field is simply echoing back the server address the client already connected to — it does not expand the attack surface.
- `serde_json::json!()` properly escapes the string, ruling out JSON injection.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-field addition to an existing JSON request body with no new error paths or data-flow changes.

The change is a one-line addition that sends the already-known api_server address back to itself as apiDomain. The value is already trusted (it's the server the client is talking to) and is safely serialized. No new branches, state mutations, or dependencies are introduced.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/hbbs_http/account.rs | Adds `"apiDomain": api_server` to the OIDC auth request body; one-line change, no new error paths or data-flow issues introduced. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as RustDesk Client
    participant Server as API Server (api_server)
    participant OIDC as OIDC Provider

    Client->>Server: "POST /api/oidc/auth { op, id, uuid, deviceInfo, apiDomain }"
    Note over Server: Server verifies apiDomain against trusted origins
    Server-->>Client: "{ code, url }"
    Client->>OIDC: Open browser to url (OIDC login page)
    OIDC-->>Server: Callback with auth result
    loop Poll until authed or timeout
        Client->>Server: "GET /api/oidc/auth-query?code=..."
        Server-->>Client: AuthBody (access_token) or No authed oidc found
    end
    Client->>Client: Store access_token (if remember_me)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refact(oidc): login with api domain"](https://github.com/rustdesk/rustdesk/commit/7ebdf8876383af5decf51b860fb8281809365556) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48268691)</sub>

<!-- /greptile_comment -->