### PR TITLE
fix(linux): a session logout should hand the peer to the login screen

### DIFF
--- a/flutter/lib/desktop/pages/server_page.dart
+++ b/flutter/lib/desktop/pages/server_page.dart
@@ -22,6 +22,14 @@ import '../../models/file_model.dart';
 import '../../models/platform_model.dart';
 import '../../models/server_model.dart';
 
+/// Set only by this window's own close control, and only once the user has confirmed. Any other
+/// way the window can go - a session logout closing every window, the window manager, a native
+/// title-bar button this app does not draw - leaves it false, which is the honest answer:
+/// nothing in that close says who asked for it. It lives at file scope because the control that
+/// sets it (`ConnectionManagerState`) and the handler that reads it (`_DesktopServerPageState`)
+/// are different widgets.
+bool _cmClosedByOperator = false;
+
 class DesktopServerPage extends StatefulWidget {
   const DesktopServerPage({Key? key}) : super(key: key);
 
@@ -55,7 +63,10 @@ class _DesktopServerPageState extends State<DesktopServerPage>
 
   @override
   void onWindowClose() {
-    Future.wait([gFFI.serverModel.closeAll(), gFFI.close()]).then((_) {
+    // Other platforms keep the old behaviour exactly: the ambiguity this guards against is a
+    // Linux session logout, which closes every window in the session.
+    final byOperator = _cmClosedByOperator || !isLinux;
+    Future.wait([gFFI.serverModel.closeAll(byOperator: byOperator), gFFI.close()]).then((_) {
       if (isMacOS) {
         RdPlatformChannel.instance.terminate();
       } else {
@@ -327,6 +338,7 @@ class ConnectionManagerState extends State<ConnectionManager>
     var tabController = gFFI.serverModel.tabController;
     final connLength = tabController.length;
     if (connLength <= 1) {
+      _cmClosedByOperator = true;
       windowManager.close();
       return true;
     } else {
@@ -338,6 +350,9 @@ class ConnectionManagerState extends State<ConnectionManager>
         res = await closeConfirmDialog();
       }
       if (res) {
+        // After the dialog, never before it: an external close while it is open must not
+        // inherit an intent the user had not expressed yet.
+        _cmClosedByOperator = true;
         windowManager.close();
       }
       return res;

--- a/flutter/lib/models/server_model.dart
+++ b/flutter/lib/models/server_model.dart
@@ -738,9 +738,13 @@ class ServerModel with ChangeNotifier {
     }
   }
 
-  Future<void> closeAll() async {
-    await Future.wait(
-        _clients.map((client) => bind.cmCloseConnection(connId: client.id)));
+  /// `byOperator` false means the CM's window went away rather than a person asking for the
+  /// peers to go. The sessions end either way; only the close reason differs, and with it
+  /// whether the peer is allowed to reconnect. See `ipc::Data::CmWindowClosed`.
+  Future<void> closeAll({bool byOperator = true}) async {
+    await Future.wait(_clients.map((client) => byOperator
+        ? bind.cmCloseConnection(connId: client.id)
+        : bind.cmCloseConnectionWindow(connId: client.id)));
     _clients.clear();
     tabController.state.value.tabs.clear();
     if (isAndroid) androidUpdatekeepScreenOn();

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -1373,6 +1373,10 @@ class RustdeskImpl {
     throw UnimplementedError("cmLoginRes");
   }
 
+  Future<void> cmCloseConnectionWindow({required int connId, dynamic hint}) {
+    throw UnimplementedError("cmCloseConnectionWindow");
+  }
+
   Future<void> cmCloseConnection({required int connId, dynamic hint}) {
     throw UnimplementedError("cmCloseConnection");
   }

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -58,10 +58,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.11.0"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -90,10 +90,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   bot_toast:
     dependency: "direct main"
     description:
@@ -340,7 +340,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: 533883bcb0ffe91a9afdb13b8bac9b14b3e054ba
+      resolved-ref: "533883bcb0ffe91a9afdb13b8bac9b14b3e054ba"
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"
@@ -417,6 +417,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   ffi:
     dependency: "direct main"
     description:
@@ -644,6 +652,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  flutter_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -849,6 +862,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.5"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -877,10 +914,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1218,10 +1255,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.0"
   sqflite:
     dependency: "direct main"
     description:
@@ -1242,18 +1279,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -1266,10 +1303,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.2.0"
   synchronized:
     dependency: transitive
     description:
@@ -1282,18 +1319,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.2"
   texture_rgba_renderer:
     dependency: "direct main"
     description:
@@ -1473,7 +1510,7 @@ packages:
     source: hosted
     version: "1.1.16"
   vector_math:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
@@ -1528,6 +1565,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.0+2"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.2.5"
   wakelock_plus:
     dependency: "direct main"
     description:

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -58,10 +58,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -90,10 +90,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   bot_toast:
     dependency: "direct main"
     description:
@@ -340,7 +340,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "533883bcb0ffe91a9afdb13b8bac9b14b3e054ba"
+      resolved-ref: 533883bcb0ffe91a9afdb13b8bac9b14b3e054ba
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"
@@ -417,14 +417,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
-  fake_async:
-    dependency: transitive
-    description:
-      name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
   ffi:
     dependency: "direct main"
     description:
@@ -652,11 +644,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
-  flutter_test:
-    dependency: "direct dev"
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -862,30 +849,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.5"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.5"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -914,10 +877,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1255,10 +1218,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   sqflite:
     dependency: "direct main"
     description:
@@ -1279,18 +1242,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -1303,10 +1266,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   synchronized:
     dependency: transitive
     description:
@@ -1319,18 +1282,18 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.6"
   texture_rgba_renderer:
     dependency: "direct main"
     description:
@@ -1510,7 +1473,7 @@ packages:
     source: hosted
     version: "1.1.16"
   vector_math:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
@@ -1565,14 +1528,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.0+2"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "14.2.5"
   wakelock_plus:
     dependency: "direct main"
     description:

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2197,6 +2197,15 @@ pub fn cm_close_connection(conn_id: i32) {
     crate::ui_cm_interface::close(conn_id);
 }
 
+/// The CM window closed. On Linux that is ambiguous - a logout closes it the same way a person
+/// does - so it ends the session without the no-retry reason; elsewhere it is a plain close.
+pub fn cm_close_connection_window(conn_id: i32) {
+    #[cfg(target_os = "linux")]
+    crate::ui_cm_interface::close_window(conn_id);
+    #[cfg(all(not(target_os = "linux"), not(target_os = "ios")))]
+    crate::ui_cm_interface::close(conn_id);
+}
+
 pub fn cm_remove_disconnected_connection(conn_id: i32) {
     #[cfg(not(any(target_os = "ios")))]
     crate::ui_cm_interface::remove(conn_id);

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -510,6 +510,15 @@ pub enum Data {
     // the header extensible. The zero-copy `DrmFrameDmabuf(DmabufDesc)` sibling below carries only a
     // small JSON metadata descriptor; the scanout dma-buf fd rides an SCM_RIGHTS ancillary message on
     // the same `DrmConn` send (see `DrmConn::send_msg`), so it has NO trailing `send_raw()` body.
+    /// CM -> server: the connection manager's WINDOW went away, which is not the same event
+    /// as the operator disconnecting a peer. Linux only, and deliberately: there a session
+    /// logout closes every window, and the close arrives at the CM indistinguishable from a
+    /// person clicking it - measured on KDE, the CM gets no signal and logind still reports the
+    /// session active. So the ambiguous case ends the session WITHOUT the no-retry reason and
+    /// the peer is allowed to reconnect (landing on the greeter after a logout), while the
+    /// explicit Disconnect button keeps sending `Close` and kicking for good.
+    #[cfg(target_os = "linux")]
+    CmWindowClosed,
     /// Client -> service: begin streaming the chosen display.
     #[cfg(all(target_os = "linux", feature = "drm"))]
     // `need_cpu` is set by an unprivileged consumer that could not open a render-node convert context

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -501,15 +501,6 @@ pub enum Data {
     ControlPermissionsRemoteModify(Option<bool>),
     #[cfg(target_os = "windows")]
     FileTransferEnabledState(Option<bool>),
-    // --- DRM/KMS capture (opt-in `drm` feature) over the `_drm` service-scoped channel ---
-    // All of the following are `cfg(all(linux, drm))`, so the drm-off IPC wire is byte-identical
-    // to upstream. Protocol on `_drm`: on connect the root service sends `DrmDisplayList`, the
-    // client replies `DrmStart{display}`, then the service streams `DrmFrame` + send_raw(BGRA) and
-    // `DrmCursor` + send_raw(RGBA). A frame/cursor header is ALWAYS immediately followed by exactly
-    // one `send_raw()` payload (the same header-then-raw pairing as `FileBlockFromCM`). This keeps
-    // the header extensible. The zero-copy `DrmFrameDmabuf(DmabufDesc)` sibling below carries only a
-    // small JSON metadata descriptor; the scanout dma-buf fd rides an SCM_RIGHTS ancillary message on
-    // the same `DrmConn` send (see `DrmConn::send_msg`), so it has NO trailing `send_raw()` body.
     /// CM -> server: the connection manager's WINDOW went away, which is not the same event
     /// as the operator disconnecting a peer. Linux only, and deliberately: there a session
     /// logout closes every window, and the close arrives at the CM indistinguishable from a
@@ -519,6 +510,15 @@ pub enum Data {
     /// explicit Disconnect button keeps sending `Close` and kicking for good.
     #[cfg(target_os = "linux")]
     CmWindowClosed,
+    // --- DRM/KMS capture (opt-in `drm` feature) over the `_drm` service-scoped channel ---
+    // All of the following are `cfg(all(linux, drm))`, so the drm-off IPC wire is byte-identical
+    // to upstream. Protocol on `_drm`: on connect the root service sends `DrmDisplayList`, the
+    // client replies `DrmStart{display}`, then the service streams `DrmFrame` + send_raw(BGRA) and
+    // `DrmCursor` + send_raw(RGBA). A frame/cursor header is ALWAYS immediately followed by exactly
+    // one `send_raw()` payload (the same header-then-raw pairing as `FileBlockFromCM`). This keeps
+    // the header extensible. The zero-copy `DrmFrameDmabuf(DmabufDesc)` sibling below carries only a
+    // small JSON metadata descriptor; the scanout dma-buf fd rides an SCM_RIGHTS ancillary message on
+    // the same `DrmConn` send (see `DrmConn::send_msg`), so it has NO trailing `send_raw()` body.
     /// Client -> service: begin streaming the chosen display.
     #[cfg(all(target_os = "linux", feature = "drm"))]
     // `need_cpu` is set by an unprivileged consumer that could not open a render-node convert context

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -642,6 +642,18 @@ impl Connection {
                             conn.on_close("connection manager", true).await;
                             break;
                         }
+                        // The connection manager's window went away rather than a person
+                        // disconnecting this peer. End the session exactly as above, but do not
+                        // send the manual close reason: it is the one thing that stops the peer
+                        // from retrying, and on a logout the retry is the whole point - it is
+                        // what puts the peer back on the login screen a moment later.
+                        #[cfg(target_os = "linux")]
+                        ipc::Data::CmWindowClosed => {
+                            conn.chat_unanswered = false; // seen
+                            conn.file_transferred = false; //seen
+                            conn.on_close("connection manager window closed", true).await;
+                            break;
+                        }
                         ipc::Data::CmErr(e) => {
                             if e != "expected" {
                                 // cm closed before connection

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1213,6 +1213,13 @@ impl Connection {
                             ipc::Data::Close => {
                                 bail!("Close requested from connection manager");
                             }
+                            // Same end as above: a tunnel must not outlive the window either.
+                            // Only the reason differs, and a port forward carries none - the
+                            // peer sees the tunnel drop and decides for itself.
+                            #[cfg(target_os = "linux")]
+                            ipc::Data::CmWindowClosed => {
+                                bail!("Connection manager window closed");
+                            }
                             ipc::Data::CmErr(e) => {
                                 log::error!("Connection manager error: {e}");
                                 bail!("{e}");

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -377,6 +377,15 @@ pub fn close(id: i32) {
     };
 }
 
+/// Like `close`, but says the CM's WINDOW closed rather than a person disconnecting this peer.
+/// See `ipc::Data::CmWindowClosed`.
+#[cfg(target_os = "linux")]
+pub fn close_window(id: i32) {
+    if let Some(client) = CLIENTS.read().unwrap().get(&id) {
+        allow_err!(client.tx.send(Data::CmWindowClosed));
+    };
+}
+
 #[inline]
 pub fn remove(id: i32) {
     CLIENTS.write().unwrap().remove(&id);


### PR DESCRIPTION
fixes #15892.

logging out closes every window in the session, the connection manager's included, and its close
handler kicks every peer with the reason a person gets when they disconnect one by hand. that
reason is the one thing the client never retries on (`check_if_retry` refuses on "manually"), so
the remote session dies on a frozen frame while the greeter it should have landed on is already up
behind it.

## what the close actually carries

nothing that says why it happened, and i went looking before designing anything:

- the CM receives no signal at logout - its threads exit 0, so it closes through its ordinary
window path, the same one a person triggers
- logind still reports the session `active` at the instant the CM dies
- the user `--server` is SIGKILLed about 230 ms after the CM's request in a logout, and about 90 ms
after the CM when a person closes the window instead

measured on plasma/sddm with a client attached. the last two are why a "wait and see whether i
survive" design does not work: both cases kill the server fast, so the wait only stops the
operator's kick from working. i built that version and the bench caught it.

## what is distinguishable

not who closed the window, but which action happened. disconnecting a peer is a different event
from this window going away, and the CM knows which one it is without guessing.

so the window-close path says so with its own ipc message, and the server ends the session exactly
as before minus the no-retry reason - the peer is then free to retry, which is what puts it on the
greeter a moment later. `Data::Close` is untouched: the Disconnect button, the app's own close
control and `stopService` still kick for good. linux only, since that is where a logout closes the
window; the wire on every other platform is byte-identical.

## measured, both directions

| | server log | client |
|---|---|---|
| logout | `connection manager window closed` | reconnects, live greeter, no dialog |
| operator closes the window | `connection manager` | "Closed manually by the peer", as today |

the reported symptom, before and after, is the dialog in #15892 replaced by the greeter itself.

## the trade-off, stated

a close this cannot attribute - alt+f4, the window manager's close, a taskbar close - now ends the
session in retry mode, so an operator using one of those sees the peer come back rather than stay
out. that is deliberate. the alternative i tried first was to leave those sessions running, and it
is worse in a way that matters: the connection manager never respawns on linux (the server only
logs a warning when its ipc dies), so the host would keep a live session with no window, no kick
control, audio busy-looping and file transfers hanging. between "the peer reconnects" and "the host
loses control of a session", i took the first, and the Disconnect button remains the unambiguous
way to put someone out.

port-forward sessions take the same path: `try_port_forward_loop` is a second consumer of that
channel and gets the mirrored arm, so a tunnel does not outlive the window either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Closing the connection manager window on Linux now cleanly ends active sessions and port-forward tunnels.
  * Remote sessions can distinguish a window closure from an explicit disconnection and may reconnect automatically.
* **Bug Fixes**
  * Improved cleanup of transfer and chat state when the connection manager window is closed.
  * Preserved existing close behavior on non-Linux platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR distinguishes an explicit operator disconnect from an ambiguous Linux connection-manager window closure so peers can retry after logout and reach the greeter.
- Tracks whether the application’s own close control initiated the window close.
- Adds a Linux-only `CmWindowClosed` IPC event and sends it for ambiguous window closures.
- Handles the event for desktop and port-forward sessions without emitting the manual, no-retry close reason.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The new Linux-only close path preserves session termination while intentionally omitting the manual no-retry reason, and explicit disconnects and non-Linux behavior retain their existing semantics.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/desktop/pages/server_page.dart | Records explicit close intent and selects the new Linux window-close behavior while retaining existing behavior on other platforms. |
| flutter/lib/models/server_model.dart | Routes each active client through either the explicit disconnect or ambiguous window-close FFI call. |
| src/flutter_ffi.rs | Exposes the window-close operation to Flutter and limits its distinct behavior to Linux. |
| src/ipc.rs | Adds the Linux-only `CmWindowClosed` message representing an ambiguous connection-manager window closure. |
| src/server/connection.rs | Ends desktop and port-forward sessions on the new message without applying the manual no-retry reason. |
| src/ui_cm_interface.rs | Sends `CmWindowClosed` through the existing per-connection IPC channel. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant WM as Linux window/session manager
    participant CM as Connection Manager UI
    participant IPC as CM IPC channel
    participant Server as Connection server
    participant Peer as Remote peer

    alt Explicit Disconnect control
        CM->>IPC: Data::Close
        IPC->>Server: Close
        Server->>Peer: Manual no-retry close reason
        Server->>Server: End session
    else Ambiguous window closure or logout
        WM->>CM: Close window
        CM->>IPC: Data::CmWindowClosed
        IPC->>Server: CmWindowClosed
        Server->>Server: End session without no-retry reason
        Peer->>Server: Retry connection
        Server-->>Peer: Login screen / greeter
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(linux): close the tunnel too, and ke..."](https://github.com/rustdesk/rustdesk/commit/755d3627a60cff272263363d1827dd318215f87a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54646034)</sub>

<!-- /greptile_comment -->