### PR TITLE
fix: prevent multitouch gesture state from sticking on Android

### DIFF
--- a/flutter/lib/common/widgets/gestures.dart
+++ b/flutter/lib/common/widgets/gestures.dart
@@ -10,6 +10,9 @@ enum GestureState {
   threeFingerVerticalDrag
 }
 
+// What the pending-start debounce timer is currently pending for.
+enum _PendingStart { none, oneFinger, twoFinger }
+
 class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
   CustomTouchGestureRecognizer({
     Object? debugOwner,
@@ -38,28 +41,38 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
   GestureDragEndCallback? onThreeFingerVerticalDragEnd;
 
   var _currentState = GestureState.none;
+  // Pending lower-finger start only; the post-end reset uses _resetTimer.
   Timer? _debounceTimer;
+  Timer? _resetTimer;
+  bool _ended = false;
+  _PendingStart _pendingStart = _PendingStart.none;
+  ScaleUpdateDetails? _pendingDetails;
 
   void _init() {
     debugPrint("CustomTouchGestureRecognizer init");
     // onStart = (d) {};
     onUpdate = (d) {
-      _debounceTimer?.cancel();
-      if (d.pointerCount == 1 && _currentState != GestureState.oneFingerPan) {
-        onOneFingerStartDebounce(d);
-      } else if (d.pointerCount == 2 &&
-          _currentState != GestureState.twoFingerScale) {
-        onTwoFingerStartDebounce(d);
-      } else if (d.pointerCount == 3 &&
-          _currentState != GestureState.threeFingerVerticalDrag) {
-        _currentState = GestureState.threeFingerVerticalDrag;
-        if (onThreeFingerVerticalDragStart != null) {
-          onThreeFingerVerticalDragStart!(
-              DragStartDetails(globalPosition: d.localFocalPoint));
+      final count = d.pointerCount;
+      if (count >= 3) {
+        // Three or more fingers are always the three-finger drag.
+        _cancelPendingStart();
+        if (_currentState != GestureState.threeFingerVerticalDrag || _ended) {
+          _startThreeFinger(d);
         }
-        debugPrint("start threeFingerScale");
+      } else if (count == 2) {
+        if (_currentState == GestureState.twoFingerScale && !_ended) {
+          _cancelPendingStart();
+        } else {
+          _armPendingStart(_PendingStart.twoFinger, d);
+        }
+      } else if (count == 1) {
+        if (_currentState == GestureState.oneFingerPan && !_ended) {
+          _cancelPendingStart();
+        } else {
+          _armPendingStart(_PendingStart.oneFinger, d);
+        }
       }
-      if (_currentState != GestureState.none) {
+      if (_currentState != GestureState.none && !_ended) {
         switch (_currentState) {
           case GestureState.oneFingerPan:
             if (onOneFingerPanUpdate != null) {
@@ -84,82 +97,130 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
     };
     onEnd = (d) {
       debugPrint("ScaleGestureRecognizer onEnd");
-      _debounceTimer?.cancel();
-      // end
-      switch (_currentState) {
-        case GestureState.oneFingerPan:
-          debugPrint("OneFingerState.pan onEnd");
-          if (onOneFingerPanEnd != null) {
-            onOneFingerPanEnd!(_getDragEndDetails(d));
-          }
-          break;
-        case GestureState.twoFingerScale:
-          debugPrint("TwoFingerState.scale onEnd");
-          if (onTwoFingerScaleEnd != null) {
-            onTwoFingerScaleEnd!(d);
-          }
-          if (isSpecialHoldDragActive) {
-            // If we are in special drag mode, we need to reset the state.
-            // Otherwise, the next `onTwoFingerScaleUpdate()` will handle a wrong `focalPoint`.
-            _currentState = GestureState.none;
-            return;
-          }
-          break;
-        case GestureState.threeFingerVerticalDrag:
-          debugPrint("ThreeFingerState.vertical onEnd");
-          if (onThreeFingerVerticalDragEnd != null) {
-            onThreeFingerVerticalDragEnd!(_getDragEndDetails(d));
-          }
-          break;
-        default:
-          break;
+      // A pending lower-finger start must not fire once the pointers changed.
+      _cancelPendingStart();
+      // A second onEnd before a restart must not fire the end callback again.
+      if (!_ended) {
+        switch (_currentState) {
+          case GestureState.oneFingerPan:
+            debugPrint("OneFingerState.pan onEnd");
+            if (onOneFingerPanEnd != null) {
+              onOneFingerPanEnd!(_getDragEndDetails(d));
+            }
+            break;
+          case GestureState.twoFingerScale:
+            debugPrint("TwoFingerState.scale onEnd");
+            if (onTwoFingerScaleEnd != null) {
+              onTwoFingerScaleEnd!(d);
+            }
+            if (isSpecialHoldDragActive) {
+              // If we are in special drag mode, we need to reset the state.
+              // Otherwise, the next `onTwoFingerScaleUpdate()` will handle a wrong `focalPoint`.
+              _currentState = GestureState.none;
+              return;
+            }
+            break;
+          case GestureState.threeFingerVerticalDrag:
+            debugPrint("ThreeFingerState.vertical onEnd");
+            if (onThreeFingerVerticalDragEnd != null) {
+              onThreeFingerVerticalDragEnd!(_getDragEndDetails(d));
+            }
+            break;
+          default:
+            break;
+        }
       }
-      _debounceTimer = Timer(Duration(milliseconds: 200), () {
+      _ended = true;
+      // Cancel the previous reset timer so it cannot fire into a new gesture.
+      _resetTimer?.cancel();
+      _resetTimer = Timer(Duration(milliseconds: 200), () {
+        _resetTimer = null;
         _currentState = GestureState.none;
+        _ended = false;
       });
     };
   }
 
-  // FIXME: This debounce logic is not working properly.
-  // If we move our finger very fast, we won't be able to detect the "oneFingerPan" event sometimes.
-  void onOneFingerStartDebounce(ScaleUpdateDetails d) {
-    start(ScaleUpdateDetails d) {
-      _currentState = GestureState.oneFingerPan;
-      if (onOneFingerPanStart != null) {
-        onOneFingerPanStart!(DragStartDetails(
-            localPosition: d.localFocalPoint, globalPosition: d.focalPoint));
-      }
+  // Debounce downward transitions (twoFingerScale -> oneFingerPan,
+  // threeFingerVerticalDrag -> twoFingerScale); refreshes of the same pending
+  // target keep the original deadline instead of extending it.
+  void _armPendingStart(_PendingStart pending, ScaleUpdateDetails d) {
+    final bool immediate = pending == _PendingStart.oneFinger
+        ? _currentState == GestureState.none ||
+            (_ended && _currentState == GestureState.oneFingerPan)
+        : _currentState != GestureState.threeFingerVerticalDrag;
+    if (immediate) {
+      _cancelPendingStart();
+      _startPending(pending, d);
+      return;
     }
+    if (_pendingStart == pending) {
+      _pendingDetails = d;
+      return;
+    }
+    _cancelPendingStart();
+    _pendingStart = pending;
+    _pendingDetails = d;
+    _debounceTimer = Timer(Duration(milliseconds: 200), _firePendingStart);
+  }
 
-    if (_currentState != GestureState.none) {
-      _debounceTimer = Timer(Duration(milliseconds: 200), () {
-        start(d);
-        debugPrint("debounce start oneFingerPan");
-      });
-    } else {
-      start(d);
-      debugPrint("start oneFingerPan");
+  void _firePendingStart() {
+    _debounceTimer = null;
+    final _PendingStart pending = _pendingStart;
+    final ScaleUpdateDetails? details = _pendingDetails;
+    _pendingStart = _PendingStart.none;
+    _pendingDetails = null;
+    if (details == null) {
+      return;
+    }
+    _startPending(pending, details);
+  }
+
+  void _startPending(_PendingStart pending, ScaleUpdateDetails d) {
+    _cancelReset();
+    switch (pending) {
+      case _PendingStart.oneFinger:
+        _currentState = GestureState.oneFingerPan;
+        if (onOneFingerPanStart != null) {
+          onOneFingerPanStart!(DragStartDetails(
+              localPosition: d.localFocalPoint, globalPosition: d.focalPoint));
+        }
+        debugPrint("start oneFingerPan");
+        break;
+      case _PendingStart.twoFinger:
+        _currentState = GestureState.twoFingerScale;
+        if (onTwoFingerScaleStart != null) {
+          onTwoFingerScaleStart!(ScaleStartDetails(
+              localFocalPoint: d.localFocalPoint, focalPoint: d.focalPoint));
+        }
+        debugPrint("start twoFingerScale");
+        break;
+      case _PendingStart.none:
+        break;
     }
   }
 
-  void onTwoFingerStartDebounce(ScaleUpdateDetails d) {
-    start(ScaleUpdateDetails d) {
-      _currentState = GestureState.twoFingerScale;
-      if (onTwoFingerScaleStart != null) {
-        onTwoFingerScaleStart!(ScaleStartDetails(
-            localFocalPoint: d.localFocalPoint, focalPoint: d.focalPoint));
-      }
+  void _startThreeFinger(ScaleUpdateDetails d) {
+    _cancelReset();
+    _currentState = GestureState.threeFingerVerticalDrag;
+    if (onThreeFingerVerticalDragStart != null) {
+      onThreeFingerVerticalDragStart!(
+          DragStartDetails(globalPosition: d.localFocalPoint));
     }
+    debugPrint("start threeFingerScale");
+  }
 
-    if (_currentState == GestureState.threeFingerVerticalDrag) {
-      _debounceTimer = Timer(Duration(milliseconds: 200), () {
-        start(d);
-        debugPrint("debounce start twoFingerScale");
-      });
-    } else {
-      start(d);
-      debugPrint("start twoFingerScale");
-    }
+  void _cancelPendingStart() {
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    _pendingStart = _PendingStart.none;
+    _pendingDetails = null;
+  }
+
+  void _cancelReset() {
+    _resetTimer?.cancel();
+    _resetTimer = null;
+    _ended = false;
   }
 
   DragUpdateDetails _getDragUpdateDetails(ScaleUpdateDetails d) =>
@@ -174,6 +235,8 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
   @override
   void rejectGesture(int pointer) {
     super.rejectGesture(pointer);
+    _cancelPendingStart();
+    _cancelReset();
     switch (_currentState) {
       case GestureState.oneFingerPan:
         if (onOneFingerPanCancel != null) {
@@ -190,6 +253,13 @@ class CustomTouchGestureRecognizer extends ScaleGestureRecognizer {
         break;
     }
     _currentState = GestureState.none;
+  }
+
+  @override
+  void dispose() {
+    _cancelPendingStart();
+    _cancelReset();
+    super.dispose();
   }
 }
 

--- a/flutter/test/common/widgets/gestures_test.dart
+++ b/flutter/test/common/widgets/gestures_test.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_hbb/common/widgets/gestures.dart';
+
+/// Records the callbacks fired by [CustomTouchGestureRecognizer].
+class _Recorder {
+  int oneFingerStart = 0;
+  int oneFingerUpdate = 0;
+  int oneFingerEnd = 0;
+  int twoFingerStart = 0;
+  int twoFingerEnd = 0;
+  int threeFingerStart = 0;
+  int threeFingerUpdate = 0;
+  int threeFingerEnd = 0;
+  Offset? lastOneFingerStartPos;
+}
+
+CustomTouchGestureRecognizer _makeRecognizer(_Recorder recorder) {
+  final recognizer = CustomTouchGestureRecognizer();
+  recognizer
+    ..onOneFingerPanStart = (d) {
+      recorder.oneFingerStart++;
+      recorder.lastOneFingerStartPos = d.globalPosition;
+    }
+    ..onOneFingerPanUpdate = (d) {
+      recorder.oneFingerUpdate++;
+    }
+    ..onOneFingerPanEnd = (d) {
+      recorder.oneFingerEnd++;
+    }
+    ..onTwoFingerScaleStart = (d) {
+      recorder.twoFingerStart++;
+    }
+    ..onTwoFingerScaleEnd = (d) {
+      recorder.twoFingerEnd++;
+    }
+    ..onThreeFingerVerticalDragStart = (d) {
+      recorder.threeFingerStart++;
+    }
+    ..onThreeFingerVerticalDragUpdate = (d) {
+      recorder.threeFingerUpdate++;
+    }
+    ..onThreeFingerVerticalDragEnd = (d) {
+      recorder.threeFingerEnd++;
+    };
+  return recognizer;
+}
+
+ScaleUpdateDetails _updateDetails({
+  required int pointerCount,
+  Offset focalPoint = Offset.zero,
+}) {
+  return ScaleUpdateDetails(
+    focalPoint: focalPoint,
+    localFocalPoint: focalPoint,
+    focalPointDelta: Offset.zero,
+    pointerCount: pointerCount,
+  );
+}
+
+ScaleEndDetails _endDetails({required int pointerCount}) {
+  return ScaleEndDetails(pointerCount: pointerCount);
+}
+
+void main() {
+  group('CustomTouchGestureRecognizer pointer-count transitions', () {
+    testWidgets(
+        'two fingers to one finger fires the start exactly once during '
+        'continuous moves', (tester) async {
+      final recorder = _Recorder();
+      final recognizer = _makeRecognizer(recorder);
+
+      // Two-finger scale is established.
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 2));
+      expect(recorder.twoFingerStart, 1);
+
+      // One finger lifts: the scale recognizer ends with the new count.
+      recognizer.onEnd!.call(_endDetails(pointerCount: 1));
+      expect(recorder.twoFingerEnd, 1);
+
+      // The remaining finger keeps moving below the 200ms debounce.
+      final pos1 = const Offset(10, 10);
+      final pos2 = const Offset(20, 20);
+      final pos3 = const Offset(30, 30);
+      recognizer.onUpdate!
+          .call(_updateDetails(pointerCount: 1, focalPoint: pos1));
+      await tester.pump(const Duration(milliseconds: 50));
+      recognizer.onUpdate!
+          .call(_updateDetails(pointerCount: 1, focalPoint: pos2));
+      await tester.pump(const Duration(milliseconds: 50));
+      recognizer.onUpdate!
+          .call(_updateDetails(pointerCount: 1, focalPoint: pos3));
+      await tester.pump(const Duration(milliseconds: 50));
+      // The debounce deadline is still running (150ms < 200ms).
+      expect(recorder.oneFingerStart, 0);
+
+      // The deadline is measured from the first count change, not refreshed.
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(recorder.oneFingerStart, 1);
+      expect(recorder.lastOneFingerStartPos, const Offset(30, 30));
+
+      // It must not fire a second time.
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(recorder.oneFingerStart, 1);
+
+      // Subsequent moves flow to the one-finger state.
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 1));
+      expect(recorder.oneFingerUpdate, 1);
+
+      recognizer.dispose();
+    });
+
+    testWidgets(
+        'three fingers to two fingers fires the start exactly once during '
+        'continuous moves', (tester) async {
+      final recorder = _Recorder();
+      final recognizer = _makeRecognizer(recorder);
+
+      // Three-finger drag is established.
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 3));
+      expect(recorder.threeFingerStart, 1);
+
+      // One finger lifts.
+      recognizer.onEnd!.call(_endDetails(pointerCount: 2));
+      expect(recorder.threeFingerEnd, 1);
+
+      // The remaining two fingers keep moving below the debounce.
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 2));
+      await tester.pump(const Duration(milliseconds: 50));
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 2));
+      await tester.pump(const Duration(milliseconds: 50));
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 2));
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(recorder.twoFingerStart, 0);
+
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(recorder.twoFingerStart, 1);
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(recorder.twoFingerStart, 1);
+
+      recognizer.dispose();
+    });
+
+    testWidgets(
+        'a pending one-finger start is cancelled when two fingers return',
+        (tester) async {
+      final recorder = _Recorder();
+      final recognizer = _makeRecognizer(recorder);
+
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 2));
+      recognizer.onEnd!.call(_endDetails(pointerCount: 1));
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 1));
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // The second finger returns before the debounce elapses; the ended
+      // two-finger gesture restarts instead of resuming silently.
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 2));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(recorder.oneFingerStart, 0);
+      expect(recorder.twoFingerStart, 2);
+
+      recognizer.dispose();
+    });
+
+    testWidgets('onEnd cancels a pending start so no ghost gesture fires',
+        (tester) async {
+      final recorder = _Recorder();
+      final recognizer = _makeRecognizer(recorder);
+
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 2));
+      recognizer.onEnd!.call(_endDetails(pointerCount: 1));
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 1));
+
+      // All pointers are gone before the debounce elapses.
+      recognizer.onEnd!.call(_endDetails(pointerCount: 0));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(recorder.oneFingerStart, 0);
+      expect(recorder.oneFingerEnd, 0);
+      expect(recorder.twoFingerEnd, 1);
+
+      recognizer.dispose();
+    });
+
+    testWidgets('four or more fingers are treated as the three-finger drag',
+        (tester) async {
+      final recorder = _Recorder();
+      final recognizer = _makeRecognizer(recorder);
+
+      // From none, four fingers start the three-finger drag immediately.
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 4));
+      expect(recorder.threeFingerStart, 1);
+
+      // Adding a fifth finger must not restart the gesture.
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 5));
+      expect(recorder.threeFingerStart, 1);
+      expect(recorder.threeFingerUpdate, 2);
+
+      recognizer.dispose();
+    });
+
+    testWidgets('one finger from none starts immediately and ends',
+        (tester) async {
+      final recorder = _Recorder();
+      final recognizer = _makeRecognizer(recorder);
+
+      final pos = const Offset(5, 5);
+      recognizer.onUpdate!
+          .call(_updateDetails(pointerCount: 1, focalPoint: pos));
+      expect(recorder.oneFingerStart, 1);
+      expect(recorder.lastOneFingerStartPos, pos);
+
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 1));
+      expect(recorder.oneFingerUpdate, 2);
+
+      recognizer.onEnd!.call(_endDetails(pointerCount: 0));
+      expect(recorder.oneFingerEnd, 1);
+
+      recognizer.dispose();
+    });
+
+    testWidgets(
+        'a second one-finger gesture within 200ms starts again and ends '
+        'normally', (tester) async {
+      final recorder = _Recorder();
+      final recognizer = _makeRecognizer(recorder);
+
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 1));
+      expect(recorder.oneFingerStart, 1);
+
+      // All fingers up; the state reset is deferred by 200ms.
+      recognizer.onEnd!.call(_endDetails(pointerCount: 0));
+      expect(recorder.oneFingerEnd, 1);
+
+      // A fresh one-finger gesture begins before the reset deadline elapses.
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 1));
+      expect(recorder.oneFingerStart, 2);
+      // The start frame also delivers an update.
+      expect(recorder.oneFingerUpdate, 2);
+
+      recognizer.onEnd!.call(_endDetails(pointerCount: 0));
+      expect(recorder.oneFingerEnd, 2);
+
+      await tester.pump(const Duration(milliseconds: 300));
+      recognizer.dispose();
+    });
+
+    testWidgets(
+        'a second onEnd replaces the reset deadline instead of leaving a '
+        'stale timer', (tester) async {
+      final recorder = _Recorder();
+      final recognizer = _makeRecognizer(recorder);
+
+      // First gesture: start and end.
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 1));
+      expect(recorder.oneFingerStart, 1);
+      recognizer.onEnd!.call(_endDetails(pointerCount: 0));
+      expect(recorder.oneFingerEnd, 1);
+
+      // A second onEnd 50ms later must not double-fire the end callback and
+      // re-arms the reset timer (deadline t=250) instead of stacking a second
+      // one with the original deadline (t=200).
+      await tester.pump(const Duration(milliseconds: 50));
+      recognizer.onEnd!.call(_endDetails(pointerCount: 0));
+      expect(recorder.oneFingerEnd, 1);
+
+      // The gesture restarts 50ms later, before either deadline.
+      await tester.pump(const Duration(milliseconds: 50));
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 1));
+      expect(recorder.oneFingerStart, 2);
+
+      // Past the first timer's original deadline (t=200) but before the
+      // replacement deadline (t=250): the stale timer must not fire.
+      await tester.pump(const Duration(milliseconds: 110));
+      recognizer.onUpdate!.call(_updateDetails(pointerCount: 1));
+      expect(recorder.oneFingerStart, 2);
+      expect(recorder.oneFingerEnd, 1);
+
+      // The restarted gesture ends normally.
+      recognizer.onEnd!.call(_endDetails(pointerCount: 0));
+      expect(recorder.oneFingerEnd, 2);
+
+      await tester.pump(const Duration(milliseconds: 300));
+      recognizer.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Problem

On Android, lifting a finger while continuing a multi-finger gesture can leave the remote session in the old gesture mode. I reproduced this on an Xperia 1 VII running Android 16 (Arm64): after a two- or three-finger gesture, cursor movement, taps, and scroll cancellation no longer behave normally.

[Reproduction video](https://github.com/TsukinowaRin/rustdesk/releases/download/android-multitouch-repro-20260807/screen-20260807-193853.mp4)

## Root cause

Flutter 3.24.5 calls ScaleGestureRecognizer.onEnd when the pointer configuration changes, including 2-to-1 and 3-to-2. RustDesk kept the ended gesture state for 200 ms, while every following move cancelled and re-armed the same timer. Continuous movement could therefore keep the stale state indefinitely.

## Fix

Reset the ended gesture state synchronously before the existing 200 ms timer is scheduled.

The production change is exactly one added line. It preserves the existing timer and gesture state machine, with no new fields, helpers, platform gates, coordinate changes, or deletions.

## Testing

- The focused regression test fails on the base revision: Expected 1, Actual 0.
- The same test passes with this one-line change.
- Additional non-committed checks pass for 3-to-2, duplicate onEnd, same-count restart, and special-hold behavior.
- Focused Flutter analyze reports no issues.
- An Arm64-only release APK builds successfully and passes archive structure, alignment, ABI, and v1/v2 signature verification.
- Xperia 1 VII confirmation is pending, so this PR remains Draft.
