### PR TITLE
Update Dutch translation

### DIFF
--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -774,6 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("id_whitelist_caveat_tip", "De ID wordt vermeld door de verbindende client. Deze witte lijst vermindert de zichtbaarheid en vervangt niet het wachtwoord of 2FA."),
         ("whitelist_cidr_tip", "CIDR-notatie wordt ondersteund, bijv. 192.168.1.0/24"),
         ("Continue", "Doorgaan"),
-        ("Browser didn't open? Use the url below to sign in.", ""),
+        ("Browser didn't open? Use the url below to sign in.", "Is de browser niet geopend? Gebruik  onderstaande URL om in te loggen."),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -774,6 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("id_whitelist_caveat_tip", "De ID wordt vermeld door de verbindende client. Deze witte lijst vermindert de zichtbaarheid en vervangt niet het wachtwoord of 2FA."),
         ("whitelist_cidr_tip", "CIDR-notatie wordt ondersteund, bijv. 192.168.1.0/24"),
         ("Continue", "Doorgaan"),
-        ("Browser didn't open? Use the url below to sign in.", "Is de browser niet geopend? Gebruik  onderstaande URL om in te loggen."),
+        ("Browser didn't open? Use the url below to sign in.", "Is de browser niet geopend? Gebruik onderstaande URL om in te loggen."),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added the missing Dutch translation for the browser sign-in fallback instruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds the previously missing Dutch translation for the browser sign-in fallback instruction.
- Provides Dutch guidance when the browser does not open automatically.
- Removes the extra word space identified in the previous review.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lang/nl.rs | Adds the Dutch browser sign-in fallback text, with the previously reported extra space corrected. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Update src/lang/nl.rs"](https://github.com/rustdesk/rustdesk/commit/ced593026207575e24bece01ea04f732af8dc5fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50339042)</sub>

<!-- /greptile_comment -->