### PR TITLE
Login options error feedback

### DIFF
--- a/.github/workflows/update-webpki-roots.yml
+++ b/.github/workflows/update-webpki-roots.yml
@@ -1,0 +1,64 @@
+name: Update webpki-roots
+
+# Weekly refresh of the compiled-in TLS root certificates (the webpki-roots
+# crate, a snapshot of the Mozilla root store). Roots are otherwise frozen at
+# whatever Cargo.lock pins, so old builds miss newly added CAs and keep
+# removed (distrusted) ones. Changes go through a PR on purpose: added or
+# removed roots should be reviewed, not silently baked into releases.
+#
+# Note: PRs created with the default GITHUB_TOKEN do not trigger other
+# workflows (GitHub limitation). Close and reopen the PR, or push to its
+# branch, to run CI on it.
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      BRANCH: auto-update-webpki-roots
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Update webpki-roots in all lockfiles
+        id: update
+        run: |
+          set -e
+          for lock in $(git ls-files '*Cargo.lock'); do
+            dir=$(dirname "$lock")
+            for v in $(sed -n '/name = "webpki-roots"/{n;s/.*version = "\(.*\)"/\1/p;}' "$lock" | sort -u); do
+              echo "updating webpki-roots@$v in $dir"
+              (cd "$dir" && cargo update -p "webpki-roots@$v")
+            done
+          done
+          if git diff --quiet -- '*Cargo.lock'; then
+            echo "changed=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=1" >> "$GITHUB_OUTPUT"
+            git --no-pager diff -- '*Cargo.lock'
+          fi
+
+      - name: Create pull request
+        if: steps.update.outputs.changed == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add -- '*Cargo.lock'
+          git commit -m "chore: update webpki-roots to latest Mozilla root store"
+          git push -f origin "$BRANCH"
+          if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --title "chore: update webpki-roots to latest Mozilla root store" \
+              --body "Automated weekly refresh of the compiled-in TLS root certificates (webpki-roots). Please review the added/removed roots. CI does not run automatically on PRs created by GITHUB_TOKEN; close and reopen this PR to trigger it."
+          fi

--- a/.github/workflows/update-webpki-roots.yml
+++ b/.github/workflows/update-webpki-roots.yml
@@ -15,6 +15,13 @@ on:
     - cron: "0 3 * * 1"
   workflow_dispatch:
 
+# A manual dispatch overlapping the weekly run would race it force-pushing
+# the same branch; queue instead of overlapping, and never cancel a run
+# that may have already pushed.
+concurrency:
+  group: update-webpki-roots
+  cancel-in-progress: false
+
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -31,7 +38,7 @@ jobs:
         id: update
         run: |
           set -e
-          for lock in $(git ls-files '*Cargo.lock'); do
+          git ls-files -z '*Cargo.lock' | while IFS= read -r -d '' lock; do
             dir=$(dirname "$lock")
             for v in $(sed -n '/name = "webpki-roots"/{n;s/.*version = "\(.*\)"/\1/p;}' "$lock" | sort -u); do
               echo "updating webpki-roots@$v in $dir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3821,7 +3821,7 @@ dependencies = [
  "url",
  "users 0.11.0",
  "uuid",
- "webpki-roots 1.0.4",
+ "webpki-roots 1.0.9",
  "webrtc",
  "whoami",
  "winapi 0.3.9",
@@ -4020,7 +4020,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.4",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -7112,7 +7112,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.4",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -8826,7 +8826,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tungstenite",
- "webpki-roots 0.26.9",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -9140,7 +9140,7 @@ dependencies = [
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
- "webpki-roots 0.26.9",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -9813,18 +9813,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.9"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "rustls-pki-types",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -4048,7 +4048,8 @@ Widget netWorkErrorWidget() {
     mainAxisAlignment: MainAxisAlignment.center,
     crossAxisAlignment: CrossAxisAlignment.center,
     children: [
-      Text(translate("network_error_tip")),
+      if (!gFFI.userModel.networkErrorFromServer.value)
+        Text(translate("network_error_tip")),
       ElevatedButton(
               onPressed: gFFI.userModel.refreshCurrentUser,
               child: Text(translate("Retry")))

--- a/flutter/lib/common/widgets/login.dart
+++ b/flutter/lib/common/widgets/login.dart
@@ -267,8 +267,7 @@ class _WidgetOPState extends State<WidgetOP> {
                   Padding(
                     padding: const EdgeInsets.only(top: 8.0),
                     child: Builder(builder: (context) {
-                      final errorColor =
-                          Theme.of(context).colorScheme.error;
+                      final errorColor = Theme.of(context).colorScheme.error;
                       final bgColor = Theme.of(context)
                           .colorScheme
                           .errorContainer
@@ -289,12 +288,11 @@ class _WidgetOPState extends State<WidgetOP> {
                             Flexible(
                               child: SelectableText(
                                 translate(_failedMsg),
-                                style: DefaultTextStyle.of(context)
-                                    .style
-                                    .copyWith(
-                                      fontSize: 13,
-                                      color: errorColor,
-                                    ),
+                                style:
+                                    DefaultTextStyle.of(context).style.copyWith(
+                                          fontSize: 13,
+                                          color: errorColor,
+                                        ),
                               ),
                             ),
                           ],
@@ -469,13 +467,17 @@ Future<bool?> loginDialog() async {
 
   final loginOptions = [].obs;
   final loginOptionsError = Rxn<String>();
+  final loginOptionsInProgress = false.obs;
   fetchLoginOptions() async {
-    loginOptionsError.value = null;
+    loginOptionsInProgress.value = true;
     try {
       loginOptions.value = await UserModel.queryOidcLoginOptions();
+      loginOptionsError.value = null;
     } catch (e) {
       debugPrint("queryOidcLoginOptions failed: $e");
       loginOptionsError.value = e.toString();
+    } finally {
+      loginOptionsInProgress.value = false;
     }
   }
 
@@ -584,17 +586,20 @@ Future<bool?> loginDialog() async {
 
     thirdAuthWidget() => Obx(() {
           final error = loginOptionsError.value;
+          final inProgress = loginOptionsInProgress.value;
           if (error != null) {
             return Column(
               children: [
                 const SizedBox(height: 8.0),
+                // NOT use Offstage to wrap LinearProgressIndicator
+                if (inProgress) const LinearProgressIndicator(),
                 Text(
                   translate('network_error_tip'),
                   style: const TextStyle(fontSize: 12),
                   textAlign: TextAlign.center,
                 ),
                 TextButton(
-                  onPressed: fetchLoginOptions,
+                  onPressed: inProgress ? null : fetchLoginOptions,
                   child: Text(translate('Retry')),
                 ),
                 SelectableText(

--- a/flutter/lib/common/widgets/login.dart
+++ b/flutter/lib/common/widgets/login.dart
@@ -593,20 +593,25 @@ Future<bool?> loginDialog() async {
                 const SizedBox(height: 8.0),
                 // NOT use Offstage to wrap LinearProgressIndicator
                 if (inProgress) const LinearProgressIndicator(),
-                Text(
-                  translate('network_error_tip'),
-                  style: const TextStyle(fontSize: 12),
-                  textAlign: TextAlign.center,
-                ),
+                if (!inProgress)
+                  Text(
+                    translate('network_error_tip'),
+                    style: const TextStyle(fontSize: 12),
+                    textAlign: TextAlign.center,
+                  ),
                 TextButton(
+                  style: TextButton.styleFrom(
+                    foregroundColor: Theme.of(context).colorScheme.primary,
+                  ),
                   onPressed: inProgress ? null : fetchLoginOptions,
                   child: Text(translate('Retry')),
                 ),
-                SelectableText(
-                  error,
-                  style: const TextStyle(fontSize: 11, color: Colors.red),
-                  textAlign: TextAlign.center,
-                ),
+                if (!inProgress)
+                  SelectableText(
+                    error,
+                    style: const TextStyle(fontSize: 11, color: Colors.red),
+                    textAlign: TextAlign.center,
+                  ),
               ],
             );
           }

--- a/flutter/lib/common/widgets/login.dart
+++ b/flutter/lib/common/widgets/login.dart
@@ -468,9 +468,18 @@ Future<bool?> loginDialog() async {
   bool isCloseHovered = false;
 
   final loginOptions = [].obs;
-  Future.delayed(Duration.zero, () async {
-    loginOptions.value = await UserModel.queryOidcLoginOptions();
-  });
+  final loginOptionsError = Rxn<String>();
+  fetchLoginOptions() async {
+    loginOptionsError.value = null;
+    try {
+      loginOptions.value = await UserModel.queryOidcLoginOptions();
+    } catch (e) {
+      debugPrint("queryOidcLoginOptions failed: $e");
+      loginOptionsError.value = e.toString();
+    }
+  }
+
+  Future.delayed(Duration.zero, fetchLoginOptions);
 
   final res = await gFFI.dialogManager.show<bool>((setState, close, context) {
     username.addListener(() {
@@ -574,6 +583,28 @@ Future<bool?> loginDialog() async {
     }
 
     thirdAuthWidget() => Obx(() {
+          final error = loginOptionsError.value;
+          if (error != null) {
+            return Column(
+              children: [
+                const SizedBox(height: 8.0),
+                Text(
+                  translate('network_error_tip'),
+                  style: const TextStyle(fontSize: 12),
+                  textAlign: TextAlign.center,
+                ),
+                TextButton(
+                  onPressed: fetchLoginOptions,
+                  child: Text(translate('Retry')),
+                ),
+                SelectableText(
+                  error,
+                  style: const TextStyle(fontSize: 11, color: Colors.red),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            );
+          }
           return Offstage(
             offstage: loginOptions.isEmpty,
             child: Column(

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -219,11 +219,13 @@ class UserModel {
     return loginResponse;
   }
 
+  /// Throws on network failure so callers can surface the error and offer a
+  /// retry; returns an empty list when the server has no third-party login.
   static Future<List<dynamic>> queryOidcLoginOptions() async {
+    final url = await bind.mainGetApiServer();
+    if (url.trim().isEmpty) return [];
+    final resp = await http.get(Uri.parse('$url/api/login-options'));
     try {
-      final url = await bind.mainGetApiServer();
-      if (url.trim().isEmpty) return [];
-      final resp = await http.get(Uri.parse('$url/api/login-options'));
       final List<String> ops = [];
       for (final item in jsonDecode(resp.body)) {
         ops.add(item as String);

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -240,24 +240,25 @@ class UserModel {
     final url = await bind.mainGetApiServer();
     if (url.trim().isEmpty) return [];
     final resp = await http.get(Uri.parse('$url/api/login-options'));
-    try {
-      final List<String> ops = [];
-      for (final item in jsonDecode(resp.body)) {
-        ops.add(item as String);
-      }
-      for (final item in ops) {
-        if (item.startsWith('common-oidc/')) {
-          return jsonDecode(item.substring('common-oidc/'.length));
-        }
-      }
-      return ops
-          .where((item) => item.startsWith('oidc/'))
-          .map((item) => {'name': item.substring('oidc/'.length)})
-          .toList();
-    } catch (e) {
-      debugPrint(
-          "queryOidcLoginOptions: jsonDecode resp body failed: ${e.toString()}");
-      return [];
+    const successStatusCodeStart = 200;
+    const successStatusCodeEnd = 300;
+    if (resp.statusCode < successStatusCodeStart ||
+        resp.statusCode >= successStatusCodeEnd) {
+      throw RequestException(
+          resp.statusCode, resp.reasonPhrase ?? 'Request failed');
     }
+    final List<String> ops = [];
+    for (final item in jsonDecode(resp.body)) {
+      ops.add(item as String);
+    }
+    for (final item in ops) {
+      if (item.startsWith('common-oidc/')) {
+        return jsonDecode(item.substring('common-oidc/'.length));
+      }
+    }
+    return ops
+        .where((item) => item.startsWith('oidc/'))
+        .map((item) => {'name': item.substring('oidc/'.length)})
+        .toList();
   }
 }

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -20,6 +20,9 @@ class UserModel {
   final RxString avatar = ''.obs;
   final RxBool isAdmin = false.obs;
   final RxString networkError = ''.obs;
+  // True when networkError carries a server-reported error rather than a
+  // connectivity failure; netWorkErrorWidget hides the network tip then.
+  final RxBool networkErrorFromServer = false.obs;
   bool get isLogin => userName.isNotEmpty;
   String get displayNameOrUserName =>
       displayName.value.trim().isEmpty ? userName.value : displayName.value;
@@ -50,6 +53,7 @@ class UserModel {
   void refreshCurrentUser() async {
     if (bind.isDisableAccount()) return;
     networkError.value = '';
+    networkErrorFromServer.value = false;
     final token = bind.mainGetLocalOption(key: 'access_token');
     if (token == '') {
       await updateOtherModels();
@@ -92,9 +96,12 @@ class UserModel {
       _parseAndUpdateUser(user);
     } catch (e) {
       debugPrint('Failed to refreshCurrentUser: $e');
-      // Also surface non-transport failures (bad status, non-JSON body) in
-      // the address book / group tabs, which offer a retry.
+      // Also surface non-transport failures in the address book / group
+      // tabs, which offer a retry. A FormatException means the body was not
+      // the expected JSON (e.g. a filter's block page), so the network tip
+      // still applies; anything else is an error the server reported.
       if (networkError.value.isEmpty) {
+        networkErrorFromServer.value = e is! FormatException;
         networkError.value = e.toString();
       }
     } finally {

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -89,6 +89,10 @@ class UserModel {
       final data = json.decode(decode_http_response(response));
       final error = data['error'];
       if (error != null) {
+        // The only failure known to come from the server itself, so the
+        // check-your-network tip does not apply. Flag before the message is
+        // set in the catch below so rebuilds read a consistent pair.
+        networkErrorFromServer.value = true;
         throw error;
       }
 
@@ -96,12 +100,11 @@ class UserModel {
       _parseAndUpdateUser(user);
     } catch (e) {
       debugPrint('Failed to refreshCurrentUser: $e');
-      // Also surface non-transport failures in the address book / group
-      // tabs, which offer a retry. A FormatException means the body was not
-      // the expected JSON (e.g. a filter's block page), so the network tip
-      // still applies; anything else is an error the server reported.
+      // Surface failures in the address book / group tabs, which offer a
+      // retry. Anything not flagged above -- transport errors, non-JSON or
+      // unexpected-schema bodies (e.g. a filter's block page) -- keeps the
+      // check-your-network tip.
       if (networkError.value.isEmpty) {
-        networkErrorFromServer.value = e is! FormatException;
         networkError.value = e.toString();
       }
     } finally {

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -92,6 +92,11 @@ class UserModel {
       _parseAndUpdateUser(user);
     } catch (e) {
       debugPrint('Failed to refreshCurrentUser: $e');
+      // Also surface non-transport failures (bad status, non-JSON body) in
+      // the address book / group tabs, which offer a retry.
+      if (networkError.value.isEmpty) {
+        networkError.value = e.toString();
+      }
     } finally {
       refreshingUser = false;
       await updateOtherModels();

--- a/flutter/lib/utils/http_service.dart
+++ b/flutter/lib/utils/http_service.dart
@@ -57,33 +57,38 @@ class HttpService {
     Map<String, String>? headers,
     dynamic body,
   }) async {
-    var response = http.Response('', 400);
+    final client = http.Client();
+    try {
+      var response = http.Response('', 400);
 
-    switch (method) {
-      case HttpMethod.get:
-        response =
-            await http.get(url, headers: headers).timeout(_requestTimeout);
-        break;
-      case HttpMethod.post:
-        response = await http
-            .post(url, headers: headers, body: body)
-            .timeout(_requestTimeout);
-        break;
-      case HttpMethod.put:
-        response = await http
-            .put(url, headers: headers, body: body)
-            .timeout(_requestTimeout);
-        break;
-      case HttpMethod.delete:
-        response = await http
-            .delete(url, headers: headers, body: body)
-            .timeout(_requestTimeout);
-        break;
-      default:
-        throw Exception('Unsupported HTTP method');
+      switch (method) {
+        case HttpMethod.get:
+          response =
+              await client.get(url, headers: headers).timeout(_requestTimeout);
+          break;
+        case HttpMethod.post:
+          response = await client
+              .post(url, headers: headers, body: body)
+              .timeout(_requestTimeout);
+          break;
+        case HttpMethod.put:
+          response = await client
+              .put(url, headers: headers, body: body)
+              .timeout(_requestTimeout);
+          break;
+        case HttpMethod.delete:
+          response = await client
+              .delete(url, headers: headers, body: body)
+              .timeout(_requestTimeout);
+          break;
+        default:
+          throw Exception('Unsupported HTTP method');
+      }
+
+      return response;
+    } finally {
+      client.close();
     }
-
-    return response;
   }
 
   Future<String> _pollForResponse(String url) async {

--- a/flutter/lib/utils/http_service.dart
+++ b/flutter/lib/utils/http_service.dart
@@ -44,6 +44,11 @@ class HttpService {
     return _parseHttpResponse(resJson);
   }
 
+  // Keep this above the Rust side's per-attempt timeout (12s) so it only
+  // bounds requests the OS would otherwise let hang (e.g. a black-holed
+  // TLS handshake), see #15700.
+  static const _requestTimeout = Duration(seconds: 15);
+
   Future<http.Response> _pollFlutterHttp(
     Uri url,
     HttpMethod method, {
@@ -54,16 +59,23 @@ class HttpService {
 
     switch (method) {
       case HttpMethod.get:
-        response = await http.get(url, headers: headers);
+        response =
+            await http.get(url, headers: headers).timeout(_requestTimeout);
         break;
       case HttpMethod.post:
-        response = await http.post(url, headers: headers, body: body);
+        response = await http
+            .post(url, headers: headers, body: body)
+            .timeout(_requestTimeout);
         break;
       case HttpMethod.put:
-        response = await http.put(url, headers: headers, body: body);
+        response = await http
+            .put(url, headers: headers, body: body)
+            .timeout(_requestTimeout);
         break;
       case HttpMethod.delete:
-        response = await http.delete(url, headers: headers, body: body);
+        response = await http
+            .delete(url, headers: headers, body: body)
+            .timeout(_requestTimeout);
         break;
       default:
         throw Exception('Unsupported HTTP method');

--- a/flutter/lib/utils/http_service.dart
+++ b/flutter/lib/utils/http_service.dart
@@ -44,10 +44,12 @@ class HttpService {
     return _parseHttpResponse(resJson);
   }
 
-  // Keep this above the Rust side's per-attempt timeout (12s) so it only
-  // bounds requests the OS would otherwise let hang (e.g. a black-holed
-  // TLS handshake), see #15700.
-  static const _requestTimeout = Duration(seconds: 15);
+  // Bounds only the pure-Dart branch below, which the OS would otherwise
+  // let hang forever (e.g. a black-holed TLS handshake), see #15700.
+  // The Rust branch has its own 12s-per-attempt timeouts and must be
+  // awaited to completion: a Dart-side timeout there would race the
+  // URL-keyed ASYNC_HTTP_STATUS entry of the abandoned request.
+  static const _requestTimeout = Duration(seconds: 30);
 
   Future<http.Response> _pollFlutterHttp(
     Uri url,


### PR DESCRIPTION
- https://github.com/rustdesk/rustdesk/discussions/15700
- update webpki-roots CI
- currentMe retry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC login-option loading with progress indicators and detailed, retryable error messages.
  * Improved handling and reporting of server and connectivity errors during sign-in and user refresh.
  * Added a 30-second timeout to Dart-based HTTP requests to prevent requests from hanging indefinitely.
  * Updated network error displays to avoid showing connectivity guidance for server-reported errors.

* **Chores**
  * Added automated weekly or manual updates for web security roots and pull request creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves error feedback for OIDC login-option loading and user-refresh: errors now propagate and display with a retry button instead of silently returning empty, a 30-second timeout is added to the Dart HTTP path, and a `networkErrorFromServer` flag hides misleading "check your network" guidance when the server itself reported the error.

- `queryOidcLoginOptions` now throws on non-2xx responses and network failures rather than swallowing them, and `loginDialog` shows a retryable error UI with a progress indicator on subsequent attempts.
- `refreshCurrentUser` sets `networkErrorFromServer` before re-throwing server-reported errors so `netWorkErrorWidget` can distinguish them from connectivity failures.
- A new weekly GitHub Actions workflow bumps `webpki-roots` in all `Cargo.lock` files and opens a PR for review, keeping the compiled-in Mozilla root store current.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the changes are well-scoped improvements to error reporting and do not alter authentication logic or data persistence.

The error-propagation refactor in queryOidcLoginOptions and the networkErrorFromServer flag are straightforward and correctly wired up. The 30-second timeout is gated to the Flutter HTTP path only, with appropriate justification for leaving the Rust path unchanged. The one observation (network tip shown for server errors in the login-options UI) is a cosmetic inconsistency and does not affect correctness or security.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/models/user_model.dart | queryOidcLoginOptions now propagates errors (status-code check + removed silent catch), networkErrorFromServer flag correctly distinguishes server vs connectivity errors in refreshCurrentUser |
| flutter/lib/common/widgets/login.dart | Adds fetchLoginOptions with retry UI and progress indicator; network_error_tip is always shown for server-side errors, inconsistent with the updated netWorkErrorWidget behavior |
| flutter/lib/utils/http_service.dart | Adds 30s timeout to the Flutter HTTP path via client.timeout(); properly scoped to _pollFlutterHttp only, as the Rust path has its own timeouts |
| flutter/lib/common.dart | netWorkErrorWidget conditionally hides 'check your network' tip when networkErrorFromServer is true; callers are inside Obx so reactivity is correct |
| .github/workflows/update-webpki-roots.yml | New weekly/manual workflow to bump webpki-roots in all Cargo.lock files and open a PR; correctly handles concurrency, force-push, and duplicate PR detection |
| Cargo.lock | Bumps webpki-roots 1.0.4→1.0.9 and 0.26.9→0.26.11 (Mozilla root store refresh); routine security maintenance |

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(flutter): surface login option respo..."](https://github.com/rustdesk/rustdesk/commit/338e066d17f3357f5bc4fae5fdbca08d70a2b382) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48887522)</sub>

<!-- /greptile_comment -->