### PR TITLE
Add SBOM (Software Bill of Materials) for the EU Cyber Resilience Act (EU CRA)

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -60,7 +60,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: recursive
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -53,6 +53,32 @@ env:
   SIGN_BASE_URL: "${{ secrets.SIGN_BASE_URL }}-2"
 
 jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Generate SBOM
+        run: |
+          syft dir:. \
+            -o cyclonedx-json=rustdesk.sbom.json
+
+      - name: Publish Release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        if: env.UPLOAD_ARTIFACT == 'true'
+        with:
+          prerelease: true
+          tag_name: ${{ env.TAG_NAME }}
+          files: |
+            rustdesk.sbom.json
+
   generate-bridge:
     uses: ./.github/workflows/bridge.yml
 


### PR DESCRIPTION
From 2027, the **EU Cyber Resilience Act (CRA)** will require manufacturers of products with "digital elements" to provide and maintain software component information as part of their security obligations.

To support this, I suggest that RustDesk automatically generates a **Software Bill of Materials (SBOM)** for each release. The SBOM can be generated in the CycloneDX format and published as an additional release asset.

This only requires adding a dedicated SBOM job to the GitHub Actions workflow that:

* installs **Syft**,
* generates a CycloneDX JSON SBOM,
* uploads the SBOM as an additional GitHub Release asset.

This approach keeps the existing Windows/Linux/macOS build jobs unchanged while automatically publishing an SBOM with every release.


**Note:** I initially tried using `cargo-cyclonedx`, but the current RustDesk toolchain (Rust 1.75) only supports `cargo-cyclonedx` v0.5.8. That version cannot generate a single SBOM for the entire workspace and instead produces separate `.cdx.json` files for each library crate. **Syft** generates a single CycloneDX SBOM for the complete project without requiring any changes to the Rust toolchain or build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated generation of a CycloneDX software bill of materials (SBOM).
  * SBOM files can be published as prerelease build assets when artifact uploads are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `generate-sbom` job to the flutter-build workflow that uses Syft to produce a CycloneDX JSON SBOM and publishes it as a GitHub release asset, aiding EU CRA compliance. The checkout is correctly pinned to a commit SHA and uses `submodules: recursive` for full coverage.

- The new job installs Syft via `anchore/sbom-action/download-syft@v0`, generates `rustdesk.sbom.json` from `dir:.`, and uploads it with `softprops/action-gh-release` (consistent with all other release jobs).
- The job has no job-level `if: env.UPLOAD_ARTIFACT == 'true'` guard, so the expensive checkout + Syft scan runs on every workflow invocation even when no artifact will be published.
- The `anchore/sbom-action/download-syft@v0` action uses a mutable floating tag rather than a pinned commit SHA, inconsistent with every other third-party action in this workflow.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is additive — a new standalone CI job that generates and publishes an SBOM, with no modifications to existing build steps or application code.

The new job is well-isolated and follows the same release-publish pattern as every other job in the workflow. The checkout is properly pinned and includes submodules. The only concerns are a floating action tag (already flagged in a prior review round) and the job running unconditionally when artifacts are not being uploaded, neither of which affects application correctness or release integrity.

**Files Needing Attention:** .github/workflows/flutter-build.yml — specifically the generate-sbom job's missing job-level guard and the unpinned Syft installer action.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/flutter-build.yml | Adds a new `generate-sbom` job that checks out the repo (with submodules), installs Syft via the anchore action, generates a CycloneDX JSON SBOM, and uploads it as a prerelease asset. The checkout and submodule settings have been properly addressed versus the initial draft, but the `anchore/sbom-action/download-syft@v0` action remains at a floating tag, and the job lacks a job-level `if` guard to skip entirely when `UPLOAD_ARTIFACT` is false. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions Runner
    participant Checkout as actions/checkout
    participant Syft as anchore/sbom-action/download-syft
    participant FS as Filesystem
    participant Release as softprops/action-gh-release

    GHA->>Checkout: checkout repo (submodules: recursive)
    Checkout-->>FS: full source tree + submodules
    GHA->>Syft: "download-syft@v0"
    Syft-->>GHA: syft binary in PATH
    GHA->>FS: "syft dir:. -o cyclonedx-json=rustdesk.sbom.json"
    FS-->>GHA: rustdesk.sbom.json
    alt "UPLOAD_ARTIFACT == true"
        GHA->>Release: upload rustdesk.sbom.json as prerelease asset
        Release-->>GHA: asset published to GitHub Release
    else "UPLOAD_ARTIFACT == false"
        GHA->>GHA: skip upload step (SBOM still generated)
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["SBOM Generation: Also checkout submodule..."](https://github.com/rustdesk/rustdesk/commit/ac79b18a8783b2ee8443e7033bf44ff8129393ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49171121)</sub>

<!-- /greptile_comment -->