### PR TITLE
docs: fix comma splice gui tutorial in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ RustDesk welcomes contribution from everyone. See [CONTRIBUTING.md](docs/CONTRIB
 
 ## Dependencies
 
-Desktop versions use Flutter or Sciter (deprecated) for GUI, this tutorial is for Sciter only, since it is easier and more friendly to start. Check out our [CI](https://github.com/rustdesk/rustdesk/blob/master/.github/workflows/flutter-build.yml) for building Flutter version.
+Desktop versions use Flutter or Sciter (deprecated) for GUI. This tutorial is for Sciter only, since it is easier and more friendly to start. Check out our [CI](https://github.com/rustdesk/rustdesk/blob/master/.github/workflows/flutter-build.yml) for building the Flutter version.
 
 Please download Sciter dynamic library yourself.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 41).

## Problem

Comma splice: two independent clauses joined by a comma without a conjunction

The problematic text:

```markdown
Desktop versions use Flutter or Sciter (deprecated) for GUI, this tutorial is for Sciter only
```

## Fix

Replaced with:

```markdown
Desktop versions use Flutter or Sciter (deprecated) for GUI. This tutorial is for Sciter only
```

Also added missing article: "building Flutter version" → "building the Flutter version"

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Sciter build documentation.
  * Added a separate note directing readers to the CI workflow for Flutter builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR corrects a comma splice and adds a missing article in the README dependency guidance.
- Splits two independent clauses into separate sentences.
- Changes “building Flutter version” to “building the Flutter version.”
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it makes only accurate, narrowly scoped grammar corrections.

The README edits preserve the original technical meaning and link while improving grammatical correctness, with no actionable issues identified.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Corrects two grammar issues without changing the documented setup instructions or links. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix comma splice gui tutorial in R..."](https://github.com/rustdesk/rustdesk/commit/cd765a37730b3adc1149bb371e55d7b0730d40ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51217862)</sub>

<!-- /greptile_comment -->