### PR TITLE
fix(http): zstd support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,8 @@ dependencies = [
  "compression-core",
  "flate2",
  "memchr",
+ "zstd 0.13.1",
+ "zstd-safe 7.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ shutdown_hooks = "0.1"
 totp-rs = { version = "5.4", default-features = false, features = ["gen_secret", "otpauth"] }
 stunclient = "0.4"
 kcp-sys= { git = "https://github.com/rustdesk-org/kcp-sys"}
-reqwest = { version = "0.12", features = ["blocking", "socks", "json", "native-tls", "rustls-tls", "rustls-tls-native-roots", "gzip"], default-features=false }
+reqwest = { version = "0.12", features = ["blocking", "socks", "json", "native-tls", "rustls-tls", "rustls-tls-native-roots", "gzip", "zstd"], default-features=false }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 # https://github.com/rustdesk/rustdesk/discussions/10197, not use cpal on linux


### PR DESCRIPTION
HTTP, supports both `gzip` and `zstd`.


## Testing

- [x] reverse proxy, force `zstd` compression
- [x] reverse proxy, force `gzip` compression. Master branch also works fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced network response handling by enabling Zstandard compression support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `zstd` feature support to `reqwest` 0.12, enabling the HTTP client to negotiate and decompress `zstd`-encoded responses in addition to the already-supported `gzip`. The change is a single-feature addition to the `reqwest` dependency in `Cargo.toml`.

- `Cargo.toml`: adds `"zstd"` to reqwest's feature list; `gzip` remains active so existing behaviour is unchanged.
- `Cargo.lock`: reqwest now lists `zstd 0.13.1` and `zstd-safe 7.1.0` as dependencies — both versions were already present in the lock file as transitive dependencies of other crates, so no new C libraries are compiled.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds a single reqwest feature flag with no logic changes.

The change is a one-word addition to reqwest's feature list. The zstd and zstd-safe crates added to the lock file were already compiled into the binary as transitive dependencies of other crates, so the net increase in binary size is minimal. Existing gzip behaviour is unaffected, and reqwest's built-in content-encoding negotiation handles the new codec transparently.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Adds "zstd" to reqwest's feature list; all other reqwest features and the rest of Cargo.toml are untouched. |
| Cargo.lock | Adds zstd 0.13.1 and zstd-safe 7.1.0 to reqwest's resolved dependency list; both packages were already present elsewhere in the lock file, so the underlying zstd-sys C library is shared and no new compiled artifact is introduced. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as RustDesk HTTP Client
    participant Reqwest as reqwest 0.12
    participant Server as HTTP Server / Reverse Proxy

    Client->>Reqwest: make HTTP request
    Reqwest->>Server: "GET /resource<br/>Accept-Encoding: gzip, zstd"
    alt Server responds with zstd
        Server-->>Reqwest: 200 OK Content-Encoding: zstd
        Reqwest-->>Client: transparently decompressed body
    else Server responds with gzip
        Server-->>Reqwest: 200 OK Content-Encoding: gzip
        Reqwest-->>Client: transparently decompressed body
    else Server responds uncompressed
        Server-->>Reqwest: 200 OK plain body
        Reqwest-->>Client: plain body
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(http): zstd support"](https://github.com/rustdesk/rustdesk/commit/97205dfba8117ba3d4ef751969c366724af9c8b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48633755)</sub>

<!-- /greptile_comment -->