### PR TITLE
Replace privacy mode entry dialog with status icon

### DIFF
--- a/flutter/lib/common/widgets/privacy_mode_indicator.dart
+++ b/flutter/lib/common/widgets/privacy_mode_indicator.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class PrivacyModeIndicator extends StatelessWidget {
+  const PrivacyModeIndicator({
+    Key? key,
+    required this.state,
+    required this.color,
+    required this.semanticsLabel,
+  }) : super(key: key);
+
+  final RxString state;
+  final Color color;
+  final String semanticsLabel;
+
+  @override
+  Widget build(BuildContext context) => Obx(
+        () => state.isEmpty
+            ? const SizedBox.shrink()
+            : IgnorePointer(
+                child: Semantics(
+                  image: true,
+                  label: semanticsLabel,
+                  child: Container(
+                    width: 32,
+                    height: 32,
+                    decoration: BoxDecoration(
+                      color: color.withOpacity(0.92),
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(
+                      Icons.privacy_tip,
+                      color: Colors.white,
+                      size: 20,
+                    ),
+                  ),
+                ),
+              ),
+      );
+}

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -7,6 +7,7 @@ import 'package:flutter_hbb/common.dart';
 import 'package:flutter_hbb/common/shared_state.dart';
 import 'package:flutter_hbb/common/widgets/dialog.dart';
 import 'package:flutter_hbb/common/widgets/login.dart';
+import 'package:flutter_hbb/common/widgets/privacy_mode_indicator.dart';
 import 'package:flutter_hbb/consts.dart';
 import 'package:flutter_hbb/desktop/widgets/remote_toolbar.dart';
 import 'package:flutter_hbb/models/model.dart';
@@ -69,6 +70,15 @@ Widget waylandKeyboardScopeChip(BuildContext context, String text) {
         context,
       ).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600),
     ),
+  );
+}
+
+// Keep the status non-interactive so remote keyboard focus is unaffected.
+Widget privacyModeIndicator(String id) {
+  return PrivacyModeIndicator(
+    state: PrivacyModeState.find(id),
+    color: MyTheme.accent,
+    semanticsLabel: translate('Privacy mode'),
   );
 }
 

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -974,6 +974,13 @@ class _RemotePageState extends State<RemotePage>
             QualityMonitor(_ffi.qualityMonitorModel), null, null),
       ),
     );
+    paints.add(
+      Positioned(
+        top: 10,
+        left: 10,
+        child: privacyModeIndicator(widget.id),
+      ),
+    );
     return Stack(
       children: paints,
     );

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -712,6 +712,11 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
               ffi: gFFI,
             ));
           }
+          paints.add(Positioned(
+            top: 10,
+            left: 10,
+            child: privacyModeIndicator(widget.id),
+          ));
           return paints;
         }()));
   }
@@ -726,6 +731,11 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
         paints.add(CursorPaint(widget.id));
       }
     }
+    paints.add(Positioned(
+      top: 10,
+      left: 10,
+      child: privacyModeIndicator(widget.id),
+    ));
     return Container(
         color: MyTheme.canvasColor, child: Stack(children: paints));
   }

--- a/flutter/test/privacy_mode_indicator_test.dart
+++ b/flutter/test/privacy_mode_indicator_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hbb/common/widgets/privacy_mode_indicator.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+void main() {
+  testWidgets('privacy mode indicator follows state without blocking input',
+      (tester) async {
+    final state = ''.obs;
+    addTearDown(state.close);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PrivacyModeIndicator(
+          state: state,
+          color: Colors.blue,
+          semanticsLabel: 'Privacy mode',
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.privacy_tip), findsNothing);
+
+    state.value = 'privacy_mode_impl_mag';
+    await tester.pump();
+
+    expect(find.byIcon(Icons.privacy_tip), findsOneWidget);
+    final ignorePointer = tester.widget<IgnorePointer>(
+      find.descendant(
+        of: find.byType(PrivacyModeIndicator),
+        matching: find.byType(IgnorePointer),
+      ),
+    );
+    expect(ignorePointer.ignoring, isTrue);
+
+    state.value = '';
+    await tester.pump();
+
+    expect(find.byIcon(Icons.privacy_tip), findsNothing);
+  });
+}

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -2279,8 +2279,6 @@ impl<T: InvokeUiSession> Remote<T> {
                 self.update_privacy_mode(impl_key, false);
             }
             back_notification::PrivacyModeState::PrvOnSucceeded => {
-                self.handler
-                    .msgbox("custom-nocancel", "Privacy mode", "Enter privacy mode", "");
                 self.update_privacy_mode(impl_key, true);
             }
             back_notification::PrivacyModeState::PrvOnFailedDenied => {


### PR DESCRIPTION
## Summary

- replace the successful privacy-mode entry dialog with a persistent status icon
- show the indicator in mobile, web-desktop, and desktop Flutter remote views
- keep the indicator non-interactive so it cannot affect remote keyboard or password focus

## Tests

- `flutter test --no-pub test/privacy_mode_indicator_test.dart`
- Dart analyzer on the changed Flutter files (no errors)
- `rustfmt --check --edition 2021 src/client/io_loop.rs`

## Environment note

- `cargo check --lib --features flutter` reached `scrap` but could not finish because local `libyuv` is not installed under `/opt/homebrew/Cellar/libyuv`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a privacy-mode indicator to remote sessions on desktop and mobile.
  - The indicator appears only when privacy mode is active and includes an accessibility label.
  - Added visual placement alongside existing session status indicators.

- **Bug Fixes**
  - Removed the non-interactive confirmation dialog shown after privacy mode activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces the modal privacy-mode success notification with a persistent, non-interactive Flutter status indicator.
- Adds a reactive privacy indicator with accessibility semantics and pointer-event pass-through.
- Places the indicator in desktop, web-desktop, and mobile remote views.
- Removes the successful-entry message box while retaining the existing privacy-state update.
- Adds a widget test covering visibility changes and non-interactive behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The new indicator follows the existing privacy-mode state, correctly passes input through to the remote view, and replaces only the successful-entry dialog while preserving failure notifications and state transitions.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/common/widgets/privacy_mode_indicator.dart | Adds a reactive, accessible indicator whose visible subtree is excluded from pointer hit testing. |
| flutter/lib/common/widgets/toolbar.dart | Adds the shared factory that binds the indicator to the existing per-peer privacy-mode state. |
| flutter/lib/desktop/pages/remote_page.dart | Adds the indicator to the top-left overlay layer of the desktop and web-desktop remote view. |
| flutter/lib/mobile/pages/remote_page.dart | Adds the same indicator to both mobile remote-view layouts. |
| flutter/test/privacy_mode_indicator_test.dart | Verifies reactive visibility and confirms that the visible indicator ignores pointer input. |
| src/client/io_loop.rs | Removes the successful-entry modal while preserving the state update that drives the replacement indicator. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Remote as Remote peer
  participant Client as Rust client
  participant State as Flutter privacy state
  participant View as Remote view
  Remote->>Client: PrvOnSucceeded
  Client->>Client: update_privacy_mode(impl, true)
  Client->>State: update_privacy_mode event
  State->>State: Set non-empty implementation value
  State-->>View: Reactive Obx rebuild
  View->>View: Show non-interactive privacy icon
  Remote->>Client: Privacy mode off state
  Client->>State: update_privacy_mode event
  State->>State: Clear value
  State-->>View: Reactive Obx rebuild
  View->>View: Hide privacy icon
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: show privacy mode status without m..."](https://github.com/rustdesk/rustdesk/commit/913afd257b655077a06b1df652c483b996876521) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52068447)</sub>

<!-- /greptile_comment -->