### PR TITLE
fix(windows): restore keyboard focus when the cursor re-enters the remote image

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -835,7 +835,17 @@ class _RemotePageState extends State<RemotePage>
       _macOSLocalFocusLost = false;
       stateGlobal.getInputSource(force: true);
       _syncMacOSKeyboardGrab(reassert: true, allowInactiveLifecycle: true);
-    } else if (!isWindows) {
+    } else if (isWindows) {
+      // Blur unfocuses this node and nothing restores it, so the keyboard stayed
+      // dead until a click. Focus only while the window is really active, or a
+      // background window would grab system keys. onFocusChange does enterOrLeave.
+      if (!_isWindowBlur &&
+          _isSelectedTab &&
+          _blockableOverlayState.middleBlocked.isFalse &&
+          !_rawKeyFocusNode.hasFocus) {
+        _rawKeyFocusNode.requestFocus();
+      }
+    } else {
       if (!_rawKeyFocusNode.hasFocus) {
         _rawKeyFocusNode.requestFocus();
       }

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -273,6 +273,11 @@ class _RemotePageState extends State<RemotePage>
         tabState.tabs[selected].key == widget.id;
   }
 
+  // Every Windows requestFocus() must pass this, or a blocking dialog or an
+  // inactive tab could hand remote input to this page.
+  bool get _windowsCanFocusRemoteInput =>
+      _isSelectedTab && _blockableOverlayState.middleBlocked.isFalse;
+
   bool get _isMacOSKeyboardContextActive {
     return stateGlobal.isFocused.value && !_isWindowBlur && _isSelectedTab;
   }
@@ -517,8 +522,7 @@ class _RemotePageState extends State<RemotePage>
     // focus returns (Alt+Tab, taskbar), so enterView() never fires again.
     if (isWindows &&
         _cursorOverImage.value &&
-        _isSelectedTab &&
-        _blockableOverlayState.middleBlocked.isFalse &&
+        _windowsCanFocusRemoteInput &&
         !_rawKeyFocusNode.hasFocus) {
       _rawKeyFocusNode.requestFocus();
     }
@@ -533,7 +537,7 @@ class _RemotePageState extends State<RemotePage>
           _cursorOverImage.value = true;
           _macOSLocalFocusLost = false;
         }
-      } else {
+      } else if (!isWindows || _windowsCanFocusRemoteInput) {
         _rawKeyFocusNode.requestFocus();
       }
       _ffi.inputModel.onWindowFocus();
@@ -850,8 +854,7 @@ class _RemotePageState extends State<RemotePage>
       // dead until a click. Focus only while the window is really active, or a
       // background window would grab system keys. onFocusChange does enterOrLeave.
       if (!_isWindowBlur &&
-          _isSelectedTab &&
-          _blockableOverlayState.middleBlocked.isFalse &&
+          _windowsCanFocusRemoteInput &&
           !_rawKeyFocusNode.hasFocus) {
         _rawKeyFocusNode.requestFocus();
       }

--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -513,6 +513,16 @@ class _RemotePageState extends State<RemotePage>
       _queueMacOSKeyboardAfterFullScreen(allowHiddenLifecycle: true);
     }
 
+    // Refocus without PointerEnter: the cursor already hovers the image when
+    // focus returns (Alt+Tab, taskbar), so enterView() never fires again.
+    if (isWindows &&
+        _cursorOverImage.value &&
+        _isSelectedTab &&
+        _blockableOverlayState.middleBlocked.isFalse &&
+        !_rawKeyFocusNode.hasFocus) {
+      _rawKeyFocusNode.requestFocus();
+    }
+
     // Restore relative mouse mode constraints when window regains focus.
     if (_ffi.inputModel.relativeMouseMode.value) {
       if (isMacOS) {


### PR DESCRIPTION
### Problem

On Windows, entering a window that is already connected to a peer leaves the keyboard dead — keystrokes go nowhere until the user clicks on the remote image.

`onWindowBlur()` deliberately unfocuses `_rawKeyFocusNode` so the OS handles keys while the window is inactive, but nothing requests focus back:

- `onWindowFocus()` only calls `requestFocus()` in relative mouse mode.
- `enterView()` skipped Windows entirely (`else if (!isWindows)`).

So the only remaining path was `onPointerDown` -> `requestFocus()`, i.e. an actual click inside the canvas. The same applies after switching to another tab in the window.

### Change

`enterView()` now requests focus on Windows too, matching the Linux behaviour, but gated so a background window can never take over the keyboard:

- `!_isWindowBlur` — Windows delivers hover events to inactive windows as well; without this guard, moving the mouse across a background remote window would start the grab-key thread and steal system keys (Alt+Tab, Win) from the focused app.
- `_isSelectedTab` — a non-selected tab must not own the keyboard.
- `middleBlocked.isFalse` — a local dialog keeps input.

`enterOrLeave(true)` is intentionally not called here: on Windows it is already driven by `RawKeyFocusScope.onFocusChange`, and calling it twice would reset modifiers twice.

`leaveView()` is unchanged, so focus is not dropped when the cursor moves to the toolbar — same as the existing behaviour after a click. The `onPointerDown` path stays as a fallback for the known cases where Windows does not deliver a focus event and `_isWindowBlur` stays stale.

Tab switching within a window still needs pointer movement over the image (there is no tab-state listener on Windows, only on macOS); that is left for a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard and mouse input focus handling on Windows when the app regains focus.
  * Restored remote-input focus more reliably when the selected remote view is active and unobstructed.
  * Prevented focus from being reclaimed while another tab, overlay, window, or control is active.
  * Improved focus restoration when entering remote views and re-enabling relative mouse mode.
  * Preserved existing input activation behavior on other platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores Windows keyboard focus when an active remote image regains window focus or receives pointer entry.
- Centralizes selected-tab and blocking-overlay focus guards.
- Restores focus after window activation when the cursor is already over the remote image.
- Applies the same guards to relative mouse mode and pointer-entry focus paths.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/desktop/pages/remote_page.dart | Adds guarded Windows keyboard-focus restoration and brings the focus rationale comment within repository limits. |

</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(windows): share one focus predi..."](https://github.com/rustdesk/rustdesk/commit/d77367383c841862ebca024f4c4b25b4a477907c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53795607)</sub>

<!-- /greptile_comment -->