### PR TITLE
Translate sign-in message to Portuguese

### DIFF
--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -774,6 +774,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("id_whitelist_caveat_tip", "O ID é informado pelo cliente que se conecta. A lista reduz a exposição e não substitui a senha ou o 2FA"),
         ("whitelist_cidr_tip", "A notação CIDR é suportada, por exemplo 192.168.1.0/24"),
         ("Continue", "Continuar"),
-        ("Browser didn't open? Use the url below to sign in.", ""),
+        ("Browser didn't open? Use the url below to sign in.", "O navegador não foi aberto? Use a URL abaixo para fazer login."),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
Translate sign-in message to Portuguese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Brazilian Portuguese browser sign-in fallback message with a translated prompt instead of leaving it blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds the previously missing Portuguese translation for the browser-based sign-in fallback message.
- Portuguese users are now instructed to use the displayed URL when the browser does not open.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The change only fills an empty Portuguese localization value, preserves the lookup key and formatting requirements, and uses terminology consistent with existing translations.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lang/ptbr.rs | Fills one empty localization value with a consistent Portuguese translation while preserving the source key and formatting contract. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Translate sign-in message to Portuguese"](https://github.com/rustdesk/rustdesk/commit/ecf647dab8faed266a09207a0b9fe946307b3abe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50435877)</sub>

<!-- /greptile_comment -->