### PR TITLE
fix(terminal): send SGR mouse wheel reports with the button codes app…

### DIFF
--- a/flutter/lib/models/terminal_model.dart
+++ b/flutter/lib/models/terminal_model.dart
@@ -129,10 +129,8 @@ class TerminalModel with ChangeNotifier {
   }
 
   TerminalModel(this.parent, [this.terminalId = 0]) : id = parent.id {
-    terminal = Terminal(
-      maxLines: 10000,
-      mouseHandler: const WheelButtonFixMouseHandler(),
-    );
+    terminal = Terminal(maxLines: 10000);
+    terminal.mouseHandler = const WheelButtonFixMouseHandler();
     terminalController = TerminalController();
 
     // Setup terminal callbacks

--- a/flutter/lib/models/terminal_model.dart
+++ b/flutter/lib/models/terminal_model.dart
@@ -10,6 +10,7 @@ import 'package:xterm/xterm.dart';
 import 'input_modifier_utils.dart';
 import 'model.dart';
 import 'platform_model.dart';
+import 'terminal_mouse_handler.dart';
 
 class TerminalModel with ChangeNotifier {
   final String id; // peer id
@@ -128,7 +129,10 @@ class TerminalModel with ChangeNotifier {
   }
 
   TerminalModel(this.parent, [this.terminalId = 0]) : id = parent.id {
-    terminal = Terminal(maxLines: 10000);
+    terminal = Terminal(
+      maxLines: 10000,
+      mouseHandler: const WheelButtonFixMouseHandler(),
+    );
     terminalController = TerminalController();
 
     // Setup terminal callbacks

--- a/flutter/lib/models/terminal_mouse_handler.dart
+++ b/flutter/lib/models/terminal_mouse_handler.dart
@@ -8,15 +8,21 @@ class WheelButtonFixMouseHandler implements TerminalMouseHandler {
 
   @override
   String? call(TerminalMouseEvent event) {
-    final report = defaultMouseHandler(event);
-    if (report == null || !event.button.isWheel) {
-      return report;
+    if (!event.button.isWheel) {
+      return defaultMouseHandler(event);
+    }
+    // Same gate as UpDownMouseHandler: only the scroll modes report a wheel,
+    // and a wheel release is never reported, so the report is always a press.
+    if (!event.state.mouseMode.reportScroll ||
+        event.buttonState == TerminalMouseButtonState.up) {
+      return null;
     }
     return _reportWheel(event);
   }
 
   String _reportWheel(TerminalMouseEvent event) {
-    final button = _wheelButtonId(event.button);
+    // Wheel buttons 4..7 go on the wire as 64..67, but `id` is 64 + 4..7.
+    final button = event.button.id - 4;
     final x = event.position.x + 1;
     final y = event.position.y + 1;
     switch (event.state.mouseReportMode) {
@@ -25,27 +31,12 @@ class WheelButtonFixMouseHandler implements TerminalMouseHandler {
         final limit =
             event.state.mouseReportMode == MouseReportMode.normal ? 223 : 2015;
         final col = x > limit ? '\x00' : String.fromCharCode(32 + x);
-        final row = y > limit ? '\x00' : String.fromCharCode(32 + y + 1);
+        final row = y > limit ? '\x00' : String.fromCharCode(32 + y);
         return '\x1b[M${String.fromCharCode(32 + button)}$col$row';
       case MouseReportMode.sgr:
         return '\x1b[<$button;$x;${y}M';
       case MouseReportMode.urxvt:
         return '\x1b[${32 + button};$x;${y}M';
-    }
-  }
-
-  int _wheelButtonId(TerminalMouseButton button) {
-    switch (button) {
-      case TerminalMouseButton.wheelUp:
-        return 64;
-      case TerminalMouseButton.wheelDown:
-        return 65;
-      case TerminalMouseButton.wheelLeft:
-        return 66;
-      case TerminalMouseButton.wheelRight:
-        return 67;
-      default:
-        return button.id;
     }
   }
 }

--- a/flutter/lib/models/terminal_mouse_handler.dart
+++ b/flutter/lib/models/terminal_mouse_handler.dart
@@ -1,0 +1,51 @@
+import 'package:xterm/xterm.dart';
+
+/// xterm 4.0.0 encodes wheel buttons as 68..71; the extra bit reads as a Shift
+/// modifier, so strict full-screen apps ignore the report and never scroll.
+/// Upstream fix: TerminalStudio/xterm.dart#238.
+class WheelButtonFixMouseHandler implements TerminalMouseHandler {
+  const WheelButtonFixMouseHandler();
+
+  @override
+  String? call(TerminalMouseEvent event) {
+    final report = defaultMouseHandler(event);
+    if (report == null || !event.button.isWheel) {
+      return report;
+    }
+    return _reportWheel(event);
+  }
+
+  String _reportWheel(TerminalMouseEvent event) {
+    final button = _wheelButtonId(event.button);
+    final x = event.position.x + 1;
+    final y = event.position.y + 1;
+    switch (event.state.mouseReportMode) {
+      case MouseReportMode.normal:
+      case MouseReportMode.utf:
+        final limit =
+            event.state.mouseReportMode == MouseReportMode.normal ? 223 : 2015;
+        final col = x > limit ? '\x00' : String.fromCharCode(32 + x);
+        final row = y > limit ? '\x00' : String.fromCharCode(32 + y + 1);
+        return '\x1b[M${String.fromCharCode(32 + button)}$col$row';
+      case MouseReportMode.sgr:
+        return '\x1b[<$button;$x;${y}M';
+      case MouseReportMode.urxvt:
+        return '\x1b[${32 + button};$x;${y}M';
+    }
+  }
+
+  int _wheelButtonId(TerminalMouseButton button) {
+    switch (button) {
+      case TerminalMouseButton.wheelUp:
+        return 64;
+      case TerminalMouseButton.wheelDown:
+        return 65;
+      case TerminalMouseButton.wheelLeft:
+        return 66;
+      case TerminalMouseButton.wheelRight:
+        return 67;
+      default:
+        return button.id;
+    }
+  }
+}

--- a/flutter/test/terminal_model_lifecycle_test.dart
+++ b/flutter/test/terminal_model_lifecycle_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/terminal_model.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
 
 class _FakeFFI implements FFI {
   @override
@@ -47,5 +48,21 @@ void main() {
     expect(checkedCtrlLock, isFalse);
     expect(clearedCtrlLock, isFalse);
     expect(model.debugBufferedInputCount, 0);
+  });
+
+  test('builds its terminal with the wheel button fix', () {
+    final model = TerminalModel(_FakeFFI());
+    addTearDown(model.dispose);
+
+    final captured = <String>[];
+    model.terminal.onOutput = captured.add;
+    model.terminal.write('\x1b[?1000h\x1b[?1006h');
+    model.terminal.mouseInput(
+      TerminalMouseButton.wheelUp,
+      TerminalMouseButtonState.down,
+      const CellOffset(10, 5),
+    );
+
+    expect(captured.single, '\x1b[<64;11;6M');
   });
 }

--- a/flutter/test/terminal_mouse_handler_test.dart
+++ b/flutter/test/terminal_mouse_handler_test.dart
@@ -15,9 +15,10 @@ void main() {
   String? report(
     TerminalMouseButton button, [
     TerminalMouseButtonState state = TerminalMouseButtonState.down,
+    CellOffset position = const CellOffset(10, 5),
   ]) {
     output.clear();
-    terminal.mouseInput(button, state, const CellOffset(10, 5));
+    terminal.mouseInput(button, state, position);
     return output.isEmpty ? null : output.single;
   }
 
@@ -36,7 +37,46 @@ void main() {
     expect(
       report(TerminalMouseButton.wheelUp),
       '\x1b[M${String.fromCharCode(32 + 64)}'
-      '${String.fromCharCode(32 + 11)}${String.fromCharCode(32 + 6 + 1)}',
+      '${String.fromCharCode(32 + 11)}${String.fromCharCode(32 + 6)}',
+    );
+    expect(
+      report(TerminalMouseButton.wheelDown),
+      '\x1b[M${String.fromCharCode(32 + 65)}'
+      '${String.fromCharCode(32 + 11)}${String.fromCharCode(32 + 6)}',
+    );
+  });
+
+  test('reports utf-encoding wheel buttons beyond the normal-mode range', () {
+    terminal.write('\x1b[?1000h\x1b[?1005h');
+
+    expect(
+      report(
+        TerminalMouseButton.wheelDown,
+        TerminalMouseButtonState.down,
+        const CellOffset(400, 300),
+      ),
+      '\x1b[M${String.fromCharCode(32 + 65)}'
+      '${String.fromCharCode(32 + 401)}${String.fromCharCode(32 + 301)}',
+    );
+  });
+
+  test('reports urxvt-encoding wheel buttons shifted by 32', () {
+    terminal.write('\x1b[?1000h\x1b[?1015h');
+
+    expect(report(TerminalMouseButton.wheelUp), '\x1b[96;11;6M');
+    expect(report(TerminalMouseButton.wheelDown), '\x1b[97;11;6M');
+  });
+
+  test('sends a null byte for coordinates past the encoding limit', () {
+    terminal.write('\x1b[?1000h');
+
+    expect(
+      report(
+        TerminalMouseButton.wheelUp,
+        TerminalMouseButtonState.down,
+        const CellOffset(300, 300),
+      ),
+      '\x1b[M${String.fromCharCode(32 + 64)}\x00\x00',
     );
   });
 
@@ -54,6 +94,13 @@ void main() {
   test('stays silent when the peer has not enabled mouse reporting', () {
     expect(report(TerminalMouseButton.wheelDown), isNull);
     expect(report(TerminalMouseButton.left), isNull);
+  });
+
+  test('stays silent for the wheel in click-only mode', () {
+    terminal.write('\x1b[?9h\x1b[?1006h');
+
+    expect(report(TerminalMouseButton.wheelDown), isNull);
+    expect(report(TerminalMouseButton.left), '\x1b[<0;11;6M');
   });
 
   test('does not report wheel button releases', () {

--- a/flutter/test/terminal_mouse_handler_test.dart
+++ b/flutter/test/terminal_mouse_handler_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_hbb/models/terminal_mouse_handler.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xterm/xterm.dart';
+
+void main() {
+  late Terminal terminal;
+  late List<String> output;
+
+  setUp(() {
+    output = <String>[];
+    terminal = Terminal(mouseHandler: const WheelButtonFixMouseHandler())
+      ..onOutput = output.add;
+  });
+
+  String? report(
+    TerminalMouseButton button, [
+    TerminalMouseButtonState state = TerminalMouseButtonState.down,
+  ]) {
+    output.clear();
+    terminal.mouseInput(button, state, const CellOffset(10, 5));
+    return output.isEmpty ? null : output.single;
+  }
+
+  test('reports SGR wheel buttons without the Shift modifier bit', () {
+    terminal.write('\x1b[?1000h\x1b[?1006h');
+
+    expect(report(TerminalMouseButton.wheelUp), '\x1b[<64;11;6M');
+    expect(report(TerminalMouseButton.wheelDown), '\x1b[<65;11;6M');
+    expect(report(TerminalMouseButton.wheelLeft), '\x1b[<66;11;6M');
+    expect(report(TerminalMouseButton.wheelRight), '\x1b[<67;11;6M');
+  });
+
+  test('reports normal-encoding wheel buttons in the 64..67 range', () {
+    terminal.write('\x1b[?1000h');
+
+    expect(
+      report(TerminalMouseButton.wheelUp),
+      '\x1b[M${String.fromCharCode(32 + 64)}'
+      '${String.fromCharCode(32 + 11)}${String.fromCharCode(32 + 6 + 1)}',
+    );
+  });
+
+  test('leaves non-wheel buttons to the upstream handler', () {
+    terminal.write('\x1b[?1000h\x1b[?1006h');
+
+    expect(report(TerminalMouseButton.left), '\x1b[<0;11;6M');
+    expect(report(TerminalMouseButton.middle), '\x1b[<1;11;6M');
+    expect(
+      report(TerminalMouseButton.right, TerminalMouseButtonState.up),
+      '\x1b[<2;11;6m',
+    );
+  });
+
+  test('stays silent when the peer has not enabled mouse reporting', () {
+    expect(report(TerminalMouseButton.wheelDown), isNull);
+    expect(report(TerminalMouseButton.left), isNull);
+  });
+
+  test('does not report wheel button releases', () {
+    terminal.write('\x1b[?1000h\x1b[?1006h');
+
+    expect(
+      report(TerminalMouseButton.wheelDown, TerminalMouseButtonState.up),
+      isNull,
+    );
+  });
+}


### PR DESCRIPTION
…s expect

xterm.dart 4.0.0 encodes the wheel buttons as 64+4..64+7 rather than 64+0..64+3, so the low bits land on the modifier field and every wheel report the terminal emits reads as wheel-with-Shift. Strict full-screen applications reject the modified event, which is why neither the mouse wheel nor the trackpad scrolls anything once the peer application takes over the alternate screen.

Install a mouse handler that keeps every upstream reporting decision and only re-encodes the wheel buttons as 64..67. Non-wheel reports pass through untouched, and the emitted bytes stay identical once upstream ships the same fix, so this can be dropped without a behavior change.

Upstream: TerminalStudio/xterm.dart#238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal mouse-wheel handling across supported mouse-reporting modes, including SGR, normal, UTF, and URXVT.
  * Corrected wheel button mappings and coordinate reporting for more reliable terminal input.
  * Prevented unnecessary wheel-button release events and suppressed unsupported wheel actions.
  * Preserved existing behavior for non-wheel mouse actions and disabled or click-only reporting.
  * Improved handling of coordinate limits to ensure valid mouse reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR installs a custom terminal mouse handler that corrects xterm.dart 4.0.0 wheel-button codes while preserving upstream behavior for non-wheel events.
- Re-encodes wheel buttons as protocol values 64–67 across normal, UTF, SGR, and urxvt reporting modes.
- Suppresses wheel releases and respects the terminal’s active mouse-reporting mode.
- Adds handler-level and `TerminalModel` lifecycle coverage for encoding, coordinates, reporting gates, and delegation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/models/terminal_model.dart | Installs the wheel-button compatibility handler on every newly constructed terminal. |
| flutter/lib/models/terminal_mouse_handler.dart | Corrects wheel-button encoding while retaining reporting gates, coordinate conversion, mode-specific formatting, and upstream handling for non-wheel events. |
| flutter/test/terminal_model_lifecycle_test.dart | Verifies that `TerminalModel` configures the handler and emits the corrected SGR wheel report. |
| flutter/test/terminal_mouse_handler_test.dart | Covers all reporting modes, coordinate bounds, non-wheel delegation, disabled reporting, click-only mode, and wheel releases. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Terminal mouse input] --> B{Wheel event?}
    B -- No --> C[Delegate to default mouse handler]
    B -- Yes --> D{Scroll reporting enabled and button down?}
    D -- No --> E[Emit nothing]
    D -- Yes --> F[Map wheel button to 64–67]
    F --> G{Mouse report mode}
    G --> H[Normal or UTF encoding]
    G --> I[SGR encoding]
    G --> J[urxvt encoding]
    H --> K[Send report]
    I --> K
    J --> K
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(terminal): correct the wheel report ..."](https://github.com/rustdesk/rustdesk/commit/ae5ef08c11fb58fec32691cd28ff5f5b544f8147) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51783574)</sub>

<!-- /greptile_comment -->