### PR TITLE
fix: do not abort when the rendezvous server offers no key exchange

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -32,7 +32,7 @@ use crate::{
     common::input::{MOUSE_BUTTON_LEFT, MOUSE_BUTTON_RIGHT, MOUSE_TYPE_DOWN, MOUSE_TYPE_UP},
     create_symmetric_key_msg, decode_id_pk, get_rs_pk, is_keyboard_mode_supported,
     kcp_stream::KcpStream,
-    secure_tcp,
+    secure_tcp_optional,
     ui_interface::{get_builtin_option, resolve_avatar_url, use_texture_render},
     ui_session_interface::{InvokeUiSession, Session},
 };
@@ -428,9 +428,8 @@ impl Client {
 
         let switch_code = interface.get_switch_code();
         if !key.is_empty() && (!token.is_empty() || !switch_code.is_empty()) {
-            secure_tcp(&mut socket, &key)
-                .await
-                .map_err(|e| anyhow!("Failed to secure tcp: {}", e))?;
+            // mainly for the security of token
+            secure_tcp_optional(&mut socket, &key).await;
         } else if let Some(udp) = udp.1.as_ref() {
             let tm = Instant::now();
             loop {
@@ -860,7 +859,8 @@ impl Client {
                 .with_context(|| "Failed to connect to rendezvous server")?;
 
             if !key.is_empty() && (!token.is_empty() || !switch_code.is_empty()) {
-                secure_tcp(&mut socket, key).await?;
+                // mainly for the security of token
+                secure_tcp_optional(&mut socket, key).await;
             }
 
             ipv4 = socket.local_addr().is_ipv4();
@@ -4062,7 +4062,7 @@ async fn hc_connection_(
     let host = check_port(&rendezvous_server, RENDEZVOUS_PORT);
     let mut conn = connect_tcp(host.clone(), CONNECT_TIMEOUT).await?;
     let key = crate::get_key(true).await;
-    crate::secure_tcp(&mut conn, &key).await?;
+    crate::secure_tcp_optional(&mut conn, &key).await;
     let mut msg_out = RendezvousMessage::new();
     msg_out.set_hc(HealthCheck {
         token,

--- a/src/common.rs
+++ b/src/common.rs
@@ -62,6 +62,10 @@ pub const PLATFORM_ANDROID: &str = "Android";
 
 pub const TIMER_OUT: Duration = Duration::from_secs(1);
 pub const DEFAULT_KEEP_ALIVE: i32 = 60_000;
+// A server that supports key exchange sends KeyExchange right after accept, so
+// the reply arrives within one RTT. One second is a generous bound for that,
+// while a server that never sends it no longer costs a full READ_TIMEOUT.
+const SECURE_TCP_TIMEOUT: u64 = 1_000;
 
 const MIN_VER_MULTI_UI_SESSION: &str = "1.2.4";
 
@@ -1185,7 +1189,7 @@ fn get_tcp_proxy_addr() -> String {
 }
 
 /// Send an HTTP request via the rendezvous server's TCP proxy using protobuf.
-/// Connects with `connect_tcp` + `secure_tcp`, sends `HttpProxyRequest`,
+/// Connects with `connect_tcp` + `secure_tcp_silent`, sends `HttpProxyRequest`,
 /// receives `HttpProxyResponse`.
 ///
 /// The entire operation (connect + handshake + send + receive) is wrapped in
@@ -2033,8 +2037,22 @@ async fn secure_tcp_impl(conn: &mut Stream, key: &str, log_on_success: bool) -> 
     Ok(())
 }
 
-pub async fn secure_tcp(conn: &mut Stream, key: &str) -> ResultType<()> {
-    secure_tcp_impl(conn, key, true).await
+// Only hbbs from rustdesk-server-pro initiates the key exchange. The
+// open-source rustdesk-server replies to client messages but stays silent on a
+// bare connection, so secure_tcp_impl waits out READ_TIMEOUT and the caller
+// aborts: with an account logged in (token is not empty) no outgoing connection
+// can be established at all against a self-hosted server.
+//
+// Give the server a short window and, if it stays silent, continue over the
+// plain channel the way the client did before key exchange existed. On servers
+// that do implement it nothing changes: the exchange completes within one RTT
+// and the token keeps its confidentiality.
+pub async fn secure_tcp_optional(conn: &mut Stream, key: &str) {
+    match timeout(SECURE_TCP_TIMEOUT, secure_tcp_impl(conn, key, true)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => log::warn!("Failed to secure tcp: {err}"),
+        Err(_) => log::info!("Rendezvous server offers no key exchange, continuing unencrypted"),
+    }
 }
 
 async fn secure_tcp_silent(conn: &mut Stream, key: &str) -> ResultType<()> {

--- a/src/rendezvous_mediator.rs
+++ b/src/rendezvous_mediator.rs
@@ -425,7 +425,7 @@ impl RendezvousMediator {
         log::info!("start tcp: {}", hbb_common::websocket::check_ws(&host));
         let mut conn = connect_tcp(host.clone(), CONNECT_TIMEOUT).await?;
         let key = crate::get_key(true).await;
-        crate::secure_tcp(&mut conn, &key).await?;
+        crate::secure_tcp_optional(&mut conn, &key).await;
         let mut rz = Self {
             addr: conn.local_addr().into_target_addr()?,
             host: host.clone(),


### PR DESCRIPTION
### Problem

`secure_tcp` waits `READ_TIMEOUT` (18s) for a `KeyExchange` message and returns an error if none arrives. Only `hbbs` from rustdesk-server-pro sends it; the open-source `rustdesk-server` stays silent on a bare connection and only replies to client messages.

As a result, as soon as an account is logged in (`token` is not empty), **every** outgoing connection against a self-hosted server fails with `Failed to secure tcp` after 18 seconds. All four call sites are affected:

- `Client::_start_inner` — punch hole
- `Client::request_relay` — relay request
- `RendezvousMediator::start_tcp` — TCP registration fallback when UDP 21116 is unavailable
- `hc_connection_` — health check

Logging out restores connectivity, which is what makes this easy to misdiagnose as an API-server problem.

### Fix

`secure_tcp` becomes `secure_tcp_optional`: the exchange is bounded by a short timeout and, if the server stays silent, the client continues over the plain channel the way it did before key exchange existed.

### Why this does not weaken the token

A server that implements key exchange sends `KeyExchange` immediately after `accept`, so the reply arrives within one RTT and the exchange completes normally — the token stays encrypted exactly where it is encrypted today. Only servers that never offered the exchange fall back, and there the current behaviour is not a protected token but a client that cannot connect at all.

This is deliberately the targeted variant suggested during review of #15743, which addressed the same failure by removing `secure_tcp` outright and was rejected for sending the access token in cleartext even against servers that do support the exchange.

`secure_tcp_silent` (TCP proxy) is left untouched.

### Testing

Running in production on a self-hosted open-source `rustdesk-server` since 2026-08-01 across Windows, Linux and Android builds: outgoing connections, relay and health check all work with an account logged in, and the 18-second stall is gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP rendezvous connection reliability by allowing connections to continue when optional security negotiation is unavailable.
  * Added a brief timeout for secure handshake attempts, preventing connections from stalling.
  * Added logging for handshake failures and timeouts while preserving connectivity with compatible servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces mandatory rendezvous key exchange with a one-second optional attempt so clients can continue with servers that remain silent on new connections.
- Adds `secure_tcp_optional` and a dedicated handshake timeout.
- Migrates punch-hole, relay, health-check, and TCP registration paths to optional negotiation.
- Leaves the TCP proxy’s `secure_tcp_silent` behavior unchanged.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until failed or invalid key exchanges abort rather than allowing token-bearing traffic to continue unencrypted.

The intended silence-only compatibility fallback also catches signature mismatches and malformed exchanges, turning authenticated-handshake failures into plaintext continuation across the changed rendezvous callers.

**Files Needing Attention:** src/common.rs, src/client.rs, src/rendezvous_mediator.rs
</details>

<details open><summary><h3>Security Review</h3></summary>

The fallback currently includes authenticated-handshake failures, not only server silence. A malformed exchange or signature mismatch therefore causes token-bearing traffic to continue over the plaintext stream rather than aborting.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/common.rs | Introduces optional key exchange but conflates server silence with authentication and validation failures, enabling an unintended plaintext downgrade. |
| src/client.rs | Migrates three token-bearing connection paths to the optional handshake, exposing them to the overly broad fallback in common.rs. |
| src/rendezvous_mediator.rs | Migrates TCP rendezvous registration to optional key exchange and inherits the same failure-handling behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Connect to rendezvous server] --> B[Wait up to one second for KeyExchange]
    B -->|Valid exchange| C[Install symmetric key]
    B -->|No message| D[Continue plaintext]
    B -->|Invalid exchange or signature| D
    C --> E[Send rendezvous request]
    D --> E
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fcommon.rs%3A2053%0A**Handshake%20failures%20permit%20plaintext%20downgrade**%0A%0AWhen%20a%20server%20offers%20an%20invalid%20key%20exchange%20or%20its%20signature%20fails%20verification%2C%20%60secure_tcp_optional%60%20logs%20the%20authentication%20error%20and%20continues%20on%20the%20unencrypted%20stream%2C%20causing%20subsequent%20token-bearing%20punch-hole%2C%20relay%2C%20and%20health-check%20requests%20to%20be%20transmitted%20without%20the%20expected%20transport%20encryption.%0A%0A**How%20this%20was%20verified%3A**%20The%20validation%20errors%20returned%20by%20%60secure_tcp_impl%60%20reach%20the%20new%20%60Ok%28Err%28err%29%29%60%20branch%2C%20which%20returns%20normally%20before%20the%20callers%20construct%20their%20token-bearing%20requests.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fcommon.rs%3A2040-2049%0A**Comment%20embeds%20implementation%20history**%0A%0AThis%20nine-line%20comment%20records%20the%20former%20timeout%20failure%2C%20server%20implementation%20differences%2C%20and%20historical%20fallback%20rationale.%20Repository%20guidance%20limits%20comments%20to%20three%20lines%20and%20reserves%20this%20historical%20context%20for%20the%20PR%20or%20commit%20message%2C%20so%20retaining%20it%20here%20adds%20documentation%20that%20can%20drift%20from%20the%20implementation.%0A%0A%60%60%60suggestion%0A%2F%2F%20Attempt%20key%20exchange%20briefly%2C%20then%20retain%20plaintext%20compatibility%20with%0A%2F%2F%20rendezvous%20servers%20that%20do%20not%20initiate%20it.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15809&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix%2Fgraceful-key-exchange%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgraceful-key-exchange%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcommon.rs%3A2053%0A**Handshake%20failures%20permit%20plaintext%20downgrade**%0A%0AWhen%20a%20server%20offers%20an%20invalid%20key%20exchange%20or%20its%20signature%20fails%20verification%2C%20%60secure_tcp_optional%60%20logs%20the%20authentication%20error%20and%20continues%20on%20the%20unencrypted%20stream%2C%20causing%20subsequent%20token-bearing%20punch-hole%2C%20relay%2C%20and%20health-check%20requests%20to%20be%20transmitted%20without%20the%20expected%20transport%20encryption.%0A%0A**How%20this%20was%20verified%3A**%20The%20validation%20errors%20returned%20by%20%60secure_tcp_impl%60%20reach%20the%20new%20%60Ok%28Err%28err%29%29%60%20branch%2C%20which%20returns%20normally%20before%20the%20callers%20construct%20their%20token-bearing%20requests.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fcommon.rs%3A2040-2049%0A**Comment%20embeds%20implementation%20history**%0A%0AThis%20nine-line%20comment%20records%20the%20former%20timeout%20failure%2C%20server%20implementation%20differences%2C%20and%20historical%20fallback%20rationale.%20Repository%20guidance%20limits%20comments%20to%20three%20lines%20and%20reserves%20this%20historical%20context%20for%20the%20PR%20or%20commit%20message%2C%20so%20retaining%20it%20here%20adds%20documentation%20that%20can%20drift%20from%20the%20implementation.%0A%0A%60%60%60suggestion%0A%2F%2F%20Attempt%20key%20exchange%20briefly%2C%20then%20retain%20plaintext%20compatibility%20with%0A%2F%2F%20rendezvous%20servers%20that%20do%20not%20initiate%20it.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15809&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/common.rs:2053
**Handshake failures permit plaintext downgrade**

When a server offers an invalid key exchange or its signature fails verification, `secure_tcp_optional` logs the authentication error and continues on the unencrypted stream, causing subsequent token-bearing punch-hole, relay, and health-check requests to be transmitted without the expected transport encryption.

**How this was verified:** The validation errors returned by `secure_tcp_impl` reach the new `Ok(Err(err))` branch, which returns normally before the callers construct their token-bearing requests.

### Issue 2
src/common.rs:2040-2049
**Comment embeds implementation history**

This nine-line comment records the former timeout failure, server implementation differences, and historical fallback rationale. Repository guidance limits comments to three lines and reserves this historical context for the PR or commit message, so retaining it here adds documentation that can drift from the implementation.

```suggestion
// Attempt key exchange briefly, then retain plaintext compatibility with
// rendezvous servers that do not initiate it.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: do not abort when the rendezvous se..."](https://github.com/rustdesk/rustdesk/commit/7cefd4e607179ad6ea9c4588bc98ad18e59e348f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51618392)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rustdesk/rustdesk/blob/master/AGENTS.md))

<!-- /greptile_comment -->