### PR TITLE
Audit retry nonce

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1405,6 +1405,58 @@ pub async fn post_request(url: String, body: String, header: &str) -> ResultType
     .await
 }
 
+/// POST request via TCP proxy, preserving the HTTP status code.
+async fn post_request_via_tcp_proxy_status(
+    url: &str,
+    body: &str,
+    header: &str,
+) -> ResultType<(u16, String)> {
+    let headers = parse_simple_header(header);
+    let resp = tcp_proxy_request("POST", url, body.as_bytes(), headers).await?;
+    if !resp.error.is_empty() {
+        bail!("TCP proxy error: {}", resp.error);
+    }
+    Ok((
+        resp.status as u16,
+        String::from_utf8_lossy(&resp.body).to_string(),
+    ))
+}
+
+/// Like `post_request`, but returns the HTTP status code so callers can tell
+/// a server-side failure from success. Same fallback rules: on connection
+/// failure or 5xx, retry once through the raw TCP proxy when eligible.
+pub async fn post_request_with_status(
+    url: String,
+    body: String,
+    header: &str,
+) -> ResultType<(u16, String)> {
+    if should_use_raw_tcp_for_api(&url) {
+        return post_request_via_tcp_proxy_status(&url, &body, header).await;
+    }
+    let http_result = post_request_http(&url, &body, header).await;
+    let should_fallback = match &http_result {
+        Err(_) => true,
+        Ok((status, _)) => *status >= 500,
+    };
+    if should_fallback && can_fallback_to_raw_tcp(&url) {
+        log::warn!(
+            "HTTP POST to {} failed or 5xx (result: {:?}), trying TCP proxy fallback",
+            tcp_proxy_log_target(&url),
+            http_result
+                .as_ref()
+                .map(|(s, _)| *s)
+                .map_err(|e| e.to_string()),
+        );
+        match post_request_via_tcp_proxy_status(&url, &body, header).await {
+            Ok(resp) => return Ok(resp),
+            Err(tcp_err) => {
+                log::warn!("TCP proxy fallback also failed: {:?}", tcp_err);
+            }
+        }
+    }
+    http_result
+}
+
 #[async_recursion]
 async fn post_request_(
     url: &str,

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1694,6 +1694,17 @@ impl Connection {
             );
             // In range by construction: the guard above returns at ATTEMPTS.
             time::sleep(Duration::from_secs(RETRY_BACKOFF_SECS[attempt - 1])).await;
+            // Re-checked after the delay so no attempt starts past the deadline;
+            // the check above alone would let one begin up to a backoff later.
+            if started.elapsed() >= RETRY_DEADLINE {
+                log::error!(
+                    "Audit post dropped (attempt {}/{}, deadline passed during backoff): {}",
+                    attempt,
+                    ATTEMPTS,
+                    err
+                );
+                bail!("{}", err);
+            }
         }
     }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1643,13 +1643,11 @@ impl Connection {
                             // failures (e.g. a db write error) as 200 with an
                             // {"error": ...} body - retryable: the server
                             // releases the record's nonce when its write fails,
-                            // and answers a post whose earlier attempt is still
-                            // being written with an error too, so in both cases
-                            // trying again is what stores the record. Any other
-                            // nonempty body did not come from the audit handler
-                            // (a proxy interposing a 2xx maintenance page, a
-                            // malformed error) and must not be mistaken for
-                            // storage, so it is retried rather than dropped.
+                            // so trying again is what stores the record. Any
+                            // other nonempty body did not come from the audit
+                            // handler (a proxy interposing a 2xx maintenance
+                            // page, a malformed error) and must not be mistaken
+                            // for storage, so it is retried rather than dropped.
                             if text.trim().is_empty() {
                                 return Ok(text);
                             }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1639,24 +1639,30 @@ impl Connection {
                 match crate::post_request_with_status(url.clone(), body.clone(), "").await {
                     Ok((status, text)) => {
                         if (200..300).contains(&status) {
-                            // hbbs reports handler failures (e.g. a db write
-                            // error) as 200 with an {"error": ...} body;
-                            // success is an empty body. Retryable: the server
+                            // Success is an empty body. hbbs reports handler
+                            // failures (e.g. a db write error) as 200 with an
+                            // {"error": ...} body - retryable: the server
                             // releases the record's nonce when its write fails,
                             // and answers a post whose earlier attempt is still
                             // being written with an error too, so in both cases
-                            // trying again is what stores the record.
+                            // trying again is what stores the record. Any other
+                            // nonempty body did not come from the audit handler
+                            // (a proxy interposing a 2xx maintenance page, a
+                            // malformed error) and must not be mistaken for
+                            // storage, so it is retried rather than dropped.
+                            if text.trim().is_empty() {
+                                return Ok(text);
+                            }
                             let server_err = serde_json::from_str::<Value>(&text)
                                 .ok()
                                 .and_then(|v| v.get("error")?.as_str().map(|s| s.to_owned()))
                                 .filter(|e| !e.is_empty());
-                            match server_err {
-                                Some(e) => {
-                                    let brief: String = e.chars().take(128).collect();
-                                    (true, format!("server error: {}", brief))
-                                }
-                                None => return Ok(text),
-                            }
+                            let (label, detail) = match &server_err {
+                                Some(e) => ("server error", e.as_str()),
+                                None => ("unexpected response body", text.as_str()),
+                            };
+                            let brief: String = detail.chars().take(128).collect();
+                            (true, format!("{}: {}", label, brief))
                         } else {
                             let brief: String = text.chars().take(128).collect();
                             // 408 and 429 are the transient 4xx: the request timed

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1636,9 +1636,11 @@ impl Connection {
                         if (200..300).contains(&status) {
                             // hbbs reports handler failures (e.g. a db write
                             // error) as 200 with an {"error": ...} body;
-                            // success is an empty body. Not retryable: the
-                            // server already consumed the nonce, and fixing
-                            // persistence is the server's job.
+                            // success is an empty body. Retryable: the server
+                            // releases the record's nonce when its write fails,
+                            // and answers a post whose earlier attempt is still
+                            // being written with an error too, so in both cases
+                            // trying again is what stores the record.
                             let server_err = serde_json::from_str::<Value>(&text)
                                 .ok()
                                 .and_then(|v| v.get("error")?.as_str().map(|s| s.to_owned()))
@@ -1646,7 +1648,7 @@ impl Connection {
                             match server_err {
                                 Some(e) => {
                                     let brief: String = e.chars().take(128).collect();
-                                    (false, format!("server error: {}", brief))
+                                    (true, format!("server error: {}", brief))
                                 }
                                 None => return Ok(text),
                             }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1612,9 +1612,22 @@ impl Connection {
         // 5xx (e.g. a reverse proxy answering while the api server restarts)
         // so transient failures don't silently drop them. A 4xx is a
         // deterministic rejection and fails immediately.
-        const ATTEMPTS: u32 = 3;
+        //
+        // The delays, not the attempt count, are what cover the case this exists
+        // for: a proxy answering 502 during a restart fails fast, so without them
+        // every attempt lands within a few seconds and none outlives the restart.
+        //
+        // The window is bounded on the other side: the api server dedups by nonce
+        // for five minutes, and a retry arriving after that expired would be
+        // stored a second time. Worst case here is ATTEMPTS * (12s HTTP timeout +
+        // 36s TCP-proxy fallback) plus these delays, a little over three minutes.
+        //
+        // One delay per retry, so the attempt count follows from the table and the
+        // two cannot drift apart.
+        const RETRY_BACKOFF_SECS: [u64; 2] = [10, 30];
+        const ATTEMPTS: usize = RETRY_BACKOFF_SECS.len() + 1;
         let body = v.to_string();
-        let mut attempt = 0;
+        let mut attempt = 0usize;
         loop {
             attempt += 1;
             let (retryable, err) =
@@ -1659,7 +1672,8 @@ impl Connection {
                 ATTEMPTS,
                 err
             );
-            time::sleep(Duration::from_secs(1 << (attempt - 1))).await;
+            // In range by construction: the guard above returns at ATTEMPTS.
+            time::sleep(Duration::from_secs(RETRY_BACKOFF_SECS[attempt - 1])).await;
         }
     }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1617,16 +1617,21 @@ impl Connection {
         // for: a proxy answering 502 during a restart fails fast, so without them
         // every attempt lands within a few seconds and none outlives the restart.
         //
-        // The window is bounded on the other side: the api server dedups by nonce
-        // for five minutes, and a retry arriving after that expired would be
-        // stored a second time. Worst case here is ATTEMPTS * (12s HTTP timeout +
-        // 36s TCP-proxy fallback) plus these delays, a little over three minutes.
-        //
+        // The window is bounded on the other side: the api server only remembers a
+        // record's nonce for five minutes, so a retry arriving after that expired
+        // would be stored a second time. Counting attempts cannot bound it - one
+        // attempt is already up to 84s (post_request_ retries the TLS handshake up
+        // to four times at 12s each, then the TCP-proxy fallback adds 36s), and a
+        // suspend between attempts stretches the wall clock without limit. So stop
+        // by elapsed time instead, early enough that the last attempt still lands
+        // inside the server's window.
+        const RETRY_DEADLINE: Duration = Duration::from_secs(120);
         // One delay per retry, so the attempt count follows from the table and the
         // two cannot drift apart.
         const RETRY_BACKOFF_SECS: [u64; 2] = [10, 30];
         const ATTEMPTS: usize = RETRY_BACKOFF_SECS.len() + 1;
         let body = v.to_string();
+        let started = Instant::now();
         let mut attempt = 0usize;
         loop {
             attempt += 1;
@@ -1654,16 +1659,23 @@ impl Connection {
                             }
                         } else {
                             let brief: String = text.chars().take(128).collect();
-                            (status >= 500, format!("status {}: {}", status, brief))
+                            // 408 and 429 are the transient 4xx: the request timed
+                            // out upstream, or a proxy is shedding load. Every other
+                            // 4xx is a deterministic rejection and retrying it would
+                            // only delay the log line.
+                            let transient = status >= 500 || status == 408 || status == 429;
+                            (transient, format!("status {}: {}", status, brief))
                         }
                     }
                     Err(e) => (true, e.to_string()),
                 };
-            if !retryable || attempt >= ATTEMPTS {
+            let elapsed = started.elapsed();
+            if !retryable || attempt >= ATTEMPTS || elapsed >= RETRY_DEADLINE {
                 log::error!(
-                    "Audit post dropped (attempt {}/{}): {}",
+                    "Audit post dropped (attempt {}/{}, {:?} elapsed): {}",
                     attempt,
                     ATTEMPTS,
+                    elapsed,
                     err
                 );
                 bail!("{}", err);

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1621,10 +1621,26 @@ impl Connection {
                 match crate::post_request_with_status(url.clone(), body.clone(), "").await {
                     Ok((status, text)) => {
                         if (200..300).contains(&status) {
-                            return Ok(text);
+                            // hbbs reports handler failures (e.g. a db write
+                            // error) as 200 with an {"error": ...} body;
+                            // success is an empty body. Not retryable: the
+                            // server already consumed the nonce, and fixing
+                            // persistence is the server's job.
+                            let server_err = serde_json::from_str::<Value>(&text)
+                                .ok()
+                                .and_then(|v| v.get("error")?.as_str().map(|s| s.to_owned()))
+                                .filter(|e| !e.is_empty());
+                            match server_err {
+                                Some(e) => {
+                                    let brief: String = e.chars().take(128).collect();
+                                    (false, format!("server error: {}", brief))
+                                }
+                                None => return Ok(text),
+                            }
+                        } else {
+                            let brief: String = text.chars().take(128).collect();
+                            (status >= 500, format!("status {}: {}", status, brief))
                         }
-                        let brief: String = text.chars().take(128).collect();
-                        (status >= 500, format!("status {}: {}", status, brief))
                     }
                     Err(e) => (true, e.to_string()),
                 };

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1506,6 +1506,8 @@ impl Connection {
         v["uuid"] = json!(crate::encode64(hbb_common::get_uuid()));
         v["conn_id"] = json!(self.inner.id);
         v["session_id"] = json!(self.lr.session_id);
+        // Unique per record; the api server dedups retried posts by it.
+        v["nonce"] = json!(uuid::Uuid::new_v4().to_string());
         allow_err!(self.tx_post_seq.send((url, v)));
     }
 
@@ -1555,6 +1557,7 @@ impl Connection {
             "path":path,
             "is_file":is_file,
             "info":json!(info).to_string(),
+            "nonce": uuid::Uuid::new_v4().to_string(),
         });
         tokio::spawn(async move {
             allow_err!(Self::post_audit_async(url, v).await);
@@ -1576,6 +1579,7 @@ impl Connection {
         v["typ"] = json!(typ as i8);
         v["info"] = serde_json::Value::String(info.to_string());
         v["conn_id"] = json!(self.inner.id());
+        v["nonce"] = json!(uuid::Uuid::new_v4().to_string());
         if typ == AlarmAuditType::IpWhitelist || typ == AlarmAuditType::IdWhitelist {
             if let Some(audit_ref) = self.conn_audit_ref() {
                 v["conn_audit_ref"] = json!(audit_ref);
@@ -1603,9 +1607,24 @@ impl Connection {
         );
     }
 
-    #[inline]
     async fn post_audit_async(url: String, v: Value) -> ResultType<String> {
-        crate::post_request(url, v.to_string(), "").await
+        // Audit records are compliance evidence; retry transient api-server
+        // failures so they are not silently dropped.
+        const ATTEMPTS: u32 = 3;
+        let body = v.to_string();
+        for i in 1..ATTEMPTS {
+            match crate::post_request(url.clone(), body.clone(), "").await {
+                Ok(x) => return Ok(x),
+                Err(e) => {
+                    log::warn!("Audit post failed (attempt {}/{}): {}", i, ATTEMPTS, e);
+                    time::sleep(Duration::from_secs(1 << (i - 1))).await;
+                }
+            }
+        }
+        crate::post_request(url, body, "").await.map_err(|e| {
+            log::error!("Audit post dropped after {} attempts: {}", ATTEMPTS, e);
+            e
+        })
     }
 
     fn set_conn_audit_primary_auth(&mut self, method: ConnAuditPrimaryAuth) {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1608,23 +1608,43 @@ impl Connection {
     }
 
     async fn post_audit_async(url: String, v: Value) -> ResultType<String> {
-        // Audit records are compliance evidence; retry transient api-server
-        // failures so they are not silently dropped.
+        // Audit records are compliance evidence; retry transport errors and
+        // 5xx (e.g. a reverse proxy answering while the api server restarts)
+        // so transient failures don't silently drop them. A 4xx is a
+        // deterministic rejection and fails immediately.
         const ATTEMPTS: u32 = 3;
         let body = v.to_string();
-        for i in 1..ATTEMPTS {
-            match crate::post_request(url.clone(), body.clone(), "").await {
-                Ok(x) => return Ok(x),
-                Err(e) => {
-                    log::warn!("Audit post failed (attempt {}/{}): {}", i, ATTEMPTS, e);
-                    time::sleep(Duration::from_secs(1 << (i - 1))).await;
-                }
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            let (retryable, err) =
+                match crate::post_request_with_status(url.clone(), body.clone(), "").await {
+                    Ok((status, text)) => {
+                        if (200..300).contains(&status) {
+                            return Ok(text);
+                        }
+                        let brief: String = text.chars().take(128).collect();
+                        (status >= 500, format!("status {}: {}", status, brief))
+                    }
+                    Err(e) => (true, e.to_string()),
+                };
+            if !retryable || attempt >= ATTEMPTS {
+                log::error!(
+                    "Audit post dropped (attempt {}/{}): {}",
+                    attempt,
+                    ATTEMPTS,
+                    err
+                );
+                bail!("{}", err);
             }
+            log::warn!(
+                "Audit post failed (attempt {}/{}): {}",
+                attempt,
+                ATTEMPTS,
+                err
+            );
+            time::sleep(Duration::from_secs(1 << (attempt - 1))).await;
         }
-        crate::post_request(url, body, "").await.map_err(|e| {
-            log::error!("Audit post dropped after {} attempts: {}", ATTEMPTS, e);
-            e
-        })
     }
 
     fn set_conn_audit_primary_auth(&mut self, method: ConnAuditPrimaryAuth) {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proxy-based POST requests now preserve and return the server’s HTTP status and response body.
  * Requests automatically fall back to an alternate connection method when appropriate.
  * Audit records now include unique identifiers for improved tracking and troubleshooting.

* **Bug Fixes**
  * Audit submissions retry temporary connection issues, rate limits, timeouts, and server-reported errors.
  * Permanent client errors and retries exceeding the time limit stop promptly with clear error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds unique nonce fields to every audit record (`post_conn_audit`, `post_file_audit`, `post_alarm_audit`) so the API server can deduplicate retried POSTs, and upgrades `post_audit_async` from a single fire-and-forget call to a bounded retry loop with deadline enforcement.

- **Nonce generation**: each nonce is generated once in the synchronous caller, serialised into `body` before the loop, and reused across all retry attempts — correct for idempotent deduplication.
- **New `post_request_with_status`**: mirrors the existing `with_tcp_proxy_fallback` path but preserves the HTTP status code so the caller can distinguish success, server errors (2xx+error body), and transient vs. permanent HTTP errors.
- **Retry loop**: three attempts with 10 s / 30 s back-off, guarded by a 120 s wall-clock deadline; the deadline bounds total elapsed time rather than attempt count, matching the stated 5-minute server nonce window.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the retry/fallback logic is well-bounded and nonces are correctly scoped to each audit record.

The nonce is generated once before serialisation and reused across retries — matching the server's idempotency contract. The backoff index RETRY_BACKOFF_SECS[attempt - 1] is provably in-bounds at the point it is evaluated (attempt < ATTEMPTS = 3, so index <= 1, array length = 2). The 120 s deadline is checked both after each request and after each sleep, preventing spurious retries outside the server's 5-minute nonce window. No data-loss or correctness issues found.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/common.rs | Adds `post_request_with_status` and a private `post_request_via_tcp_proxy_status` helper; the fallback logic is a close parallel of the existing `with_tcp_proxy_fallback`, returning `(u16, String)` instead of `String`. |
| src/server/connection.rs | Adds `uuid::Uuid::new_v4()` nonces to all three audit paths, converts `post_audit_async` from a single request to a bounded retry loop with deadline, and adds `post_request_with_status` for status-aware error classification. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[post_conn_audit / post_file_audit / post_alarm_audit] -->|nonce = new_v4| B[post_audit_async]
    B --> C[body = v.to_string\nstarted = Instant::now\nattempt = 0]
    C --> D{loop: attempt += 1}
    D --> E[post_request_with_status]
    E -->|should_use_raw_tcp?| F[TCP proxy only]
    E -->|HTTP first| G[post_request_http]
    G -->|Err or 5xx + can_fallback?| H[TCP proxy fallback]
    G -->|4xx or 2xx| I[return status]
    H -->|Ok| I
    H -->|Err| I
    F --> I
    I --> J{Ok 2xx?}
    J -->|empty body| K[return Ok - success]
    J -->|non-empty body| L[retryable=true\nserver-error or unexpected]
    J -->|4xx non-transient| M[retryable=false]
    J -->|5xx / 408 / 429| L
    J -->|Err| L
    L --> N{!retryable OR attempt>=3 OR elapsed>=120s?}
    M --> N
    N -->|bail| O[log error, bail]
    N -->|retry| P[sleep RETRY_BACKOFF_SECS\nattempt-1: 10s or 30s]
    P --> Q{elapsed>=120s after sleep?}
    Q -->|yes| O
    Q -->|no| D
```
</details>

<sub>Reviews (6): Last reviewed commit: ["docs: drop a retry rationale the server ..."](https://github.com/rustdesk/rustdesk/commit/653ecc662ac208bed0c432bf3663e8fd56ce2ae7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49966466)</sub>

<!-- /greptile_comment -->