### PR TITLE
fix(flutter): initialize the cursor hotspot y from its own origin

### DIFF
--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2842,7 +2842,7 @@ class CursorData {
     required this.width,
     required this.height,
   })  : hotx = hotxOrigin * scale,
-        hoty = hotxOrigin * scale;
+        hoty = hotyOrigin * scale;
 
   int _doubleToInt(double v) => (v * 10e6).round().toInt();
 


### PR DESCRIPTION
one line: the CursorData constructor initializes hoty from hotxOrigin - a copy-paste slip.

it is latent today, and the pr says so: both consumers (native and web custom_cursor.dart) call updateGetKey() before reading, and _checkUpdateScale recomputes hoty from hotyOrigin on that path. but any future read of hoty before that call silently inherits the x value, so the initializer should be right on its own.

found while measuring cursor hotspots for #15897; independent of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cursor positioning by calculating the vertical coordinate from the appropriate origin value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Corrects the `CursorData` constructor so the vertical cursor hotspot is initialized from its own origin.
- Changes `hoty` initialization from `hotxOrigin * scale` to `hotyOrigin * scale`.
- Aligns constructor initialization with the existing scale-update behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The corrected initializer matches the semantics of the constructor parameters and the existing scaling path, while current consumers continue to recompute the hotspot before use.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/models/model.dart | The one-line constructor fix uses the correct vertical hotspot origin and is consistent with subsequent hotspot recalculation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(flutter): initialize the cursor hots..."](https://github.com/rustdesk/rustdesk/commit/6bf2f92da2b251c61a0b548d03f055393808de9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54603474)</sub>

<!-- /greptile_comment -->