### PR TITLE
chore(flutter): point window_manager at the post-revert main

### DIFF
--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -1589,7 +1589,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "7d9a674818826d7205dcf2d36ebbd2c46df3aaff"
+      resolved-ref: cf4aef0512092fad9344a27ffe1c47ad83269dfc
       url: "https://github.com/rustdesk-org/window_manager"
     source: git
     version: "0.3.6"


### PR DESCRIPTION
The lock still pinned 7d9a674, the commit rustdesk-org/window_manager#8 reverted. Move it to current main (cf4aef0), which carries the reworked guard for methods called after the toplevel window is destroyed.

Edited by hand rather than via pub upgrade: upgrading re-resolved 17 packages, downgrading some and pulling flutter_test and its leak_tracker tree in as new entries, none of which belongs in this change.

https://github.com/rustdesk/rustdesk/issues/15703