### PR TITLE
WebClient:  3.44 webcodecs offline

### DIFF
--- a/.github/patches/apply_flutter_3.44_source_patches.sh
+++ b/.github/patches/apply_flutter_3.44_source_patches.sh
@@ -17,6 +17,90 @@
 # therefore CRLF-safe.
 set -euo pipefail
 
+readonly NO_MATCHES=0
+readonly SINGLE_MATCH=1
+readonly THEME_MATCHES=2
+
+has_exact_count() {
+  local -r expected_count="$1"
+  local -r pattern="$2"
+  local -r file="$3"
+  local actual_count
+  [[ -r "$file" ]] || return 1
+  actual_count="$(grep -cF "$pattern" "$file" || true)"
+  [[ "$actual_count" -eq "$expected_count" ]]
+}
+
+has_dialog_background_in_theme_range() {
+  local -r start_pattern="$1"
+  local -r end_pattern="$2"
+  local -r target_pattern="$3"
+  awk -v start_pattern="$start_pattern" \
+    -v end_pattern="$end_pattern" \
+    -v target_pattern="$target_pattern" '
+      index($0, start_pattern) {
+        in_theme = 1
+        next
+      }
+      in_theme && index($0, end_pattern) {
+        exit
+      }
+      in_theme && index($0, "dialogTheme: DialogThemeData(") {
+        if (getline > 0) {
+          line = $0
+          sub(/\r$/, "", line)
+          sub(/^[[:space:]]+/, "", line)
+          matched = line == target_pattern
+        }
+        exit
+      }
+      END {
+        exit matched ? 0 : 1
+      }
+    ' flutter/lib/common.dart
+}
+
+is_complete_patch_state() {
+  has_exact_count "$THEME_MATCHES" 'dialogTheme: DialogThemeData(' flutter/lib/common.dart &&
+    has_exact_count "$THEME_MATCHES" 'tabBarTheme: const TabBarThemeData(' flutter/lib/common.dart &&
+    has_exact_count "$SINGLE_MATCH" 'backgroundColor: Colors.white,' flutter/lib/common.dart &&
+    has_exact_count "$SINGLE_MATCH" 'backgroundColor: Color(0xFF18191E),' flutter/lib/common.dart &&
+    has_exact_count "$SINGLE_MATCH" 'extended_text: 15.0.2' flutter/pubspec.yaml &&
+    has_exact_count "$SINGLE_MATCH" 'google_fonts: ^8.1.0' flutter/pubspec.yaml &&
+    has_exact_count "$NO_MATCHES" 'dialogTheme: DialogTheme(' flutter/lib/common.dart &&
+    has_exact_count "$NO_MATCHES" 'tabBarTheme: const TabBarTheme(' flutter/lib/common.dart &&
+    has_exact_count "$NO_MATCHES" 'extended_text: 14.0.0' flutter/pubspec.yaml &&
+    has_exact_count "$NO_MATCHES" 'google_fonts: ^6.2.1' flutter/pubspec.yaml &&
+    has_dialog_background_in_theme_range 'static ThemeData lightTheme = ThemeData(' \
+      'static ThemeData darkTheme = ThemeData(' 'backgroundColor: Colors.white,' &&
+    has_dialog_background_in_theme_range 'static ThemeData darkTheme = ThemeData(' \
+      'scrollbarTheme: scrollbarThemeDark,' 'backgroundColor: Color(0xFF18191E),'
+}
+
+is_unpatched_state() {
+  has_exact_count "$THEME_MATCHES" 'dialogTheme: DialogTheme(' flutter/lib/common.dart &&
+    has_exact_count "$THEME_MATCHES" 'tabBarTheme: const TabBarTheme(' flutter/lib/common.dart &&
+    has_exact_count "$SINGLE_MATCH" 'extended_text: 14.0.0' flutter/pubspec.yaml &&
+    has_exact_count "$SINGLE_MATCH" 'google_fonts: ^6.2.1' flutter/pubspec.yaml &&
+    has_exact_count "$NO_MATCHES" 'dialogTheme: DialogThemeData(' flutter/lib/common.dart &&
+    has_exact_count "$NO_MATCHES" 'tabBarTheme: const TabBarThemeData(' flutter/lib/common.dart &&
+    has_exact_count "$NO_MATCHES" 'backgroundColor: Colors.white,' flutter/lib/common.dart &&
+    has_exact_count "$NO_MATCHES" 'backgroundColor: Color(0xFF18191E),' flutter/lib/common.dart &&
+    has_exact_count "$NO_MATCHES" 'extended_text: 15.0.2' flutter/pubspec.yaml &&
+    has_exact_count "$NO_MATCHES" 'google_fonts: ^8.1.0' flutter/pubspec.yaml
+}
+
+if is_complete_patch_state; then
+  echo "Flutter 3.44 source patches already applied."
+  git --no-pager diff -- flutter/lib/common.dart flutter/pubspec.yaml
+  exit 0
+fi
+
+if ! is_unpatched_state; then
+  echo "Flutter 3.44 source patches are partially applied or their anchors have drifted." >&2
+  exit 1
+fi
+
 # ThemeData API renames (Flutter 3.27+):
 sed -i 's/dialogTheme: DialogTheme(/dialogTheme: DialogThemeData(/g' flutter/lib/common.dart
 sed -i 's/tabBarTheme: const TabBarTheme(/tabBarTheme: const TabBarThemeData(/g' flutter/lib/common.dart
@@ -28,12 +112,10 @@ sed -i '/static ThemeData darkTheme = ThemeData(/,/scrollbarTheme: scrollbarThem
 sed -i 's/extended_text: 14.0.0/extended_text: 15.0.2/' flutter/pubspec.yaml
 sed -i 's/google_fonts: \^6.2.1/google_fonts: ^8.1.0/' flutter/pubspec.yaml
 
-# Fail loudly if any expected string drifted, so we never silently build unpatched:
-grep -qF 'dialogTheme: DialogThemeData(' flutter/lib/common.dart
-grep -qF 'tabBarTheme: const TabBarThemeData(' flutter/lib/common.dart
-grep -qF 'backgroundColor: Colors.white,' flutter/lib/common.dart
-grep -qF 'backgroundColor: Color(0xFF18191E),' flutter/lib/common.dart
-grep -qF 'extended_text: 15.0.2' flutter/pubspec.yaml
-grep -qF 'google_fonts: ^8.1.0' flutter/pubspec.yaml
+# Fail loudly if any expected substitution did not produce the complete state.
+if ! is_complete_patch_state; then
+  echo "Flutter 3.44 source patches did not produce the expected state." >&2
+  exit 1
+fi
 
 git --no-pager diff -- flutter/lib/common.dart flutter/pubspec.yaml

--- a/.github/patches/apply_flutter_3.44_source_patches.sh
+++ b/.github/patches/apply_flutter_3.44_source_patches.sh
@@ -31,10 +31,12 @@ has_exact_count() {
   [[ "$actual_count" -eq "$expected_count" ]]
 }
 
+# The target background-color line must directly follow DialogThemeData in the selected range.
 has_dialog_background_in_theme_range() {
   local -r start_pattern="$1"
   local -r end_pattern="$2"
   local -r target_pattern="$3"
+  local -r file="$4"
   awk -v start_pattern="$start_pattern" \
     -v end_pattern="$end_pattern" \
     -v target_pattern="$target_pattern" '
@@ -57,7 +59,18 @@ has_dialog_background_in_theme_range() {
       END {
         exit matched ? 0 : 1
       }
-    ' flutter/lib/common.dart
+    ' "$file"
+}
+
+validate_patch_inputs() {
+  if [[ ! -f flutter/lib/common.dart || ! -r flutter/lib/common.dart ]]; then
+    echo "Flutter 3.44 source patch input is missing or unreadable: flutter/lib/common.dart" >&2
+    return 1
+  fi
+  if [[ ! -f flutter/pubspec.yaml || ! -r flutter/pubspec.yaml ]]; then
+    echo "Flutter 3.44 source patch input is missing or unreadable: flutter/pubspec.yaml" >&2
+    return 1
+  fi
 }
 
 is_complete_patch_state() {
@@ -72,9 +85,11 @@ is_complete_patch_state() {
     has_exact_count "$NO_MATCHES" 'extended_text: 14.0.0' flutter/pubspec.yaml &&
     has_exact_count "$NO_MATCHES" 'google_fonts: ^6.2.1' flutter/pubspec.yaml &&
     has_dialog_background_in_theme_range 'static ThemeData lightTheme = ThemeData(' \
-      'static ThemeData darkTheme = ThemeData(' 'backgroundColor: Colors.white,' &&
+      'static ThemeData darkTheme = ThemeData(' 'backgroundColor: Colors.white,' \
+      flutter/lib/common.dart &&
     has_dialog_background_in_theme_range 'static ThemeData darkTheme = ThemeData(' \
-      'scrollbarTheme: scrollbarThemeDark,' 'backgroundColor: Color(0xFF18191E),'
+      'scrollbarTheme: scrollbarThemeDark,' 'backgroundColor: Color(0xFF18191E),' \
+      flutter/lib/common.dart
 }
 
 is_unpatched_state() {
@@ -89,6 +104,10 @@ is_unpatched_state() {
     has_exact_count "$NO_MATCHES" 'extended_text: 15.0.2' flutter/pubspec.yaml &&
     has_exact_count "$NO_MATCHES" 'google_fonts: ^8.1.0' flutter/pubspec.yaml
 }
+
+if ! validate_patch_inputs; then
+  exit 1
+fi
 
 if is_complete_patch_state; then
   echo "Flutter 3.44 source patches already applied."

--- a/.github/patches/apply_flutter_3.44_web_patches.sh
+++ b/.github/patches/apply_flutter_3.44_web_patches.sh
@@ -20,11 +20,8 @@ flutter --version | grep -q "Flutter 3\.44\." || {
   exit 1
 }
 
-# Shared 3.44 source/pubspec patches. Skip when already applied: they are not
-# idempotent (rerunning would insert the dialog backgroundColor twice).
-if ! grep -qF 'dialogTheme: DialogThemeData(' flutter/lib/common.dart; then
-  bash .github/patches/apply_flutter_3.44_source_patches.sh
-fi
+# Shared 3.44 source/pubspec patches own their complete-state validation.
+bash .github/patches/apply_flutter_3.44_source_patches.sh
 
 # Populate the pub cache with the 3.44 dependency resolution.
 (cd flutter && flutter pub get)
@@ -36,6 +33,9 @@ fi
 QR_WEB="${PUB_CACHE:-$HOME/.pub-cache}/hosted/pub.dev/qr_code_scanner-1.0.1/lib/src/web/flutter_qr_web.dart"
 if ! grep -qF "dart:ui_web" "$QR_WEB"; then
   sed -i.bak "s|import 'dart:ui' as ui;|import 'dart:ui' as ui; import 'dart:ui_web' as ui_web;|" "$QR_WEB"
+  rm -f "$QR_WEB.bak"
+fi
+if grep -qF "ui.platformViewRegistry" "$QR_WEB"; then
   sed -i.bak "s|ui\.platformViewRegistry|ui_web.platformViewRegistry|g" "$QR_WEB"
   rm -f "$QR_WEB.bak"
 fi

--- a/.github/patches/apply_flutter_3.44_web_patches.sh
+++ b/.github/patches/apply_flutter_3.44_web_patches.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Prepares a web build on Flutter 3.44.x. Companion to
+# apply_flutter_3.44_source_patches.sh (which it runs first): the web target
+# additionally needs qr_code_scanner's web implementation patched for the
+# dart:ui platformViewRegistry removal, and flutter/web/fonts refreshed with
+# the font paths the 3.44 engine requests for offline/air-gapped support
+# (rustdesk-server-pro#996; see flutter/web/fonts/sync_fonts.py).
+#
+# Run from the repository root with Flutter 3.44.x on PATH, then build:
+#   bash .github/patches/apply_flutter_3.44_web_patches.sh
+#   (cd flutter && flutter build web --release)   # or ./web/js/flutter_build.py
+#
+# Idempotent. To undo the source changes locally:
+#   git checkout -- flutter/lib/common.dart flutter/pubspec.yaml flutter/pubspec.lock
+set -euo pipefail
+
+flutter --version | grep -q "Flutter 3\.44\." || {
+  echo "Flutter 3.44.x must be on PATH; found:" >&2
+  flutter --version | grep "^Flutter" >&2 || true
+  exit 1
+}
+
+# Shared 3.44 source/pubspec patches. Skip when already applied: they are not
+# idempotent (rerunning would insert the dialog backgroundColor twice).
+if ! grep -qF 'dialogTheme: DialogThemeData(' flutter/lib/common.dart; then
+  bash .github/patches/apply_flutter_3.44_source_patches.sh
+fi
+
+# Populate the pub cache with the 3.44 dependency resolution.
+(cd flutter && flutter pub get)
+
+# qr_code_scanner 1.0.1 (unmaintained) reads platformViewRegistry from
+# dart:ui, which Flutter 3.44 removed; point it at dart:ui_web instead. The
+# patched file also compiles on Flutter 3.24 (dart:ui_web exists there), so
+# mutating the shared pub cache is safe for other local builds.
+QR_WEB="${PUB_CACHE:-$HOME/.pub-cache}/hosted/pub.dev/qr_code_scanner-1.0.1/lib/src/web/flutter_qr_web.dart"
+if ! grep -qF "dart:ui_web" "$QR_WEB"; then
+  sed -i.bak "s|import 'dart:ui' as ui;|import 'dart:ui' as ui; import 'dart:ui_web' as ui_web;|" "$QR_WEB"
+  sed -i.bak "s|ui\.platformViewRegistry|ui_web.platformViewRegistry|g" "$QR_WEB"
+  rm -f "$QR_WEB.bak"
+fi
+
+# Mirror the fonts this engine version requests into flutter/web/fonts.
+python3 flutter/web/fonts/sync_fonts.py
+
+# Fail loudly if any expected state is missing:
+grep -qF "import 'dart:ui' as ui; import 'dart:ui_web' as ui_web;" "$QR_WEB"
+grep -qF "ui_web.platformViewRegistry" "$QR_WEB"
+grep -qF 'google_fonts: ^8.1.0' flutter/pubspec.yaml
+
+echo "Flutter 3.44 web patches applied."

--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -30,7 +30,7 @@ jobs:
               target: x86_64-unknown-linux-gnu,
               os: ubuntu-22.04,
               extra-build-args: "",
-              flutter-version: "3.44.0",
+              flutter-version: "3.44.8",
               artifact-name: "bridge-artifact-flutter-3.44",
             }
     steps:

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -31,7 +31,7 @@ env:
   # engine is 3.44. Every other platform stays on FLUTTER_VERSION (3.24.5) until Windows 7
   # support is restored after the upstream-wide Flutter bump. The arm64 job patches the few
   # 3.44-only source/pubspec changes on the fly (see "Patch RustDesk sources for Flutter 3.44").
-  FLUTTER_WINDOWS_ARM_VERSION: "3.44.0"
+  FLUTTER_WINDOWS_ARM_VERSION: "3.44.8"
   # for arm64 linux because official Dart SDK does not work
   FLUTTER_ELINUX_VERSION: "3.16.9"
   TAG_NAME: "${{ inputs.upload-tag }}"
@@ -196,7 +196,9 @@ jobs:
         run: |
           cp .github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff $(dirname $(dirname $(which flutter)))
           cd $(dirname $(dirname $(which flutter)))
-          [[ "3.24.5" == ${{env.FLUTTER_VERSION}} ]] && git apply flutter_3.24.4_dropdown_menu_enableFilter.diff
+          if [[ "3.24.5" == ${{env.FLUTTER_VERSION}} ]]; then
+            git apply flutter_3.24.4_dropdown_menu_enableFilter.diff
+          fi
 
       - name: Patch RustDesk sources for Flutter 3.44 (arm64)
         # arm64 is the only target on Flutter 3.44; apply its source/pubspec deltas on the fly
@@ -567,7 +569,9 @@ jobs:
       - name: Patch flutter
         run: |
           cd $(dirname $(dirname $(which flutter)))
-          [[ "3.24.5" == ${{env.FLUTTER_VERSION}} ]] && git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+          if [[ "3.24.5" == ${{env.FLUTTER_VERSION}} ]]; then
+            git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+          fi
 
       - name: Setup vcpkg with Github Actions binary cache
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11
@@ -746,7 +750,9 @@ jobs:
       - name: Patch flutter
         run: |
           cd $(dirname $(dirname $(which flutter)))
-          [[ "3.24.5" == ${{env.FLUTTER_VERSION}} ]] && git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+          if [[ "3.24.5" == ${{env.FLUTTER_VERSION}} ]]; then
+            git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+          fi
 
       - name: Workaround for flutter issue
         shell: bash
@@ -1005,7 +1011,9 @@ jobs:
       - name: Patch flutter
         run: |
           cd $(dirname $(dirname $(which flutter)))
-          [[ "3.24.5" == ${{env.ANDROID_FLUTTER_VERSION}} ]] && git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+          if [[ "3.24.5" == ${{env.ANDROID_FLUTTER_VERSION}} ]]; then
+            git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+          fi
 
       - uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1
         id: setup-ndk
@@ -1277,7 +1285,9 @@ jobs:
       - name: Patch flutter
         run: |
           cd $(dirname $(dirname $(which flutter)))
-          [[ "3.24.5" == ${{env.ANDROID_FLUTTER_VERSION}} ]] && git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+          if [[ "3.24.5" == ${{env.ANDROID_FLUTTER_VERSION}} ]]; then
+            git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+          fi
 
       - name: Restore bridge files
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -2115,7 +2125,18 @@ jobs:
         shell: bash
         run: |
           cd $(dirname $(dirname $(which flutter)))
-          [[ "3.24.5" == ${{env.FLUTTER_VERSION}} ]] && git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+          if [[ "3.24.5" == ${{env.FLUTTER_VERSION}} ]]; then
+            git apply ${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff
+          fi
+
+      - name: Patch sources for Flutter 3.44 web
+        # No-op while the web stays on Flutter 3.24.5; makes this job work as-is
+        # once FLUTTER_VERSION moves to 3.44.x (qr_code_scanner + fonts, see script).
+        shell: bash
+        run: |
+          if [[ "${{ env.FLUTTER_VERSION }}" == 3.44.* ]]; then
+            bash .github/patches/apply_flutter_3.44_web_patches.sh
+          fi
 
       # https://rustdesk.com/docs/en/dev/build/web/
       - name: Build web

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -588,7 +588,8 @@ _registerEventHandler() {
 
 Widget keyListenerBuilder(BuildContext context, Widget? child) {
   return RawKeyboardListener(
-    focusNode: FocusNode(),
+    // `skipTraversal: isWeb` is to fix "Bad state: RenderBox was not laid out: minified:aeL#c19e4"
+    focusNode: FocusNode(skipTraversal: isWeb),
     child: child ?? Container(),
     onKey: (RawKeyEvent event) {
       if (event.logicalKey == LogicalKeyboardKey.shiftLeft) {

--- a/flutter/lib/mobile/pages/terminal_page.dart
+++ b/flutter/lib/mobile/pages/terminal_page.dart
@@ -10,6 +10,8 @@ import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:flutter_hbb/models/terminal_model.dart';
 import 'package:flutter_hbb/mobile/terminal_keyboard_utils.dart';
+import 'package:flutter_hbb/web/dummy.dart'
+    if (dart.library.html) 'package:flutter_hbb/web/terminal_font.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:xterm/xterm.dart';
 import '../../desktop/pages/terminal_connection_manager.dart';
@@ -66,6 +68,10 @@ class _TerminalPageState extends State<TerminalPage>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+
+    if (isWeb) {
+      loadLocalTerminalFontIfNeeded();
+    }
 
     debugPrint(
         '[TerminalPage] Initializing terminal ${widget.terminalId} for peer ${widget.id}');

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1969,7 +1969,10 @@ class ImageModel with ChangeNotifier {
           ? ui.PixelFormat.rgba8888
           : ui.PixelFormat.bgra8888,
     );
-    if (parent.target?.id != pid) return;
+    if (parent.target?.id != pid) {
+      image?.dispose();
+      return;
+    }
     await update(image);
   }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1953,12 +1953,9 @@ class ImageModel with ChangeNotifier {
   }
 
   // web only: image already created from a decoded WebCodecs frame
-  onImage(int display, ui.Image image) async {
-    try {
-      await update(image);
-    } catch (e) {
-      debugPrint('onImage error: $e');
-    }
+  Future<void> onImage(
+      int display, ui.Image image, bool Function() isCurrentSession) async {
+    await update(image, isCurrentSession: isCurrentSession);
   }
 
   decodeAndUpdate(int display, Uint8List rgba) async {
@@ -1976,7 +1973,9 @@ class ImageModel with ChangeNotifier {
     await update(image);
   }
 
-  update(ui.Image? image) async {
+  Future<void> update(ui.Image? image,
+      {bool Function()? isCurrentSession}) async {
+    if (_disposeIfStale(image, isCurrentSession)) return;
     if (_image == null && image != null) {
       if (isDesktop || isWebDesktop) {
         await parent.target?.canvasModel.updateViewStyle();
@@ -1987,9 +1986,17 @@ class ImageModel with ChangeNotifier {
         await initializeCursorAndCanvas(parent.target!);
       }
     }
+    if (_disposeIfStale(image, isCurrentSession)) return;
     _image?.dispose();
     _image = image;
     if (image != null) notifyListeners();
+  }
+
+  bool _disposeIfStale(ui.Image? image, bool Function()? isCurrentSession) {
+    if (image == null || isCurrentSession == null) return false;
+    if (isCurrentSession()) return false;
+    image.dispose();
+    return true;
   }
 
   // mobile only
@@ -3862,9 +3869,14 @@ class FFI {
         onEvent2UIRgba();
         imageModel.onRgba(display, data);
       });
-      platformFFI.setVideoFrameCallback((int display, ui.Image image) {
-        onEvent2UIRgba();
-        imageModel.onImage(display, image);
+      platformFFI.setVideoFrameCallback((int display, ui.Image image,
+          bool Function() isCurrentSession) async {
+        if (!isCurrentSession()) {
+          image.dispose();
+          return;
+        }
+        await onEvent2UIRgba();
+        await imageModel.onImage(display, image, isCurrentSession);
       });
       this.id = id;
       return;
@@ -3953,7 +3965,7 @@ class FFI {
     this.id = id;
   }
 
-  void onEvent2UIRgba() async {
+  Future<void> onEvent2UIRgba() async {
     if (ffiModel.waitForImageDialogShow.isTrue) {
       ffiModel.waitForImageDialogShow.value = false;
       ffiModel.waitForImageTimer?.cancel();
@@ -4009,6 +4021,9 @@ class FFI {
   /// Close the remote session.
   Future<void> close({bool closeSession = true}) async {
     closed = true;
+    if (isWeb) {
+      platformFFI.clearVideoFrameCallback();
+    }
     chatModel.close();
     // Close all terminal models
     for (final model in _terminalModels.values) {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -1952,6 +1952,15 @@ class ImageModel with ChangeNotifier {
     platformFFI.nextRgba(sessionId, display);
   }
 
+  // web only: image already created from a decoded WebCodecs frame
+  onImage(int display, ui.Image image) async {
+    try {
+      await update(image);
+    } catch (e) {
+      debugPrint('onImage error: $e');
+    }
+  }
+
   decodeAndUpdate(int display, Uint8List rgba) async {
     final pid = parent.target?.id;
     final rect = parent.target?.ffiModel.pi.getDisplayRect(display);
@@ -3852,6 +3861,10 @@ class FFI {
       platformFFI.setRgbaCallback((int display, Uint8List data) {
         onEvent2UIRgba();
         imageModel.onRgba(display, data);
+      });
+      platformFFI.setVideoFrameCallback((int display, ui.Image image) {
+        onEvent2UIRgba();
+        imageModel.onImage(display, image);
       });
       this.id = id;
       return;

--- a/flutter/lib/models/native_model.dart
+++ b/flutter/lib/models/native_model.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
+import 'dart:ui' as ui;
 
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:external_path/external_path.dart';
@@ -282,6 +283,9 @@ class PlatformFFI {
   }
 
   void setRgbaCallback(void Function(int, Uint8List) fun) async {}
+
+  // web only, decoded WebCodecs frames arriving as ready-made images
+  void setVideoFrameCallback(void Function(int, ui.Image) fun) {}
 
   void startDesktopWebListener() {}
 

--- a/flutter/lib/models/native_model.dart
+++ b/flutter/lib/models/native_model.dart
@@ -285,7 +285,10 @@ class PlatformFFI {
   void setRgbaCallback(void Function(int, Uint8List) fun) async {}
 
   // web only, decoded WebCodecs frames arriving as ready-made images
-  void setVideoFrameCallback(void Function(int, ui.Image) fun) {}
+  void setVideoFrameCallback(
+      Future<void> Function(int, ui.Image, bool Function()) fun) {}
+
+  void clearVideoFrameCallback() {}
 
   void startDesktopWebListener() {}
 

--- a/flutter/lib/models/web_model.dart
+++ b/flutter/lib/models/web_model.dart
@@ -33,8 +33,8 @@ int _videoFrameHeight(JSObject frame) =>
 void _closeVideoFrame(JSObject frame) {
   try {
     frame.callMethod<JSAny?>('close'.toJS);
-  } catch (_) {
-    // closing twice is the only failure mode and is harmless
+  } catch (error) {
+    debugPrint('VideoFrame.close failed: $error');
   }
 }
 

--- a/flutter/lib/models/web_model.dart
+++ b/flutter/lib/models/web_model.dart
@@ -2,7 +2,7 @@
 
 import 'dart:convert';
 import 'dart:js_interop';
-import 'dart:js_util' as js_util;
+import 'dart:js_interop_unsafe';
 import 'dart:typed_data';
 import 'dart:js';
 import 'dart:html';
@@ -13,6 +13,7 @@ import 'dart:ui_web' as ui_web;
 import 'package:flutter/foundation.dart';
 import 'package:flutter_hbb/common/widgets/login.dart';
 import 'package:flutter_hbb/models/state_model.dart';
+import 'package:flutter_hbb/models/web_video_frame_queue.dart';
 
 import 'package:flutter_hbb/web/bridge.dart';
 import 'package:flutter_hbb/common.dart';
@@ -25,13 +26,13 @@ final List<StreamSubscription<KeyboardEvent>> keyListeners = [];
 // interop objects (the package language version predates extension types).
 // This side owns each frame and must close it quickly: hardware decoders
 // stall once their small output frame pool is exhausted.
-int _videoFrameWidth(Object frame) =>
-    js_util.getProperty(frame, 'displayWidth');
-int _videoFrameHeight(Object frame) =>
-    js_util.getProperty(frame, 'displayHeight');
-void _closeVideoFrame(Object frame) {
+int _videoFrameWidth(JSObject frame) =>
+    frame.getProperty<JSNumber>('displayWidth'.toJS).toDartInt;
+int _videoFrameHeight(JSObject frame) =>
+    frame.getProperty<JSNumber>('displayHeight'.toJS).toDartInt;
+void _closeVideoFrame(JSObject frame) {
   try {
-    js_util.callMethod(frame, 'close', []);
+    frame.callMethod<JSAny?>('close'.toJS);
   } catch (_) {
     // closing twice is the only failure mode and is harmless
   }
@@ -52,6 +53,13 @@ class PlatformFFI {
   }
 
   PlatformFFI._() {
+    _videoFrameQueue = WebVideoFrameQueue(
+      importFrame: _importVideoFrame,
+      closeFrame: _closeVideoFrame,
+      disposeImage: (image) => image.dispose(),
+      onImportError: _handleVideoFrameImportError,
+      onCallbackError: _handleVideoImageCallbackError,
+    );
     window.document.addEventListener(
         'visibilitychange',
         (event) => {
@@ -181,77 +189,44 @@ class PlatformFFI {
     };
   }
 
-  void Function(int, ui.Image)? _videoImageCallback;
-  final Map<int, Object> _pendingVideoFrames = {};
-  bool _processingVideoFrames = false;
-  bool _videoFramesDisabled = false;
+  late final WebVideoFrameQueue<JSObject, ui.Image> _videoFrameQueue;
 
   // Zero-readback video path: the JS decoder hands decoded VideoFrames here
   // (checking typeof window.onVideoFrame before every frame), and the engine
   // imports them GPU-to-GPU via createImageBitmap. Unregistering the JS global
   // reverts the JS side to the RGBA readback path.
-  void setVideoFrameCallback(void Function(int, ui.Image) fun) {
-    _videoImageCallback = fun;
-    if (_videoFramesDisabled) return;
-    js_util.setProperty(js_util.globalThis, 'onVideoFrame',
-        js_util.allowInterop((int display, Object frame) {
-      _handleVideoFrame(display, frame);
-    }));
+  void setVideoFrameCallback(
+      Future<void> Function(int, ui.Image, bool Function()) fun) {
+    _videoFrameQueue.beginSession(fun);
+    if (!_videoFrameQueue.isEnabled) return;
+    globalContext.setProperty(
+      'onVideoFrame'.toJS,
+      ((JSNumber display, JSObject frame) {
+        _videoFrameQueue.submit(display.toDartInt, frame);
+      }).toJS,
+    );
   }
 
-  void _handleVideoFrame(int display, Object frame) {
-    if (_videoFramesDisabled || _videoImageCallback == null) {
-      _closeVideoFrame(frame);
-      return;
-    }
-    // Keep only the newest undrawn frame per display: a remote desktop wants
-    // freshness, and the decoder needs its frame pool returned promptly.
-    final stale = _pendingVideoFrames[display];
-    if (stale != null) {
-      _closeVideoFrame(stale);
-    }
-    _pendingVideoFrames[display] = frame;
-    if (_processingVideoFrames) return;
-    _processingVideoFrames = true;
-    Future(() async {
-      while (_pendingVideoFrames.isNotEmpty) {
-        final display = _pendingVideoFrames.keys.first;
-        final frame = _pendingVideoFrames.remove(display)!;
-        if (_videoFramesDisabled) {
-          _closeVideoFrame(frame);
-          continue;
-        }
-        ui.Image? image;
-        try {
-          image = await ui_web.createImageFromTextureSource(frame as JSAny,
-              width: _videoFrameWidth(frame),
-              height: _videoFrameHeight(frame));
-        } catch (e) {
-          debugPrint(
-              'createImageFromTextureSource failed, using RGBA path: $e');
-          _videoFramesDisabled = true;
-          js_util.setProperty(js_util.globalThis, 'onVideoFrame', null);
-        } finally {
-          _closeVideoFrame(frame);
-        }
-        if (image != null) {
-          final callback = _videoImageCallback;
-          if (callback == null) {
-            image.dispose();
-          } else {
-            try {
-              callback(display, image);
-            } catch (e) {
-              // Nothing downstream took ownership (ImageModel catches its own
-              // errors before adopting the image), so free the texture here.
-              image.dispose();
-              debugPrint('video image callback error: $e');
-            }
-          }
-        }
-      }
-      _processingVideoFrames = false;
-    });
+  void clearVideoFrameCallback() {
+    _videoFrameQueue.endSession();
+    globalContext.setProperty('onVideoFrame'.toJS, null);
+  }
+
+  Future<ui.Image> _importVideoFrame(JSObject frame) async {
+    return await ui_web.createImageFromTextureSource(frame,
+        width: _videoFrameWidth(frame), height: _videoFrameHeight(frame));
+  }
+
+  void _handleVideoFrameImportError(Object error, StackTrace stackTrace) {
+    debugPrintStack(
+        label: 'createImageFromTextureSource failed, using RGBA path: $error',
+        stackTrace: stackTrace);
+    globalContext.setProperty('onVideoFrame'.toJS, null);
+  }
+
+  void _handleVideoImageCallbackError(Object error, StackTrace stackTrace) {
+    debugPrintStack(
+        label: 'video image callback error: $error', stackTrace: stackTrace);
   }
 
   void startDesktopWebListener() {

--- a/flutter/lib/models/web_model.dart
+++ b/flutter/lib/models/web_model.dart
@@ -2,10 +2,13 @@
 
 import 'dart:convert';
 import 'dart:js_interop';
+import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 import 'dart:js';
 import 'dart:html';
 import 'dart:async';
+import 'dart:ui' as ui;
+import 'dart:ui_web' as ui_web;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_hbb/common/widgets/login.dart';
@@ -17,6 +20,22 @@ import 'package:uuid/uuid.dart';
 
 final List<StreamSubscription<MouseEvent>> mouseListeners = [];
 final List<StreamSubscription<KeyboardEvent>> keyListeners = [];
+
+// WebCodecs VideoFrames handed over from js/src/webcodecs.js arrive as plain
+// interop objects (the package language version predates extension types).
+// This side owns each frame and must close it quickly: hardware decoders
+// stall once their small output frame pool is exhausted.
+int _videoFrameWidth(Object frame) =>
+    js_util.getProperty(frame, 'displayWidth');
+int _videoFrameHeight(Object frame) =>
+    js_util.getProperty(frame, 'displayHeight');
+void _closeVideoFrame(Object frame) {
+  try {
+    js_util.callMethod(frame, 'close', []);
+  } catch (_) {
+    // closing twice is the only failure mode and is harmless
+  }
+}
 
 typedef HandleEvent = Future<void> Function(Map<String, dynamic> evt);
 
@@ -160,6 +179,79 @@ class PlatformFFI {
         fun(display, rgba);
       }
     };
+  }
+
+  void Function(int, ui.Image)? _videoImageCallback;
+  final Map<int, Object> _pendingVideoFrames = {};
+  bool _processingVideoFrames = false;
+  bool _videoFramesDisabled = false;
+
+  // Zero-readback video path: the JS decoder hands decoded VideoFrames here
+  // (checking typeof window.onVideoFrame before every frame), and the engine
+  // imports them GPU-to-GPU via createImageBitmap. Unregistering the JS global
+  // reverts the JS side to the RGBA readback path.
+  void setVideoFrameCallback(void Function(int, ui.Image) fun) {
+    _videoImageCallback = fun;
+    if (_videoFramesDisabled) return;
+    js_util.setProperty(js_util.globalThis, 'onVideoFrame',
+        js_util.allowInterop((int display, Object frame) {
+      _handleVideoFrame(display, frame);
+    }));
+  }
+
+  void _handleVideoFrame(int display, Object frame) {
+    if (_videoFramesDisabled || _videoImageCallback == null) {
+      _closeVideoFrame(frame);
+      return;
+    }
+    // Keep only the newest undrawn frame per display: a remote desktop wants
+    // freshness, and the decoder needs its frame pool returned promptly.
+    final stale = _pendingVideoFrames[display];
+    if (stale != null) {
+      _closeVideoFrame(stale);
+    }
+    _pendingVideoFrames[display] = frame;
+    if (_processingVideoFrames) return;
+    _processingVideoFrames = true;
+    Future(() async {
+      while (_pendingVideoFrames.isNotEmpty) {
+        final display = _pendingVideoFrames.keys.first;
+        final frame = _pendingVideoFrames.remove(display)!;
+        if (_videoFramesDisabled) {
+          _closeVideoFrame(frame);
+          continue;
+        }
+        ui.Image? image;
+        try {
+          image = await ui_web.createImageFromTextureSource(frame as JSAny,
+              width: _videoFrameWidth(frame),
+              height: _videoFrameHeight(frame));
+        } catch (e) {
+          debugPrint(
+              'createImageFromTextureSource failed, using RGBA path: $e');
+          _videoFramesDisabled = true;
+          js_util.setProperty(js_util.globalThis, 'onVideoFrame', null);
+        } finally {
+          _closeVideoFrame(frame);
+        }
+        if (image != null) {
+          final callback = _videoImageCallback;
+          if (callback == null) {
+            image.dispose();
+          } else {
+            try {
+              callback(display, image);
+            } catch (e) {
+              // Nothing downstream took ownership (ImageModel catches its own
+              // errors before adopting the image), so free the texture here.
+              image.dispose();
+              debugPrint('video image callback error: $e');
+            }
+          }
+        }
+      }
+      _processingVideoFrames = false;
+    });
   }
 
   void startDesktopWebListener() {

--- a/flutter/lib/models/web_video_frame_queue.dart
+++ b/flutter/lib/models/web_video_frame_queue.dart
@@ -71,13 +71,6 @@ class WebVideoFrameQueue<Frame, Image> {
     return true;
   }
 
-  // Test hook for synchronizing with an in-flight frame import.
-  Future<void> waitForImport() =>
-      _importStarted?.future ?? Future<void>.value();
-
-  // Test hook for synchronizing with queue processing completion.
-  Future<void> waitUntilIdle() => _idle?.future ?? Future<void>.value();
-
   void _startProcessing() {
     if (_processing) return;
     _processing = true;

--- a/flutter/lib/models/web_video_frame_queue.dart
+++ b/flutter/lib/models/web_video_frame_queue.dart
@@ -30,8 +30,6 @@ class WebVideoFrameQueue<Frame, Image> {
   final Map<int, _QueuedFrame<Frame>> _pending = {};
 
   VideoImageCallback<Image>? _callback;
-  Completer<void>? _idle;
-  Completer<void>? _importStarted;
   int _generation = 0;
   bool _processing = false;
   bool _enabled = true;
@@ -74,8 +72,6 @@ class WebVideoFrameQueue<Frame, Image> {
   void _startProcessing() {
     if (_processing) return;
     _processing = true;
-    _idle = Completer<void>();
-    _importStarted = Completer<void>();
     unawaited(Future<void>(_process));
   }
 
@@ -90,14 +86,11 @@ class WebVideoFrameQueue<Frame, Image> {
       await _importAndDeliver(queued);
     }
     _processing = false;
-    _idle?.complete();
   }
 
   Future<void> _importAndDeliver(_QueuedFrame<Frame> queued) async {
     Image? image;
     try {
-      _importStarted?.complete();
-      _importStarted = null;
       image = await _importFrame(queued.frame);
     } catch (error, stackTrace) {
       if (queued.generation == _generation) {

--- a/flutter/lib/models/web_video_frame_queue.dart
+++ b/flutter/lib/models/web_video_frame_queue.dart
@@ -40,6 +40,7 @@ class WebVideoFrameQueue<Frame, Image> {
 
   void beginSession(VideoImageCallback<Image> callback) {
     _invalidateSession();
+    _enabled = true;
     _callback = callback;
   }
 
@@ -70,9 +71,11 @@ class WebVideoFrameQueue<Frame, Image> {
     return true;
   }
 
+  // Test hook for synchronizing with an in-flight frame import.
   Future<void> waitForImport() =>
       _importStarted?.future ?? Future<void>.value();
 
+  // Test hook for synchronizing with queue processing completion.
   Future<void> waitUntilIdle() => _idle?.future ?? Future<void>.value();
 
   void _startProcessing() {

--- a/flutter/lib/models/web_video_frame_queue.dart
+++ b/flutter/lib/models/web_video_frame_queue.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+typedef VideoFrameImporter<Frame, Image> = Future<Image> Function(Frame frame);
+typedef VideoFrameCloser<Frame> = void Function(Frame frame);
+typedef VideoImageDisposer<Image> = void Function(Image image);
+typedef VideoSessionValidator = bool Function();
+typedef VideoImageCallback<Image> = Future<void> Function(
+    int display, Image image, VideoSessionValidator isCurrentSession);
+typedef VideoQueueErrorCallback = void Function(
+    Object error, StackTrace stackTrace);
+
+class WebVideoFrameQueue<Frame, Image> {
+  WebVideoFrameQueue({
+    required VideoFrameImporter<Frame, Image> importFrame,
+    required VideoFrameCloser<Frame> closeFrame,
+    required VideoImageDisposer<Image> disposeImage,
+    required VideoQueueErrorCallback onImportError,
+    required VideoQueueErrorCallback onCallbackError,
+  })  : _importFrame = importFrame,
+        _closeFrame = closeFrame,
+        _disposeImage = disposeImage,
+        _onImportError = onImportError,
+        _onCallbackError = onCallbackError;
+
+  final VideoFrameImporter<Frame, Image> _importFrame;
+  final VideoFrameCloser<Frame> _closeFrame;
+  final VideoImageDisposer<Image> _disposeImage;
+  final VideoQueueErrorCallback _onImportError;
+  final VideoQueueErrorCallback _onCallbackError;
+  final Map<int, _QueuedFrame<Frame>> _pending = {};
+
+  VideoImageCallback<Image>? _callback;
+  Completer<void>? _idle;
+  Completer<void>? _importStarted;
+  int _generation = 0;
+  bool _processing = false;
+  bool _enabled = true;
+
+  bool get isEnabled => _enabled;
+
+  void beginSession(VideoImageCallback<Image> callback) {
+    _invalidateSession();
+    _callback = callback;
+  }
+
+  void endSession() {
+    _invalidateSession();
+    _callback = null;
+  }
+
+  void _invalidateSession() {
+    _generation++;
+    for (final queued in _pending.values) {
+      _closeFrame(queued.frame);
+    }
+    _pending.clear();
+  }
+
+  bool submit(int display, Frame frame) {
+    if (!_enabled || _callback == null) {
+      _closeFrame(frame);
+      return false;
+    }
+    final replaced = _pending.remove(display);
+    if (replaced != null) {
+      _closeFrame(replaced.frame);
+    }
+    _pending[display] = _QueuedFrame(display, frame, _generation);
+    _startProcessing();
+    return true;
+  }
+
+  Future<void> waitForImport() =>
+      _importStarted?.future ?? Future<void>.value();
+
+  Future<void> waitUntilIdle() => _idle?.future ?? Future<void>.value();
+
+  void _startProcessing() {
+    if (_processing) return;
+    _processing = true;
+    _idle = Completer<void>();
+    _importStarted = Completer<void>();
+    unawaited(Future<void>(_process));
+  }
+
+  Future<void> _process() async {
+    while (_pending.isNotEmpty) {
+      final display = _pending.keys.first;
+      final queued = _pending.remove(display)!;
+      if (!_enabled || queued.generation != _generation) {
+        _closeFrame(queued.frame);
+        continue;
+      }
+      await _importAndDeliver(queued);
+    }
+    _processing = false;
+    _idle?.complete();
+  }
+
+  Future<void> _importAndDeliver(_QueuedFrame<Frame> queued) async {
+    Image? image;
+    try {
+      _importStarted?.complete();
+      _importStarted = null;
+      image = await _importFrame(queued.frame);
+    } catch (error, stackTrace) {
+      if (queued.generation == _generation) {
+        _enabled = false;
+        _onImportError(error, stackTrace);
+      }
+    } finally {
+      _closeFrame(queued.frame);
+    }
+    if (image != null) {
+      await _deliver(queued, image);
+    }
+  }
+
+  Future<void> _deliver(_QueuedFrame<Frame> queued, Image image) async {
+    final callback = _callback;
+    bool isCurrentSession() =>
+        _enabled &&
+        queued.generation == _generation &&
+        identical(callback, _callback);
+    if (!isCurrentSession() || callback == null) {
+      _disposeImage(image);
+      return;
+    }
+    try {
+      await callback(queued.display, image, isCurrentSession);
+    } catch (error, stackTrace) {
+      _disposeImage(image);
+      _onCallbackError(error, stackTrace);
+    }
+  }
+}
+
+class _QueuedFrame<Frame> {
+  const _QueuedFrame(this.display, this.frame, this.generation);
+
+  final int display;
+  final Frame frame;
+  final int generation;
+}

--- a/flutter/lib/web/dummy.dart
+++ b/flutter/lib/web/dummy.dart
@@ -12,3 +12,5 @@ Future<void> webSendLocalFiles(
     required bool isRemote}) {
   throw UnimplementedError("webSendLocalFiles");
 }
+
+Future<void> loadLocalTerminalFontIfNeeded() async {}

--- a/flutter/lib/web/terminal_font.dart
+++ b/flutter/lib/web/terminal_font.dart
@@ -27,6 +27,7 @@ Future<void> loadLocalTerminalFontIfNeeded() async {
       ..addFont(Future.value(data));
     await loader.load();
   } catch (e) {
+    _loadRequested = false;
     debugPrint('Failed to load bundled Roboto Mono: $e');
   }
 }

--- a/flutter/lib/web/terminal_font.dart
+++ b/flutter/lib/web/terminal_font.dart
@@ -1,0 +1,32 @@
+import 'dart:html' as html;
+import 'dart:js' as js;
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+bool _loadRequested = false;
+
+/// When Google CDNs are unreachable, `index.html` sets
+/// `window.rustdeskLocalFonts` and `GoogleFonts.robotoMono()` cannot download
+/// the terminal font. Load the copy bundled with the web app instead,
+/// registered under the family name google_fonts gives the terminal's
+/// TextStyle ('RobotoMono_regular').
+Future<void> loadLocalTerminalFontIfNeeded() async {
+  if (_loadRequested || js.context['rustdeskLocalFonts'] != true) {
+    return;
+  }
+  _loadRequested = true;
+  try {
+    final req = await html.HttpRequest.request(
+      'fonts/RobotoMono-Regular.ttf',
+      responseType: 'arraybuffer',
+    );
+    final data = ByteData.view(req.response as ByteBuffer);
+    final loader = FontLoader('RobotoMono_regular')
+      ..addFont(Future.value(data));
+    await loader.load();
+  } catch (e) {
+    debugPrint('Failed to load bundled Roboto Mono: $e');
+  }
+}


### PR DESCRIPTION
- Fixing https://github.com/rustdesk/rustdesk-server-pro/issues/996
- Use webcodec, ffmpeg as fallback
- render with texture, rgba as fallback
- upgrade to 3.44.8

Title: Web client: WebCodecs texture path, offline terminal font, Flutter 3.44.8 CI

# Be noted, webcodec requires https or localhost

## What this does

Three related changes backing the web client work in rustdesk-web-js
(`web-3.44-webcodecs-offline` there, meant to land together):

### 1. Zero-readback WebCodecs video path (`model.dart`, `web_model.dart`, `native_model.dart`)
The JS side (rustdesk-web-js) now decodes video with WebCodecs where the
browser supports it. Decoded `VideoFrame`s are handed to Flutter through a
`window.onVideoFrame` hook and imported GPU-to-GPU via
`ui_web.createImageFromTextureSource` — no RGBA readback on the hot path.
- Frames are owned strictly: closed on every path, only the newest undrawn
  frame per display is kept, so hardware decoder frame pools never starve.
- If texture import fails, the hook unregisters itself and the JS side falls
  back to its RGBA readback path automatically. Old/new JS and Dart bundles
  are compatible in both directions.

### 2. Bundled terminal font for air-gapped deployments (`terminal_page.dart`, `web/terminal_font.dart`, `web/dummy.dart`)
`GoogleFonts.robotoMono()` cannot download the terminal font without
internet. When `index.html` detects that Google CDNs are unreachable, the
bundled Roboto Mono is loaded under the family name google_fonts registers.
Part of the fix for rustdesk/rustdesk-server-pro#996.

### 3. CI: Windows arm64 on Flutter 3.44.8 + web build patch script (`.github/`)
- `FLUTTER_WINDOWS_ARM_VERSION` 3.44.0 → 3.44.8 (latest 3.44.x hotfix line;
  includes the external-texture resource leak fix in 3.44.7). Bridge job
  bumped in lockstep.
- New `.github/patches/apply_flutter_3.44_web_patches.sh`: prepares a 3.44.x
  *web* build on top of the shared source patches — patches
  qr_code_scanner's web impl for the removed `ui.platformViewRegistry`
  (`dart:ui_web`), and refreshes `flutter/web/fonts` to the paths the 3.44
  engine requests. The (currently disabled) `build-rustdesk-web` job runs it
  automatically once `FLUTTER_VERSION` moves to 3.44.x.
- Version-guarded `Patch flutter` steps used `[[ ... ]] && git apply` as the
  last command, which fails the step whenever the guard doesn't match;
  converted to `if`/`fi` everywhere so a future version bump doesn't break
  every job.

## Testing
- `flutter analyze` clean; web release builds verified on both 3.24.5 and
  3.44.8 (with the patch script).
- Headless-Chrome E2E: offline (gstatic DNS-blocked) and online runs, plus
  CJK input — see the rustdesk-web-js PR for the full matrix.
- The committed sources stay Flutter 3.24.5-compatible; 3.44-only source
  changes remain build-time patches by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Improved web video rendering with more efficient frame handling and smoother playback.
- Added support for loading the bundled Roboto Mono font in web terminal sessions when enabled.

## Bug Fixes
- Improved compatibility and reliability for Flutter 3.44 web builds, including version 3.44.8.
- Updated QR code scanning support for Flutter web.
- Prevented stale video frames from appearing after session changes.
- Improved handling of web video-frame and font resources.
- Strengthened build patch validation and refreshed web font assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a zero-readback WebCodecs video path for the web client (GPU-to-GPU frame import via `ui_web.createImageFromTextureSource`), a bundled Roboto Mono fallback for air-gapped terminal sessions, and bumps Flutter Windows arm64 CI to 3.44.8. The three previous comment-thread issues (permanent disable after import failure, missing staleness guard on `onImage`, no retry on font load failure) are all addressed in this revision.

- **WebCodecs path**: `WebVideoFrameQueue` manages frame lifetime with generation-based session tracking; frames are closed on every path and the newest frame per display wins. Import failures disable the path for that session and automatically revert JS to RGBA readback.
- **Terminal font**: `loadLocalTerminalFontIfNeeded` fetches the bundled TTF only when `window.rustdeskLocalFonts` is set, resets `_loadRequested` on failure to allow a retry.
- **CI**: `[[ ]] && git apply` one-liners converted to `if/fi` blocks to prevent spurious step failures on version mismatch; new `apply_flutter_3.44_web_patches.sh` handles qr_code_scanner and font refresh for 3.44.x web builds.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge. The three previously flagged issues are resolved, and no new functional regressions were found.
- All frame-lifecycle paths close or dispose correctly; generation tracking prevents stale frames painting across reconnects; the terminal font retry path is now guarded; CI patch steps no longer silently pass on version mismatch. The one dead-code guard in setVideoFrameCallback is a readability nit with no runtime impact.
- flutter/lib/models/web_model.dart — the isEnabled guard after beginSession is dead code and worth cleaning up in a follow-on, but it does not affect correctness.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/models/web_video_frame_queue.dart | New generic queue that manages WebCodecs VideoFrame lifetime — closes frames on session invalidation, enforces newest-frame-wins per display, and propagates a staleness closure into the deliver callback. Frame ownership and generation tracking look correct. |
| flutter/lib/models/web_model.dart | Adds zero-readback WebCodecs path via WebVideoFrameQueue and ui_web.createImageFromTextureSource. The isEnabled guard after beginSession is dead code (beginSession always resets _enabled=true); otherwise lifetime and fallback logic is correct. |
| flutter/lib/models/model.dart | Adds onImage for WebCodecs frames; introduces _disposeIfStale with isCurrentSession guard around both check points in update(); fixes missing image.dispose() on stale-peer return from decodeAndUpdate; calls clearVideoFrameCallback on session close. |
| flutter/lib/web/terminal_font.dart | Loads bundled Roboto Mono from the web asset path when window.rustdeskLocalFonts signals CDN unavailability. _loadRequested is reset to false on failure, allowing one retry on next navigation. |
| .github/patches/apply_flutter_3.44_web_patches.sh | New script for Flutter 3.44.x web builds: patches qr_code_scanner's dart:ui → dart:ui_web reference and refreshes web fonts. Idempotent, version-guarded, and validated with grep checks at the end. |
| .github/workflows/flutter-build.yml | Bumps FLUTTER_WINDOWS_ARM_VERSION to 3.44.8 and converts five [[ ]] && git apply one-liners to if/fi to prevent spurious step failures when the version guard doesn't match. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant JS as JS (webcodecs.js)
    participant WFQ as WebVideoFrameQueue
    participant FFI as PlatformFFI
    participant IM as ImageModel
    participant Flutter as Flutter canvas

    note over JS,Flutter: Session start (setVideoFrameCallback)
    FFI->>WFQ: "beginSession(callback)<br/>sets _enabled=true, _generation++"
    FFI->>JS: registers window.onVideoFrame

    loop Per decoded frame
        JS->>WFQ: submit(display, VideoFrame)
        WFQ->>WFQ: drop older frame for same display
        WFQ->>WFQ: _startProcessing()
        WFQ->>WFQ: "_importFrame(frame)<br/>(ui_web.createImageFromTextureSource)"
        WFQ->>WFQ: _closeVideoFrame(frame)
        alt import OK
            WFQ->>WFQ: _deliver(display, ui.Image, isCurrentSession)
            WFQ->>IM: callback(display, image, isCurrentSession)
            IM->>IM: "onEvent2UIRgba()<br/>(dismiss wait dialog)"
            IM->>IM: "update(image, isCurrentSession)<br/>_disposeIfStale checks x2"
            IM->>Flutter: notifyListeners()
        else import failed
            WFQ->>WFQ: "_enabled = false"
            WFQ->>JS: "clear window.onVideoFrame<br/>(JS falls back to RGBA)"
        end
    end

    note over JS,Flutter: Session end (clearVideoFrameCallback)
    FFI->>WFQ: "endSession()<br/>_generation++, clear pending"
    FFI->>JS: clear window.onVideoFrame
```
</details>

<sub>Reviews (8): Last reviewed commit: ["fix(web): Bad state: RenderBox was not l..."](https://github.com/rustdesk/rustdesk/commit/83192b6efd03d95e6a4394efaae270fb4fd9bc1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48640051)</sub>

<!-- /greptile_comment -->