### PR TITLE
fix: skip secure_tcp on connect after account login

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -32,7 +32,6 @@ use crate::{
     common::input::{MOUSE_BUTTON_LEFT, MOUSE_BUTTON_RIGHT, MOUSE_TYPE_DOWN, MOUSE_TYPE_UP},
     create_symmetric_key_msg, decode_id_pk, get_rs_pk, is_keyboard_mode_supported,
     kcp_stream::KcpStream,
-    secure_tcp,
     ui_interface::{get_builtin_option, resolve_avatar_url, use_texture_render},
     ui_session_interface::{InvokeUiSession, Session},
 };
@@ -426,12 +425,10 @@ impl Client {
             NatType::from_i32(my_nat_type).unwrap_or(NatType::UNKNOWN_NAT)
         };
 
-        if !key.is_empty() && !token.is_empty() {
-            // mainly for the security of token
-            secure_tcp(&mut socket, &key)
-                .await
-                .map_err(|e| anyhow!("Failed to secure tcp: {}", e))?;
-        } else if let Some(udp) = udp.1.as_ref() {
+        // Do not force secure_tcp when logged in (token present).
+        // That handshake often fails on self-hosted/open-source hbbs and blocks connect.
+        // Trade-off: access_token may be sent in cleartext to rendezvous over TCP.
+        if let Some(udp) = udp.1.as_ref() {
             let tm = Instant::now();
             loop {
                 let port = *udp.lock().unwrap();
@@ -855,10 +852,7 @@ impl Client {
                 .await
                 .with_context(|| "Failed to connect to rendezvous server")?;
 
-            if !key.is_empty() && !token.is_empty() {
-                // mainly for the security of token
-                secure_tcp(&mut socket, key).await?;
-            }
+            // Skip secure_tcp after login; see _start_inner comment above.
 
             ipv4 = socket.local_addr().is_ipv4();
             let mut msg_out = RendezvousMessage::new();


### PR DESCRIPTION
Avoid Failed to secure tcp when access_token is present by not forcing rendezvous KeyExchange; enables self-hosted login+connect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection establishment by avoiding unnecessary secure TCP handshakes.
  * Connections now proceed directly through UDP NAT probing or rendezvous messaging, including authenticated connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a connection failure (\"Failed to secure tcp\") that occurred on self-hosted / open-source `hbbs` rendezvous servers after account login by removing the `secure_tcp` key-exchange step that was protecting the `access_token` in transit. The fix is acknowledged by the author as a security trade-off.

- **Two `secure_tcp` calls removed** — one in `_start_inner` (punch-hole path) and one in `request_relay` — so the `access_token` is now transmitted in cleartext over TCP to the rendezvous server whenever a user is logged in.
- **`else if` → `if` restructure** — the UDP NAT-wait block now always runs when a UDP socket is present, even for token-authenticated connections; this was previously skipped while `secure_tcp` ran.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

The change fixes a real self-hosted compatibility problem but deliberately removes the token-in-transit encryption that was explicitly placed there to protect login credentials, leaving the access token readable to any on-path observer.

Both the punch-hole and relay flows now transmit the access token over an unencrypted TCP channel to the rendezvous server. The original secure_tcp code was added precisely to prevent this, and the PR's own inline comment acknowledges the exposure. A more surgical fix — making secure_tcp_impl treat a missing KeyExchange response as a graceful no-op rather than hard-failing — would restore self-hosted compatibility without dropping token confidentiality on servers that do implement key exchange.

**Files Needing Attention:** src/client.rs — both the punch-hole path (~line 428) and the relay path (~line 855) need attention.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Cleartext token exposure (src/client.rs, lines 428–431 and 855)**: The `secure_tcp` calls that encrypted the TCP connection to the rendezvous server before transmitting the `access_token` have been removed. Both the `PunchHoleRequest` (token field) and `RequestRelay` (token field) are now sent over an unencrypted TCP socket when a user is logged in. An on-path attacker between the client and the rendezvous server can now read the access token.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/client.rs | Removes two `secure_tcp` calls that were guarding the `access_token` in transit; the token is now sent in cleartext over TCP to the rendezvous server in both the punch-hole and relay flows. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fclient.rs%3A428-431%0A**Access%20token%20sent%20in%20cleartext%20over%20TCP**%0A%0AThe%20PR%20removes%20the%20%60secure_tcp%60%20call%20that%20was%20added%20explicitly%20%22mainly%20for%20the%20security%20of%20token%22%20%28per%20the%20removed%20comment%29.%20When%20both%20%60key%60%20and%20%60token%60%20are%20non-empty%2C%20the%20%60PunchHoleRequest%60%20%E2%80%94%20which%20carries%20%60token%3A%20token.to_owned%28%29%60%20%E2%80%94%20is%20now%20transmitted%20unencrypted%20over%20the%20TCP%20socket%20to%20the%20rendezvous%20server.%20The%20same%20is%20true%20for%20the%20%60RequestRelay%60%20message%20in%20%60request_relay%60.%20The%20PR%20author%20acknowledges%20this%20as%20a%20trade-off%2C%20but%20it's%20a%20security%20regression%20for%20anyone%20using%20an%20official%20or%20properly%20configured%20self-hosted%20server.%0A%0AThe%20root%20cause%20on%20incompatible%20%60hbbs%60%20builds%20is%20that%20%60secure_tcp_impl%60%20waits%20up%20to%20%60READ_TIMEOUT%60%20for%20the%20server%20to%20send%20a%20%60KeyExchange%60%20message%3B%20if%20the%20server%20never%20sends%20one%2C%20the%20%60timeout%28READ_TIMEOUT%2C%20conn.next%28%29%29.await%3F%60%20propagates%20the%20elapsed%20error.%20A%20more%20targeted%20fix%20would%20be%20to%20treat%20that%20timeout%20%28and%20the%20non-%60KeyExchange%60%20branch%29%20as%20a%20graceful%20no-op%20%E2%80%94%20proceed%20without%20encryption%20rather%20than%20aborting%20%E2%80%94%20which%20would%20restore%20self-hosted%20compatibility%20without%20sacrificing%20token%20confidentiality%20on%20servers%20that%20do%20support%20key%20exchange.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15743&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix%2Fskip-secure-tcp-after-login%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fskip-secure-tcp-after-login%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fclient.rs%3A428-431%0A**Access%20token%20sent%20in%20cleartext%20over%20TCP**%0A%0AThe%20PR%20removes%20the%20%60secure_tcp%60%20call%20that%20was%20added%20explicitly%20%22mainly%20for%20the%20security%20of%20token%22%20%28per%20the%20removed%20comment%29.%20When%20both%20%60key%60%20and%20%60token%60%20are%20non-empty%2C%20the%20%60PunchHoleRequest%60%20%E2%80%94%20which%20carries%20%60token%3A%20token.to_owned%28%29%60%20%E2%80%94%20is%20now%20transmitted%20unencrypted%20over%20the%20TCP%20socket%20to%20the%20rendezvous%20server.%20The%20same%20is%20true%20for%20the%20%60RequestRelay%60%20message%20in%20%60request_relay%60.%20The%20PR%20author%20acknowledges%20this%20as%20a%20trade-off%2C%20but%20it's%20a%20security%20regression%20for%20anyone%20using%20an%20official%20or%20properly%20configured%20self-hosted%20server.%0A%0AThe%20root%20cause%20on%20incompatible%20%60hbbs%60%20builds%20is%20that%20%60secure_tcp_impl%60%20waits%20up%20to%20%60READ_TIMEOUT%60%20for%20the%20server%20to%20send%20a%20%60KeyExchange%60%20message%3B%20if%20the%20server%20never%20sends%20one%2C%20the%20%60timeout%28READ_TIMEOUT%2C%20conn.next%28%29%29.await%3F%60%20propagates%20the%20elapsed%20error.%20A%20more%20targeted%20fix%20would%20be%20to%20treat%20that%20timeout%20%28and%20the%20non-%60KeyExchange%60%20branch%29%20as%20a%20graceful%20no-op%20%E2%80%94%20proceed%20without%20encryption%20rather%20than%20aborting%20%E2%80%94%20which%20would%20restore%20self-hosted%20compatibility%20without%20sacrificing%20token%20confidentiality%20on%20servers%20that%20do%20support%20key%20exchange.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15743&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/client.rs:428-431
**Access token sent in cleartext over TCP**

The PR removes the `secure_tcp` call that was added explicitly "mainly for the security of token" (per the removed comment). When both `key` and `token` are non-empty, the `PunchHoleRequest` — which carries `token: token.to_owned()` — is now transmitted unencrypted over the TCP socket to the rendezvous server. The same is true for the `RequestRelay` message in `request_relay`. The PR author acknowledges this as a trade-off, but it's a security regression for anyone using an official or properly configured self-hosted server.

The root cause on incompatible `hbbs` builds is that `secure_tcp_impl` waits up to `READ_TIMEOUT` for the server to send a `KeyExchange` message; if the server never sends one, the `timeout(READ_TIMEOUT, conn.next()).await?` propagates the elapsed error. A more targeted fix would be to treat that timeout (and the non-`KeyExchange` branch) as a graceful no-op — proceed without encryption rather than aborting — which would restore self-hosted compatibility without sacrificing token confidentiality on servers that do support key exchange.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: skip secure\_tcp on connect after ac..."](https://github.com/rustdesk/rustdesk/commit/8256da2618e02181579c385ba40675534bd00c8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49454726)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->