### PR TITLE
fix(linux): keep-awake does nothing on a GNOME login screen

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1982,18 +1982,167 @@ mod desktop {
     }
 }
 
-pub struct WakeLock(Option<keepawake::AwakeHandle>);
+/// A session-bus idle-inhibit interface, tried in order; the first that answers wins.
+/// `org.freedesktop.ScreenSaver` is absent on purpose: that is the one `keepawake` already tried.
+struct SessionInhibitTarget {
+    dest: &'static str,
+    path: &'static str,
+    iface: &'static str,
+    /// GNOME takes `(app_id, xid, reason, flags)`; PowerManagement takes `(app, reason)`.
+    gnome_shape: bool,
+    uninhibit: &'static str,
+}
+
+/// `org.gnome.SessionManager.Inhibit` flag 8 = idle only; logout/switch-user/suspend would take
+/// away actions the person at the machine should keep.
+const GNOME_INHIBIT_IDLE: u32 = 8;
+
+const SESSION_INHIBIT_TARGETS: &[SessionInhibitTarget] = &[
+    // Measured on a GDM greeter: output held 129.9 s with the inhibit, 30.3 s without.
+    SessionInhibitTarget {
+        dest: "org.gnome.SessionManager",
+        path: "/org/gnome/SessionManager",
+        iface: "org.gnome.SessionManager",
+        gnome_shape: true,
+        uninhibit: "Uninhibit",
+    },
+    // What powerdevil and xfce4-power-manager implement. NOT tested here; costs one failed call
+    // where absent, and the log below names every interface tried.
+    SessionInhibitTarget {
+        dest: "org.freedesktop.PowerManagement",
+        path: "/org/freedesktop/PowerManagement/Inhibit",
+        iface: "org.freedesktop.PowerManagement.Inhibit",
+        gnome_shape: false,
+        uninhibit: "UnInhibit",
+    },
+];
+
+/// Idle inhibit for the case `keepawake` cannot serve: it inhibits `org.freedesktop.ScreenSaver`,
+/// which a GDM greeter bus neither provides nor can activate, so its `create()` fails outright.
+/// The connection is kept because the inhibit is bound to it: dropping it releases the inhibit.
+struct SessionIdleInhibit {
+    conn: dbus::blocking::Connection,
+    target: &'static SessionInhibitTarget,
+    cookie: u32,
+}
+
+impl SessionIdleInhibit {
+    fn new(reason: &str) -> Option<Self> {
+        let conn = match dbus::blocking::Connection::new_session() {
+            Ok(conn) => conn,
+            Err(err) => {
+                log::info!("wakelock: no session bus for the idle inhibit fallback ({err})");
+                return None;
+            }
+        };
+        let app = crate::get_app_name();
+        let mut refused = Vec::new();
+        for target in SESSION_INHIBIT_TARGETS {
+            let res: Result<(u32,), dbus::Error> = {
+                let proxy = conn.with_proxy(
+                    target.dest,
+                    target.path,
+                    std::time::Duration::from_secs(3),
+                );
+                if target.gnome_shape {
+                    // Inhibit(s app_id, u xid, s reason, u flags) -> u cookie; xid 0 = no window.
+                    proxy.method_call(
+                        target.iface,
+                        "Inhibit",
+                        (app.clone(), 0u32, reason.to_owned(), GNOME_INHIBIT_IDLE),
+                    )
+                } else {
+                    proxy.method_call(target.iface, "Inhibit", (app.clone(), reason.to_owned()))
+                }
+            };
+            match res {
+                Ok((cookie,)) => {
+                    log::info!(
+                        "wakelock: holding a {} idle inhibit (cookie {cookie})",
+                        target.dest
+                    );
+                    return Some(Self {
+                        conn,
+                        target,
+                        cookie,
+                    });
+                }
+                Err(err) => refused.push(format!("{}: {err}", target.dest)),
+            }
+        }
+        // Name every interface tried and why it failed: on an untested desktop this log is what
+        // turns "the screen still blanks" into a report naming the missing interface.
+        log::info!(
+            "wakelock: no session idle inhibitor answered, so the compositor may still blank this \
+             screen ({})",
+            refused.join("; ")
+        );
+        None
+    }
+}
+
+impl Drop for SessionIdleInhibit {
+    fn drop(&mut self) {
+        let proxy = self.conn.with_proxy(
+            self.target.dest,
+            self.target.path,
+            std::time::Duration::from_secs(3),
+        );
+        // Best effort: the session manager ties the inhibit to the caller's bus name, so dropping
+        // `conn` below releases it even if this call does not get through.
+        let res: Result<(), dbus::Error> =
+            proxy.method_call(self.target.iface, self.target.uninhibit, (self.cookie,));
+        if let Err(err) = res {
+            log::debug!("wakelock: releasing the idle inhibit by closing the bus instead ({err})");
+        }
+    }
+}
+
+pub struct WakeLock(Option<keepawake::AwakeHandle>, Option<SessionIdleInhibit>);
 
 impl WakeLock {
     pub fn new(display: bool, idle: bool, sleep: bool) -> Self {
-        WakeLock(
-            keepawake::Builder::new()
-                .display(display)
-                .idle(idle)
-                .sleep(sleep)
-                .create()
-                .ok(),
-        )
+        match keepawake::Builder::new()
+            .display(display)
+            .idle(idle)
+            .sleep(sleep)
+            .create()
+        {
+            Ok(handle) => WakeLock(Some(handle), None),
+            Err(err) => {
+                // Not `.ok()`: a discarded error is how a login screen ran with no inhibitor at
+                // all and nobody noticed.
+                log::info!("wakelock: keepawake could not take the inhibit ({err})");
+                // keepawake asks for the ScreenSaver inhibit first and abandons the whole request
+                // if it fails, losing the logind idle/sleep inhibits that stop the HOST suspending
+                // mid-session. Re-ask without the display part: those are on the system bus.
+                let system = if idle || sleep {
+                    match keepawake::Builder::new()
+                        .display(false)
+                        .idle(idle)
+                        .sleep(sleep)
+                        .create()
+                    {
+                        Ok(handle) => Some(handle),
+                        Err(err) => {
+                            log::info!(
+                                "wakelock: the logind idle/sleep inhibit did not come back \
+                                 either ({err})"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+                let session = if display {
+                    SessionIdleInhibit::new("incoming session")
+                } else {
+                    None
+                };
+                WakeLock(system, session)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #15741. One file, one commit, independent of any other work.

## The problem

`WakeLock` keeps the display on through the `keepawake` crate, which inhibits `org.freedesktop.ScreenSaver`. That is the right interface inside a desktop session.

It is **not present on a GDM login screen**. Measured on a GNOME/Wayland greeter, that bus name answers `was not provided by any .service files` and cannot be activated either, so `keepawake::Builder::create()` fails as a whole and the wake lock is silently a no-op. The screen then blanks under a live incoming connection, which on Wayland means the compositor eventually disables the connector and there is nothing left to capture.

## The fix

When `keepawake` fails, fall back to a session-bus inhibit, trying the interfaces a greeter actually offers:

- `org.gnome.SessionManager.Inhibit` with flag 8 (idle only). **Verified on a GDM greeter:** with the inhibit held the output stayed on 129.9 s against 30.3 s without it, which matches the greeter idle timer exactly.
- `org.freedesktop.PowerManagement.Inhibit`, which is what powerdevil and xfce4-power-manager implement. **Not verified** — no KDE or XFCE machine here. It costs one failed method call where it is absent, and the log names every interface tried, so a user report is enough to learn what a given desktop wants.

Only the idle flag is requested. The others (logout, switch-user, suspend) would take away actions the person at the machine should keep.

`org.freedesktop.ScreenSaver` is deliberately not in the list: if it had answered, this fallback would not have run.

## Scope

Only reached when the existing path fails, so a normal desktop session behaves exactly as before. No new dependency: the D-Bus client is already in the tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux wake-lock reliability with fallback inhibition methods when the primary request fails.
  * Added support for desktop session idle inhibition through GNOME and freedesktop power-management services.
  * Wake locks now report inhibition errors and cleanly release all active inhibitors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds Linux session-bus idle-inhibit fallbacks for environments where the existing ScreenSaver-based wake lock fails.
- Tries GNOME SessionManager and freedesktop PowerManagement inhibition in order.
- Retains separate logind idle/sleep protection by retrying keepawake without display inhibition.
- Holds and releases the selected session inhibitor for the wake-lock lifetime.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains within the eligible follow-up review scope.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/platform/linux.rs | Adds an ordered session-bus idle-inhibition fallback and preserves idle/sleep inhibition when the primary display-inhibit request fails. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Create Linux wake lock] --> B{keepawake succeeds?}
    B -->|Yes| C[Hold keepawake handle]
    B -->|No| D[Retry idle or sleep inhibit without display]
    D --> E{Display inhibit requested?}
    E -->|Yes| F[Try GNOME SessionManager]
    F -->|Refused| G[Try freedesktop PowerManagement]
    F -->|Accepted| H[Hold system and session inhibitors]
    G -->|Accepted| H
    G -->|Refused| I[Hold system inhibitor if available]
    E -->|No| I
    C --> J[Drop WakeLock]
    H --> J
    I --> J
    J --> K[Release handles and close D-Bus connection]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(linux): stop losing every inhibitor ..."](https://github.com/rustdesk/rustdesk/commit/1dbfed1b9cdbb1f50daad0eabe67e87095d8beb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50479388)</sub>

<!-- /greptile_comment -->