### PR TITLE
fix(client): allow switch-sides back-connection in incoming-only mode

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1779,9 +1779,6 @@ pub struct LoginConfigHandler {
     switch_uuid: Option<String>,
     #[cfg(feature = "flutter")]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    authorized_switch_uuid: Option<(String, Uuid)>,
-    #[cfg(feature = "flutter")]
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     switch_back_allowed: bool,
     pub save_ab_password_to_recent: bool, // true: connected with ab password
     pub other_server: Option<(String, String, String)>,
@@ -1902,7 +1899,6 @@ impl LoginConfigHandler {
         #[cfg(feature = "flutter")]
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
-            self.authorized_switch_uuid = None;
             self.switch_back_allowed = false;
         }
         self.switch_uuid = switch_uuid;
@@ -3460,7 +3456,7 @@ pub fn handle_login_error(
 }
 
 // "Switch sides" requires the incoming-only client to connect back to its
-// controlling peer; claim the local pending uuid before opening the connection.
+// controlling peer; verify the local pending uuid before opening the connection.
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 async fn is_switch_sides_back(conn_type: ConnType, interface: &impl Interface) -> bool {
@@ -3478,20 +3474,22 @@ async fn is_switch_sides_back(conn_type: ConnType, interface: &impl Interface) -
         };
         (lc.id.clone(), uuid)
     };
-    if !consume_local_switch_sides_uuid(&id, &uuid).await {
+    if !request_local_switch_sides_uuid(
+        &id,
+        &uuid,
+        crate::ipc::SwitchSidesUuidAction::Check,
+    )
+    .await
+    {
         return false;
     }
     let lch = interface.get_lch();
-    let mut lc = lch.write().unwrap();
+    let lc = lch.read().unwrap();
     let current_uuid = lc
         .switch_uuid
         .as_deref()
         .and_then(|value| Uuid::parse_str(value).ok());
-    if lc.id != id || current_uuid.as_ref() != Some(&uuid) {
-        return false;
-    }
-    lc.authorized_switch_uuid = Some((id, uuid));
-    true
+    lc.id == id && current_uuid.as_ref() == Some(&uuid)
 }
 
 #[cfg(not(all(feature = "flutter", not(any(target_os = "android", target_os = "ios")))))]
@@ -3501,7 +3499,11 @@ async fn is_switch_sides_back(_conn_type: ConnType, _interface: &impl Interface)
 
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-async fn consume_local_switch_sides_uuid(id: &str, uuid: &Uuid) -> bool {
+async fn request_local_switch_sides_uuid(
+    id: &str,
+    uuid: &Uuid,
+    action: crate::ipc::SwitchSidesUuidAction,
+) -> bool {
     let Ok(mut conn) = crate::ipc::connect(1000, "").await else {
         return false;
     };
@@ -3510,6 +3512,7 @@ async fn consume_local_switch_sides_uuid(id: &str, uuid: &Uuid) -> bool {
         .send(&crate::ipc::Data::SwitchSidesUuid(
             uuid.clone(),
             id.to_owned(),
+            action,
             None,
         ))
         .await
@@ -3521,9 +3524,10 @@ async fn consume_local_switch_sides_uuid(id: &str, uuid: &Uuid) -> bool {
         Ok(Some(crate::ipc::Data::SwitchSidesUuid(
             returned_uuid,
             returned_id,
+            returned_action,
             Some(true),
         ))) => {
-            returned_uuid == uuid && returned_id == id
+            returned_uuid == uuid && returned_id == id && returned_action == action
         }
         _ => false,
     }
@@ -3556,15 +3560,13 @@ pub async fn handle_hash(
         if let Some(uuid) = uuid {
             if let Ok(uuid) = uuid::Uuid::from_str(&uuid) {
                 let id = lc.read().unwrap().id.clone();
-                let authorized = lc
-                    .write()
-                    .unwrap()
-                    .authorized_switch_uuid
-                    .take()
-                    .map_or(false, |(authorized_id, authorized_uuid)| {
-                        authorized_id == id && authorized_uuid == uuid
-                    });
-                if !authorized && !consume_local_switch_sides_uuid(&id, &uuid).await {
+                if !request_local_switch_sides_uuid(
+                    &id,
+                    &uuid,
+                    crate::ipc::SwitchSidesUuidAction::Consume,
+                )
+                .await
+                {
                     log::warn!("Ignored untrusted switch_uuid");
                 } else {
                     lc.write().unwrap().allow_switch_back_once();

--- a/src/client.rs
+++ b/src/client.rs
@@ -3575,19 +3575,19 @@ pub async fn handle_hash(
                     return;
                 }
             }
-            // Incoming-only may connect out solely for a verified switch-back;
-            // never fall through to password login.
-            if config::is_incoming_only() {
-                interface.msgbox("error", "Connection Error", "Incoming only mode", "");
-                let mut misc = Misc::new();
-                misc.set_close_reason(
-                    "Connection not allowed in incoming-only mode".to_owned(),
-                );
-                let mut msg = Message::new();
-                msg.set_misc(misc);
-                allow_err!(peer.send(&msg).await);
-                return;
-            }
+        }
+        // Incoming-only may connect out solely for a verified switch-back;
+        // never fall through to password login, including on repeated hashes.
+        if config::is_incoming_only() {
+            interface.msgbox("error", "Connection Error", "Incoming only mode", "");
+            let mut misc = Misc::new();
+            misc.set_close_reason(
+                "Connection not allowed in incoming-only mode".to_owned(),
+            );
+            let mut msg = Message::new();
+            msg.set_misc(misc);
+            allow_err!(peer.send(&msg).await);
+            return;
         }
     }
     // last password

--- a/src/client.rs
+++ b/src/client.rs
@@ -252,7 +252,7 @@ impl Client {
         (i32, String),
         bool,
     )> {
-        if config::is_incoming_only() && !is_switch_sides_back(conn_type, &interface) {
+        if config::is_incoming_only() && !is_switch_sides_back(conn_type, &interface).await {
             bail!("Incoming only mode");
         }
         // to-do: remember the port for each peer, so that we can retry easier
@@ -3456,17 +3456,58 @@ pub fn handle_login_error(
 }
 
 // "Switch sides" requires the incoming-only client to connect back to its
-// controlling peer; the uuid is verified in `handle_hash()` before any login.
+// controlling peer; check the local pending uuid before opening the connection.
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-fn is_switch_sides_back(conn_type: ConnType, interface: &impl Interface) -> bool {
-    conn_type == ConnType::DEFAULT_CONN
-        && interface.get_lch().read().unwrap().switch_uuid.is_some()
+async fn is_switch_sides_back(conn_type: ConnType, interface: &impl Interface) -> bool {
+    if conn_type != ConnType::DEFAULT_CONN {
+        return false;
+    }
+    let (id, uuid) = {
+        let lch = interface.get_lch();
+        let lc = lch.read().unwrap();
+        let Some(uuid) = lc.switch_uuid.as_deref() else {
+            return false;
+        };
+        let Ok(uuid) = Uuid::parse_str(uuid) else {
+            return false;
+        };
+        (lc.id.clone(), uuid)
+    };
+    check_local_switch_sides_uuid(&id, &uuid).await
 }
 
 #[cfg(not(all(feature = "flutter", not(any(target_os = "android", target_os = "ios")))))]
-fn is_switch_sides_back(_conn_type: ConnType, _interface: &impl Interface) -> bool {
+async fn is_switch_sides_back(_conn_type: ConnType, _interface: &impl Interface) -> bool {
     false
+}
+
+#[cfg(feature = "flutter")]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+async fn check_local_switch_sides_uuid(id: &str, uuid: &Uuid) -> bool {
+    let Ok(mut conn) = crate::ipc::connect(1000, "").await else {
+        return false;
+    };
+    let uuid = uuid.to_string();
+    if conn
+        .send(&crate::ipc::Data::CheckSwitchSidesUuid(
+            uuid.clone(),
+            id.to_owned(),
+            None,
+        ))
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    match conn.next_timeout(1000).await {
+        Ok(Some(crate::ipc::Data::CheckSwitchSidesUuid(
+            returned_uuid,
+            returned_id,
+            Some(true),
+        ))) => returned_uuid == uuid && returned_id == id,
+        _ => false,
+    }
 }
 
 #[cfg(feature = "flutter")]
@@ -3539,6 +3580,13 @@ pub async fn handle_hash(
             // never fall through to password login.
             if config::is_incoming_only() {
                 interface.msgbox("error", "Connection Error", "Incoming only mode", "");
+                let mut misc = Misc::new();
+                misc.set_close_reason(
+                    "Connection not allowed in incoming-only mode".to_owned(),
+                );
+                let mut msg = Message::new();
+                msg.set_misc(misc);
+                allow_err!(peer.send(&msg).await);
                 return;
             }
         }
@@ -4051,7 +4099,23 @@ pub fn check_if_retry(msgtype: &str, title: &str, text: &str, retry_for_relay: b
                 && !text.to_lowercase().contains("mismatch")
                 && !text.to_lowercase().contains("manually")
                 && !text.to_lowercase().contains("restricted")
+                && !text.to_lowercase().contains("incoming only")
                 && !text.to_lowercase().contains("not allowed")))
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use super::check_if_retry;
+
+    #[test]
+    fn incoming_only_error_is_not_retryable() {
+        assert!(!check_if_retry(
+            "error",
+            "Connection Error",
+            "Incoming only mode",
+            false,
+        ));
+    }
 }
 
 pub async fn hc_connection(

--- a/src/client.rs
+++ b/src/client.rs
@@ -252,7 +252,7 @@ impl Client {
         (i32, String),
         bool,
     )> {
-        if config::is_incoming_only() {
+        if config::is_incoming_only() && !is_switch_sides_back(conn_type, &interface) {
             bail!("Incoming only mode");
         }
         // to-do: remember the port for each peer, so that we can retry easier
@@ -3455,6 +3455,20 @@ pub fn handle_login_error(
     }
 }
 
+// "Switch sides" requires the incoming-only client to connect back to its
+// controlling peer; the uuid is verified in `handle_hash()` before any login.
+#[cfg(feature = "flutter")]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn is_switch_sides_back(conn_type: ConnType, interface: &impl Interface) -> bool {
+    conn_type == ConnType::DEFAULT_CONN
+        && interface.get_lch().read().unwrap().switch_uuid.is_some()
+}
+
+#[cfg(not(all(feature = "flutter", not(any(target_os = "android", target_os = "ios")))))]
+fn is_switch_sides_back(_conn_type: ConnType, _interface: &impl Interface) -> bool {
+    false
+}
+
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 async fn consume_local_switch_sides_uuid(id: &str, uuid: &Uuid) -> bool {
@@ -3520,6 +3534,12 @@ pub async fn handle_hash(
                     lc.write().unwrap().password_source = Default::default();
                     return;
                 }
+            }
+            // Incoming-only may connect out solely for a verified switch-back;
+            // never fall through to password login.
+            if config::is_incoming_only() {
+                interface.msgbox("error", "Connection Error", "Incoming only mode", "");
+                return;
             }
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1779,6 +1779,9 @@ pub struct LoginConfigHandler {
     switch_uuid: Option<String>,
     #[cfg(feature = "flutter")]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    authorized_switch_uuid: Option<(String, Uuid)>,
+    #[cfg(feature = "flutter")]
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     switch_back_allowed: bool,
     pub save_ab_password_to_recent: bool, // true: connected with ab password
     pub other_server: Option<(String, String, String)>,
@@ -1899,6 +1902,7 @@ impl LoginConfigHandler {
         #[cfg(feature = "flutter")]
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         {
+            self.authorized_switch_uuid = None;
             self.switch_back_allowed = false;
         }
         self.switch_uuid = switch_uuid;
@@ -3456,7 +3460,7 @@ pub fn handle_login_error(
 }
 
 // "Switch sides" requires the incoming-only client to connect back to its
-// controlling peer; check the local pending uuid before opening the connection.
+// controlling peer; claim the local pending uuid before opening the connection.
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 async fn is_switch_sides_back(conn_type: ConnType, interface: &impl Interface) -> bool {
@@ -3474,40 +3478,25 @@ async fn is_switch_sides_back(conn_type: ConnType, interface: &impl Interface) -
         };
         (lc.id.clone(), uuid)
     };
-    check_local_switch_sides_uuid(&id, &uuid).await
+    if !consume_local_switch_sides_uuid(&id, &uuid).await {
+        return false;
+    }
+    let lch = interface.get_lch();
+    let mut lc = lch.write().unwrap();
+    let current_uuid = lc
+        .switch_uuid
+        .as_deref()
+        .and_then(|value| Uuid::parse_str(value).ok());
+    if lc.id != id || current_uuid.as_ref() != Some(&uuid) {
+        return false;
+    }
+    lc.authorized_switch_uuid = Some((id, uuid));
+    true
 }
 
 #[cfg(not(all(feature = "flutter", not(any(target_os = "android", target_os = "ios")))))]
 async fn is_switch_sides_back(_conn_type: ConnType, _interface: &impl Interface) -> bool {
     false
-}
-
-#[cfg(feature = "flutter")]
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-async fn check_local_switch_sides_uuid(id: &str, uuid: &Uuid) -> bool {
-    let Ok(mut conn) = crate::ipc::connect(1000, "").await else {
-        return false;
-    };
-    let uuid = uuid.to_string();
-    if conn
-        .send(&crate::ipc::Data::CheckSwitchSidesUuid(
-            uuid.clone(),
-            id.to_owned(),
-            None,
-        ))
-        .await
-        .is_err()
-    {
-        return false;
-    }
-    match conn.next_timeout(1000).await {
-        Ok(Some(crate::ipc::Data::CheckSwitchSidesUuid(
-            returned_uuid,
-            returned_id,
-            Some(true),
-        ))) => returned_uuid == uuid && returned_id == id,
-        _ => false,
-    }
 }
 
 #[cfg(feature = "flutter")]
@@ -3567,7 +3556,15 @@ pub async fn handle_hash(
         if let Some(uuid) = uuid {
             if let Ok(uuid) = uuid::Uuid::from_str(&uuid) {
                 let id = lc.read().unwrap().id.clone();
-                if !consume_local_switch_sides_uuid(&id, &uuid).await {
+                let authorized = lc
+                    .write()
+                    .unwrap()
+                    .authorized_switch_uuid
+                    .take()
+                    .map_or(false, |(authorized_id, authorized_uuid)| {
+                        authorized_id == id && authorized_uuid == uuid
+                    });
+                if !authorized && !consume_local_switch_sides_uuid(&id, &uuid).await {
                     log::warn!("Ignored untrusted switch_uuid");
                 } else {
                     lc.write().unwrap().allow_switch_back_once();

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -544,9 +544,6 @@ pub enum Data {
         hotx: i32,
         hoty: i32,
     },
-    #[cfg(feature = "flutter")]
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    CheckSwitchSidesUuid(String, String, Option<bool>),
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -1056,24 +1053,11 @@ async fn handle(data: Data, stream: &mut Connection) {
         Data::SwitchSidesUuid(uuid, id, None) => {
             let allowed = uuid
                 .parse::<uuid::Uuid>()
-                .map(|uuid| crate::server::remove_pending_switch_sides_uuid(&id, &uuid))
+                .map(|uuid| crate::server::claim_pending_switch_sides_uuid(&id, &uuid))
                 .unwrap_or(false);
             allow_err!(
                 stream
                     .send(&Data::SwitchSidesUuid(uuid, id, Some(allowed)))
-                    .await
-            );
-        }
-        #[cfg(feature = "flutter")]
-        #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        Data::CheckSwitchSidesUuid(uuid, id, None) => {
-            let allowed = uuid
-                .parse::<uuid::Uuid>()
-                .map(|uuid| crate::server::has_pending_switch_sides_uuid(&id, &uuid))
-                .unwrap_or(false);
-            allow_err!(
-                stream
-                    .send(&Data::CheckSwitchSidesUuid(uuid, id, Some(allowed)))
                     .await
             );
         }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -544,6 +544,9 @@ pub enum Data {
         hotx: i32,
         hoty: i32,
     },
+    #[cfg(feature = "flutter")]
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    CheckSwitchSidesUuid(String, String, Option<bool>),
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -1058,6 +1061,19 @@ async fn handle(data: Data, stream: &mut Connection) {
             allow_err!(
                 stream
                     .send(&Data::SwitchSidesUuid(uuid, id, Some(allowed)))
+                    .await
+            );
+        }
+        #[cfg(feature = "flutter")]
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        Data::CheckSwitchSidesUuid(uuid, id, None) => {
+            let allowed = uuid
+                .parse::<uuid::Uuid>()
+                .map(|uuid| crate::server::has_pending_switch_sides_uuid(&id, &uuid))
+                .unwrap_or(false);
+            allow_err!(
+                stream
+                    .send(&Data::CheckSwitchSidesUuid(uuid, id, Some(allowed)))
                     .await
             );
         }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -312,6 +312,14 @@ pub enum DataPortableService {
     CmShowElevation(bool),
 }
 
+#[cfg(feature = "flutter")]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum SwitchSidesUuidAction {
+    Check,
+    Consume,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "t", content = "c")]
 pub enum Data {
@@ -387,7 +395,7 @@ pub enum Data {
     SwitchSidesRequest(String),
     #[cfg(feature = "flutter")]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    SwitchSidesUuid(String, String, Option<bool>),
+    SwitchSidesUuid(String, String, SwitchSidesUuidAction, Option<bool>),
     #[cfg(feature = "flutter")]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     SwitchSidesBack,
@@ -1050,14 +1058,21 @@ async fn handle(data: Data, stream: &mut Connection) {
         }
         #[cfg(feature = "flutter")]
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
-        Data::SwitchSidesUuid(uuid, id, None) => {
+        Data::SwitchSidesUuid(uuid, id, action, None) => {
             let allowed = uuid
                 .parse::<uuid::Uuid>()
-                .map(|uuid| crate::server::claim_pending_switch_sides_uuid(&id, &uuid))
+                .map(|uuid| match action {
+                    SwitchSidesUuidAction::Check => {
+                        crate::server::has_pending_switch_sides_uuid(&id, &uuid)
+                    }
+                    SwitchSidesUuidAction::Consume => {
+                        crate::server::claim_pending_switch_sides_uuid(&id, &uuid)
+                    }
+                })
                 .unwrap_or(false);
             allow_err!(
                 stream
-                    .send(&Data::SwitchSidesUuid(uuid, id, Some(allowed)))
+                    .send(&Data::SwitchSidesUuid(uuid, id, action, Some(allowed)))
                     .await
             );
         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -93,9 +93,13 @@ lazy_static::lazy_static! {
 
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
+const SWITCH_SIDES_UUID_TTL: Duration = Duration::from_secs(10);
+
+#[cfg(feature = "flutter")]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 lazy_static::lazy_static! {
     static ref SWITCH_SIDES_UUID: Arc::<Mutex<HashMap<String, (Instant, uuid::Uuid)>>> = Default::default();
-    static ref PENDING_SWITCH_SIDES_UUID: Arc::<Mutex<HashMap<String, (Instant, uuid::Uuid)>>> = Default::default();
+    static ref PENDING_SWITCH_SIDES_UUID: Arc::<Mutex<HashMap<String, (Instant, uuid::Uuid, bool)>>> = Default::default();
 }
 
 #[cfg(target_os = "windows")]
@@ -2994,7 +2998,7 @@ impl Connection {
                 SWITCH_SIDES_UUID
                     .lock()
                     .unwrap()
-                    .retain(|_, v| v.0.elapsed() < Duration::from_secs(10));
+                    .retain(|_, v| v.0.elapsed() < SWITCH_SIDES_UUID_TTL);
                 let uuid_old = SWITCH_SIDES_UUID.lock().unwrap().remove(&lr.my_id);
                 if let Ok(uuid) = uuid::Uuid::from_slice(_s.uuid.to_vec().as_ref()) {
                     if let Some((_instant, uuid_old)) = uuid_old {
@@ -3734,17 +3738,18 @@ impl Connection {
                     #[cfg(not(any(target_os = "android", target_os = "ios")))]
                     Some(misc::Union::SwitchSidesRequest(s)) => {
                         if let Ok(uuid) = uuid::Uuid::from_slice(&s.uuid.to_vec()[..]) {
-                            crate::server::insert_pending_switch_sides_uuid(
+                            if crate::server::insert_pending_switch_sides_uuid(
                                 self.lr.my_id.clone(),
                                 uuid.clone(),
-                            );
-                            crate::run_me(vec![
-                                "--connect",
-                                &self.lr.my_id,
-                                "--switch_uuid",
-                                uuid.to_string().as_ref(),
-                            ])
-                            .ok();
+                            ) {
+                                crate::run_me(vec![
+                                    "--connect",
+                                    &self.lr.my_id,
+                                    "--switch_uuid",
+                                    uuid.to_string().as_ref(),
+                                ])
+                                .ok();
+                            }
                             self.on_close("switch sides", false).await;
                             return false;
                         }
@@ -6048,31 +6053,29 @@ pub fn insert_switch_sides_uuid(id: String, uuid: uuid::Uuid) {
 
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
-pub fn insert_pending_switch_sides_uuid(id: String, uuid: uuid::Uuid) {
+pub fn insert_pending_switch_sides_uuid(id: String, uuid: uuid::Uuid) -> bool {
     let mut uuids = PENDING_SWITCH_SIDES_UUID.lock().unwrap();
-    uuids.retain(|_, (instant, _)| instant.elapsed() < Duration::from_secs(10));
-    uuids.insert(id, (tokio::time::Instant::now(), uuid));
-}
-
-#[cfg(feature = "flutter")]
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-pub fn has_pending_switch_sides_uuid(id: &str, uuid: &uuid::Uuid) -> bool {
-    let mut uuids = PENDING_SWITCH_SIDES_UUID.lock().unwrap();
-    uuids.retain(|_, (instant, _)| instant.elapsed() < Duration::from_secs(10));
-    uuids.get(id).map(|(_, stored_uuid)| stored_uuid == uuid) == Some(true)
-}
-
-#[cfg(feature = "flutter")]
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-pub fn remove_pending_switch_sides_uuid(id: &str, uuid: &uuid::Uuid) -> bool {
-    let mut uuids = PENDING_SWITCH_SIDES_UUID.lock().unwrap();
-    uuids.retain(|_, (instant, _)| instant.elapsed() < Duration::from_secs(10));
-    if uuids.get(id).map(|(_, stored_uuid)| stored_uuid == uuid) == Some(true) {
-        uuids.remove(id);
-        true
-    } else {
-        false
+    uuids.retain(|_, (instant, _, _)| instant.elapsed() < SWITCH_SIDES_UUID_TTL);
+    if uuids.get(&id).map(|(_, stored_uuid, _)| stored_uuid) == Some(&uuid) {
+        return false;
     }
+    uuids.insert(id, (tokio::time::Instant::now(), uuid, false));
+    true
+}
+
+#[cfg(feature = "flutter")]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn claim_pending_switch_sides_uuid(id: &str, uuid: &uuid::Uuid) -> bool {
+    let mut uuids = PENDING_SWITCH_SIDES_UUID.lock().unwrap();
+    uuids.retain(|_, (instant, _, _)| instant.elapsed() < SWITCH_SIDES_UUID_TTL);
+    // Keep claimed entries until expiry so replaying a request cannot launch another connection.
+    if let Some((_, stored_uuid, claimed)) = uuids.get_mut(id) {
+        if stored_uuid == uuid && !*claimed {
+            *claimed = true;
+            return true;
+        }
+    }
+    false
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -7014,18 +7017,18 @@ mod test {
     #[cfg(feature = "flutter")]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     #[test]
-    fn test_pending_switch_sides_uuid_check_does_not_consume() {
+    fn test_pending_switch_sides_uuid_is_claimed_once() {
         let id = uuid::Uuid::new_v4().to_string();
         let uuid = uuid::Uuid::new_v4();
         let other_uuid = uuid::Uuid::new_v4();
-        insert_pending_switch_sides_uuid(id.clone(), uuid.clone());
+        assert!(insert_pending_switch_sides_uuid(id.clone(), uuid.clone()));
 
-        assert!(has_pending_switch_sides_uuid(&id, &uuid));
-        assert!(has_pending_switch_sides_uuid(&id, &uuid));
-        assert!(!has_pending_switch_sides_uuid("other-peer", &uuid));
-        assert!(!has_pending_switch_sides_uuid(&id, &other_uuid));
-        assert!(remove_pending_switch_sides_uuid(&id, &uuid));
-        assert!(!has_pending_switch_sides_uuid(&id, &uuid));
+        assert!(!insert_pending_switch_sides_uuid(id.clone(), uuid.clone()));
+        assert!(!claim_pending_switch_sides_uuid("other-peer", &uuid));
+        assert!(!claim_pending_switch_sides_uuid(&id, &other_uuid));
+        assert!(claim_pending_switch_sides_uuid(&id, &uuid));
+        assert!(!claim_pending_switch_sides_uuid(&id, &uuid));
+        assert!(!insert_pending_switch_sides_uuid(id, uuid));
     }
 
     #[test]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -6065,6 +6065,17 @@ pub fn insert_pending_switch_sides_uuid(id: String, uuid: uuid::Uuid) -> bool {
 
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn has_pending_switch_sides_uuid(id: &str, uuid: &uuid::Uuid) -> bool {
+    let mut uuids = PENDING_SWITCH_SIDES_UUID.lock().unwrap();
+    uuids.retain(|_, (instant, _, _)| instant.elapsed() < SWITCH_SIDES_UUID_TTL);
+    uuids
+        .get(id)
+        .map(|(_, stored_uuid, claimed)| stored_uuid == uuid && !*claimed)
+        == Some(true)
+}
+
+#[cfg(feature = "flutter")]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub fn claim_pending_switch_sides_uuid(id: &str, uuid: &uuid::Uuid) -> bool {
     let mut uuids = PENDING_SWITCH_SIDES_UUID.lock().unwrap();
     uuids.retain(|_, (instant, _, _)| instant.elapsed() < SWITCH_SIDES_UUID_TTL);
@@ -7024,9 +7035,12 @@ mod test {
         assert!(insert_pending_switch_sides_uuid(id.clone(), uuid.clone()));
 
         assert!(!insert_pending_switch_sides_uuid(id.clone(), uuid.clone()));
+        assert!(has_pending_switch_sides_uuid(&id, &uuid));
+        assert!(!has_pending_switch_sides_uuid(&id, &other_uuid));
         assert!(!claim_pending_switch_sides_uuid("other-peer", &uuid));
         assert!(!claim_pending_switch_sides_uuid(&id, &other_uuid));
         assert!(claim_pending_switch_sides_uuid(&id, &uuid));
+        assert!(!has_pending_switch_sides_uuid(&id, &uuid));
         assert!(!claim_pending_switch_sides_uuid(&id, &uuid));
         assert!(!insert_pending_switch_sides_uuid(id, uuid));
     }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -6056,6 +6056,14 @@ pub fn insert_pending_switch_sides_uuid(id: String, uuid: uuid::Uuid) {
 
 #[cfg(feature = "flutter")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub fn has_pending_switch_sides_uuid(id: &str, uuid: &uuid::Uuid) -> bool {
+    let mut uuids = PENDING_SWITCH_SIDES_UUID.lock().unwrap();
+    uuids.retain(|_, (instant, _)| instant.elapsed() < Duration::from_secs(10));
+    uuids.get(id).map(|(_, stored_uuid)| stored_uuid == uuid) == Some(true)
+}
+
+#[cfg(feature = "flutter")]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub fn remove_pending_switch_sides_uuid(id: &str, uuid: &uuid::Uuid) -> bool {
     let mut uuids = PENDING_SWITCH_SIDES_UUID.lock().unwrap();
     uuids.retain(|_, (instant, _)| instant.elapsed() < Duration::from_secs(10));
@@ -7002,6 +7010,23 @@ fn wildcard_match(pattern: &str, text: &str) -> bool {
 mod test {
     #[allow(unused)]
     use super::*;
+
+    #[cfg(feature = "flutter")]
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    #[test]
+    fn test_pending_switch_sides_uuid_check_does_not_consume() {
+        let id = uuid::Uuid::new_v4().to_string();
+        let uuid = uuid::Uuid::new_v4();
+        let other_uuid = uuid::Uuid::new_v4();
+        insert_pending_switch_sides_uuid(id.clone(), uuid.clone());
+
+        assert!(has_pending_switch_sides_uuid(&id, &uuid));
+        assert!(has_pending_switch_sides_uuid(&id, &uuid));
+        assert!(!has_pending_switch_sides_uuid("other-peer", &uuid));
+        assert!(!has_pending_switch_sides_uuid(&id, &other_uuid));
+        assert!(remove_pending_switch_sides_uuid(&id, &uuid));
+        assert!(!has_pending_switch_sides_uuid(&id, &uuid));
+    }
 
     #[test]
     fn test_wildcard_match() {


### PR DESCRIPTION
"Switch sides" makes the controlled client run `--connect <peer> --switch_uuid <uuid>`, which Client::_start rejected outright in incoming-only custom clients, so the feature silently dropped the session and never switched.

Exempt exactly that back-connection: a default-conn session carrying a switch uuid may proceed. The uuid is then verified against the local server process in handle_hash(); if it is missing there (forged or expired), an incoming-only client now aborts with an error instead of falling through to password login, so the outgoing-connection restriction cannot be bypassed with a crafted --switch_uuid.

Fixes rustdesk/rustdesk#11200 (discussion)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of verified switch-back connection attempts in incoming-only mode.
  * Invalid or unverified incoming-only connections now show a connection error and stop before password login.
  * Added validation to prevent unauthorized connection switching.
  * Prevented repeated connection attempts from replaying the same switch request.
  * Retry behavior no longer repeatedly attempts failed incoming-only connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR permits incoming-only desktop clients to initiate a locally authorized switch-sides back-connection without opening the normal outbound-login path.
- Adds separate non-consuming Check and atomic Consume operations for pending switch UUIDs.
- Retains claimed grants until expiration to prevent replayed process launches and authentication.
- Rejects invalid or repeated switch authentication challenges before password login.
- Marks incoming-only rejection errors as non-retryable.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported pre-connect, replay, recovery, and repeated-Hash paths are addressed by preflight validation, non-consuming checks, atomic one-time consumption, retained claimed state, and explicit rejection before password login.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/client.rs | Gates the incoming-only exception through a local UUID check, atomically consumes the grant during authentication, and blocks fallback password login. |
| src/ipc.rs | Extends the local IPC message with explicit non-consuming Check and atomic Consume actions. |
| src/server/connection.rs | Tracks pending switch grants with claim state and TTL, suppressing duplicate launches and one-time grant reuse. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Peer as Controlling peer
    participant Server as Controlled server
    participant Client as Back-connection client
    participant IPC as Local IPC server
    Peer->>Server: SwitchSidesRequest(UUID)
    Server->>Server: Insert pending UUID
    Server->>Client: Launch --connect --switch_uuid
    Client->>IPC: Check(peer ID, UUID)
    IPC->>Server: Verify pending and unclaimed
    Server-->>Client: Allowed
    Client->>Peer: Establish back-connection
    Peer->>Client: Hash challenge
    Client->>IPC: Consume(peer ID, UUID)
    IPC->>Server: Atomically claim grant
    Server-->>Client: Consumed
    Client->>Peer: SwitchSidesResponse(login request)
    Peer->>Peer: Validate switch UUID and authorize session
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(client): reject repeated hash login ..."](https://github.com/rustdesk/rustdesk/commit/4bf44c2072d89d032496d03a196f9e2fa895b279) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51024722)</sub>

<!-- /greptile_comment -->