### PR TITLE
fix(windows): filter detached DXGI outputs for Win+P single-display modes

### DIFF
--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -8,6 +8,10 @@ on:
 
 jobs:
   run-flutter-nightly-build:
+    # Caller must grant at least what nested jobs request (e.g. generate-sbom).
+    # Forks default GITHUB_TOKEN to read-only, which otherwise fails validation.
+    permissions:
+      contents: write
     uses: ./.github/workflows/flutter-build.yml
     secrets: inherit
     with:

--- a/libs/scrap/src/common/dxgi.rs
+++ b/libs/scrap/src/common/dxgi.rs
@@ -132,7 +132,9 @@ impl Display {
             .map(Display)
             .collect::<Vec<_>>();
 
-        let displays_dxgi = Self::all_().unwrap_or(Default::default());
+        let mut displays_dxgi = Self::all_().unwrap_or(Default::default());
+        // Win+P "Show only on 1/2" still enumerates detached DXGI outputs.
+        displays_dxgi.retain(|d| d.is_online() && d.width() > 0 && d.height() > 0);
 
         // Return gdi displays if dxgi is not supported
         if displays_dxgi.is_empty() {
@@ -155,7 +157,6 @@ impl Display {
         }
 
         // Reorder displays from dxgi
-        let mut displays_dxgi = displays_dxgi;
         let mut displays_dxgi_ordered = Vec::new();
         for name in names_gdi.iter() {
             let pos = match displays_dxgi.iter().position(|d| d.name() == *name) {
@@ -201,7 +202,8 @@ impl Display {
 
     pub fn is_primary(&self) -> bool {
         // https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-devmodea
-        self.origin() == (0, 0)
+        // Detached outputs can still report origin (0,0) with a zero size.
+        self.origin() == (0, 0) && self.width() > 0 && self.height() > 0
     }
 
     #[cfg(feature = "vram")]


### PR DESCRIPTION
## Summary
- Filter DXGI outputs that are not attached to the desktop (or have zero size) in `Display::all()`, so Win+P "Show only on 1/2" no longer exposes detached monitors.
- Tighten `is_primary()` to require non-zero width/height, avoiding zero-size detached outputs being treated as the primary display.
- Fixes clients hanging on "Connected, waiting for image..." when connecting to a dual-monitor Windows host that is not in Extend mode ([Discussion #15450](https://github.com/rustdesk/rustdesk/discussions/15450)).

## Test plan
- [ ] On a laptop + external monitor Windows host, set Win+P to **PC screen only**, connect from a phone → image should appear (not stuck waiting).
- [ ] Same with Win+P **Second screen only**.
- [ ] Same with Win+P **Extend** (regression).
- [ ] Connect while in Extend, then switch to single-display mode → session should keep working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display detection by excluding offline and zero-sized displays.
  * Improved primary display identification to require valid dimensions and a standard origin.
  * Prevented detached or invalid display outputs from appearing in display listings.

* **Chores**
  * Updated nightly build permissions for reliable workflow execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR filters detached or zero-sized Windows DXGI outputs and prevents them from being identified as primary displays. It also grants the nightly reusable workflow the content permission requested by nested jobs.
- Retains only attached, non-zero-sized DXGI displays before reconciliation with GDI enumeration.
- Requires valid dimensions when identifying a primary Windows display.
- Grants `contents: write` to the Flutter nightly workflow caller.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/scrap/src/common/dxgi.rs | Filters invalid DXGI outputs and tightens primary-display detection to avoid selecting detached monitors. |
| .github/workflows/flutter-nightly.yml | Grants the reusable nightly workflow the content permission required by nested jobs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: grant contents write to Flutter Nigh..."](https://github.com/rustdesk/rustdesk/commit/bb4bccd3e38706da142a2e23a967f4cdd5427b60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51686996)</sub>

<!-- /greptile_comment -->