### PR TITLE
fix(CI): rust 1.75, linux sciter

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -2203,7 +2203,7 @@ jobs:
             mkdir -p ~/.cargo/
             echo """
               [source.crates-io]
-              registry = 'https://github.com/rust-lang/crates.io-index'
+              registry = 'sparse+https://index.crates.io/'
             """ > ~/.cargo/config
             cat ~/.cargo/config
             # install dependencies from vcpkg


### PR DESCRIPTION
Issue: https://github.com/rustdesk/rustdesk/actions/runs/31916588291/job/95089270548

Fixed: https://github.com/fufesou/rustdesk/actions/runs/31921472743/job/95101889468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux build configuration to use the sparse crates.io index, improving dependency retrieval during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the Linux Sciter CI job to use Cargo’s official sparse crates.io index.
- Replaces the Git-based crates.io registry URL with `sparse+https://index.crates.io/`.
- Retains the existing Rust 1.75 toolchain and locked dependency build.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The Linux Sciter workflow uses Rust 1.75, whose Cargo version supports the configured sparse crates.io registry, and the change does not violate applicable repository guidance.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/flutter-build.yml | The registry configuration now uses a sparse index supported by the job’s Cargo version; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(CI): rust 1.75, linux sciter"](https://github.com/rustdesk/rustdesk/commit/ef48e16a5a8168f0382bfb17c03869106cb02424) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53707028)</sub>

<!-- /greptile_comment -->