### PR TITLE
fix(drm): say so when the machine has no display attached at all

### DIFF
--- a/libs/scrap/src/common/drm_reader.rs
+++ b/libs/scrap/src/common/drm_reader.rs
@@ -433,17 +433,24 @@ impl DrmReader {
         }
     }
 
-    pub fn displays(&mut self) -> Vec<DisplaySnapshot> {
+    /// `None` is an enumeration FAILURE (drmtap_list_displays returns -errno when
+    /// drmModeGetResources fails on an otherwise-open device); only `Some(empty)` means the
+    /// device truly reports no connector with a display.
+    pub fn displays(&mut self) -> Option<Vec<DisplaySnapshot>> {
         // SAFETY: ctx valid; raw is a zeroed, correctly-sized array; count is clamped to the buffer before indexing.
         unsafe {
             let mut raw = vec![std::mem::zeroed::<drmtap_display>(); 16];
             let cap = raw.len() as i32;
             let n = (self.lib.list_displays)(self.ctx, raw.as_mut_ptr(), cap);
-            if n <= 0 {
-                return Vec::new();
+            if n < 0 {
+                log::warn!("drmtap_list_displays failed ({n})");
+                return None;
+            }
+            if n == 0 {
+                return Some(Vec::new());
             }
             let count = (n as usize).min(raw.len());
-            (0..count)
+            let snaps = (0..count)
                 .map(|i| {
                     let name_bytes: Vec<u8> = raw[i]
                         .name
@@ -461,7 +468,8 @@ impl DrmReader {
                         active: raw[i].active != 0,
                     }
                 })
-                .collect()
+                .collect();
+            Some(snaps)
         }
     }
 }

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -699,7 +699,18 @@ fn schedule_drm_cache_refresh() {
                     Ok(g) => g,
                     Err(poisoned) => poisoned.into_inner(),
                 };
-                if *cache != fresh {
+                if trust.uninspected && fresh.len() < cache.len() {
+                    // A card that did not answer cannot prove ITS displays are gone. Only the
+                    // shrink is refused: growth and identity changes still land, and a real
+                    // removal takes the node out of /dev/dri and sysfs together, so the counts
+                    // fall in step and this round is no longer partial.
+                    log::debug!(
+                        "drm: keeping {} cached display(s) through a partial enumeration ({} seen)",
+                        cache.len(),
+                        fresh.len()
+                    );
+                    false
+                } else if *cache != fresh {
                     *cache = fresh;
                     true
                 } else {

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -651,14 +651,21 @@ fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
 /// a display that is still there, land. A real removal takes the node out of /dev/dri and sysfs
 /// together, so the counts fall in step and that round is not partial in the first place.
 ///
-/// Connector names identify: they are unique among live connectors, and the card minor is not
-/// (`/dev/dri/cardN` comes from an allocator that recycles across a rebind).
+/// Identity is the card AND the connector name. Two LIVE connectors never share a name - the index
+/// comes from a per-type ida that is global to drm.ko, measured on a 3-card machine whose DP
+/// numbering ran 1..3 on one card and 4..7 on the next - but the cache and the fresh list are not
+/// contemporaneous: the kernel returns a name to that allocator when a connector goes, so between
+/// two rounds `DP-1` can come back on another card. Matching by name alone would call that the same
+/// display and swap it in, and the consumer keys on `(device, crtc_id)`, so its stream would end.
 fn round_may_replace_cache(
     cache: &[DrmDisplayInfo],
     fresh: &[DrmDisplayInfo],
     uninspected: bool,
 ) -> bool {
-    !uninspected || cache.iter().all(|c| fresh.iter().any(|f| f.name == c.name))
+    !uninspected
+        || cache
+            .iter()
+            .all(|c| fresh.iter().any(|f| f.name == c.name && f.device == c.device))
 }
 
 /// The SINGLE writer of DRM_DISPLAY_CACHE (+ DRM_DISPLAY_GENERATION), off the caller's thread and
@@ -1707,7 +1714,7 @@ mod drm_conn_tests {
             height: 1080,
             active: true,
             render_node: String::new(),
-            device: String::new(),
+            device: "/dev/dri/card1".to_owned(),
         }
     }
 
@@ -1727,6 +1734,18 @@ mod drm_conn_tests {
 
         let swapped = [display("DP-1", 3840), display("DP-4", 1280)];
         assert!(!round_may_replace_cache(&cache, &swapped, true));
+
+        // Same connector NAME, another card. Between two rounds the kernel can hand `DP-1` back
+        // out, so a name-only match would accept this and the consumer, which keys on the card and
+        // the crtc, would see its display disappear.
+        let moved = [
+            DrmDisplayInfo {
+                device: "/dev/dri/card2".to_owned(),
+                ..display("DP-1", 3840)
+            },
+            display("HDMI-A-1", 1920),
+        ];
+        assert!(!round_may_replace_cache(&cache, &moved, true));
 
         let grown = [
             display("DP-1", 3840),

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -182,19 +182,41 @@ struct EnumerationTrust {
     uninspected: bool,
 }
 
-/// Card nodes visible in /dev/dri, whether or not they can be opened.
-fn dri_card_count() -> usize {
-    std::fs::read_dir("/dev/dri")
+/// Card nodes that can DRIVE an output: a card with no `/sys/class/drm/cardN-*` connector
+/// directory (a render-only node like v3d or tegra) is display-incapable by construction, and
+/// counting it would keep absence unprovable forever on every split render/display SoC.
+fn dri_display_card_count() -> usize {
+    let Ok(rd) = std::fs::read_dir("/sys/class/drm") else {
+        return 0;
+    };
+    let mut cards = std::collections::HashSet::new();
+    let mut with_connector = std::collections::HashSet::new();
+    for e in rd.filter_map(|e| e.ok()) {
+        let name = e.file_name().to_string_lossy().into_owned();
+        if let Some((card, _)) = name.split_once('-') {
+            if card.starts_with("card") {
+                with_connector.insert(card.to_owned());
+            }
+        } else if name.starts_with("card") && name[4..].chars().all(|c| c.is_ascii_digit()) {
+            cards.insert(name);
+        }
+    }
+    cards.intersection(&with_connector).count()
+}
+
+/// Whether `/dev/dri/cardN` has any sysfs connector: a failed open of a connector-less card says
+/// nothing about display presence.
+fn dev_card_has_connectors(path: &str) -> bool {
+    let Some(card) = std::path::Path::new(path).file_name().and_then(|n| n.to_str()) else {
+        return true;
+    };
+    let prefix = format!("{card}-");
+    std::fs::read_dir("/sys/class/drm")
         .map(|rd| {
             rd.filter_map(|e| e.ok())
-                .filter(|e| {
-                    e.file_name()
-                        .to_str()
-                        .is_some_and(|n| n.starts_with("card") && n[4..].chars().all(|c| c.is_ascii_digit()))
-                })
-                .count()
+                .any(|e| e.file_name().to_string_lossy().starts_with(&prefix))
         })
-        .unwrap_or(0)
+        .unwrap_or(true)
 }
 
 /// Active displays of every DRM device + the connected-but-undriven identities, from ONE look.
@@ -220,8 +242,9 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
         let mut undriven_total = Vec::new();
         let mut any_opened = false;
         // list_devices silently skips card nodes it cannot open, so absence is only proven when
-        // its list covers every node /dev/dri shows.
-        let mut uninspected = devices.len() < dri_card_count();
+        // its list covers every card that could drive an output (render-only nodes are skipped
+        // by design and prove nothing).
+        let mut uninspected = devices.len() < dri_display_card_count();
         let mut enumerated = false;
         for dev in devices {
             if let Some(mut r) = scrap::drm_reader::DrmReader::open(Some(&dev.path), 0) {
@@ -284,7 +307,8 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
                 }
                 None => uninspected = true,
             }
-        } else {
+        } else if dev_card_has_connectors(path) {
+            // A render-only card (v3d, tegra) fails this open by design and proves nothing.
             uninspected = true;
         }
     }
@@ -446,6 +470,7 @@ fn drm_wake_displays(reason: &str) -> bool {
 /// back to the portal, which then asks for consent on a screen nobody can look at. Said on the
 /// edge rather than every poll.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
 enum PresenceVerdict {
     /// Nothing completed an enumeration; presence is unknowable this round.
     Unknown,
@@ -470,40 +495,34 @@ fn presence_verdict(any_display: bool, any_undriven: bool, trust: EnumerationTru
 }
 
 fn note_output_presence(displays: &[DrmDisplayInfo], undriven: &[String], trust: EnumerationTrust) {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    static NO_OUTPUT: AtomicBool = AtomicBool::new(false);
-    static NO_PROBE: AtomicBool = AtomicBool::new(false);
-    match presence_verdict(!displays.is_empty(), !undriven.is_empty(), trust) {
-        PresenceVerdict::Unknown => {
-            if !NO_PROBE.swap(true, Ordering::Relaxed) {
-                log::warn!(
-                    "drm: no DRM device completed a connector enumeration, so display presence is \
-                     unknown (each failure logged its own error above)"
-                );
-            }
-        }
-        PresenceVerdict::UnprovenAbsence => {
-            // Not the dummy-plug advice: an uninspected sibling card may be driving a display.
-            if !NO_PROBE.swap(true, Ordering::Relaxed) {
-                log::warn!(
-                    "drm: every card that could be enumerated reports no display, but at least one \
-                     card could not be inspected; display presence is unknown"
-                );
-            }
-        }
-        PresenceVerdict::NoOutput => {
-            NO_PROBE.store(false, Ordering::Relaxed);
-            if !NO_OUTPUT.swap(true, Ordering::Relaxed) {
-                log::warn!(
-                    "drm: no connector reports a display, so this machine has no scanout to capture. \
-                     Attach a display or a dummy plug; a headless box can also force a connector on \
-                     (echo on > /sys/class/drm/<card>-<connector>/status)"
-                );
-            }
-        }
+    use std::sync::atomic::{AtomicU8, Ordering};
+    // One latch holding the LAST verdict, not per-state booleans: every transition between the
+    // four states is a different diagnosis and each deserves its line, exactly once.
+    static LAST: AtomicU8 = AtomicU8::new(u8::MAX);
+    let verdict = presence_verdict(!displays.is_empty(), !undriven.is_empty(), trust);
+    let prev = LAST.swap(verdict as u8, Ordering::Relaxed);
+    if prev == verdict as u8 {
+        return;
+    }
+    match verdict {
+        PresenceVerdict::Unknown => log::warn!(
+            "drm: no DRM device completed a connector enumeration, so display presence is \
+             unknown (each failure logged its own error above)"
+        ),
+        // Not the dummy-plug advice: an uninspected sibling card may be driving a display.
+        PresenceVerdict::UnprovenAbsence => log::warn!(
+            "drm: every card that could be enumerated reports no display, but at least one \
+             card could not be inspected; display presence is unknown"
+        ),
+        PresenceVerdict::NoOutput => log::warn!(
+            "drm: no connector reports a display, so this machine has no scanout to capture. \
+             Attach a display or a dummy plug; a headless box can also force a connector on \
+             (echo on > /sys/class/drm/<card>-<connector>/status)"
+        ),
         PresenceVerdict::SomeOutput => {
-            NO_PROBE.store(false, Ordering::Relaxed);
-            if NO_OUTPUT.swap(false, Ordering::Relaxed) {
+            // The very first verdict of the process being SomeOutput is the ordinary boot; only
+            // a RETURN to it closes an earlier warning.
+            if prev != u8::MAX {
                 log::info!("drm: an output is present again");
             }
         }
@@ -649,10 +668,15 @@ fn schedule_drm_cache_refresh() {
                         EnumerationTrust { enumerated: false, uninspected: true },
                     )
                 });
-            // The hotplug edge reports presence too; the edge-latched statics keep it idempotent
+            // The hotplug edge reports presence too; the verdict latch keeps it idempotent
             // across this worker and the handshake path.
             note_output_presence(&fresh, &undriven, trust);
-            let changed = {
+            let changed = if !trust.enumerated {
+                // A round that measured nothing must not wipe a good cache: the stale topology
+                // beats an empty one that only means the measurement failed.
+                log::debug!("drm: keeping the cached topology through a failed enumeration");
+                false
+            } else {
                 let mut cache = match DRM_DISPLAY_CACHE.lock() {
                     Ok(g) => g,
                     Err(poisoned) => poisoned.into_inner(),

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -386,9 +386,32 @@ fn drm_wake_displays(reason: &str) -> bool {
     true
 }
 
+
+/// Nothing plugged in at all is a different failure from a display that is merely asleep: there
+/// is no scanout now and there will not be one until an output exists, so capture silently falls
+/// back to the portal, which then asks for consent on a screen nobody can look at. Said on the
+/// edge rather than every poll.
+fn note_output_presence(displays: &[DrmDisplayInfo], undriven: &[String]) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static NO_OUTPUT: AtomicBool = AtomicBool::new(false);
+    let none = displays.is_empty() && undriven.is_empty();
+    if none != NO_OUTPUT.swap(none, Ordering::Relaxed) {
+        if none {
+            log::warn!(
+                "drm: no connector reports a display, so this machine has no scanout to capture. \
+                 Attach a display or a dummy plug; a headless box can also force a connector on \
+                 (echo on > /sys/class/drm/<card>-<connector>/status)"
+            );
+        } else {
+            log::info!("drm: an output is present again");
+        }
+    }
+}
+
 #[cfg(not(feature = "drm-wake"))]
 fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
     let (displays, undriven) = drm_enumerate_all_displays();
+    note_output_presence(&displays, &undriven);
     if !undriven.is_empty() {
         log::debug!(
             "drm: {} connected display(s) have no CRTC ({reason}); this build has no display wake",
@@ -405,6 +428,7 @@ fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
     use std::sync::atomic::Ordering;
 
     let (displays, undriven) = drm_enumerate_all_displays();
+    note_output_presence(&displays, &undriven);
     if !hbb_common::config::Config::get_bool_option(OPTION_ENABLE_DRM_DISPLAY_WAKE) {
         if !undriven.is_empty() {
             log::info!(

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -185,13 +185,14 @@ struct EnumerationTrust {
 /// Card nodes that can DRIVE an output: a card with no `/sys/class/drm/cardN-*` connector
 /// directory (a render-only node like v3d or tegra) is display-incapable by construction, and
 /// counting it would keep absence unprovable forever on every split render/display SoC.
-fn dri_display_card_count() -> usize {
-    let Ok(rd) = std::fs::read_dir("/sys/class/drm") else {
-        return 0;
-    };
+/// `None` when the inventory could not be read, which is a different fact from zero cards.
+fn dri_display_card_count() -> Option<usize> {
+    let rd = std::fs::read_dir("/sys/class/drm").ok()?;
     let mut cards = std::collections::HashSet::new();
     let mut with_connector = std::collections::HashSet::new();
-    for e in rd.filter_map(|e| e.ok()) {
+    for e in rd {
+        // A partial listing cannot bound the inventory, so it must not answer as if it did.
+        let e = e.ok()?;
         let name = e.file_name().to_string_lossy().into_owned();
         if let Some((card, _)) = name.split_once('-') {
             if card.starts_with("card") {
@@ -201,7 +202,7 @@ fn dri_display_card_count() -> usize {
             cards.insert(name);
         }
     }
-    cards.intersection(&with_connector).count()
+    Some(cards.intersection(&with_connector).count())
 }
 
 /// Whether `/dev/dri/cardN` has any sysfs connector: a failed open of a connector-less card says
@@ -244,7 +245,7 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
         // list_devices silently skips card nodes it cannot open, so absence is only proven when
         // its list covers every card that could drive an output (render-only nodes are skipped
         // by design and prove nothing).
-        let mut uninspected = devices.len() < dri_display_card_count();
+        let mut uninspected = dri_display_card_count().is_none_or(|n| devices.len() < n);
         let mut enumerated = false;
         for dev in devices {
             if let Some(mut r) = scrap::drm_reader::DrmReader::open(Some(&dev.path), 0) {
@@ -277,9 +278,17 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
     // the panel idle-disabled it binds card0 (the Touch Bar); the panel on card2 is invisible to it.
     let mut all = Vec::new();
     let mut undriven_total = Vec::new();
+    let mut inventory_failed = false;
     let mut paths: Vec<std::path::PathBuf> = match std::fs::read_dir("/dev/dri") {
         Ok(rd) => rd
-            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter_map(|e| match e {
+                Ok(e) => Some(e.path()),
+                Err(err) => {
+                    log::debug!("drm: cannot read a /dev/dri entry: {err}");
+                    inventory_failed = true;
+                    None
+                }
+            })
             .filter(|p| {
                 p.file_name()
                     .and_then(|n| n.to_str())
@@ -288,13 +297,16 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
             .collect(),
         Err(err) => {
             log::debug!("drm: cannot read /dev/dri to enumerate cards: {err}");
+            // An inventory we could not read is not an empty one: the reader below can still
+            // auto-detect a card, and the siblings it never saw stay unaccounted for.
+            inventory_failed = true;
             Vec::new()
         }
     };
     // Deterministic order, so the display list does not depend on directory order.
     paths.sort();
     let n_paths = paths.len();
-    let mut uninspected = false;
+    let mut uninspected = inventory_failed;
     let mut enumerated = false;
     for p in paths {
         let Some(path) = p.to_str() else { continue };
@@ -305,10 +317,11 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
                     all.append(&mut got);
                     undriven_total.append(&mut undriven);
                 }
-                None => uninspected = true,
+                // Measured on a split SoC (pi 5): the render-only node OPENS and fails here,
+                // so this arm needs the same connector filter as the failed-open one below.
+                None => uninspected |= dev_card_has_connectors(path),
             }
         } else if dev_card_has_connectors(path) {
-            // A render-only card (v3d, tegra) fails this open by design and proves nothing.
             uninspected = true;
         }
     }
@@ -323,11 +336,12 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
         if let Some(mut r) = scrap::drm_reader::DrmReader::open(None, 0) {
             log::info!("drm: no card enumerated by path; falling back to the auto-detected reader");
             if let Some((got, undriven)) = drm_displays_from_reader(&mut r, "") {
-                // Auto-detect inspects one card; with siblings around, absence stays unproven.
+                // The loop above already recorded every card it could not account for; the raw
+                // path count would re-add render-only siblings that prove nothing.
                 return (
                     got,
                     undriven,
-                    EnumerationTrust { enumerated: true, uninspected: uninspected || n_paths > 1 },
+                    EnumerationTrust { enumerated: true, uninspected },
                 );
             }
             uninspected = true;

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -186,7 +186,7 @@ struct EnumerationTrust {
 /// directory (a render-only node like v3d or tegra) is display-incapable by construction, and
 /// counting it would keep absence unprovable forever on every split render/display SoC.
 /// `None` when the inventory could not be read, which is a different fact from zero cards.
-fn dri_display_card_count() -> Option<usize> {
+fn dri_display_cards() -> Option<std::collections::HashSet<String>> {
     let rd = std::fs::read_dir("/sys/class/drm").ok()?;
     let mut cards = std::collections::HashSet::new();
     let mut with_connector = std::collections::HashSet::new();
@@ -202,7 +202,20 @@ fn dri_display_card_count() -> Option<usize> {
             cards.insert(name);
         }
     }
-    Some(cards.intersection(&with_connector).count())
+    Some(cards.intersection(&with_connector).cloned().collect())
+}
+
+/// Whether every connector-bearing card sysfs knows of is among the devices libdrmtap handed
+/// back. Identities, not counts: `list_devices` returns every device with KMS resources, which
+/// includes connectorless ones, so a connectorless `card1` can make the counts equal while the
+/// `card0` that carries the display is missing - and a round that then enumerates `card1` cleanly
+/// with no displays would be taken as proof of absence.
+fn inventory_is_covered(sysfs_cards: &std::collections::HashSet<String>, device_paths: &[&str]) -> bool {
+    sysfs_cards.iter().all(|card| {
+        device_paths
+            .iter()
+            .any(|p| std::path::Path::new(p).file_name().and_then(|n| n.to_str()) == Some(card))
+    })
 }
 
 /// Whether `/dev/dri/cardN` has any sysfs connector: a failed open of a connector-less card says
@@ -248,10 +261,10 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
         let mut any_opened = false;
         // list_devices silently skips card nodes it cannot open, so absence is only proven when
         // its list covers every card that could drive an output (render-only nodes are skipped
-        // by design and prove nothing).
-        // Written out rather than `is_none_or`, which needs a newer rustc than the DRM CI image.
-        let mut uninspected = match dri_display_card_count() {
-            Some(n) => devices.len() < n,
+        // by design and prove nothing). Covered by identity, see `inventory_is_covered`.
+        let device_paths: Vec<&str> = devices.iter().map(|d| d.path.as_str()).collect();
+        let mut uninspected = match dri_display_cards() {
+            Some(cards) => !inventory_is_covered(&cards, &device_paths),
             None => true,
         };
         let mut enumerated = false;
@@ -1716,6 +1729,20 @@ mod drm_conn_tests {
             render_node: String::new(),
             device: "/dev/dri/card1".to_owned(),
         }
+    }
+
+    // rustdesk#15906: equal cardinality is not coverage. sysfs knows one connector-bearing card and
+    // libdrmtap returns one KMS device: only the same card counts.
+    #[test]
+    fn coverage_is_by_card_identity_not_by_count() {
+        let sysfs: std::collections::HashSet<String> = ["card0".to_owned()].into_iter().collect();
+        assert!(!inventory_is_covered(&sysfs, &["/dev/dri/card1"]));
+        assert!(inventory_is_covered(&sysfs, &["/dev/dri/card0"]));
+        assert!(inventory_is_covered(&sysfs, &["/dev/dri/card1", "/dev/dri/card0"]));
+        // Nothing to cover is covered, whatever came back.
+        let none: std::collections::HashSet<String> = Default::default();
+        assert!(inventory_is_covered(&none, &[]));
+        assert!(inventory_is_covered(&none, &["/dev/dri/card3"]));
     }
 
     // A round where one card answers and a sibling does not cannot prove the sibling's displays

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -213,9 +213,13 @@ fn dev_card_has_connectors(path: &str) -> bool {
     };
     let prefix = format!("{card}-");
     std::fs::read_dir("/sys/class/drm")
-        .map(|rd| {
-            rd.filter_map(|e| e.ok())
-                .any(|e| e.file_name().to_string_lossy().starts_with(&prefix))
+        .map(|mut rd| {
+            rd.any(|e| match e {
+                // An entry we could not read might BE this card's connector, and the answer this
+                // function owes is the conservative one: could this card drive an output.
+                Err(_) => true,
+                Ok(e) => e.file_name().to_string_lossy().starts_with(&prefix),
+            })
         })
         .unwrap_or(true)
 }

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -249,7 +249,11 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
         // list_devices silently skips card nodes it cannot open, so absence is only proven when
         // its list covers every card that could drive an output (render-only nodes are skipped
         // by design and prove nothing).
-        let mut uninspected = dri_display_card_count().is_none_or(|n| devices.len() < n);
+        // Written out rather than `is_none_or`, which needs a newer rustc than the DRM CI image.
+        let mut uninspected = match dri_display_card_count() {
+            Some(n) => devices.len() < n,
+            None => true,
+        };
         let mut enumerated = false;
         for dev in devices {
             if let Some(mut r) = scrap::drm_reader::DrmReader::open(Some(&dev.path), 0) {

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -173,7 +173,8 @@ fn drm_displays_from_reader(
 }
 
 /// Active displays of every DRM device + the connected-but-undriven identities, from ONE look.
-fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>) {
+/// Third field: whether any device opened. An empty list with nothing probed is not evidence.
+fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, bool) {
     if let Some(devices) = scrap::drm_reader::list_devices() {
         if devices.len() > 1 {
             log::info!(
@@ -210,7 +211,7 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>) {
         }
         // Take this even when the list is EMPTY: the fallback re-keys identities under `device = ""`.
         if any_opened {
-            return (all, undriven_total);
+            return (all, undriven_total, true);
         }
     }
     // Auto-detect alone is not enough: it picks a card that is SCANNING OUT. Measured on the T2 with
@@ -234,9 +235,11 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>) {
     // Deterministic order, so the display list does not depend on directory order.
     paths.sort();
     let n_paths = paths.len();
+    let mut any_opened = false;
     for p in paths {
         let Some(path) = p.to_str() else { continue };
         if let Some(mut r) = scrap::drm_reader::DrmReader::open(Some(path), 0) {
+            any_opened = true;
             let (mut got, mut undriven) = drm_displays_from_reader(&mut r, path);
             all.append(&mut got);
             undriven_total.append(&mut undriven);
@@ -252,10 +255,11 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>) {
     if all.is_empty() && undriven_total.is_empty() {
         if let Some(mut r) = scrap::drm_reader::DrmReader::open(None, 0) {
             log::info!("drm: no card enumerated by path; falling back to the auto-detected reader");
-            return drm_displays_from_reader(&mut r, "");
+            let (got, undriven) = drm_displays_from_reader(&mut r, "");
+            return (got, undriven, true);
         }
     }
-    (all, undriven_total)
+    (all, undriven_total, any_opened)
 }
 
 /// Connectors a wake did NOT bring back. SELF-REFUTING: an entry later seen DRIVEN is removed.
@@ -391,9 +395,21 @@ fn drm_wake_displays(reason: &str) -> bool {
 /// is no scanout now and there will not be one until an output exists, so capture silently falls
 /// back to the portal, which then asks for consent on a screen nobody can look at. Said on the
 /// edge rather than every poll.
-fn note_output_presence(displays: &[DrmDisplayInfo], undriven: &[String]) {
+fn note_output_presence(displays: &[DrmDisplayInfo], undriven: &[String], probed: bool) {
     use std::sync::atomic::{AtomicBool, Ordering};
     static NO_OUTPUT: AtomicBool = AtomicBool::new(false);
+    static NO_PROBE: AtomicBool = AtomicBool::new(false);
+    // Nothing probed = every open failed, not a headless machine; do not advise a dummy plug.
+    if !probed {
+        if !NO_PROBE.swap(true, Ordering::Relaxed) {
+            log::warn!(
+                "drm: no DRM device could be opened, so display presence is unknown (each open \
+                 logged its own error above)"
+            );
+        }
+        return;
+    }
+    NO_PROBE.store(false, Ordering::Relaxed);
     let none = displays.is_empty() && undriven.is_empty();
     if none != NO_OUTPUT.swap(none, Ordering::Relaxed) {
         if none {
@@ -410,8 +426,8 @@ fn note_output_presence(displays: &[DrmDisplayInfo], undriven: &[String]) {
 
 #[cfg(not(feature = "drm-wake"))]
 fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
-    let (displays, undriven) = drm_enumerate_all_displays();
-    note_output_presence(&displays, &undriven);
+    let (displays, undriven, probed) = drm_enumerate_all_displays();
+    note_output_presence(&displays, &undriven, probed);
     if !undriven.is_empty() {
         log::debug!(
             "drm: {} connected display(s) have no CRTC ({reason}); this build has no display wake",
@@ -427,8 +443,8 @@ fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
 fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
     use std::sync::atomic::Ordering;
 
-    let (displays, undriven) = drm_enumerate_all_displays();
-    note_output_presence(&displays, &undriven);
+    let (displays, undriven, probed) = drm_enumerate_all_displays();
+    note_output_presence(&displays, &undriven, probed);
     if !hbb_common::config::Config::get_bool_option(OPTION_ENABLE_DRM_DISPLAY_WAKE) {
         if !undriven.is_empty() {
             log::info!(
@@ -464,7 +480,7 @@ fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
     let mut cur_wakeable = wakeable;
     while !cur_wakeable.is_empty() && std::time::Instant::now() < deadline {
         std::thread::sleep(std::time::Duration::from_millis(300));
-        let (next, next_undriven) = drm_enumerate_all_displays();
+        let (next, next_undriven, _) = drm_enumerate_all_displays();
         cur_wakeable = drm_wakeable_undriven(&next, &next_undriven);
         cur = next;
     }
@@ -541,7 +557,7 @@ fn schedule_drm_cache_refresh() {
             let fresh = std::panic::catch_unwind(drm_enumerate_all_displays)
                 .unwrap_or_else(|_| {
                     log::error!("drm: display enumeration panicked; treating as no displays");
-                    (Vec::new(), Vec::new())
+                    (Vec::new(), Vec::new(), false)
                 })
                 .0;
             let changed = {

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -142,11 +142,11 @@ static DRM_DISPLAY_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic:
 fn drm_displays_from_reader(
     reader: &mut scrap::drm_reader::DrmReader,
     device: &str,
-) -> (Vec<DrmDisplayInfo>, Vec<String>) {
+) -> Option<(Vec<DrmDisplayInfo>, Vec<String>)> {
     let render_node = reader.render_node().unwrap_or_default();
     let mut undriven = Vec::new();
     let displays: Vec<DrmDisplayInfo> = reader
-        .displays()
+        .displays()?
         .into_iter()
         // Only outputs bound to a CRTC: a CONNECTED-but-unbound connector enumerates with
         // `crtc_id == 0`, and `open(crtc=0)` auto-selects the FIRST ACTIVE CRTC and streams ITS frames.
@@ -169,12 +169,36 @@ fn drm_displays_from_reader(
             device: device.to_owned(),
         })
         .collect();
-    (displays, undriven)
+    Some((displays, undriven))
+}
+
+/// What the enumeration can honestly claim. `enumerated` = at least one card COMPLETED a
+/// connector enumeration (an open alone proves nothing: drmtap_list_displays returns -errno on
+/// an open device whose resources cannot be read); `uninspected` = some visible card was skipped
+/// or failed, so an empty list does not prove absence.
+#[derive(Clone, Copy)]
+struct EnumerationTrust {
+    enumerated: bool,
+    uninspected: bool,
+}
+
+/// Card nodes visible in /dev/dri, whether or not they can be opened.
+fn dri_card_count() -> usize {
+    std::fs::read_dir("/dev/dri")
+        .map(|rd| {
+            rd.filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.file_name()
+                        .to_str()
+                        .is_some_and(|n| n.starts_with("card") && n[4..].chars().all(|c| c.is_ascii_digit()))
+                })
+                .count()
+        })
+        .unwrap_or(0)
 }
 
 /// Active displays of every DRM device + the connected-but-undriven identities, from ONE look.
-/// Third field: whether any device opened. An empty list with nothing probed is not evidence.
-fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, bool) {
+fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, EnumerationTrust) {
     if let Some(devices) = scrap::drm_reader::list_devices() {
         if devices.len() > 1 {
             log::info!(
@@ -195,23 +219,35 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, bool) {
         let mut all = Vec::new();
         let mut undriven_total = Vec::new();
         let mut any_opened = false;
+        // list_devices silently skips card nodes it cannot open, so absence is only proven when
+        // its list covers every node /dev/dri shows.
+        let mut uninspected = devices.len() < dri_card_count();
+        let mut enumerated = false;
         for dev in devices {
             if let Some(mut r) = scrap::drm_reader::DrmReader::open(Some(&dev.path), 0) {
                 any_opened = true;
-                let (mut got, mut undriven) = drm_displays_from_reader(&mut r, &dev.path);
-                all.append(&mut got);
-                undriven_total.append(&mut undriven);
-            } else if dev.display_count == 0 {
-                log::debug!(
-                    "drm: {} has no active display and did not open; cannot tell whether it has a \
-                     connected output that is merely switched off",
-                    dev.path
-                );
+                match drm_displays_from_reader(&mut r, &dev.path) {
+                    Some((mut got, mut undriven)) => {
+                        enumerated = true;
+                        all.append(&mut got);
+                        undriven_total.append(&mut undriven);
+                    }
+                    None => uninspected = true,
+                }
+            } else {
+                uninspected = true;
+                if dev.display_count == 0 {
+                    log::debug!(
+                        "drm: {} has no active display and did not open; cannot tell whether it has a \
+                         connected output that is merely switched off",
+                        dev.path
+                    );
+                }
             }
         }
         // Take this even when the list is EMPTY: the fallback re-keys identities under `device = ""`.
         if any_opened {
-            return (all, undriven_total, true);
+            return (all, undriven_total, EnumerationTrust { enumerated, uninspected });
         }
     }
     // Auto-detect alone is not enough: it picks a card that is SCANNING OUT. Measured on the T2 with
@@ -235,14 +271,21 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, bool) {
     // Deterministic order, so the display list does not depend on directory order.
     paths.sort();
     let n_paths = paths.len();
-    let mut any_opened = false;
+    let mut uninspected = false;
+    let mut enumerated = false;
     for p in paths {
         let Some(path) = p.to_str() else { continue };
         if let Some(mut r) = scrap::drm_reader::DrmReader::open(Some(path), 0) {
-            any_opened = true;
-            let (mut got, mut undriven) = drm_displays_from_reader(&mut r, path);
-            all.append(&mut got);
-            undriven_total.append(&mut undriven);
+            match drm_displays_from_reader(&mut r, path) {
+                Some((mut got, mut undriven)) => {
+                    enumerated = true;
+                    all.append(&mut got);
+                    undriven_total.append(&mut undriven);
+                }
+                None => uninspected = true,
+            }
+        } else {
+            uninspected = true;
         }
     }
     log::info!(
@@ -255,11 +298,18 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, bool) {
     if all.is_empty() && undriven_total.is_empty() {
         if let Some(mut r) = scrap::drm_reader::DrmReader::open(None, 0) {
             log::info!("drm: no card enumerated by path; falling back to the auto-detected reader");
-            let (got, undriven) = drm_displays_from_reader(&mut r, "");
-            return (got, undriven, true);
+            if let Some((got, undriven)) = drm_displays_from_reader(&mut r, "") {
+                // Auto-detect inspects one card; with siblings around, absence stays unproven.
+                return (
+                    got,
+                    undriven,
+                    EnumerationTrust { enumerated: true, uninspected: uninspected || n_paths > 1 },
+                );
+            }
+            uninspected = true;
         }
     }
-    (all, undriven_total, any_opened)
+    (all, undriven_total, EnumerationTrust { enumerated, uninspected })
 }
 
 /// Connectors a wake did NOT bring back. SELF-REFUTING: an entry later seen DRIVEN is removed.
@@ -395,39 +445,75 @@ fn drm_wake_displays(reason: &str) -> bool {
 /// is no scanout now and there will not be one until an output exists, so capture silently falls
 /// back to the portal, which then asks for consent on a screen nobody can look at. Said on the
 /// edge rather than every poll.
-fn note_output_presence(displays: &[DrmDisplayInfo], undriven: &[String], probed: bool) {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum PresenceVerdict {
+    /// Nothing completed an enumeration; presence is unknowable this round.
+    Unknown,
+    /// Every inspected card is empty, but some card was skipped or failed: not proven absent.
+    UnprovenAbsence,
+    /// Every card enumerated and none has a display: the honest headless diagnosis.
+    NoOutput,
+    SomeOutput,
+}
+
+fn presence_verdict(any_display: bool, any_undriven: bool, trust: EnumerationTrust) -> PresenceVerdict {
+    if !trust.enumerated {
+        return PresenceVerdict::Unknown;
+    }
+    if any_display || any_undriven {
+        return PresenceVerdict::SomeOutput;
+    }
+    if trust.uninspected {
+        return PresenceVerdict::UnprovenAbsence;
+    }
+    PresenceVerdict::NoOutput
+}
+
+fn note_output_presence(displays: &[DrmDisplayInfo], undriven: &[String], trust: EnumerationTrust) {
     use std::sync::atomic::{AtomicBool, Ordering};
     static NO_OUTPUT: AtomicBool = AtomicBool::new(false);
     static NO_PROBE: AtomicBool = AtomicBool::new(false);
-    // Nothing probed = every open failed, not a headless machine; do not advise a dummy plug.
-    if !probed {
-        if !NO_PROBE.swap(true, Ordering::Relaxed) {
-            log::warn!(
-                "drm: no DRM device could be opened, so display presence is unknown (each open \
-                 logged its own error above)"
-            );
+    match presence_verdict(!displays.is_empty(), !undriven.is_empty(), trust) {
+        PresenceVerdict::Unknown => {
+            if !NO_PROBE.swap(true, Ordering::Relaxed) {
+                log::warn!(
+                    "drm: no DRM device completed a connector enumeration, so display presence is \
+                     unknown (each failure logged its own error above)"
+                );
+            }
         }
-        return;
-    }
-    NO_PROBE.store(false, Ordering::Relaxed);
-    let none = displays.is_empty() && undriven.is_empty();
-    if none != NO_OUTPUT.swap(none, Ordering::Relaxed) {
-        if none {
-            log::warn!(
-                "drm: no connector reports a display, so this machine has no scanout to capture. \
-                 Attach a display or a dummy plug; a headless box can also force a connector on \
-                 (echo on > /sys/class/drm/<card>-<connector>/status)"
-            );
-        } else {
-            log::info!("drm: an output is present again");
+        PresenceVerdict::UnprovenAbsence => {
+            // Not the dummy-plug advice: an uninspected sibling card may be driving a display.
+            if !NO_PROBE.swap(true, Ordering::Relaxed) {
+                log::warn!(
+                    "drm: every card that could be enumerated reports no display, but at least one \
+                     card could not be inspected; display presence is unknown"
+                );
+            }
+        }
+        PresenceVerdict::NoOutput => {
+            NO_PROBE.store(false, Ordering::Relaxed);
+            if !NO_OUTPUT.swap(true, Ordering::Relaxed) {
+                log::warn!(
+                    "drm: no connector reports a display, so this machine has no scanout to capture. \
+                     Attach a display or a dummy plug; a headless box can also force a connector on \
+                     (echo on > /sys/class/drm/<card>-<connector>/status)"
+                );
+            }
+        }
+        PresenceVerdict::SomeOutput => {
+            NO_PROBE.store(false, Ordering::Relaxed);
+            if NO_OUTPUT.swap(false, Ordering::Relaxed) {
+                log::info!("drm: an output is present again");
+            }
         }
     }
 }
 
 #[cfg(not(feature = "drm-wake"))]
 fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
-    let (displays, undriven, probed) = drm_enumerate_all_displays();
-    note_output_presence(&displays, &undriven, probed);
+    let (displays, undriven, trust) = drm_enumerate_all_displays();
+    note_output_presence(&displays, &undriven, trust);
     if !undriven.is_empty() {
         log::debug!(
             "drm: {} connected display(s) have no CRTC ({reason}); this build has no display wake",
@@ -443,8 +529,8 @@ fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
 fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
     use std::sync::atomic::Ordering;
 
-    let (displays, undriven, probed) = drm_enumerate_all_displays();
-    note_output_presence(&displays, &undriven, probed);
+    let (displays, undriven, trust) = drm_enumerate_all_displays();
+    note_output_presence(&displays, &undriven, trust);
     if !hbb_common::config::Config::get_bool_option(OPTION_ENABLE_DRM_DISPLAY_WAKE) {
         if !undriven.is_empty() {
             log::info!(
@@ -554,12 +640,18 @@ fn schedule_drm_cache_refresh() {
         .name("drm-cache-refresh".into())
         .spawn(move || loop {
             PENDING.store(false, Ordering::Release);
-            let fresh = std::panic::catch_unwind(drm_enumerate_all_displays)
+            let (fresh, undriven, trust) = std::panic::catch_unwind(drm_enumerate_all_displays)
                 .unwrap_or_else(|_| {
                     log::error!("drm: display enumeration panicked; treating as no displays");
-                    (Vec::new(), Vec::new(), false)
-                })
-                .0;
+                    (
+                        Vec::new(),
+                        Vec::new(),
+                        EnumerationTrust { enumerated: false, uninspected: true },
+                    )
+                });
+            // The hotplug edge reports presence too; the edge-latched statics keep it idempotent
+            // across this worker and the handshake path.
+            note_output_presence(&fresh, &undriven, trust);
             let changed = {
                 let mut cache = match DRM_DISPLAY_CACHE.lock() {
                     Ok(g) => g,
@@ -1513,6 +1605,29 @@ mod drm_conn_tests {
     use hbb_common::libc;
     use hbb_common::tokio::{self, io::AsyncWriteExt};
     use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
+
+    #[test]
+    fn presence_is_only_proven_by_a_complete_enumeration() {
+        let complete = EnumerationTrust { enumerated: true, uninspected: false };
+        let partial = EnumerationTrust { enumerated: true, uninspected: true };
+        let nothing = EnumerationTrust { enumerated: false, uninspected: true };
+        assert_eq!(
+            presence_verdict(false, false, complete),
+            PresenceVerdict::NoOutput
+        );
+        assert_eq!(
+            presence_verdict(false, false, partial),
+            PresenceVerdict::UnprovenAbsence,
+            "a skipped card may be driving a display"
+        );
+        assert_eq!(presence_verdict(false, false, nothing), PresenceVerdict::Unknown);
+        assert_eq!(presence_verdict(true, false, partial), PresenceVerdict::SomeOutput);
+        assert_eq!(
+            presence_verdict(false, true, complete),
+            PresenceVerdict::SomeOutput,
+            "an undriven connector is still evidence of a display"
+        );
+    }
 
     // Added to the wire later: an older peer's message must still decode.
     #[test]

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -642,6 +642,21 @@ fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
     cur
 }
 
+/// Whether a refresh round may replace the cache. A round that could not inspect every card cannot
+/// prove a display is GONE, so one that drops a cached connector is refused; growth, and changes to
+/// a display that is still there, land. A real removal takes the node out of /dev/dri and sysfs
+/// together, so the counts fall in step and that round is not partial in the first place.
+///
+/// Connector names identify: they are unique among live connectors, and the card minor is not
+/// (`/dev/dri/cardN` comes from an allocator that recycles across a rebind).
+fn round_may_replace_cache(
+    cache: &[DrmDisplayInfo],
+    fresh: &[DrmDisplayInfo],
+    uninspected: bool,
+) -> bool {
+    !uninspected || cache.iter().all(|c| fresh.iter().any(|f| f.name == c.name))
+}
+
 /// The SINGLE writer of DRM_DISPLAY_CACHE (+ DRM_DISPLAY_GENERATION), off the caller's thread and
 /// SINGLE-FLIGHT: a request arriving during a run coalesces into exactly one follow-up.
 fn schedule_drm_cache_refresh() {
@@ -699,11 +714,7 @@ fn schedule_drm_cache_refresh() {
                     Ok(g) => g,
                     Err(poisoned) => poisoned.into_inner(),
                 };
-                if trust.uninspected && fresh.len() < cache.len() {
-                    // A card that did not answer cannot prove ITS displays are gone. Only the
-                    // shrink is refused: growth and identity changes still land, and a real
-                    // removal takes the node out of /dev/dri and sysfs together, so the counts
-                    // fall in step and this round is no longer partial.
+                if !round_may_replace_cache(&cache, &fresh, trust.uninspected) {
                     log::debug!(
                         "drm: keeping {} cached display(s) through a partial enumeration ({} seen)",
                         cache.len(),
@@ -1680,6 +1691,50 @@ mod drm_conn_tests {
             PresenceVerdict::SomeOutput,
             "an undriven connector is still evidence of a display"
         );
+    }
+
+    fn display(name: &str, width: u32) -> DrmDisplayInfo {
+        DrmDisplayInfo {
+            name: name.to_owned(),
+            crtc_id: 0,
+            x: 0,
+            y: 0,
+            width,
+            height: 1080,
+            active: true,
+            render_node: String::new(),
+            device: String::new(),
+        }
+    }
+
+    // A round where one card answers and a sibling does not cannot prove the sibling's displays
+    // are gone. Refusing only a SHORTER list was not enough: the failing card can lose one while
+    // another gains one, and the count is unchanged.
+    #[test]
+    fn a_partial_round_may_not_drop_a_cached_display() {
+        let cache = [display("DP-1", 3840), display("HDMI-A-1", 1920)];
+
+        let shrunk = [display("DP-1", 3840)];
+        assert!(!round_may_replace_cache(&cache, &shrunk, true));
+        assert!(
+            round_may_replace_cache(&cache, &shrunk, false),
+            "a complete round measured the removal and must land"
+        );
+
+        let swapped = [display("DP-1", 3840), display("DP-4", 1280)];
+        assert!(!round_may_replace_cache(&cache, &swapped, true));
+
+        let grown = [
+            display("DP-1", 3840),
+            display("HDMI-A-1", 1920),
+            display("DP-4", 1280),
+        ];
+        assert!(round_may_replace_cache(&cache, &grown, true));
+
+        // A mode change on a display that is still there is not a loss, so a partial round must
+        // not freeze it out: uninspected can stay pinned true (an unreadable /sys/class/drm).
+        let resized = [display("DP-1", 2560), display("HDMI-A-1", 1920)];
+        assert!(round_may_replace_cache(&cache, &resized, true));
     }
 
     // Added to the wire later: an older peer's message must still decode.

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -237,6 +237,18 @@ fn dev_card_has_connectors(path: &str) -> bool {
         .unwrap_or(true)
 }
 
+/// Whether a round's card inventory accounts for every connector-bearing card sysfs knows of.
+///
+/// Both rounds ask this, and they must ask it the same way: a card that sysfs says can drive an
+/// output and that the round never looked at is the difference between "no display" and "did not
+/// look". Sysfs being unreadable is not coverage either - it is the case where we cannot tell.
+fn round_covers_every_card(card_paths: &[&str]) -> bool {
+    match dri_display_cards() {
+        Some(cards) => inventory_is_covered(&cards, card_paths),
+        None => false,
+    }
+}
+
 /// Active displays of every DRM device + the connected-but-undriven identities, from ONE look.
 fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, EnumerationTrust) {
     if let Some(devices) = scrap::drm_reader::list_devices() {
@@ -263,10 +275,7 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
         // its list covers every card that could drive an output (render-only nodes are skipped
         // by design and prove nothing). Covered by identity, see `inventory_is_covered`.
         let device_paths: Vec<&str> = devices.iter().map(|d| d.path.as_str()).collect();
-        let mut uninspected = match dri_display_cards() {
-            Some(cards) => !inventory_is_covered(&cards, &device_paths),
-            None => true,
-        };
+        let mut uninspected = !round_covers_every_card(&device_paths);
         let mut enumerated = false;
         for dev in devices {
             if let Some(mut r) = scrap::drm_reader::DrmReader::open(Some(&dev.path), 0) {
@@ -327,7 +336,12 @@ fn drm_enumerate_all_displays() -> (Vec<DrmDisplayInfo>, Vec<String>, Enumeratio
     // Deterministic order, so the display list does not depend on directory order.
     paths.sort();
     let n_paths = paths.len();
-    let mut uninspected = inventory_failed;
+    // The per-card checks below only account for the cards this directory listed. A connector-
+    // bearing card that sysfs knows about and `/dev/dri` does not is never looked at at all, and
+    // without this it would leave the round looking complete - the same false absence the card
+    // inventory is checked for on the other path, asked here with the same question.
+    let card_paths: Vec<&str> = paths.iter().filter_map(|p| p.to_str()).collect();
+    let mut uninspected = inventory_failed || !round_covers_every_card(&card_paths);
     let mut enumerated = false;
     for p in paths {
         let Some(path) = p.to_str() else { continue };
@@ -662,7 +676,8 @@ fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
 /// Whether a refresh round may replace the cache. A round that could not inspect every card cannot
 /// prove a display is GONE, so one that drops a cached connector is refused; growth, and changes to
 /// a display that is still there, land. A real removal takes the node out of /dev/dri and sysfs
-/// together, so the counts fall in step and that round is not partial in the first place.
+/// together, so the two inventories lose it together, coverage still holds, and that round is not
+/// partial in the first place.
 ///
 /// Identity is the card AND the connector name. Two LIVE connectors never share a name - the index
 /// comes from a per-type ida that is global to drm.ko, measured on a 3-card machine whose DP


### PR DESCRIPTION
a machine with nothing plugged into it fails in the least helpful way available today: enumeration returns nothing, capture quietly falls back to the portal, and the portal asks for screen-share consent on a screen nobody can look at. the client just sits there. nothing in the log separates that from a display that is merely asleep, which is already reported ("N connected display(s) have no CRTC").

this says it, once, on the edge into and out of the state - not per poll, which on a headless box would be a line every 300 ms - and names the three ways out.

measured on an intel box with no monitor attached, both directions:

- no connector connected: the warning appears once
- a connector present (forced on for the test): zero appearances

diagnosing it means reading /sys/class/drm by hand to learn something the service already knew, which is the whole reason for the patch. the reader returns an option now, so a failed enumeration stops being indistinguishable from a machine with no displays. that is the behaviour change, and it is the patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display connection status reporting for display-capable and render-only graphics devices.
  * Preserved uncertainty when hardware inventories or display inspection cannot be completed.
  * Prevented valid display information from being replaced after temporary detection failures.
  * Added clearer notifications when no display outputs are detected or when an output becomes available again.
  * Reduced repeated warnings by showing each display status notification only once per condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->























<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves DRM display-presence diagnostics while preserving uncertainty during failed or partial hardware enumeration.
- Distinguishes failed display enumeration from a successfully enumerated empty result.
- Checks connector-bearing card coverage before declaring a machine headless.
- Emits transition-based presence diagnostics without logging on every poll.
- Protects cached display topology from failed or partial refreshes.
- Adds tests for presence verdicts, card identity coverage, and partial cache replacement.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The pull request appears safe to merge, with no outstanding actionable findings.

The latest changes consistently verify connector-bearing card coverage in both enumeration paths, and the previously reported partial-probe and identity-replacement issues are resolved in the current code.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/scrap/src/common/drm_reader.rs | Distinguishes negative libdrmtap enumeration failures from valid empty display lists. |
| src/ipc/drm.rs | Adds conservative inventory trust tracking, edge-triggered presence logging, cache protection, and focused regression tests. |

</details>

<sub>Reviews (13): Last reviewed commit: ["fix(drm): ask the coverage question of t..."](https://github.com/rustdesk/rustdesk/commit/536b68b1a006cfec67025d7379a3e8a80029249b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54671225)</sub>

<!-- /greptile_comment -->
