### PR TITLE
Hide printer tab when settings disabled

### DIFF
--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -191,6 +191,7 @@ const String kOptionHideProxySetting = "hide-proxy-settings";
 const String kOptionHideWebSocketSetting = "hide-websocket-settings";
 const String kOptionHideStopService = "hide-stop-service";
 const String kOptionHideRemotePrinterSetting = "hide-remote-printer-settings";
+const String kOptionHideGeneralSetting = "hide-general-settings";
 const String kOptionHideSecuritySetting = "hide-security-settings";
 const String kOptionHideNetworkSetting = "hide-network-settings";
 const String kOptionRemovePresetPasswordWarning =

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -61,7 +61,8 @@ enum SettingsTabKey {
 class DesktopSettingPage extends StatefulWidget {
   final SettingsTabKey initialTabkey;
   static final List<SettingsTabKey> tabKeys = [
-    SettingsTabKey.general,
+    if (bind.mainGetBuildinOption(key: kOptionHideGeneralSetting) != 'Y')
+      SettingsTabKey.general,
     if (!isWeb &&
         !bind.isOutgoingOnly() &&
         !bind.isDisableSettings() &&

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -73,6 +73,7 @@ class DesktopSettingPage extends StatefulWidget {
     if (!bind.isIncomingOnly()) SettingsTabKey.display,
     if (!bind.isDisableAccount()) SettingsTabKey.account,
     if (isWindows &&
+        !bind.isDisableSettings() &&
         bind.mainGetBuildinOption(key: kOptionHideRemotePrinterSetting) != 'Y')
       SettingsTabKey.printer,
     SettingsTabKey.about,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to hide the General settings tab.
  * Windows Printer settings are now hidden when settings are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds support for hiding the General settings tab through a built-in option and hides the Windows printer tab whenever settings are globally disabled.
- Adds the `hide-general-settings` option constant.
- Conditionally includes the General tab based on that option.
- Applies the global disable-settings condition to printer-tab visibility.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete functional or security defects identified in the changed paths.

Hidden initial tabs are handled by the existing fallback to the first available tab, the tab list always retains the About entry, and printer visibility now consistently honors the global settings-disable state.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/consts.dart | Adds the built-in option key used to control General-tab visibility. |
| flutter/lib/desktop/pages/desktop_setting_page.dart | Updates tab visibility conditions while preserving safe selection behavior when the requested initial tab is hidden. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add hide-general-settings builtin ..."](https://github.com/rustdesk/rustdesk/commit/e275052df4997b6d405d53ea41767e6c8ee9bce3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54617634)</sub>

<!-- /greptile_comment -->