### PR TITLE
feat(windows): Add selectable ASIO input pairs for Windows audio capture

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -121,7 +121,7 @@ jobs:
               arch: x86_64,
               flutter-arch: x64,
               vcpkg-triplet: x64-windows-static,
-              build-args: "--vram",
+              build-args: "--vram --asio",
             }
           - {
               target: aarch64-pc-windows-msvc,
@@ -159,6 +159,47 @@ jobs:
         uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
         with:
           version: ${{ env.LLVM_VERSION }}
+
+      # CPAL's ASIO backend needs the Steinberg SDK at build time. Keep this x64-only:
+      # the ASIO feature is not enabled for the Windows-on-ARM artifact.
+      - name: Install Steinberg ASIO SDK
+        if: ${{ matrix.job.arch == 'x86_64' }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $sdkRoot = Join-Path $env:RUNNER_TEMP "asio_sdk"
+          $extractRoot = Join-Path $env:RUNNER_TEMP "asio_sdk_extract"
+          $zipPath = Join-Path $env:RUNNER_TEMP "asio_sdk.zip"
+          Remove-Item -Recurse -Force $sdkRoot -ErrorAction SilentlyContinue
+          Remove-Item -Recurse -Force $extractRoot -ErrorAction SilentlyContinue
+          Invoke-WebRequest -Uri "https://www.steinberg.net/asiosdk" -OutFile $zipPath
+          New-Item -ItemType Directory -Force -Path $extractRoot | Out-Null
+          Expand-Archive -Path $zipPath -DestinationPath $extractRoot -Force
+          $source = Get-ChildItem -Path $extractRoot -Directory | Where-Object {
+            (Test-Path (Join-Path $_.FullName "host")) -and
+            (Test-Path (Join-Path $_.FullName "host\pc")) -and
+            (Test-Path (Join-Path $_.FullName "common"))
+          } | Select-Object -First 1
+          if ($null -eq $source) {
+            Get-ChildItem -Path $extractRoot -Recurse -Depth 2 | Select-Object -ExpandProperty FullName
+            throw "Failed to find extracted ASIO SDK root"
+          }
+          Move-Item -Path $source.FullName -Destination $sdkRoot
+          $requiredPaths = @(
+            "host",
+            "host\pc",
+            "host\asiodrivers.h",
+            "common",
+            "common\asio.h",
+            "common\asiosys.h"
+          )
+          foreach ($relativePath in $requiredPaths) {
+            $path = Join-Path $sdkRoot $relativePath
+            if (!(Test-Path $path)) {
+              throw "ASIO SDK is missing required path: $relativePath"
+            }
+          }
+          "CPAL_ASIO_DIR=$sdkRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install flutter
         id: flutter

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "asio-sys"
+version = "0.2.2"
+source = "git+https://github.com/rustdesk-org/cpal?branch=osx-screencapturekit#6b374bcaed076750ca8fce6da518ab39b882e14a"
+dependencies = [
+ "bindgen 0.69.4",
+ "cc",
+ "num-derive 0.4.2",
+ "num-traits 0.2.19",
+ "parse_cfg",
+ "walkdir",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,12 +758,15 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
+ "log",
+ "prettyplease",
  "proc-macro2 1.0.93",
  "quote 1.0.36",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.98",
+ "which",
 ]
 
 [[package]]
@@ -1765,6 +1781,7 @@ version = "0.15.3"
 source = "git+https://github.com/rustdesk-org/cpal?branch=osx-screencapturekit#6b374bcaed076750ca8fce6da518ab39b882e14a"
 dependencies = [
  "alsa",
+ "asio-sys",
  "cidre",
  "core-foundation-sys 0.8.7",
  "coreaudio-rs",
@@ -1775,6 +1792,7 @@ dependencies = [
  "mach2",
  "ndk 0.8.0",
  "ndk-context",
+ "num-traits 0.2.19",
  "oboe",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -6056,6 +6074,15 @@ dependencies = [
  "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "parse_cfg"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905787a434a2c721408e7c9a252e85f3d93ca0f118a5283022636c0e05a7ea49"
+dependencies = [
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ unix-file-copy-paste = [
     "clipboard/unix-file-copy-paste",
 ]
 screencapturekit = ["cpal/screencapturekit"]
+asio = ["cpal/asio"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/build.py
+++ b/build.py
@@ -140,6 +140,11 @@ def make_parser():
         help='Build with unix file copy paste feature'
     )
     parser.add_argument(
+        '--asio',
+        action='store_true',
+        help='Enable ASIO audio support on Windows'
+    )
+    parser.add_argument(
         '--drm',
         action='store_true',
         help='Linux only: build the DRM/KMS capture backend (bundles libdrmtap.so, '
@@ -322,6 +327,10 @@ def get_features(args):
         features.append('flutter')
     if args.unix_file_copy_paste:
         features.append('unix-file-copy-paste')
+    if args.asio:
+        if not windows:
+            raise Exception('--asio is Windows only')
+        features.append('asio')
     if args.drm:
         # Say so rather than quietly handing back a stock build: the backend is Linux-only, so on
         # any other host the flag cannot be honoured and the resulting binary would look like a

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -20,7 +20,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 pub const NAME: &'static str = "audio";
 pub const AUDIO_DATA_SIZE_U8: usize = 960 * 4; // 10ms in 48000 stereo
+pub const ASIO_INPUT_PREFIX: &str = "[ASIO] ";
 static RESTARTING: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AsioInputChoice {
+    display: String,
+    channels: Vec<usize>,
+}
 
 lazy_static::lazy_static! {
     static ref VOICE_CALL_INPUT_DEVICE: Arc::<Mutex::<Option<String>>> = Default::default();
@@ -65,6 +72,66 @@ fn get_audio_input() -> String {
         .unwrap()
         .clone()
         .unwrap_or(Config::get_option("audio-input"))
+}
+
+fn asio_input_choices(device_name: &str, channel_count: u16) -> Vec<AsioInputChoice> {
+    let channel_count = channel_count as usize;
+    let mut choices = Vec::with_capacity((channel_count + 1) / 2);
+    for first in (0..channel_count).step_by(2) {
+        let channels = if first + 1 < channel_count {
+            vec![first, first + 1]
+        } else {
+            vec![first]
+        };
+        let display = if channels.len() == 2 {
+            format!(
+                "{ASIO_INPUT_PREFIX}{device_name} - Inputs {}-{}",
+                first + 1,
+                first + 2
+            )
+        } else {
+            format!("{ASIO_INPUT_PREFIX}{device_name} - Input {}", first + 1)
+        };
+        choices.push(AsioInputChoice { display, channels });
+    }
+    choices
+}
+
+fn select_interleaved_channels(
+    data: &[f32],
+    source_channels: usize,
+    selected_channels: &[usize],
+) -> Option<Vec<f32>> {
+    if source_channels == 0
+        || selected_channels.is_empty()
+        || selected_channels
+            .iter()
+            .any(|channel| *channel >= source_channels)
+    {
+        return None;
+    }
+    let frame_count = data.len() / source_channels;
+    let mut out = Vec::with_capacity(frame_count * selected_channels.len());
+    for frame in data.chunks_exact(source_channels) {
+        for channel in selected_channels {
+            out.push(frame[*channel]);
+        }
+    }
+    Some(out)
+}
+
+#[cfg(all(windows, feature = "asio"))]
+pub fn get_asio_input_devices() -> Vec<String> {
+    cpal_impl::get_asio_input_devices()
+}
+
+#[cfg(not(all(windows, feature = "asio")))]
+pub fn get_asio_input_devices() -> Vec<String> {
+    Vec::new()
+}
+
+pub fn append_asio_input_devices(out: &mut Vec<String>) {
+    out.extend(get_asio_input_devices());
 }
 
 pub fn restart() {
@@ -180,6 +247,8 @@ mod cpal_impl {
         BufferSize, Device, Host, InputCallbackInfo, StreamConfig, SupportedStreamConfig,
     };
 
+    type CaptureDevice = (Device, SupportedStreamConfig, Option<Vec<usize>>);
+
     lazy_static::lazy_static! {
         static ref HOST: Host = cpal::default_host();
         static ref INPUT_BUFFER: Arc<Mutex<std::collections::VecDeque<f32>>> = Default::default();
@@ -267,7 +336,7 @@ mod cpal_impl {
     }
 
     #[cfg(feature = "screencapturekit")]
-    fn get_device() -> ResultType<(Device, SupportedStreamConfig)> {
+    fn get_device() -> ResultType<CaptureDevice> {
         let audio_input = super::get_audio_input();
         if !audio_input.is_empty() {
             return get_audio_input(&audio_input);
@@ -284,13 +353,17 @@ mod cpal_impl {
             .map_err(|e| anyhow!(e))
             .with_context(|| "Failed to get input output format")?;
         log::info!("Default input format: {:?}", format);
-        Ok((device, format))
+        Ok((device, format, None))
     }
 
     #[cfg(windows)]
-    fn get_device() -> ResultType<(Device, SupportedStreamConfig)> {
+    fn get_device() -> ResultType<CaptureDevice> {
         let audio_input = super::get_audio_input();
         if !audio_input.is_empty() {
+            #[cfg(feature = "asio")]
+            if audio_input.starts_with(super::ASIO_INPUT_PREFIX) {
+                return get_asio_audio_input(&audio_input);
+            }
             return get_audio_input(&audio_input);
         }
         let device = HOST
@@ -305,16 +378,100 @@ mod cpal_impl {
             .map_err(|e| anyhow!(e))
             .with_context(|| "Failed to get default output format")?;
         log::info!("Default output format: {:?}", format);
-        Ok((device, format))
+        Ok((device, format, None))
+    }
+
+    #[cfg(all(windows, feature = "asio"))]
+    pub(super) fn get_asio_input_devices() -> Vec<String> {
+        let mut out = Vec::new();
+        let host = match cpal::host_from_id(cpal::HostId::Asio) {
+            Ok(host) => host,
+            Err(err) => {
+                log::debug!("Failed to initialize ASIO host: {:?}", err);
+                return out;
+            }
+        };
+        let devices = match host.devices() {
+            Ok(devices) => devices,
+            Err(err) => {
+                log::debug!("Failed to enumerate ASIO devices: {:?}", err);
+                return out;
+            }
+        };
+        for device in devices {
+            let device_name = match device.name() {
+                Ok(name) => name,
+                Err(err) => {
+                    log::debug!("Failed to get ASIO device name: {:?}", err);
+                    continue;
+                }
+            };
+            let format = match device.default_input_config() {
+                Ok(format) => format,
+                Err(err) => {
+                    log::debug!(
+                        "Failed to get ASIO input config for {}: {:?}",
+                        device_name,
+                        err
+                    );
+                    continue;
+                }
+            };
+            out.extend(
+                super::asio_input_choices(&device_name, format.channels())
+                    .into_iter()
+                    .map(|choice| choice.display),
+            );
+        }
+        out
+    }
+
+    #[cfg(all(windows, feature = "asio"))]
+    fn get_asio_audio_input(audio_input: &str) -> ResultType<CaptureDevice> {
+        let host = cpal::host_from_id(cpal::HostId::Asio)
+            .map_err(|e| anyhow!("{:?}", e))
+            .with_context(|| "Failed to initialize ASIO host")?;
+        for device in host
+            .devices()
+            .with_context(|| "Failed to enumerate ASIO devices")?
+        {
+            let device_name = match device.name() {
+                Ok(name) => name,
+                Err(err) => {
+                    log::debug!("Failed to get ASIO device name: {:?}", err);
+                    continue;
+                }
+            };
+            let format = match device.default_input_config() {
+                Ok(format) => format,
+                Err(err) => {
+                    log::debug!(
+                        "Failed to get ASIO input config for {}: {:?}",
+                        device_name,
+                        err
+                    );
+                    continue;
+                }
+            };
+            if let Some(choice) = super::asio_input_choices(&device_name, format.channels())
+                .into_iter()
+                .find(|choice| choice.display == audio_input)
+            {
+                log::info!("ASIO input route: {}", choice.display);
+                log::info!("ASIO input format: {:?}", format);
+                return Ok((device, format, Some(choice.channels)));
+            }
+        }
+        bail!("Failed to get ASIO input route: {}", audio_input);
     }
 
     #[cfg(not(any(windows, feature = "screencapturekit")))]
-    fn get_device() -> ResultType<(Device, SupportedStreamConfig)> {
+    fn get_device() -> ResultType<CaptureDevice> {
         let audio_input = super::get_audio_input();
         get_audio_input(&audio_input)
     }
 
-    fn get_audio_input(audio_input: &str) -> ResultType<(Device, SupportedStreamConfig)> {
+    fn get_audio_input(audio_input: &str) -> ResultType<CaptureDevice> {
         let mut device = None;
         #[cfg(feature = "screencapturekit")]
         if !audio_input.is_empty() && is_screen_capture_kit_available() {
@@ -350,12 +507,12 @@ mod cpal_impl {
             .map_err(|e| anyhow!(e))
             .with_context(|| "Failed to get default input format")?;
         log::info!("Default input format: {:?}", format);
-        Ok((device, format))
+        Ok((device, format, None))
     }
 
     fn play(sp: &GenericService) -> ResultType<(Box<dyn StreamTrait>, Arc<Message>)> {
         use cpal::SampleFormat::*;
-        let (device, config) = get_device()?;
+        let (device, config, selected_channels) = get_device()?;
         let sp = sp.clone();
         // Sample rate must be one of 8000, 12000, 16000, 24000, or 48000.
         let sample_rate_0 = config.sample_rate().0;
@@ -370,18 +527,46 @@ mod cpal_impl {
         } else {
             48000
         };
-        let ch = if config.channels() > 1 { Stereo } else { Mono };
+        let capture_channel_count = selected_channels
+            .as_ref()
+            .map(|channels| channels.len() as u16)
+            .unwrap_or_else(|| config.channels());
+        let ch = if capture_channel_count > 1 {
+            Stereo
+        } else {
+            Mono
+        };
         let stream = match config.sample_format() {
-            I8 => build_input_stream::<i8>(device, &config, sp, sample_rate, ch)?,
-            I16 => build_input_stream::<i16>(device, &config, sp, sample_rate, ch)?,
-            I32 => build_input_stream::<i32>(device, &config, sp, sample_rate, ch)?,
-            I64 => build_input_stream::<i64>(device, &config, sp, sample_rate, ch)?,
-            U8 => build_input_stream::<u8>(device, &config, sp, sample_rate, ch)?,
-            U16 => build_input_stream::<u16>(device, &config, sp, sample_rate, ch)?,
-            U32 => build_input_stream::<u32>(device, &config, sp, sample_rate, ch)?,
-            U64 => build_input_stream::<u64>(device, &config, sp, sample_rate, ch)?,
-            F32 => build_input_stream::<f32>(device, &config, sp, sample_rate, ch)?,
-            F64 => build_input_stream::<f64>(device, &config, sp, sample_rate, ch)?,
+            I8 => {
+                build_input_stream::<i8>(device, &config, sp, sample_rate, ch, selected_channels)?
+            }
+            I16 => {
+                build_input_stream::<i16>(device, &config, sp, sample_rate, ch, selected_channels)?
+            }
+            I32 => {
+                build_input_stream::<i32>(device, &config, sp, sample_rate, ch, selected_channels)?
+            }
+            I64 => {
+                build_input_stream::<i64>(device, &config, sp, sample_rate, ch, selected_channels)?
+            }
+            U8 => {
+                build_input_stream::<u8>(device, &config, sp, sample_rate, ch, selected_channels)?
+            }
+            U16 => {
+                build_input_stream::<u16>(device, &config, sp, sample_rate, ch, selected_channels)?
+            }
+            U32 => {
+                build_input_stream::<u32>(device, &config, sp, sample_rate, ch, selected_channels)?
+            }
+            U64 => {
+                build_input_stream::<u64>(device, &config, sp, sample_rate, ch, selected_channels)?
+            }
+            F32 => {
+                build_input_stream::<f32>(device, &config, sp, sample_rate, ch, selected_channels)?
+            }
+            F64 => {
+                build_input_stream::<f64>(device, &config, sp, sample_rate, ch, selected_channels)?
+            }
             f => bail!("unsupported audio format: {:?}", f),
         };
         stream.play()?;
@@ -397,6 +582,7 @@ mod cpal_impl {
         sp: GenericService,
         sample_rate: u32,
         encode_channel: magnum_opus::Channels,
+        selected_channels: Option<Vec<usize>>,
     ) -> ResultType<cpal::Stream>
     where
         T: cpal::SizedSample + dasp::sample::ToSample<f32>,
@@ -410,7 +596,20 @@ mod cpal_impl {
         unsafe {
             AUDIO_ZERO_COUNT = 0;
         }
-        let device_channel = config.channels();
+        let source_channel = config.channels();
+        if let Some(channels) = selected_channels.as_ref() {
+            if channels.is_empty()
+                || channels
+                    .iter()
+                    .any(|channel| *channel >= source_channel as usize)
+            {
+                bail!("Invalid ASIO channel selection: {:?}", channels);
+            }
+        }
+        let device_channel = selected_channels
+            .as_ref()
+            .map(|channels| channels.len() as u16)
+            .unwrap_or(source_channel);
         let mut encoder = Encoder::new(sample_rate, encode_channel, LowDelay)?;
         // https://www.opus-codec.org/docs/html_api/group__opusencoder.html#gace941e4ef26ed844879fde342ffbe546
         // https://chromium.googlesource.com/chromium/deps/opus/+/1.1.1/include/opus.h
@@ -423,14 +622,24 @@ mod cpal_impl {
         INPUT_BUFFER.lock().unwrap().clear();
         let timeout = None;
         let stream_config = StreamConfig {
-            channels: device_channel,
+            channels: source_channel,
             sample_rate: config.sample_rate(),
             buffer_size: BufferSize::Default,
         };
         let stream = device.build_input_stream(
             &stream_config,
             move |data: &[T], _: &InputCallbackInfo| {
-                let buffer: Vec<f32> = data.iter().map(|s| T::to_sample(*s)).collect();
+                let source_buffer: Vec<f32> = data.iter().map(|s| T::to_sample(*s)).collect();
+                let buffer = if let Some(channels) = selected_channels.as_deref() {
+                    super::select_interleaved_channels(
+                        &source_buffer,
+                        source_channel as usize,
+                        channels,
+                    )
+                    .unwrap_or_default()
+                } else {
+                    source_buffer
+                };
                 let mut lock = INPUT_BUFFER.lock().unwrap();
                 lock.extend(buffer);
                 while lock.len() >= rechannel_len {
@@ -530,5 +739,53 @@ fn send_f32(data: &[f32], encoder: &mut Encoder, sp: &GenericService) {
             sp.send(msg_out);
         }
         Err(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asio_input_choices_are_stereo_pairs_with_a_mono_tail() {
+        let choices = asio_input_choices("Example Driver", 5);
+        assert_eq!(choices.len(), 3);
+        assert_eq!(
+            choices[0],
+            AsioInputChoice {
+                display: "[ASIO] Example Driver - Inputs 1-2".to_owned(),
+                channels: vec![0, 1],
+            }
+        );
+        assert_eq!(
+            choices[1],
+            AsioInputChoice {
+                display: "[ASIO] Example Driver - Inputs 3-4".to_owned(),
+                channels: vec![2, 3],
+            }
+        );
+        assert_eq!(
+            choices[2],
+            AsioInputChoice {
+                display: "[ASIO] Example Driver - Input 5".to_owned(),
+                channels: vec![4],
+            }
+        );
+    }
+
+    #[test]
+    fn selects_an_asio_pair_from_interleaved_frames() {
+        let source = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        assert_eq!(
+            select_interleaved_channels(&source, 4, &[2, 3]),
+            Some(vec![3.0, 4.0, 7.0, 8.0])
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_asio_channel_selection() {
+        assert_eq!(select_interleaved_channels(&[1.0, 2.0], 2, &[2]), None);
+        assert_eq!(select_interleaved_channels(&[1.0, 2.0], 0, &[0]), None);
+        assert_eq!(select_interleaved_channels(&[1.0, 2.0], 2, &[]), None);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -846,6 +846,7 @@ fn get_sound_inputs() -> Vec<String> {
             }
         }
     }
+    crate::audio_service::append_asio_input_devices(&mut out);
     out
 }
 

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -380,6 +380,7 @@ pub fn get_sound_inputs() -> Vec<String> {
                     }
                 }
             }
+            crate::audio_service::append_asio_input_devices(&mut out);
             out
         }
 


### PR DESCRIPTION
/claim #3762

## Summary

This draft addresses #3762 with a different routing model from the previously closed ASIO-input attempt.

RustDesk's existing Windows **System Sound** path remains on WASAPI loopback. When ASIO support is compiled in, this patch additionally exposes each ASIO driver's input channels as selectable stereo pairs (`1-2`, `3-4`, ...) with a mono tail when needed.

This is intended for interfaces/drivers that expose their playback/loopback mix on dedicated ASIO input channels, instead of treating the entire ASIO device as if it were a system-loopback source.

## Why this direction

The previous ASIO attempt (#15232) selected an ASIO device and captured its default input configuration. It was closed with feedback that it did not address ASIO loopback and lacked real-device validation.

ASIO does not provide the same WASAPI-style system-loopback semantic. RustDesk's CPAL ASIO backend instead exposes driver input channels.

This patch therefore makes those driver-provided routes selectable and extracts only the selected input pair before RustDesk's existing resample/rechannel/Opus pipeline.

## Changes

- Add opt-in Cargo feature `asio = ["cpal/asio"]`.
- Add `build.py --asio` with a Windows-only guard.
- Enable ASIO for the Windows x64 Flutter build.
- Install the Steinberg ASIO SDK in the Windows x64 CI build.
- Enumerate ASIO-capable drivers and expose their inputs as:
  - `[ASIO] <driver> - Inputs 1-2`
  - `[ASIO] <driver> - Inputs 3-4`
  - etc.
- Resolve the selected ASIO input pair to channel indices.
- Extract only the selected channels from the interleaved ASIO stream.
- Preserve the existing WASAPI/System Sound behavior when no ASIO route is selected.
- Add unit tests for:
  - stereo-pair generation
  - interleaved-channel extraction
  - invalid channel selections

## Validation

The implementation is one commit on top of upstream master and changes 7 files.

Completed checks:

- patch SHA-256 verification
- `git apply --check`
- `git diff --check`
- `python3 -m py_compile build.py`
- `rustfmt --edition 2021`
- `rustfmt --edition 2021 --check`
- Windows dependency-resolution probe

The Windows dependency probe confirmed:

- the default Windows feature graph does **not** include `asio-sys`
- `--features asio` resolves `asio-sys v0.2.2`
- dependency path is:
  `rustdesk feature "asio" -> cpal feature "asio" -> asio-sys`

## Hardware validation still required

This PR is intentionally submitted as a **draft** because real ASIO hardware validation is still required.

Please test on Windows x64 with an ASIO driver/interface that exposes a loopback or playback-mix input:

1. Confirm normal **System Sound** still works through WASAPI.
2. Confirm the ASIO driver appears as separate input pairs.
3. Identify the pair carrying the interface's loopback/playback mix.
4. Select that pair and play audio on the controlled machine.
5. Confirm the controller receives that audio.
6. Confirm unrelated physical inputs are not mixed into the selected route.
7. Switch back to System Sound and confirm there is no regression.

If @21pages or anyone with a real ASIO device can provide hardware test results, I can adjust the routing based on the findings before marking this ready for review.

## Scope

This does not invent a generic ASIO loopback facility where an ASIO driver exposes none.

It makes driver-provided loopback/input channels usable and selectable while preserving RustDesk's existing WASAPI loopback path.

Fixes #3762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows ASIO audio input support.
  * ASIO devices now appear alongside standard audio inputs and can be selected for recording.
  * Added stereo-pair and mono channel routing options for ASIO devices.
  * Windows builds can enable ASIO support when the required SDK is available.

* **Bug Fixes**
  * Improved validation and fallback handling for unavailable ASIO devices, formats, or channel selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds opt-in Windows ASIO capture and exposes each driver's input channels as selectable stereo pairs or a mono tail while retaining WASAPI for System Sound.
- Adds the Cargo/build feature and installs the Steinberg SDK for Windows x64 CI builds.
- Enumerates and resolves ASIO input-pair routes.
- Extracts selected channels before the existing resample, rechannel, and Opus pipeline.
- Adds unit coverage for pair generation, extraction, and invalid selections.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after hardware validation, with the non-blocking caveat that Sciter sound-input discovery can freeze the UI while an ASIO driver initializes.

The capture routing validates channel selections and preserves the WASAPI path, but the newly added Sciter enumeration performs potentially blocking ASIO host and driver queries synchronously.

**Files Needing Attention:** src/ui.rs, src/server/audio_service.rs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/server/audio_service.rs | Adds ASIO route enumeration, display-string resolution, selected-channel extraction, and tests; synchronous driver discovery may block callers. |
| src/ui.rs | Adds ASIO routes to the Sciter sound-input list synchronously, leaving third-party driver discovery on the UI thread. |
| src/ui_interface.rs | Adds ASIO routes to the existing thread-isolated Flutter device enumeration path. |
| build.py | Adds a Windows-only --asio option that enables the Cargo feature. |
| .github/workflows/flutter-build.yml | Enables ASIO for Windows x64 and installs and validates the required Steinberg SDK. |
| Cargo.toml | Exposes CPAL ASIO support through an opt-in project feature. |
| Cargo.lock | Locks the transitive ASIO backend and build dependencies. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    UI[Sound input selector] -->|System Sound| WASAPI[WASAPI loopback]
    UI -->|ASIO pair string| Resolve[Resolve ASIO driver and channel indices]
    Resolve --> Stream[Capture full ASIO input stream]
    Stream --> Extract[Extract selected pair or mono channel]
    WASAPI --> Pipeline[Resample / rechannel / Opus]
    Extract --> Pipeline
    Pipeline --> Remote[Send audio to controller]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fui.rs%3A849%0A**ASIO%20discovery%20blocks%20Sciter%20UI**%0A%0AIf%20an%20installed%20ASIO%20driver%20is%20slow%2C%20blocked%2C%20or%20displays%20initialization%20UI%2C%20this%20synchronous%20call%20initializes%20the%20ASIO%20host%2C%20enumerates%20every%20driver%2C%20and%20queries%20their%20input%20configurations%20on%20the%20Sciter%20UI%20thread%2C%20leaving%20the%20interface%20unresponsive%20without%20a%20timeout%20or%20cancellation%20path.%20The%20Flutter%20path%20already%20isolates%20audio-device%20enumeration%20from%20its%20UI%20thread.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15805&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22bounty-3762-asio-loopback%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bounty-3762-asio-loopback%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fui.rs%3A849%0A**ASIO%20discovery%20blocks%20Sciter%20UI**%0A%0AIf%20an%20installed%20ASIO%20driver%20is%20slow%2C%20blocked%2C%20or%20displays%20initialization%20UI%2C%20this%20synchronous%20call%20initializes%20the%20ASIO%20host%2C%20enumerates%20every%20driver%2C%20and%20queries%20their%20input%20configurations%20on%20the%20Sciter%20UI%20thread%2C%20leaving%20the%20interface%20unresponsive%20without%20a%20timeout%20or%20cancellation%20path.%20The%20Flutter%20path%20already%20isolates%20audio-device%20enumeration%20from%20its%20UI%20thread.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15805&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ui.rs:849
**ASIO discovery blocks Sciter UI**

If an installed ASIO driver is slow, blocked, or displays initialization UI, this synchronous call initializes the ASIO host, enumerates every driver, and queries their input configurations on the Sciter UI thread, leaving the interface unresponsive without a timeout or cancellation path. The Flutter path already isolates audio-device enumeration from its UI thread.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(windows): add ASIO input pair routi..."](https://github.com/rustdesk/rustdesk/commit/847d9ccfedf2f876f06cff46a2c8fb712d61d8d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51557448)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->