### PR TITLE
docs: fix 'lowlevel' spelling to 'low-level' in libs/clipboard/README.md

### DIFF
--- a/libs/clipboard/README.md
+++ b/libs/clipboard/README.md
@@ -1,7 +1,7 @@
 # clipboard
 
 Copy files and text through network.
-Main lowlevel logic from [FreeRDP](https://github.com/FreeRDP/FreeRDP).
+Main low-level logic from [FreeRDP](https://github.com/FreeRDP/FreeRDP).
 
 To enjoy file copy and paste feature on Linux/OSX,
 please build with `unix-file-copy-paste` feature.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `libs/clipboard/README.md` (line 4).

## Problem

"lowlevel" is not a standard English word; should be "low-level".

The problematic text:

```markdown
Main lowlevel logic from [FreeRDP]
```

## Fix

Replaced with:

```markdown
Main low-level logic from [FreeRDP]
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes a single documentation spelling fix in `libs/clipboard/README.md`, correcting "lowlevel" to the standard hyphenated form "low-level". No code or logic is affected.

- Fixes the non-standard compound adjective "lowlevel" → "low-level" on line 4 of `libs/clipboard/README.md`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only a single word in a documentation file is changed.

The change is limited to one word in a README with no effect on code, build, or runtime behavior.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/clipboard/README.md | Single-word typo fix: "lowlevel" → "low-level" on line 4; no other changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix &#39;lowlevel&#39; spelling to &#39;low-le..."](https://github.com/rustdesk/rustdesk/commit/cf99d473d8e1ea656b27d755671c8293356f9501) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48382118)</sub>

<!-- /greptile_comment -->