### PR TITLE
fix(drm): hold off after a failed compositor lookup instead of re-probing every poll

### DIFF
--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -743,6 +743,16 @@ enum ProbeState {
 }
 
 static DRM_STATE: Mutex<ProbeState> = Mutex::new(ProbeState::Unknown);
+/// When the compositor could not be enumerated, hold off before asking again: `get_displays()`
+/// does not cache that case, and the display service polls three times a second, so a greeter
+/// whose compositor stops answering would otherwise pay a probe per poll.
+static WAYLAND_GEOMETRY_FAILED_AT: Mutex<Option<Instant>> = Mutex::new(None);
+/// The last layout the compositor actually gave, served during that hold-off. Deliberately never
+/// an empty list: `augment_with_wayland_geometry_from` reads empty as "no compositor here" and
+/// leaves every monitor at DRM's (0, 0), so answering empty would publish a stacked desktop.
+static WAYLAND_GEOMETRY_LAST_GOOD: Mutex<Option<std::sync::Arc<scrap::wayland::display::Displays>>> =
+    Mutex::new(None);
+const WAYLAND_GEOMETRY_BACKOFF: Duration = Duration::from_secs(5);
 const NEGATIVE_TTL: Duration = Duration::from_secs(30);
 const POSITIVE_TTL: Duration = Duration::from_secs(15);
 
@@ -1216,7 +1226,7 @@ pub(super) fn get_display_infos_and_primary() -> Option<(Vec<DisplayInfo>, usize
         ProbeState::Available(_, list) => list.clone(),
         _ => return None,
     };
-    let wl = scrap::wayland::display::get_displays();
+    let wl = wayland_displays_for_geometry();
     let assignment = assign_wayland_outputs(&list, &wl.displays);
     let mut infos = augment_with_wayland_geometry_from(&list, &wl, &assignment);
     mark_demoted_displays(&list, &mut infos);
@@ -1242,9 +1252,36 @@ pub(super) fn get_display_infos() -> Option<Vec<DisplayInfo>> {
 /// cannot answer, the list comes back empty and everything stays unaugmented, which is what the
 /// old is-login-screen gate produced unconditionally.
 fn augment_with_wayland_geometry(drm: &[DrmDisplayInfo]) -> Vec<DisplayInfo> {
-    let wl = scrap::wayland::display::get_displays();
+    let wl = wayland_displays_for_geometry();
     let assignment = assign_wayland_outputs(drm, &wl.displays);
     augment_with_wayland_geometry_from(drm, &wl, &assignment)
+}
+
+/// The compositor layout, without re-probing a failure on every call.
+///
+/// A failed lookup is not cached below, so the display-service poll paid one probe per turn where
+/// there is no answer to be had. While the hold-off runs, the last layout the compositor really
+/// gave is served instead: the poll only publishes CHANGES, so repeating the layout the client
+/// already has is the quiet answer, where an empty one would advertise the raw DRM stack. Until
+/// there is a layout to repeat, ask.
+fn wayland_displays_for_geometry() -> std::sync::Arc<scrap::wayland::display::Displays> {
+    let holding_off = matches!(
+        *WAYLAND_GEOMETRY_FAILED_AT.lock().unwrap(),
+        Some(failed_at) if failed_at.elapsed() < WAYLAND_GEOMETRY_BACKOFF
+    );
+    if holding_off {
+        if let Some(last_good) = WAYLAND_GEOMETRY_LAST_GOOD.lock().unwrap().clone() {
+            return last_good;
+        }
+    }
+    let wl = scrap::wayland::display::get_displays();
+    if wl.displays.is_empty() {
+        *WAYLAND_GEOMETRY_FAILED_AT.lock().unwrap() = Some(Instant::now());
+    } else {
+        *WAYLAND_GEOMETRY_FAILED_AT.lock().unwrap() = None;
+        *WAYLAND_GEOMETRY_LAST_GOOD.lock().unwrap() = Some(wl.clone());
+    }
+    wl
 }
 
 fn augment_with_wayland_geometry_from(

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -750,7 +750,11 @@ static WAYLAND_GEOMETRY_FAILED_AT: Mutex<Option<Instant>> = Mutex::new(None);
 /// The last layout the compositor actually gave, served during that hold-off. Deliberately never
 /// an empty list: `augment_with_wayland_geometry_from` reads empty as "no compositor here" and
 /// leaves every monitor at DRM's (0, 0), so answering empty would publish a stacked desktop.
-static WAYLAND_GEOMETRY_LAST_GOOD: Mutex<Option<std::sync::Arc<scrap::wayland::display::Displays>>> =
+///
+/// Kept with the `DRM_STATE_GEN` it was captured under and dropped when that moves, because the
+/// assignment matches connectors to outputs by name and resolution: replaying a layout from a
+/// different topology could hand a new connector another monitor's origin.
+static WAYLAND_GEOMETRY_LAST_GOOD: Mutex<Option<(u64, std::sync::Arc<scrap::wayland::display::Displays>)>> =
     Mutex::new(None);
 const WAYLAND_GEOMETRY_BACKOFF: Duration = Duration::from_secs(5);
 const NEGATIVE_TTL: Duration = Duration::from_secs(30);
@@ -1265,21 +1269,35 @@ fn augment_with_wayland_geometry(drm: &[DrmDisplayInfo]) -> Vec<DisplayInfo> {
 /// already has is the quiet answer, where an empty one would advertise the raw DRM stack. Until
 /// there is a layout to repeat, ask.
 fn wayland_displays_for_geometry() -> std::sync::Arc<scrap::wayland::display::Displays> {
+    let gen = DRM_STATE_GEN.load(Ordering::Acquire);
+    let last_good = || {
+        WAYLAND_GEOMETRY_LAST_GOOD
+            .lock()
+            .unwrap()
+            .as_ref()
+            .filter(|(captured_gen, _)| *captured_gen == gen)
+            .map(|(_, wl)| wl.clone())
+    };
     let holding_off = matches!(
         *WAYLAND_GEOMETRY_FAILED_AT.lock().unwrap(),
         Some(failed_at) if failed_at.elapsed() < WAYLAND_GEOMETRY_BACKOFF
     );
     if holding_off {
-        if let Some(last_good) = WAYLAND_GEOMETRY_LAST_GOOD.lock().unwrap().clone() {
-            return last_good;
+        if let Some(wl) = last_good() {
+            return wl;
         }
     }
     let wl = scrap::wayland::display::get_displays();
     if wl.displays.is_empty() {
         *WAYLAND_GEOMETRY_FAILED_AT.lock().unwrap() = Some(Instant::now());
+        // This answer would leave every monitor at (0, 0) too, so the previous layout stands here
+        // as well, not only on the calls the hold-off covers.
+        if let Some(wl) = last_good() {
+            return wl;
+        }
     } else {
         *WAYLAND_GEOMETRY_FAILED_AT.lock().unwrap() = None;
-        *WAYLAND_GEOMETRY_LAST_GOOD.lock().unwrap() = Some(wl.clone());
+        *WAYLAND_GEOMETRY_LAST_GOOD.lock().unwrap() = Some((gen, wl.clone()));
     }
     wl
 }


### PR DESCRIPTION
follow up to the P2 in the #15792 review. the "one blocking task, one roundtrip" half landed with the merge; this is the failure backoff half.

`scrap::wayland::display::get_displays()` caches a successful enumeration but not a failed one, and the display service polls about three times a second. so on a host where the compositor cannot be enumerated - a greeter whose socket is not answering, a drm build with no compositor to reach - every poll pays another probe process, each able to wait out the socket probe deadline.

the lookup now holds off for 5 s after an empty answer.

the part worth reviewing is what it serves during that window. the obvious answer, an empty list, is wrong: `augment_with_wayland_geometry_from` reads empty as "no compositor here" and leaves every monitor at DRM's (0, 0), so answering empty would publish a stacked desktop for 5 s where the un-backed-off code published it for one 300 ms tick. so it serves the last layout the compositor really gave instead. the poll only sends changes, so repeating the layout the client already has is silence, which is the right thing to say while you do not know. until there is a layout to repeat it just asks.

master consolidated the enumeration into two call sites, which is why this is one helper and not a per-caller split.

tested on a two head gdm greeter vm: two sessions with an abrupt disconnect between them, capture over dma-buf, probe answering two outputs, libEGL still 0 in the root service, and the uinput rect still the compositor union (0,6400),(0,2160) rather than the drm stack - so the augmentation is unaffected by the hold-off. cpu measured from /proc/pid/stat deltas, idle after the sequence. builds with and without the drm feature, 33 drm tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Wayland display geometry handling when compositor information is unavailable or empty.
  - Reuses the most recent valid display layout during temporary lookup failures.
  - Reduces repeated failed geometry checks and prevents empty layout information from being shown.
  - Refreshes cached display geometry when the connected display configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->