### PR TITLE
test3

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -21,4 +21,4 @@ jobs:
   run-ci:
     uses: ./.github/workflows/flutter-build.yml
     with:
-      upload-artifact: false
+      upload-artifact: true

--- a/flutter/android/app/src/main/AndroidManifest.xml
+++ b/flutter/android/app/src/main/AndroidManifest.xml
@@ -78,6 +78,12 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="rustdesk" />
             </intent-filter>
+
+             <!-- НОВЫЙ фильтр для открытия меню Screen Sharing -->
+            <intent-filter>
+                <action android:name="com.carriez.flutter_hbb.action.OPEN_SCREEN_SHARING" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -45,6 +45,7 @@ class MainActivity : FlutterActivity() {
 
     private val channelTag = "mChannel"
     private val logTag = "mMainActivity"
+    private var pendingIntentAction: String? = null
     private var mainService: MainService? = null
 
     private var isAudioStart = false
@@ -62,6 +63,12 @@ class MainActivity : FlutterActivity() {
             channelTag
         )
         initFlutterChannel(flutterMethodChannel!!)
+        // === ДОБАВЛЕНО: обработка Intent, полученного до готовности FlutterEngine ===
+        pendingIntentAction?.let { action ->
+            sendIntentToFlutter(flutterEngine, action)
+            pendingIntentAction = null
+        }
+        // =================================
         thread {
             try {
                 setCodecInfo()
@@ -96,12 +103,18 @@ class MainActivity : FlutterActivity() {
         }
     }
 
+    override fun onNewIntent(intent: Intent) {        // === ДОБАВЛЕНО ===
+        super.onNewIntent(intent)
+        handleIntent(intent)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (_rdClipboardManager == null) {
             _rdClipboardManager = RdClipboardManager(getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
             FFI.setClipboardManager(_rdClipboardManager!!)
         }
+        handleIntent(intent)                          // === ДОБАВЛЕНО ===
     }
 
     override fun onDestroy() {
@@ -274,12 +287,37 @@ class MainActivity : FlutterActivity() {
                 "on_voice_call_closed" -> {
                     onVoiceCallClosed()
                 }
+                // === ДОБАВЛЕНО ===
+                "onIntent" -> {
+                    val action = call.argument<String>("action")
+                    // Здесь можно обработать, если нужно что-то вернуть
+                    result.success(null)
+                }
+                // =================
                 else -> {
                     result.error("-1", "No such method", null)
                 }
             }
         }
     }
+
+    // === ДОБАВЛЕННЫЕ МЕТОДЫ ===
+    private fun handleIntent(intent: Intent?) {
+        if (intent?.action == "com.carriez.flutter_hbb.action.OPEN_SCREEN_SHARING") {
+            val engine = flutterEngine
+            if (engine != null) {
+                sendIntentToFlutter(engine, intent.action!!)
+            } else {
+                pendingIntentAction = intent.action!!
+            }
+        }
+    }
+
+    private fun sendIntentToFlutter(engine: FlutterEngine, action: String) {
+        MethodChannel(engine.dartExecutor.binaryMessenger, channelTag)
+            .invokeMethod("onIntent", mapOf("action" to action))
+    }
+    // ===========================
 
     private fun setCodecInfo() {
         val codecList = MediaCodecList(MediaCodecList.REGULAR_CODECS)

--- a/flutter/lib/mobile/pages/server_page.dart
+++ b/flutter/lib/mobile/pages/server_page.dart
@@ -965,7 +965,7 @@ void androidChannelInit() {
 
 void _openScreenSharing() {
   // Используем Get для навигации, так как приложение уже на GetMaterialApp
-  Get.to(() => const ServerPage());
+  Get.to(() => ServerPage());
 }
 
 void showScamWarning(BuildContext context, ServerModel serverModel) {

--- a/flutter/lib/mobile/pages/server_page.dart
+++ b/flutter/lib/mobile/pages/server_page.dart
@@ -947,12 +947,25 @@ void androidChannelInit() {
             }
             break;
           }
+        case "onIntent":
+          {
+            final action = arguments['action'] as String?;
+            if (action == 'com.carriez.flutter_hbb.action.OPEN_SCREEN_SHARING') {
+              _openScreenSharing();
+            }
+            break;
+          }
       }
     } catch (e) {
       debugPrintStack(label: "MethodCallHandler err:$e");
     }
     return "";
   });
+}
+
+void _openScreenSharing() {
+  // Используем Get для навигации, так как приложение уже на GetMaterialApp
+  Get.to(() => const ServerPage());
 }
 
 void showScamWarning(BuildContext context, ServerModel serverModel) {


### PR DESCRIPTION
uytu

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an Android intent-based mechanism to open the RustDesk screen-sharing page (`ServerPage`) from outside the app, wiring up a new custom intent-filter in the manifest, Kotlin intent-handling code in `MainActivity`, and a Dart handler in `server_page.dart`. It also flips the CI workflow's artifact-upload flag to `true`.

- **CI change**: `upload-artifact` is set to `true` in the shared Flutter CI workflow, which will upload build artifacts on every run — this looks like a leftover debug change and should be reverted.
- **Security concern**: The new `OPEN_SCREEN_SHARING` intent-filter is attached to the already-exported `MainActivity` with no permission guard, allowing any app on the device to force-open the screen-sharing UI.
- **Timing bug**: The pending-intent is dispatched inside `configureFlutterEngine` before Dart code has started, so the `onIntent` message is sent before the Dart handler is registered and will be silently dropped.
- **Navigation bug**: `_openScreenSharing()` pushes `ServerPage` as a standalone `Get.to()` route instead of switching to the correct tab in `HomePage`, resulting in a navigation-bar-less floating screen.
</details>

<details><summary><h3>Confidence Score: 1/5</h3></summary>

Not safe to merge: the CI artifact change is a debug leftover, the core intent-routing feature has a timing bug that silently drops cold-start intents, the navigation approach breaks the app's tab structure, and the unguarded exported intent-filter introduces a security concern.

The PR has four distinct defects across all four changed files. The CI artifact upload change affects every build on master. The Kotlin timing issue means the primary feature (cold-start intent routing) doesn't actually work. The Dart navigation approach produces a broken UI. The unprotected intent-filter on an exported activity lets any installed app open the screen-sharing setup page without user intent.

**Files Needing Attention:** All four changed files need attention: the CI workflow flag must be reverted, the manifest needs a permission guard on the new intent-filter, `MainActivity.kt` needs the pending-intent dispatch moved to after Dart is ready, and `server_page.dart` needs the navigation fixed to switch tabs rather than push a standalone route.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Unprotected exported activity intent-filter** (`AndroidManifest.xml`): The new `com.carriez.flutter_hbb.action.OPEN_SCREEN_SHARING` intent-filter is registered on `MainActivity`, which is already `android:exported=\"true\"`. Any third-party app can send this intent to force-open the screen-sharing UI, potentially tricking a user into granting screen-capture permission. The filter should be protected with a `android:permission` attribute using `protectionLevel=\"signature\"`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/flutter-ci.yml | Enables artifact uploads for every CI run by flipping `upload-artifact` to `true`; this is a debug-only change that should not be merged to master |
| flutter/android/app/src/main/AndroidManifest.xml | Adds an unprotected custom intent-filter to the exported `MainActivity`, allowing any third-party app to open the screen-sharing UI without user consent |
| flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt | Adds intent-routing to Flutter via a pending-intent pattern, but dispatches the intent inside `configureFlutterEngine` before the Dart handler is registered, causing the message to be silently dropped |
| flutter/lib/mobile/pages/server_page.dart | Adds `_openScreenSharing()` which uses `Get.to()` to push a standalone `ServerPage` outside the tab structure, breaking navigation UX and potentially creating duplicate instances |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ExtApp as External App
    participant OS as Android OS
    participant Main as MainActivity (Kotlin)
    participant Engine as FlutterEngine
    participant Dart as server_page.dart (Dart)

    ExtApp->>OS: startActivity(OPEN_SCREEN_SHARING intent)
    OS->>Main: onNewIntent() / onCreate()
    Main->>Main: handleIntent(intent)
    alt FlutterEngine ready
        Main->>Engine: MethodChannel.invokeMethod("onIntent", action)
        Engine->>Dart: onIntent handler (androidChannelInit)
        Dart->>Dart: _openScreenSharing() → Get.to(ServerPage)
    else FlutterEngine not ready
        Main->>Main: "pendingIntentAction = action"
        Note over Main,Engine: configureFlutterEngine() called later
        Main->>Engine: sendIntentToFlutter() ⚠️ Dart handler not yet registered
        Engine--xDart: message dropped (no handler)
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fflutter-ci.yml%3A24%0A**CI%20artifact%20uploads%20enabled%20for%20every%20run**%0A%0ASetting%20%60upload-artifact%3A%20true%60%20in%20the%20shared%20CI%20workflow%20means%20every%20triggered%20build%20%E2%80%94%20including%20every%20PR%20and%20branch%20push%20%E2%80%94%20will%20upload%20build%20artifacts.%20This%20substantially%20increases%20repository%20storage%20consumption%20and%20CI%20costs%2C%20and%20is%20typically%20reserved%20for%20release%20or%20nightly%20builds.%20This%20appears%20to%20be%20a%20debug-only%20change%20%28matching%20the%20PR%20title%20%22test3%22%29%20and%20should%20be%20reverted%20before%20merging.%0A%0A%23%23%23%20Issue%202%0Aflutter%2Fandroid%2Fapp%2Fsrc%2Fmain%2FAndroidManifest.xml%3A83-86%0A**Custom%20intent-filter%20on%20exported%20activity%20is%20reachable%20by%20any%20app**%0A%0A%60MainActivity%60%20already%20has%20%60android%3Aexported%3D%22true%22%60%2C%20so%20registering%20a%20custom%20%60OPEN_SCREEN_SHARING%60%20intent-filter%20means%20any%20other%20app%20installed%20on%20the%20device%20can%20fire%20%60startActivity%28Intent%28%22com.carriez.flutter_hbb.action.OPEN_SCREEN_SHARING%22%29%29%60%20and%20force%20RustDesk%20to%20navigate%20to%20the%20screen-sharing%20setup%20UI%20without%20any%20user%20action%20inside%20RustDesk.%20A%20malicious%20app%20could%20use%20this%20to%20confuse%20users%20into%20granting%20screen-capture%20permission%20while%20the%20user%20believes%20they%20initiated%20the%20action%20themselves.%20If%20the%20intent%20must%20be%20accepted%2C%20it%20should%20be%20guarded%20with%20a%20custom%20permission%20%28%60android%3Apermission%60%29%20declared%20with%20%60protectionLevel%3D%22signature%22%60%20so%20only%20apps%20signed%20with%20the%20same%20key%20can%20send%20it.%0A%0A%23%23%23%20Issue%203%0Aflutter%2Fandroid%2Fapp%2Fsrc%2Fmain%2Fkotlin%2Fcom%2Fcarriez%2Fflutter_hbb%2FMainActivity.kt%3A66-70%0A**Intent%20dispatched%20before%20Dart%20handler%20is%20registered%20%E2%80%94%20will%20be%20silently%20dropped**%0A%0A%60sendIntentToFlutter%60%20is%20called%20inside%20%60configureFlutterEngine%60%2C%20which%20runs%20before%20the%20Flutter%2FDart%20engine%20has%20executed%20any%20Dart%20code.%20The%20%60onIntent%60%20handler%20on%20the%20Dart%20side%20is%20registered%20in%20%60androidChannelInit%28%29%60%2C%20which%20is%20invoked%20from%20Dart%20code%20that%20starts%20running%20only%20after%20%60configureFlutterEngine%60%20returns%20and%20the%20engine%20actually%20launches.%20Calling%20%60invokeMethod%28%22onIntent%22%2C%20...%29%60%20at%20this%20point%20races%20against%20Dart%20startup%3B%20in%20practice%20the%20%60MethodChannel%60%20message%20is%20sent%20with%20no%20handler%20on%20the%20Dart%20side%2C%20so%20it%20is%20silently%20discarded%20and%20the%20intent%20is%20lost.%20The%20pending-intent%20pattern%20here%20solves%20the%20problem%20of%20the%20engine%20not%20existing%20yet%2C%20but%20doesn't%20solve%20the%20problem%20of%20the%20Dart%20handler%20not%20being%20registered%20yet.%20The%20intent%20should%20be%20stored%20and%20re-dispatched%20once%20the%20Dart%20side%20signals%20readiness%20%28e.g.%2C%20from%20within%20%60androidChannelInit%28%29%60%20itself%20via%20a%20round-trip%20call%29.%0A%0A%23%23%23%20Issue%204%0Aflutter%2Flib%2Fmobile%2Fpages%2Fserver_page.dart%3A966-969%0A**%60Get.to%28%29%60%20creates%20an%20orphaned%20%60ServerPage%60%20outside%20the%20tab%20navigation**%0A%0A%60Get.to%28%28%29%20%3D%3E%20ServerPage%28%29%29%60%20pushes%20%60ServerPage%60%20as%20a%20new%20named%20route%20on%20top%20of%20whatever%20is%20currently%20on%20the%20navigation%20stack.%20%60ServerPage%60%20normally%20lives%20as%20a%20tab%20inside%20%60HomePage%60%20%28bottom%20navigation%29.%20Pushing%20it%20as%20an%20independent%20route%20creates%20a%20floating%20page%20without%20the%20%60BottomNavigationBar%60%2C%20making%20it%20impossible%20for%20the%20user%20to%20navigate%20back%20to%20the%20other%20tabs%20except%20via%20the%20back%20button.%20If%20the%20user%20is%20already%20on%20the%20%60ServerPage%60%20tab%20this%20also%20creates%20a%20duplicate%20instance%20with%20its%20own%20timer%20and%20%60checkService%60%20calls.%20The%20correct%20approach%20is%20to%20navigate%20to%20%60HomePage%60%20and%20then%20switch%20the%20bottom-nav%20index%20to%20the%20%60ServerPage%60%20tab%2C%20rather%20than%20pushing%20a%20new%20standalone%20route.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15711&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22master%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22master%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fflutter-ci.yml%3A24%0A**CI%20artifact%20uploads%20enabled%20for%20every%20run**%0A%0ASetting%20%60upload-artifact%3A%20true%60%20in%20the%20shared%20CI%20workflow%20means%20every%20triggered%20build%20%E2%80%94%20including%20every%20PR%20and%20branch%20push%20%E2%80%94%20will%20upload%20build%20artifacts.%20This%20substantially%20increases%20repository%20storage%20consumption%20and%20CI%20costs%2C%20and%20is%20typically%20reserved%20for%20release%20or%20nightly%20builds.%20This%20appears%20to%20be%20a%20debug-only%20change%20%28matching%20the%20PR%20title%20%22test3%22%29%20and%20should%20be%20reverted%20before%20merging.%0A%0A%23%23%23%20Issue%202%0Aflutter%2Fandroid%2Fapp%2Fsrc%2Fmain%2FAndroidManifest.xml%3A83-86%0A**Custom%20intent-filter%20on%20exported%20activity%20is%20reachable%20by%20any%20app**%0A%0A%60MainActivity%60%20already%20has%20%60android%3Aexported%3D%22true%22%60%2C%20so%20registering%20a%20custom%20%60OPEN_SCREEN_SHARING%60%20intent-filter%20means%20any%20other%20app%20installed%20on%20the%20device%20can%20fire%20%60startActivity%28Intent%28%22com.carriez.flutter_hbb.action.OPEN_SCREEN_SHARING%22%29%29%60%20and%20force%20RustDesk%20to%20navigate%20to%20the%20screen-sharing%20setup%20UI%20without%20any%20user%20action%20inside%20RustDesk.%20A%20malicious%20app%20could%20use%20this%20to%20confuse%20users%20into%20granting%20screen-capture%20permission%20while%20the%20user%20believes%20they%20initiated%20the%20action%20themselves.%20If%20the%20intent%20must%20be%20accepted%2C%20it%20should%20be%20guarded%20with%20a%20custom%20permission%20%28%60android%3Apermission%60%29%20declared%20with%20%60protectionLevel%3D%22signature%22%60%20so%20only%20apps%20signed%20with%20the%20same%20key%20can%20send%20it.%0A%0A%23%23%23%20Issue%203%0Aflutter%2Fandroid%2Fapp%2Fsrc%2Fmain%2Fkotlin%2Fcom%2Fcarriez%2Fflutter_hbb%2FMainActivity.kt%3A66-70%0A**Intent%20dispatched%20before%20Dart%20handler%20is%20registered%20%E2%80%94%20will%20be%20silently%20dropped**%0A%0A%60sendIntentToFlutter%60%20is%20called%20inside%20%60configureFlutterEngine%60%2C%20which%20runs%20before%20the%20Flutter%2FDart%20engine%20has%20executed%20any%20Dart%20code.%20The%20%60onIntent%60%20handler%20on%20the%20Dart%20side%20is%20registered%20in%20%60androidChannelInit%28%29%60%2C%20which%20is%20invoked%20from%20Dart%20code%20that%20starts%20running%20only%20after%20%60configureFlutterEngine%60%20returns%20and%20the%20engine%20actually%20launches.%20Calling%20%60invokeMethod%28%22onIntent%22%2C%20...%29%60%20at%20this%20point%20races%20against%20Dart%20startup%3B%20in%20practice%20the%20%60MethodChannel%60%20message%20is%20sent%20with%20no%20handler%20on%20the%20Dart%20side%2C%20so%20it%20is%20silently%20discarded%20and%20the%20intent%20is%20lost.%20The%20pending-intent%20pattern%20here%20solves%20the%20problem%20of%20the%20engine%20not%20existing%20yet%2C%20but%20doesn't%20solve%20the%20problem%20of%20the%20Dart%20handler%20not%20being%20registered%20yet.%20The%20intent%20should%20be%20stored%20and%20re-dispatched%20once%20the%20Dart%20side%20signals%20readiness%20%28e.g.%2C%20from%20within%20%60androidChannelInit%28%29%60%20itself%20via%20a%20round-trip%20call%29.%0A%0A%23%23%23%20Issue%204%0Aflutter%2Flib%2Fmobile%2Fpages%2Fserver_page.dart%3A966-969%0A**%60Get.to%28%29%60%20creates%20an%20orphaned%20%60ServerPage%60%20outside%20the%20tab%20navigation**%0A%0A%60Get.to%28%28%29%20%3D%3E%20ServerPage%28%29%29%60%20pushes%20%60ServerPage%60%20as%20a%20new%20named%20route%20on%20top%20of%20whatever%20is%20currently%20on%20the%20navigation%20stack.%20%60ServerPage%60%20normally%20lives%20as%20a%20tab%20inside%20%60HomePage%60%20%28bottom%20navigation%29.%20Pushing%20it%20as%20an%20independent%20route%20creates%20a%20floating%20page%20without%20the%20%60BottomNavigationBar%60%2C%20making%20it%20impossible%20for%20the%20user%20to%20navigate%20back%20to%20the%20other%20tabs%20except%20via%20the%20back%20button.%20If%20the%20user%20is%20already%20on%20the%20%60ServerPage%60%20tab%20this%20also%20creates%20a%20duplicate%20instance%20with%20its%20own%20timer%20and%20%60checkService%60%20calls.%20The%20correct%20approach%20is%20to%20navigate%20to%20%60HomePage%60%20and%20then%20switch%20the%20bottom-nav%20index%20to%20the%20%60ServerPage%60%20tab%2C%20rather%20than%20pushing%20a%20new%20standalone%20route.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15711&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/flutter-ci.yml:24
**CI artifact uploads enabled for every run**

Setting `upload-artifact: true` in the shared CI workflow means every triggered build — including every PR and branch push — will upload build artifacts. This substantially increases repository storage consumption and CI costs, and is typically reserved for release or nightly builds. This appears to be a debug-only change (matching the PR title "test3") and should be reverted before merging.

### Issue 2
flutter/android/app/src/main/AndroidManifest.xml:83-86
**Custom intent-filter on exported activity is reachable by any app**

`MainActivity` already has `android:exported="true"`, so registering a custom `OPEN_SCREEN_SHARING` intent-filter means any other app installed on the device can fire `startActivity(Intent("com.carriez.flutter_hbb.action.OPEN_SCREEN_SHARING"))` and force RustDesk to navigate to the screen-sharing setup UI without any user action inside RustDesk. A malicious app could use this to confuse users into granting screen-capture permission while the user believes they initiated the action themselves. If the intent must be accepted, it should be guarded with a custom permission (`android:permission`) declared with `protectionLevel="signature"` so only apps signed with the same key can send it.

### Issue 3
flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt:66-70
**Intent dispatched before Dart handler is registered — will be silently dropped**

`sendIntentToFlutter` is called inside `configureFlutterEngine`, which runs before the Flutter/Dart engine has executed any Dart code. The `onIntent` handler on the Dart side is registered in `androidChannelInit()`, which is invoked from Dart code that starts running only after `configureFlutterEngine` returns and the engine actually launches. Calling `invokeMethod("onIntent", ...)` at this point races against Dart startup; in practice the `MethodChannel` message is sent with no handler on the Dart side, so it is silently discarded and the intent is lost. The pending-intent pattern here solves the problem of the engine not existing yet, but doesn't solve the problem of the Dart handler not being registered yet. The intent should be stored and re-dispatched once the Dart side signals readiness (e.g., from within `androidChannelInit()` itself via a round-trip call).

### Issue 4
flutter/lib/mobile/pages/server_page.dart:966-969
**`Get.to()` creates an orphaned `ServerPage` outside the tab navigation**

`Get.to(() => ServerPage())` pushes `ServerPage` as a new named route on top of whatever is currently on the navigation stack. `ServerPage` normally lives as a tab inside `HomePage` (bottom navigation). Pushing it as an independent route creates a floating page without the `BottomNavigationBar`, making it impossible for the user to navigate back to the other tabs except via the back button. If the user is already on the `ServerPage` tab this also creates a duplicate instance with its own timer and `checkService` calls. The correct approach is to navigate to `HomePage` and then switch the bottom-nav index to the `ServerPage` tab, rather than pushing a new standalone route.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update flutter-ci.yml"](https://github.com/rustdesk/rustdesk/commit/a34c9907192e54a394753f21f09a05d8b11a70a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48375681)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening the Screen Sharing menu through an Android intent.
  * Screen Sharing now opens correctly when triggered before the app is fully initialized.
  * Enabled CI build artifact uploads for improved access to generated build files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->