### PR TITLE
docs: fix singular contribution in docs/CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to RustDesk
 
-RustDesk welcomes contribution from everyone. Here are the guidelines if you are
+RustDesk welcomes contributions from everyone. Here are the guidelines if you are
 thinking of helping us:
 
 ## Contributions


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/CONTRIBUTING.md` (line 3).

## Problem

Singular 'contribution' should be plural 'contributions'

The problematic text:

```markdown
RustDesk welcomes contribution from everyone.
```

## Fix

Replaced with:

```markdown
RustDesk welcomes contributions from everyone.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contribution guidelines introduction for clearer wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects a grammatical error in the contributor documentation.
- Changes “welcomes contribution” to “welcomes contributions.”
- Aligns the sentence with plural terminology already used elsewhere in the document.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The sole change is an accurate grammar correction that introduces no behavioral, security, or documentation-contract issue.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/CONTRIBUTING.md | Corrects singular “contribution” to the grammatically appropriate plural form without changing the document’s meaning. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix singular contribution in docs/..."](https://github.com/rustdesk/rustdesk/commit/902c9f5fbadf31b015c25a21801f3ba5aa6a4063) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51218115)</sub>

<!-- /greptile_comment -->