### PR TITLE
Fix macOS multi-click position tracking

### DIFF
--- a/libs/enigo/src/macos/macos_impl.rs
+++ b/libs/enigo/src/macos/macos_impl.rs
@@ -39,6 +39,7 @@ const BUF_LEN: usize = 4;
 
 const MOUSE_EVENT_BUTTON_NUMBER_BACK: i64 = 3;
 const MOUSE_EVENT_BUTTON_NUMBER_FORWARD: i64 = 4;
+const MULTI_CLICK_MAX_DISTANCE: u32 = 4;
 
 /// The event source user data value of cgevent.
 pub const ENIGO_INPUT_EXTRA_VALUE: i64 = 100;
@@ -110,10 +111,27 @@ pub struct Enigo {
     event_source: Option<CGEventSource>,
     double_click_interval: u32,
     last_click_time: Option<std::time::Instant>,
+    last_click_position: Option<(i32, i32)>,
+    last_click_button: Option<MouseButton>,
     multiple_click: i64,
     ignore_flags: bool,
     flags: CGEventFlags,
     char_to_vkey_map: Map<String, Map<char, CGKeyCode>>,
+}
+
+fn is_same_click_sequence(
+    last_position: Option<(i32, i32)>,
+    position: (i32, i32),
+    last_button: Option<MouseButton>,
+    button: MouseButton,
+) -> bool {
+    last_button == Some(button)
+        && last_position
+            .map(|last| {
+                last.0.abs_diff(position.0) <= MULTI_CLICK_MAX_DISTANCE
+                    && last.1.abs_diff(position.1) <= MULTI_CLICK_MAX_DISTANCE
+            })
+            .unwrap_or(false)
 }
 
 impl Enigo {
@@ -191,6 +209,8 @@ impl Default for Enigo {
             double_click_interval,
             multiple_click: 1,
             last_click_time: None,
+            last_click_position: None,
+            last_click_button: None,
             ignore_flags: false,
             flags: CGEventFlags::CGEventFlagNull,
             char_to_vkey_map: Default::default(),
@@ -262,15 +282,25 @@ impl MouseControllable for Enigo {
 
     fn mouse_down(&mut self, button: MouseButton) -> crate::ResultType {
         let now = std::time::Instant::now();
+        let (current_x, current_y) = Self::mouse_location();
+        let position = (current_x, current_y);
         if let Some(t) = self.last_click_time {
-            if t.elapsed().as_millis() as u32 <= self.double_click_interval {
+            if t.elapsed().as_millis() as u32 <= self.double_click_interval
+                && is_same_click_sequence(
+                    self.last_click_position,
+                    position,
+                    self.last_click_button,
+                    button,
+                )
+            {
                 self.multiple_click += 1;
             } else {
                 self.multiple_click = 1;
             }
         }
         self.last_click_time = Some(now);
-        let (current_x, current_y) = Self::mouse_location();
+        self.last_click_position = Some(position);
+        self.last_click_button = Some(button);
         let (button, event_type, btn_value) = match button {
             MouseButton::Left => (CGMouseButton::Left, CGEventType::LeftMouseDown, None),
             MouseButton::Middle => (CGMouseButton::Center, CGEventType::OtherMouseDown, None),
@@ -862,3 +892,34 @@ fn get_map(name: &str, layout: *const u8) -> Map<char, CGKeyCode> {
     map
 }
 unsafe impl Send for Enigo {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nearby_clicks_with_same_button_continue_sequence() {
+        assert!(is_same_click_sequence(
+            Some((100, 100)),
+            (104, 96),
+            Some(MouseButton::Left),
+            MouseButton::Left,
+        ));
+    }
+
+    #[test]
+    fn distant_click_or_different_button_resets_sequence() {
+        assert!(!is_same_click_sequence(
+            Some((100, 100)),
+            (200, 200),
+            Some(MouseButton::Left),
+            MouseButton::Left,
+        ));
+        assert!(!is_same_click_sequence(
+            Some((100, 100)),
+            (100, 100),
+            Some(MouseButton::Left),
+            MouseButton::Right,
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- track the previous macOS mouse-down position and button
- continue a multi-click sequence only within the configured double-click interval, for the same button, and within a 4-point position tolerance
- add regression tests for nearby, distant, and different-button clicks

Fixes #15878

## Root cause

The macOS Enigo backend incremented `MOUSE_EVENT_CLICK_STATE` using only elapsed time. A rapid click at an unrelated screen position could therefore be emitted as click state 3 after a double-click, causing macOS text controls to select a whole line or paragraph.

## Testing

- `cargo test -p enigo nearby_clicks_with_same_button_continue_sequence` — passed
- `cargo test -p enigo distant_click_or_different_button_resets_sequence` — passed
- `cargo test -p enigo` — 6 passed; the pre-existing interactive `tests::test_get_key_state` failed because the non-interactive test process did not observe a keyboard-state change
- `git diff --check upstream/master...HEAD` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-click recognition on macOS by considering both timing and cursor position.
  * Consecutive clicks now count as part of the same multi-click action only when they occur close together and use the same mouse button.
  * Prevents distant clicks or clicks with different buttons from being incorrectly interpreted as double- or triple-clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes macOS multi-click tracking by requiring consecutive clicks to occur within the configured interval, use the same mouse button, and remain within a four-point per-axis tolerance.
- Stores the previous mouse-down position and button in the macOS Enigo backend.
- Resets the click count when timing, button, or position no longer matches.
- Adds regression tests for nearby, distant, and different-button clicks.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking issues identified.

The updated mouse-down path consistently records the position and button used to classify and emit each click, resets mismatched sequences, and includes tests for the intended boundaries.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/enigo/src/macos/macos_impl.rs | Adds position- and button-aware multi-click sequence tracking with focused unit coverage; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix macOS multi-click position tracking"](https://github.com/rustdesk/rustdesk/commit/fbb981d591a0d4c3bdd1a0f2bd3f934481e5cc31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55253254)</sub>

<!-- /greptile_comment -->