### PR TITLE
fix(wayland): wait before retrying an enumeration that just failed

### DIFF
--- a/libs/scrap/src/wayland/display.rs
+++ b/libs/scrap/src/wayland/display.rs
@@ -12,7 +12,16 @@ use hbb_common::platform::linux::{get_wayland_displays, WaylandDisplayInfo};
 
 lazy_static! {
     static ref DISPLAYS: Mutex<Option<Arc<Displays>>> = Mutex::new(None);
+    /// When the last enumeration failed, so the next one waits instead of paying for the same
+    /// answer again. Cleared with the layout cache below: an explicit invalidation asks for a
+    /// fresh read, and a stale stamp would refuse to take one.
+    static ref PROBE_FAILED_AT: Mutex<Option<Instant>> = Mutex::new(None);
 }
+
+/// A failed enumeration is not cached, and both callers below poll: the display service about
+/// three times a second, the live layout every 1.5 s. Where there is no compositor to reach, each
+/// of those forks the probe subprocess and waits out its deadline for the same failure.
+const PROBE_RETRY_DELAY: Duration = Duration::from_secs(5);
 
 static MISSING_LOGICAL_SIZE_WARNED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
@@ -171,11 +180,35 @@ fn get_primary_monitor() -> Option<String> {
         .or_else(try_gdbus_primary)
 }
 
+/// Whether a probe may run now, given when the last one failed. Pure so the policy can be tested
+/// without a compositor.
+fn probe_allowed(failed_at: Option<Instant>, now: Instant, delay: Duration) -> bool {
+    match failed_at {
+        Some(failed_at) => now.saturating_duration_since(failed_at) >= delay,
+        None => true,
+    }
+}
+
+/// `get_wayland_displays` behind that delay. A refused probe reports a failure, which is what the
+/// callers already do with one, so nothing downstream learns a new state to handle.
+fn probe_wayland_displays() -> hbb_common::ResultType<Vec<WaylandDisplayInfo>> {
+    if !probe_allowed(
+        *PROBE_FAILED_AT.lock().unwrap(),
+        Instant::now(),
+        PROBE_RETRY_DELAY,
+    ) {
+        hbb_common::bail!("the last wayland enumeration failed; not probing again yet");
+    }
+    let probed = get_wayland_displays();
+    *PROBE_FAILED_AT.lock().unwrap() = probed.is_err().then(Instant::now);
+    probed
+}
+
 pub fn get_displays() -> Arc<Displays> {
     let mut lock = DISPLAYS.lock().unwrap();
     match lock.as_ref() {
         Some(displays) => displays.clone(),
-        None => match get_wayland_displays() {
+        None => match probe_wayland_displays() {
             Ok(displays) => {
                 let mut primary_index = None;
                 if let Some(name) = get_primary_monitor() {
@@ -215,6 +248,7 @@ pub fn get_displays() -> Arc<Displays> {
 #[inline]
 pub fn clear_wayland_displays_cache() {
     let _ = DISPLAYS.lock().unwrap().take();
+    let _ = PROBE_FAILED_AT.lock().unwrap().take();
 }
 
 // Return (min_x, max_x, min_y, max_y)
@@ -228,7 +262,7 @@ pub fn get_desktop_rect_for_uinput() -> Option<(i32, i32, i32, i32)> {
 // detection (which may spawn external commands), so it is cheap enough to poll for
 // layout changes. https://github.com/rustdesk/rustdesk/issues/15601
 pub fn get_layout_for_uinput_live() -> Option<((i32, i32, i32, i32), Vec<DisplayRect>)> {
-    match get_wayland_displays() {
+    match probe_wayland_displays() {
         Ok(displays) => {
             desktop_rect_of(&displays).map(|rect| (rect, logical_rects_of(&displays)))
         }
@@ -385,6 +419,32 @@ fn map_axis(v: i32, base_origin: i32, base_extent: i32, live_origin: i32, live_e
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_probe_runs_when_none_has_failed() {
+        assert!(probe_allowed(None, Instant::now(), PROBE_RETRY_DELAY));
+    }
+
+    #[test]
+    fn a_probe_waits_out_the_delay_after_a_failure() {
+        let now = Instant::now();
+        let failed_at = now - PROBE_RETRY_DELAY / 2;
+        assert!(!probe_allowed(Some(failed_at), now, PROBE_RETRY_DELAY));
+    }
+
+    #[test]
+    fn a_probe_runs_again_once_the_delay_has_passed() {
+        let now = Instant::now();
+        let failed_at = now - PROBE_RETRY_DELAY;
+        assert!(probe_allowed(Some(failed_at), now, PROBE_RETRY_DELAY));
+    }
+
+    #[test]
+    fn a_stamp_from_the_future_does_not_wedge_the_probe_forever() {
+        // saturating_duration_since answers zero rather than panicking, so this only waits.
+        let now = Instant::now();
+        assert!(!probe_allowed(Some(now + PROBE_RETRY_DELAY), now, PROBE_RETRY_DELAY));
+    }
 
     fn display(
         x: i32,

--- a/libs/scrap/src/wayland/display.rs
+++ b/libs/scrap/src/wayland/display.rs
@@ -18,6 +18,10 @@ lazy_static! {
     static ref PROBE_FAILED_AT: Mutex<Option<Instant>> = Mutex::new(None);
 }
 
+/// Counts invalidations, so a probe that was already out when one landed knows its answer is
+/// about the layout that was just discarded.
+static INVALIDATIONS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// A failed enumeration is not cached, and both callers below poll: the display service about
 /// three times a second, the live layout every 1.5 s. Where there is no compositor to reach, each
 /// of those forks the probe subprocess and waits out its deadline for the same failure.
@@ -189,6 +193,14 @@ fn probe_allowed(failed_at: Option<Instant>, now: Instant, delay: Duration) -> b
     }
 }
 
+/// Whether a finished probe may still stamp its failure. A probe runs unlocked and takes seconds,
+/// so an invalidation can land while it is out; its failure then belongs to the layout that was
+/// just discarded, and stamping it would refuse the fresh read the invalidation asked for. Pure,
+/// for the same reason as above.
+fn failure_still_counts(invalidations_before: u64, invalidations_now: u64) -> bool {
+    invalidations_before == invalidations_now
+}
+
 /// `get_wayland_displays` behind that delay. A refused probe reports a failure, which is what the
 /// callers already do with one, so nothing downstream learns a new state to handle.
 fn probe_wayland_displays() -> hbb_common::ResultType<Vec<WaylandDisplayInfo>> {
@@ -199,8 +211,12 @@ fn probe_wayland_displays() -> hbb_common::ResultType<Vec<WaylandDisplayInfo>> {
     ) {
         hbb_common::bail!("the last wayland enumeration failed; not probing again yet");
     }
+    let invalidations_before = INVALIDATIONS.load(std::sync::atomic::Ordering::Acquire);
     let probed = get_wayland_displays();
-    *PROBE_FAILED_AT.lock().unwrap() = probed.is_err().then(Instant::now);
+    let invalidations_now = INVALIDATIONS.load(std::sync::atomic::Ordering::Acquire);
+    if failure_still_counts(invalidations_before, invalidations_now) {
+        *PROBE_FAILED_AT.lock().unwrap() = probed.is_err().then(Instant::now);
+    }
     probed
 }
 
@@ -247,6 +263,7 @@ pub fn get_displays() -> Arc<Displays> {
 
 #[inline]
 pub fn clear_wayland_displays_cache() {
+    INVALIDATIONS.fetch_add(1, std::sync::atomic::Ordering::Release);
     let _ = DISPLAYS.lock().unwrap().take();
     let _ = PROBE_FAILED_AT.lock().unwrap().take();
 }
@@ -437,6 +454,27 @@ mod tests {
         let now = Instant::now();
         let failed_at = now - PROBE_RETRY_DELAY;
         assert!(probe_allowed(Some(failed_at), now, PROBE_RETRY_DELAY));
+    }
+
+    #[test]
+    fn a_failure_stamps_when_nothing_was_invalidated_while_it_ran() {
+        assert!(failure_still_counts(7, 7));
+    }
+
+    #[test]
+    fn a_failure_from_before_an_invalidation_does_not_stamp() {
+        // The clear asked for a fresh read; this answer is about the layout it discarded.
+        assert!(!failure_still_counts(7, 8));
+    }
+
+    #[test]
+    fn an_invalidation_lets_the_next_probe_run_even_after_a_failure() {
+        // What the counter protects, end to end on the two pure halves: a stamp is dropped by the
+        // clear, so the delay cannot refuse the read that clear was asking for.
+        let now = Instant::now();
+        assert!(!probe_allowed(Some(now), now, PROBE_RETRY_DELAY));
+        let after_clear: Option<Instant> = None;
+        assert!(probe_allowed(after_clear, now, PROBE_RETRY_DELAY));
     }
 
     #[test]


### PR DESCRIPTION
the negative cache where you said it belongs in #15855 point 10, replacing that pr.

`get_wayland_displays` has exactly two callers, both in this file: `get_displays`, which caches a success and is reached by the ~300 ms display-service poll, and `get_layout_for_uinput_live`, which bypasses the cache and runs every 1.5 s while a client is subscribed. neither caches a failure, so where there is no compositor to reach both fork the probe subprocess and wait out its deadline to learn the same thing again. wrapping the shared function covers both, which the drm-side attempt did not.

a refused probe reports a failure. that is what both callers already do with one, so nothing downstream sees a state it did not see before, and the layout cache above keeps serving the last good answer exactly as it did - no replay, no second cache, no generation key.

`clear_wayland_displays_cache` drops the stamp with the layout, so an explicit invalidation still takes a fresh read.

scope: the delay is armed by the `Err` arm only. `Ok(vec![])` still caches as before - i am not changing enumeration semantics here, only what happens when the lookup fails.

measured on a two head gdm greeter vm with the compositor socket moved out of the scan path the probe uses, one client subscribed, 60 s windows:

| | failed lookups | refused by the delay | probe forks |
|---|---|---|---|
| master | 162 | 0 | 162 |
| this | 201 | 188 | 13 |

the call count goes up because a refused lookup returns immediately and the pollers turn faster; the fork count is what drops. restoring the socket returns it to zero refusals.

the decision is a pure function over (failed_at, now, delay) with tests, including a stamp from the future, which saturating_duration_since turns into a wait rather than a panic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wayland display detection reliability by preventing repeated retries after failed attempts.
  * Display detection now retries automatically after a short cooldown.
  * Resetting display information immediately allows fresh detection attempts.
  * Prevented outdated in-progress detection results from overriding newer display state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a five-second negative cache for failed Wayland display enumeration and generation-based coordination with explicit cache invalidation. The attempted coordination still leaves a check-to-write race that can restore a stale failure after invalidation.
- Routes both cached and live display enumeration through the shared retry delay.
- Clears the negative-cache timestamp during explicit invalidation.
- Adds generation checks intended to discard failures from probes overlapping invalidation.
- Adds unit tests for retry timing and generation comparisons.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because explicit invalidation can still be followed by a stale failure stamp that suppresses the requested fresh enumeration.

The probe compares invalidation generations before locking the failure timestamp, so invalidation can increment the generation and clear the timestamp between the comparison and the probe's write, leaving the previously reported failure reachable.

**Files Needing Attention:** libs/scrap/src/wayland/display.rs
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/scrap/src/wayland/display.rs | Adds shared failure throttling and invalidation generations, but the generation check is not synchronized with the subsequent failure-stamp write. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as Failed probe
    participant I as Invalidation
    participant S as Failure stamp
    P->>P: "Load INVALIDATIONS = N"
    I->>I: Increment INVALIDATIONS to N+1
    I->>S: Lock and clear stamp
    I-->>I: Invalidation completes
    P->>S: Lock and write failed_at
    Note over P,S: Stale failure is restored after invalidation
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2315860%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=15860&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alibs%2Fscrap%2Fsrc%2Fwayland%2Fdisplay.rs%3A216-218%0A**Invalidation%20still%20loses%20to%20stamping**%0A%0AWhen%20invalidation%20increments%20the%20generation%20and%20clears%20%60PROBE_FAILED_AT%60%20after%20the%20probe's%20final%20generation%20load%20but%20before%20it%20acquires%20the%20stamp%20mutex%2C%20the%20probe%20writes%20its%20stale%20failure%20after%20the%20clear%2C%20causing%20the%20requested%20fresh%20enumeration%20to%20be%20refused%20for%20up%20to%20five%20seconds.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15860&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/scrap/src/wayland/display.rs:216-218
**Invalidation still loses to stamping**

When invalidation increments the generation and clears `PROBE_FAILED_AT` after the probe's final generation load but before it acquires the stamp mutex, the probe writes its stale failure after the clear, causing the requested fresh enumeration to be refused for up to five seconds.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(wayland): do not let a probe that wa..."](https://github.com/rustdesk/rustdesk/commit/1e6fa651d653b8fe3f2b37891ebcd67d5edc31fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53242386)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->