### PR TITLE
Add hotkey to switch remote monitor

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -18,12 +18,18 @@ class RawKeyFocusScope extends StatelessWidget {
   final ValueChanged<bool>? onFocusChange;
   final InputModel inputModel;
   final Widget child;
+  // Called before a key event would be forwarded to the remote peer. Return
+  // true to consume the event locally instead of forwarding it.
+  final bool Function(RawKeyEvent)? shouldConsumeRawKeyEvent;
+  final bool Function(KeyEvent)? shouldConsumeKeyEvent;
 
   RawKeyFocusScope({
     this.focusNode,
     this.onFocusChange,
     required this.inputModel,
     required this.child,
+    this.shouldConsumeRawKeyEvent,
+    this.shouldConsumeKeyEvent,
   });
 
   @override
@@ -41,12 +47,16 @@ class RawKeyFocusScope extends StatelessWidget {
             onFocusChange: onFocusChange,
             onKey: useRawKeyEvents
                 ? (FocusNode data, RawKeyEvent event) =>
-                    inputModel.handleRawKeyEvent(event)
+                    (shouldConsumeRawKeyEvent?.call(event) ?? false)
+                        ? KeyEventResult.handled
+                        : inputModel.handleRawKeyEvent(event)
                 : null,
             onKeyEvent: useRawKeyEvents
                 ? null
                 : (FocusNode node, KeyEvent event) =>
-                    inputModel.handleKeyEvent(event),
+                    (shouldConsumeKeyEvent?.call(event) ?? false)
+                        ? KeyEventResult.handled
+                        : inputModel.handleKeyEvent(event),
             child: child));
   }
 }

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -161,6 +161,7 @@ const String kOptionPeerTabVisible = "peer-tab-visible";
 const String kOptionPeerCardUiType = "peer-card-ui-type";
 const String kOptionCurrentAbName = "current-ab-name";
 const String kOptionEnableConfirmClosingTabs = "enable-confirm-closing-tabs";
+const String kOptionEnableMonitorSwitchHotkey = "enable-monitor-switch-hotkey";
 const String kOptionAllowAlwaysSoftwareRender = "allow-always-software-render";
 const String kOptionEnableCheckUpdate = "enable-check-update";
 const String kOptionAllowAutoUpdate = "allow-auto-update";

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -492,6 +492,12 @@ class _GeneralState extends State<_General> {
         _OptionCheckBox(context, 'Confirm before closing multiple tabs',
             kOptionEnableConfirmClosingTabs,
             isServer: false),
+      if (!isWeb && !incomingOnly)
+        _OptionCheckBox(
+            context,
+            'Switch monitor with Cmd/Ctrl+Alt+Left/Right',
+            kOptionEnableMonitorSwitchHotkey,
+            isServer: false),
       if (!incomingOnly)
         _OptionCheckBox(
           context,

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -225,6 +225,52 @@ class _RemotePageState extends State<RemotePage>
     }
   }
 
+  // Cmd+Alt+Left/Right on macOS, Ctrl+Alt+Left/Right elsewhere: jump to the
+  // previous/next monitor of the remote peer without opening the display
+  // switcher in the toolbar. Must be checked from inside RawKeyFocusScope's
+  // key callbacks (passed down as shouldConsumeKeyEvent/shouldConsumeRawKeyEvent
+  // below) rather than a separate HardwareKeyboard.addHandler: HardwareKeyboard
+  // handlers run on their own dispatch chain and can't veto forwarding to the
+  // remote peer, which happens via Focus.onKeyEvent -> InputModel.handleKeyEvent.
+  bool _tryMonitorSwitch(LogicalKeyboardKey key) {
+    if (key != LogicalKeyboardKey.arrowLeft &&
+        key != LogicalKeyboardKey.arrowRight) {
+      return false;
+    }
+    if (!mainGetLocalBoolOptionSync(kOptionEnableMonitorSwitchHotkey)) {
+      return false;
+    }
+    final modifiersMatch = isMacOS
+        ? HardwareKeyboard.instance.isMetaPressed &&
+            HardwareKeyboard.instance.isAltPressed &&
+            !HardwareKeyboard.instance.isControlPressed &&
+            !HardwareKeyboard.instance.isShiftPressed
+        : HardwareKeyboard.instance.isControlPressed &&
+            HardwareKeyboard.instance.isAltPressed &&
+            !HardwareKeyboard.instance.isMetaPressed &&
+            !HardwareKeyboard.instance.isShiftPressed;
+    if (!modifiersMatch) return false;
+    if (!_ffi.ffiModel.pi.isSupportMultiDisplay) return false;
+    final cycle = MonitorCycle(widget.id, _ffi);
+    if (cycle.total < 2) return false;
+    if (key == LogicalKeyboardKey.arrowRight) {
+      cycle.next();
+    } else {
+      cycle.prev();
+    }
+    return true;
+  }
+
+  bool _shouldConsumeMonitorSwitchKeyEvent(KeyEvent event) {
+    if (event is! KeyDownEvent) return false;
+    return _tryMonitorSwitch(event.logicalKey);
+  }
+
+  bool _shouldConsumeMonitorSwitchRawKeyEvent(RawKeyEvent event) {
+    if (event is! RawKeyDownEvent) return false;
+    return _tryMonitorSwitch(event.logicalKey);
+  }
+
   Future<void> _normalizeWaylandKeyboardModeIfNeeded() async {
     if (!mounted ||
         _waylandKeyboardModeNormalized ||
@@ -709,6 +755,9 @@ class _RemotePageState extends State<RemotePage>
               color: kColorCanvas,
               child: RawKeyFocusScope(
                   focusNode: _rawKeyFocusNode,
+                  shouldConsumeKeyEvent: _shouldConsumeMonitorSwitchKeyEvent,
+                  shouldConsumeRawKeyEvent:
+                      _shouldConsumeMonitorSwitchRawKeyEvent,
                   onFocusChange: (bool imageFocused) {
                     debugPrint(
                         "onFocusChange(window active:${!_isWindowBlur}) $imageFocused");

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -117,6 +117,12 @@ class _RemotePageState extends State<RemotePage>
 
   final FocusNode _rawKeyFocusNode = FocusNode(debugLabel: "rawkeyFocusNode");
 
+  // Logical keys currently suppressed by the monitor-switch hotkey (i.e. we
+  // consumed their KeyDownEvent/RawKeyDownEvent), so their matching repeats
+  // and the eventual release are also consumed instead of leaking through to
+  // the remote peer as an un-paired key-up.
+  final Set<LogicalKeyboardKey> _consumedMonitorSwitchKeys = {};
+
   // Debounce timer for pointer lock center updates during window events.
   // Uses kDefaultPointerLockCenterThrottleMs from consts.dart for the duration.
   Timer? _pointerLockCenterDebounceTimer;
@@ -262,13 +268,39 @@ class _RemotePageState extends State<RemotePage>
   }
 
   bool _shouldConsumeMonitorSwitchKeyEvent(KeyEvent event) {
+    final key = event.logicalKey;
+    if (event is KeyUpEvent) {
+      return _consumedMonitorSwitchKeys.remove(key);
+    }
+    if (_consumedMonitorSwitchKeys.contains(key)) {
+      // Auto-repeat of an already-consumed key: keep consuming it locally
+      // without switching monitors again.
+      return true;
+    }
     if (event is! KeyDownEvent) return false;
-    return _tryMonitorSwitch(event.logicalKey);
+    if (_tryMonitorSwitch(key)) {
+      _consumedMonitorSwitchKeys.add(key);
+      return true;
+    }
+    return false;
   }
 
   bool _shouldConsumeMonitorSwitchRawKeyEvent(RawKeyEvent event) {
+    final key = event.logicalKey;
+    if (event is RawKeyUpEvent) {
+      return _consumedMonitorSwitchKeys.remove(key);
+    }
+    if (_consumedMonitorSwitchKeys.contains(key)) {
+      // RawKeyEvent has no distinct repeat type: auto-repeat resends
+      // RawKeyDownEvent, so keep consuming without switching again.
+      return true;
+    }
     if (event is! RawKeyDownEvent) return false;
-    return _tryMonitorSwitch(event.logicalKey);
+    if (_tryMonitorSwitch(key)) {
+      _consumedMonitorSwitchKeys.add(key);
+      return true;
+    }
+    return false;
   }
 
   Future<void> _normalizeWaylandKeyboardModeIfNeeded() async {

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -977,10 +977,10 @@ class _MobileActionMenu extends StatelessWidget {
   }
 }
 
-class _MonitorCycle {
+class MonitorCycle {
   final String id;
   final FFI ffi;
-  const _MonitorCycle(this.id, this.ffi);
+  const MonitorCycle(this.id, this.ffi);
 
   PeerInfo get _pi => ffi.ffiModel.pi;
   int get total => _pi.displays.length;
@@ -990,11 +990,7 @@ class _MonitorCycle {
   String get label => _inRange ? '${_current + 1}' : '*';
   String get tooltip => '${translate('Switch display')} ($label/$total)';
 
-  void next() {
-    final t = total;
-    if (t < 2) return;
-    final from = _inRange ? _current : -1;
-    final target = (from + 1) % t;
+  void _switchTo(int target) {
     final isChooseDisplayToOpenInNewWindow = _pi.isSupportMultiDisplay &&
         bind.sessionGetDisplaysAsIndividualWindows(sessionId: ffi.sessionId) ==
             'Y';
@@ -1003,6 +999,20 @@ class _MonitorCycle {
     } else {
       openMonitorInTheSameTab(target, ffi, _pi, updateCursorPos: false);
     }
+  }
+
+  void next() {
+    final t = total;
+    if (t < 2) return;
+    final from = _inRange ? _current : -1;
+    _switchTo((from + 1) % t);
+  }
+
+  void prev() {
+    final t = total;
+    if (t < 2) return;
+    final from = _inRange ? _current : 0;
+    _switchTo((from - 1 + t) % t);
   }
 }
 
@@ -1018,7 +1028,7 @@ class _MainMonitorSwitchButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cycle = _MonitorCycle(id, ffi);
+    final cycle = MonitorCycle(id, ffi);
     return Obx(() {
       if (cycle.total < 2) return const Offstage();
       final label = cycle.label;
@@ -3527,7 +3537,7 @@ class _MinimizedMonitorSwitchButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const double iconSize = 20;
-    final cycle = _MonitorCycle(id, ffi);
+    final cycle = MonitorCycle(id, ffi);
 
     return Obx(() {
       final label = cycle.label;

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "تم حظر عنوان IP الخاص بك من قبل الطرف الآخر"),
         ("id_whitelist_caveat_tip", "يتم الإبلاغ عن المعرف من قبل العميل المتصل. القائمة البيضاء تقلل من التعرض ولا تغني عن كلمة المرور أو 2FA"),
         ("whitelist_cidr_tip", "يتم دعم صيغة CIDR، مثال: 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Ваш IP-адрас заблакаваны аддаленай прыладай"),
         ("id_whitelist_caveat_tip", "ID паведамляецца кліентам, які падключаецца. Белы спіс памяншае паверхню атакі і не замяняе пароль або 2FA"),
         ("whitelist_cidr_tip", "Падтрымліваецца натацыя CIDR, напрыклад: 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Вашият IP адрес е блокиран от отсрещната страна"),
         ("id_whitelist_caveat_tip", "ID се съобщава от свързващия се клиент. Белият списък намалява изложеността и не замества паролата или 2FA"),
         ("whitelist_cidr_tip", "Поддържа се CIDR нотация, например: 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "La vostra IP està bloquejada per l'altre extrem"),
         ("id_whitelist_caveat_tip", "L'ID és informat pel client que es connecta. Aquesta llista blanca redueix l'exposició i no substitueix la contrasenya ni la 2FA"),
         ("whitelist_cidr_tip", "S'admet la notació CIDR, per exemple 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "你的 IP 已被对方阻止"),
         ("id_whitelist_caveat_tip", "ID 由对端客户端上报，白名单用于减少暴露面，不能替代密码或 2FA"),
         ("whitelist_cidr_tip", "支持 CIDR 写法，例如 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Vaše IP adresa je protistranou blokována"),
         ("id_whitelist_caveat_tip", "ID je hlášeno připojujícím se klientem. Tento seznam snižuje vystavení a nenahrazuje heslo ani 2FA"),
         ("whitelist_cidr_tip", "Je podporován zápis CIDR, například 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Din IP-adresse er blokeret af modparten"),
         ("id_whitelist_caveat_tip", "ID'et rapporteres af den klient, der opretter forbindelse. Whitelisten reducerer eksponeringen og erstatter ikke adgangskode eller 2FA"),
         ("whitelist_cidr_tip", "CIDR-notation understøttes, f.eks. 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Ihre IP-Adresse wird von der Gegenstelle blockiert"),
         ("id_whitelist_caveat_tip", "Die ID wird vom verbindenden Client gemeldet. Die Whitelist verringert die Angriffsfläche und ersetzt weder Passwort noch 2FA"),
         ("whitelist_cidr_tip", "Die CIDR-Notation wird unterstützt, z. B. 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Η διεύθυνση IP σας έχει αποκλειστεί από τον απομακρυσμένο υπολογιστή"),
         ("id_whitelist_caveat_tip", "Το ID αναφέρεται από τον πελάτη που συνδέεται. Η λίστα επιτρεπόμενων μειώνει την έκθεση και δεν αντικαθιστά τον κωδικό πρόσβασης ή το 2FA"),
         ("whitelist_cidr_tip", "Υποστηρίζεται η σημειογραφία CIDR, π.χ. 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Via IP estas blokita de la alia flanko"),
         ("id_whitelist_caveat_tip", "La ID estas raportata de la konektiĝanta kliento. La blanka listo malpliigas la eksponiĝon kaj ne anstataŭas la pasvorton aŭ 2FA"),
         ("whitelist_cidr_tip", "La notacio CIDR estas subtenata, ekzemple 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Tu IP está bloqueada por el dispositivo remoto"),
         ("id_whitelist_caveat_tip", "El ID lo comunica el cliente que se conecta. Esta lista blanca reduce la exposición y no sustituye a la contraseña ni al 2FA"),
         ("whitelist_cidr_tip", "Se admite la notación CIDR, por ejemplo 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Teine pool on sinu IP-aadressi blokeerinud"),
         ("id_whitelist_caveat_tip", "ID edastab ühenduv klient. Lubamisloend vähendab eksponeeritust ega asenda parooli või 2FA-d"),
         ("whitelist_cidr_tip", "Toetatud on CIDR-tähistus, näiteks 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Beste aldeak zure IP helbidea blokeatu du"),
         ("id_whitelist_caveat_tip", "IDa konektatzen den bezeroak jakinarazten du. Zerrenda honek esposizioa murrizten du eta ez du pasahitza edo 2FA ordezkatzen"),
         ("whitelist_cidr_tip", "CIDR notazioa onartzen da, adibidez 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "نشانی IP شما توسط طرف مقابل مسدود شده است"),
         ("id_whitelist_caveat_tip", "شناسه توسط کلاینت متصل شونده گزارش می شود. لیست مجاز سطح در معرض بودن را کاهش می دهد و جایگزین رمز عبور یا 2FA نیست"),
         ("whitelist_cidr_tip", "نماد CIDR پشتیبانی می شود، برای مثال 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Vastapuoli on estänyt IP-osoitteesi"),
         ("id_whitelist_caveat_tip", "ID on yhdistävän asiakkaan ilmoittama. Sallintalista pienentää altistusta eikä korvaa salasanaa tai 2FA:ta"),
         ("whitelist_cidr_tip", "CIDR-merkintä on tuettu, esimerkiksi 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Votre adresse IP est bloquée par l’appareil distant"),
         ("id_whitelist_caveat_tip", "L’ID est déclaré par le client qui se connecte. Cette liste blanche réduit l’exposition et ne remplace ni le mot de passe ni la 2FA"),
         ("whitelist_cidr_tip", "La notation CIDR est prise en charge, par exemple 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "თქვენი IP მისამართი დაბლოკილია მეორე მხარის მიერ"),
         ("id_whitelist_caveat_tip", "ID-ს აცხადებს დამაკავშირებელი კლიენტი. თეთრი სია ამცირებს ექსპოზიციას და ვერ ჩაანაცვლებს პაროლს ან 2FA-ს"),
         ("whitelist_cidr_tip", "მხარდაჭერილია CIDR ჩანაწერი, მაგალითად 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "તમારું IP સામેના પક્ષ દ્વારા બ્લોક કરવામાં આવ્યું છે"),
         ("id_whitelist_caveat_tip", "ID કનેક્ટ થતા ક્લાયન્ટ દ્વારા જણાવવામાં આવે છે. વ્હાઇટલિસ્ટ એક્સપોઝર ઘટાડે છે અને પાસવર્ડ કે 2FA નો વિકલ્પ નથી"),
         ("whitelist_cidr_tip", "CIDR નોટેશન સપોર્ટેડ છે, ઉदાહરણ તરીકે 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "כתובת ה-IP שלך נחסמה על ידי הצד המרוחק"),
         ("id_whitelist_caveat_tip", "המזהה מדווח על ידי הלקוח המתחבר. הרשימה הלבנה מצמצמת חשיפה ואינה מחליפה סיסמה או 2FA"),
         ("whitelist_cidr_tip", "יש תמיכה בסימון CIDR, לדוגמה 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "आपका IP दूसरे पक्ष द्वारा अवरुद्ध कर दिया गया है"),
         ("id_whitelist_caveat_tip", "ID कनेक्ट करने वाले क्लाइंट द्वारा बताई जाती है। श्वेतसूची जोखिम कम करती है और पासवर्ड या 2FA का विकल्प नहीं है"),
         ("whitelist_cidr_tip", "CIDR नोटेशन समर्थित है, उदाहरण के लिए 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Vašu IP adresu je blokiralo udaljeno računalo"),
         ("id_whitelist_caveat_tip", "ID prijavljuje klijent koji se povezuje. Ova lista smanjuje izloženost i ne zamjenjuje lozinku ni 2FA"),
         ("whitelist_cidr_tip", "Podržan je CIDR zapis, primjerice 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Az IP-címét a távoli fél letiltotta"),
         ("id_whitelist_caveat_tip", "Az azonosítót a csatlakozó kliens jelenti. Az engedélyezési lista csökkenti a kitettséget, és nem helyettesíti a jelszót vagy a 2FA-t"),
         ("whitelist_cidr_tip", "A CIDR jelölés támogatott, például 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "IP Anda diblokir oleh perangkat remote"),
         ("id_whitelist_caveat_tip", "ID dilaporkan oleh klien yang terhubung. Daftar ini mengurangi paparan dan bukan pengganti kata sandi atau 2FA"),
         ("whitelist_cidr_tip", "Notasi CIDR didukung, misalnya 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Il tuo IP è bloccato dal dispositivo remoto"),
         ("id_whitelist_caveat_tip", "L'ID è dichiarato dal client che si connette. Questo elenco riduce l'esposizione e non sostituisce la password o la 2FA"),
         ("whitelist_cidr_tip", "È supportata la notazione CIDR, ad esempio 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "あなたの IP アドレスは接続先によってブロックされています"),
         ("id_whitelist_caveat_tip", "ID は接続するクライアントから申告されます。ホワイトリストは露出を減らすもので、パスワードや 2FA の代わりにはなりません"),
         ("whitelist_cidr_tip", "CIDR 表記に対応しています。例: 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -773,5 +773,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "귀하의 IP가 상대방에 의해 차단되었습니다"),
         ("id_whitelist_caveat_tip", "ID는 연결하는 클라이언트가 보고합니다. 화이트리스트는 노출을 줄이는 것으로 비밀번호나 2FA를 대체하지 않습니다"),
         ("whitelist_cidr_tip", "CIDR 표기를 지원합니다. 예: 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Сіздің IP-мекенжайыңыз қарсы тараппен бұғатталған"),
         ("id_whitelist_caveat_tip", "ID қосылатын клиентпен хабарланады. Ақ-тізім әсер ету аумағын азайтады және құпия сөзді немесе 2FA-ны алмастырмайды"),
         ("whitelist_cidr_tip", "CIDR жазбасына қолдау көрсетіледі, мысалы 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Jūsų IP adresą užblokavo nuotolinis įrenginys"),
         ("id_whitelist_caveat_tip", "ID praneša prisijungiantis klientas. Šis sąrašas sumažina atakos paviršių ir nepakeičia slaptažodžio ar 2FA"),
         ("whitelist_cidr_tip", "Palaikomas CIDR žymėjimas, pavyzdžiui 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Jūsu IP adresi ir bloķējusi otra puse"),
         ("id_whitelist_caveat_tip", "ID paziņo klients, kas veido savienojumu. Baltais saraksts samazina pakļautību un neaizstāj paroli vai 2FA"),
         ("whitelist_cidr_tip", "Tiek atbalstīts CIDR pieraksts, piemēram 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "നിങ്ങളുടെ IP വിലാസം മറുവശം ബ്ലോക്ക് ചെയ്തിരിക്കുന്നു"),
         ("id_whitelist_caveat_tip", "കണക്റ്റ് ചെയ്യുന്ന ക്ലയന്റാണ് ID റിപ്പോർട്ട് ചെയ്യുന്നത്. വൈറ്റ്‌ലിസ്റ്റ് എക്സ്പോഷർ കുറയ്ക്കുന്നു; പാസ്‌വേഡിനോ 2FA-യ്ക്കോ പകരമല്ല"),
         ("whitelist_cidr_tip", "CIDR നൊട്ടേഷൻ പിന്തുണയ്ക്കുന്നു, ഉദാഹരണത്തിന് 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "IP-adressen din er blokkert av motparten"),
         ("id_whitelist_caveat_tip", "ID-en rapporteres av klienten som kobler til. Hvitelisten reduserer eksponeringen og erstatter ikke passord eller 2FA"),
         ("whitelist_cidr_tip", "CIDR-notasjon støttes, for eksempel 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Je IP-adres is geblokkeerd door de andere partij"),
         ("id_whitelist_caveat_tip", "Het ID wordt gemeld door de verbindende client. De witte lijst vermindert blootstelling en vervangt het wachtwoord of 2FA niet"),
         ("whitelist_cidr_tip", "CIDR-notatie wordt ondersteund, bijvoorbeeld 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Twój adres IP został zablokowany przez drugą stronę"),
         ("id_whitelist_caveat_tip", "ID jest zgłaszane przez łączącego się klienta. Biała lista zmniejsza ekspozycję i nie zastępuje hasła ani 2FA"),
         ("whitelist_cidr_tip", "Obsługiwana jest notacja CIDR, na przykład 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "O seu IP está bloqueado pelo dispositivo remoto"),
         ("id_whitelist_caveat_tip", "O ID é comunicado pelo cliente que se liga. A whitelist reduz a exposição e não substitui a palavra-passe nem o 2FA"),
         ("whitelist_cidr_tip", "A notação CIDR é suportada, por exemplo 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Seu IP foi bloqueado pelo dispositivo remoto"),
         ("id_whitelist_caveat_tip", "O ID é informado pelo cliente que se conecta. A lista reduz a exposição e não substitui a senha ou o 2FA"),
         ("whitelist_cidr_tip", "A notação CIDR é suportada, por exemplo 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Adresa ta IP este blocată de dispozitivul de la distanță"),
         ("id_whitelist_caveat_tip", "ID-ul este raportat de clientul care se conectează. Lista albă reduce expunerea și nu înlocuiește parola sau 2FA"),
         ("whitelist_cidr_tip", "Notația CIDR este acceptată, de exemplu 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Ваш IP-адрес заблокирован удалённым устройством"),
         ("id_whitelist_caveat_tip", "ID сообщается подключающимся клиентом. Белый список уменьшает поверхность атаки и не заменяет пароль или 2FA"),
         ("whitelist_cidr_tip", "Поддерживается нотация CIDR, например 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "S'indiritzu IP tuo est blocadu dae s'àtera parte"),
         ("id_whitelist_caveat_tip", "S'ID est decraradu dae su cliente chi si connetet. Custu elencu minimat s'espositzione e non sostituit sa crae o su 2FA"),
         ("whitelist_cidr_tip", "Sa notatzione CIDR est suportada, pro esempru 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Vaša IP adresa je blokovaná protistranou"),
         ("id_whitelist_caveat_tip", "ID nahlasuje pripájajúci sa klient. Tento zoznam znižuje vystavenie a nenahrádza heslo ani 2FA"),
         ("whitelist_cidr_tip", "Je podporovaný zápis CIDR, napríklad 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Vaš IP je blokirala oddaljena naprava"),
         ("id_whitelist_caveat_tip", "ID sporoči odjemalec, ki se povezuje. Seznam zmanjšuje izpostavljenost in ne nadomešča gesla ali 2FA"),
         ("whitelist_cidr_tip", "Podprt je zapis CIDR, na primer 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "IP-ja juaj është bllokuar nga pala tjetër"),
         ("id_whitelist_caveat_tip", "ID-ja raportohet nga klienti që lidhet. Lista e bardhë zvogëlon ekspozimin dhe nuk zëvendëson fjalëkalimin ose 2FA"),
         ("whitelist_cidr_tip", "Mbështetet shënimi CIDR, për shembull 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Vašu IP adresu je blokirala druga strana"),
         ("id_whitelist_caveat_tip", "ID prijavljuje klijent koji se povezuje. Ova lista smanjuje izloženost i ne zamenjuje lozinku ni 2FA"),
         ("whitelist_cidr_tip", "Podržan je CIDR zapis, na primer 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Din IP-adress är blockerad av motparten"),
         ("id_whitelist_caveat_tip", "ID:t rapporteras av klienten som ansluter. Vitlistan minskar exponeringen och ersätter inte lösenord eller 2FA"),
         ("whitelist_cidr_tip", "CIDR-notation stöds, till exempel 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "உங்கள் IP முகவரி மறுமுனையால் தடுக்கப்பட்டுள்ளது"),
         ("id_whitelist_caveat_tip", "இணைக்கும் கிளையண்டே ID-ஐ தெரிவிக்கிறது. அனுமதிப்பட்டியல் வெளிப்பாட்டைக் குறைக்கிறது; கடவுச்சொல் அல்லது 2FA-க்கு மாற்றாகாது"),
         ("whitelist_cidr_tip", "CIDR குறியீடு ஆதரிக்கப்படுகிறது, எடுத்துக்காட்டாக 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", ""),
         ("id_whitelist_caveat_tip", ""),
         ("whitelist_cidr_tip", ""),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "IP ของคุณถูกบล็อกโดยฝั่งตรงข้าม"),
         ("id_whitelist_caveat_tip", "ID ถูกรายงานโดยไคลเอนต์ที่เชื่อมต่อ ไวท์ลิสต์ช่วยลดการเปิดเผยและไม่สามารถใช้แทนรหัสผ่านหรือ 2FA ได้"),
         ("whitelist_cidr_tip", "รองรับรูปแบบ CIDR เช่น 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "IP adresiniz karşı taraf tarafından engellendi"),
         ("id_whitelist_caveat_tip", "ID, bağlanan istemci tarafından bildirilir. Bu liste maruziyeti azaltır; parolanın veya 2FA'nın yerini tutmaz"),
         ("whitelist_cidr_tip", "CIDR gösterimi desteklenir, örneğin 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "你的 IP 已被對方封鎖"),
         ("id_whitelist_caveat_tip", "ID 由對端用戶端回報，白名單用於減少暴露面，不能取代密碼或 2FA"),
         ("whitelist_cidr_tip", "支援 CIDR 寫法，例如 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "Вашу IP-адресу заблоковано віддаленим пристроєм"),
         ("id_whitelist_caveat_tip", "ID повідомляється клієнтом, що підключається. Білий список зменшує поверхню атаки і не замінює пароль або 2FA"),
         ("whitelist_cidr_tip", "Підтримується нотація CIDR, наприклад 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -774,5 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "IP của bạn đã bị phía bên kia chặn"),
         ("id_whitelist_caveat_tip", "ID do máy khách kết nối tự khai báo. Danh sách trắng giúp giảm mức độ lộ diện và không thay thế mật khẩu hay 2FA"),
         ("whitelist_cidr_tip", "Hỗ trợ ký hiệu CIDR, ví dụ 192.168.1.0/24"),
+        ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", ""),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
## Summary
- Add Cmd+Alt+Left/Right (macOS) / Ctrl+Alt+Left/Right (other platforms) to cycle the viewed monitor of a multi-display remote peer, without needing to open the toolbar's display switcher.
- The shortcut is intercepted inside `RawKeyFocusScope`'s key callbacks so it's consumed locally and not also forwarded to the remote peer (forwarding happens via the `Focus.onKeyEvent` pipeline, which a `HardwareKeyboard.addHandler` can't veto since it runs on a separate dispatch chain).
- Gated behind a new local option `enable-monitor-switch-hotkey` (default on), exposed as a checkbox under Settings > General, in case the combo collides with something a user wants forwarded to the remote host instead.

## Test plan
- [x] Built and ran the macOS desktop client from this branch.
- [x] Connected to a multi-monitor Windows peer; confirmed Cmd+Alt+Left/Right switches the local monitor view and is not sent to the remote host.
- [x] Confirmed the setting checkbox toggles the behavior on/off.
- [ ] Not tested on Linux (Ctrl+Alt+Left/Right via the `RawKeyEvent`/`onKey` path) or Windows client — no such machine available; would appreciate a maintainer/CI sanity check there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Cmd/Ctrl+Alt+Left/Right shortcuts to switch between remote monitors.
  * Added a General settings option to enable or disable monitor-switch hotkeys.
  * Monitor switching now cycles forward or backward through available displays.
  * Keyboard events can be handled locally before being forwarded to remote input.

* **Documentation**
  * Added localization entries for the monitor-switching shortcut across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a keyboard shortcut (Cmd+Alt+Left/Right on macOS, Ctrl+Alt+Left/Right elsewhere) to cycle through remote monitors without opening the toolbar's display switcher. A new `enable-monitor-switch-hotkey` local option (default on) lets users disable the shortcut if it conflicts with a combo they want forwarded to the remote host.

- `RawKeyFocusScope` gains two optional `shouldConsume*` callbacks that intercept key events before `InputModel.handleKeyEvent/handleRawKeyEvent`, cleanly preventing unwanted forwarding to the remote peer; the shared `_consumedMonitorSwitchKeys` set correctly tracks held-key state across both the new-style `KeyEvent` and legacy `RawKeyEvent` dispatch paths (only one active at a time).
- `_MonitorCycle` is promoted to `MonitorCycle` (public) so `remote_page.dart` can instantiate it; a `prev()` method and `_switchTo()` helper are extracted from `next()` to enable bidirectional cycling.
- The new translation key is properly appended to `template.rs` and all 50+ locale files with empty values pending translation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is purely additive, the key-interception logic is correctly scoped to the RawKeyFocusScope callbacks, and the previously flagged missing translation key has been resolved.

The new hotkey interception path is well-isolated: it only fires for arrowLeft/arrowRight with the specific modifier combo, is guarded by both isSupportMultiDisplay and cycle.total < 2, and the consumed-key tracking correctly handles down/repeat/up for both key-event APIs. No existing behaviour is modified for sessions without multi-display support or when the option is off.

**Files Needing Attention:** The Ctrl+Alt+Left/Right shortcut on Linux (remote_page.dart lines 254–257) is untested and conflicts with common workspace-switching bindings in GNOME/KDE; worth a maintainer sanity-check on a Linux client before a wide release.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/desktop/pages/remote_page.dart | Adds _tryMonitorSwitch, _shouldConsumeMonitorSwitchKeyEvent, and _shouldConsumeMonitorSwitchRawKeyEvent to intercept Cmd/Ctrl+Alt+Left/Right before forwarding to remote; correctly tracks consumed keys in _consumedMonitorSwitchKeys for both new-style (KeyEvent) and legacy (RawKeyEvent) paths. |
| flutter/lib/common/widgets/remote_input.dart | Adds shouldConsumeRawKeyEvent and shouldConsumeKeyEvent optional callbacks to RawKeyFocusScope; callback is consulted before delegating to inputModel.handleRawKeyEvent / handleKeyEvent, consuming the event if the callback returns true. |
| flutter/lib/desktop/widgets/remote_toolbar.dart | Renames _MonitorCycle to MonitorCycle (public) to allow use from remote_page.dart; extracts _switchTo() helper and adds prev() method; next() and existing call sites updated correctly. |
| flutter/lib/desktop/pages/desktop_setting_page.dart | Adds _OptionCheckBox for kOptionEnableMonitorSwitchHotkey under General settings, gated behind !isWeb && !incomingOnly; translation key is now registered in all lang files. |
| flutter/lib/consts.dart | Adds kOptionEnableMonitorSwitchHotkey constant string; no issues. |
| src/lang/template.rs | Appends ("Switch monitor with Cmd/Ctrl+Alt+Left/Right", "") to the master key list; mirrored in all 50+ locale files as required. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as User
    participant RKF as RawKeyFocusScope
    participant RPS as _RemotePageState
    participant MC as MonitorCycle
    participant IM as InputModel (remote peer)

    User->>RKF: KeyDown (e.g. Ctrl+Alt+Left)
    RKF->>RPS: shouldConsumeKeyEvent / shouldConsumeRawKeyEvent
    RPS->>RPS: _shouldConsumeMonitorSwitchKeyEvent(event)
    RPS->>RPS: _tryMonitorSwitch(arrowLeft)
    RPS->>RPS: check kOptionEnableMonitorSwitchHotkey
    RPS->>RPS: check HardwareKeyboard modifiers
    RPS->>MC: prev()
    MC->>MC: _switchTo(target)
    RPS-->>RKF: true (consume event)
    Note over RKF,IM: Event NOT forwarded to remote peer

    User->>RKF: KeyRepeat (Ctrl+Alt+Left held)
    RKF->>RPS: shouldConsumeKeyEvent
    RPS->>RPS: arrowLeft in _consumedMonitorSwitchKeys → true
    RPS-->>RKF: true (consume, no re-switch)

    User->>RKF: KeyUp (Ctrl+Alt+Left released)
    RKF->>RPS: shouldConsumeKeyEvent
    RPS->>RPS: _consumedMonitorSwitchKeys.remove(arrowLeft)
    RPS-->>RKF: true (consume key-up)

    User->>RKF: KeyDown (plain Left arrow, no modifier)
    RKF->>RPS: shouldConsumeKeyEvent
    RPS->>RPS: _tryMonitorSwitch → modifiers mismatch → false
    RPS-->>RKF: false (do not consume)
    RKF->>IM: handleKeyEvent(event)
    IM-->>User: forwarded to remote peer
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address review feedback on monitor-..."](https://github.com/rustdesk/rustdesk/commit/f8876fe178bd602736669723388449be1418e23e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49364592)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/rustdesk/github/rustdesk/rustdesk/-/custom-context?memory=f7c8a0b7-52cb-4813-8d03-0dc35dfcbc0b))
- Context used - AGENTS.md ([source](https://app.greptile.com/rustdesk/github/rustdesk/rustdesk/-/custom-context?memory=6f40c3eb-3820-4b4f-b8a8-5d251a60df3a))

<!-- /greptile_comment -->