### PR TITLE
Bump aom to v3.14.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ env:
 #   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
   # for multiarch gcc compatibility
-  VCPKG_COMMIT_ID: "120deac3062162151622ca4860575a33844ba10b"
+  VCPKG_COMMIT_ID: "9e593bb18ea69cc5095e012465dcd675a822ed0d"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -36,13 +36,13 @@ env:
   FLUTTER_ELINUX_VERSION: "3.16.9"
   TAG_NAME: "${{ inputs.upload-tag }}"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-  # vcpkg version: 2025.08.27
+  # vcpkg version: 2026.07.29
   # If we change the `VCPKG COMMIT_ID`, please remember:
   # 1. Call `$VCPKG_ROOT/vcpkg x-update-baseline` to update the baseline in `vcpkg.json`.
   #  Or we may face build issue like 
   #  https://github.com/rustdesk/rustdesk/actions/runs/14414119794/job/40427970174
   # 2. Update the `VCPKG_COMMIT_ID` in `ci.yml` and `playground.yml`.
-  VCPKG_COMMIT_ID: "120deac3062162151622ca4860575a33844ba10b"
+  VCPKG_COMMIT_ID: "9e593bb18ea69cc5095e012465dcd675a822ed0d"
   ARMV7_VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836" # 2025.01.13, got "/opt/artifacts/vcpkg/vcpkg: No such file or directory" with latest version
   VERSION: "1.4.9"
   NDK_VERSION: "r28c"

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -16,7 +16,7 @@ env:
   FLUTTER_ELINUX_VERSION: "3.16.9"
   TAG_NAME: "nightly"
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-  VCPKG_COMMIT_ID: "120deac3062162151622ca4860575a33844ba10b"
+  VCPKG_COMMIT_ID: "9e593bb18ea69cc5095e012465dcd675a822ed0d"
   VERSION: "1.4.9"
   NDK_VERSION: "r26d"
   #signing keys env variable checks

--- a/build.rs
+++ b/build.rs
@@ -72,7 +72,6 @@ fn install_android_deps() {
         path.join("lib").to_str().unwrap()
     );
     println!("cargo:rustc-link-lib=ndk_compat");
-    println!("cargo:rustc-link-lib=oboe");
     println!("cargo:rustc-link-lib=c++");
     println!("cargo:rustc-link-lib=OpenSLES");
 }

--- a/res/vcpkg/aom/aom-uninitialized-pointer-3.9.1.diff
+++ b/res/vcpkg/aom/aom-uninitialized-pointer-3.9.1.diff
@@ -1,7 +1,7 @@
-diff --git a/cmake/aom_configure.cmake b/cmake/aom_configure.cmake
+diff --git a/build/cmake/aom_configure.cmake b/build/cmake/aom_configure.cmake
 index aaef2c310..5500ad4a3 100644
---- a/cmake/aom_configure.cmake
-+++ b/cmake/aom_configure.cmake
+--- a/build/cmake/aom_configure.cmake
++++ b/build/cmake/aom_configure.cmake
 @@ -309,6 +309,8 @@ if(MSVC)
  
    # Disable MSVC warnings that suggest making code non-portable.

--- a/res/vcpkg/aom/portfile.cmake
+++ b/res/vcpkg/aom/portfile.cmake
@@ -9,25 +9,24 @@ get_filename_component(PERL_PATH ${PERL} DIRECTORY)
 vcpkg_add_to_path(${PERL_PATH})
 
 if(DEFINED ENV{USE_AOM_391})
+    set(AOM_CONFIG_PATH "lib/cmake/aom")
     vcpkg_from_git(
         OUT_SOURCE_PATH SOURCE_PATH
         URL "https://aomedia.googlesource.com/aom"
         REF 8ad484f8a18ed1853c094e7d3a4e023b2a92df28 # 3.9.1
         PATCHES
-            aom-uninitialized-pointer.diff
+            aom-uninitialized-pointer-3.9.1.diff
             aom-avx2.diff
             aom-install.diff
     )
 else()
+    set(AOM_CONFIG_PATH "lib/cmake/AOM")
     vcpkg_from_git(
         OUT_SOURCE_PATH SOURCE_PATH
         URL "https://aomedia.googlesource.com/aom"
-        REF 10aece4157eb79315da205f39e19bf6ab3ee30d0 # 3.12.1
+        REF 03087864cf4bea6abb0d28f95cf7843511413d8f # 3.14.1
         PATCHES
             aom-uninitialized-pointer.diff
-            # aom-avx2.diff
-            # Can be dropped when https://bugs.chromium.org/p/aomedia/issues/detail?id=3029 is merged into the upstream
-            aom-install.diff
     )
 endif()
 
@@ -67,7 +66,7 @@ if(VCPKG_TARGET_IS_WINDOWS)
 endif()
 
 # Move cmake configs
-vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_cmake_config_fixup(CONFIG_PATH ${AOM_CONFIG_PATH})
 
 # Remove duplicate files
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include

--- a/res/vcpkg/aom/vcpkg.json
+++ b/res/vcpkg/aom/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "aom",
-  "version-semver": "3.12.1",
+  "version-semver": "3.14.1",
   "port-version": 0,
   "description": "AV1 codec library",
   "homepage": "https://aomedia.googlesource.com/aom",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -26,10 +26,6 @@
       "platform": "windows & arm64"
     },
     {
-      "name": "oboe",
-      "platform": "android"
-    },
-    {
       "name": "opus",
       "host": true
     },

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -91,7 +91,7 @@
   "vcpkg-configuration": {
     "default-registry": {
       "kind": "builtin",
-      "baseline": "120deac3062162151622ca4860575a33844ba10b"
+      "baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d"
     },
     "overlay-ports": [
       "./res/vcpkg"


### PR DESCRIPTION
This PR upgrades the aom dependency from v3.12.1 to v3.14.1 ("Pinkie Pie"),
which also includes all improvements from v3.13.0 ("Opaline") and v3.14.0.

Key improvements for RustDesk:

- **Compression efficiency (v3.14.0)**: Up to 30% better efficiency for
  layered image encoding at similar visual quality (realtime mode), and up
  to 15% for good-quality mode. This means smaller file sizes or better
  quality for the same bitrate in screen sharing / remote desktop scenarios.

- **Compression efficiency (v3.13.0)**: Up to 6.9% SSIMULACRA 2 BD-Rate
  gains at speed 8, and up to 2.2% at speed 9 for all-intra mode. Variance
  Boost is now enabled for AOM_TUNE_IQ and AOM_TUNE_SSIMULACRA2 tuning
  modes (2-5% gains at speeds 8-9).

- **Encoder speed (v3.14.0)**: 20-30% encoder time reduction with 1-5%
  VMAF quality gains across speed levels. Especially noticeable at speed 1-3.

- **Encoder speed (v3.13.0)**: RTC screen content encoding gets ~2x speedup
  at speed 12 for slide/scene changes (>= 720p). ML-based partition pruning
  improvements for speed <= 2.

- **Perceptual quality**: Tuning modes AOM_TUNE_IQ and AOM_TUNE_SSIMULACRA2
  now work with inter-frame encoding (good-quality and realtime), improving
  visual quality of layered image encoding. Adaptive sharpness, loop
  restoration, CDEF and temporal filter algorithms also improved.
  (v3.13.0 introduced the SSIMULACRA2 tuning mode and adaptive sharpness
  feature.)

- **Realtime encoding**: Now supports non-zero lookahead, enabling better
  quality for real-time streaming.

- **AArch64 optimizations**: Further SIMD optimizations for filtering,
  quantization, SAD, subpel variance and intra-predictors.

- **ROI feature (v3.13.0)**: ROI support is now fully implemented for RTC,
  enabling delta QP, skip encoding, and reference frame selection.

- **SVC external scaling (v3.13.0)**: Allows downscaled images to be passed
  into encoder for spatial layers without reconfiguring it.

- **Bug fixes (v3.14.1)**: Fixes a NULL pointer dereference in validate_img
  with 10-bit monochrome input, and increases ctx->cx_data_sz to 2.5x
  uncompressed frame size to prevent overflow issues.

ABI compatible with v3.12.1. v3.13.0, v3.14.0 and v3.14.1 each explicitly
declare ABI compatibility with their respective previous releases.

Build notes (v3.14.0+):
- The `build` directory in the source tree has been removed; the original
  `build/cmake` directory was moved up one level.
- `aom-install.cmake` has been merged into the new CMake structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows builds by handling compiler warnings related to potentially uninitialized pointers.
  - Added version-specific build handling to preserve compatibility with the older AOM release.

- **Chores**
  - Updated the bundled AOM codec to a newer version.
  - Refreshed package and build configuration pins across supported workflows for more consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR upgrades the bundled AOM codec to 3.14.1 while retaining a separate path for AOM 3.9.1 builds.
- Splits the warning-suppression patch by AOM source-tree layout.
- Selects version-specific CMake package paths and updates the vcpkg baseline across workflows.
- Removes the Android Oboe dependency and linker directive.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the version-specific patch selection resolves the previously reported AOM 3.9.1 build issue.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| res/vcpkg/aom/portfile.cmake | Selects distinct source revisions, patches, and CMake config paths for AOM 3.9.1 and 3.14.1; the previously reported shared-patch issue is resolved. |
| res/vcpkg/aom/aom-uninitialized-pointer-3.9.1.diff | Preserves the legacy `build/cmake` target path specifically for AOM 3.9.1. |
| res/vcpkg/aom/aom-uninitialized-pointer.diff | Retargets the warning-suppression patch to the newer AOM `cmake` source layout. |
| vcpkg.json | Updates the vcpkg baseline and removes the Android Oboe dependency consistently with the linker change. |
| build.rs | Removes the Android Oboe linker directive alongside removal of the corresponding vcpkg dependency. |

</details>

<sub>Reviews (8): Last reviewed commit: ["Remove oboe dependency in vcpkg.json"](https://github.com/rustdesk/rustdesk/commit/588638771a6bed8d74d701cf1e4e9116e191b303) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53933124)</sub>

<!-- /greptile_comment -->