### PR TITLE
docs: fix 'gressful' misspelling to 'graceful' in libs/clipboard/README.md

### DIFF
--- a/libs/clipboard/README.md
+++ b/libs/clipboard/README.md
@@ -151,7 +151,7 @@ the FUSE server will figure out the file system tree and rearrange its content.
 - you may notice
   the mountpoint is still occupied after the application quits.
   That's because the FUSE server was not mounted with `AUTO_UNMOUNT`.
-  - It's hard to implement gressful shutdown for a multi-processed program
+  - It's hard to implement graceful shutdown for a multi-processed program
   - `AUTO_UNMOUNT` was not enabled by default and requires enable
     `user_allow_other` in configure. Letting users edit such global
     configuration to use this feature might not be a good idea.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `libs/clipboard/README.md` (line 154).

## Problem

"gressful" is not a word; should be "graceful".

The problematic text:

```markdown
It's hard to implement gressful shutdown
```

## Fix

Replaced with:

```markdown
It's hard to implement graceful shutdown
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a single-word typo in `libs/clipboard/README.md`, correcting "gressful" to "graceful" on line 154.

- Corrects the misspelling in the phrase "It's hard to implement gressful shutdown for a multi-processed program" → "graceful shutdown".
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it changes a single word in a documentation file with no code or logic impact.

The change corrects a straightforward typo ("gressful" → "graceful") in one README file. No code, configuration, or behavior is modified.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/clipboard/README.md | Single-word typo fix: "gressful" → "graceful". Documentation-only change with no functional impact. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix &#39;gressful&#39; misspelling to &#39;gra..."](https://github.com/rustdesk/rustdesk/commit/f07e215ed51f9ed2d14084da217e4d07471233d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48382221)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the Groceries section describing graceful shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->