### PR TITLE
fix(wayland): subscribe to portal Response before making the request

### DIFF
--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -507,6 +507,22 @@ where
     })
 }
 
+// The request object path a portal method call will use, derived from our unique
+// bus name and the `handle_token` we pass in the call arguments. Knowing it up
+// front lets us subscribe to the `Response` signal *before* making the call.
+// https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html
+fn get_request_path(
+    conn: &SyncConnection,
+    handle_token: &str,
+) -> Result<dbus::Path<'static>, dbus::Error> {
+    let sender = conn.unique_name().trim_start_matches(':').replace('.', "_");
+    dbus::Path::new(format!(
+        "/org/freedesktop/portal/desktop/request/{}/{}",
+        sender, handle_token
+    ))
+    .map_err(|_| dbus::Error::new_failed("Failed to construct portal request path"))
+}
+
 pub fn get_portal(conn: &SyncConnection) -> Proxy<&SyncConnection> {
     conn.with_proxy(
         "org.freedesktop.portal.Desktop",
@@ -632,13 +648,14 @@ pub fn request_remote_desktop(
     let failure_res = failure.clone();
     let session: Arc<Mutex<Option<dbus::Path>>> = Arc::new(Mutex::new(None));
     let session_res = session.clone();
+    let create_session_handle_token = "u1";
     args.insert(
         "session_handle_token".to_string(),
-        Variant(Box::new("u1".to_string())),
+        Variant(Box::new(create_session_handle_token.to_string())),
     );
     args.insert(
         "handle_token".to_string(),
-        Variant(Box::new("u1".to_string())),
+        Variant(Box::new(create_session_handle_token.to_string())),
     );
 
     let mut is_support_restore_token = false;
@@ -654,15 +671,9 @@ pub fn request_remote_desktop(
     // between the caller subscribing to the signal after receiving the reply for the method call and the signal getting emitted,
     // a convention for Request object paths has been established that allows
     // the caller to subscribe to the signal before making the method call.
-    let path;
-    if is_server_running() {
-        path = screencast_portal::create_session(&portal, args)?;
-    } else {
-        path = remote_desktop_portal::create_session(&portal, args)?;
-    }
     handle_response(
         &conn,
-        path,
+        get_request_path(&conn, create_session_handle_token)?,
         on_create_session_response(
             fd.clone(),
             streams.clone(),
@@ -673,6 +684,11 @@ pub fn request_remote_desktop(
         ),
         failure_res.clone(),
     )?;
+    if is_server_running() {
+        let _ = screencast_portal::create_session(&portal, args)?;
+    } else {
+        let _ = remote_desktop_portal::create_session(&portal, args)?;
+    }
 
     // wait 3 minutes for user interaction
     for _ in 0..1800 {
@@ -751,9 +767,10 @@ fn on_create_session_response(
                 // persist_mode may be configured by the user.
                 args.insert("persist_mode".to_string(), Variant(Box::new(2u32)));
             }
+            let select_sources_handle_token = "u3";
             args.insert(
                 "handle_token".to_string(),
-                Variant(Box::new("u3".to_string())),
+                Variant(Box::new(select_sources_handle_token.to_string())),
             );
             // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html
             if is_server_running() {
@@ -769,42 +786,43 @@ fn on_create_session_response(
                 });
             }
 
-            let path = portal.select_sources(ses.clone(), args)?;
             handle_response(
                 c,
-                path,
+                get_request_path(c, select_sources_handle_token)?,
                 on_select_sources_response(
                     fd.clone(),
                     streams.clone(),
                     failure.clone(),
-                    ses,
+                    ses.clone(),
                     is_support_restore_token,
                 ),
                 failure.clone(),
             )?;
+            let _ = portal.select_sources(ses.clone(), args)?;
         } else {
             // TODO: support persist_mode for remote_desktop_portal
             // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.RemoteDesktop.html
 
+            let select_devices_handle_token = "u2";
             args.insert(
                 "handle_token".to_string(),
-                Variant(Box::new("u2".to_string())),
+                Variant(Box::new(select_devices_handle_token.to_string())),
             );
             args.insert("types".to_string(), Variant(Box::new(7u32)));
 
-            let path = portal.select_devices(ses.clone(), args)?;
             handle_response(
                 c,
-                path,
+                get_request_path(c, select_devices_handle_token)?,
                 on_select_devices_response(
                     fd.clone(),
                     streams.clone(),
                     failure.clone(),
-                    ses,
+                    ses.clone(),
                     is_support_restore_token,
                 ),
                 failure.clone(),
             )?;
+            let _ = portal.select_devices(ses.clone(), args)?;
         }
 
         Ok(())
@@ -825,9 +843,10 @@ fn on_select_devices_response(
     move |_: OrgFreedesktopPortalRequestResponse, c, _| {
         let portal = get_portal(c);
         let mut args: PropMap = HashMap::new();
+        let select_sources_handle_token = "u3";
         args.insert(
             "handle_token".to_string(),
-            Variant(Box::new("u3".to_string())),
+            Variant(Box::new(select_sources_handle_token.to_string())),
         );
         // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.ScreenCast.html
         if is_server_running() {
@@ -836,19 +855,19 @@ fn on_select_devices_response(
         args.insert("types".into(), Variant(Box::new(1u32))); //| 2u32)));
 
         let session = session.clone();
-        let path = portal.select_sources(session.clone(), args)?;
         handle_response(
             c,
-            path,
+            get_request_path(c, select_sources_handle_token)?,
             on_select_sources_response(
                 fd.clone(),
                 streams.clone(),
                 failure.clone(),
-                session,
+                session.clone(),
                 is_support_restore_token,
             ),
             failure.clone(),
         )?;
+        let _ = portal.select_sources(session.clone(), args)?;
 
         Ok(())
     }
@@ -868,19 +887,14 @@ fn on_select_sources_response(
     move |_: OrgFreedesktopPortalRequestResponse, c, _| {
         let portal = get_portal(c);
         let mut args: PropMap = HashMap::new();
+        let start_handle_token = "u4";
         args.insert(
             "handle_token".to_string(),
-            Variant(Box::new("u4".to_string())),
+            Variant(Box::new(start_handle_token.to_string())),
         );
-        let path;
-        if is_server_running() {
-            path = screencast_portal::start(&portal, session.clone(), "", args)?;
-        } else {
-            path = remote_desktop_portal::start(&portal, session.clone(), "", args)?;
-        }
         handle_response(
             c,
-            path,
+            get_request_path(c, start_handle_token)?,
             on_start_response(
                 fd.clone(),
                 streams.clone(),
@@ -889,6 +903,11 @@ fn on_select_sources_response(
             ),
             failure.clone(),
         )?;
+        if is_server_running() {
+            let _ = screencast_portal::start(&portal, session.clone(), "", args)?;
+        } else {
+            let _ = remote_desktop_portal::start(&portal, session.clone(), "", args)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
### Problem

`request_remote_desktop` and its response handlers call each portal method first and only then subscribe to the resulting `Request`'s `Response` signal, using the object path returned by the call.

The comment directly above the `CreateSession` call already explains why that ordering is wrong:

> To avoid a race condition between the caller subscribing to the signal after receiving the reply for the method call and the signal getting emitted, a convention for Request object paths has been established that allows the caller to subscribe to the signal before making the method call.

The code then does the opposite of what the comment describes.

When the portal emits `Response` before the match rule is installed, the signal is lost and the flow stalls. `request_remote_desktop` spins its 3-minute wait loop and gives up, so the user sees the screen picker again — or a failure — even when a valid restore token would have restored the session silently. It is timing-dependent, which fits the shape of the intermittent "Wayland keeps asking me to pick a screen" reports.

### Fix

Build the request object path from the connection's unique bus name plus the `handle_token` passed in the call arguments, exactly as [the Request documentation](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html) prescribes, and subscribe before making the call.

Applied to all five portal calls:

- `CreateSession` (both the ScreenCast and RemoteDesktop variants)
- `SelectSources` (the ScreenCast path, and the one reached after `SelectDevices`)
- `SelectDevices`
- `Start` (both variants)

The `handle_token` values are unchanged (`u1`–`u4`). They are now named locals so the request path and the call argument cannot drift apart.

### Scope

One file, `libs/scrap/src/wayland/pipewire.rs`. No behaviour change other than the subscribe/call ordering — no new dependencies, no config, no signature changes to anything outside the module.

### Testing

- `cargo check -p scrap --features wayland` clean against this branch's base.
- `rustfmt --check` clean.
- Exercised on Hyprland (xdg-desktop-portal-hyprland) with restore tokens: sessions restore without a picker across reconnects and process restarts.

I do not have GNOME or KDE Wayland hardware to hand, so I have not verified it there. The change is compositor-independent — it only affects when the D-Bus match rule is installed relative to the method call — but a second pair of eyes from someone on mutter or kwin would be welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen-sharing setup reliability by registering portal response handling before requests are sent.
  * Improved session creation, source selection, and stream startup flow for Wayland and PipeWire environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in the Wayland portal D-Bus integration where the `Response` signal subscription was registered *after* making the portal method call, violating the xdg-desktop-portal specification and causing intermittent failures when sessions should have been silently restored via a persist token.

- Adds `get_request_path()` to compute the portal `Request` object path deterministically from the connection's unique bus name and `handle_token`, exactly as the [portal spec](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html) prescribes, so `handle_response()` can be called before the method invocation.
- Promotes the five hardcoded `handle_token` strings (`u1`–`u4`) to named locals so the path construction and the D-Bus call argument cannot silently drift apart.
- All five portal calls — `CreateSession` (both variants), `SelectSources` (both reaches), `SelectDevices`, and `Start` (both variants) — are updated to subscribe first, then call.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is confined to a single file, touches only the ordering of D-Bus subscribe/call pairs, and has been tested end-to-end on Hyprland with restore tokens.

The reordering is a direct, textbook application of the portal spec's documented convention. `get_request_path` implements the sender-name transformation exactly as the spec describes. Named token locals prevent the only class of future regression (path/arg drift). Error propagation is preserved via `?` on every portal call.

**Files Needing Attention:** No files require special attention. The only changed file, `libs/scrap/src/wayland/pipewire.rs`, is self-contained and the diff is straightforward to verify.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/scrap/src/wayland/pipewire.rs | Reorders D-Bus match-rule registration before portal method calls for all five xdg-desktop-portal interactions; adds `get_request_path()` to compute the Request object path deterministically per spec. Logic is correct, token locality prevents argument/path drift, and the `let _ = call()?` pattern still propagates errors. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant DBusDaemon as D-Bus Daemon
    participant Portal as xdg-desktop-portal

    Note over App,Portal: OLD (racy) flow
    App->>Portal: "CreateSession(handle_token=u1)"
    Portal-->>App: Ok(request_path)
    Portal-)DBusDaemon: emit Response signal on request_path
    App->>DBusDaemon: AddMatch(request_path) — LATE, signal already gone
    Note over App: Signal missed → 3-min timeout → failure

    Note over App,Portal: NEW (fixed) flow
    App->>App: get_request_path(unique_name, u1)
    App->>DBusDaemon: AddMatch(computed_path) — subscribed BEFORE call
    App->>Portal: "CreateSession(handle_token=u1)"
    Portal-)DBusDaemon: emit Response signal on computed_path
    DBusDaemon-)App: deliver Response (match already installed)
    App->>App: on_create_session_response callback fires correctly
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(wayland): subscribe to portal Respon..."](https://github.com/rustdesk/rustdesk/commit/7a737a5fcba89aad86b60ee597ed302c29e8f9a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48882528)</sub>

<!-- /greptile_comment -->