### PR TITLE
fix(i18n): complete Traditional Chinese sign-in strings

### DIFF
--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -773,7 +773,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Your ip is blocked by the peer", "你的 IP 已被對方封鎖"),
         ("id_whitelist_caveat_tip", "ID 由對端用戶端回報，白名單用於減少暴露面，不能取代密碼或 2FA"),
         ("whitelist_cidr_tip", "支援 CIDR 寫法，例如 192.168.1.0/24"),
-        ("Continue", ""),
-        ("Browser didn't open? Use the url below to sign in.", ""),
+        ("Continue", "繼續"),
+        ("Browser didn't open? Use the url below to sign in.", "瀏覽器未開啟？請使用下方網址登入。"),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
## Summary

- translate the remaining `Continue` action in `tw.rs`
- translate the browser fallback instruction used by the sign-in flow

Only previously empty zh-TW values are filled; keys and existing translations are unchanged.

## Validation

- confirmed `tw.rs` and `template.rs` retain the same 774 unique keys in the same order
- confirmed no empty zh-TW values remain
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Traditional Chinese translations for the “Continue” action.
  - Added localized text for the browser sign-in fallback message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Completes two previously empty Traditional Chinese sign-in translations without changing localization keys or existing translations.
- Translates the `Continue` action.
- Translates the browser fallback instruction used during sign-in.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The changed strings match the canonical localization keys, preserve all formatting requirements, and provide semantically correct Traditional Chinese text without altering runtime behavior or localization structure.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lang/tw.rs | Fills two empty zh-TW localization values with accurate translations while preserving keys, formatting, and localization conventions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(i18n): complete Traditional Chinese ..."](https://github.com/rustdesk/rustdesk/commit/e1006d281251bd65123ca03d0cc029e88da60c91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52083596)</sub>

<!-- /greptile_comment -->