### PR TITLE
fix(drm): measure the cursor hotspot the kernel does not expose

### DIFF
--- a/libs/scrap/src/common/drm_reader.rs
+++ b/libs/scrap/src/common/drm_reader.rs
@@ -29,7 +29,34 @@ pub struct CursorSnapshot {
     pub height: u32,
     pub hotx: i32,
     pub hoty: i32,
+    /// Cursor plane position (CRTC_X/CRTC_Y), scanout px of this reader's display.
+    pub x: i32,
+    pub y: i32,
+    /// True when hotx/hoty came from the HOTSPOT_X/Y plane property. Only
+    /// DRIVER_CURSOR_HOTSPOT drivers (virtio, vmwgfx, qxl) create it; on real hardware the
+    /// kernel has no hotspot to give and hotx/hoty are `guess_hotspot`'s estimate. Inferred
+    /// from the VALUES being non-zero (libdrmtap zero-fills an absent property), so a VM shape
+    /// whose true hotspot IS (0,0) reads as a guess - accepted: the consumer's measurement
+    /// then lands on ~(0,0) anyway.
+    pub hot_from_property: bool,
     pub colors: Vec<u8>,
+}
+
+/// Best-effort hotspot from the opaque-pixel bounding box, for when the kernel gives none: a
+/// tall glyph (I-beam) grabs at its center, anything else at its opaque top-left. A WIDE
+/// center-hotspot glyph (a horizontal resize arrow) is wrong here by half its width - the
+/// consumer measures the real value against the peer-injected position and overrides (see
+/// drm_capturer's cursor calibration), so this only has to be a first frame's seed.
+pub(crate) fn guess_hotspot(minx: i32, miny: i32, maxx: i32, maxy: i32) -> (i32, i32) {
+    if maxx < minx || maxy < miny {
+        return (0, 0);
+    }
+    let (bw, bh) = (maxx - minx + 1, maxy - miny + 1);
+    if bh > bw * 2 {
+        ((minx + maxx) / 2, (miny + maxy) / 2)
+    } else {
+        (minx, miny)
+    }
 }
 
 /// One enumerated DRM display, physical geometry only (the server overlays the Wayland logical origin/scale where it can match one).
@@ -363,6 +390,9 @@ impl DrmReader {
                     height: 1,
                     hotx: 0,
                     hoty: 0,
+                    x: 0,
+                    y: 0,
+                    hot_from_property: false,
                     colors: vec![0, 0, 0, 0],
                 })
             } else if !c.pixels.is_null()
@@ -397,17 +427,11 @@ impl DrmReader {
                         if y > maxy { maxy = y; }
                     }
                 }
-                let (hotx, hoty) = if c.hot_x != 0 || c.hot_y != 0 {
+                let hot_from_property = c.hot_x != 0 || c.hot_y != 0;
+                let (hotx, hoty) = if hot_from_property {
                     (c.hot_x, c.hot_y)
-                } else if maxx >= minx && maxy >= miny {
-                    let (bw, bh) = (maxx - minx + 1, maxy - miny + 1);
-                    if bh > bw * 2 {
-                        ((minx + maxx) / 2, (miny + maxy) / 2)
-                    } else {
-                        (minx, miny)
-                    }
                 } else {
-                    (0, 0)
+                    guess_hotspot(minx, miny, maxx, maxy)
                 };
                 // Fold geometry + hotspot into the id: identical pixels with a changed size or
                 // hotspot must count as a new shape, otherwise drm_capture_worker suppresses the
@@ -423,6 +447,9 @@ impl DrmReader {
                     height: ch as u32,
                     hotx,
                     hoty,
+                    x: c.x,
+                    y: c.y,
+                    hot_from_property,
                     colors,
                 })
             } else {
@@ -473,5 +500,28 @@ impl Drop for DrmReader {
             unsafe { (self.lib.close)(self.ctx) };
             self.ctx = std::ptr::null_mut();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::guess_hotspot;
+
+    #[test]
+    fn a_tall_glyph_guesses_its_center() {
+        // I-beam: 4 wide, 20 tall starting at (10, 2).
+        assert_eq!(guess_hotspot(10, 2, 13, 21), (11, 11));
+    }
+
+    #[test]
+    fn a_wide_glyph_guesses_its_top_left_which_the_consumer_must_correct() {
+        // Horizontal resize arrow: 24 wide, 8 tall. The real hotspot is the center; this
+        // guess is what the calibration in drm_capturer exists to replace.
+        assert_eq!(guess_hotspot(4, 12, 27, 19), (4, 12));
+    }
+
+    #[test]
+    fn an_empty_bounding_box_guesses_zero() {
+        assert_eq!(guess_hotspot(64, 64, -1, -1), (0, 0));
     }
 }

--- a/libs/scrap/src/wayland/display.rs
+++ b/libs/scrap/src/wayland/display.rs
@@ -407,6 +407,15 @@ pub fn get_display_rects_for_uinput() -> Vec<DisplayRect> {
     logical_rects_of(&get_displays().displays)
 }
 
+/// The rects `get_display_rects_for_uinput` would produce for a GIVEN snapshot, for a caller
+/// that must derive several values from ONE consistent view instead of re-fetching (a refresh
+/// between two fetches would misalign the indices).
+pub fn logical_rects_of_displays(
+    displays: &[hbb_common::platform::linux::WaylandDisplayInfo],
+) -> Vec<DisplayRect> {
+    logical_rects_of(displays)
+}
+
 /// Remap an injected coordinate from the layout the client still believes in
 /// (`baseline`, captured at session init) to the current compositor layout (`live`).
 ///

--- a/libs/scrap/src/wayland/display.rs
+++ b/libs/scrap/src/wayland/display.rs
@@ -429,6 +429,26 @@ pub fn logical_rects_of_displays(
 /// Returns the input unchanged when the point is outside every baseline display or the
 /// matched display is gone, so a failed match never moves the cursor further off than
 /// leaving it alone. https://github.com/rustdesk/rustdesk/issues/15601
+/// The live counterpart of `baseline[bi]`: matched by connector name, or by index while the
+/// compositor reports no names and the display count is unchanged. A named display that is simply
+/// gone from the live layout has none, rather than being matched to whatever now sits at its index.
+pub fn live_counterpart<'a>(
+    bi: usize,
+    baseline: &[DisplayRect],
+    live: &'a [DisplayRect],
+) -> Option<&'a DisplayRect> {
+    let b = baseline.get(bi)?;
+    if b.name.is_empty() {
+        if baseline.len() == live.len() {
+            live.get(bi)
+        } else {
+            None
+        }
+    } else {
+        live.iter().find(|r| r.name == b.name)
+    }
+}
+
 pub fn remap_to_live_layout(
     x: i32,
     y: i32,
@@ -442,19 +462,7 @@ pub fn remap_to_live_layout(
     else {
         return (x, y);
     };
-    let matched = if b.name.is_empty() {
-        // Nameless compositor: index-match, but only while the count is unchanged. A
-        // named display that is simply gone from the live layout must fall through to
-        // "unchanged" below, not get index-matched to whatever now sits at its index.
-        if baseline.len() == live.len() {
-            live.get(bi)
-        } else {
-            None
-        }
-    } else {
-        live.iter().find(|r| r.name == b.name)
-    };
-    let Some(l) = matched else {
+    let Some(l) = live_counterpart(bi, baseline, live) else {
         return (x, y);
     };
     // Map the point into the live rectangle, preserving position within the display so a
@@ -570,6 +578,26 @@ mod tests {
             w,
             h,
         }
+    }
+
+    // The hotspot calibration measures an injected point that the input path has ALREADY
+    // remapped, so the rect it measures against has to come from the live layout too. Same
+    // rescale as the case below: DP-2 has shifted, and the init snapshot still says 2560.
+    #[test]
+    fn test_live_counterpart_follows_a_shifted_display() {
+        let baseline = [
+            rect("DP-1", 0, 0, 2560, 1440),
+            rect("DP-2", 2560, 0, 2560, 1440),
+        ];
+        let live = [
+            rect("DP-1", 0, 0, 2048, 1440),
+            rect("DP-2", 2048, 0, 2560, 1440),
+        ];
+        assert_eq!(live_counterpart(1, &baseline, &live).map(|r| r.x), Some(2048));
+        // A display the live layout no longer carries has no counterpart, so the caller can
+        // fall back rather than measure against a stranger.
+        let gone = [rect("DP-1", 0, 0, 2048, 1440)];
+        assert!(live_counterpart(1, &baseline, &gone).is_none());
     }
 
     // The reported failure: connect to the second display, rescale the primary.

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -564,10 +564,12 @@ pub enum Data {
         #[serde(default)]
         hot_from_property: bool,
     },
-    /// Service -> client: the cursor plane position, re-sent every capture tick while the cursor
-    /// is visible (same scanout space as `DrmCursor.x/y`). NO `send_raw()` body. The consumer
-    /// pairs a settled position with the last peer-injected point to MEASURE the hotspot the
-    /// kernel does not expose on non-VM drivers (see drm_capturer's cursor calibration).
+    /// Service -> client: the cursor plane position while the cursor is visible (same scanout
+    /// space as `DrmCursor.x/y`), only when `DrmStart.want_cursor_pos` asked for it. Cadence:
+    /// every capture tick through a position change, a shape transition and the ~40 ticks a
+    /// consumer needs to see it settle, then one tick in eight while still. NO `send_raw()`
+    /// body. The consumer pairs a settled position with the last peer-injected point to MEASURE
+    /// the hotspot the kernel does not expose on non-VM drivers (see drm_capturer's calibration).
     #[cfg(all(target_os = "linux", feature = "drm"))]
     DrmCursorPos { x: i32, y: i32 },
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -516,7 +516,16 @@ pub enum Data {
     // (drmtap_open_render failed, e.g. no /dev/dri/renderD* access). The service then streams the
     // CPU-converted `DrmFrame` path for this connection instead of a dma-buf fd the consumer cannot
     // detile, so a render-node-less seat still captures instead of losing the stream.
-    DrmStart { display: i32, need_cpu: bool },
+    // `want_cursor_pos` is the consumer opting in to the per-tick `DrmCursorPos` stream. It
+    // defaults false so a NEW service never sends the variant to an OLD `--server` that cannot
+    // decode it (serde_json errors on an unknown variant and would kill the stream every tick);
+    // an OLD service ignores the unknown field. Keeps the `_drm` protocol append-only.
+    DrmStart {
+        display: i32,
+        need_cpu: bool,
+        #[serde(default)]
+        want_cursor_pos: bool,
+    },
     /// Service -> client: the enumerated DRM displays (sent once, before frames).
     #[cfg(all(target_os = "linux", feature = "drm"))]
     DrmDisplayList(Vec<DrmDisplayInfo>),
@@ -538,6 +547,9 @@ pub enum Data {
     #[cfg(all(target_os = "linux", feature = "drm"))]
     DrmFrameDmabuf(DmabufDesc),
     /// Service -> client: a hardware-cursor header; the RGBA pixels follow via `send_raw()`.
+    /// `x`/`y` are the cursor PLANE position (scanout px of the streamed display) at read time;
+    /// `hot_from_property` says whether hotx/hoty are kernel truth (the HOTSPOT_X/Y plane
+    /// property, VM drivers only) or the reader's bounding-box guess the consumer may correct.
     #[cfg(all(target_os = "linux", feature = "drm"))]
     DrmCursor {
         id: u64,
@@ -545,7 +557,19 @@ pub enum Data {
         height: u32,
         hotx: i32,
         hoty: i32,
+        #[serde(default)]
+        x: i32,
+        #[serde(default)]
+        y: i32,
+        #[serde(default)]
+        hot_from_property: bool,
     },
+    /// Service -> client: the cursor plane position, re-sent every capture tick while the cursor
+    /// is visible (same scanout space as `DrmCursor.x/y`). NO `send_raw()` body. The consumer
+    /// pairs a settled position with the last peer-injected point to MEASURE the hotspot the
+    /// kernel does not expose on non-VM drivers (see drm_capturer's cursor calibration).
+    #[cfg(all(target_os = "linux", feature = "drm"))]
+    DrmCursorPos { x: i32, y: i32 },
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -107,8 +107,13 @@ enum DrmProducerMsg {
         height: u32,
         hotx: i32,
         hoty: i32,
+        x: i32,
+        y: i32,
+        hot_from_property: bool,
         colors: Vec<u8>,
     },
+    /// Cursor plane position, every capture tick while visible (see `Data::DrmCursorPos`).
+    CursorPos { x: i32, y: i32 },
 }
 
 struct DrmStopGuard(std::sync::Arc<std::sync::atomic::AtomicBool>);
@@ -793,7 +798,7 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
     drop(stream);
 
     let (frame_tx, mut frame_rx) = tokio::sync::mpsc::channel::<DrmProducerMsg>(2);
-    let (crtc_tx, crtc_rx) = std::sync::mpsc::channel::<(String, u32, bool)>();
+    let (crtc_tx, crtc_rx) = std::sync::mpsc::channel::<(String, u32, bool, bool)>();
     let stop = Arc::new(AtomicBool::new(false));
     let _stop_guard = DrmStopGuard(stop.clone());
     let worker_stop = stop.clone();
@@ -813,8 +818,15 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
     };
     conn.send_msg(&Data::DrmDisplayList(displays.clone()), None).await?;
 
-    let (display_idx, need_cpu) = match conn.recv_msg_timeout2(10_000).await {
-        Some(Ok((Data::DrmStart { display, need_cpu }, _fd))) => (display, need_cpu),
+    let (display_idx, need_cpu, want_cursor_pos) = match conn.recv_msg_timeout2(10_000).await {
+        Some(Ok((
+            Data::DrmStart {
+                display,
+                need_cpu,
+                want_cursor_pos,
+            },
+            _fd,
+        ))) => (display, need_cpu, want_cursor_pos),
         Some(Ok((_, _fd))) => {
             log::info!("drm: peer sent something other than DrmStart in the handshake; closing");
             return Ok(());
@@ -834,7 +846,10 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
         );
         return Ok(());
     }
-    if crtc_tx.send((target_device, target_crtc, need_cpu)).is_err() {
+    if crtc_tx
+        .send((target_device, target_crtc, need_cpu, want_cursor_pos))
+        .is_err()
+    {
         return Ok(());
     }
 
@@ -915,6 +930,9 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
                     height,
                     hotx,
                     hoty,
+                    x,
+                    y,
+                    hot_from_property,
                     colors,
                 } => {
                     conn.send_msg(
@@ -924,11 +942,20 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
                             height,
                             hotx,
                             hoty,
+                            x,
+                            y,
+                            hot_from_property,
                         },
                         None,
                     )
                     .await?;
                     conn.send_raw(Bytes::from(colors)).await?;
+                }
+                DrmProducerMsg::CursorPos { x, y } => {
+                    // Position-only header, NO send_raw() body (like DrmDisplaysChanged). Sent
+                    // inline rather than coalesced: the producer emits at most one per capture
+                    // tick, so this cannot outpace the frame stream it rides with.
+                    conn.send_msg(&Data::DrmCursorPos { x, y }, None).await?;
                 }
                 DrmProducerMsg::Displays(_) => {}
             }
@@ -970,7 +997,7 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
 
 fn drm_capture_worker(
     frame_tx: tokio::sync::mpsc::Sender<DrmProducerMsg>,
-    crtc_rx: std::sync::mpsc::Receiver<(String, u32, bool)>,
+    crtc_rx: std::sync::mpsc::Receiver<(String, u32, bool, bool)>,
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
     frames_gated: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) {
@@ -991,7 +1018,7 @@ fn drm_capture_worker(
         return;
     }
 
-    let (target_device, target_crtc, need_cpu) = match crtc_rx.recv() {
+    let (target_device, target_crtc, need_cpu, want_cursor_pos) = match crtc_rx.recv() {
         Ok(c) => c,
         Err(_) => return,
     };
@@ -1063,6 +1090,44 @@ fn drm_capture_worker(
                 Err(err) => Err(err),
             })
         };
+        // Ship the cursor shape only when it changes (id is a content hash or the hidden sentinel),
+        // and - when the consumer opted in via DrmStart - the PLANE POSITION every tick while
+        // visible: the consumer needs a settled position, not the racy one frozen at the
+        // shape-change instant, to measure the real hotspot. This runs BEFORE the grab result is
+        // examined, so an EAGAIN/gated stretch (no new frame) still streams cursor state.
+        if let Some(c) = reader.cursor() {
+            let visible = c.id != scrap::drm_reader::HIDDEN_CURSOR_ID;
+            let pos = (c.x, c.y);
+            if c.id != last_cursor_id {
+                last_cursor_id = c.id;
+                if frame_tx
+                    .blocking_send(DrmProducerMsg::Cursor {
+                        id: c.id,
+                        width: c.width,
+                        height: c.height,
+                        hotx: c.hotx,
+                        hoty: c.hoty,
+                        x: c.x,
+                        y: c.y,
+                        hot_from_property: c.hot_from_property,
+                        colors: c.colors,
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+            if want_cursor_pos
+                && visible
+                && frame_tx
+                    .blocking_send(DrmProducerMsg::CursorPos { x: pos.0, y: pos.1 })
+                    .is_err()
+            {
+                break;
+            }
+        }
+
+
         match grabbed {
             None => {}
             Some(Ok(msg)) => {
@@ -1101,26 +1166,6 @@ fn drm_capture_worker(
             Some(Err(err)) => {
                 log::warn!("drm: capture error: {err}; closing _drm connection");
                 break;
-            }
-        }
-
-        // Ship the cursor shape only when it changes (id is a content hash or the hidden sentinel).
-        if let Some(c) = reader.cursor() {
-            if c.id != last_cursor_id {
-                last_cursor_id = c.id;
-                if frame_tx
-                    .blocking_send(DrmProducerMsg::Cursor {
-                        id: c.id,
-                        width: c.width,
-                        height: c.height,
-                        hotx: c.hotx,
-                        hoty: c.hoty,
-                        colors: c.colors,
-                    })
-                    .is_err()
-                {
-                    break;
-                }
             }
         }
 

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -1180,7 +1180,6 @@ fn drm_capture_worker(
                 // can never block this thread away from grabbing frames. The cadence below only
                 // bounds wakeups for a still cursor; a stale streak decimates to one in eight,
                 // which the late-input reopen path tolerates (it needs SOME tick, not every one).
-                cursor_pos.store(pos.0, pos.1);
                 let changed = last_pos_sent != Some(pos);
                 if changed {
                     pos_streak = 0;
@@ -1189,6 +1188,11 @@ fn drm_capture_worker(
                     pos_streak = pos_streak.saturating_add(1);
                 }
                 if changed || pos_streak <= 40 || pos_streak % 8 == 0 {
+                    // The store lives INSIDE the cadence gate: the connection loop iterates per
+                    // frame and re-reads the slot after every drain, so a store on every tick
+                    // would defeat the one-in-eight idle decimation the wire contract documents.
+                    // Nothing is lost - a skipped store always carries the value already stored.
+                    cursor_pos.store(pos.0, pos.1);
                     let _ = frame_tx.try_send(DrmProducerMsg::CursorPos { x: pos.0, y: pos.1 });
                 }
             }

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -112,8 +112,46 @@ enum DrmProducerMsg {
         hot_from_property: bool,
         colors: Vec<u8>,
     },
-    /// Cursor plane position while visible; the cadence contract is on `Data::DrmCursorPos`.
+    /// Wakeup only: the freshest position lives in `CursorPosSlot`, never in this queue, so a
+    /// slow consumer cannot backpressure the capture worker through position traffic.
     CursorPos { x: i32, y: i32 },
+}
+
+/// Latest-wins cursor position shared between the capture worker and the connection task: the
+/// worker overwrites, the connection takes, and a dropped wakeup costs nothing.
+struct CursorPosSlot {
+    dirty: std::sync::atomic::AtomicBool,
+    packed: std::sync::atomic::AtomicU64,
+}
+
+impl CursorPosSlot {
+    fn new() -> Self {
+        Self {
+            dirty: std::sync::atomic::AtomicBool::new(false),
+            packed: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+    fn store(&self, x: i32, y: i32) {
+        use std::sync::atomic::Ordering;
+        self.packed.store(pack_cursor_pos(x, y), Ordering::Release);
+        self.dirty.store(true, Ordering::Release);
+    }
+    fn take(&self) -> Option<(i32, i32)> {
+        use std::sync::atomic::Ordering;
+        if self.dirty.swap(false, Ordering::AcqRel) {
+            Some(unpack_cursor_pos(self.packed.load(Ordering::Acquire)))
+        } else {
+            None
+        }
+    }
+}
+
+fn pack_cursor_pos(x: i32, y: i32) -> u64 {
+    ((x as u32 as u64) << 32) | y as u32 as u64
+}
+
+fn unpack_cursor_pos(p: u64) -> (i32, i32) {
+    ((p >> 32) as u32 as i32, p as u32 as i32)
 }
 
 struct DrmStopGuard(std::sync::Arc<std::sync::atomic::AtomicBool>);
@@ -804,9 +842,13 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
     let worker_stop = stop.clone();
     let frames_gated = Arc::new(AtomicBool::new(false));
     let worker_gate = frames_gated.clone();
+    let cursor_pos_slot = Arc::new(CursorPosSlot::new());
+    let worker_cursor_pos = cursor_pos_slot.clone();
     std::thread::Builder::new()
         .name("drm-capture".into())
-        .spawn(move || drm_capture_worker(frame_tx, crtc_rx, worker_stop, worker_gate))
+        .spawn(move || {
+            drm_capture_worker(frame_tx, crtc_rx, worker_stop, worker_gate, worker_cursor_pos)
+        })
         .map_err(|err| anyhow::anyhow!("could not spawn the drm capture worker: {err}"))?;
 
     let displays = match frame_rx.recv().await {
@@ -858,6 +900,7 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
     let mut credit: i32 = DRM_FRAME_CREDIT;
     let mut credit_since = std::time::Instant::now();
     let mut held_frame: Option<DrmProducerMsg> = None;
+    let mut last_cursor_pos_sent: Option<(i32, i32)> = None;
     loop {
         conn.drain_frame_acks(&mut credit, DRM_FRAME_CREDIT)?;
         // While gated the worker does not grab, so it cannot advance its own MAX_STALLED watchdog: a
@@ -951,15 +994,26 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
                     .await?;
                     conn.send_raw(Bytes::from(colors)).await?;
                 }
-                DrmProducerMsg::CursorPos { x, y } => {
-                    // Position-only header, NO send_raw() body (like DrmDisplaysChanged). Sent
-                    // inline rather than coalesced: the producer emits at most one per capture
-                    // tick, so this cannot outpace the frame stream it rides with.
-                    conn.send_msg(&Data::DrmCursorPos { x, y }, None).await?;
+                DrmProducerMsg::CursorPos { .. } => {
+                    // The payload is only a wakeup; the slot holds the freshest position, and a
+                    // value already sent never goes out again.
+                    if let Some((x, y)) = cursor_pos_slot.take() {
+                        if last_cursor_pos_sent != Some((x, y)) {
+                            last_cursor_pos_sent = Some((x, y));
+                            conn.send_msg(&Data::DrmCursorPos { x, y }, None).await?;
+                        }
+                    }
                 }
                 DrmProducerMsg::Displays(_) => {}
             }
             msg = frame_rx.try_recv().ok();
+        }
+        // Wakeups may drop on a full queue, so the slot is read once more after every drain.
+        if let Some((x, y)) = cursor_pos_slot.take() {
+            if last_cursor_pos_sent != Some((x, y)) {
+                last_cursor_pos_sent = Some((x, y));
+                conn.send_msg(&Data::DrmCursorPos { x, y }, None).await?;
+            }
         }
         conn.drain_frame_acks(&mut credit, DRM_FRAME_CREDIT)?;
         if credit <= 0 {
@@ -1000,6 +1054,7 @@ fn drm_capture_worker(
     crtc_rx: std::sync::mpsc::Receiver<(String, u32, bool, bool)>,
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
     frames_gated: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    cursor_pos: std::sync::Arc<CursorPosSlot>,
 ) {
     use std::sync::atomic::Ordering;
     use std::time::Duration;
@@ -1125,11 +1180,12 @@ fn drm_capture_worker(
                 }
             }
             if want_cursor_pos && visible {
-                // Bound the idle stream: the channel holds 2 messages and a per-tick position
-                // next to every frame halves the slack a transiently slow consumer has before
-                // this thread blocks. Transitions and the consumer's ~1 s settle window ship
-                // every tick; a cursor still beyond that decimates to one tick in eight, which
-                // its late-input reopen path tolerates (it only needs SOME tick, not every one).
+                // Latest-wins: the slot always carries the freshest position, and the channel
+                // message is only a wakeup that may drop on a full queue - so position traffic
+                // can never block this thread away from grabbing frames. The cadence below only
+                // bounds wakeups for a still cursor; a stale streak decimates to one in eight,
+                // which the late-input reopen path tolerates (it needs SOME tick, not every one).
+                cursor_pos.store(pos.0, pos.1);
                 let changed = last_pos_sent != Some(pos);
                 if changed {
                     pos_streak = 0;
@@ -1137,12 +1193,8 @@ fn drm_capture_worker(
                 } else {
                     pos_streak = pos_streak.saturating_add(1);
                 }
-                if (changed || pos_streak <= 40 || pos_streak % 8 == 0)
-                    && frame_tx
-                        .blocking_send(DrmProducerMsg::CursorPos { x: pos.0, y: pos.1 })
-                        .is_err()
-                {
-                    break;
+                if changed || pos_streak <= 40 || pos_streak % 8 == 0 {
+                    let _ = frame_tx.try_send(DrmProducerMsg::CursorPos { x: pos.0, y: pos.1 });
                 }
             }
         }
@@ -1538,6 +1590,20 @@ mod drm_conn_tests {
     use hbb_common::libc;
     use hbb_common::tokio::{self, io::AsyncWriteExt};
     use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
+
+    #[test]
+    fn the_cursor_pos_slot_is_latest_wins_and_survives_negatives() {
+        // Cursor plane coordinates go negative when partially offscreen; the packing must
+        // round-trip the full i32 range.
+        assert_eq!(unpack_cursor_pos(pack_cursor_pos(-1, -1)), (-1, -1));
+        assert_eq!(unpack_cursor_pos(pack_cursor_pos(i32::MIN, i32::MAX)), (i32::MIN, i32::MAX));
+        let slot = CursorPosSlot::new();
+        assert_eq!(slot.take(), None, "an untouched slot yields nothing");
+        slot.store(10, 20);
+        slot.store(30, 40);
+        assert_eq!(slot.take(), Some((30, 40)), "the newest store wins");
+        assert_eq!(slot.take(), None, "and a take clears the slot");
+    }
 
     // Added to the wire later: an older peer's message must still decode.
     #[test]

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -900,7 +900,6 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
     let mut credit: i32 = DRM_FRAME_CREDIT;
     let mut credit_since = std::time::Instant::now();
     let mut held_frame: Option<DrmProducerMsg> = None;
-    let mut last_cursor_pos_sent: Option<(i32, i32)> = None;
     loop {
         conn.drain_frame_acks(&mut credit, DRM_FRAME_CREDIT)?;
         // While gated the worker does not grab, so it cannot advance its own MAX_STALLED watchdog: a
@@ -995,13 +994,12 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
                     conn.send_raw(Bytes::from(colors)).await?;
                 }
                 DrmProducerMsg::CursorPos { .. } => {
-                    // The payload is only a wakeup; the slot holds the freshest position, and a
-                    // value already sent never goes out again.
+                    // The payload is only a wakeup; the slot holds the freshest position, which
+                    // goes out on every wakeup, REPEATS INCLUDED: consecutive equal positions
+                    // are the consumer's stillness signal for the hotspot calibration, so
+                    // deduplicating here would keep it from ever settling.
                     if let Some((x, y)) = cursor_pos_slot.take() {
-                        if last_cursor_pos_sent != Some((x, y)) {
-                            last_cursor_pos_sent = Some((x, y));
-                            conn.send_msg(&Data::DrmCursorPos { x, y }, None).await?;
-                        }
+                        conn.send_msg(&Data::DrmCursorPos { x, y }, None).await?;
                     }
                 }
                 DrmProducerMsg::Displays(_) => {}
@@ -1010,10 +1008,7 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
         }
         // Wakeups may drop on a full queue, so the slot is read once more after every drain.
         if let Some((x, y)) = cursor_pos_slot.take() {
-            if last_cursor_pos_sent != Some((x, y)) {
-                last_cursor_pos_sent = Some((x, y));
-                conn.send_msg(&Data::DrmCursorPos { x, y }, None).await?;
-            }
+            conn.send_msg(&Data::DrmCursorPos { x, y }, None).await?;
         }
         conn.drain_frame_acks(&mut credit, DRM_FRAME_CREDIT)?;
         if credit <= 0 {

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -1193,7 +1193,13 @@ fn drm_capture_worker(
                     // would defeat the one-in-eight idle decimation the wire contract documents.
                     // Nothing is lost - a skipped store always carries the value already stored.
                     cursor_pos.store(pos.0, pos.1);
-                    let _ = frame_tx.try_send(DrmProducerMsg::CursorPos { x: pos.0, y: pos.1 });
+                    // The wakeup goes out only when this tick enqueues no frame: with frames
+                    // flowing, the post-drain slot read already delivers the position, and a
+                    // wakeup would occupy a queue slot the frame's own blocking send then waits
+                    // on behind a slow peer - cursor traffic must never block the capture path.
+                    if !matches!(grabbed, Some(Ok(_))) {
+                        let _ = frame_tx.try_send(DrmProducerMsg::CursorPos { x: pos.0, y: pos.1 });
+                    }
                 }
             }
         }

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -1051,6 +1051,8 @@ fn drm_capture_worker(
     let mut use_dmabuf = !need_cpu;
 
     let mut last_cursor_id: u64 = 0;
+    let mut last_pos_sent: Option<(i32, i32)> = None;
+    let mut pos_streak: u32 = 0;
     let mut stalled: u32 = 0;
     let mut logged_first = false;
     while !stop.load(Ordering::Relaxed) {
@@ -1117,13 +1119,26 @@ fn drm_capture_worker(
                     break;
                 }
             }
-            if want_cursor_pos
-                && visible
-                && frame_tx
-                    .blocking_send(DrmProducerMsg::CursorPos { x: pos.0, y: pos.1 })
-                    .is_err()
-            {
-                break;
+            if want_cursor_pos && visible {
+                // Bound the idle stream: the channel holds 2 messages and a per-tick position
+                // next to every frame halves the slack a transiently slow consumer has before
+                // this thread blocks. Transitions and the consumer's ~1 s settle window ship
+                // every tick; a cursor still beyond that decimates to one tick in eight, which
+                // its late-input reopen path tolerates (it only needs SOME tick, not every one).
+                let changed = last_pos_sent != Some(pos);
+                if changed {
+                    pos_streak = 0;
+                    last_pos_sent = Some(pos);
+                } else {
+                    pos_streak = pos_streak.saturating_add(1);
+                }
+                if (changed || pos_streak <= 40 || pos_streak % 8 == 0)
+                    && frame_tx
+                        .blocking_send(DrmProducerMsg::CursorPos { x: pos.0, y: pos.1 })
+                        .is_err()
+                {
+                    break;
+                }
             }
         }
 

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -112,8 +112,7 @@ enum DrmProducerMsg {
         hot_from_property: bool,
         colors: Vec<u8>,
     },
-    /// Cursor plane position while visible: every capture tick through a transition and the
-    /// consumer's settle window, one tick in eight once still (see `Data::DrmCursorPos`).
+    /// Cursor plane position while visible; the cadence contract is on `Data::DrmCursorPos`.
     CursorPos { x: i32, y: i32 },
 }
 

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -122,6 +122,10 @@ enum DrmProducerMsg {
 struct CursorPosSlot {
     dirty: std::sync::atomic::AtomicBool,
     packed: std::sync::atomic::AtomicU64,
+    /// One wakeup may be in flight at a time. Without it a stalled peer lets wakeups from
+    /// successive ticks fill the two-slot queue, and the next frame's blocking send waits behind
+    /// them - the queue must never hold cursor traffic that the capture path can block on.
+    wakeup_queued: std::sync::atomic::AtomicBool,
 }
 
 impl CursorPosSlot {
@@ -129,7 +133,18 @@ impl CursorPosSlot {
         Self {
             dirty: std::sync::atomic::AtomicBool::new(false),
             packed: std::sync::atomic::AtomicU64::new(0),
+            wakeup_queued: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+    /// True when this caller now owns the single wakeup token.
+    fn claim_wakeup(&self) -> bool {
+        !self
+            .wakeup_queued
+            .swap(true, std::sync::atomic::Ordering::AcqRel)
+    }
+    fn release_wakeup(&self) {
+        self.wakeup_queued
+            .store(false, std::sync::atomic::Ordering::Release);
     }
     fn store(&self, x: i32, y: i32) {
         use std::sync::atomic::Ordering;
@@ -994,6 +1009,7 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
                     conn.send_raw(Bytes::from(colors)).await?;
                 }
                 DrmProducerMsg::CursorPos { .. } => {
+                    cursor_pos_slot.release_wakeup();
                     // The payload is only a wakeup; the slot holds the freshest position, which
                     // goes out on every wakeup, REPEATS INCLUDED: consecutive equal positions
                     // are the consumer's stillness signal for the hotspot calibration, so
@@ -1197,8 +1213,16 @@ fn drm_capture_worker(
                     // flowing, the post-drain slot read already delivers the position, and a
                     // wakeup would occupy a queue slot the frame's own blocking send then waits
                     // on behind a slow peer - cursor traffic must never block the capture path.
-                    if !matches!(grabbed, Some(Ok(_))) {
-                        let _ = frame_tx.try_send(DrmProducerMsg::CursorPos { x: pos.0, y: pos.1 });
+                    // At most one wakeup outstanding: a second one would only occupy a queue
+                    // slot the next frame has to wait on, and the slot already carries the
+                    // freshest position for whenever the consumer gets there.
+                    if !matches!(grabbed, Some(Ok(_))) && cursor_pos.claim_wakeup() {
+                        if frame_tx
+                            .try_send(DrmProducerMsg::CursorPos { x: pos.0, y: pos.1 })
+                            .is_err()
+                        {
+                            cursor_pos.release_wakeup();
+                        }
                     }
                 }
             }
@@ -1608,6 +1632,17 @@ mod drm_conn_tests {
         slot.store(30, 40);
         assert_eq!(slot.take(), Some((30, 40)), "the newest store wins");
         assert_eq!(slot.take(), None, "and a take clears the slot");
+    }
+
+    #[test]
+    fn only_one_cursor_wakeup_is_outstanding_at_a_time() {
+        // A stalled peer must never accumulate wakeups in the frame queue: the next frame's
+        // blocking send would wait behind them.
+        let slot = CursorPosSlot::new();
+        assert!(slot.claim_wakeup(), "the first tick owns the token");
+        assert!(!slot.claim_wakeup(), "a later tick cannot enqueue a second");
+        slot.release_wakeup();
+        assert!(slot.claim_wakeup(), "the consumer's release re-arms it");
     }
 
     // Added to the wire later: an older peer's message must still decode.

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -112,7 +112,8 @@ enum DrmProducerMsg {
         hot_from_property: bool,
         colors: Vec<u8>,
     },
-    /// Cursor plane position, every capture tick while visible (see `Data::DrmCursorPos`).
+    /// Cursor plane position while visible: every capture tick through a transition and the
+    /// consumer's settle window, one tick in eight once still (see `Data::DrmCursorPos`).
     CursorPos { x: i32, y: i32 },
 }
 
@@ -1102,6 +1103,11 @@ fn drm_capture_worker(
             let pos = (c.x, c.y);
             if c.id != last_cursor_id {
                 last_cursor_id = c.id;
+                // A shape transition restarts the position cadence even at an unchanged
+                // position (hidden -> visible in place, or a hover morph while still), or the
+                // consumer's fresh settling window would wait on a decimated stream.
+                last_pos_sent = None;
+                pos_streak = 0;
                 if frame_tx
                     .blocking_send(DrmProducerMsg::Cursor {
                         id: c.id,

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -80,6 +80,14 @@ pub(super) fn set_wayland_layout_baseline(baseline: Vec<scrap::wayland::display:
     lock.live.clear();
 }
 
+/// The layout injected coordinates are remapped onto. Anything that compares against a coordinate
+/// the input path already remapped needs this, not the session-init snapshot. Empty before the
+/// first poll.
+#[cfg(all(target_os = "linux", feature = "drm"))]
+pub(super) fn live_wayland_layout() -> Vec<scrap::wayland::display::DisplayRect> {
+    WAYLAND_LAYOUT.lock().unwrap().live.clone()
+}
+
 // Remap an injected coordinate onto the live compositor layout when it has drifted from
 // what the client was told at session init. Lock-free no-op otherwise.
 #[cfg(target_os = "linux")]

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -80,12 +80,23 @@ pub(super) fn set_wayland_layout_baseline(baseline: Vec<scrap::wayland::display:
     lock.live.clear();
 }
 
-/// The layout injected coordinates are remapped onto. Anything that compares against a coordinate
-/// the input path already remapped needs this, not the session-init snapshot. Empty before the
-/// first poll.
+/// The layout injected coordinates are actually in, which is the only thing a consumer that
+/// measures such a coordinate may compare against.
+///
+/// It is NOT simply `live`: the poll writes `live` before it knows whether the uinput range could
+/// be reprogrammed, and until that succeeds `remap_wayland_uinput_coord` is still a no-op, so the
+/// points it records are in the baseline space. A range apply can take up to three seconds and can
+/// fail outright, and a reader that took `live` through that window would measure a point against
+/// a rectangle it was never mapped into. Reading the same flag the remap reads keeps the two in one
+/// space by construction.
 #[cfg(all(target_os = "linux", feature = "drm"))]
-pub(super) fn live_wayland_layout() -> Vec<scrap::wayland::display::DisplayRect> {
-    WAYLAND_LAYOUT.lock().unwrap().live.clone()
+pub(super) fn wayland_layout_of_injected_coords() -> Vec<scrap::wayland::display::DisplayRect> {
+    let lock = WAYLAND_LAYOUT.lock().unwrap();
+    if WAYLAND_LAYOUT_DRIFTED.load(Ordering::Relaxed) {
+        lock.live.clone()
+    } else {
+        lock.baseline.clone()
+    }
 }
 
 // Remap an injected coordinate onto the live compositor layout when it has drifted from
@@ -727,5 +738,48 @@ mod tests {
         assert_eq!(normalize_primary_display_idx(0, 2), 0);
         assert_eq!(normalize_primary_display_idx(1, 2), 1);
         assert_eq!(normalize_primary_display_idx(2, 2), 0);
+    }
+}
+
+#[cfg(all(test, target_os = "linux", feature = "drm"))]
+mod injected_space_tests {
+    use super::*;
+    use scrap::wayland::display::{remap_to_live_layout, DisplayRect};
+
+    fn rect(name: &str, x: i32, w: i32) -> DisplayRect {
+        DisplayRect {
+            name: name.to_owned(),
+            x,
+            y: 0,
+            w,
+            h: 1440,
+        }
+    }
+
+    // rustdesk#15897: whatever measures an injected coordinate has to read the same space the input
+    // path put it in. The poll writes `live` before it knows the uinput range could be reprogrammed,
+    // and until then the remap is still a no-op, so `live` alone is the wrong answer.
+    #[test]
+    fn the_calibration_reads_the_space_the_remap_writes() {
+        let baseline = vec![rect("DP-1", 0, 2560), rect("DP-2", 2560, 2560)];
+        let live = vec![rect("DP-1", 0, 2048), rect("DP-2", 2048, 2560)];
+        {
+            let mut lock = WAYLAND_LAYOUT.lock().unwrap();
+            lock.baseline = baseline.clone();
+            lock.live = live.clone();
+        }
+
+        // Range not applied yet: the remap leaves the point alone, so the point is in the baseline.
+        WAYLAND_LAYOUT_DRIFTED.store(false, Ordering::Relaxed);
+        assert_eq!(remap_to_live_layout(2560, 0, &baseline, &live), (2048, 0));
+        assert_eq!(remap_wayland_uinput_coord(2560, 0), (2560, 0));
+        assert_eq!(wayland_layout_of_injected_coords(), baseline);
+
+        // Range applied: now the remap moves it, and the accessor has to follow.
+        WAYLAND_LAYOUT_DRIFTED.store(true, Ordering::Relaxed);
+        assert_eq!(remap_wayland_uinput_coord(2560, 0), (2048, 0));
+        assert_eq!(wayland_layout_of_injected_coords(), live);
+
+        WAYLAND_LAYOUT_DRIFTED.store(false, Ordering::Relaxed);
     }
 }

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -77,6 +77,14 @@ fn connector_key(d: &DrmDisplayInfo) -> String {
 }
 
 /// Takes DRM_STATE: never call it while holding one of the per-display maps below.
+fn available_drm_display_list() -> Vec<DrmDisplayInfo> {
+    match &*DRM_STATE.lock().unwrap() {
+        ProbeState::Available(_, list) => list.clone(),
+        _ => Vec::new(),
+    }
+}
+
+/// Takes DRM_STATE: never call it while holding one of the per-display maps below.
 fn display_info_of(display: i32) -> Option<DrmDisplayInfo> {
     match &*DRM_STATE.lock().unwrap() {
         ProbeState::Available(_, list) => list.get(display.max(0) as usize).cloned(),
@@ -450,6 +458,7 @@ async fn recv_thread(
             &Data::DrmStart {
                 display: wire_idx as i32,
                 need_cpu,
+                want_cursor_pos: true,
             },
             None,
         )
@@ -460,6 +469,29 @@ async fn recv_thread(
     }
     let _ = tx.send(Ok((displays, wire_idx)));
 
+    // Cursor hotspot calibration state for THIS stream (see `calibrated_hotspot`): the last
+    // visible shape as the wire delivered it, whether its hotspot is kernel truth, how long the
+    // plane has sat still, and the per-settle-window bookkeeping. `cal_rect_phys` snapshots the
+    // display-rect lookup ONCE per settle window: the enumeration behind it is backed off and
+    // fork-heavy on failure, so it must not be polled per tick from this loop.
+    let mut cal_wire: Option<DrmCursorData> = None;
+    let mut cal_from_property = false;
+    let mut cal_plane: Option<(i32, i32)> = None;
+    let mut cal_plane_stable: u32 = 0;
+    let mut cal_applied: Option<(i32, i32)> = None;
+    let mut cal_rect_phys: Option<((i32, i32, i32, i32), (i32, i32))> = None;
+    let mut cal_window: u64 = 0;
+    // A measurement only enters the cross-shape cache once a SECOND settle window agrees, so a
+    // one-off race (a local user parking the mouse near the peer's stale point) cannot poison it.
+    let mut cal_pending_cache: Option<((i32, i32), u64)> = None;
+    // Reopen trigger: the peer's last injected point at the last attempt window, so input that
+    // arrives AFTER the ~1 s window closed (without moving the plane) re-arms one window.
+    let mut cal_seen_inj: Option<(i32, i32)> = None;
+    // Stale-producer diagnostic: a service that predates the calibration decodes DrmStart fine
+    // (serde default) and simply never streams DrmCursorPos - say so once instead of never firing.
+    let mut cal_pos_seen = false;
+    let mut cal_frames_without_pos: u32 = 0;
+
     let end_reason = loop {
         if stop.load(Ordering::SeqCst) {
             break "stopped".to_owned();
@@ -469,6 +501,21 @@ async fn recv_thread(
             Some(Ok(pair)) => pair,
             Some(Err(err)) => break format!("recv: {err}"),
         };
+        // A service that predates the calibration decodes our DrmStart fine (serde default) and
+        // simply never streams DrmCursorPos; frames keep flowing, so count them and say so ONCE
+        // instead of leaving "hotspot stays the guess" unattributable.
+        if matches!(msg, Data::DrmFrameDmabuf(_) | Data::DrmFrame { .. })
+            && cal_wire.is_some()
+            && !cal_pos_seen
+        {
+            cal_frames_without_pos = cal_frames_without_pos.saturating_add(1);
+            if cal_frames_without_pos == 90 {
+                log::info!(
+                    "drm: 90 frames with a visible cursor and no cursor-position stream; \
+                     the service predates cursor calibration, hotspots stay the reader guess"
+                );
+            }
+        }
         match msg {
             Data::DrmFrameDmabuf(desc) => {
                 let conv = match converter.as_mut() {
@@ -562,6 +609,9 @@ async fn recv_thread(
                 height,
                 hotx,
                 hoty,
+                x,
+                y,
+                hot_from_property,
             } => {
                 // get_cursor_data() hands `colors` straight to the client, which renders
                 // width*height*4 RGBA bytes: a short body would make it READ PAST THE BUFFER. A
@@ -580,20 +630,186 @@ async fn recv_thread(
                                 raw.len()
                             );
                         }
-                        set_drm_cursor(
-                            display,
-                            cursor_epoch,
-                            DrmCursorData {
-                                id,
-                                width: width as i32,
-                                height: height as i32,
-                                hotx,
-                                hoty,
-                                colors: raw,
-                            },
-                        );
+                        let mut data = DrmCursorData {
+                            id,
+                            width: width as i32,
+                            height: height as i32,
+                            hotx,
+                            hoty,
+                            colors: raw,
+                        };
+                        if id == scrap::drm_reader::HIDDEN_CURSOR_ID {
+                            cal_wire = None;
+                            cal_plane = None;
+                            cal_pending_cache = None;
+                        } else {
+                            cal_from_property = hot_from_property;
+                            // The position frozen at the shape-change instant is the FIRST
+                            // stability sample, not a measurement: the pointer usually moves at
+                            // the moment the shape flips (that is what flipped it).
+                            cal_plane = Some((x, y));
+                            cal_plane_stable = 0;
+                            cal_rect_phys = None;
+                            cal_applied = None;
+                            cal_pending_cache = None;
+                            cal_frames_without_pos = 0;
+                            if hot_from_property {
+                                cal_wire = None;
+                            } else {
+                                cal_wire = Some(data.clone());
+                                // A shape the compositor re-uses keeps its wire id, so a cached
+                                // measurement corrects it from its first frame.
+                                if let Some((cx, cy)) = cached_cursor_cal(id) {
+                                    if cx < data.width && cy < data.height {
+                                        cal_applied = Some((cx, cy));
+                                        data.hotx = cx;
+                                        data.hoty = cy;
+                                        data.id = remix_cursor_id(id, cx, cy);
+                                    }
+                                }
+                            }
+                        }
+                        set_drm_cursor(display, cursor_epoch, data);
                     }
                     Ok(Err(err)) => break format!("cursor body: {err}"),
+                }
+            }
+            Data::DrmCursorPos { x, y } => {
+                // Position-only header, no raw body; only sent because DrmStart asked for it.
+                // One arrives per capture tick while the cursor is visible; consecutive equal
+                // positions are the stillness signal.
+                cal_pos_seen = true;
+                if cal_plane == Some((x, y)) {
+                    cal_plane_stable = cal_plane_stable.saturating_add(1);
+                } else {
+                    cal_plane = Some((x, y));
+                    cal_plane_stable = 0;
+                    cal_rect_phys = None;
+                }
+                if cal_from_property || cal_wire.is_none() {
+                    // Kernel truth, or no visible shape: nothing to measure.
+                } else {
+                    // Cheap gate first (one mutex): the display lookups below must not run for
+                    // an idle pointer or before the peer ever moved the mouse.
+                    let injected =
+                        crate::server::input_service::last_peer_input_pos_and_age_ms();
+                    // Reopen: input that arrives AFTER the window closed, without moving the
+                    // plane (the peer parked the pointer, then came back), re-arms one window.
+                    if cal_plane_stable > CURSOR_CAL_STABLE_TICKS + CURSOR_CAL_WINDOW_TICKS {
+                        if let Some((pos, age)) = injected {
+                            if (CURSOR_CAL_MIN_INPUT_AGE_MS..=CURSOR_CAL_MAX_INPUT_AGE_MS)
+                                .contains(&age)
+                                && cal_seen_inj != Some(pos)
+                            {
+                                cal_plane_stable = CURSOR_CAL_STABLE_TICKS;
+                                cal_rect_phys = None;
+                            }
+                        }
+                    }
+                    let in_window = (CURSOR_CAL_STABLE_TICKS
+                        ..=CURSOR_CAL_STABLE_TICKS + CURSOR_CAL_WINDOW_TICKS)
+                        .contains(&cal_plane_stable);
+                    if in_window {
+                        if cal_plane_stable == CURSOR_CAL_STABLE_TICKS {
+                            // ONCE per settle window: resolve THIS stream's monitor in the space
+                            // the peer injects in. The wayland output list drives the uinput
+                            // mapping, but its ORDER is not the DRM list's (measured on a T2
+                            // with a cloned external: index 1 named the wrong output), so map
+                            // through the same connector-identity assignment the advertised
+                            // geometry uses; clone layouts overlap at (0,0), which is why
+                            // containment alone cannot pick the rect. At a greeter the wayland
+                            // list is empty and the advertised layout IS the DRM physical one,
+                            // so fall back to it (the mapping degenerates to scale 1).
+                            cal_window = cal_window.wrapping_add(1);
+                            cal_seen_inj = injected.map(|(pos, _)| pos);
+                            let drm_list = available_drm_display_list();
+                            let wl = scrap::wayland::display::get_displays();
+                            let rect = if wl.displays.is_empty() {
+                                display_info_of(display)
+                                    .map(|d| (d.x, d.y, d.width as i32, d.height as i32))
+                            } else {
+                                let rects =
+                                    scrap::wayland::display::logical_rects_of_displays(
+                                        &wl.displays,
+                                    );
+                                assign_wayland_outputs(&drm_list, &wl.displays)
+                                    .get(display.max(0) as usize)
+                                    .copied()
+                                    .flatten()
+                                    .and_then(|j| rects.get(j).map(|r| (r.x, r.y, r.w, r.h)))
+                            };
+                            let phys = display_info_of(display)
+                                .map(|d| (d.width as i32, d.height as i32));
+                            cal_rect_phys = rect.zip(phys);
+                            // One diagnostic line per settle: every input the decision reads,
+                            // so a silent non-calibration is attributable from a log.
+                            if let Some(wire) = &cal_wire {
+                                log::debug!(
+                                    "drm: cursor cal probe d{}: plane=({}, {}) wire={}x{} hot({},{}) prop={} inj={:?} rect_phys={:?}",
+                                    display,
+                                    x,
+                                    y,
+                                    wire.width,
+                                    wire.height,
+                                    wire.hotx,
+                                    wire.hoty,
+                                    cal_from_property,
+                                    injected,
+                                    cal_rect_phys,
+                                );
+                            }
+                        }
+                        let measured = cal_rect_phys.zip(cal_wire.as_ref()).and_then(
+                            |((rect, phys), wire)| {
+                                calibrated_hotspot(
+                                    cal_from_property,
+                                    (wire.width, wire.height),
+                                    injected,
+                                    rect,
+                                    phys,
+                                    (x, y),
+                                    cal_plane_stable,
+                                )
+                            },
+                        );
+                        if let (Some(h), Some(wire)) = (measured, &cal_wire) {
+                            let close = |a: (i32, i32), b: (i32, i32)| {
+                                (a.0 - b.0).abs() <= CURSOR_CAL_TOLERANCE
+                                    && (a.1 - b.1).abs() <= CURSOR_CAL_TOLERANCE
+                            };
+                            let current = cal_applied.unwrap_or((wire.hotx, wire.hoty));
+                            if close(current, h) {
+                                // Converged. A correction only enters the cross-shape cache once
+                                // a SECOND, later window agrees with it.
+                                if cal_applied.is_some() {
+                                    if let Some((p, w)) = cal_pending_cache {
+                                        if w != cal_window && close(p, current) {
+                                            store_cursor_cal(wire.id, current);
+                                        }
+                                    }
+                                }
+                            } else {
+                                log::info!(
+                                    "drm: cursor {:#x} hotspot measured ({}, {}), replacing ({}, {})",
+                                    wire.id,
+                                    h.0,
+                                    h.1,
+                                    current.0,
+                                    current.1
+                                );
+                                // Republish under a remixed id even when h equals the reader's
+                                // guess: this branch also REPAIRS a wrong applied correction,
+                                // and only a new id makes the dedup layers resend the shape.
+                                cal_applied = Some(h);
+                                cal_pending_cache = Some((h, cal_window));
+                                let mut data = wire.clone();
+                                data.hotx = h.0;
+                                data.hoty = h.1;
+                                data.id = remix_cursor_id(wire.id, h.0, h.1);
+                                set_drm_cursor(display, cursor_epoch, data);
+                            }
+                        }
+                    }
                 }
             }
             Data::DrmDisplaysChanged(list) => {
@@ -715,6 +931,102 @@ fn remove_drm_cursor(display: i32, epoch: u64) {
     if map.get(&display).map(|(e, _)| *e) == Some(epoch) {
         map.remove(&display);
     }
+}
+
+// ---- Cursor hotspot calibration ----
+// The kernel only exposes a cursor hotspot on DRIVER_CURSOR_HOTSPOT drivers (VMs), so on real
+// hardware the wire carries the reader's bounding-box guess - wrong by half a glyph for a wide
+// center-hotspot shape like the horizontal resize arrow, which the client then draws visibly
+// off target. But `plane_origin = pointer_tip - hotspot`, this process INJECTS the tip itself,
+// and the service streams the plane position every tick: once both sit still, the difference IS
+// the hotspot, measured rather than guessed.
+
+/// The plane must hold one position this many consecutive ticks before it counts as settled.
+const CURSOR_CAL_STABLE_TICKS: u32 = 3;
+/// Measurement attempts run for this many ticks (~1 s) after a settle, then stop until the
+/// plane moves again or fresh peer input reopens one window.
+const CURSOR_CAL_WINDOW_TICKS: u32 = 30;
+/// Corrections within this many px of what the client already renders are jitter, not news:
+/// the peer coordinate is quantized to LOGICAL px, so at a fractional scale the measurement
+/// legitimately wobbles +/- ceil(scale) physical px between windows, and re-publishing inside
+/// that band would only mint ids and churn the client's shape caches.
+const CURSOR_CAL_TOLERANCE: i32 = 2;
+/// The last injected move must be at least this old (the compositor has consumed it) ...
+const CURSOR_CAL_MIN_INPUT_AGE_MS: i64 = 150;
+/// ... and at most this old: on a seated box a LOCAL user may have moved the pointer since the
+/// peer last did, and the stale injected point would calibrate garbage.
+const CURSOR_CAL_MAX_INPUT_AGE_MS: i64 = 10_000;
+
+/// Measured hotspots per WIRE cursor id: a shape the compositor re-uses (arrow -> beam ->
+/// arrow) keeps its id, so it is corrected again from its first frame. Bounded by wholesale
+/// clearing; ids churn on theme/size changes, and re-measuring is cheap.
+static CURSOR_CAL_CACHE: Mutex<BTreeMap<u64, (i32, i32)>> = Mutex::new(BTreeMap::new());
+const CURSOR_CAL_CACHE_CAP: usize = 64;
+
+fn cached_cursor_cal(wire_id: u64) -> Option<(i32, i32)> {
+    CURSOR_CAL_CACHE.lock().unwrap().get(&wire_id).copied()
+}
+
+fn store_cursor_cal(wire_id: u64, h: (i32, i32)) {
+    let mut cache = CURSOR_CAL_CACHE.lock().unwrap();
+    if cache.len() >= CURSOR_CAL_CACHE_CAP && !cache.contains_key(&wire_id) {
+        cache.clear();
+    }
+    cache.insert(wire_id, h);
+}
+
+/// Domain-separated from the reader's FNV fold, so a corrected id cannot collide with a wire id
+/// and the client's shape cache treats the corrected cursor as new.
+fn remix_cursor_id(wire_id: u64, hotx: i32, hoty: i32) -> u64 {
+    let mut id = wire_id ^ 0x9e37_79b9_7f4a_7c15;
+    for v in [hotx as u32 as u64, hoty as u32 as u64] {
+        id ^= v;
+        id = id.wrapping_mul(1099511628211);
+    }
+    id
+}
+
+/// Measure the hotspot, or say why not: kernel truth is never overridden, the plane and the
+/// injected point must both be settled, and the answer must lie inside the bitmap (anything
+/// else is a race, an edge clip, or a local user having moved the pointer). Pure, so every gate
+/// is testable.
+///
+/// SPACES, measured on a kwin panel at scale 1.45: the peer injects in the ADVERTISED layout
+/// (`get_display_rects_for_uinput` - logical px on a multi-display session), while the plane is
+/// PHYSICAL scanout px of one CRTC. The point is first required to fall inside this display's
+/// advertised rect (otherwise the cursor is on another monitor and that stream calibrates), then
+/// scaled into scanout space; only then is the plane subtracted. On a scale-1 single display the
+/// mapping degenerates to a plain subtraction.
+fn calibrated_hotspot(
+    hot_from_property: bool,
+    dims: (i32, i32),
+    injected: Option<((i32, i32), i64)>,
+    advertised_rect: (i32, i32, i32, i32),
+    physical_size: (i32, i32),
+    plane: (i32, i32),
+    plane_stable_ticks: u32,
+) -> Option<(i32, i32)> {
+    if hot_from_property || plane_stable_ticks < CURSOR_CAL_STABLE_TICKS {
+        return None;
+    }
+    let ((ix, iy), age_ms) = injected?;
+    if !(CURSOR_CAL_MIN_INPUT_AGE_MS..=CURSOR_CAL_MAX_INPUT_AGE_MS).contains(&age_ms) {
+        return None;
+    }
+    let (ax, ay, aw, ah) = advertised_rect;
+    if aw <= 0 || ah <= 0 || physical_size.0 <= 0 || physical_size.1 <= 0 {
+        return None;
+    }
+    if ix < ax || ix >= ax + aw || iy < ay || iy >= ay + ah {
+        return None;
+    }
+    let tipx = ((ix - ax) as f64 * physical_size.0 as f64 / aw as f64).round() as i32;
+    let tipy = ((iy - ay) as f64 * physical_size.1 as f64 / ah as f64).round() as i32;
+    let h = (tipx - plane.0, tipy - plane.1);
+    if h.0 < 0 || h.1 < 0 || h.0 >= dims.0 || h.1 >= dims.1 {
+        return None;
+    }
+    Some(h)
 }
 
 fn with_drm_cursor<T>(f: impl Fn(&DrmCursorData) -> T) -> Option<T> {
@@ -1844,5 +2156,125 @@ mod drm_capturer_tests {
         let burn = Duration::from_secs(5); // four failed sessions
         assert!(demote_cooldown(1) + burn < Duration::from_secs(40));
         assert!(demote_cooldown(5) + burn > Duration::from_secs(8 * 60));
+    }
+}
+
+#[cfg(test)]
+mod cursor_calibration_tests {
+    use super::*;
+
+    const DIMS: (i32, i32) = (32, 32);
+    const SETTLED: Option<((i32, i32), i64)> = Some(((500, 300), 400));
+    // A scale-1 single display: advertised rect == scanout.
+    const RECT1: (i32, i32, i32, i32) = (0, 0, 1920, 1080);
+    const PHYS1: (i32, i32) = (1920, 1080);
+
+    #[test]
+    fn a_settled_pointer_and_plane_yield_the_difference() {
+        // Plane origin at (488, 288), tip injected at (500, 300): hotspot (12, 12).
+        assert_eq!(
+            calibrated_hotspot(false, DIMS, SETTLED, RECT1, PHYS1, (488, 288), 3),
+            Some((12, 12))
+        );
+    }
+
+    #[test]
+    fn a_scaled_display_maps_the_injected_point_into_scanout_space() {
+        // The T2 measurement that found the space mismatch: kwin panel 2880x1800 advertised
+        // as 1986x1241 (scale ~1.4502). inj (1643, 577) -> tip (2383, 837); plane (2357, 814)
+        // under a resize glyph whose real hotspot is its center.
+        assert_eq!(
+            calibrated_hotspot(
+                false,
+                (128, 128),
+                Some(((1643, 577), 400)),
+                (0, 0, 1986, 1241),
+                (2880, 1800),
+                (2357, 814),
+                3
+            ),
+            Some((26, 23))
+        );
+    }
+
+    #[test]
+    fn a_point_on_another_display_is_not_this_streams_to_measure() {
+        // The advertised rect of THIS display starts at x=1920; the peer sits left of it.
+        assert_eq!(
+            calibrated_hotspot(
+                false,
+                DIMS,
+                SETTLED,
+                (1920, 0, 1920, 1080),
+                PHYS1,
+                (488, 288),
+                3
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn a_degenerate_advertised_rect_measures_nothing() {
+        assert_eq!(
+            calibrated_hotspot(false, DIMS, SETTLED, (0, 0, 0, 0), PHYS1, (488, 288), 3),
+            None
+        );
+    }
+
+    #[test]
+    fn kernel_truth_is_never_overridden() {
+        assert_eq!(
+            calibrated_hotspot(true, DIMS, SETTLED, RECT1, PHYS1, (488, 288), 3),
+            None
+        );
+    }
+
+    #[test]
+    fn an_unsettled_plane_is_not_measured() {
+        assert_eq!(
+            calibrated_hotspot(false, DIMS, SETTLED, RECT1, PHYS1, (488, 288), 2),
+            None
+        );
+    }
+
+    #[test]
+    fn input_too_fresh_or_too_stale_is_rejected() {
+        let fresh = Some(((500, 300), 50));
+        let stale = Some(((500, 300), 60_000));
+        assert_eq!(calibrated_hotspot(false, DIMS, fresh, RECT1, PHYS1, (488, 288), 3), None);
+        assert_eq!(calibrated_hotspot(false, DIMS, stale, RECT1, PHYS1, (488, 288), 3), None);
+        assert_eq!(calibrated_hotspot(false, DIMS, None, RECT1, PHYS1, (488, 288), 3), None);
+    }
+
+    #[test]
+    fn an_answer_outside_the_bitmap_is_a_race_not_a_hotspot() {
+        // Injected point far from the plane (a local user moved the mouse).
+        assert_eq!(
+            calibrated_hotspot(false, DIMS, Some(((900, 300), 400)), RECT1, PHYS1, (488, 288), 3),
+            None
+        );
+        // Negative: plane ahead of the injected point.
+        assert_eq!(
+            calibrated_hotspot(false, DIMS, Some(((480, 300), 400)), RECT1, PHYS1, (488, 288), 3),
+            None
+        );
+    }
+
+    #[test]
+    fn a_corrected_id_differs_from_the_wire_id_and_is_deterministic() {
+        let wire = 0xabcdef0123456789u64;
+        let a = remix_cursor_id(wire, 12, 12);
+        assert_ne!(a, wire);
+        assert_eq!(a, remix_cursor_id(wire, 12, 12));
+        assert_ne!(a, remix_cursor_id(wire, 13, 12));
+    }
+
+    #[test]
+    fn the_calibration_cache_is_bounded() {
+        for i in 0..(CURSOR_CAL_CACHE_CAP as u64 * 2) {
+            store_cursor_cal(i, (1, 1));
+        }
+        assert!(CURSOR_CAL_CACHE.lock().unwrap().len() <= CURSOR_CAL_CACHE_CAP);
     }
 }

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -732,11 +732,23 @@ async fn recv_thread(
                                     scrap::wayland::display::logical_rects_of_displays(
                                         &wl.displays,
                                     );
+                                // `wl` is the session-init snapshot, but the injected point was
+                                // already moved onto the LIVE layout by the input path, so the
+                                // rect it is measured against has to be the live one. Matched the
+                                // same way the remap matches; the snapshot is the fallback while
+                                // no poll has run.
+                                let live = super::display_service::live_wayland_layout();
                                 assign_wayland_outputs(&drm_list, &wl.displays)
                                     .get(display.max(0) as usize)
                                     .copied()
                                     .flatten()
-                                    .and_then(|j| rects.get(j).map(|r| (r.x, r.y, r.w, r.h)))
+                                    .and_then(|j| {
+                                        let r = scrap::wayland::display::live_counterpart(
+                                            j, &rects, &live,
+                                        )
+                                        .or_else(|| rects.get(j))?;
+                                        Some((r.x, r.y, r.w, r.h))
+                                    })
                             };
                             let phys = display_info_of(display)
                                 .map(|d| (d.width as i32, d.height as i32));

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -732,12 +732,13 @@ async fn recv_thread(
                                     scrap::wayland::display::logical_rects_of_displays(
                                         &wl.displays,
                                     );
-                                // `wl` is the session-init snapshot, but the injected point was
-                                // already moved onto the LIVE layout by the input path, so the
-                                // rect it is measured against has to be the live one. Matched the
-                                // same way the remap matches; the snapshot is the fallback while
-                                // no poll has run.
-                                let live = super::display_service::live_wayland_layout();
+                                // `wl` is the session-init snapshot, but the input path may have
+                                // moved the point onto a different layout, so the rect it is
+                                // measured against has to come from wherever the point actually
+                                // is. Matched the same way the remap matches; the snapshot is the
+                                // fallback while no poll has run.
+                                let live =
+                                    super::display_service::wayland_layout_of_injected_coords();
                                 assign_wayland_outputs(&drm_list, &wl.displays)
                                     .get(display.max(0) as usize)
                                     .copied()

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -995,6 +995,19 @@ fn get_last_input_cursor_pos() -> (i32, i32) {
     (lock.x, lock.y)
 }
 
+/// The last ABSOLUTE peer-injected pointer position (post-remap desktop px) and its age in ms.
+/// `None` until a peer has moved the mouse this session. The DRM cursor calibration subtracts
+/// the cursor-plane position from this to recover the hotspot the kernel does not expose.
+#[cfg(all(target_os = "linux", feature = "drm"))]
+pub(crate) fn last_peer_input_pos_and_age_ms() -> Option<((i32, i32), i64)> {
+    let lock = LATEST_PEER_INPUT_CURSOR.lock().unwrap();
+    // Both sentinels are huge negatives: INVALID_CURSOR_POS (unpolled) and half it (inactive).
+    if lock.time == 0 || lock.x <= INVALID_CURSOR_POS / 2 {
+        return None;
+    }
+    Some(((lock.x, lock.y), get_time() - lock.time))
+}
+
 // check if mouse is moved by the controlled side user to make controlled side has higher mouse priority than remote.
 fn active_mouse_(_conn: i32) -> bool {
     true


### PR DESCRIPTION
fixes #15896 (cursor offset reported in #10016).

the HOTSPOT_X/Y plane property only exists on DRIVER_CURSOR_HOTSPOT drivers (VMs). on real
hardware the drm path guessed the hotspot from the opaque bounding box, and a wide center-hotspot
glyph - the horizontal resize arrow - rendered half its width off target on the client.

the relation plane_origin = pointer_tip - hotspot holds on every compositor, this process injects
the tip itself, and the service already reads the plane. so:

- the reader ships the plane position and a hot_from_property flag next to the bitmap
- the service streams a position-only DrmCursorPos header each capture tick while the cursor is
visible, only when the consumer opted in via a defaulted DrmStart field, so the _drm protocol
stays append-only and an old --server never sees an unknown variant
- the consumer measures hotspot = injected - plane once both settle (plane still for 3 ticks,
input age 150ms..10s, bounded attempt window), mapping the injected point from the advertised
layout into scanout space first - the peer coordinate is logical px and the plane is physical, and
on a scaled or cloned layout the display is resolved by connector identity, not list index
- an answer outside the bitmap is a race or a local user on the mouse and is rejected; a
correction enters the cross-shape cache only after a second settle window agrees; kernel-provided
hotspots are never overridden

measured on a plasma/amdgpu box (panel at scale 1.45, cloned external): before, the resize glyph
drew at (+19, +6) px from the pointer; after, (-2, -1). the server logs the measurement:
hotspot measured (26, 23), replacing (4, 16) - and the arrow corrected from (4,4) to the real
(7,7). unit tests pin the space mapping (including the measured scale-1.45 case), the gates, the
id remix and the cache bound.

known limitations, on purpose: the in-bitmap bound accepts the full cursor fb rather than the
opaque bbox (shipping the bbox would widen the wire for a marginal gate); touch or pen input does
not update the injected point, so a touch-only session keeps the guess until a mouse move; and the
per-shape ids the corrections mint are bounded by the 2 px tolerance but still add entries to the
client's unbounded shape caches, which predate this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional DRM cursor-position updates for smoother pointer tracking.
  * Cursor updates can be delivered independently of screen-frame updates.
  * Added richer cursor metadata and hotspot provenance reporting.
  * Improved Wayland display-bound calculations.

* **Bug Fixes**
  * Improved hotspot estimation and pointer alignment through cursor calibration.
  * Improved handling of hidden, unsupported, and invalid cursor data.
  * Reduced redundant updates while maintaining responsive movement.
  * Preserved corrected cursor positioning across cursor changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



















<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds DRM cursor-hotspot calibration by correlating peer-injected pointer coordinates with streamed cursor-plane positions.
- Extends the DRM IPC protocol with opt-in, latest-position cursor updates.
- Maps injected coordinates between Wayland logical layout and physical scanout space.
- Adds settling, validation, correction caching, and tests for hotspot measurement.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR does not yet appear safe to merge because a slow cursor-position write can still allow cursor traffic to block subsequent frame capture.

The reply states that the wakeup token fix was completed, but the current branch releases that token before awaiting the position write; a slow peer can therefore permit a replacement wakeup and a frame to fill the bounded channel, leaving the next frame submission blocked.

**Files Needing Attention:** src/ipc/drm.rs
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ipc/drm.rs | Adds the latest-wins cursor-position transport and wakeup-token lifecycle used by the calibration stream. |
| src/server/drm_capturer.rs | Implements cursor hotspot calibration, coordinate-space mapping, validation gates, corrected IDs, and bounded calibration caching. |
| libs/scrap/src/common/drm_reader.rs | Exposes cursor-plane coordinates and hotspot provenance while retaining the bounding-box fallback. |
| libs/scrap/src/wayland/display.rs | Adds reusable snapshot and connector-counterpart helpers for consistent display-space mapping. |
| src/server/display_service.rs | Exposes the layout space currently used for injected coordinates. |
| src/ipc.rs | Extends the DRM wire messages with backward-compatible cursor-position negotiation and metadata. |
| src/server/input_service.rs | Exposes the latest peer-injected absolute pointer position and its age to calibration. |

</details>

<sub>Reviews (12): Last reviewed commit: ["fix(drm): measure an injected point agai..."](https://github.com/rustdesk/rustdesk/commit/61a91cc5cea333cde5149453f18e3ca23a2f3639) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54550769)</sub>

<!-- /greptile_comment -->