### PR TITLE
fix(linux): bound the xrandr call in the wayland primary-display lookup

### DIFF
--- a/libs/scrap/src/wayland/display.rs
+++ b/libs/scrap/src/wayland/display.rs
@@ -76,7 +76,9 @@ fn run_with_timeout(
 // 2. The distro may not have xrandr installed by default.
 // 3. xrandr may not report "primary" in its output. eg. openSUSE Leap 15.6 KDE Plasma.
 fn try_xrandr_primary() -> Option<String> {
-    let output = Command::new("xrandr").output().ok()?;
+    // Bounded like its two siblings below: this runs inside the held `DISPLAYS` guard, and from a
+    // service with no DISPLAY and no session bus, where an X client can block indefinitely.
+    let output = run_with_timeout("xrandr", &[], COMMAND_TIMEOUT, "xrandr")?;
     if !output.status.success() {
         return None;
     }


### PR DESCRIPTION
`try_xrandr_primary` in `libs/scrap/src/wayland/display.rs` runs a bare `Command::new("xrandr").output()`. Its two siblings in the same file, `try_kscreen_primary` and the gdbus lookup, both go through `run_with_timeout(.., COMMAND_TIMEOUT)`, and the comment above that helper spells out why: these commands are known to hang. xrandr is the one that was left bare.

Where it runs is what makes it worth bounding. `get_primary_monitor` is reached from `get_displays` with the process-wide `DISPLAYS` guard held, and on a Wayland host the caller can be the service, which has no `DISPLAY` and no session bus. An X client that blocks there blocks every consumer of the display list behind the same lock.

No behaviour change when xrandr answers: same command, same parsing, one second of patience. Came out of the review on rustdesk/hbb_common#580, which is where the path becomes reachable more often.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved primary display detection by preventing display queries from hanging indefinitely.
  * Applied consistent handling for command timeouts and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bounds the Wayland primary-display xrandr lookup with the existing one-second subprocess timeout.
- Reuses `run_with_timeout` consistently with the kscreen and gdbus lookup paths.
- Preserves successful output parsing and fallback behavior.
- Kills and reaps xrandr when it exceeds the timeout, preventing it from indefinitely holding the shared display-list lock.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with successful xrandr behavior preserved while hung invocations are bounded and cleaned up.

The changed call retains stdout parsing, spawn-failure handling, and non-zero-exit fallback behavior while adding the intended timeout through an existing helper.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/scrap/src/wayland/display.rs | Replaces the unbounded xrandr execution with the existing timeout helper without introducing a concrete behavioral regression. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(linux): bound the xrandr call in the..."](https://github.com/rustdesk/rustdesk/commit/4a48391dcd9cdce5e989e6144592a4050830c944) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51482556)</sub>

<!-- /greptile_comment -->