### PR TITLE
fix(windows): filter detached DXGI outputs for Win+P single-display modes

### DIFF
--- a/libs/scrap/src/common/dxgi.rs
+++ b/libs/scrap/src/common/dxgi.rs
@@ -132,7 +132,15 @@ impl Display {
             .map(Display)
             .collect::<Vec<_>>();
 
-        let displays_dxgi = Self::all_().unwrap_or(Default::default());
+        let mut displays_dxgi = match Self::all_() {
+            Ok(displays) => displays,
+            Err(e) => {
+                hbb_common::log::error!("DXGI display enumeration failed: {e}");
+                Vec::new()
+            }
+        };
+        // Win+P "Show only on 1/2" still enumerates detached DXGI outputs.
+        displays_dxgi.retain(|d| d.is_online() && d.width() > 0 && d.height() > 0);
 
         // Return gdi displays if dxgi is not supported
         if displays_dxgi.is_empty() {
@@ -155,7 +163,6 @@ impl Display {
         }
 
         // Reorder displays from dxgi
-        let mut displays_dxgi = displays_dxgi;
         let mut displays_dxgi_ordered = Vec::new();
         for name in names_gdi.iter() {
             let pos = match displays_dxgi.iter().position(|d| d.name() == *name) {
@@ -176,11 +183,11 @@ impl Display {
     }
 
     pub fn width(&self) -> usize {
-        self.0.width() as usize
+        self.0.width().max(0) as usize
     }
 
     pub fn height(&self) -> usize {
-        self.0.height() as usize
+        self.0.height().max(0) as usize
     }
 
     pub fn name(&self) -> String {
@@ -201,7 +208,8 @@ impl Display {
 
     pub fn is_primary(&self) -> bool {
         // https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-devmodea
-        self.origin() == (0, 0)
+        // Detached outputs can still report origin (0,0) with a zero size.
+        self.origin() == (0, 0) && self.width() > 0 && self.height() > 0
     }
 
     #[cfg(feature = "vram")]


### PR DESCRIPTION
> **Disclaimer — please review carefully before merging**
>
> This PR was prepared with an AI coding agent. I am not familiar with Rust or remote-desktop internals; I attempted this fix only because RustDesk is open source and I hit the bug myself. **Please do not merge without maintainer review.** Treat the change as a minimal, hypothesis-driven patch that needs domain-expert validation.

## Problem

Reported in https://github.com/rustdesk/rustdesk/discussions/15450

On a Windows host with a laptop + external monitor:

- Win+P **Extend** → remote connection works
- Win+P **PC screen only** / **Second screen only** → client stays on **"Connected, waiting for image..."**
- If a session is already connected in Extend mode, switching to a single-display mode may keep working; after disconnect/reconnect in single-display mode, it hangs again

I found this empirically while using the software; I do not claim deep expertise in the capture stack.

## Suspected root cause

On Win+P single-display modes:

1. GDI enumeration (`DISPLAY_DEVICE_ACTIVE`) usually returns only the active display
2. DXGI `EnumOutputs` can still return **detached** outputs (`AttachedToDesktop == 0`), often with **zero size**
3. `Display::all()` currently falls back to the unfiltered DXGI list when GDI/DXGI counts differ
4. `is_primary()` treats `origin == (0, 0)` as primary, so a zero-size detached output can be selected
5. Capture then fails to produce frames → client waits forever for the first image

## Minimal fix

In `libs/scrap/src/common/dxgi.rs` only:

1. After DXGI enumeration, drop outputs that are offline or have zero width/height
2. Require non-zero size in `is_primary()` so a detached `(0,0)` output is not treated as primary

No Flutter / protocol / UI changes.

## Verification

I replaced `librustdesk.dll` on the affected Windows host with a CI build of this change and retested:

- [x] Win+P **PC screen only** — connects and shows image
- [x] Win+P **Second screen only** — connects and shows image
- [x] Win+P **Extend** — still works

## Request to maintainers

Please review whether filtering detached DXGI outputs is the correct long-term approach (vs. intersecting with the GDI ACTIVE set, or another Windows display-selection path). If there is a preferred pattern already used elsewhere in the codebase, I am happy to adjust under guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display detection by excluding offline or zero-sized displays.
  * Corrected primary display identification to require valid, positive dimensions.
  * Prevented invalid negative display dimensions from affecting reported screen sizes.
  * Improved resilience when display information cannot be enumerated by safely falling back to no detected displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR filters detached or zero-sized DXGI outputs from Windows display enumeration and prevents zero-sized outputs at `(0, 0)` from being classified as primary.

- Retains only attached DXGI outputs with positive dimensions.
- Preserves GDI fallback when no usable DXGI output remains.
- Tightens primary-display detection for detached outputs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The filtered outputs are detached or zero-sized, GDI fallback remains available when filtering empties the DXGI list, and callers already handle the absence of a primary match by selecting a safe fallback path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/scrap/src/common/dxgi.rs | Adds narrowly scoped validity filtering and primary-display guards without an identified regression in existing enumeration or capture callers. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Filter detached DXGI outputs for Win+P s..."](https://github.com/rustdesk/rustdesk/commit/f54bf44c97105091f56bce74cef1a10714181db6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51706270)</sub>

<!-- /greptile_comment -->