### PR TITLE
fix(scrap): link libva and libswresample for hwcodec on Linux

### DIFF
--- a/libs/scrap/build.rs
+++ b/libs/scrap/build.rs
@@ -137,6 +137,33 @@ fn find_package(name: &str) -> Vec<PathBuf> {
     }
 }
 
+/// Whether the linker will be able to resolve `-l<stem>` from a default search
+/// path. Checks for the `.so`/`.a` the linker needs (the versioned `.so.N` that
+/// runtime-only installs ship is not enough), so we can decline to name a library
+/// that is not there instead of failing the build.
+///
+/// These are host paths, so the answer is only meaningful for a native build.
+/// A cross build gets `false`: the target sysroot is not searched here, and
+/// naming a library that exists only on the build machine would break the target
+/// link. That leaves cross builds exactly as they were before this check existed.
+fn has_system_lib(stem: &str) -> bool {
+    if env::var("HOST").ok() != env::var("TARGET").ok() {
+        return false;
+    }
+    [
+        "/usr/lib",
+        "/usr/lib64",
+        "/usr/local/lib",
+        "/usr/lib/x86_64-linux-gnu",
+        "/usr/lib/aarch64-linux-gnu",
+    ]
+    .iter()
+    .any(|dir| {
+        let dir = Path::new(dir);
+        dir.join(format!("lib{stem}.so")).exists() || dir.join(format!("lib{stem}.a")).exists()
+    })
+}
+
 fn generate_bindings(
     ffi_header: &Path,
     include_paths: &[PathBuf],
@@ -244,11 +271,54 @@ fn main() {
     env::remove_var("CARGO_CFG_TARGET_FEATURE");
     env::set_var("CARGO_CFG_TARGET_FEATURE", "crt-static");
 
-    find_package("libyuv");
+    let vcpkg_includes = find_package("libyuv");
     gen_vcpkg_package("libvpx", "vpx_ffi.h", "vpx_ffi.rs", "^[vV].*");
     gen_vcpkg_package("aom", "aom_ffi.h", "aom_ffi.rs", "^(aom|AOM|OBU|AV1).*");
     gen_vcpkg_package("libyuv", "yuv_ffi.h", "yuv_ffi.rs", ".*");
     // ffmpeg();
+
+    // hwcodec offers `h264_vaapi` as a Linux encoder, but its build script links
+    // only drm/X11/stdc++ — never libva. That is harmless as long as ffmpeg is
+    // built without the `vaapi` feature, as this tree's vcpkg manifest does: the
+    // encoder is dead code and nothing calls into libva. Build ffmpeg as
+    // `ffmpeg[vaapi]` and the vaapi objects link in with undefined `va*` symbols;
+    // a cdylib links anyway, so the failure only appears when the encoder is first
+    // used. See the commented-out `ffmpeg()` above, which lists these same libs and
+    // notes "Linux require link in hwcodec". Only `va` and `va-drm` are needed —
+    // nothing references the X11 or VDPAU entry points.
+    //
+    // Both libs are named only when actually present. Naming a missing `static`
+    // lib is a hard rustc error and a missing dylib breaks the final link, so an
+    // unconditional directive would turn a host that needs neither into a build
+    // failure.
+    if target_os == "linux" && std::env::var("CARGO_FEATURE_HWCODEC").is_ok() {
+        if has_system_lib("va") && has_system_lib("va-drm") {
+            println!("cargo:rustc-link-lib=va");
+            println!("cargo:rustc-link-lib=va-drm");
+        } else {
+            println!("cargo:warning=libva/libva-drm not found on the host, skipping VAAPI link; h264_vaapi and hevc_vaapi will be unavailable");
+        }
+        // hwcodec links only avcodec/avutil/avformat, but those reference
+        // libswresample internally, leaving swr_* unresolved. Harmless until an
+        // audio-resampling path is hit, then it is a load/call-time failure.
+        //
+        // Located via the libyuv include paths because vcpkg installs every port
+        // into one prefix per triplet, so libyuv's prefix is also ffmpeg's, and it
+        // is already resolved for the *target* triplet. Only the static archive is
+        // looked for: a shared ffmpeg needs nothing here, since libavcodec.so
+        // carries a DT_NEEDED on libswresample.so and the loader resolves swr_*.
+        let swresample_dir = vcpkg_includes
+            .iter()
+            .filter_map(|include| include.parent())
+            .map(|prefix| prefix.join("lib"))
+            .find(|lib_dir| lib_dir.join("libswresample.a").exists());
+        if let Some(lib_dir) = swresample_dir {
+            println!("cargo:rustc-link-search={}", lib_dir.display());
+            println!("cargo:rustc-link-lib=static=swresample");
+        } else {
+            println!("cargo:warning=libswresample.a not found, skipping; hwcodec audio resampling paths would fail if reached");
+        }
+    }
 
     if target_os == "ios" {
         // nothing


### PR DESCRIPTION
## What this fixes

`hwcodec` advertises `h264_vaapi` / `hevc_vaapi` as Linux encoders, but its build script links only `drm`/`X11`/`stdc++`/`z` — never `libva`.

Today that is invisible, because `vcpkg.json` builds ffmpeg **without** the `vaapi` feature, so the VAAPI encoder is dead code and nothing ever calls into libva.

Build ffmpeg as `ffmpeg[vaapi]` and the vaapi objects link in with **39 undefined `va*` symbols**. The important part: a `cdylib` links happily with undefined symbols, so **the build still succeeds** and the failure only surfaces when the encoder is first used, at runtime.

The same applies to libswresample — hwcodec links `avcodec`/`avutil`/`avformat`, but those reference swresample internally, leaving 6 undefined `swr_*`.

Both are linked explicitly here so the dependency is resolved at build time instead of failing at first use.

## Why the presence checks

Naming a missing `static` library is a hard `rustc` error, and a missing dylib breaks the final link. An unconditional directive would therefore break every host that does *not* need these libs — including this repository's own CI, which builds ffmpeg without vaapi and produces no `libswresample.a`.

So each is probed before being named:

- **libva / libva-drm** — probed on the default linker search paths. Only `va` and `va-drm` are named; nothing references the X11 or VDPAU entry points, so linking those would add runtime deps for no gain.
- **libswresample** — probed inside the vcpkg tree being built against, and given its own `rustc-link-search`, since nothing else guarantees that directory is on the search path.

If either is absent, the build emits a `cargo:warning` and skips it. A stock tree builds exactly as before, apart from those two warnings.

There is precedent in this same file: the commented-out `ffmpeg()` function already lists these libraries with the note *"Linux require link in hwcodec"*.

## Verification

On Arch Linux / RDNA3 (Mesa radeonsi) with ffmpeg built as `ffmpeg[vaapi]`:

- `ldd -r` reports zero unresolved symbols (previously 39 `va*` + 6 `swr_*`)
- the runtime probe now lists `h264_vaapi` as an available encoder

With a stock ffmpeg (no vaapi), the build is unchanged apart from the two skip warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux hardware-accelerated codec builds by detecting and linking available video acceleration libraries.
  * Added support for locating static audio resampling libraries in configured package installations.
  * Added warnings when optional codec libraries are unavailable, helping clarify build configuration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR conditionally links VAAPI and static swresample dependencies for Linux hardware-codec builds.
- Adds native-build probing for `libva` and `libva-drm`.
- Locates `libswresample.a` through the resolved vcpkg prefix.
- Emits warnings when optional native libraries are unavailable.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because valid native Linux builds using custom linker paths can still omit required VAAPI link directives.

The current probe avoids examining host paths during cross-compilation, but native builds still search only hardcoded directories; libraries supplied through valid custom linker paths remain undetected, preserving the previously reported failure.

**Files Needing Attention:** libs/scrap/build.rs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/scrap/build.rs | Adds conditional Linux native-library detection and link directives for VAAPI and swresample. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(scrap): link libva and libswresample..."](https://github.com/rustdesk/rustdesk/commit/d44266e117de1038a0c6e7acb1a57ae4ff111fb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50331003)</sub>

<!-- /greptile_comment -->