### PR TITLE
fix: route a mid session resolution decrease through capturer rebuild (#15695)

### DIFF
--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -724,6 +724,20 @@ fn run(vs: VideoService) -> ResultType<()> {
         let res = match c.frame(spf) {
             Ok(frame) => {
                 repeat_encode_counter = 0;
+                // Rebuild when a mode change hands back a frame that no longer matches the size
+                // this capturer/encoder pair was built with: convert_to_yuv only refuses LARGER
+                // sources, and a smaller one lands in the old canvas leaving stale edges.
+                if let scrap::Frame::PixelBuffer(f) = &frame {
+                    if f.width() != capture_width || f.height() != capture_height {
+                        bail!(
+                            "frame {}x{} is not the {}x{} this capturer was built with; rebuilding",
+                            f.width(),
+                            f.height(),
+                            capture_width,
+                            capture_height
+                        );
+                    }
+                }
                 if frame.valid() {
                     let screenshot_key = (vs.source, display_idx);
                     let screenshot = SCREENSHOTS.lock().unwrap().remove(&screenshot_key);


### PR DESCRIPTION
as discussed in #15695. the check compares each PixelBuffer frame against the size the capturer was built with and bails on a mismatch, which routes a decrease through the same rebuild an increase already takes today, since convert_to_yuv refuses oversized sources. a smaller frame currently passes that check and is written into the old canvas, which leaves the stale right and bottom edges the issue shows.

on the VideoCropMeta question: yes, a cropped frame with a size different from the capture size is legal, and our own pipewire path already produces one. libs/scrap/src/wayland/pipewire.rs reads VideoCropMeta, copies the crop region and reports the cropped width and height upward, so when a compositor shrinks the content while the stream still runs at the old buffer size, video_service receives a frame smaller than the capture size. that is exactly the case this check catches. a crop equal to the full frame is normalized away in the recorder, so it never reaches the comparison.

the bail is not a dead end for a legal crop. run() tears down, the teardown clears the wayland display caches, and the rebuilt session renegotiates at the current size. check_display_changed returns None on wayland by design, so without a per frame check nothing else notices the mismatch on the pipewire path.

the comparison is against the capture size and not the encoder format on purpose: vpx_img_wrap aligns the encoder width up, so a legitimate frame is routinely narrower than dst_fmt.w.

what i measured and what i could not:

- x11: a resolution decrease under a live session recovers already, check_display_changed broadcasts and the capturer is rebuilt before a mismatched frame is dequeued. the new check stays silent there
- wayland with the drm backend of #15420: the reader ends the stream on a dimension change first, the check stays silent there too
- wayland with pipewire is the exposed path, and i do not have a portal screencast setup here to drive a live repro, so the crop behavior above is verified in code, not live. validation there belongs to whoever can run a portal session with a mode switch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video capture reliability by rejecting frames with unexpected dimensions.
  * Automatically rebuilds the capture session when an invalid frame is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR detects pixel-buffer dimensions that differ from the active capture dimensions and rebuilds the capture session rather than encoding into a stale canvas.
- Compares each pixel-buffer frame against the capturer’s configured width and height.
- Aborts the current capture run on mismatch so the existing teardown and rebuild path can renegotiate the dimensions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/video_service.rs | Adds a per-frame dimension guard that routes mismatched pixel buffers through capture-session rebuilding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: reject a frame that does not match ..."](https://github.com/rustdesk/rustdesk/commit/1fb4ed4ba1906a6a339a7d5ddf99050c4b1773bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51527746)</sub>

<!-- /greptile_comment -->