### PR TITLE
Update de.rs

### DIFF
--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -332,7 +332,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Relay Connection", "Relay-Verbindung"),
         ("Secure Connection", "Sichere Verbindung"),
         ("Insecure Connection", "Unsichere Verbindung"),
-        ("Continue", ""),
+        ("Continue", "Weiter"),
         ("Scale original", "Keine Skalierung"),
         ("Scale adaptive", "Anpassbare Skalierung"),
         ("General", "Allgemein"),
@@ -772,7 +772,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Invalid ID", "Ungültige ID"),
         ("Your ID is blocked by the peer", "Ihre ID wird von der Gegenstelle blockiert"),
         ("Your ip is blocked by the peer", "Ihre IP-Adresse wird von der Gegenstelle blockiert"),
-        ("id_whitelist_caveat_tip", "Die ID wird vom verbindenden Client gemeldet. Die Whitelist verringert die Angriffsfläche und ersetzt weder Passwort noch 2FA"),
+        ("id_whitelist_caveat_tip", "Die ID wird vom verbindenden Client gemeldet. Die Whitelist verringert die Angriffsfläche und ersetzt weder Passwort noch 2FA."),
         ("whitelist_cidr_tip", "Die CIDR-Notation wird unterstützt, z. B. 192.168.1.0/24"),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Corrected German translations by adding missing terminal periods to two messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes two small corrections to the German (`de.rs`) locale file: it provides the missing translation for the `"Continue"` key and adds a trailing period to `id_whitelist_caveat_tip` to match the English source string.

- `("Continue", "Weiter")` — previously an empty string, now correctly translated; "Weiter" is the standard German equivalent.
- `id_whitelist_caveat_tip` — trailing period added, bringing punctuation in line with the English reference (`"...or 2FA."`).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are limited to two translation string corrections in the German locale file with no logic or runtime impact.

Both changes are straightforward: a previously empty translation entry is filled with the correct German word, and a missing sentence-ending period is added to match the English source. Neither change touches code paths, data handling, or application logic.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lang/de.rs | German translation file — fills in the previously empty "Continue" → "Weiter" entry and appends a missing trailing period to the id_whitelist_caveat_tip string to match the English source. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Update de.rs"](https://github.com/rustdesk/rustdesk/commit/dd3f1fdeaff2a77aa36da10fe5086dc6a6e3bebc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49220498)</sub>

<!-- /greptile_comment -->