### PR TITLE
fix(linux): make quit_cm actually quit the connection manager

### DIFF
--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -1686,6 +1686,19 @@ pub fn quit_cm() {
     // in case of std::process::exit not work
     log::info!("quit cm");
     CLIENTS.write().unwrap().clear();
+    // `quit_gui()` ends the process on Windows and macOS, but on Linux it calls
+    // `gtk_main_quit()`, which has no effect in the Flutter connection manager:
+    // `flutter/linux/main.cc` runs `g_application_run()` (GtkApplication), so
+    // `gtk_main()` is never called. Exit directly instead, otherwise this
+    // process keeps running while no longer serving the `_cm` ipc endpoint, so
+    // the server can't reuse it and spawns one more connection manager.
+    //
+    // NOTE: a client merely disconnecting does not come here, the Flutter side
+    // closes the window then, so this is a fallback rather than an explanation
+    // for the stale processes of #15698.
+    #[cfg(all(target_os = "linux", feature = "flutter"))]
+    std::process::exit(0);
+    #[cfg(not(all(target_os = "linux", feature = "flutter")))]
     crate::platform::quit_gui();
 }
 


### PR DESCRIPTION
quit_gui() ends the process on Windows (std::process::exit) and macOS (NSApp terminate), but on Linux it calls gtk_main_quit(), which has no effect in the Flutter connection manager: flutter/linux/main.cc runs g_application_run() (GtkApplication), so gtk_main() is never called and the assertion inside gtk_main_quit() just fails.

quit_cm() is the only caller that relies on quit_gui() to end the process. The main window path in ipc.rs calls std::process::exit(-1) right after it, and the two remaining call sites are in the Sciter UI, which is not compiled for flutter builds. So a connection manager reaching quit_cm() on Linux kept running while no longer serving the `_cm` ipc endpoint, which also stops the server from reusing it, so the next connection spawns one more.

NOTE: this is a fallback, not an explanation for the stale processes of #15698: a client merely disconnecting does not reach quit_cm(), the Flutter side closes the window instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application exit behavior for the Linux Flutter connection manager.
  * Ensured the application closes promptly and reliably in this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the connection manager process on Linux (Flutter build) would not terminate when `quit_cm()` was called, because `quit_gui()` → `gtk_main_quit()` has no effect when GLib's `g_application_run()` (used by Flutter's GtkApplication) is the event loop rather than `gtk_main()`.

- Adds a `#[cfg(all(target_os = \"linux\", feature = \"flutter\"))]` early exit via `std::process::exit(0)` in `quit_cm()`, mirroring what Windows already does in its `quit_gui()` implementation, so the process correctly terminates instead of lingering as a stale `_cm` IPC endpoint.
- The `#[cfg(not(all(target_os = \"linux\", feature = \"flutter\")))]` guard on the existing `quit_gui()` call preserves all other-platform behavior (Windows, macOS, Linux Sciter) unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-function, two-line patch that makes the Linux Flutter connection manager exit correctly, and the approach is already used on Windows.

The fix is minimal and well-scoped: std::process::exit(0) is gated precisely to linux + flutter and the existing quit_gui() call is preserved for every other configuration. The Windows quit_gui() already uses std::process::exit(0), so skipping Rust drop handlers here is consistent, intentional, and safe. CLIENTS is cleared before the exit, and OS-level resource cleanup happens automatically. No other callers of quit_cm() exist outside the IPC loop.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/ui_cm_interface.rs | Adds a platform-gated std::process::exit(0) in quit_cm() to force-terminate the Linux Flutter connection manager, which previously kept running because gtk_main_quit() is a no-op in a g_application_run() event loop. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["start_listen() — IPC loop ends"] --> B["quit_cm()"]
    B --> C["CLIENTS.write().clear()"]
    C --> D{Platform?}
    D -->|"Linux + Flutter (NEW)"| E["std::process::exit(0)\n✅ process terminates"]
    D -->|"Windows"| F["quit_gui() → process::exit(0)\n✅ process terminates"]
    D -->|"macOS"| G["quit_gui() → NSApp terminate\n✅ process terminates"]
    D -->|"Linux + Sciter / other"| H["quit_gui() → gtk_main_quit()\n✅ works (gtk_main is running)"]
    D -->|"Linux + Flutter (BEFORE)"| I["quit_gui() → gtk_main_quit()\n❌ no-op: gtk_main() never called\n→ process keeps running as stale IPC server"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(linux): make quit\_cm actually quit t..."](https://github.com/rustdesk/rustdesk/commit/00b24c602486036e27d36887dd232585ffd7cb93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48576539)</sub>

<!-- /greptile_comment -->