### PR TITLE
docs: fix comma splice cached subsequent in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Then, each time you need to build the application, run the following command:
 docker run --rm -it -v $PWD:/home/user/rustdesk -v rustdesk-git-cache:/home/user/.cargo/git -v rustdesk-registry-cache:/home/user/.cargo/registry -e PUID="$(id -u)" -e PGID="$(id -g)" rustdesk-builder
 ```
 
-Note that the first build may take longer before dependencies are cached, subsequent builds will be faster. Additionally, if you need to specify different arguments to the build command, you may do so at the end of the command in the `<OPTIONAL-ARGS>` position. For instance, if you wanted to build an optimized release version, you would run the command above followed by `--release`. The resulting executable will be available in the target folder on your system, and can be run with:
+Note that the first build may take longer before dependencies are cached. Subsequent builds will be faster. Additionally, if you need to specify different arguments to the build command, you may do so at the end of the command in the `<OPTIONAL-ARGS>` position. For instance, if you wanted to build an optimized release version, you would run the command above followed by `--release`. The resulting executable will be available in the target folder on your system, and can be run with:
 
 ```sh
 target/debug/rustdesk


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 145).

## Problem

Comma splice: two independent clauses joined by a comma without a conjunction

The problematic text:

```markdown
before dependencies are cached, subsequent builds will be faster.
```

## Fix

Replaced with:

```markdown
before dependencies are cached. Subsequent builds will be faster.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a comma splice in the Docker build instructions without changing their meaning.
- Replaces the comma after “cached” with a period.
- Capitalizes “Subsequent” to form a new sentence.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The documentation-only punctuation change is grammatically correct, preserves the original meaning, and does not affect build or runtime behavior.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Correctly splits two independent clauses while preserving the existing Docker build guidance. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix comma splice cached subsequent..."](https://github.com/rustdesk/rustdesk/commit/1339176dcd96b3ac8d6537eaed9b88fe2555d898) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51217969)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Docker build documentation to distinguish initial and subsequent build times.
  * Noted that build arguments, such as `--release`, can be added to the build command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->