### PR TITLE
docs: fix dead code of conduct links in ID/IT contributing guides

### DIFF
--- a/docs/CONTRIBUTING-ID.md
+++ b/docs/CONTRIBUTING-ID.md
@@ -24,7 +24,7 @@ Untuk instruksi Git yang lebih lanjut, cek disini [GitHub workflow 101](https://
 
 ## Tindakan
 
-<https://github.com/rustdesk/rustdesk/blob/master/docs/CODE_OF_CONDUCT-ID.md>
+<https://github.com/rustdesk/rustdesk/blob/master/docs/CODE_OF_CONDUCT.md>
 
 ## Komunikasi
 

--- a/docs/CONTRIBUTING-IT.md
+++ b/docs/CONTRIBUTING-IT.md
@@ -30,7 +30,7 @@ Per istruzioni specifiche su git, vedi [Workflow GitHub - 101](https://github.co
 
 ## Condotta
 
-https://github.com/rustdesk/rustdesk/blob/master/docs/CODE_OF_CONDUCT-IT.md
+https://github.com/rustdesk/rustdesk/blob/master/docs/CODE_OF_CONDUCT.md
 
 ## Comunicazioni
 


### PR DESCRIPTION
`CONTRIBUTING-ID.md` and `CONTRIBUTING-IT.md` link to `CODE_OF_CONDUCT-ID.md` and `CODE_OF_CONDUCT-IT.md`, which do not exist in `docs/` (the repo has CoC translations for DE/FR/JP/KR/NL/NO/PL/RO/RU/TR/ZH but not ID/IT), so both links 404. This PR points them to the canonical `CODE_OF_CONDUCT.md` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Code of Conduct links in the Indonesian and Italian contribution guides to reference the main English document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR repairs dead Code of Conduct links in the Indonesian and Italian contributing guides.
- Replaces references to nonexistent localized Code of Conduct files.
- Points both guides to the existing canonical `docs/CODE_OF_CONDUCT.md`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

Both changed links target an existing canonical document and follow the link convention already used by the primary contributing guide and several translations.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/CONTRIBUTING-ID.md | Replaces the nonexistent Indonesian Code of Conduct target with the existing canonical document. |
| docs/CONTRIBUTING-IT.md | Replaces the nonexistent Italian Code of Conduct target with the existing canonical document. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix dead code of conduct links in ..."](https://github.com/rustdesk/rustdesk/commit/5916ed4094a8b5d6f856b60b44acf9e8f973e968) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53443304)</sub>

<!-- /greptile_comment -->