### PR TITLE
fix: reject a frame that does not match the size the capturer was built with

### DIFF
--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -724,6 +724,20 @@ fn run(vs: VideoService) -> ResultType<()> {
         let res = match c.frame(spf) {
             Ok(frame) => {
                 repeat_encode_counter = 0;
+                // Rebuild when a mode change hands back a frame that no longer matches the size
+                // this capturer/encoder pair was built with: convert_to_yuv only refuses LARGER
+                // sources, and a smaller one lands in the old canvas leaving stale edges.
+                if let scrap::Frame::PixelBuffer(f) = &frame {
+                    if f.width() != capture_width || f.height() != capture_height {
+                        bail!(
+                            "frame {}x{} is not the {}x{} this capturer was built with; rebuilding",
+                            f.width(),
+                            f.height(),
+                            capture_width,
+                            capture_height
+                        );
+                    }
+                }
                 if frame.valid() {
                     let screenshot_key = (vs.source, display_idx);
                     let screenshot = SCREENSHOTS.lock().unwrap().remove(&screenshot_key);

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -736,8 +736,13 @@ fn run(vs: VideoService) -> ResultType<()> {
                         // With another wayland stream active, exiting alone rebuilds NOTHING:
                         // the shared state survives and the retry reuses the same stale
                         // rectangle. Ask every wayland service to drain so the last one clears.
+                        // Monitors only: the flag is process-global, and a camera owns nothing in
+                        // that shared state, so raising it there would tear down unrelated screen
+                        // sharing. A camera still bails and rebuilds its own capturer and encoder.
                         #[cfg(target_os = "linux")]
-                        super::wayland::request_restart();
+                        if vs.source.is_monitor() {
+                            super::wayland::request_restart();
+                        }
                         bail!(
                             "frame {}x{} is not the {}x{} this capturer was built with; rebuilding",
                             f.width(),

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -550,11 +550,10 @@ fn run(vs: VideoService) -> ResultType<()> {
         SimpleCallOnReturn {
             b: true,
             f: Box::new(|| {
-                // Decrement active display count and only clear if this was the last display
-                let remaining_count = super::wayland::decrement_active_display_count();
-                if remaining_count == 0 {
-                    super::wayland::clear();
-                }
+                // Decrement and clear under ONE count guard: a separate decrement-then-clear lets
+                // a newly admitted service grab the old capturer pointer right before clear()
+                // frees it.
+                super::wayland::decrement_active_display_count_and_clear_if_last();
             }),
         }
     };

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -675,6 +675,11 @@ fn run(vs: VideoService) -> ResultType<()> {
             log::info!("switch to refresh");
             bail!("SWITCH");
         }
+        #[cfg(target_os = "linux")]
+        if super::wayland::restart_pending() {
+            log::info!("switch so the shared wayland capture state can rebuild");
+            bail!("SWITCH");
+        }
         if codec_format != Encoder::negotiated_codec() {
             log::info!(
                 "switch due to codec changed, {:?} -> {:?}",
@@ -729,6 +734,11 @@ fn run(vs: VideoService) -> ResultType<()> {
                 // sources, and a smaller one lands in the old canvas leaving stale edges.
                 if let scrap::Frame::PixelBuffer(f) = &frame {
                     if f.width() != capture_width || f.height() != capture_height {
+                        // With another wayland stream active, exiting alone rebuilds NOTHING:
+                        // the shared state survives and the retry reuses the same stale
+                        // rectangle. Ask every wayland service to drain so the last one clears.
+                        #[cfg(target_os = "linux")]
+                        super::wayland::request_restart();
                         bail!(
                             "frame {}x{} is not the {}x{} this capturer was built with; rebuilding",
                             f.width(),

--- a/src/server/video_service.rs
+++ b/src/server/video_service.rs
@@ -731,25 +731,25 @@ fn run(vs: VideoService) -> ResultType<()> {
                 // Rebuild when a mode change hands back a frame that no longer matches the size
                 // this capturer/encoder pair was built with: convert_to_yuv only refuses LARGER
                 // sources, and a smaller one lands in the old canvas leaving stale edges.
-                if let scrap::Frame::PixelBuffer(f) = &frame {
-                    if f.width() != capture_width || f.height() != capture_height {
-                        // With another wayland stream active, exiting alone rebuilds NOTHING:
-                        // the shared state survives and the retry reuses the same stale
-                        // rectangle. Ask every wayland service to drain so the last one clears.
-                        // Monitors only: the flag is process-global, and a camera owns nothing in
-                        // that shared state, so raising it there would tear down unrelated screen
-                        // sharing. A camera still bails and rebuilds its own capturer and encoder.
-                        #[cfg(target_os = "linux")]
-                        if vs.source.is_monitor() {
+                // Monitors only. A camera's size comes from the cache `Cameras::all_info()` filled
+                // before the stream was open, and nothing refreshes it on a retry, so bailing here
+                // would rebuild with the same size that just failed and bail again forever.
+                if vs.source.is_monitor() {
+                    if let scrap::Frame::PixelBuffer(f) = &frame {
+                        if f.width() != capture_width || f.height() != capture_height {
+                            // With another wayland stream active, exiting alone rebuilds NOTHING:
+                            // the shared state survives and the retry reuses the same stale
+                            // rectangle. Ask every wayland service to drain so the last one clears.
+                            #[cfg(target_os = "linux")]
                             super::wayland::request_restart();
+                            bail!(
+                                "frame {}x{} is not the {}x{} this capturer was built with; rebuilding",
+                                f.width(),
+                                f.height(),
+                                capture_width,
+                                capture_height
+                            );
                         }
-                        bail!(
-                            "frame {}x{} is not the {}x{} this capturer was built with; rebuilding",
-                            f.width(),
-                            f.height(),
-                            capture_width,
-                            capture_height
-                        );
                     }
                 }
                 if frame.valid() {

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -41,6 +41,23 @@ pub(super) fn decrement_active_display_count() -> usize {
     *count
 }
 
+/// A geometry bail must rebuild the SHARED capture state, but `clear()` only runs when the last
+/// service exits - with another monitor or camera stream active the count never reaches zero and
+/// every retry reuses the same cached capturer and rectangle. The flag asks EVERY wayland service
+/// to exit its loop so the count drains, the last one clears, and the next entries rebuild fresh.
+static RESTART_PENDING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+pub(super) fn request_restart() {
+    if is_x11() {
+        return;
+    }
+    RESTART_PENDING.store(true, std::sync::atomic::Ordering::SeqCst);
+}
+
+pub(super) fn restart_pending() -> bool {
+    !is_x11() && RESTART_PENDING.load(std::sync::atomic::Ordering::SeqCst)
+}
+
 fn map_err_scrap(err: String) -> io::Error {
     // to-do: Handle error better, do not restart server
     if err.starts_with("Did not receive a reply") {
@@ -426,6 +443,8 @@ pub fn clear() {
 
     // Reset PipeWire initialization flag to allow recreation on next init
     *PIPEWIRE_INITIALIZED.write().unwrap() = false;
+    // The teardown this flag asked for has happened; later services start clean.
+    RESTART_PENDING.store(false, std::sync::atomic::Ordering::SeqCst);
 }
 
 /// Initialize the PipeWire/portal capture path from the plain (sync) video thread, so a DRM display

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -33,12 +33,20 @@ pub(super) fn increment_active_display_count() -> usize {
     *count
 }
 
-pub(super) fn decrement_active_display_count() -> usize {
+/// Decrement and, when this was the last service, tear the shared state down UNDER THE SAME count
+/// guard. A separate decrement-then-clear leaves a window where a newly admitted service grabs the
+/// old capturer pointer and clear() then frees it out from under `c.frame()`; holding the guard
+/// makes admission (which increments under the same lock) wait until the teardown is done. Lock
+/// order is COUNT then CAP_DISPLAY_INFO everywhere: run() increments before ensure_inited touches
+/// the map, never while holding it.
+pub(super) fn decrement_active_display_count_and_clear_if_last() {
     let mut count = ACTIVE_DISPLAY_COUNT.write().unwrap();
     if *count > 0 {
         *count -= 1;
     }
-    *count
+    if *count == 0 {
+        clear();
+    }
 }
 
 /// A geometry bail must rebuild the SHARED capture state, but `clear()` only runs when the last

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -36,9 +36,10 @@ pub(super) fn increment_active_display_count() -> usize {
 /// Decrement and, when this was the last service, tear the shared state down UNDER THE SAME count
 /// guard. A separate decrement-then-clear leaves a window where a newly admitted service grabs the
 /// old capturer pointer and clear() then frees it out from under `c.frame()`; holding the guard
-/// makes admission (which increments under the same lock) wait until the teardown is done. Lock
-/// order is COUNT then CAP_DISPLAY_INFO everywhere: run() increments before ensure_inited touches
-/// the map, never while holding it.
+/// makes admission (which increments under the same lock) wait until the teardown is done.
+/// run() calls ensure_inited BEFORE it increments, so the two locks are never held together: the
+/// map guard is released inside ensure_inited, and the capturer pointer is only read after the
+/// count has been taken.
 pub(super) fn decrement_active_display_count_and_clear_if_last() {
     let mut count = ACTIVE_DISPLAY_COUNT.write().unwrap();
     if *count > 0 {


### PR DESCRIPTION
fixes #15695.

the encoder is sized once when the capturer is built, and convert_to_yuv only refuses a source LARGER than the destination, so a mid session resolution decrease lands in the old canvas and leaves stale right and bottom edges until the session is torn down. this rejects a PixelBuffer frame whose size is not the one the capturer was built with, which routes a decrease through the same rebuild an increase already takes: the bail leaves run(), and GenericService re-enters its loop with a fresh capturer.

what it is not is a live repro, and i would rather say so than dress it up. i measured the three backends when i filed the issue: x11 recovers on its own through check_display_changed, the drm path recovers through the topology restart from #15420, and pipewire i could not drive back then. i have since measured pipewire for #15804 on kde, gnome 50 and gnome 46 aarch64 with the modeset verified from sysfs, and the portal stream never renegotiates its size, not even on an increase. so this is a defensive guard on the one path i cannot make fire.

on your VideoCropMeta question: yes, it can legally hand back a frame smaller than the caps, and the pipewire path here already applies the crop (the buffer_cropped branch in libs/scrap/src/wayland/pipewire.rs) and reports the cropped size as the capturable size. that is exactly why the comparison is against capture_width and capture_height, the size the capturer reported at build time and therefore already post crop, rather than the caps or the encoder format: vpx_img_wrap aligns the encoder width up, so comparing there would reject every capture whose width is not already aligned. a stable crop cannot trip this, and a crop that changes takes one rebuild, same as a mode change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video capture reliability by limiting frame-size mismatch recovery to monitor sources.
  * Camera capture no longer triggers unnecessary errors or capture-pipeline rebuilds when frame dimensions differ.
  * Improved Wayland recovery by restarting services when monitor capture requires rebuilding.
  * Improved cleanup of shared display capture state when the final capture service exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR rejects monitor frames whose dimensions no longer match the capturer and encoder configuration, causing the capture pipeline to rebuild instead of retaining stale image edges.
- Coordinates Wayland-wide restart requests when shared capture geometry changes.
- Makes final shared-state cleanup atomic with active-service count decrement.
- Clears the restart request after shared Wayland state has been torn down.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/video_service.rs | Adds frame-dimension validation and routes mismatches through the existing service retry lifecycle while coordinating Wayland restarts. |
| src/server/wayland.rs | Adds shared restart signaling and performs last-service teardown under the active-count guard to prevent stale capturer access. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Video service
    participant C as Capturer
    participant W as Shared Wayland state
    C-->>S: PixelBuffer frame
    alt Frame dimensions match
        S->>S: Encode frame
    else Frame dimensions differ
        S->>W: request_restart()
        S-->>S: Exit run()
        S->>W: decrement active count
        W-->>S: Other services observe restart_pending
        S->>W: Final service clears shared state
        W->>W: Reset restart flag
        S->>W: Retry with rebuilt capturer
    end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: the size check is for monitors, not..."](https://github.com/rustdesk/rustdesk/commit/507556aa3207dbeaed162a67a7ba820fc7149e90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54619229)</sub>

<!-- /greptile_comment -->