### PR TITLE
Revert "fix: upgrade fuser to 0.16.0 (GHSA-cvmj-47v9-35m9)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,9 +3074,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fuser"
-version = "0.16.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb29a3ae32279fe3e79a958fe01899f5fb23eadccee919cf88e145b54ed9367"
+checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
 dependencies = [
  "libc",
  "log",

--- a/libs/clipboard/Cargo.toml
+++ b/libs/clipboard/Cargo.toml
@@ -43,7 +43,7 @@ once_cell = {version = "1.18", optional = true}
 percent-encoding = {version  ="2.3", optional = true}
 x11-clipboard = {git="https://github.com/clslaid/x11-clipboard", branch = "feat/store-batch", optional = true}
 x11rb =  {version = "0.12", features = ["all-extensions"], optional = true}
-fuser = {version = "0.16", default-features = false, optional = true}
+fuser = {version = "0.15", default-features = false, optional = true}
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cacao = {git="https://github.com/clslaid/cacao", branch = "feat/set-file-urls", optional = true}


### PR DESCRIPTION
Reverts rustdesk/rustdesk#15834

It requires rust edition 2024， but we need lower version to support windows 7.

We will apply the security patch on old fuser crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux clipboard component’s supporting package version for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->