### PR TITLE
Revert "fix(linux): bound the xrandr call in the wayland primary-display lookup"

### DIFF
--- a/libs/scrap/src/wayland/display.rs
+++ b/libs/scrap/src/wayland/display.rs
@@ -76,9 +76,7 @@ fn run_with_timeout(
 // 2. The distro may not have xrandr installed by default.
 // 3. xrandr may not report "primary" in its output. eg. openSUSE Leap 15.6 KDE Plasma.
 fn try_xrandr_primary() -> Option<String> {
-    // Bounded like its two siblings below: this runs inside the held `DISPLAYS` guard, and from a
-    // service with no DISPLAY and no session bus, where an X client can block indefinitely.
-    let output = run_with_timeout("xrandr", &[], COMMAND_TIMEOUT, "xrandr")?;
+    let output = Command::new("xrandr").output().ok()?;
     if !output.status.success() {
         return None;
     }


### PR DESCRIPTION
Reverts rustdesk/rustdesk#15802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display detection reliability in Wayland environments.
  * Reduced unnecessary interruption during primary display identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reverts the timeout around the xrandr-based Wayland primary-display lookup.
- Restores direct synchronous execution of xrandr.
- Removes the finite command bound while the shared display cache is locked.
- Restores silent handling of command execution errors.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until the xrandr lookup is bounded so a stalled subprocess cannot indefinitely block Wayland display and session operations.

The changed first-choice lookup can wait forever while holding DISPLAYS, preventing all dependent display initialization and geometry paths from progressing; it also discards execution errors without diagnostics.

**Files Needing Attention:** libs/scrap/src/wayland/display.rs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/scrap/src/wayland/display.rs | Replaces the bounded xrandr invocation with an unbounded, silently failing subprocess wait inside the shared display-cache critical section. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alibs%2Fscrap%2Fsrc%2Fwayland%2Fdisplay.rs%3A79%0A**Unbounded%20lookup%20holds%20display%20lock**%0A%0AIf%20%60xrandr%60%20does%20not%20return%20because%20the%20X%20display%20or%20session%20bus%20is%20unavailable%2C%20%60get_displays%60%20waits%20indefinitely%20while%20holding%20%60DISPLAYS%60%2C%20blocking%20display%20enumeration%2C%20remote-session%20initialization%2C%20uinput%20geometry%20setup%2C%20and%20PipeWire%20or%20DRM%20display%20correction.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20output%20%3D%20run_with_timeout%28%22xrandr%22%2C%20%26%5B%5D%2C%20COMMAND_TIMEOUT%2C%20%22xrandr%22%29%3F%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Alibs%2Fscrap%2Fsrc%2Fwayland%2Fdisplay.rs%3A79%0A**Command%20errors%20lose%20diagnostics**%0A%0AConverting%20%60Command%3A%3Aoutput%60%20errors%20directly%20to%20%60None%60%20silently%20hides%20missing%20or%20unexecutable%20%60xrandr%60%20failures%2C%20making%20primary-display%20selection%20problems%20indistinguishable%20from%20a%20normal%20unavailable%20result%20and%20harder%20to%20diagnose.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15806&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22revert-15802-fix%2Fxrandr-timeout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22revert-15802-fix%2Fxrandr-timeout%22.%0A%0A%23%23%23%20Issue%201%0Alibs%2Fscrap%2Fsrc%2Fwayland%2Fdisplay.rs%3A79%0A**Unbounded%20lookup%20holds%20display%20lock**%0A%0AIf%20%60xrandr%60%20does%20not%20return%20because%20the%20X%20display%20or%20session%20bus%20is%20unavailable%2C%20%60get_displays%60%20waits%20indefinitely%20while%20holding%20%60DISPLAYS%60%2C%20blocking%20display%20enumeration%2C%20remote-session%20initialization%2C%20uinput%20geometry%20setup%2C%20and%20PipeWire%20or%20DRM%20display%20correction.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20output%20%3D%20run_with_timeout%28%22xrandr%22%2C%20%26%5B%5D%2C%20COMMAND_TIMEOUT%2C%20%22xrandr%22%29%3F%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Alibs%2Fscrap%2Fsrc%2Fwayland%2Fdisplay.rs%3A79%0A**Command%20errors%20lose%20diagnostics**%0A%0AConverting%20%60Command%3A%3Aoutput%60%20errors%20directly%20to%20%60None%60%20silently%20hides%20missing%20or%20unexecutable%20%60xrandr%60%20failures%2C%20making%20primary-display%20selection%20problems%20indistinguishable%20from%20a%20normal%20unavailable%20result%20and%20harder%20to%20diagnose.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15806&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/scrap/src/wayland/display.rs:79
**Unbounded lookup holds display lock**

If `xrandr` does not return because the X display or session bus is unavailable, `get_displays` waits indefinitely while holding `DISPLAYS`, blocking display enumeration, remote-session initialization, uinput geometry setup, and PipeWire or DRM display correction.

```suggestion
    let output = run_with_timeout("xrandr", &[], COMMAND_TIMEOUT, "xrandr")?;
```

### Issue 2
libs/scrap/src/wayland/display.rs:79
**Command errors lose diagnostics**

Converting `Command::output` errors directly to `None` silently hides missing or unexecutable `xrandr` failures, making primary-display selection problems indistinguishable from a normal unavailable result and harder to diagnose.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;fix(linux): bound the xrandr cal..."](https://github.com/rustdesk/rustdesk/commit/71572f7adbda5834221e5204093652803362e135) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51565289)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/rustdesk/rustdesk/blob/master/CLAUDE.md))

<!-- /greptile_comment -->