### PR TITLE
fix(rdp): improve mstsc title and credential handling on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Security_Authorization",
+    "Win32_Security_Credentials",
     "Win32_Storage_FileSystem",
     "Win32_System",
     "Win32_System_Com",

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -13,6 +13,7 @@
 
 typedef char** (*FUNC_RUSTDESK_CORE_MAIN)(int*);
 typedef void (*FUNC_RUSTDESK_FREE_ARGS)( char**, int);
+typedef void (*FUNC_RUSTDESK_CORE_CLEANUP)();
 typedef int (*FUNC_RUSTDESK_GET_APP_NAME)(wchar_t*, int);
 typedef int (*FUNC_RUSTDESK_IS_DISABLE_INSTALLATION)();
 /// Note: `--server`, `--service` are already handled in [core_main.rs].
@@ -41,6 +42,13 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   if (!free_c_args)
   {
     std::cout << "Failed to get free_c_args." << std::endl;
+    return EXIT_FAILURE;
+  }
+  FUNC_RUSTDESK_CORE_CLEANUP rustdesk_core_cleanup =
+      (FUNC_RUSTDESK_CORE_CLEANUP)GetProcAddress(hInstance, "rustdesk_core_cleanup");
+  if (!rustdesk_core_cleanup)
+  {
+    std::cout << "Failed to get rustdesk_core_cleanup." << std::endl;
     return EXIT_FAILURE;
   }
   std::vector<std::string> command_line_arguments =
@@ -179,6 +187,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
     ::DispatchMessage(&msg);
   }
 
+  rustdesk_core_cleanup();
   ::CoUninitialize();
   return EXIT_SUCCESS;
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -133,7 +133,10 @@ pub fn global_init() -> bool {
     true
 }
 
-pub fn global_clean() {}
+pub fn global_clean() {
+    #[cfg(windows)]
+    crate::platform::cleanup_temporary_rdp_credentials();
+}
 
 #[inline]
 pub fn set_server_running(b: bool) {

--- a/src/common.rs
+++ b/src/common.rs
@@ -133,7 +133,7 @@ pub fn global_init() -> bool {
     true
 }
 
-pub fn global_clean() {
+pub fn clean_ui_process() {
     #[cfg(windows)]
     crate::platform::cleanup_temporary_rdp_credentials();
 }

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -139,7 +139,7 @@ pub extern "C" fn rustdesk_core_main_args(args_len: *mut c_int) -> *mut *mut c_c
 #[cfg(windows)]
 #[no_mangle]
 pub extern "C" fn rustdesk_core_cleanup() {
-    crate::common::global_clean();
+    crate::common::clean_ui_process();
 }
 
 #[cfg(windows)]

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -138,6 +138,12 @@ pub extern "C" fn rustdesk_core_main_args(args_len: *mut c_int) -> *mut *mut c_c
 
 #[cfg(windows)]
 #[no_mangle]
+pub extern "C" fn rustdesk_core_cleanup() {
+    crate::common::global_clean();
+}
+
+#[cfg(windows)]
+#[no_mangle]
 pub extern "C" fn rustdesk_is_disable_installation() -> c_int {
     hbb_common::config::is_disable_installation() as c_int
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ fn main() {
     }
     common::test_rendezvous_server();
     common::test_nat_type();
-    common::global_clean();
 }
 
 #[cfg(not(any(

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,6 @@ fn main() {
     }
     if let Some(args) = crate::core_main::core_main().as_mut() {
         ui::start(args);
+        common::clean_ui_process();
     }
-    common::global_clean();
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3090,7 +3090,7 @@ pub fn monitor_rdp_process<F>(
     _credential: Option<TemporaryRdpCredential>,
     _loopback: Option<RdpLoopbackAddress>,
 ) where
-    F: Fn() -> (String, String) + Send + 'static,
+    F: Fn() -> (String, bool) + Send + 'static,
 {
     let process_id = child.id();
     if let Err(err) = std::thread::Builder::new()
@@ -3098,7 +3098,8 @@ pub fn monitor_rdp_process<F>(
         .spawn(move || {
             let _credential = _credential;
             let _loopback = _loopback;
-            let mut title_attempted = false;
+            let mut title_applied = false;
+            let mut warned = false;
             loop {
                 match child.try_wait() {
                     Ok(Some(_)) => break,
@@ -3107,15 +3108,17 @@ pub fn monitor_rdp_process<F>(
                         break;
                     }
                     Ok(None) => {
-                        if !title_attempted {
-                            let (name, hostname) = name_of();
+                        if !title_applied {
+                            let (name, peer_info_received) = name_of();
                             let name = sanitize_rdp_window_title(&name);
-                            if !hostname.is_empty() && !name.is_empty() {
-                                title_attempted = true;
-                                if let Err(err) =
-                                    set_process_rdp_window_title(process_id, &name, &endpoint)
-                                {
-                                    log::warn!("Failed to set RDP window title: {}", err);
+                            if peer_info_received && !name.is_empty() {
+                                match set_process_rdp_window_title(process_id, &name, &endpoint) {
+                                    Ok(applied) => title_applied = applied,
+                                    Err(err) if !warned => {
+                                        log::warn!("Failed to set RDP window title: {}", err);
+                                        warned = true;
+                                    }
+                                    Err(_) => {}
                                 }
                             }
                         }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2644,6 +2644,49 @@ pub fn wide_string(s: &str) -> Vec<u16> {
 
 const RDP_CREDENTIAL_COMMENT_PREFIX: &str = "RustDesk temporary RDP credential ";
 
+#[derive(Clone)]
+pub struct RdpLoopbackAddress(Arc<RdpLoopbackAddressInner>);
+
+struct RdpLoopbackAddressInner {
+    index: u8,
+    host: String,
+}
+
+impl RdpLoopbackAddress {
+    pub fn bind_host(&self) -> &str {
+        &self.0.host
+    }
+
+    pub fn mstsc_host(&self) -> &str {
+        &self.0.host
+    }
+}
+
+impl Drop for RdpLoopbackAddressInner {
+    fn drop(&mut self) {
+        rdp_loopback_addresses().lock().unwrap().remove(&self.index);
+    }
+}
+
+fn rdp_loopback_addresses() -> &'static Mutex<std::collections::HashSet<u8>> {
+    static ADDRESSES: std::sync::OnceLock<Mutex<std::collections::HashSet<u8>>> =
+        std::sync::OnceLock::new();
+    ADDRESSES.get_or_init(|| Mutex::new(std::collections::HashSet::new()))
+}
+
+pub fn reserve_rdp_loopback_address() -> ResultType<RdpLoopbackAddress> {
+    let mut addresses = rdp_loopback_addresses().lock().unwrap();
+    let index = (2..=254)
+        .find(|index| !addresses.contains(index))
+        .ok_or_else(|| anyhow!("No RDP loopback address is available"))?;
+    addresses.insert(index);
+    let host = format!("127.0.0.{}", index);
+    Ok(RdpLoopbackAddress(Arc::new(RdpLoopbackAddressInner {
+        index,
+        host,
+    })))
+}
+
 struct RdpCredentialBuffer(*mut windows::Win32::Security::Credentials::CREDENTIALW);
 
 // CredReadW returns a self-contained allocation that remains valid until
@@ -2941,26 +2984,34 @@ fn sanitize_rdp_window_title(name: &str) -> String {
         .collect()
 }
 
-fn should_update_rdp_window_title(current: &str, name: &str, applied_name: &str) -> bool {
+fn should_update_rdp_window_title(
+    current: &str,
+    name: &str,
+    applied_name: &str,
+    endpoint: &str,
+) -> bool {
     current != name
-        && (current.contains("localhost") || (!applied_name.is_empty() && current == applied_name))
+        && (current.contains(endpoint) || (!applied_name.is_empty() && current == applied_name))
 }
 
 pub fn set_rdp_window_title<F>(
     mut child: std::process::Child,
     name_of: F,
+    endpoint: String,
     _credential: Option<TemporaryRdpCredential>,
+    _loopback: Option<RdpLoopbackAddress>,
 ) where
     F: Fn() -> String + Send + 'static,
 {
     let process_id = child.id();
-    // mstsc owns the title and can restore "localhost" while connecting or
+    // mstsc owns the title and can restore the endpoint while connecting or
     // reconnecting. Follow only the process we launched and reapply the peer
     // name until it exits, so concurrent RDP sessions cannot rename each other.
     if let Err(err) = std::thread::Builder::new()
         .name("rdp-window-title".to_owned())
         .spawn(move || {
             let _credential = _credential;
+            let _loopback = _loopback;
             let mut warned = false;
             let mut applied_name = String::new();
             loop {
@@ -2973,7 +3024,12 @@ pub fn set_rdp_window_title<F>(
                     Ok(None) => {
                         let name = sanitize_rdp_window_title(&name_of());
                         if !name.is_empty() {
-                            match set_process_rdp_window_title(process_id, &name, &applied_name) {
+                            match set_process_rdp_window_title(
+                                process_id,
+                                &name,
+                                &applied_name,
+                                &endpoint,
+                            ) {
                                 Ok(applied) => {
                                     if applied {
                                         applied_name = name;
@@ -3001,11 +3057,13 @@ fn set_process_rdp_window_title(
     process_id: DWORD,
     name: &str,
     applied_name: &str,
+    endpoint: &str,
 ) -> io::Result<bool> {
     struct Context<'a> {
         process_id: DWORD,
         name: &'a str,
         applied_name: &'a str,
+        endpoint: &'a str,
         title: Vec<u16>,
         applied: bool,
         error: Option<io::Error>,
@@ -3032,7 +3090,12 @@ fn set_process_rdp_window_title(
             context.applied = true;
             return TRUE;
         }
-        if !should_update_rdp_window_title(&current, context.name, context.applied_name) {
+        if !should_update_rdp_window_title(
+            &current,
+            context.name,
+            context.applied_name,
+            context.endpoint,
+        ) {
             return TRUE;
         }
         let mut result = 0;
@@ -3071,6 +3134,7 @@ fn set_process_rdp_window_title(
         process_id,
         name,
         applied_name,
+        endpoint,
         title: wide_string(name),
         applied: false,
         error: None,
@@ -5009,23 +5073,47 @@ mod tests {
         assert!(should_update_rdp_window_title(
             "localhost - Remote Desktop Connection",
             "peer",
-            ""
+            "",
+            "localhost"
+        ));
+        assert!(should_update_rdp_window_title(
+            "127.0.0.2 - Remote Desktop Connection",
+            "peer",
+            "",
+            "127.0.0.2"
         ));
         assert!(should_update_rdp_window_title(
             "peer",
             "peer (hostname)",
-            "peer"
+            "peer",
+            "127.0.0.2"
         ));
         assert!(!should_update_rdp_window_title(
             "localhost tunnel",
             "localhost tunnel",
-            "localhost tunnel"
+            "localhost tunnel",
+            "localhost"
         ));
         assert!(!should_update_rdp_window_title(
             "Remote Desktop Connection",
             "peer",
-            ""
+            "",
+            "localhost"
         ));
+    }
+
+    #[test]
+    fn rdp_loopback_addresses_are_unique_while_reserved() {
+        let first = reserve_rdp_loopback_address().unwrap();
+        let second = reserve_rdp_loopback_address().unwrap();
+        assert_eq!(first.bind_host(), "127.0.0.2");
+        assert_eq!(first.mstsc_host(), "127.0.0.2");
+        assert_eq!(second.bind_host(), "127.0.0.3");
+        assert_eq!(second.mstsc_host(), "127.0.0.3");
+
+        drop(first);
+        let reused = reserve_rdp_loopback_address().unwrap();
+        assert_eq!(reused.bind_host(), "127.0.0.2");
     }
 
     // Test-only reusable Win32 HANDLE RAII helper.

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2687,9 +2687,20 @@ impl Drop for RdpCredentialBuffer {
     }
 }
 
+struct RdpCredentialState {
+    original: Option<RdpCredentialBuffer>,
+    active: Vec<String>,
+    current_comment: String,
+}
+
+fn rdp_credential_states() -> &'static Mutex<HashMap<String, RdpCredentialState>> {
+    static STATES: std::sync::OnceLock<Mutex<HashMap<String, RdpCredentialState>>> =
+        std::sync::OnceLock::new();
+    STATES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 pub struct TemporaryRdpCredential {
     target: windows::core::HSTRING,
-    previous: Option<RdpCredentialBuffer>,
     comment: String,
 }
 
@@ -2779,29 +2790,74 @@ pub fn prepare_temporary_rdp_credential(
     }
 
     let target = windows::core::HSTRING::from(target);
+    let target_key = target.to_string_lossy();
+    let mut states = rdp_credential_states().lock().unwrap();
     let existing = read_rdp_credential(&target)?;
-    let existing_is_rustdesk = existing
-        .as_ref()
-        .map(RdpCredentialBuffer::has_rustdesk_comment)
+    let matches_current = states
+        .get(&target_key)
+        .map(|state| {
+            existing
+                .as_ref()
+                .map(|credential| credential.has_comment(&state.current_comment))
+                .unwrap_or(false)
+        })
         .unwrap_or(false);
-    let previous = if existing_is_rustdesk { None } else { existing };
+    if states.contains_key(&target_key) && !matches_current {
+        states.remove(&target_key);
+    }
 
     let comment = format!(
         "{}{}",
         RDP_CREDENTIAL_COMMENT_PREFIX,
         uuid::Uuid::new_v4().simple()
     );
-    write_rdp_credential(&target, username, password, &comment)?;
-    Ok(Some(TemporaryRdpCredential {
-        target,
-        previous,
-        comment,
-    }))
+    if let Some(state) = states.get_mut(&target_key) {
+        write_rdp_credential(&target, username, password, &comment)?;
+        state.active.push(comment.clone());
+        state.current_comment = comment.clone();
+    } else {
+        let original = if existing
+            .as_ref()
+            .map(RdpCredentialBuffer::has_rustdesk_comment)
+            .unwrap_or(false)
+        {
+            None
+        } else {
+            existing
+        };
+        write_rdp_credential(&target, username, password, &comment)?;
+        states.insert(
+            target_key,
+            RdpCredentialState {
+                original,
+                active: vec![comment.clone()],
+                current_comment: comment.clone(),
+            },
+        );
+    }
+    Ok(Some(TemporaryRdpCredential { target, comment }))
 }
 
 impl Drop for TemporaryRdpCredential {
     fn drop(&mut self) {
         use windows::Win32::Security::Credentials::CredWriteW;
+
+        let target_key = self.target.to_string_lossy();
+        let mut states = rdp_credential_states().lock().unwrap();
+        let Some(state) = states.get_mut(&target_key) else {
+            return;
+        };
+        let Some(index) = state
+            .active
+            .iter()
+            .position(|comment| comment == &self.comment)
+        else {
+            return;
+        };
+        state.active.remove(index);
+        if !state.active.is_empty() {
+            return;
+        }
 
         let current = match read_rdp_credential(&self.target) {
             Ok(current) => current,
@@ -2814,28 +2870,32 @@ impl Drop for TemporaryRdpCredential {
                 return;
             }
         };
-        let unchanged = current
+        let owned = current
             .as_ref()
-            .map(|credential| credential.has_comment(&self.comment))
+            .map(|credential| credential.has_comment(&state.current_comment))
             .unwrap_or(false);
-        if !unchanged {
+        if !owned {
+            states.remove(&target_key);
             return;
         }
 
-        let result = if let Some(previous) = self.previous.as_ref() {
-            unsafe { CredWriteW(previous.0, 0) }
+        let result = if let Some(original) = state.original.as_ref() {
+            unsafe { CredWriteW(original.0, 0) }
                 .map_err(|err| anyhow!("CredWriteW failed while restoring: {}", err))
-        } else if current.is_some() {
-            delete_rdp_credential(&self.target)
         } else {
-            Ok(())
+            delete_rdp_credential(&self.target)
         };
-        if let Err(err) = result {
-            log::warn!(
-                "Failed to restore RDP credential for target '{}': {}",
-                self.target.to_string_lossy(),
-                err
-            );
+        match result {
+            Ok(()) => {
+                states.remove(&target_key);
+            }
+            Err(err) => {
+                log::warn!(
+                    "Failed to restore RDP credential for target '{}': {}",
+                    self.target.to_string_lossy(),
+                    err
+                );
+            }
         }
     }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2294,6 +2294,7 @@ pub fn get_win_key_state() -> bool {
 }
 
 pub fn quit_gui() {
+    crate::common::clean_ui_process();
     std::process::exit(0);
     // unsafe { PostQuitMessage(0) }; // some how not work
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2722,6 +2722,49 @@ pub fn reserve_rdp_loopback_address() -> ResultType<RdpLoopbackAddress> {
     bail!("No RDP loopback address is available")
 }
 
+pub fn new_mstsc_command() -> std::process::Command {
+    if cfg!(target_arch = "x86") && is_x64() {
+        match windows_directory() {
+            Ok(directory) => {
+                // A WOW64 mstsc launcher can exit after handing off to native mstsc, dropping
+                // the temporary credential too early. Sysnative makes the guard track the
+                // actual mstsc process.
+                let path = directory.join("Sysnative").join("mstsc.exe");
+                match fs::metadata(&path) {
+                    Ok(metadata) if metadata.is_file() => {
+                        return std::process::Command::new(path);
+                    }
+                    Ok(_) => log::warn!("Native mstsc path is not a file: {}", path.display()),
+                    Err(err) => log::warn!(
+                        "Failed to find native mstsc at '{}': {}",
+                        path.display(),
+                        err
+                    ),
+                }
+            }
+            Err(err) => log::warn!("Failed to locate native mstsc: {}", err),
+        }
+    }
+    std::process::Command::new("mstsc")
+}
+
+fn windows_directory() -> io::Result<PathBuf> {
+    use winapi::um::sysinfoapi::GetWindowsDirectoryW;
+
+    let mut buffer = vec![0u16; 260];
+    loop {
+        let length = unsafe { GetWindowsDirectoryW(buffer.as_mut_ptr(), buffer.len() as _) };
+        if length == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if (length as usize) < buffer.len() {
+            buffer.truncate(length as usize);
+            return Ok(PathBuf::from(OsString::from_wide(&buffer)));
+        }
+        buffer.resize(length as usize + 1, 0);
+    }
+}
+
 struct RdpCredentialBuffer(*mut windows::Win32::Security::Credentials::CREDENTIALW);
 
 // CredReadW returns a self-contained allocation that remains valid until

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2752,18 +2752,20 @@ pub fn new_mstsc_command() -> std::process::Command {
 fn windows_directory() -> io::Result<PathBuf> {
     use winapi::um::sysinfoapi::GetWindowsDirectoryW;
 
-    let mut buffer = vec![0u16; 260];
-    loop {
-        let length = unsafe { GetWindowsDirectoryW(buffer.as_mut_ptr(), buffer.len() as _) };
-        if length == 0 {
-            return Err(io::Error::last_os_error());
-        }
-        if (length as usize) < buffer.len() {
-            buffer.truncate(length as usize);
-            return Ok(PathBuf::from(OsString::from_wide(&buffer)));
-        }
-        buffer.resize(length as usize + 1, 0);
+    let mut buffer = [0u16; winapi::shared::minwindef::MAX_PATH];
+    let length = unsafe { GetWindowsDirectoryW(buffer.as_mut_ptr(), buffer.len() as _) };
+    if length == 0 {
+        return Err(io::Error::last_os_error());
     }
+    if length as usize >= buffer.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Windows directory path exceeds MAX_PATH",
+        ));
+    }
+    Ok(PathBuf::from(OsString::from_wide(
+        &buffer[..length as usize],
+    )))
 }
 
 struct RdpCredentialBuffer(*mut windows::Win32::Security::Credentials::CREDENTIALW);

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2687,15 +2687,10 @@ impl Drop for RdpCredentialBuffer {
     }
 }
 
-enum TemporaryRdpCredentialState {
-    Present { comment: String },
-    Absent,
-}
-
 pub struct TemporaryRdpCredential {
     target: windows::core::HSTRING,
     previous: Option<RdpCredentialBuffer>,
-    state: TemporaryRdpCredentialState,
+    comment: String,
 }
 
 fn is_rdp_credential_not_found(err: &windows::core::Error) -> bool {
@@ -2776,30 +2771,20 @@ pub fn prepare_temporary_rdp_credential(
     username: &str,
     password: &str,
 ) -> ResultType<Option<TemporaryRdpCredential>> {
+    // Credential Guard may reject mstsc-saved Windows credentials; peer credentials use Generic.
+    // Without a peer username, leave Credential Manager untouched and let mstsc handle its entry.
+    // See https://learn.microsoft.com/windows/security/identity-protection/credential-guard/considerations-known-issues#saved-windows-credentials-considerations
+    if username.is_empty() {
+        return Ok(None);
+    }
+
     let target = windows::core::HSTRING::from(target);
     let existing = read_rdp_credential(&target)?;
-    let had_existing = existing.is_some();
     let existing_is_rustdesk = existing
         .as_ref()
         .map(RdpCredentialBuffer::has_rustdesk_comment)
         .unwrap_or(false);
     let previous = if existing_is_rustdesk { None } else { existing };
-
-    if username.is_empty() && password.is_empty() {
-        if !had_existing {
-            return Ok(None);
-        }
-        delete_rdp_credential(&target)?;
-        return if previous.is_some() {
-            Ok(Some(TemporaryRdpCredential {
-                target,
-                previous,
-                state: TemporaryRdpCredentialState::Absent,
-            }))
-        } else {
-            Ok(None)
-        };
-    }
 
     let comment = format!(
         "{}{}",
@@ -2810,7 +2795,7 @@ pub fn prepare_temporary_rdp_credential(
     Ok(Some(TemporaryRdpCredential {
         target,
         previous,
-        state: TemporaryRdpCredentialState::Present { comment },
+        comment,
     }))
 }
 
@@ -2829,13 +2814,10 @@ impl Drop for TemporaryRdpCredential {
                 return;
             }
         };
-        let unchanged = match &self.state {
-            TemporaryRdpCredentialState::Present { comment } => current
-                .as_ref()
-                .map(|credential| credential.has_comment(comment))
-                .unwrap_or(false),
-            TemporaryRdpCredentialState::Absent => current.is_none(),
-        };
+        let unchanged = current
+            .as_ref()
+            .map(|credential| credential.has_comment(&self.comment))
+            .unwrap_or(false);
         if !unchanged {
             return;
         }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2642,6 +2642,222 @@ pub fn wide_string(s: &str) -> Vec<u16> {
         .collect()
 }
 
+const RDP_CREDENTIAL_COMMENT_PREFIX: &str = "RustDesk temporary RDP credential ";
+
+struct RdpCredentialBuffer(*mut windows::Win32::Security::Credentials::CREDENTIALW);
+
+// CredReadW returns a self-contained allocation that remains valid until
+// CredFree. Moving ownership to the mstsc monitor thread is therefore safe.
+unsafe impl Send for RdpCredentialBuffer {}
+
+impl RdpCredentialBuffer {
+    fn has_comment(&self, expected: &str) -> bool {
+        unsafe {
+            let comment = (*self.0).Comment;
+            !comment.is_null()
+                && comment
+                    .to_string()
+                    .map(|comment| comment == expected)
+                    .unwrap_or(false)
+        }
+    }
+
+    fn has_rustdesk_comment(&self) -> bool {
+        unsafe {
+            let comment = (*self.0).Comment;
+            !comment.is_null()
+                && comment
+                    .to_string()
+                    .ok()
+                    .and_then(|comment| {
+                        comment
+                            .strip_prefix(RDP_CREDENTIAL_COMMENT_PREFIX)
+                            .map(|id| uuid::Uuid::parse_str(id).is_ok())
+                    })
+                    .unwrap_or(false)
+        }
+    }
+}
+
+impl Drop for RdpCredentialBuffer {
+    fn drop(&mut self) {
+        use windows::Win32::Security::Credentials::CredFree;
+
+        unsafe { CredFree(self.0.cast::<std::ffi::c_void>()) };
+    }
+}
+
+enum TemporaryRdpCredentialState {
+    Present { comment: String },
+    Absent,
+}
+
+pub struct TemporaryRdpCredential {
+    target: windows::core::HSTRING,
+    previous: Option<RdpCredentialBuffer>,
+    state: TemporaryRdpCredentialState,
+}
+
+fn is_rdp_credential_not_found(err: &windows::core::Error) -> bool {
+    use windows::{core::HRESULT, Win32::Foundation::ERROR_NOT_FOUND};
+
+    err.code() == HRESULT::from_win32(ERROR_NOT_FOUND.0)
+}
+
+fn read_rdp_credential(target: &windows::core::HSTRING) -> ResultType<Option<RdpCredentialBuffer>> {
+    use windows::Win32::Security::Credentials::{CredReadW, CRED_TYPE_GENERIC};
+
+    let mut credential = null_mut();
+    match unsafe { CredReadW(target, CRED_TYPE_GENERIC, None, &mut credential) } {
+        Ok(()) if credential.is_null() => bail!("CredReadW returned an empty credential"),
+        Ok(()) => Ok(Some(RdpCredentialBuffer(credential))),
+        Err(err) if is_rdp_credential_not_found(&err) => Ok(None),
+        Err(err) => Err(anyhow!("CredReadW failed: {}", err)),
+    }
+}
+
+fn delete_rdp_credential(target: &windows::core::HSTRING) -> ResultType<()> {
+    use windows::Win32::Security::Credentials::{CredDeleteW, CRED_TYPE_GENERIC};
+
+    unsafe { CredDeleteW(target, CRED_TYPE_GENERIC, None) }
+        .map_err(|err| anyhow!("CredDeleteW failed: {}", err))
+}
+
+fn write_rdp_credential(
+    target: &windows::core::HSTRING,
+    username: &str,
+    password: &str,
+    comment: &str,
+) -> ResultType<()> {
+    use windows::{
+        core::{HSTRING, PWSTR},
+        Win32::Security::Credentials::{
+            CredWriteW, CREDENTIALW, CRED_MAX_CREDENTIAL_BLOB_SIZE, CRED_PERSIST_SESSION,
+            CRED_TYPE_GENERIC,
+        },
+    };
+
+    let username = HSTRING::from(username);
+    let comment = HSTRING::from(comment);
+    let blob_size = password
+        .encode_utf16()
+        .count()
+        .checked_mul(std::mem::size_of::<u16>())
+        .and_then(|size| u32::try_from(size).ok())
+        .filter(|size| *size <= CRED_MAX_CREDENTIAL_BLOB_SIZE)
+        .ok_or_else(|| anyhow!("RDP credential password is too long"))?;
+    let mut password: Vec<u16> = password.encode_utf16().collect();
+    let mut credential = CREDENTIALW {
+        Type: CRED_TYPE_GENERIC,
+        TargetName: PWSTR(target.as_ptr() as *mut u16),
+        Comment: PWSTR(comment.as_ptr() as *mut u16),
+        CredentialBlobSize: blob_size,
+        CredentialBlob: if password.is_empty() {
+            null_mut()
+        } else {
+            password.as_mut_ptr().cast::<u8>()
+        },
+        Persist: CRED_PERSIST_SESSION,
+        UserName: if username.is_empty() {
+            PWSTR::null()
+        } else {
+            PWSTR(username.as_ptr() as *mut u16)
+        },
+        ..Default::default()
+    };
+    let result = unsafe { CredWriteW(&mut credential, 0) }
+        .map_err(|err| anyhow!("CredWriteW failed: {}", err));
+    password.fill(0);
+    result
+}
+
+pub fn prepare_temporary_rdp_credential(
+    target: &str,
+    username: &str,
+    password: &str,
+) -> ResultType<Option<TemporaryRdpCredential>> {
+    let target = windows::core::HSTRING::from(target);
+    let existing = read_rdp_credential(&target)?;
+    let had_existing = existing.is_some();
+    let existing_is_rustdesk = existing
+        .as_ref()
+        .map(RdpCredentialBuffer::has_rustdesk_comment)
+        .unwrap_or(false);
+    let previous = if existing_is_rustdesk { None } else { existing };
+
+    if username.is_empty() && password.is_empty() {
+        if !had_existing {
+            return Ok(None);
+        }
+        delete_rdp_credential(&target)?;
+        return if previous.is_some() {
+            Ok(Some(TemporaryRdpCredential {
+                target,
+                previous,
+                state: TemporaryRdpCredentialState::Absent,
+            }))
+        } else {
+            Ok(None)
+        };
+    }
+
+    let comment = format!(
+        "{}{}",
+        RDP_CREDENTIAL_COMMENT_PREFIX,
+        uuid::Uuid::new_v4().simple()
+    );
+    write_rdp_credential(&target, username, password, &comment)?;
+    Ok(Some(TemporaryRdpCredential {
+        target,
+        previous,
+        state: TemporaryRdpCredentialState::Present { comment },
+    }))
+}
+
+impl Drop for TemporaryRdpCredential {
+    fn drop(&mut self) {
+        use windows::Win32::Security::Credentials::CredWriteW;
+
+        let current = match read_rdp_credential(&self.target) {
+            Ok(current) => current,
+            Err(err) => {
+                log::warn!(
+                    "Failed to inspect temporary RDP credential for target '{}': {}",
+                    self.target.to_string_lossy(),
+                    err
+                );
+                return;
+            }
+        };
+        let unchanged = match &self.state {
+            TemporaryRdpCredentialState::Present { comment } => current
+                .as_ref()
+                .map(|credential| credential.has_comment(comment))
+                .unwrap_or(false),
+            TemporaryRdpCredentialState::Absent => current.is_none(),
+        };
+        if !unchanged {
+            return;
+        }
+
+        let result = if let Some(previous) = self.previous.as_ref() {
+            unsafe { CredWriteW(previous.0, 0) }
+                .map_err(|err| anyhow!("CredWriteW failed while restoring: {}", err))
+        } else if current.is_some() {
+            delete_rdp_credential(&self.target)
+        } else {
+            Ok(())
+        };
+        if let Err(err) = result {
+            log::warn!(
+                "Failed to restore RDP credential for target '{}': {}",
+                self.target.to_string_lossy(),
+                err
+            );
+        }
+    }
+}
+
 // This only changes mstsc's top-level window title. The full-screen connection
 // bar is rendered separately and cannot be customized when mstsc.exe is
 // launched as an independent process.
@@ -2688,8 +2904,11 @@ fn should_update_rdp_window_title(current: &str, name: &str, applied_name: &str)
         && (current.contains("localhost") || (!applied_name.is_empty() && current == applied_name))
 }
 
-pub fn set_rdp_window_title<F>(mut child: std::process::Child, name_of: F)
-where
+pub fn set_rdp_window_title<F>(
+    mut child: std::process::Child,
+    name_of: F,
+    _credential: Option<TemporaryRdpCredential>,
+) where
     F: Fn() -> String + Send + 'static,
 {
     let process_id = child.id();
@@ -2699,6 +2918,7 @@ where
     if let Err(err) = std::thread::Builder::new()
         .name("rdp-window-title".to_owned())
         .spawn(move || {
+            let _credential = _credential;
             let mut warned = false;
             let mut applied_name = String::new();
             loop {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2648,9 +2648,15 @@ const RDP_CREDENTIAL_COMMENT_PREFIX: &str = "RustDesk temporary RDP credential "
 pub struct RdpLoopbackAddress(Arc<RdpLoopbackAddressInner>);
 
 struct RdpLoopbackAddressInner {
-    index: u8,
     host: String,
+    _mutex: RdpLoopbackMutex,
 }
+
+struct RdpLoopbackMutex(HANDLE);
+
+// Kernel handles may be closed from any thread and are otherwise immutable here.
+unsafe impl Send for RdpLoopbackMutex {}
+unsafe impl Sync for RdpLoopbackMutex {}
 
 impl RdpLoopbackAddress {
     pub fn bind_host(&self) -> &str {
@@ -2662,29 +2668,58 @@ impl RdpLoopbackAddress {
     }
 }
 
-impl Drop for RdpLoopbackAddressInner {
+impl Drop for RdpLoopbackMutex {
     fn drop(&mut self) {
-        rdp_loopback_addresses().lock().unwrap().remove(&self.index);
+        if unsafe { CloseHandle(self.0) } == FALSE {
+            log::warn!(
+                "Failed to release RDP loopback mutex: {}",
+                io::Error::last_os_error()
+            );
+        }
     }
 }
 
-fn rdp_loopback_addresses() -> &'static Mutex<std::collections::HashSet<u8>> {
-    static ADDRESSES: std::sync::OnceLock<Mutex<std::collections::HashSet<u8>>> =
-        std::sync::OnceLock::new();
-    ADDRESSES.get_or_init(|| Mutex::new(std::collections::HashSet::new()))
+fn reserve_rdp_loopback_mutex(index: u8) -> ResultType<Option<RdpLoopbackMutex>> {
+    use winapi::um::{errhandlingapi::SetLastError, synchapi::CreateMutexW};
+
+    let name = wide_string(&format!("Local\\RustDesk_RdpLoopback_{}", index));
+    unsafe {
+        SetLastError(ERROR_SUCCESS);
+        let handle = CreateMutexW(null_mut(), FALSE, name.as_ptr());
+        let error = GetLastError();
+        if handle.is_null() {
+            if error == ERROR_ACCESS_DENIED {
+                return Ok(None);
+            }
+            bail!(
+                "Failed to reserve RDP loopback address 127.0.0.{}: {}",
+                index,
+                io::Error::from_raw_os_error(error as _)
+            );
+        }
+        if error == ERROR_ALREADY_EXISTS {
+            if CloseHandle(handle) == FALSE {
+                log::warn!(
+                    "Failed to close existing RDP loopback mutex: {}",
+                    io::Error::last_os_error()
+                );
+            }
+            return Ok(None);
+        }
+        Ok(Some(RdpLoopbackMutex(handle)))
+    }
 }
 
 pub fn reserve_rdp_loopback_address() -> ResultType<RdpLoopbackAddress> {
-    let mut addresses = rdp_loopback_addresses().lock().unwrap();
-    let index = (2..=254)
-        .find(|index| !addresses.contains(index))
-        .ok_or_else(|| anyhow!("No RDP loopback address is available"))?;
-    addresses.insert(index);
-    let host = format!("127.0.0.{}", index);
-    Ok(RdpLoopbackAddress(Arc::new(RdpLoopbackAddressInner {
-        index,
-        host,
-    })))
+    for index in 2..=254 {
+        if let Some(mutex) = reserve_rdp_loopback_mutex(index)? {
+            return Ok(RdpLoopbackAddress(Arc::new(RdpLoopbackAddressInner {
+                host: format!("127.0.0.{}", index),
+                _mutex: mutex,
+            })));
+        }
+    }
+    bail!("No RDP loopback address is available")
 }
 
 struct RdpCredentialBuffer(*mut windows::Win32::Security::Credentials::CREDENTIALW);

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2645,18 +2645,39 @@ pub fn wide_string(s: &str) -> Vec<u16> {
 // This only changes mstsc's top-level window title. The full-screen connection
 // bar is rendered separately and cannot be customized when mstsc.exe is
 // launched as an independent process.
+fn is_unicode_format_character(c: char) -> bool {
+    matches!(
+        c,
+        '\u{00AD}'
+            | '\u{0600}'..='\u{0605}'
+            | '\u{061C}'
+            | '\u{06DD}'
+            | '\u{070F}'
+            | '\u{0890}'..='\u{0891}'
+            | '\u{08E2}'
+            | '\u{180E}'
+            | '\u{200B}'..='\u{200F}'
+            | '\u{202A}'..='\u{202E}'
+            | '\u{2060}'..='\u{2064}'
+            | '\u{2066}'..='\u{206F}'
+            | '\u{FEFF}'
+            | '\u{FFF9}'..='\u{FFFB}'
+            | '\u{110BD}'
+            | '\u{110CD}'
+            | '\u{13430}'..='\u{1343F}'
+            | '\u{1BCA0}'..='\u{1BCA3}'
+            | '\u{1D173}'..='\u{1D17A}'
+            | '\u{E0001}'
+            | '\u{E0020}'..='\u{E007F}'
+    )
+}
+
 fn sanitize_rdp_window_title(name: &str) -> String {
     name.chars()
         .filter(|c| {
             !c.is_control()
-                && !matches!(
-                    *c,
-                    '\u{061C}'
-                        | '\u{200B}'..='\u{200F}'
-                        | '\u{2028}'..='\u{202E}'
-                        | '\u{2060}'..='\u{206F}'
-                        | '\u{FEFF}'
-                )
+                && !is_unicode_format_character(*c)
+                && !matches!(*c, '\u{2028}' | '\u{2029}' | '\u{2065}')
         })
         .take(120)
         .collect()
@@ -4706,8 +4727,12 @@ mod tests {
     #[test]
     fn rdp_window_title_removes_control_and_format_characters() {
         assert_eq!(
-            sanitize_rdp_window_title("peer\n\u{061C}\u{200D}\u{202E}\u{2066}\u{FEFF} (服务器)"),
-            "peer (服务器)"
+            sanitize_rdp_window_title(
+                "peer\n\u{00AD}\u{0600}\u{061C}\u{06DD}\u{070F}\u{0890}\u{08E2}\u{180E}\
+                 \u{200D}\u{2028}\u{202E}\u{2065}\u{2066}\u{FEFF}\u{FFF9}\u{110BD}\u{110CD}\
+                 \u{13430}\u{1BCA0}\u{1D173}\u{E0001}\u{E0020} (host)"
+            ),
+            "peer (host)"
         );
     }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3079,36 +3079,26 @@ fn sanitize_rdp_window_title(name: &str) -> String {
         .collect()
 }
 
-fn should_update_rdp_window_title(
-    current: &str,
-    name: &str,
-    applied_name: &str,
-    endpoint: &str,
-) -> bool {
-    current != name
-        && (current.contains(endpoint) || (!applied_name.is_empty() && current == applied_name))
+fn should_update_rdp_window_title(current: &str, name: &str, endpoint: &str) -> bool {
+    current != name && current.contains(endpoint)
 }
 
-pub fn set_rdp_window_title<F>(
+pub fn monitor_rdp_process<F>(
     mut child: std::process::Child,
     name_of: F,
     endpoint: String,
     _credential: Option<TemporaryRdpCredential>,
     _loopback: Option<RdpLoopbackAddress>,
 ) where
-    F: Fn() -> String + Send + 'static,
+    F: Fn() -> (String, String) + Send + 'static,
 {
     let process_id = child.id();
-    // mstsc owns the title and can restore the endpoint while connecting or
-    // reconnecting. Follow only the process we launched and reapply the peer
-    // name until it exits, so concurrent RDP sessions cannot rename each other.
     if let Err(err) = std::thread::Builder::new()
-        .name("rdp-window-title".to_owned())
+        .name("rdp-process-monitor".to_owned())
         .spawn(move || {
             let _credential = _credential;
             let _loopback = _loopback;
-            let mut warned = false;
-            let mut applied_name = String::new();
+            let mut title_attempted = false;
             loop {
                 match child.try_wait() {
                     Ok(Some(_)) => break,
@@ -3117,25 +3107,16 @@ pub fn set_rdp_window_title<F>(
                         break;
                     }
                     Ok(None) => {
-                        let name = sanitize_rdp_window_title(&name_of());
-                        if !name.is_empty() {
-                            match set_process_rdp_window_title(
-                                process_id,
-                                &name,
-                                &applied_name,
-                                &endpoint,
-                            ) {
-                                Ok(applied) => {
-                                    if applied {
-                                        applied_name = name;
-                                    }
-                                    warned = false;
-                                }
-                                Err(err) if !warned => {
+                        if !title_attempted {
+                            let (name, hostname) = name_of();
+                            let name = sanitize_rdp_window_title(&name);
+                            if !hostname.is_empty() && !name.is_empty() {
+                                title_attempted = true;
+                                if let Err(err) =
+                                    set_process_rdp_window_title(process_id, &name, &endpoint)
+                                {
                                     log::warn!("Failed to set RDP window title: {}", err);
-                                    warned = true;
                                 }
-                                Err(_) => {}
                             }
                         }
                     }
@@ -3144,20 +3125,14 @@ pub fn set_rdp_window_title<F>(
             }
         })
     {
-        log::warn!("Failed to start RDP window title thread: {}", err);
+        log::warn!("Failed to start RDP process monitor thread: {}", err);
     }
 }
 
-fn set_process_rdp_window_title(
-    process_id: DWORD,
-    name: &str,
-    applied_name: &str,
-    endpoint: &str,
-) -> io::Result<bool> {
+fn set_process_rdp_window_title(process_id: DWORD, name: &str, endpoint: &str) -> io::Result<bool> {
     struct Context<'a> {
         process_id: DWORD,
         name: &'a str,
-        applied_name: &'a str,
         endpoint: &'a str,
         title: Vec<u16>,
         applied: bool,
@@ -3185,12 +3160,7 @@ fn set_process_rdp_window_title(
             context.applied = true;
             return TRUE;
         }
-        if !should_update_rdp_window_title(
-            &current,
-            context.name,
-            context.applied_name,
-            context.endpoint,
-        ) {
+        if !should_update_rdp_window_title(&current, context.name, context.endpoint) {
             return TRUE;
         }
         let mut result = 0;
@@ -3228,7 +3198,6 @@ fn set_process_rdp_window_title(
     let mut context = Context {
         process_id,
         name,
-        applied_name,
         endpoint,
         title: wide_string(name),
         applied: false,
@@ -5164,27 +5133,18 @@ mod tests {
     }
 
     #[test]
-    fn rdp_window_title_updates_only_the_tunnel_or_the_previously_applied_name() {
+    fn rdp_window_title_updates_only_the_tunnel_title() {
         assert!(should_update_rdp_window_title(
             "localhost - Remote Desktop Connection",
             "peer",
-            "",
             "localhost"
         ));
         assert!(should_update_rdp_window_title(
             "127.0.0.2 - Remote Desktop Connection",
             "peer",
-            "",
-            "127.0.0.2"
-        ));
-        assert!(should_update_rdp_window_title(
-            "peer",
-            "peer (hostname)",
-            "peer",
             "127.0.0.2"
         ));
         assert!(!should_update_rdp_window_title(
-            "localhost tunnel",
             "localhost tunnel",
             "localhost tunnel",
             "localhost"
@@ -5192,7 +5152,6 @@ mod tests {
         assert!(!should_update_rdp_window_title(
             "Remote Desktop Connection",
             "peer",
-            "",
             "localhost"
         ));
     }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2820,6 +2820,48 @@ fn rdp_credential_states() -> &'static Mutex<HashMap<String, RdpCredentialState>
     STATES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+fn restore_temporary_rdp_credential(
+    target: &windows::core::HSTRING,
+    state: &RdpCredentialState,
+) -> ResultType<()> {
+    use windows::Win32::Security::Credentials::CredWriteW;
+
+    let current = read_rdp_credential(target)?;
+    let owned = current
+        .as_ref()
+        .map(|credential| credential.has_comment(&state.current_comment))
+        .unwrap_or(false);
+    if !owned {
+        return Ok(());
+    }
+
+    if let Some(original) = state.original.as_ref() {
+        unsafe { CredWriteW(original.0, 0) }
+            .map_err(|err| anyhow!("CredWriteW failed while restoring: {}", err))
+    } else {
+        delete_rdp_credential(target)
+    }
+}
+
+pub fn cleanup_temporary_rdp_credentials() {
+    use windows::core::HSTRING;
+
+    let mut states = rdp_credential_states().lock().unwrap();
+    states.retain(|target_key, state| {
+        let target = HSTRING::from(target_key.as_str());
+        if let Err(err) = restore_temporary_rdp_credential(&target, state) {
+            log::warn!(
+                "Failed to restore RDP credential for target '{}': {}",
+                target_key,
+                err
+            );
+            true
+        } else {
+            false
+        }
+    });
+}
+
 pub struct TemporaryRdpCredential {
     target: windows::core::HSTRING,
     comment: String,
@@ -2961,8 +3003,6 @@ pub fn prepare_temporary_rdp_credential(
 
 impl Drop for TemporaryRdpCredential {
     fn drop(&mut self) {
-        use windows::Win32::Security::Credentials::CredWriteW;
-
         let target_key = self.target.to_string_lossy();
         let mut states = rdp_credential_states().lock().unwrap();
         let Some(state) = states.get_mut(&target_key) else {
@@ -2980,33 +3020,7 @@ impl Drop for TemporaryRdpCredential {
             return;
         }
 
-        let current = match read_rdp_credential(&self.target) {
-            Ok(current) => current,
-            Err(err) => {
-                log::warn!(
-                    "Failed to inspect temporary RDP credential for target '{}': {}",
-                    self.target.to_string_lossy(),
-                    err
-                );
-                return;
-            }
-        };
-        let owned = current
-            .as_ref()
-            .map(|credential| credential.has_comment(&state.current_comment))
-            .unwrap_or(false);
-        if !owned {
-            states.remove(&target_key);
-            return;
-        }
-
-        let result = if let Some(original) = state.original.as_ref() {
-            unsafe { CredWriteW(original.0, 0) }
-                .map_err(|err| anyhow!("CredWriteW failed while restoring: {}", err))
-        } else {
-            delete_rdp_credential(&self.target)
-        };
-        match result {
+        match restore_temporary_rdp_credential(&self.target, state) {
             Ok(()) => {
                 states.remove(&target_key);
             }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -2645,11 +2645,32 @@ pub fn wide_string(s: &str) -> Vec<u16> {
 // This only changes mstsc's top-level window title. The full-screen connection
 // bar is rendered separately and cannot be customized when mstsc.exe is
 // launched as an independent process.
-pub fn set_rdp_window_title(mut child: std::process::Child, name: String) {
-    let name: String = name.chars().filter(|c| !c.is_control()).take(120).collect();
-    if name.is_empty() {
-        return;
-    }
+fn sanitize_rdp_window_title(name: &str) -> String {
+    name.chars()
+        .filter(|c| {
+            !c.is_control()
+                && !matches!(
+                    *c,
+                    '\u{061C}'
+                        | '\u{200B}'..='\u{200F}'
+                        | '\u{2028}'..='\u{202E}'
+                        | '\u{2060}'..='\u{206F}'
+                        | '\u{FEFF}'
+                )
+        })
+        .take(120)
+        .collect()
+}
+
+fn should_update_rdp_window_title(current: &str, name: &str, applied_name: &str) -> bool {
+    current != name
+        && (current.contains("localhost") || (!applied_name.is_empty() && current == applied_name))
+}
+
+pub fn set_rdp_window_title<F>(mut child: std::process::Child, name_of: F)
+where
+    F: Fn() -> String + Send + 'static,
+{
     let process_id = child.id();
     // mstsc owns the title and can restore "localhost" while connecting or
     // reconnecting. Follow only the process we launched and reapply the peer
@@ -2658,6 +2679,7 @@ pub fn set_rdp_window_title(mut child: std::process::Child, name: String) {
         .name("rdp-window-title".to_owned())
         .spawn(move || {
             let mut warned = false;
+            let mut applied_name = String::new();
             loop {
                 match child.try_wait() {
                     Ok(Some(_)) => break,
@@ -2665,14 +2687,24 @@ pub fn set_rdp_window_title(mut child: std::process::Child, name: String) {
                         log::warn!("Failed to query mstsc process: {}", err);
                         break;
                     }
-                    Ok(None) => match set_process_rdp_window_title(process_id, &name) {
-                        Ok(()) => warned = false,
-                        Err(err) if !warned => {
-                            log::warn!("Failed to set RDP window title: {}", err);
-                            warned = true;
+                    Ok(None) => {
+                        let name = sanitize_rdp_window_title(&name_of());
+                        if !name.is_empty() {
+                            match set_process_rdp_window_title(process_id, &name, &applied_name) {
+                                Ok(applied) => {
+                                    if applied {
+                                        applied_name = name;
+                                    }
+                                    warned = false;
+                                }
+                                Err(err) if !warned => {
+                                    log::warn!("Failed to set RDP window title: {}", err);
+                                    warned = true;
+                                }
+                                Err(_) => {}
+                            }
                         }
-                        Err(_) => {}
-                    },
+                    }
                 }
                 std::thread::sleep(Duration::from_millis(500));
             }
@@ -2682,10 +2714,17 @@ pub fn set_rdp_window_title(mut child: std::process::Child, name: String) {
     }
 }
 
-fn set_process_rdp_window_title(process_id: DWORD, name: &str) -> io::Result<()> {
-    struct Context {
+fn set_process_rdp_window_title(
+    process_id: DWORD,
+    name: &str,
+    applied_name: &str,
+) -> io::Result<bool> {
+    struct Context<'a> {
         process_id: DWORD,
+        name: &'a str,
+        applied_name: &'a str,
         title: Vec<u16>,
+        applied: bool,
         error: Option<io::Error>,
     }
 
@@ -2702,29 +2741,66 @@ fn set_process_rdp_window_title(process_id: DWORD, name: &str) -> io::Result<()>
         }
         let mut title = vec![0u16; len as usize + 1];
         let len = GetWindowTextW(hwnd, title.as_mut_ptr(), title.len() as _);
-        if len > 0 && String::from_utf16_lossy(&title[..len as usize]).contains("localhost") {
-            if SetWindowTextW(hwnd, context.title.as_ptr()) == FALSE {
-                context.error = Some(io::Error::last_os_error());
-                return FALSE;
-            }
+        if len <= 0 {
+            return TRUE;
+        }
+        let current = String::from_utf16_lossy(&title[..len as usize]);
+        if current == context.name {
+            context.applied = true;
+            return TRUE;
+        }
+        if !should_update_rdp_window_title(&current, context.name, context.applied_name) {
+            return TRUE;
+        }
+        let mut result = 0;
+        winapi::um::errhandlingapi::SetLastError(ERROR_SUCCESS);
+        let sent = SendMessageTimeoutW(
+            hwnd,
+            WM_SETTEXT,
+            0,
+            context.title.as_ptr() as LPARAM,
+            SMTO_ABORTIFHUNG,
+            1000,
+            &mut result,
+        );
+        if sent == 0 {
+            let err = io::Error::last_os_error();
+            context.error = Some(if err.raw_os_error() == Some(ERROR_SUCCESS as i32) {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    "failed to send the mstsc title update without an OS error",
+                )
+            } else {
+                err
+            });
+        } else if result == 0 {
+            context.error = Some(io::Error::new(
+                io::ErrorKind::Other,
+                "mstsc rejected the title update",
+            ));
+        } else {
+            context.applied = true;
         }
         TRUE
     }
 
     let mut context = Context {
         process_id,
+        name,
+        applied_name,
         title: wide_string(name),
+        applied: false,
         error: None,
     };
     let enumerated =
         unsafe { EnumWindows(Some(enum_window), &mut context as *mut Context as LPARAM) };
-    if let Some(err) = context.error {
-        return Err(err);
-    }
     if enumerated == FALSE {
         return Err(io::Error::last_os_error());
     }
-    Ok(())
+    match context.error {
+        Some(err) if !context.applied => Err(err),
+        _ => Ok(context.applied),
+    }
 }
 
 /// send message to currently shown window
@@ -4626,6 +4702,44 @@ pub(super) fn get_pids_with_first_arg_by_wmic<S1: AsRef<str>, S2: AsRef<str>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rdp_window_title_removes_control_and_format_characters() {
+        assert_eq!(
+            sanitize_rdp_window_title("peer\n\u{061C}\u{200D}\u{202E}\u{2066}\u{FEFF} (服务器)"),
+            "peer (服务器)"
+        );
+    }
+
+    #[test]
+    fn rdp_window_title_is_limited_to_120_characters() {
+        let title = sanitize_rdp_window_title(&"界".repeat(121));
+        assert_eq!(title.chars().count(), 120);
+    }
+
+    #[test]
+    fn rdp_window_title_updates_only_the_tunnel_or_the_previously_applied_name() {
+        assert!(should_update_rdp_window_title(
+            "localhost - Remote Desktop Connection",
+            "peer",
+            ""
+        ));
+        assert!(should_update_rdp_window_title(
+            "peer",
+            "peer (hostname)",
+            "peer"
+        ));
+        assert!(!should_update_rdp_window_title(
+            "localhost tunnel",
+            "localhost tunnel",
+            "localhost tunnel"
+        ));
+        assert!(!should_update_rdp_window_title(
+            "Remote Desktop Connection",
+            "peer",
+            ""
+        ));
+    }
 
     // Test-only reusable Win32 HANDLE RAII helper.
     // If a future non-test path needs the same pattern, move it out of this test module.

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -16,27 +16,18 @@ use hbb_common::{
 };
 
 #[cfg(windows)]
-type RdpLoopbackLease = crate::platform::RdpLoopbackAddress;
-
-#[cfg(not(windows))]
-#[derive(Clone)]
-struct RdpLoopbackLease;
-
 fn run_rdp(
     port: u16,
     host: &str,
     lc: &Arc<RwLock<LoginConfigHandler>>,
     id: &str,
-    loopback: Option<RdpLoopbackLease>,
+    loopback: Option<crate::platform::RdpLoopbackAddress>,
 ) {
-    #[cfg(windows)]
     let (username, password) = {
         let lc = lc.read().unwrap();
         (lc.get_option("rdp_username"), lc.get_option("rdp_password"))
     };
-    #[cfg(windows)]
     let credential_target = format!("TERMSRV/{}", host);
-    #[cfg(windows)]
     let (rdp_credential, prompt_for_credentials) =
         match crate::platform::prepare_temporary_rdp_credential(
             &credential_target,
@@ -55,31 +46,22 @@ fn run_rdp(
         };
     // Keep using /v instead of a generated .rdp file: mstsc then preserves the
     // user's Default.rdp settings and avoids unsigned-file warnings or policies.
-    #[cfg(windows)]
     let mut command = crate::platform::new_mstsc_command();
-    #[cfg(not(windows))]
-    let mut command = std::process::Command::new("mstsc");
     command.arg(format!("/v:{}:{}", host, port));
-    #[cfg(windows)]
     if prompt_for_credentials {
         command.arg("/prompt");
     }
     match command.spawn() {
         Ok(child) => {
-            #[cfg(windows)]
-            {
-                let lc = lc.clone();
-                let id = id.to_owned();
-                crate::platform::set_rdp_window_title(
-                    child,
-                    move || rdp_display_name(&lc, &id),
-                    host.to_owned(),
-                    rdp_credential,
-                    loopback,
-                );
-            }
-            #[cfg(not(windows))]
-            let _ = (child, lc, id, loopback);
+            let lc = lc.clone();
+            let id = id.to_owned();
+            crate::platform::set_rdp_window_title(
+                child,
+                move || rdp_display_name(&lc, &id),
+                host.to_owned(),
+                rdp_credential,
+                loopback,
+            );
         }
         Err(err) => log::warn!("Failed to launch mstsc: {}", err),
     }
@@ -115,6 +97,10 @@ pub async fn listen(
     remote_port: i32,
 ) -> ResultType<()> {
     let is_rdp = port == 0;
+    #[cfg(not(windows))]
+    if is_rdp {
+        bail!("RDP is only supported on Windows");
+    }
     #[cfg(windows)]
     let rdp_loopback = if is_rdp {
         let has_username = {
@@ -129,8 +115,6 @@ pub async fn listen(
     } else {
         None
     };
-    #[cfg(not(windows))]
-    let rdp_loopback: Option<RdpLoopbackLease> = None;
     #[cfg(windows)]
     let listener_host = rdp_loopback
         .as_ref()
@@ -146,8 +130,7 @@ pub async fn listen(
         .as_ref()
         .map(|address| address.mstsc_host())
         .unwrap_or("localhost");
-    #[cfg(not(windows))]
-    let rdp_host = "localhost";
+    #[cfg(windows)]
     if is_rdp {
         run_rdp(addr.port(), rdp_host, &lc, &id, rdp_loopback.clone());
     }
@@ -185,6 +168,7 @@ pub async fn listen(
                     Some(Data::Close) => {
                         break;
                     }
+                    #[cfg(windows)]
                     Some(Data::NewRDP) => {
                         println!("receive run_rdp from ui_receiver");
                         run_rdp(addr.port(), rdp_host, &lc, &id, rdp_loopback.clone());

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -68,8 +68,9 @@ fn run_rdp(
 }
 
 #[cfg(windows)]
-fn rdp_display_name(lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) -> (String, String) {
+fn rdp_display_name(lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) -> (String, bool) {
     let lc = lc.read().unwrap();
+    let peer_info_received = lc.version != 0;
     let alias = lc
         .options
         .get("alias")
@@ -82,7 +83,7 @@ fn rdp_display_name(lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) -> (String, 
     } else {
         format!("{} ({})", identity, hostname)
     };
-    (name, hostname.to_owned())
+    (name, peer_info_received)
 }
 
 pub async fn listen(

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -55,6 +55,9 @@ fn run_rdp(
         };
     // Keep using /v instead of a generated .rdp file: mstsc then preserves the
     // user's Default.rdp settings and avoids unsigned-file warnings or policies.
+    #[cfg(windows)]
+    let mut command = crate::platform::new_mstsc_command();
+    #[cfg(not(windows))]
     let mut command = std::process::Command::new("mstsc");
     command.arg(format!("/v:{}:{}", host, port));
     #[cfg(windows)]

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -15,7 +15,7 @@ use hbb_common::{
     ResultType, Stream,
 };
 
-fn run_rdp(port: u16, name: &str) {
+fn run_rdp(port: u16, lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) {
     std::process::Command::new("cmdkey")
         .arg("/delete:localhost")
         .output()
@@ -43,15 +43,19 @@ fn run_rdp(port: u16, name: &str) {
     {
         Ok(child) => {
             #[cfg(windows)]
-            crate::platform::set_rdp_window_title(child, name.to_owned());
+            {
+                let lc = lc.clone();
+                let id = id.to_owned();
+                crate::platform::set_rdp_window_title(child, move || rdp_display_name(&lc, &id));
+            }
             #[cfg(not(windows))]
-            let _ = (child, name);
+            let _ = (child, lc, id);
         }
         Err(err) => log::warn!("Failed to launch mstsc: {}", err),
     }
 }
 
-// Show the peer identity with its hostname, using the ID when no alias exists.
+#[cfg(windows)]
 fn rdp_display_name(lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) -> String {
     let lc = lc.read().unwrap();
     let alias = lc
@@ -85,7 +89,7 @@ pub async fn listen(
     log::info!("listening on port {:?}", addr);
     let is_rdp = port == 0;
     if is_rdp {
-        run_rdp(addr.port(), &rdp_display_name(&lc, &id));
+        run_rdp(addr.port(), &lc, &id);
     }
     let mut ui_receiver = ui_receiver;
     loop {
@@ -123,7 +127,7 @@ pub async fn listen(
                     }
                     Some(Data::NewRDP) => {
                         println!("receive run_rdp from ui_receiver");
-                        run_rdp(addr.port(), &rdp_display_name(&lc, &id));
+                        run_rdp(addr.port(), &lc, &id);
                     }
                     _ => {}
                 }

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -15,73 +15,51 @@ use hbb_common::{
     ResultType, Stream,
 };
 
+#[cfg(windows)]
 const RDP_CREDENTIAL_TARGET: &str = "TERMSRV/localhost";
 
-fn delete_rdp_credential(target: &str) {
-    match std::process::Command::new("cmdkey")
-        .arg(format!("/delete:{}", target))
-        .output()
-    {
-        Ok(output) if output.status.success() => {}
-        // A missing credential is expected on the first launch. Keep the
-        // nonzero status at debug level without logging cmdkey output.
-        Ok(output) => log::debug!(
-            "Could not delete RDP credential for target '{}': {}",
-            target,
-            output.status
-        ),
-        Err(err) => log::warn!(
-            "Failed to start cmdkey while deleting RDP credential for target '{}': {}",
-            target,
-            err
-        ),
-    }
-}
-
-fn store_rdp_credential(target: &str, username: &str, password: &str) {
-    let mut args = vec![format!("/generic:{}", target)];
-    if !username.is_empty() {
-        args.push(format!("/user:{}", username));
-    }
-    if !password.is_empty() {
-        args.push(format!("/pass:{}", password));
-    }
-    match std::process::Command::new("cmdkey").args(&args).output() {
-        Ok(output) if output.status.success() => {}
-        Ok(output) => log::warn!(
-            "Failed to store RDP credential for target '{}': {}",
-            target,
-            output.status
-        ),
-        Err(err) => log::warn!(
-            "Failed to start cmdkey while storing RDP credential for target '{}': {}",
-            target,
-            err
-        ),
-    }
-}
-
 fn run_rdp(port: u16, lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) {
-    delete_rdp_credential(RDP_CREDENTIAL_TARGET);
+    #[cfg(windows)]
     let (username, password) = {
         let lc = lc.read().unwrap();
         (lc.get_option("rdp_username"), lc.get_option("rdp_password"))
     };
-    if !username.is_empty() || !password.is_empty() {
-        store_rdp_credential(RDP_CREDENTIAL_TARGET, &username, &password);
-    }
+    #[cfg(windows)]
+    let (rdp_credential, prompt_for_credentials) =
+        match crate::platform::prepare_temporary_rdp_credential(
+            RDP_CREDENTIAL_TARGET,
+            &username,
+            &password,
+        ) {
+            Ok(credential) => (credential, false),
+            Err(err) => {
+                log::warn!(
+                    "Failed to prepare RDP credential for target '{}': {}",
+                    RDP_CREDENTIAL_TARGET,
+                    err
+                );
+                (None, true)
+            }
+        };
     // Keep using /v instead of a generated .rdp file: mstsc then preserves the
     // user's Default.rdp settings and avoids unsigned-file warnings or policies.
-    match std::process::Command::new("mstsc")
-        .arg(format!("/v:localhost:{}", port))
-        .spawn()
-    {
+    let mut command = std::process::Command::new("mstsc");
+    command.arg(format!("/v:localhost:{}", port));
+    #[cfg(windows)]
+    if prompt_for_credentials {
+        command.arg("/prompt");
+    }
+    match command.spawn() {
         Ok(child) => {
             #[cfg(windows)]
             {
                 let lc = lc.clone();
                 let id = id.to_owned();
-                crate::platform::set_rdp_window_title(child, move || rdp_display_name(&lc, &id));
+                crate::platform::set_rdp_window_title(
+                    child,
+                    move || rdp_display_name(&lc, &id),
+                    rdp_credential,
+                );
             }
             #[cfg(not(windows))]
             let _ = (child, lc, id);

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -15,25 +15,60 @@ use hbb_common::{
     ResultType, Stream,
 };
 
-fn run_rdp(port: u16, lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) {
-    std::process::Command::new("cmdkey")
-        .arg("/delete:localhost")
+const RDP_CREDENTIAL_TARGET: &str = "TERMSRV/localhost";
+
+fn delete_rdp_credential(target: &str) {
+    match std::process::Command::new("cmdkey")
+        .arg(format!("/delete:{}", target))
         .output()
-        .ok();
-    let username = std::env::var("rdp_username").unwrap_or_default();
-    let password = std::env::var("rdp_password").unwrap_or_default();
+    {
+        Ok(output) if output.status.success() => {}
+        // A missing credential is expected on the first launch. Keep the
+        // nonzero status at debug level without logging cmdkey output.
+        Ok(output) => log::debug!(
+            "Could not delete RDP credential for target '{}': {}",
+            target,
+            output.status
+        ),
+        Err(err) => log::warn!(
+            "Failed to start cmdkey while deleting RDP credential for target '{}': {}",
+            target,
+            err
+        ),
+    }
+}
+
+fn store_rdp_credential(target: &str, username: &str, password: &str) {
+    let mut args = vec![format!("/generic:{}", target)];
+    if !username.is_empty() {
+        args.push(format!("/user:{}", username));
+    }
+    if !password.is_empty() {
+        args.push(format!("/pass:{}", password));
+    }
+    match std::process::Command::new("cmdkey").args(&args).output() {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => log::warn!(
+            "Failed to store RDP credential for target '{}': {}",
+            target,
+            output.status
+        ),
+        Err(err) => log::warn!(
+            "Failed to start cmdkey while storing RDP credential for target '{}': {}",
+            target,
+            err
+        ),
+    }
+}
+
+fn run_rdp(port: u16, lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) {
+    delete_rdp_credential(RDP_CREDENTIAL_TARGET);
+    let (username, password) = {
+        let lc = lc.read().unwrap();
+        (lc.get_option("rdp_username"), lc.get_option("rdp_password"))
+    };
     if !username.is_empty() || !password.is_empty() {
-        let mut args = vec!["/generic:localhost".to_owned()];
-        if !username.is_empty() {
-            args.push(format!("/user:{}", username));
-        }
-        if !password.is_empty() {
-            args.push(format!("/pass:{}", password));
-        }
-        std::process::Command::new("cmdkey")
-            .args(&args)
-            .output()
-            .ok();
+        store_rdp_credential(RDP_CREDENTIAL_TARGET, &username, &password);
     }
     // Keep using /v instead of a generated .rdp file: mstsc then preserves the
     // user's Default.rdp settings and avoids unsigned-file warnings or policies.

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -55,7 +55,7 @@ fn run_rdp(
         Ok(child) => {
             let lc = lc.clone();
             let id = id.to_owned();
-            crate::platform::set_rdp_window_title(
+            crate::platform::monitor_rdp_process(
                 child,
                 move || rdp_display_name(&lc, &id),
                 host.to_owned(),
@@ -68,7 +68,7 @@ fn run_rdp(
 }
 
 #[cfg(windows)]
-fn rdp_display_name(lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) -> String {
+fn rdp_display_name(lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) -> (String, String) {
     let lc = lc.read().unwrap();
     let alias = lc
         .options
@@ -77,11 +77,12 @@ fn rdp_display_name(lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) -> String {
         .unwrap_or_default();
     let hostname = lc.info.hostname.trim();
     let identity = if !alias.is_empty() { alias } else { id };
-    if hostname.is_empty() || hostname == identity {
+    let name = if hostname.is_empty() || hostname == identity {
         identity.to_owned()
     } else {
         format!("{} ({})", identity, hostname)
-    }
+    };
+    (name, hostname.to_owned())
 }
 
 pub async fn listen(

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -16,18 +16,30 @@ use hbb_common::{
 };
 
 #[cfg(windows)]
-const RDP_CREDENTIAL_TARGET: &str = "TERMSRV/localhost";
+type RdpLoopbackLease = crate::platform::RdpLoopbackAddress;
 
-fn run_rdp(port: u16, lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) {
+#[cfg(not(windows))]
+#[derive(Clone)]
+struct RdpLoopbackLease;
+
+fn run_rdp(
+    port: u16,
+    host: &str,
+    lc: &Arc<RwLock<LoginConfigHandler>>,
+    id: &str,
+    loopback: Option<RdpLoopbackLease>,
+) {
     #[cfg(windows)]
     let (username, password) = {
         let lc = lc.read().unwrap();
         (lc.get_option("rdp_username"), lc.get_option("rdp_password"))
     };
     #[cfg(windows)]
+    let credential_target = format!("TERMSRV/{}", host);
+    #[cfg(windows)]
     let (rdp_credential, prompt_for_credentials) =
         match crate::platform::prepare_temporary_rdp_credential(
-            RDP_CREDENTIAL_TARGET,
+            &credential_target,
             &username,
             &password,
         ) {
@@ -35,7 +47,7 @@ fn run_rdp(port: u16, lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) {
             Err(err) => {
                 log::warn!(
                     "Failed to prepare RDP credential for target '{}': {}",
-                    RDP_CREDENTIAL_TARGET,
+                    credential_target,
                     err
                 );
                 (None, true)
@@ -44,7 +56,7 @@ fn run_rdp(port: u16, lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) {
     // Keep using /v instead of a generated .rdp file: mstsc then preserves the
     // user's Default.rdp settings and avoids unsigned-file warnings or policies.
     let mut command = std::process::Command::new("mstsc");
-    command.arg(format!("/v:localhost:{}", port));
+    command.arg(format!("/v:{}:{}", host, port));
     #[cfg(windows)]
     if prompt_for_credentials {
         command.arg("/prompt");
@@ -58,11 +70,13 @@ fn run_rdp(port: u16, lc: &Arc<RwLock<LoginConfigHandler>>, id: &str) {
                 crate::platform::set_rdp_window_title(
                     child,
                     move || rdp_display_name(&lc, &id),
+                    host.to_owned(),
                     rdp_credential,
+                    loopback,
                 );
             }
             #[cfg(not(windows))]
-            let _ = (child, lc, id);
+            let _ = (child, lc, id, loopback);
         }
         Err(err) => log::warn!("Failed to launch mstsc: {}", err),
     }
@@ -97,12 +111,42 @@ pub async fn listen(
     remote_host: String,
     remote_port: i32,
 ) -> ResultType<()> {
-    let listener = tcp::new_listener(format!("127.0.0.1:{}", port), true).await?;
+    let is_rdp = port == 0;
+    #[cfg(windows)]
+    let rdp_loopback = if is_rdp {
+        let has_username = {
+            let lc = lc.read().unwrap();
+            !lc.get_option("rdp_username").is_empty()
+        };
+        if has_username {
+            Some(crate::platform::reserve_rdp_loopback_address()?)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    #[cfg(not(windows))]
+    let rdp_loopback: Option<RdpLoopbackLease> = None;
+    #[cfg(windows)]
+    let listener_host = rdp_loopback
+        .as_ref()
+        .map(|address| address.bind_host())
+        .unwrap_or("127.0.0.1");
+    #[cfg(not(windows))]
+    let listener_host = "127.0.0.1";
+    let listener = tcp::new_listener(format!("{}:{}", listener_host, port), true).await?;
     let addr = listener.local_addr()?;
     log::info!("listening on port {:?}", addr);
-    let is_rdp = port == 0;
+    #[cfg(windows)]
+    let rdp_host = rdp_loopback
+        .as_ref()
+        .map(|address| address.mstsc_host())
+        .unwrap_or("localhost");
+    #[cfg(not(windows))]
+    let rdp_host = "localhost";
     if is_rdp {
-        run_rdp(addr.port(), &lc, &id);
+        run_rdp(addr.port(), rdp_host, &lc, &id, rdp_loopback.clone());
     }
     let mut ui_receiver = ui_receiver;
     loop {
@@ -140,7 +184,7 @@ pub async fn listen(
                     }
                     Some(Data::NewRDP) => {
                         println!("receive run_rdp from ui_receiver");
-                        run_rdp(addr.port(), &lc, &id);
+                        run_rdp(addr.port(), rdp_host, &lc, &id, rdp_loopback.clone());
                     }
                     _ => {}
                 }

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -1949,14 +1949,6 @@ pub async fn io_loop<T: InvokeUiSession>(handler: Session<T>, round: u32) {
                 .get_option("rdp_port".to_owned())
                 .parse::<i32>()
                 .unwrap_or(3389);
-            std::env::set_var(
-                "rdp_username",
-                handler.get_option("rdp_username".to_owned()),
-            );
-            std::env::set_var(
-                "rdp_password",
-                handler.get_option("rdp_password".to_owned()),
-            );
             log::info!("Remote rdp port: {}", port);
             start_one_port_forward(handler, 0, "".to_owned(), port, receiver, &key, &token).await;
         } else if handler.args.len() == 0 {


### PR DESCRIPTION
## Changes

  1. Fix the RDP title remaining ID-only when the peer is not in recent connections, and sanitize unsafe Unicode characters.
  2. Read RDP credentials from the current peer configuration instead of process-global environment variables.
  3. Fix RDP credentials stored in the peer configuration not being recognized by mstsc on Windows 11 by changing the credential target from `localhost` to `TERMSRV/localhost`. When Windows Defender Credential Guard blocks saved credentials, mstsc reports `Windows Defender Credential Guard does not allow using saved credentials`.
  4. Replace `cmdkey` with Win32 Credential APIs, removing temporary credentials or restoring existing credentials when mstsc exits.

 ## Tested

  ### Windows Server 2019 (Credential Guard disabled)

  - **Release build**
    - Without peer-configured credentials, selecting **Remember me** in mstsc creates a Windows credential for `TERMSRV/localhost`, which can be reused on subsequent connections.
    - With peer-configured credentials, RustDesk creates a Generic credential for `localhost`, which can also be reused after removing the peer credentials.

  - **PR build**
    - Without peer-configured credentials, mstsc can reuse either its `TERMSRV/localhost` Windows credential or the `localhost` Generic credential created by the release build.
    - With peer-configured credentials, RustDesk creates a Generic credential for `TERMSRV/localhost` and connects without prompting for a password.

  ### Windows 11 (Credential Guard enabled)

  - **Release build**
    - Without peer-configured credentials, selecting **Remember me** creates a Windows credential for `TERMSRV/localhost`, but it cannot be reused because of Credential Guard.
    - With peer-configured credentials, RustDesk creates a Generic credential for `localhost`, but mstsc still prompts for a password.

  - **PR build**
    - Without peer-configured credentials, selecting **Remember me** creates a Windows credential for `TERMSRV/localhost`, but it still cannot be reused because of Credential Guard.
    - With peer-configured credentials, RustDesk creates a temporary Generic credential for `TERMSRV/localhost` and connects without prompting. It can coexist with the Windows credential for the same target while the connection is active.

<img width="431" height="140" alt="image" src="https://github.com/user-attachments/assets/a14657de-f49e-42a1-8371-55e9ec4979d1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* RDP sessions now use dedicated temporary loopback addresses when credentials are configured.
* RDP window titles update with connection details while targeting only the correct session window.
* Temporary connection resources are automatically released when sessions end.

## Bug Fixes
* Prevented RDP title updates from affecting unrelated windows.
* Improved reuse and cleanup of loopback addresses across RDP sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR moves RDP authentication to temporary Win32 credentials, assigns credential-bearing listeners distinct loopback hosts, restores prior credentials after mstsc exits, and dynamically sanitizes and updates mstsc titles. The loopback allocation does not isolate concurrent client processes, so cross-peer credential replacement remains possible.
- Reads credentials directly from the peer's login configuration.
- Uses Win32 Credential APIs to install and restore temporary credentials.
- Keeps loopback leases and credentials alive for the mstsc process lifetime.
- Sanitizes and refreshes RDP window titles.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because concurrent RustDesk processes can still overwrite one another's peer-specific RDP credentials.

Loopback addresses are unique only inside one process, while both processes write to the same per-user Windows Credential Manager namespace; concurrent processes can therefore select the same TERMSRV target and cause mstsc to consume another peer session's credentials.

**Files Needing Attention:** src/platform/windows.rs and src/port_forward.rs
</details>

<details open><summary><h3>Security Review</h3></summary>

Concurrent RustDesk processes can independently reserve the same loopback address and therefore write different peer credentials to the same Windows Credential Manager target. The later write can make an earlier mstsc process consume credentials belonging to another peer session.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/platform/windows.rs | Adds loopback leasing, temporary Credential Manager state, title sanitization, and mstsc lifetime monitoring; process-local loopback allocation leaves credential targets colliding across concurrent client processes. |
| src/port_forward.rs | Reads peer credentials per launch and derives each Credential Manager target from the listener's loopback host, inheriting the cross-process target collision. |
| src/ui_session_interface.rs | Removes process-global environment-variable propagation now that RDP credentials are read from LoginConfigHandler. |
| Cargo.toml | Enables the windows crate credential-management API feature required by the new Win32 implementation. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant A as RustDesk process A
    participant B as RustDesk process B
    participant C as Windows Credential Manager
    participant M as mstsc A
    A->>A: Reserve 127.0.0.2 locally
    A->>C: Write TERMSRV/127.0.0.2 (peer A)
    A->>M: Launch /v:127.0.0.2
    B->>B: Reserve 127.0.0.2 locally
    B->>C: Overwrite TERMSRV/127.0.0.2 (peer B)
    M->>C: Read TERMSRV/127.0.0.2
    C-->>M: Return peer B credentials
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2315884%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=15884&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fplatform%2Fwindows.rs%3A2671-2675%0A**Credential%20targets%20collide%20across%20processes**%0A%0AIf%20two%20RustDesk%20client%20processes%20under%20the%20same%20Windows%20user%20concurrently%20start%20credential-bearing%20RDP%20sessions%2C%20each%20process-local%20reservation%20set%20can%20select%20%60127.0.0.2%60%2C%20causing%20both%20sessions%20to%20write%20to%20%60TERMSRV%2F127.0.0.2%60.%20The%20later%20write%20replaces%20the%20credential%20awaiting%20consumption%20by%20the%20earlier%20mstsc%20instance%2C%20which%20then%20authenticates%20with%20the%20other%20peer's%20credentials%20or%20fails%20authentication.%0A%0A**How%20this%20was%20verified%3A**%20The%20reservation%20set%20is%20process-local%2C%20while%20the%20target%20derived%20from%20the%20selected%20address%20is%20written%20to%20the%20Windows%20user's%20shared%20Credential%20Manager%20namespace.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15884&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix_rdp_window_title%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix_rdp_window_title%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fplatform%2Fwindows.rs%3A2671-2675%0A**Credential%20targets%20collide%20across%20processes**%0A%0AIf%20two%20RustDesk%20client%20processes%20under%20the%20same%20Windows%20user%20concurrently%20start%20credential-bearing%20RDP%20sessions%2C%20each%20process-local%20reservation%20set%20can%20select%20%60127.0.0.2%60%2C%20causing%20both%20sessions%20to%20write%20to%20%60TERMSRV%2F127.0.0.2%60.%20The%20later%20write%20replaces%20the%20credential%20awaiting%20consumption%20by%20the%20earlier%20mstsc%20instance%2C%20which%20then%20authenticates%20with%20the%20other%20peer's%20credentials%20or%20fails%20authentication.%0A%0A**How%20this%20was%20verified%3A**%20The%20reservation%20set%20is%20process-local%2C%20while%20the%20target%20derived%20from%20the%20selected%20address%20is%20written%20to%20the%20Windows%20user's%20shared%20Credential%20Manager%20namespace.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15884&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/platform/windows.rs:2671-2675
**Credential targets collide across processes**

If two RustDesk client processes under the same Windows user concurrently start credential-bearing RDP sessions, each process-local reservation set can select `127.0.0.2`, causing both sessions to write to `TERMSRV/127.0.0.2`. The later write replaces the credential awaiting consumption by the earlier mstsc instance, which then authenticates with the other peer's credentials or fails authentication.

**How this was verified:** The reservation set is process-local, while the target derived from the selected address is written to the Windows user's shared Credential Manager namespace.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(rdp): isolate credentials across con..."](https://github.com/rustdesk/rustdesk/commit/4b32010560ca941110c74a6c07138b7f061bbf63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53934956)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->