### PR TITLE
feat(rdp): title the mstsc window after the peer instead of "localhost"

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2642,13 +2642,9 @@ pub fn wide_string(s: &str) -> Vec<u16> {
         .collect()
 }
 
-// This changes only mstsc's top-level window title. The full-screen connection
-// bar is rendered separately by the MsTscAx ActiveX control, so SetWindowTextW
-// cannot change its displayed target. Microsoft exposes
-// IMsRdpClientNonScriptable3::ConnectionBarText for hosts that create the
-// ActiveX control themselves, but it must be set before entering full screen
-// and cannot be applied to an independently launched mstsc.exe process:
-// https://learn.microsoft.com/windows/win32/termserv/imsrdpclientnonscriptable3-connectionbartext
+// This only changes mstsc's top-level window title. The full-screen connection
+// bar is rendered separately and cannot be customized when mstsc.exe is
+// launched as an independent process.
 pub fn set_rdp_window_title(mut child: std::process::Child, name: String) {
     let name: String = name.chars().filter(|c| !c.is_control()).take(120).collect();
     if name.is_empty() {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2642,6 +2642,95 @@ pub fn wide_string(s: &str) -> Vec<u16> {
         .collect()
 }
 
+// This changes only mstsc's top-level window title. The full-screen connection
+// bar is rendered separately by the MsTscAx ActiveX control, so SetWindowTextW
+// cannot change its displayed target. Microsoft exposes
+// IMsRdpClientNonScriptable3::ConnectionBarText for hosts that create the
+// ActiveX control themselves, but it must be set before entering full screen
+// and cannot be applied to an independently launched mstsc.exe process:
+// https://learn.microsoft.com/windows/win32/termserv/imsrdpclientnonscriptable3-connectionbartext
+pub fn set_rdp_window_title(mut child: std::process::Child, name: String) {
+    let name: String = name.chars().filter(|c| !c.is_control()).take(120).collect();
+    if name.is_empty() {
+        return;
+    }
+    let process_id = child.id();
+    // mstsc owns the title and can restore "localhost" while connecting or
+    // reconnecting. Follow only the process we launched and reapply the peer
+    // name until it exits, so concurrent RDP sessions cannot rename each other.
+    if let Err(err) = std::thread::Builder::new()
+        .name("rdp-window-title".to_owned())
+        .spawn(move || {
+            let mut warned = false;
+            loop {
+                match child.try_wait() {
+                    Ok(Some(_)) => break,
+                    Err(err) => {
+                        log::warn!("Failed to query mstsc process: {}", err);
+                        break;
+                    }
+                    Ok(None) => match set_process_rdp_window_title(process_id, &name) {
+                        Ok(()) => warned = false,
+                        Err(err) if !warned => {
+                            log::warn!("Failed to set RDP window title: {}", err);
+                            warned = true;
+                        }
+                        Err(_) => {}
+                    },
+                }
+                std::thread::sleep(Duration::from_millis(500));
+            }
+        })
+    {
+        log::warn!("Failed to start RDP window title thread: {}", err);
+    }
+}
+
+fn set_process_rdp_window_title(process_id: DWORD, name: &str) -> io::Result<()> {
+    struct Context {
+        process_id: DWORD,
+        title: Vec<u16>,
+        error: Option<io::Error>,
+    }
+
+    unsafe extern "system" fn enum_window(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let context = &mut *(lparam as *mut Context);
+        let mut window_process_id = 0;
+        GetWindowThreadProcessId(hwnd, &mut window_process_id);
+        if window_process_id != context.process_id || IsWindowVisible(hwnd) == FALSE {
+            return TRUE;
+        }
+        let len = GetWindowTextLengthW(hwnd);
+        if len <= 0 {
+            return TRUE;
+        }
+        let mut title = vec![0u16; len as usize + 1];
+        let len = GetWindowTextW(hwnd, title.as_mut_ptr(), title.len() as _);
+        if len > 0 && String::from_utf16_lossy(&title[..len as usize]).contains("localhost") {
+            if SetWindowTextW(hwnd, context.title.as_ptr()) == FALSE {
+                context.error = Some(io::Error::last_os_error());
+                return FALSE;
+            }
+        }
+        TRUE
+    }
+
+    let mut context = Context {
+        process_id,
+        title: wide_string(name),
+        error: None,
+    };
+    let enumerated =
+        unsafe { EnumWindows(Some(enum_window), &mut context as *mut Context as LPARAM) };
+    if let Some(err) = context.error {
+        return Err(err);
+    }
+    if enumerated == FALSE {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
 /// send message to currently shown window
 pub fn send_message_to_hnwd(
     class_name: &str,

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -15,7 +15,7 @@ use hbb_common::{
     ResultType, Stream,
 };
 
-fn run_rdp(port: u16) {
+fn run_rdp(port: u16, name: &str) {
     std::process::Command::new("cmdkey")
         .arg("/delete:localhost")
         .output()
@@ -35,10 +35,62 @@ fn run_rdp(port: u16) {
             .output()
             .ok();
     }
-    std::process::Command::new("mstsc")
-        .arg(format!("/v:localhost:{}", port))
-        .spawn()
-        .ok();
+    match write_rdp_file(port, name) {
+        Some(rdp_file) => {
+            std::process::Command::new("mstsc")
+                .arg(rdp_file)
+                .spawn()
+                .ok();
+        }
+        None => {
+            std::process::Command::new("mstsc")
+                .arg(format!("/v:localhost:{}", port))
+                .spawn()
+                .ok();
+        }
+    }
+}
+
+// mstsc titles the session window after the launched .rdp file's base name;
+// naming the file after the peer replaces the meaningless "localhost" title.
+fn write_rdp_file(port: u16, name: &str) -> Option<std::path::PathBuf> {
+    let name: String = name
+        .chars()
+        .map(|c| {
+            if c.is_control() || r#"\/:*?"<>|"#.contains(c) {
+                '-'
+            } else {
+                c
+            }
+        })
+        .take(60)
+        .collect();
+    // Windows rejects file names that end with a dot or space.
+    let name = name.trim_matches(|c| c == ' ' || c == '.');
+    if name.is_empty() {
+        return None;
+    }
+    let path = std::env::temp_dir().join(format!("{}.rdp", name));
+    std::fs::write(&path, format!("full address:s:localhost:{}\r\n", port)).ok()?;
+    Some(path)
+}
+
+// Prefer the name the user knows the peer by: alias, then cached hostname.
+fn rdp_display_name(lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) -> String {
+    let lc = lc.read().unwrap();
+    let alias = lc
+        .options
+        .get("alias")
+        .map(|s| s.trim())
+        .unwrap_or_default();
+    if !alias.is_empty() {
+        return alias.to_owned();
+    }
+    let hostname = lc.info.hostname.trim();
+    if !hostname.is_empty() {
+        return hostname.to_owned();
+    }
+    id.to_owned()
 }
 
 pub async fn listen(
@@ -58,7 +110,7 @@ pub async fn listen(
     log::info!("listening on port {:?}", addr);
     let is_rdp = port == 0;
     if is_rdp {
-        run_rdp(addr.port());
+        run_rdp(addr.port(), &rdp_display_name(&lc, &id));
     }
     let mut ui_receiver = ui_receiver;
     loop {
@@ -96,7 +148,7 @@ pub async fn listen(
                     }
                     Some(Data::NewRDP) => {
                         println!("receive run_rdp from ui_receiver");
-                        run_rdp(addr.port());
+                        run_rdp(addr.port(), &rdp_display_name(&lc, &id));
                     }
                     _ => {}
                 }

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -35,44 +35,20 @@ fn run_rdp(port: u16, name: &str) {
             .output()
             .ok();
     }
-    match write_rdp_file(port, name) {
-        Some(rdp_file) => {
-            std::process::Command::new("mstsc")
-                .arg(rdp_file)
-                .spawn()
-                .ok();
+    // Keep using /v instead of a generated .rdp file: mstsc then preserves the
+    // user's Default.rdp settings and avoids unsigned-file warnings or policies.
+    match std::process::Command::new("mstsc")
+        .arg(format!("/v:localhost:{}", port))
+        .spawn()
+    {
+        Ok(child) => {
+            #[cfg(windows)]
+            crate::platform::set_rdp_window_title(child, name.to_owned());
+            #[cfg(not(windows))]
+            let _ = (child, name);
         }
-        None => {
-            std::process::Command::new("mstsc")
-                .arg(format!("/v:localhost:{}", port))
-                .spawn()
-                .ok();
-        }
+        Err(err) => log::warn!("Failed to launch mstsc: {}", err),
     }
-}
-
-// mstsc titles the session window after the launched .rdp file's base name;
-// naming the file after the peer replaces the meaningless "localhost" title.
-fn write_rdp_file(port: u16, name: &str) -> Option<std::path::PathBuf> {
-    let name: String = name
-        .chars()
-        .map(|c| {
-            if c.is_control() || r#"\/:*?"<>|"#.contains(c) {
-                '-'
-            } else {
-                c
-            }
-        })
-        .take(60)
-        .collect();
-    // Windows rejects file names that end with a dot or space.
-    let name = name.trim_matches(|c| c == ' ' || c == '.');
-    if name.is_empty() {
-        return None;
-    }
-    let path = std::env::temp_dir().join(format!("{}.rdp", name));
-    std::fs::write(&path, format!("full address:s:localhost:{}\r\n", port)).ok()?;
-    Some(path)
 }
 
 // Prefer the name the user knows the peer by: alias, then cached hostname.

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -51,7 +51,7 @@ fn run_rdp(port: u16, name: &str) {
     }
 }
 
-// Prefer the name the user knows the peer by: alias, then cached hostname.
+// Show the peer identity with its hostname, using the ID when no alias exists.
 fn rdp_display_name(lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) -> String {
     let lc = lc.read().unwrap();
     let alias = lc
@@ -59,14 +59,13 @@ fn rdp_display_name(lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) -> String {
         .get("alias")
         .map(|s| s.trim())
         .unwrap_or_default();
-    if !alias.is_empty() {
-        return alias.to_owned();
-    }
     let hostname = lc.info.hostname.trim();
-    if !hostname.is_empty() {
-        return hostname.to_owned();
+    let identity = if !alias.is_empty() { alias } else { id };
+    if hostname.is_empty() || hostname == identity {
+        identity.to_owned()
+    } else {
+        format!("{} ({})", identity, hostname)
     }
-    id.to_owned()
 }
 
 pub async fn listen(


### PR DESCRIPTION
The RDP tunnel launched `mstsc /v:localhost:<port>`, so with several sessions open every window is titled "localhost" and servers cannot be told apart.

mstsc titles the session window after the launched .rdp file's base name, so write a temp .rdp file (containing only the tunnel address) named after the peer alias, cached hostname, or id, and launch that instead. Falls back to the old /v: form when no usable name remains after filename sanitization or the file cannot be written. Credential handling is unchanged: cmdkey targets "localhost", which is still the host mstsc resolves credentials against.

Fixes rustdesk/rustdesk#15775 (discussion)

| Directly from RDP Client | RustDesk Release | PR Build |
|--------------------------|------------------|----------|
| <img width="293" height="27" alt="rdpnative" src="https://github.com/user-attachments/assets/91d77081-aff1-42c8-b99f-ec4fc4c0209f" /> |  <img width="281" height="26" alt="Screenshot 2026-08-13 143523" src="https://github.com/user-attachments/assets/1c5d3ec6-52ec-41a7-ac7e-fd4dc86181ef" /> | <img width="221" height="23" alt="image" src="https://github.com/user-attachments/assets/b444984f-f7d3-4a1d-aa83-9af2a5f3582c" /> |

### Known limitation

After MSTSC enters full-screen mode, the connection bar still displays `localhost`. This is expected because the RDP connection is made to the local tunnel endpoint (`localhost:<port>`).

This change uses `SetWindowTextW` to update only the top-level MSTSC window title. The full-screen connection bar is rendered separately by the MsTscAx ActiveX control and is not affected by the window title.

Microsoft provides [`IMsRdpClientNonScriptable3::ConnectionBarText`](https://learn.microsoft.com/en-us/windows/win32/termserv/imsrdpclientnonscriptable3-connectionbartext), but it is only available to applications that host the MsTscAx control themselves and must be set before entering full-screen mode. It cannot be applied to an independently launched `mstsc.exe` process.

## Where the hostname comes from, and when it is available

1. Origin — the controlled peer reports its own OS hostname. After a successful login, the controlled side fills PeerInfo (src/server/connection.rs:1874): on desktop platforms pi.hostname = crate::whoami_hostname() (the machine's actual computer name via gethostname/GetComputerName, src/common.rs:833); on Android it is the device name. This is sent to the controlling side in the LoginResponse — it is the real "TEST01" the reporter wants to see.
2. Cache — the controlling side persists it per peer. Every successful login runs LoginConfigHandler::handle_peer_info (src/client.rs:2563), which stores the hostname into that peer's config file and updates the in-memory lc.config (save_config, src/client.rs:1958). All session types refresh this cache — normal remote sessions, file transfer, and RDP tunnel sessions themselves (connect_and_login calls handle_peer_info at src/port_forward.rs:162).
3. Read — rdp_display_name reads that cache (lc.info.hostname via the Deref to PeerConfig).

## Timing implications

- The first mstsc launch happens when the tunnel listener starts, i.e. before this session's login — so it uses the hostname cached by a previous session. Any prior connection to the peer (remote / file transfer / RDP) is enough to have it populated.
- For a peer that has never been connected before, the cache is empty and the title falls back to the peer id — still far more useful than "localhost".
- Once the first login inside the RDP session completes, the cache is refreshed in memory and on disk, so "New RDP window" in the same session and all later launches show the up-to-date hostname.
- The value reflects the hostname as of the last login; if the remote machine is renamed, the title catches up on the next login — at most one session behind.
- A user-set alias takes priority over the hostname, since that is the label the user chose for the peer; the order is alias → cached hostname → peer id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * RDP windows now display a recognizable peer name, using the selected alias or available peer details.
  * Connection credentials are scoped to the specific local connection, improving reliability when using multiple RDP sessions.
  * RDP sessions continue launching directly for a faster, more consistent connection experience.
  * Window titles are safely sanitized and limited for clear display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces peer-named temporary RDP launch files with direct `/v:localhost:<port>` launches and applies the peer identity to the corresponding MSTSC window.
- Tracks each launched MSTSC process independently and reapplies its title while it remains active.
- Builds the title from the peer alias or ID, optionally including the cached hostname.
- Eliminates the shared temporary file that caused session redirection and the persistent peer-named artifacts reported previously.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because both previously reported temporary-file issues are eliminated and no blocking replacement failure was established.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/port_forward.rs | Launches MSTSC directly with the tunnel port and derives a peer-specific display name without creating shared or persistent RDP files. |
| src/platform/windows.rs | Adds process-scoped window enumeration and title updates that terminate when the launched MSTSC process exits. |

</details>

<sub>Reviews (9): Last reviewed commit: ["feat(rdp): show peer identity with hostn..."](https://github.com/rustdesk/rustdesk/commit/9604309abf92f38686f5fac3438fc1b027923104) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51026902)</sub>

<!-- /greptile_comment -->