### PR TITLE
Fix flutter white window forceredraw

### DIFF
--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -340,7 +340,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: 340ca4358ae87992e7afe4baadeacaaea6fb28de
+      resolved-ref: f8c4fce53014e21b9b58e9f12382bcd45d984d5d
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -340,7 +340,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: b47e8385e5a75d38319ad706a64b0ead3108b093
+      resolved-ref: 340ca4358ae87992e7afe4baadeacaaea6fb28de
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"

--- a/flutter/windows/runner/flutter_window.cpp
+++ b/flutter/windows/runner/flutter_window.cpp
@@ -14,7 +14,6 @@
 
 #include <windows.h>
 
-#include <iostream>
 #include <optional>
 #include <memory>
 
@@ -42,9 +41,12 @@ namespace {
 //   window created hidden and shown later, with nothing scheduling a frame.
 // - The SetNextFrameCallback used to detect the first frame fires when a frame
 //   is GENERATED (raster thread), even if the resize gate then rejects its
-//   present. So it must not be the only stop condition: when a resize was seen
-//   before the first frame, one final ForceChildRefresh() is issued to
-//   guarantee a present at the current size.
+//   present. So it must not be the only stop condition: one final
+//   ForceChildRefresh() is issued to guarantee a present at the current size.
+//   Note this premise is not load-bearing, and the redundancy is deliberate:
+//   if the callback in fact only fired on a successful present, then
+//   first_frame_rendered_ would stay false and the timer below would keep
+//   nudging until it healed.
 // This also relies on HandleTopLevelWindowProc not consuming WM_TIMER (no
 // plugin registers a delegate for it today).
 constexpr UINT_PTR kForceRedrawTimerId = 0xFB15;
@@ -186,34 +188,28 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
     case WM_FONTCHANGE:
       flutter_controller_->engine()->ReloadSystemFonts();
       break;
-    case WM_SIZE:
-      // A resize before the first frame is the FancyZones wedge described on
-      // kForceRedrawTimerId; remember it so the timer issues a final child
-      // refresh even though the first-frame callback has fired.
-      if (!first_frame_rendered_) {
-        resized_before_first_frame_ = true;
-      }
-      break;
     case WM_TIMER:
       if (wparam == kForceRedrawTimerId) {
         if (!flutter_controller_) {
           KillTimer(hwnd, kForceRedrawTimerId);
         } else if (first_frame_rendered_) {
-          // A frame was generated, but if a resize happened before it, the
-          // resize gate may have rejected its present (see the comment on
-          // kForceRedrawTimerId). One child refresh guarantees a present at
-          // the current size. Note that in practice nearly every window takes
-          // this path - a WM_SIZE usually arrives during creation/show before
-          // the first frame - so this is an effectively unconditional,
-          // imperceptible safety net rather than an exceptional case.
-          if (resized_before_first_frame_) {
-            resized_before_first_frame_ = false;
-            ForceChildRefresh(flutter_controller_->view()->GetNativeWindow());
-          }
+          // A frame was generated, which does not mean it was presented: if a
+          // resize was pending, the gate rejected it (see the comment on
+          // kForceRedrawTimerId). One child refresh guarantees a present at the
+          // current size. Unconditional because gating it bought nothing: the
+          // WM_SIZE that CreateWindow() sends already arrives before the first
+          // frame, so the flag this used to check was always set by the time we
+          // got here. Doing it unconditionally is safe either way - at worst it
+          // is one extra nudge, and it is cheap once the engine is running.
+          ForceChildRefresh(flutter_controller_->view()->GetNativeWindow());
           KillTimer(hwnd, kForceRedrawTimerId);
         } else if (++force_redraw_tries_ > kForceRedrawMaxTries) {
-          std::cerr << "Flutter window did not render its first frame, giving up."
-                    << std::endl;
+          // Not std::cerr: the runner only attaches a console when started from
+          // one or under a debugger (see main.cpp), and this fires on end-user
+          // machines. OutputDebugString is readable with DebugView there.
+          OutputDebugStringA(
+              "rustdesk: Flutter window did not render its first frame, "
+              "giving up.\n");
           KillTimer(hwnd, kForceRedrawTimerId);
         } else if (force_redraw_tries_ <= kForceRedrawCheapTries) {
           flutter_controller_->ForceRedraw();

--- a/flutter/windows/runner/flutter_window.cpp
+++ b/flutter/windows/runner/flutter_window.cpp
@@ -14,10 +14,68 @@
 
 #include <windows.h>
 
+#include <iostream>
 #include <optional>
 #include <memory>
 
 #include "win32_desktop.h"
+
+namespace {
+
+// If the window is resized between the creation of the Flutter surface and the
+// present of the first frame - which is what the PowerToys FancyZones option
+// "Move newly created windows to their last known zone" does - the embedder's
+// resize synchronization enters kResizeStarted and from then on only presents
+// frames that match the new size. A frame already generated for the old size
+// is rejected, nothing schedules a matching one, and the window stays white
+// until a real resize re-enters OnWindowSizeChanged, which resets the resize
+// target and resends the window metrics. That is why minimize/restore heals
+// it; ForceChildRefresh() below does the same programmatically.
+// https://github.com/rustdesk/rustdesk/issues/6756
+// https://github.com/flutter/flutter/issues/159630
+//
+// The timer below drives that recovery. Two subtleties, verified against the
+// embedder sources (identical in 3.24.5 and 3.44.0):
+// - FlutterViewController::ForceRedraw() only schedules a frame when NO resize
+//   is pending (resize_status_ == kDone), so it cannot heal the wedge above.
+//   It is kept as a cheap first kick for the case it was designed for: a
+//   window created hidden and shown later, with nothing scheduling a frame.
+// - The SetNextFrameCallback used to detect the first frame fires when a frame
+//   is GENERATED (raster thread), even if the resize gate then rejects its
+//   present. So it must not be the only stop condition: when a resize was seen
+//   before the first frame, one final ForceChildRefresh() is issued to
+//   guarantee a present at the current size.
+// This also relies on HandleTopLevelWindowProc not consuming WM_TIMER (no
+// plugin registers a delegate for it today).
+constexpr UINT_PTR kForceRedrawTimerId = 0xFB15;
+constexpr UINT kForceRedrawIntervalMs = 200;
+// Give up eventually (with a log), so a genuinely stuck engine doesn't keep a
+// timer alive forever. 25 * 200ms covers slow starts comfortably.
+constexpr UINT kForceRedrawMaxTries = 25;
+// The first ticks use the cheap ForceRedraw(); later ticks use
+// ForceChildRefresh(), which may block the platform thread for up to 2x100ms
+// per call (each nudge re-enters the 100ms resize wait).
+constexpr UINT kForceRedrawCheapTries = 2;
+
+// Re-enters the embedder's OnWindowSizeChanged by nudging the Flutter child
+// window by 1px and back: this resets the resize target and resends the window
+// metrics. Same as BaseFlutterWindow::ForceChildRefresh() on the
+// rustdesk_desktop_multi_window side.
+void ForceChildRefresh(HWND child) {
+  if (!child) {
+    return;
+  }
+  RECT rect;
+  GetWindowRect(child, &rect);
+  LONG width = rect.right - rect.left;
+  LONG height = rect.bottom - rect.top;
+  SetWindowPos(child, nullptr, 0, 0, width + 1, height,
+               SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOMOVE | SWP_FRAMECHANGED);
+  SetWindowPos(child, nullptr, 0, 0, width, height,
+               SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOMOVE | SWP_FRAMECHANGED);
+}
+
+}  // namespace
 
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
     : project_(project) {}
@@ -92,10 +150,17 @@ bool FlutterWindow::OnCreate() {
         registry->GetRegistrarForPlugin("FlutterGpuTextureRendererPluginCApi"));
   });
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
+
+  // See the comment on kForceRedrawTimerId above.
+  flutter_controller_->engine()->SetNextFrameCallback(
+      [this]() { first_frame_rendered_ = true; });
+  SetTimer(GetHandle(), kForceRedrawTimerId, kForceRedrawIntervalMs, nullptr);
+
   return true;
 }
 
 void FlutterWindow::OnDestroy() {
+  KillTimer(GetHandle(), kForceRedrawTimerId);
   if (flutter_controller_) {
     flutter_controller_ = nullptr;
   }
@@ -120,6 +185,54 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
   switch (message) {
     case WM_FONTCHANGE:
       flutter_controller_->engine()->ReloadSystemFonts();
+      break;
+    case WM_SIZE:
+      // A resize before the first frame is the FancyZones wedge described on
+      // kForceRedrawTimerId; remember it so the timer issues a final child
+      // refresh even though the first-frame callback has fired.
+      if (!first_frame_rendered_) {
+        resized_before_first_frame_ = true;
+      }
+      break;
+    case WM_TIMER:
+      if (wparam == kForceRedrawTimerId) {
+        if (!flutter_controller_) {
+          KillTimer(hwnd, kForceRedrawTimerId);
+        } else if (first_frame_rendered_) {
+          // A frame was generated, but if a resize happened before it, the
+          // resize gate may have rejected its present (see the comment on
+          // kForceRedrawTimerId). One child refresh guarantees a present at
+          // the current size. Note that in practice nearly every window takes
+          // this path - a WM_SIZE usually arrives during creation/show before
+          // the first frame - so this is an effectively unconditional,
+          // imperceptible safety net rather than an exceptional case.
+          if (resized_before_first_frame_) {
+            resized_before_first_frame_ = false;
+            ForceChildRefresh(flutter_controller_->view()->GetNativeWindow());
+          }
+          KillTimer(hwnd, kForceRedrawTimerId);
+        } else if (++force_redraw_tries_ > kForceRedrawMaxTries) {
+          std::cerr << "Flutter window did not render its first frame, giving up."
+                    << std::endl;
+          KillTimer(hwnd, kForceRedrawTimerId);
+        } else if (force_redraw_tries_ <= kForceRedrawCheapTries) {
+          flutter_controller_->ForceRedraw();
+        } else {
+          ForceChildRefresh(flutter_controller_->view()->GetNativeWindow());
+        }
+        return 0;
+      }
+      break;
+    case WM_SHOWWINDOW:
+      // A window created hidden (e.g. the connection manager) may be shown
+      // long after the creation-time force-redraw timer has given up, and
+      // FancyZones moves windows exactly when they are shown. Re-arm the
+      // protection if the first frame still hasn't been rendered by now (see
+      // kForceRedrawTimerId).
+      if (wparam == TRUE && !first_frame_rendered_ && flutter_controller_) {
+        force_redraw_tries_ = 0;
+        SetTimer(hwnd, kForceRedrawTimerId, kForceRedrawIntervalMs, nullptr);
+      }
       break;
   }
 

--- a/flutter/windows/runner/flutter_window.h
+++ b/flutter/windows/runner/flutter_window.h
@@ -28,6 +28,18 @@ class FlutterWindow : public Win32Window {
 
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
+
+  // Whether the engine has generated its first frame. Note that a generated
+  // frame is not necessarily presented: the resize synchronization may reject
+  // it (see kForceRedrawTimerId in the .cpp file).
+  bool first_frame_rendered_ = false;
+
+  // Whether a resize arrived before the first frame was generated, i.e. the
+  // window may be stuck white with a rejected frame.
+  bool resized_before_first_frame_ = false;
+
+  // Number of force-redraw attempts made so far.
+  UINT force_redraw_tries_ = 0;
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_

--- a/flutter/windows/runner/flutter_window.h
+++ b/flutter/windows/runner/flutter_window.h
@@ -34,10 +34,6 @@ class FlutterWindow : public Win32Window {
   // it (see kForceRedrawTimerId in the .cpp file).
   bool first_frame_rendered_ = false;
 
-  // Whether a resize arrived before the first frame was generated, i.e. the
-  // window may be stuck white with a rejected frame.
-  bool resized_before_first_frame_ = false;
-
   // Number of force-redraw attempts made so far.
   UINT force_redraw_tries_ = 0;
 };


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/issues/6756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows startup reliability by automatically recovering when the first Flutter frame is delayed or initially rejected.
  * Added automatic recovery after resizing before the first frame or when a window is reshown without rendering.
  * Implemented bounded redraw retries to restore missing content, reducing the need to restart the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the white-window-on-startup issue (issue #6756) caused by Flutter's resize-synchronization gate rejecting the first frame when a resize arrives between surface creation and the first present — a scenario triggered by PowerToys FancyZones "move to last known zone". The fix installs a 200ms `WM_TIMER` loop on `OnCreate` that drives up to 25 recovery attempts: two cheap `ForceRedraw()` kicks followed by repeated `ForceChildRefresh()` nudges (±1 px on the child HWND) to re-enter `OnWindowSizeChanged` and reset the resize target; the timer is killed once `SetNextFrameCallback` reports the first frame has been generated, or when the retry limit is reached.

- **`flutter_window.cpp`**: Adds the `ForceChildRefresh` helper, the `WM_TIMER` handler with its two-phase retry logic, and a `WM_SHOWWINDOW` handler for late-shown windows; cleanup is correctly performed in `OnDestroy`.
- **`flutter_window.h`**: Adds `first_frame_rendered_` (`bool`) and `force_redraw_tries_` (`UINT`) fields to track recovery state.
- **`pubspec.lock`**: Bumps `rustdesk_desktop_multi_window` to pick up the equivalent `ForceChildRefresh` fix on the multi-window plugin side.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The timer lifecycle is correctly managed and cleanup in OnDestroy is sound; the unresolved data race on first_frame_rendered_ (plain bool written from the raster thread, read from the platform thread) is the one outstanding concern.

The WM_TIMER and WM_SHOWWINDOW handlers are logically correct, the retry bounds prevent a runaway timer, and OutputDebugStringA is appropriate for a GUI process. The only unaddressed issue from a prior review is the missing atomic on first_frame_rendered_, which is technically undefined behavior.

**Files Needing Attention:** flutter/windows/runner/flutter_window.h — first_frame_rendered_ is written off the platform thread without atomic synchronization.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/windows/runner/flutter_window.cpp | Adds a 200ms WM_TIMER loop with up to 25 retries to recover from white-window stalls; WM_SHOWWINDOW re-arming and OnDestroy cleanup are correct. GetWindowRect return value in ForceChildRefresh is unchecked. |
| flutter/windows/runner/flutter_window.h | Adds first_frame_rendered_ (bool) and force_redraw_tries_ (UINT) fields; first_frame_rendered_ is written from the Flutter raster thread without atomic synchronization. |
| flutter/pubspec.lock | Bumps rustdesk_desktop_multi_window resolved ref to pick up the matching ForceChildRefresh implementation on the multi-window side. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OnCreate] --> B[SetNextFrameCallback]
    A --> C[SetTimer 200ms]
    R[Raster thread] -->|frame generated| B
    B --> B2[first_frame_rendered_ = true]
    C --> D[WM_TIMER fires]
    D --> E{flutter_controller_ null?}
    E -->|Yes| F[KillTimer]
    E -->|No| G{first_frame_rendered_?}
    G -->|Yes| H[ForceChildRefresh + KillTimer]
    G -->|No| I{++tries > 25?}
    I -->|Yes| J[OutputDebugStringA + KillTimer]
    I -->|No| K{tries <= 2?}
    K -->|Yes| L[ForceRedraw cheap]
    K -->|No| M[ForceChildRefresh nudge 1px]
    L --> D
    M --> D
    N[WM_SHOWWINDOW TRUE] --> O{first_frame_rendered_?}
    O -->|Yes| P[no-op]
    O -->|No| Q[reset tries=0 + SetTimer]
    Q --> D
    S[OnDestroy] --> T[KillTimer + controller=null]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(flutter): bump desktop\_multi\_windo..."](https://github.com/rustdesk/rustdesk/commit/c25d148372d43c829dac0e7d44c6fdf635ab58e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48561850)</sub>

<!-- /greptile_comment -->