### PR TITLE
fix(linux): load librustdesk.so relative to the executable

### DIFF
--- a/flutter/lib/models/native_model.dart
+++ b/flutter/lib/models/native_model.dart
@@ -25,6 +25,23 @@ typedef F3 = Pointer<Uint8> Function(Pointer<Utf8>, int);
 typedef F3Dart = Pointer<Uint8> Function(Pointer<Utf8>, Int32);
 typedef HandleEvent = Future<void> Function(Map<String, dynamic> evt);
 
+/// The Linux bundle keeps the core library at lib/librustdesk.so next to the
+/// executable. Prefer that copy, mirroring flutter/linux/main.cc: the plain
+/// name relies on the loader search path, which repackaged installs may not
+/// cover. https://github.com/rustdesk/rustdesk/discussions/14407
+DynamicLibrary _openLinuxCoreLib() {
+  final bundled =
+      '${File(Platform.resolvedExecutable).parent.path}/lib/librustdesk.so';
+  if (File(bundled).existsSync()) {
+    try {
+      return DynamicLibrary.open(bundled);
+    } catch (e) {
+      debugPrint("Failed to load '$bundled': $e");
+    }
+  }
+  return DynamicLibrary.open('librustdesk.so');
+}
+
 /// FFI wrapper around the native Rust core.
 /// Hides the platform differences.
 class PlatformFFI {
@@ -120,7 +137,7 @@ class PlatformFFI {
     final dylib = isAndroid
         ? DynamicLibrary.open('librustdesk.so')
         : isLinux
-            ? DynamicLibrary.open('librustdesk.so')
+            ? _openLinuxCoreLib()
             : isWindows
                 ? DynamicLibrary.open('librustdesk.dll')
                 :

--- a/flutter/lib/models/native_model.dart
+++ b/flutter/lib/models/native_model.dart
@@ -32,12 +32,12 @@ typedef HandleEvent = Future<void> Function(Map<String, dynamic> evt);
 DynamicLibrary _openLinuxCoreLib() {
   final bundled =
       '${File(Platform.resolvedExecutable).parent.path}/lib/librustdesk.so';
-  if (File(bundled).existsSync()) {
-    try {
+  try {
+    if (File(bundled).existsSync()) {
       return DynamicLibrary.open(bundled);
-    } catch (e) {
-      debugPrint("Failed to load '$bundled': $e");
     }
+  } catch (e) {
+    debugPrint("Failed to load '$bundled': $e");
   }
   return DynamicLibrary.open('librustdesk.so');
 }

--- a/flutter/linux/main.cc
+++ b/flutter/linux/main.cc
@@ -1,4 +1,8 @@
 #include <dlfcn.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
 #include "my_application.h"
 
 #define RUSTDESK_LIB_PATH "librustdesk.so"
@@ -7,8 +11,36 @@ bool gIsConnectionManager = false;
 
 void print_help_install_pkg(const char* so);
 
+// The bundle keeps the core library at lib/librustdesk.so next to the
+// executable. Resolve that path explicitly instead of relying on the
+// runner's RPATH, which repackaged installs may strip.
+// https://github.com/rustdesk/rustdesk/discussions/14407
+static void* dlopen_bundled_lib() {
+  char exe_path[PATH_MAX];
+  ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+  if (len <= 0) return nullptr;
+  exe_path[len] = '\0';
+  char* last_slash = strrchr(exe_path, '/');
+  if (last_slash == nullptr) return nullptr;
+  *last_slash = '\0';
+  char lib_path[PATH_MAX + sizeof("/lib/" RUSTDESK_LIB_PATH)];
+  snprintf(lib_path, sizeof(lib_path), "%s/lib/%s", exe_path, RUSTDESK_LIB_PATH);
+  if (access(lib_path, F_OK) != 0) return nullptr;
+  void* librustdesk = dlopen(lib_path, RTLD_LAZY);
+  if (!librustdesk) {
+    char* error = dlerror();
+    if (error != nullptr) {
+      fprintf(stderr, "Failed to load \"%s\": %s\n", lib_path, error);
+    }
+  }
+  return librustdesk;
+}
+
 bool flutter_rustdesk_core_main() {
-   void* librustdesk = dlopen(RUSTDESK_LIB_PATH, RTLD_LAZY);
+   void* librustdesk = dlopen_bundled_lib();
+   if (!librustdesk) {
+      librustdesk = dlopen(RUSTDESK_LIB_PATH, RTLD_LAZY);
+   }
    if (!librustdesk) {
       fprintf(stderr,"Failed to load \"librustdesk.so\"\n");
       char* error;

--- a/flutter/linux/main.cc
+++ b/flutter/linux/main.cc
@@ -18,7 +18,7 @@ void print_help_install_pkg(const char* so);
 static void* dlopen_bundled_lib() {
   char exe_path[PATH_MAX];
   ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
-  if (len <= 0) return nullptr;
+  if (len <= 0 || len >= (ssize_t)(sizeof(exe_path) - 1)) return nullptr;
   exe_path[len] = '\0';
   char* last_slash = strrchr(exe_path, '/');
   if (last_slash == nullptr) return nullptr;


### PR DESCRIPTION
The runner and the Dart FFI init loaded the core library by bare name, relying on the runner's $ORIGIN/lib RPATH. Repackaged installs (CachyOS repo, AUR) can lose that RPATH, making the app fail to start with "Failed to load librustdesk.so" unless users add the lib directory to ld.so.conf. Resolve lib/librustdesk.so next to the executable first, then fall back to the loader search path.

https://github.com/rustdesk/rustdesk/discussions/14407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Linux startup reliability by preferring the bundled native library located with the app when it’s available.
  - Added more robust fallback behavior to load the system native library if the bundled copy can’t be accessed.
  - Enhanced library loading error handling to better tolerate varied Linux deployment setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes Linux startup failures on repackaged installs (CachyOS, AUR) where the runner's `$ORIGIN/lib` RPATH is stripped, causing `dlopen("librustdesk.so")` to fail. Both the C runner (`main.cc`) and the Dart FFI initialiser (`native_model.dart`) now try a relative path (`<exe_dir>/lib/librustdesk.so`) first and fall back to the bare loader-search-path name.

- **`flutter/linux/main.cc`**: Adds `dlopen_bundled_lib()` which uses `readlink("/proc/self/exe")` to resolve the executable directory, constructs the absolute library path, checks existence with `access()`, and opens it with `dlopen()`; `flutter_rustdesk_core_main()` calls this first and only tries the bare name on failure.
- **`flutter/lib/models/native_model.dart`**: Adds `_openLinuxCoreLib()` that mirrors the same logic using `Platform.resolvedExecutable`, with a try/catch around both `existsSync()` and `DynamicLibrary.open()` to ensure fallback to the bare name on any error.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. Both code paths use kernel-provided executable resolution, include proper fallback to bare-name loading, and handle all failure modes.

The change is tightly scoped to library loading on Linux, the fallback chain is correct in both C and Dart, and no new error paths are introduced that could break startup on existing installations.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/linux/main.cc | Adds dlopen_bundled_lib() to resolve librustdesk.so relative to the executable via /proc/self/exe; includes a truncation guard (len >= PATH_MAX-1 → nullptr), access() existence check, and fallback to bare dlopen if not found or load fails. |
| flutter/lib/models/native_model.dart | Adds _openLinuxCoreLib() that prefers the bundled lib path from Platform.resolvedExecutable with existsSync()/DynamicLibrary.open() inside a try/catch, falling back to bare DynamicLibrary.open('librustdesk.so'). |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App starts] --> B[flutter_rustdesk_core_main / _openLinuxCoreLib]
    B --> C[readlink /proc/self/exe\nor Platform.resolvedExecutable]
    C --> D{Resolved OK?}
    D -- No --> F[bare dlopen librustdesk.so]
    D -- Yes --> E[Construct exe_dir/lib/librustdesk.so]
    E --> G{File exists?\naccess / existsSync}
    G -- No --> F
    G -- Yes --> H[dlopen absolute path]
    H --> I{Loaded OK?}
    I -- Yes --> J[Use bundled library]
    I -- No --> K[Log error]
    K --> F
    F --> L{Loaded OK?}
    L -- Yes --> M[Use system library]
    L -- No --> N[Fatal: log error and exit / throw]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(linux): harden bundled librustdesk.s..."](https://github.com/rustdesk/rustdesk/commit/b6777857ca790c4c34f3ecbf8eced21bdc1fe2ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48611792)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/rustdesk/github/rustdesk/rustdesk/-/custom-context?memory=f7c8a0b7-52cb-4813-8d03-0dc35dfcbc0b))
- Context used - AGENTS.md ([source](https://app.greptile.com/rustdesk/github/rustdesk/rustdesk/-/custom-context?memory=6f40c3eb-3820-4b4f-b8a8-5d251a60df3a))

<!-- /greptile_comment -->