### PR TITLE
fix(android): close outgoing sessions when the task is swiped away

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt
@@ -106,6 +106,16 @@ class MainActivity : FlutterActivity() {
 
     override fun onDestroy() {
         Log.e(logTag, "onDestroy")
+        // The process can outlive the UI whenever something keeps it alive:
+        // MainService, or the accessibility InputService on its own. Only the
+        // former gets onTaskRemoved, so close outgoing sessions here too,
+        // otherwise a session survives with no UI left to close it.
+        // `isFinishing` distinguishes the user really leaving from a destroy
+        // for recreation (configuration change, "don't keep activities"),
+        // which must not tear down a live session.
+        if (isFinishing) {
+            FFI.closeAllSessions()
+        }
         mainService?.let {
             unbindService(serviceConnection)
         }

--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt
@@ -254,6 +254,16 @@ class MainService : Service() {
         super.onDestroy()
     }
 
+    // Swiping the app away from recents destroys the UI but this service keeps
+    // the process alive, so outgoing sessions would stay connected with no way
+    // to close them. Incoming connections are unaffected: the service keeps
+    // running so the device stays reachable.
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        Log.d(logTag, "onTaskRemoved, closing outgoing sessions")
+        FFI.closeAllSessions()
+        super.onTaskRemoved(rootIntent)
+    }
+
     private var isHalfScale: Boolean? = null;
     private fun updateScreenInfo(orientation: Int) {
         var w: Int

--- a/flutter/android/app/src/main/kotlin/ffi.kt
+++ b/flutter/android/app/src/main/kotlin/ffi.kt
@@ -21,6 +21,7 @@ object FFI {
     external fun onAudioFrameUpdate(buf: ByteBuffer)
     external fun translateLocale(localeName: String, input: String): String
     external fun refreshScreen()
+    external fun closeAllSessions()
     external fun setFrameRawEnable(name: String, value: Boolean)
     external fun setCodecInfo(info: String)
     external fun getLocalOption(key: String): String

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -2140,16 +2140,19 @@ pub mod sessions {
     /// session stays established with no way to close it.
     #[cfg(any(target_os = "android", target_os = "ios"))]
     pub fn close_all_sessions() -> usize {
-        // Drain first so the map lock is released before closing each session.
+        // Release held keys before draining: the release path sends through
+        // `get_cur_session()`, which resolves against SESSIONS, so draining
+        // first would take TO_RELEASE and then silently drop every key-up,
+        // leaving the key stuck on the controlled side. A no-op when nothing
+        // is held.
+        crate::keyboard::release_remote_keys("map");
+        // Drain so the map lock is released before closing each session.
         let sessions: Vec<FlutterSession> = SESSIONS
             .write()
             .unwrap()
             .drain()
             .map(|(_, session)| session)
             .collect();
-        if !sessions.is_empty() {
-            crate::keyboard::release_remote_keys("map");
-        }
         for session in sessions.iter() {
             let session_ids: Vec<SessionID> = session
                 .ui_handler

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -2131,6 +2131,42 @@ pub mod sessions {
         s
     }
 
+    /// Close every client session, returning how many peer sessions were closed.
+    ///
+    /// Used when the UI is gone but the process keeps running, e.g. the Android
+    /// task is swiped away from recents while a foreground service keeps the
+    /// process alive. The orphaned `io_loop` would otherwise keep answering
+    /// `TestDelay`, so the peer never hits its inactivity timeout and the
+    /// session stays established with no way to close it.
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    pub fn close_all_sessions() -> usize {
+        // Drain first so the map lock is released before closing each session.
+        let sessions: Vec<FlutterSession> = SESSIONS
+            .write()
+            .unwrap()
+            .drain()
+            .map(|(_, session)| session)
+            .collect();
+        if !sessions.is_empty() {
+            crate::keyboard::release_remote_keys("map");
+        }
+        for session in sessions.iter() {
+            let session_ids: Vec<SessionID> = session
+                .ui_handler
+                .session_handlers
+                .read()
+                .unwrap()
+                .keys()
+                .cloned()
+                .collect();
+            for session_id in session_ids {
+                session.close_event_stream(session_id);
+            }
+            session.close();
+        }
+        sessions.len()
+    }
+
     /// Check if removing a session by session_id would result in removing the entire peer.
     ///
     /// Returns:

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -3128,6 +3128,16 @@ pub mod server_side {
         crate::server::video_service::refresh()
     }
 
+    /// Close outgoing sessions when the task is swiped away. The service keeps
+    /// the process alive, so without this the session outlives its UI.
+    #[no_mangle]
+    pub unsafe extern "system" fn Java_ffi_FFI_closeAllSessions(_env: JNIEnv, _class: JClass) {
+        let closed = crate::flutter::sessions::close_all_sessions();
+        if closed > 0 {
+            log::info!("closed {} session(s) on task removed", closed);
+        }
+    }
+
     #[no_mangle]
     pub unsafe extern "system" fn Java_ffi_FFI_getLocalOption(
         env: JNIEnv,

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -3128,13 +3128,13 @@ pub mod server_side {
         crate::server::video_service::refresh()
     }
 
-    /// Close outgoing sessions when the task is swiped away. The service keeps
-    /// the process alive, so without this the session outlives its UI.
+    /// Close outgoing sessions when the UI goes away but the process may not,
+    /// so a session cannot outlive the UI that is able to close it.
     #[no_mangle]
     pub unsafe extern "system" fn Java_ffi_FFI_closeAllSessions(_env: JNIEnv, _class: JClass) {
         let closed = crate::flutter::sessions::close_all_sessions();
         if closed > 0 {
-            log::info!("closed {} session(s) on task removed", closed);
+            log::info!("closed {} outgoing session(s)", closed);
         }
     }
 


### PR DESCRIPTION
FIxing https://www.reddit.com/r/rustdesk/comments/1ve2wns/sessions_dont_close_cleanly_on_android_when/

Swiping RustDesk away from recents destroys the UI but does not necessarily end the process: when MainService is running (screen share enabled, or started at boot) the process survives, and with it the native io_loop of any active outgoing session.

That orphaned io_loop keeps echoing TestDelay (client.rs handle_test_delay runs entirely on the network thread, no UI involved), which keeps refreshing last_recv_time on the controlled side. Its 30s inactivity timeout in server/connection.rs therefore never fires, so the remote session stays established with no UI left to close it, and the peer cannot be reconnected to.

Close client sessions from Service.onTaskRemoved, which fires only on explicit task removal -- not on Home or backgrounding, so ordinary backgrounding is unaffected. The service itself keeps running, so incoming connections and the device staying reachable are unchanged.

This complements 152c5c71b, which covered the route-pop path via dispose(); dispose() does not run when the task is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Active sessions now close automatically when the Android app is removed from recent apps.
  * Sessions close when the app is finishing, while remaining open during routine activity recreation.
  * Remote keyboard input is released and session resources are cleaned up during closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Closes orphaned outgoing RustDesk sessions on Android when the app is swiped from the recents list, fixing a bug where the background `io_loop` kept the remote session alive indefinitely with no UI left to close it.

- **`MainService.onTaskRemoved`** now calls `FFI.closeAllSessions()`, covering the case where the foreground service keeps the process alive after the task is removed.
- **`MainActivity.onDestroy`** additionally calls `FFI.closeAllSessions()` under an `isFinishing` guard, covering the case where only the accessibility InputService keeps the process alive (which doesn't receive `onTaskRemoved`).
- **`close_all_sessions`** in Rust safely releases any held remote keys before draining the SESSIONS map (to keep `get_cur_session()` valid during key release), then closes each session's event stream and sends the shutdown signal via `Data::Close`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the dual-path shutdown (onTaskRemoved + onDestroy isFinishing guard) is correct and the no-op on the second call is harmless.

The fix is narrowly scoped: onTaskRemoved fires only on explicit task removal (not backgrounding or Home), and the isFinishing guard in onDestroy correctly distinguishes user-initiated closure from configuration-change recreation. close_all_sessions drains SESSIONS under a write lock only after key release so get_cur_session remains valid during that step, and a concurrent or sequential second call safely finds the map empty. Incoming connections are unaffected because the service itself keeps running.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainService.kt | Adds onTaskRemoved override that calls FFI.closeAllSessions(); correct placement since the service keeps the process alive after the task is swiped away. |
| flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/MainActivity.kt | Adds FFI.closeAllSessions() in onDestroy under isFinishing guard; correctly distinguishes user-initiated closure from configuration-change recreation. |
| flutter/android/app/src/main/kotlin/ffi.kt | Adds closeAllSessions external function declaration to the FFI object to match the new JNI entry point. |
| src/flutter.rs | Adds close_all_sessions(): releases held remote keys (while SESSIONS is intact so get_cur_session works), drains SESSIONS, then closes each session's event stream and sends Data::Close. Logic is sound. |
| src/flutter_ffi.rs | Adds JNI entry point Java_ffi_FFI_closeAllSessions inside the android-only server_side module, wiring the Kotlin call to close_all_sessions(). |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as User (swipe away)
    participant Android as Android Runtime
    participant MainService as MainService
    participant MainActivity as MainActivity
    participant FFI as FFI (Kotlin)
    participant Rust as close_all_sessions() (Rust)
    participant Session as Session io_loop

    User->>Android: Swipe app from recents
    Android->>MainService: onTaskRemoved()
    MainService->>FFI: FFI.closeAllSessions()
    FFI->>Rust: Java_ffi_FFI_closeAllSessions (JNI)
    Rust->>Rust: release_remote_keys("map")
    Note over Rust: Keys released while SESSIONS intact
    Rust->>Rust: SESSIONS.write().drain()
    Rust->>Session: close_event_stream(session_id)
    Rust->>Session: session.close() → Data::Close
    Session-->>Rust: io_loop terminates

    Android->>MainActivity: "onDestroy() [isFinishing=true]"
    MainActivity->>FFI: FFI.closeAllSessions()
    FFI->>Rust: Java_ffi_FFI_closeAllSessions (JNI)
    Rust->>Rust: SESSIONS already empty → returns 0
    Note over Rust: No-op, safe second call

    Note over MainService: Service keeps running
    Note over MainService: Device stays reachable for incoming connections
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(android): release held keys before d..."](https://github.com/rustdesk/rustdesk/commit/bcb5b03af10ef02079db912c81180e5cd6f0a699) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49603491)</sub>

<!-- /greptile_comment -->