### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/hbb_common"]
 	path = libs/hbb_common
-	url = https://github.com/rustdesk/hbb_common
+	url = https://github.com/kycy624-alt/hbb_common


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the source location for a shared library component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes a single line in `.gitmodules`, redirecting the `libs/hbb_common` Git submodule from the official `rustdesk/hbb_common` repository to the PR author's personal fork. No other changes are made.

- **Submodule URL overwritten**: `url = https://github.com/rustdesk/hbb_common` is replaced with `url = https://github.com/kycy624-alt/hbb_common`, pointing all submodule checkouts at an external, unreviewed fork owned by the PR author.
- **Critical dependency affected**: `hbb_common` underpins config, protobuf protocol definitions, shared utilities, and file transfer — core components of RustDesk.
</details>

<details><summary><h3>Confidence Score: 0/5</h3></summary>

This PR must not be merged. It redirects a core submodule to the PR author's personal fork, meaning all builds would silently pull unreviewed external code.

The single changed line points the hbb_common submodule — which provides config, protocol definitions, shared utilities, and file transfer — away from the official rustdesk organization and toward the PR author's own GitHub account. Every clone, CI run, and release build would fetch whatever code that fork contains without any review by the project maintainers.

**Files Needing Attention:** .gitmodules — the only changed file, and it carries the submodule URL that must be reverted to https://github.com/rustdesk/hbb_common.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Supply chain / submodule hijack** (`.gitmodules`): The `libs/hbb_common` submodule URL is changed from `rustdesk/hbb_common` to the PR author's personal fork `kycy624-alt/hbb_common`. Merging this would cause every downstream clone, CI build, and release pipeline to silently pull arbitrary code from an unaffiliated account. `hbb_common` contains config, protobuf definitions, shared utilities, and file transfer logic — making it a high-value target for tampering.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .gitmodules | Redirects the hbb_common submodule URL from the official rustdesk/hbb_common repo to the PR author's personal fork (kycy624-alt/hbb_common), a supply chain attack vector that must not be merged. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer clones rustdesk/rustdesk] --> B[git submodule update --init]
    B -->|Before this PR| C[Fetches from rustdesk/hbb_common\nOfficial, reviewed source]
    B -->|After this PR| D[Fetches from kycy624-alt/hbb_common\nPR author's personal fork]
    D --> E[Unreviewed / potentially malicious code\nenters the build]
    E --> F[CI/CD pipelines, release builds,\nand contributor checkouts affected]
    style D fill:#ff4444,color:#fff
    style E fill:#ff4444,color:#fff
    style F fill:#ff8800,color:#fff
    style C fill:#44aa44,color:#fff
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.gitmodules%3A3%0A**Submodule%20redirected%20to%20PR%20author's%20personal%20fork**%0A%0AThis%20change%20points%20the%20%60libs%2Fhbb_common%60%20submodule%20away%20from%20the%20canonical%20%60rustdesk%2Fhbb_common%60%20repository%20and%20toward%20%60kycy624-alt%2Fhbb_common%60%2C%20which%20is%20the%20PR%20author's%20own%20account.%20Anyone%20who%20clones%20this%20repository%20with%20%60--recurse-submodules%60%20%E2%80%94%20including%20CI%2FCD%20pipelines%2C%20release%20builders%2C%20and%20contributors%20%E2%80%94%20would%20silently%20pull%20code%20from%20an%20unreviewed%20external%20fork%20instead%20of%20the%20official%20source.%20According%20to%20%60AGENTS.md%60%2C%20%60hbb_common%60%20contains%20the%20project's%20config%2C%20protobuf%20definitions%2C%20shared%20utils%2C%20and%20file%20transfer%20implementation%2C%20making%20it%20a%20highly%20sensitive%20dependency.%20This%20is%20a%20classic%20supply%20chain%20%2F%20submodule-hijacking%20pattern%20and%20this%20change%20must%20not%20be%20merged.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15729&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22master%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22master%22.%0A%0A%23%23%23%20Issue%201%0A.gitmodules%3A3%0A**Submodule%20redirected%20to%20PR%20author's%20personal%20fork**%0A%0AThis%20change%20points%20the%20%60libs%2Fhbb_common%60%20submodule%20away%20from%20the%20canonical%20%60rustdesk%2Fhbb_common%60%20repository%20and%20toward%20%60kycy624-alt%2Fhbb_common%60%2C%20which%20is%20the%20PR%20author's%20own%20account.%20Anyone%20who%20clones%20this%20repository%20with%20%60--recurse-submodules%60%20%E2%80%94%20including%20CI%2FCD%20pipelines%2C%20release%20builders%2C%20and%20contributors%20%E2%80%94%20would%20silently%20pull%20code%20from%20an%20unreviewed%20external%20fork%20instead%20of%20the%20official%20source.%20According%20to%20%60AGENTS.md%60%2C%20%60hbb_common%60%20contains%20the%20project's%20config%2C%20protobuf%20definitions%2C%20shared%20utils%2C%20and%20file%20transfer%20implementation%2C%20making%20it%20a%20highly%20sensitive%20dependency.%20This%20is%20a%20classic%20supply%20chain%20%2F%20submodule-hijacking%20pattern%20and%20this%20change%20must%20not%20be%20merged.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15729&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.gitmodules:3
**Submodule redirected to PR author's personal fork**

This change points the `libs/hbb_common` submodule away from the canonical `rustdesk/hbb_common` repository and toward `kycy624-alt/hbb_common`, which is the PR author's own account. Anyone who clones this repository with `--recurse-submodules` — including CI/CD pipelines, release builders, and contributors — would silently pull code from an unreviewed external fork instead of the official source. According to `AGENTS.md`, `hbb_common` contains the project's config, protobuf definitions, shared utils, and file transfer implementation, making it a highly sensitive dependency. This is a classic supply chain / submodule-hijacking pattern and this change must not be merged.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update .gitmodules"](https://github.com/rustdesk/rustdesk/commit/9d0061de599cfa61f2142d9b69bcc5f422763cdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48996334)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->