### PR TITLE
docs: fix double space in CODE_OF_CONDUCT.md

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -107,7 +107,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/CODE_OF_CONDUCT.md` (line 110).

## Problem

Double space after the comma before "harassment".

The problematic text:

```markdown
including sustained inappropriate behavior,  harassment
```

## Fix

Replaced with:

```markdown
including sustained inappropriate behavior, harassment
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes a double space after a comma in `docs/CODE_OF_CONDUCT.md` line 110, correcting a minor typographical error in the "Permanent Ban" section.

- Removes one extra space between `"inappropriate behavior,"` and `"harassment"` to produce correctly spaced prose.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — removes one extraneous space character from a markdown documentation file with no code or logic involved.

The change is a single-character whitespace correction in a documentation-only file. There is no executable code, configuration, or behavior affected.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/CODE_OF_CONDUCT.md | Single-character whitespace fix — removes an extra space after a comma in the Permanent Ban section; no logic or structure affected. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[docs/CODE_OF_CONDUCT.md] --> B["Before: 'behavior,  harassment'\n(double space)"]
    B --> C["After: 'behavior, harassment'\n(single space)"]
    C --> D[No other files changed]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix double space in CODE\_OF\_CONDUC..."](https://github.com/rustdesk/rustdesk/commit/3c77727fca83e03adb462bdc2b501dfc28322f12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48382323)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spacing in the “Permanent Ban” section of the Code of Conduct for improved formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->