### PR TITLE
fix(terminal): keep selection aligned after clearing scrollback

### DIFF
--- a/flutter/lib/models/rustdesk_terminal.dart
+++ b/flutter/lib/models/rustdesk_terminal.dart
@@ -1,0 +1,14 @@
+import 'package:xterm/xterm.dart';
+
+class RustDeskTerminal extends Terminal {
+  RustDeskTerminal({super.maxLines});
+
+  @override
+  void eraseScrollbackOnly() {
+    final scrollBack = buffer.scrollBack;
+    if (scrollBack == 0) return;
+
+    // Selection anchors require retained buffer lines to be reindexed.
+    buffer.lines.remove(0, scrollBack);
+  }
+}

--- a/flutter/lib/models/terminal_model.dart
+++ b/flutter/lib/models/terminal_model.dart
@@ -10,6 +10,7 @@ import 'package:xterm/xterm.dart';
 import 'input_modifier_utils.dart';
 import 'model.dart';
 import 'platform_model.dart';
+import 'rustdesk_terminal.dart';
 import 'terminal_mouse_handler.dart';
 
 class TerminalModel with ChangeNotifier {
@@ -129,7 +130,7 @@ class TerminalModel with ChangeNotifier {
   }
 
   TerminalModel(this.parent, [this.terminalId = 0]) : id = parent.id {
-    terminal = Terminal(maxLines: 10000);
+    terminal = RustDeskTerminal(maxLines: 10000);
     terminal.mouseHandler = const WheelButtonFixMouseHandler();
     terminalController = TerminalController();
 


### PR DESCRIPTION
Remove scrollback lines through the index-aware buffer operation so deleted anchors are detached and retained lines are reindexed.

## Testing

Windows, Linux, macOS

1. Establish a Terminal session.
2. Run `ls`, then press `enter` repeatedly until the screen is filled.
3. Run `clear`.
4. Run `ls` again.
5. Use the mouse to select text.

The previous version could not select the correct area. This commit works fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal scrollback clearing so retained history is removed while the current screen content remains visible.
  * Updated terminal sessions to use the enhanced scrollback behavior consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->