### PR TITLE
fix(linux): size uinput range from captured output on wayland

### DIFF
--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -112,6 +112,24 @@ fn refresh_wayland_uinput_rect_if_changed() {
     let Some((rect, live_rects)) = scrap::wayland::display::get_layout_for_uinput_live() else {
         return;
     };
+    // When a single output is shared but the compositor has more, the range must follow the
+    // captured display rather than the whole desktop: the client maps against the shared
+    // stream, so a root-sized range makes injected coordinates drift by the ratio of the
+    // two bounding boxes and drops the capture origin. The captured display is matched to
+    // the live layout by its origin, the same correlation `try_fix_logical_size` uses.
+    // https://github.com/rustdesk/rustdesk/issues/15731
+    let rect = if live_rects.len() > 1 {
+        match super::wayland::captured_single_display_origin() {
+            Some((ox, oy)) => live_rects
+                .iter()
+                .find(|r| r.x == ox && r.y == oy)
+                .map(|r| (r.x, r.x + r.w, r.y, r.y + r.h))
+                .unwrap_or(rect),
+            None => rect,
+        }
+    } else {
+        rect
+    };
     // Refresh the per-display layout every poll: monitor origins can shift (e.g. two
     // displays swap positions) without changing the overall desktop rect, and the mouse
     // path needs the current per-display geometry to correct coordinates.

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -27,6 +27,53 @@ pub fn init() {
     set_map_err(map_err_scrap);
 }
 
+/// The uinput ABS range that matches what the client sees. When exactly one display is
+/// shared but the compositor has more (e.g. a rotated secondary monitor makes the root
+/// larger than the shared output), the whole-desktop rect makes injected coordinates
+/// drift: the client maps against the shared stream while the device spans the full
+/// layout, and the capture origin is dropped too. In that case the range must derive from
+/// the captured display's rect, origin and size included.
+/// https://github.com/rustdesk/rustdesk/issues/15731
+pub(super) fn captured_uinput_rect() -> Option<(i32, i32, i32, i32)> {
+    let lock = CAP_DISPLAY_INFO.read().unwrap();
+    if lock.len() != 1 {
+        return None;
+    }
+    let addr: &u64 = lock.values().next()?;
+    let cap = unsafe { &*(*addr as *const CapDisplayInfo) };
+    if cap.num != 1 || cap.rects.is_empty() {
+        return None;
+    }
+    // The whole-desktop range is only wrong when the compositor has outputs that are not
+    // being shared. When every output is captured it already spans exactly the shared
+    // layout, and a single-output compositor has no root larger than the stream, so the
+    // desktop rect is correct there too. Only re-derive the range in between.
+    if scrap::wayland::display::get_displays().displays.len() <= 1 {
+        return None;
+    }
+    let ((x, y), w, h) = cap.rects[0];
+    Some((x, x + w as i32, y, y + h as i32))
+}
+
+/// Origin of the single captured display when exactly one output is shared, used to match
+/// its live rect when the compositor layout changes mid-session. `None` when multiple
+/// displays are shared or capture has not started. Matched by origin rather than name:
+/// the captured display's name is a PipeWire stream path while the compositor layout uses
+/// connector names, so geometry is the only stable key (same correlation `try_fix_logical_size`
+/// uses).
+pub(super) fn captured_single_display_origin() -> Option<(i32, i32)> {
+    let lock = CAP_DISPLAY_INFO.read().unwrap();
+    if lock.len() != 1 {
+        return None;
+    }
+    let addr: &u64 = lock.values().next()?;
+    let cap = unsafe { &*(*addr as *const CapDisplayInfo) };
+    if cap.num != 1 || cap.rects.is_empty() {
+        return None;
+    }
+    Some(cap.rects[0].0)
+}
+
 pub(super) fn increment_active_display_count() -> usize {
     let mut count = ACTIVE_DISPLAY_COUNT.write().unwrap();
     *count += 1;
@@ -311,6 +358,38 @@ pub(super) async fn check_init() -> ResultType<()> {
                     }));
 
                     lock.insert(idx, cap_display_info as u64);
+                }
+            }
+            drop(lock);
+            if crate::input_service::wayland_use_uinput() {
+                // When a single output is shared but the compositor has more, the range set
+                // above spans the whole desktop while the client maps against the shared
+                // stream, so injected coordinates drift by the ratio of the two bounding
+                // boxes and the capture origin is lost. Re-derive the range from the
+                // captured rect now that the capture layout is known.
+                // https://github.com/rustdesk/rustdesk/issues/15731
+                if let Some((minx, maxx, miny, maxy)) = captured_uinput_rect() {
+                    log::info!(
+                        "update mouse resolution (captured rect): ({}, {}), ({}, {})",
+                        minx,
+                        maxx,
+                        miny,
+                        maxy
+                    );
+                    match timeout(
+                        3_000,
+                        input_service::update_mouse_resolution(minx, maxx, miny, maxy),
+                    )
+                    .await
+                    {
+                        Ok(Ok(())) => {
+                            super::display_service::set_wayland_uinput_rect((
+                                minx, maxx, miny, maxy,
+                            ));
+                        }
+                        Ok(Err(err)) => log::error!("Failed to update mouse resolution: {}", err),
+                        Err(err) => log::error!("Failed to update mouse resolution: {}", err),
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #15731

When a single output is shared but the compositor has more, the uinput absolute range spans the whole desktop while the client maps against the shared stream. Injected coordinates drift by the ratio of the two bounding boxes, and the non-zero capture origin is dropped, so the cursor lands progressively further from where the user pointed.

Changes

- `src/server/wayland.rs`: after the capture layout is known at session init, if exactly one output is shared while the compositor reports more, re-derive the uinput range from the captured display's rect, origin and size included. Multi-output sharing and single-monitor hosts keep the existing desktop-rect behavior.
- `src/server/display_service.rs`: the periodic layout refresh follows the captured display when a single output is shared, matching it in the live layout by its origin (the same correlation `try_fix_logical_size` uses), so a mid-session layout change does not revert the range to the root bounding box.

The change is gated to the case where the compositor has outputs that are not being shared, which is exactly what the issue's isolation table covers. The DRM capture path is untouched, it captures all outputs where the desktop rect is correct.

Testing

I could not compile here (macOS, and the module is Linux-only), so the diff is review-only. The logic mirrors the existing single-display path in `desktop_rect_of`. The issue reporter offered to test a patch.

DCO

Signed-off-by: bunnysayzz <stfuazzo@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved single-display capture on Linux Wayland when multiple displays are connected.
  * Pointer and input coordinates now align with the captured display’s dimensions instead of the full desktop layout.
  * Added a fallback for cases where the captured display cannot be identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adjusts Linux Wayland uinput bounds to follow a singly shared output on multi-output compositors.
- Derives the initial absolute-input range from the captured display rectangle.
- Refreshes that range from the live compositor layout, although the new origin-based correlation does not preserve output identity after layout movement.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a mid-session monitor-layout change can still retarget uinput bounds to an unshared output or the whole desktop.

The initial captured-output range is corrected, but periodic refreshes identify that output through geometry frozen at session initialization; after the output moves, the fresh layout can match another monitor at the old origin or fall back to the desktop bounds.

**Files Needing Attention:** src/server/display_service.rs and src/server/wayland.rs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/wayland.rs | Adds helpers that derive initial uinput bounds and expose the captured output’s initialization-time origin. |
| src/server/display_service.rs | Refreshes uinput bounds by correlating fresh compositor rectangles with a stale captured origin, so monitor movement can select the wrong range. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Capture starts] --> B[Store captured output's initial origin]
  B --> C[Compositor layout changes]
  C --> D[Read fresh live output rectangles]
  D --> E[Match using stale initial origin]
  E -->|Another output now matches| F[Select unshared output bounds]
  E -->|No output matches| G[Use whole-desktop bounds]
  F --> H[Incorrect uinput mapping]
  G --> H
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fserver%2Fdisplay_service.rs%3A123-127%0A**Refresh%20uses%20stale%20output%20origin**%0A%0AWhen%20the%20captured%20output%20changes%20position%20during%20a%20single-output%20share%2C%20%60captured_single_display_origin%28%29%60%20still%20returns%20its%20session-initial%20origin%2C%20so%20the%20live-layout%20lookup%20selects%20another%20output%20now%20at%20that%20coordinate%20or%20falls%20back%20to%20the%20whole-desktop%20bounds%2C%20causing%20pointer%20input%20to%20drift%20or%20target%20an%20unshared%20output.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix%2Fwayland-uinput-capture-rect%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fwayland-uinput-capture-rect%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fserver%2Fdisplay_service.rs%3A123-127%0A**Refresh%20uses%20stale%20output%20origin**%0A%0AWhen%20the%20captured%20output%20changes%20position%20during%20a%20single-output%20share%2C%20%60captured_single_display_origin%28%29%60%20still%20returns%20its%20session-initial%20origin%2C%20so%20the%20live-layout%20lookup%20selects%20another%20output%20now%20at%20that%20coordinate%20or%20falls%20back%20to%20the%20whole-desktop%20bounds%2C%20causing%20pointer%20input%20to%20drift%20or%20target%20an%20unshared%20output.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15779&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/display_service.rs:123-127
**Refresh uses stale output origin**

When the captured output changes position during a single-output share, `captured_single_display_origin()` still returns its session-initial origin, so the live-layout lookup selects another output now at that coordinate or falls back to the whole-desktop bounds, causing pointer input to drift or target an unshared output.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(linux): size uinput range from captu..."](https://github.com/rustdesk/rustdesk/commit/12a851567e6e93b3e29117870aacc6be0a59e856) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50885665)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->