### PR TITLE
feat(linux): optional headless display, off by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,11 @@ drm = ["scrap/drm"]
 # kind of operation and deserves a switch that can remove it from the binary entirely, without
 # giving up DRM capture: `--features drm` builds the capture path with no wake code compiled in.
 drm-wake = ["drm"]
+# The headless display, on the same reasoning as `drm-wake` and for the same reason: it WRITES, and
+# what it writes is a global kernel module parameter plus a file under /lib/firmware. It also depends
+# on `drm` rather than standing alone, because the caches that have to be invalidated when a
+# connector appears or disappears mid-session are only wired up in the drm capture path.
+headless-display = ["drm"]
 linux-pkg-config = ["magnum-opus/linux-pkg-config", "scrap/linux-pkg-config"]
 unix-file-copy-paste = [
     "dep:x11-clipboard",

--- a/build.py
+++ b/build.py
@@ -346,6 +346,11 @@ def get_features(args):
         # this line builds the same capture backend with no wake code in the binary at all.
         # It is ALSO switchable at runtime; see OPTION_ENABLE_DRM_DISPLAY_WAKE.
         features.append('drm-wake')
+        # Same argument, same package: the headless display is the other writer in this backend, and
+        # a machine with no monitor plugged in is exactly what the unattended variant is for. Unlike
+        # the wake it is OFF at runtime until an operator turns it on, on every build; this flag only
+        # decides whether the code is in the binary at all.
+        features.append('headless-display')
     if osx:
         if args.screencapturekit:
             features.append('screencapturekit')

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -166,6 +166,7 @@ const String kOptionCurrentAbName = "current-ab-name";
 const String kOptionEnableConfirmClosingTabs = "enable-confirm-closing-tabs";
 const String kOptionEnablePortForwardMux = "enable-port-forward-mux";
 const String kOptionAllowAlwaysSoftwareRender = "allow-always-software-render";
+const String kOptionAllowHeadlessDisplay = "allow-headless-display";
 const String kOptionEnableCheckUpdate = "enable-check-update";
 const String kOptionAllowAutoUpdate = "allow-auto-update";
 const String kOptionAllowRemoveWallpaper = "allow-remove-wallpaper";

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -551,6 +551,18 @@ class _GeneralState extends State<_General> {
             ),
           ),
       ],
+      // Controlled side only, and only where there is a DRM connector to force.
+      if (isLinux &&
+          !outgoingOnly &&
+          bind.mainGetCommonSync(key: 'supports-headless-display') == 'true')
+        Tooltip(
+          message: translate('headless_display_tip'),
+          child: _OptionCheckBox(
+            context,
+            'Headless display',
+            kOptionAllowHeadlessDisplay,
+          ),
+        ),
       if (!isWeb && !bind.isCustomClient())
         _OptionCheckBox(
           context,

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -539,6 +539,56 @@ pub fn core_main() -> Option<Vec<String>> {
                 println!("Installation and administrative privileges required!");
             }
             return None;
+        } else if args[0] == "--headless-display" {
+            #[cfg(all(target_os = "linux", feature = "headless-display"))]
+            {
+                use crate::virtual_display_manager::linux as headless;
+                use headless::OPTION_ALLOW_HEADLESS_DISPLAY as KEY;
+                match args.get(1).map(String::as_str) {
+                    // Read-only, so it needs no privilege: every connector's status is world
+                    // readable. The option comes over IPC like `--option` does, because the value
+                    // that matters is the one the running server has, not this process's copy.
+                    Some("status") | None => {
+                        let enabled = hbb_common::config::option2bool(
+                            KEY,
+                            crate::ipc::get_options().get(KEY).map_or("", |v| v.as_str()),
+                        );
+                        print!("{}", headless::status_text(enabled));
+                    }
+                    Some(verb @ ("enable" | "disable")) => {
+                        if is_cli_setting_change_disabled() {
+                            println!("Settings are disabled!");
+                        } else if !headless::is_supported() {
+                            println!("No DRM connectors on this machine!");
+                        } else if crate::platform::is_installed() && is_root() {
+                            // Only the option is set here. Forcing the connector is the root
+                            // service's job.
+                            crate::ipc::set_option(KEY, if verb == "enable" { "Y" } else { "N" });
+                            // ... but on the machine this feature is FOR, that is not enough.
+                            // `ipc::set_option` talks to the user `--server`, and a box with no
+                            // display has no seat0 session, so there is no `--server` to talk to:
+                            // the call quietly falls back to rewriting this process's config file,
+                            // while the running root service keeps the config it read at startup
+                            // and never notices. So hand it to the service directly, over the one
+                            // channel that exists for exactly this and accepts exactly this
+                            // message.
+                            match crate::ipc::sync_config_to_service() {
+                                Ok(()) => println!("Done!"),
+                                Err(err) => println!(
+                                    "Saved, but the running service did not pick it up ({err}); \
+                                     restart it to apply."
+                                ),
+                            }
+                        } else {
+                            println!("Installation and administrative privileges required!");
+                        }
+                    }
+                    Some(other) => {
+                        println!("Unknown argument {other}; expected enable, disable or status")
+                    }
+                }
+            }
+            return None;
         } else if args[0] == "--assign" {
             if config::Config::no_register_device() {
                 println!("Cannot assign an unregistrable device!");
@@ -885,6 +935,7 @@ fn is_user_main_ipc_scope_cli_command(args: &[String]) -> bool {
             | Some("--option")
             | Some("--assign")
             | Some("--deploy")
+            | Some("--headless-display")
     )
 }
 
@@ -932,6 +983,7 @@ mod tests {
             "--option",
             "--assign",
             "--deploy",
+            "--headless-display",
         ] {
             assert!(is_user_main_ipc_scope_cli_command(&args(&[command])));
         }

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -551,7 +551,9 @@ pub fn core_main() -> Option<Vec<String>> {
                     Some("status") | None => {
                         let enabled = hbb_common::config::option2bool(
                             KEY,
-                            crate::ipc::get_options().get(KEY).map_or("", |v| v.as_str()),
+                            crate::ipc::get_options()
+                                .get(KEY)
+                                .map_or("", |v| v.as_str()),
                         );
                         print!("{}", headless::status_text(enabled));
                     }
@@ -563,7 +565,16 @@ pub fn core_main() -> Option<Vec<String>> {
                         } else if crate::platform::is_installed() && is_root() {
                             // Only the option is set here. Forcing the connector is the root
                             // service's job.
-                            crate::ipc::set_option(KEY, if verb == "enable" { "Y" } else { "N" });
+                            let want = if verb == "enable" { "Y" } else { "N" };
+                            crate::ipc::set_option(KEY, want);
+                            // `set_option` swallows a failed send, and `set_options` only writes the
+                            // local config after that send succeeds - so a failure here would leave
+                            // the old value in place and the push below would hand the service a
+                            // value nobody asked for. Read it back instead of assuming.
+                            if config::Config::get_option(KEY) != want {
+                                println!("Could not save the setting!");
+                                return None;
+                            }
                             // ... but on the machine this feature is FOR, that is not enough.
                             // `ipc::set_option` talks to the user `--server`, and a box with no
                             // display has no seat0 session, so there is no `--server` to talk to:

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -560,7 +560,9 @@ pub fn core_main() -> Option<Vec<String>> {
                     Some(verb @ ("enable" | "disable")) => {
                         if is_cli_setting_change_disabled() {
                             println!("Settings are disabled!");
-                        } else if !headless::is_supported() {
+                        } else if verb == "enable" && !headless::is_supported() {
+                            // Disabling must always be possible: with DRM temporarily gone the
+                            // setting would otherwise stay armed and re-fire when DRM returns.
                             println!("No DRM connectors on this machine!");
                         } else if crate::platform::is_installed() && is_root() {
                             // Only the option is set here. Forcing the connector is the root

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -600,8 +600,15 @@ pub fn core_main() -> Option<Vec<String>> {
                         println!("Unknown argument {other}; expected enable, disable or status")
                     }
                 }
+                return None;
             }
-            return None;
+            // Gating the `else if` itself would drop the flag through to the end of the chain and
+            // launch the UI, so the arm stays and only its answer changes.
+            #[cfg(not(all(target_os = "linux", feature = "headless-display")))]
+            {
+                println!("Headless display support is not compiled in!");
+                std::process::exit(1);
+            }
         } else if args[0] == "--assign" {
             if config::Config::no_register_device() {
                 println!("Cannot assign an unregistrable device!");

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -2663,6 +2663,13 @@ pub fn main_get_common(key: String) -> String {
             None => "",
         }
         .to_string();
+    } else if key == "supports-headless-display" {
+        // Whether this machine has DRM connectors to force at all, so the settings page does not
+        // offer a switch that could not do anything.
+        #[cfg(all(target_os = "linux", feature = "headless-display"))]
+        return crate::virtual_display_manager::linux::is_supported().to_string();
+        #[cfg(not(all(target_os = "linux", feature = "headless-display")))]
+        return false.to_string();
     } else if key == "has-gnome-shortcuts-inhibitor-permission" {
         #[cfg(target_os = "linux")]
         return crate::platform::linux::has_gnome_shortcuts_inhibitor_permission().to_string();

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -15,6 +15,8 @@ mod ipc_drm;
 #[cfg(all(target_os = "linux", feature = "drm"))]
 pub use ipc_drm::{start_drm, DmabufDesc, DrmDisplayInfo};
 #[cfg(all(target_os = "linux", feature = "drm"))]
+pub(crate) use ipc_drm::drm_capture_active;
+#[cfg(all(target_os = "linux", feature = "drm"))]
 pub(crate) use ipc_drm::DrmConn;
 #[cfg(all(target_os = "linux", feature = "drm"))]
 pub(crate) use ipc_drm::connect_drm;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1893,15 +1893,15 @@ pub async fn set_options(value: HashMap<String, String>) -> ResultType<()> {
 #[tokio::main(flavor = "current_thread")]
 pub async fn sync_config_to_service() -> ResultType<()> {
     let mut c = connect_service(1000).await?;
-    // From disk, not from this process's snapshot: the snapshot was taken at startup, and the
-    // service replaces its whole config with what it is sent, so anything another process saved
-    // since would be rolled back. Reading now narrows that to the moment between this read and
-    // the send; only a scoped option update on the service side would close it entirely.
-    let cfg = (
-        hbb_common::config::load_path::<Config>(Config::file()),
-        hbb_common::config::load_path::<Config2>(Config2::file()),
-    );
-    c.send(&Data::SyncConfig(Some(cfg.into()))).await?;
+    // The live values, not a fresh read of the files: on disk the id and the secrets are kept
+    // encrypted with their plaintext fields blank, and only each type's own loader undoes that.
+    // Sent as read from disk, the service would install an empty id and mint a new one. This
+    // process loaded its copy at startup, so a setting another process saved since then goes
+    // back as it was; that is the window every `--option` write has always had.
+    c.send(&Data::SyncConfig(Some(
+        (Config::get(), Config2::get()).into(),
+    )))
+    .await?;
     // The service acks a pushed config with SyncConfig(None); anything else did not apply it.
     if !matches!(c.next_timeout(1000).await?, Some(Data::SyncConfig(None))) {
         bail!("unexpected reply from the service");

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1880,6 +1880,23 @@ pub async fn set_options(value: HashMap<String, String>) -> ResultType<()> {
     Ok(())
 }
 
+/// Push this process's config into the running root service.
+///
+/// `set_options` reaches the user `--server`, which then syncs to root on its own. That leaves out
+/// the case where there is no `--server` at all: the root service keeps its config in memory from
+/// startup, so a change made by a root CLI would sit in the config file unread until a restart.
+/// `SyncConfig` is the only message the protected `_service` channel accepts, and root is an allowed
+/// peer on it, so this is the same operation the user server performs, from the other side.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[tokio::main(flavor = "current_thread")]
+pub async fn sync_config_to_service() -> ResultType<()> {
+    let mut c = connect_service(1000).await?;
+    let cfg = (Config::get(), Config2::get());
+    c.send(&Data::SyncConfig(Some(cfg.into()))).await?;
+    c.next_timeout(1000).await?;
+    Ok(())
+}
+
 #[inline]
 async fn get_nat_type_(ms_timeout: u64) -> ResultType<i32> {
     let mut c = connect(ms_timeout, "").await?;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1893,7 +1893,10 @@ pub async fn sync_config_to_service() -> ResultType<()> {
     let mut c = connect_service(1000).await?;
     let cfg = (Config::get(), Config2::get());
     c.send(&Data::SyncConfig(Some(cfg.into()))).await?;
-    c.next_timeout(1000).await?;
+    // The service acks a pushed config with SyncConfig(None); anything else did not apply it.
+    if !matches!(c.next_timeout(1000).await?, Some(Data::SyncConfig(None))) {
+        bail!("unexpected reply from the service");
+    }
     Ok(())
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -15,7 +15,7 @@ mod ipc_drm;
 #[cfg(all(target_os = "linux", feature = "drm"))]
 pub use ipc_drm::{start_drm, DmabufDesc, DrmDisplayInfo};
 #[cfg(all(target_os = "linux", feature = "drm"))]
-pub(crate) use ipc_drm::drm_capture_active;
+pub(crate) use ipc_drm::{begin_held_connector_probe, drm_capture_active};
 #[cfg(all(target_os = "linux", feature = "drm"))]
 pub(crate) use ipc_drm::DrmConn;
 #[cfg(all(target_os = "linux", feature = "drm"))]
@@ -1893,7 +1893,14 @@ pub async fn set_options(value: HashMap<String, String>) -> ResultType<()> {
 #[tokio::main(flavor = "current_thread")]
 pub async fn sync_config_to_service() -> ResultType<()> {
     let mut c = connect_service(1000).await?;
-    let cfg = (Config::get(), Config2::get());
+    // From disk, not from this process's snapshot: the snapshot was taken at startup, and the
+    // service replaces its whole config with what it is sent, so anything another process saved
+    // since would be rolled back. Reading now narrows that to the moment between this read and
+    // the send; only a scoped option update on the service side would close it entirely.
+    let cfg = (
+        hbb_common::config::load_path::<Config>(Config::file()),
+        hbb_common::config::load_path::<Config2>(Config2::file()),
+    );
     c.send(&Data::SyncConfig(Some(cfg.into()))).await?;
     // The service acks a pushed config with SyncConfig(None); anything else did not apply it.
     if !matches!(c.next_timeout(1000).await?, Some(Data::SyncConfig(None))) {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1893,11 +1893,14 @@ pub async fn set_options(value: HashMap<String, String>) -> ResultType<()> {
 #[tokio::main(flavor = "current_thread")]
 pub async fn sync_config_to_service() -> ResultType<()> {
     let mut c = connect_service(1000).await?;
-    // The live values, not a fresh read of the files: on disk the id and the secrets are kept
-    // encrypted with their plaintext fields blank, and only each type's own loader undoes that.
-    // Sent as read from disk, the service would install an empty id and mint a new one. This
-    // process loaded its copy at startup, so a setting another process saved since then goes
-    // back as it was; that is the window every `--option` write has always had.
+    // The live values, not a fresh read of the files. On disk the id is blanked and kept in
+    // `enc_id`, and the secrets are encrypted in place; only each type's own loader turns either
+    // back into what the running code uses. Sent as read from disk, the service would install an
+    // empty id and mint a new one, and would take the secrets as ciphertext.
+    // What `get()` returns is this process's in-memory copy, loaded on first use, so a value
+    // another process saved between that load and this send goes back as it was. That window is
+    // narrow but it is not the one an `--option` write has: that replaces only the options map,
+    // while this replaces the service's whole config. Closing it needs a scoped message here.
     c.send(&Data::SyncConfig(Some(
         (Config::get(), Config2::get()).into(),
     )))

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -479,6 +479,35 @@ fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
     cur
 }
 
+/// How many capture readers are open right now.
+///
+/// The headless watcher reads this. Its probe of a connector it holds costs a topology blip, and a
+/// blip while somebody is capturing restarts their video service, so the probe waits for a machine
+/// nobody is looking at. A counter rather than a flag because several displays can be captured at
+/// once.
+static DRM_CAPTURES_OPEN: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+pub(crate) fn drm_capture_active() -> bool {
+    DRM_CAPTURES_OPEN.load(Ordering::Relaxed) > 0
+}
+
+/// Decrements on Drop, so every way out of the capture loop is covered - including the panic path,
+/// which a manual decrement at the end would miss and leave the machine looking busy forever.
+struct CaptureGuard;
+
+impl CaptureGuard {
+    fn new() -> Self {
+        DRM_CAPTURES_OPEN.fetch_add(1, Ordering::Relaxed);
+        Self
+    }
+}
+
+impl Drop for CaptureGuard {
+    fn drop(&mut self) {
+        DRM_CAPTURES_OPEN.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 /// The SINGLE writer of DRM_DISPLAY_CACHE (+ DRM_DISPLAY_GENERATION), off the caller's thread and
 /// SINGLE-FLIGHT: a request arriving during a run coalesces into exactly one follow-up.
 fn schedule_drm_cache_refresh() {
@@ -1013,6 +1042,7 @@ fn drm_capture_worker(
         }
     };
     schedule_drm_cache_refresh();
+    let _capturing = CaptureGuard::new();
     log::debug!(
         "drm: capture reader for crtc {target_crtc} opened in {:?}",
         t_open.elapsed()

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -387,7 +387,7 @@ fn drm_wake_displays(reason: &str) -> bool {
 }
 
 #[cfg(not(feature = "drm-wake"))]
-fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
+fn drm_enumerate_settled(reason: &str, _admitted: &CaptureGuard) -> Vec<DrmDisplayInfo> {
     let (displays, undriven) = drm_enumerate_all_displays();
     if !undriven.is_empty() {
         log::debug!(
@@ -401,7 +401,7 @@ fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
 /// Wake build: wake an undriven display and WAIT for the settled topology. The wait applies to every
 /// handshake whose wake may still be in flight, not only the one whose attempt won the rate limit.
 #[cfg(feature = "drm-wake")]
-fn drm_enumerate_settled(reason: &str) -> Vec<DrmDisplayInfo> {
+fn drm_enumerate_settled(reason: &str, _admitted: &CaptureGuard) -> Vec<DrmDisplayInfo> {
     use std::sync::atomic::Ordering;
 
     let (displays, undriven) = drm_enumerate_all_displays();
@@ -1031,14 +1031,16 @@ fn drm_capture_worker(
 
     let t_conn = std::time::Instant::now();
 
-    // Counted in from the first enumeration, not from the reader: a probe of a held connector
-    // empties the topology for a moment, and a worker that enumerated before taking the guard
-    // would see that emptiness and send its session to the portal. Declared ahead of `reader`
-    // too, so it outlives it: no probe starts while the reader is still being torn down.
-    let _capture = CaptureGuard::new();
+    // Counted in before the first enumeration, not after the reader: a probe of a held connector
+    // takes the connector's status down for the length of its detect, and a worker that enumerated
+    // before taking the guard would read that as a machine with no displays. The enumeration takes
+    // the guard by reference rather than trusting the order here, so a call placed before it is a
+    // compile error rather than something a test has to notice. Declared ahead of `reader` so it
+    // outlives it: no probe starts while the reader is still being torn down.
+    let capture = CaptureGuard::new();
 
     // Enumerate FRESH rather than serve the cache: a cached display may no longer be driven.
-    let displays = drm_enumerate_settled("a consumer connected");
+    let displays = drm_enumerate_settled("a consumer connected", &capture);
     if frame_tx
         .blocking_send(DrmProducerMsg::Displays(displays))
         .is_err()
@@ -1529,14 +1531,10 @@ mod drm_conn_tests {
     use hbb_common::tokio::{self, io::AsyncWriteExt};
     use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
 
-    // The tests that move DRM_CAPTURES_OPEN, a process-wide counter, take turns.
-    static COUNTER_TESTS: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     // rustdesk#15908: a probe of the held connector and a capture admission exclude each other, so
     // the activity check the probe makes cannot be overtaken between the check and the writes.
     #[test]
     fn a_held_connector_probe_stands_down_for_an_open_capture() {
-        let _turn = COUNTER_TESTS.lock().unwrap_or_else(|p| p.into_inner());
         assert!(begin_held_connector_probe().is_some(), "idle machine: probe allowed");
         {
             let _open = CaptureGuard::new();
@@ -1550,32 +1548,6 @@ mod drm_conn_tests {
         assert!(gate.is_some());
         drop(gate);
         assert!(begin_held_connector_probe().is_some());
-    }
-
-    // rustdesk#15908, round 6: the guard has to be in place BEFORE the fresh enumeration, not
-    // after the reader opens, or a probe holding the gate through the whole handshake still lets
-    // the worker enumerate the topology the probe has just emptied. Driven through the real
-    // worker: it enumerates, reports its display list and blocks waiting for a target, and at
-    // that point it must already count as a capture. No target ever comes, so it returns and
-    // counts itself out.
-    #[test]
-    fn a_capture_counts_from_its_first_enumeration() {
-        let _turn = COUNTER_TESTS.lock().unwrap_or_else(|p| p.into_inner());
-        let (frame_tx, mut frame_rx) = hbb_common::tokio::sync::mpsc::channel(4);
-        let (crtc_tx, crtc_rx) = std::sync::mpsc::channel::<(String, u32, bool)>();
-        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let gated = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let worker =
-            std::thread::spawn(move || drm_capture_worker(frame_tx, crtc_rx, stop, gated));
-        assert!(
-            matches!(frame_rx.blocking_recv(), Some(DrmProducerMsg::Displays(_))),
-            "the worker's first message is its display list"
-        );
-        assert!(drm_capture_active(), "waiting for a target, the worker already counts as a capture");
-        assert!(begin_held_connector_probe().is_none(), "so no probe may start meanwhile");
-        drop(crtc_tx);
-        worker.join().expect("with no target the worker returns");
-        assert!(!drm_capture_active(), "and counts itself out on the way out");
     }
 
     // Added to the wire later: an older peer's message must still decode.

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -1031,6 +1031,12 @@ fn drm_capture_worker(
 
     let t_conn = std::time::Instant::now();
 
+    // Counted in from the first enumeration, not from the reader: a probe of a held connector
+    // empties the topology for a moment, and a worker that enumerated before taking the guard
+    // would see that emptiness and send its session to the portal. Declared ahead of `reader`
+    // too, so it outlives it: no probe starts while the reader is still being torn down.
+    let _capture = CaptureGuard::new();
+
     // Enumerate FRESH rather than serve the cache: a cached display may no longer be driven.
     let displays = drm_enumerate_settled("a consumer connected");
     if frame_tx
@@ -1062,7 +1068,6 @@ fn drm_capture_worker(
         }
     };
     schedule_drm_cache_refresh();
-    let _capturing = CaptureGuard::new();
     log::debug!(
         "drm: capture reader for crtc {target_crtc} opened in {:?}",
         t_open.elapsed()
@@ -1524,10 +1529,14 @@ mod drm_conn_tests {
     use hbb_common::tokio::{self, io::AsyncWriteExt};
     use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
 
+    // The tests that move DRM_CAPTURES_OPEN, a process-wide counter, take turns.
+    static COUNTER_TESTS: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     // rustdesk#15908: a probe of the held connector and a capture admission exclude each other, so
     // the activity check the probe makes cannot be overtaken between the check and the writes.
     #[test]
     fn a_held_connector_probe_stands_down_for_an_open_capture() {
+        let _turn = COUNTER_TESTS.lock().unwrap_or_else(|p| p.into_inner());
         assert!(begin_held_connector_probe().is_some(), "idle machine: probe allowed");
         {
             let _open = CaptureGuard::new();
@@ -1541,6 +1550,32 @@ mod drm_conn_tests {
         assert!(gate.is_some());
         drop(gate);
         assert!(begin_held_connector_probe().is_some());
+    }
+
+    // rustdesk#15908, round 6: the guard has to be in place BEFORE the fresh enumeration, not
+    // after the reader opens, or a probe holding the gate through the whole handshake still lets
+    // the worker enumerate the topology the probe has just emptied. Driven through the real
+    // worker: it enumerates, reports its display list and blocks waiting for a target, and at
+    // that point it must already count as a capture. No target ever comes, so it returns and
+    // counts itself out.
+    #[test]
+    fn a_capture_counts_from_its_first_enumeration() {
+        let _turn = COUNTER_TESTS.lock().unwrap_or_else(|p| p.into_inner());
+        let (frame_tx, mut frame_rx) = hbb_common::tokio::sync::mpsc::channel(4);
+        let (crtc_tx, crtc_rx) = std::sync::mpsc::channel::<(String, u32, bool)>();
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let gated = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let worker =
+            std::thread::spawn(move || drm_capture_worker(frame_tx, crtc_rx, stop, gated));
+        assert!(
+            matches!(frame_rx.blocking_recv(), Some(DrmProducerMsg::Displays(_))),
+            "the worker's first message is its display list"
+        );
+        assert!(drm_capture_active(), "waiting for a target, the worker already counts as a capture");
+        assert!(begin_held_connector_probe().is_none(), "so no probe may start meanwhile");
+        drop(crtc_tx);
+        worker.join().expect("with no target the worker returns");
+        assert!(!drm_capture_active(), "and counts itself out on the way out");
     }
 
     // Added to the wire later: an older peer's message must still decode.

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -491,12 +491,32 @@ pub(crate) fn drm_capture_active() -> bool {
     DRM_CAPTURES_OPEN.load(Ordering::Relaxed) > 0
 }
 
+/// Probing a held connector and admitting a capture exclude each other. The probe drops the force
+/// on the machine's only scanout for a moment; a capture admitted in that moment would enumerate
+/// an empty topology and send its session to the portal. So a probe holds this for its whole
+/// detect-check-reforce, and admission takes it before counting itself in - a probe in flight
+/// makes the newcomer wait, and a capture already counted makes the probe stand down.
+static PROBE_GATE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Hold the gate across a held-connector probe. `None` when a capture is already open, in which
+/// case there is nothing to probe now. The guard is a `MutexGuard`, so a panic inside the probe
+/// releases it.
+pub(crate) fn begin_held_connector_probe() -> Option<std::sync::MutexGuard<'static, ()>> {
+    let gate = PROBE_GATE.lock().unwrap_or_else(|p| p.into_inner());
+    if drm_capture_active() {
+        return None;
+    }
+    Some(gate)
+}
+
 /// Decrements on Drop, so every way out of the capture loop is covered - including the panic path,
 /// which a manual decrement at the end would miss and leave the machine looking busy forever.
 struct CaptureGuard;
 
 impl CaptureGuard {
     fn new() -> Self {
+        // Wait out a probe in flight before counting in: see PROBE_GATE.
+        let _admitted = PROBE_GATE.lock().unwrap_or_else(|p| p.into_inner());
         DRM_CAPTURES_OPEN.fetch_add(1, Ordering::Relaxed);
         Self
     }
@@ -1503,6 +1523,25 @@ mod drm_conn_tests {
     use hbb_common::libc;
     use hbb_common::tokio::{self, io::AsyncWriteExt};
     use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
+
+    // rustdesk#15908: a probe of the held connector and a capture admission exclude each other, so
+    // the activity check the probe makes cannot be overtaken between the check and the writes.
+    #[test]
+    fn a_held_connector_probe_stands_down_for_an_open_capture() {
+        assert!(begin_held_connector_probe().is_some(), "idle machine: probe allowed");
+        {
+            let _open = CaptureGuard::new();
+            assert!(drm_capture_active());
+            assert!(begin_held_connector_probe().is_none(), "a capture is open: no probe");
+        }
+        assert!(!drm_capture_active(), "the guard counts itself out on drop");
+        // Both sides lock PROBE_GATE, so an admission arriving during a probe waits for it; that
+        // ordering is structural, and the gate handed out here is the same mutex.
+        let gate = begin_held_connector_probe();
+        assert!(gate.is_some());
+        drop(gate);
+        assert!(begin_held_connector_probe().is_some());
+    }
 
     // Added to the wire later: an older peer's message must still decode.
     #[test]

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "متابعة"),
         ("Browser didn't open? Use the url below to sign in.", "لم يفتح المتصفح؟ استخدم الرابط أدناه لتسجيل الدخول."),
         ("Lock canvas", "قفل اللوحة"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "مزامنة الحافظة بين الجلسات"),
         ("sync-clipboard-between-sessions-tip", "النص أو الصور المنسوخة في جلسة بعيدة واحدة تُرسَل أيضًا إلى حافظة جلساتك المتصلة الأخرى."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Працягнуць"),
         ("Browser didn't open? Use the url below to sign in.", "Браўзер не адкрыўся? Скарыстайцеся спасылкай ніжэй, каб увайсці."),
         ("Lock canvas", "Заблакіраваць палатно"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Сінхранізаваць буфер абмену паміж сеансамі"),
         ("sync-clipboard-between-sessions-tip", "Тэкст або відарысы, скапіяваныя ў адным аддаленым сеансе, таксама адпраўляюцца ў буфер абмену іншых вашых падключаных сеансаў."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Продължи"),
         ("Browser didn't open? Use the url below to sign in.", "Браузърът не се отвори? Използвайте URL адреса по-долу, за да се впишете."),
         ("Lock canvas", "Заключване на платното"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Синхронизиране на клипборда между сесиите"),
         ("sync-clipboard-between-sessions-tip", "Текст или изображения, копирани в една отдалечена сесия, се изпращат и към клипборда на другите ви свързани сесии."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continua"),
         ("Browser didn't open? Use the url below to sign in.", "No s'ha obert el navegador? Utilitzeu l'URL de sota per iniciar la sessió."),
         ("Lock canvas", "Bloca el llenç"),
+        ("Headless display", "Pantalla sense monitor"),
+        ("headless_display_tip", "Quan no hi ha cap monitor connectat, força una sortida de vídeo desconnectada perquè hi hagi una pantalla per capturar. S'allibera tan bon punt es connecta un monitor en una altra sortida."),
         ("Sync clipboard between sessions", "Sincronitza el porta-retalls entre sessions"),
         ("sync-clipboard-between-sessions-tip", "El text o les imatges copiats en una sessió remota també s'envien al porta-retalls de les altres sessions connectades."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "继续"),
         ("Browser didn't open? Use the url below to sign in.", "浏览器未打开？请使用下方网址登录。"),
         ("Lock canvas", "锁定画布"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "在会话间同步剪贴板"),
         ("sync-clipboard-between-sessions-tip", "在一个远程会话中复制的文本或图片也会发送到其他已连接会话的剪贴板。"),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Pokračovat"),
         ("Browser didn't open? Use the url below to sign in.", "Neotevřel se prohlížeč? Pro přihlášení použijte URL níže."),
         ("Lock canvas", "Zamknout zobrazení"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Synchronizovat schránku mezi relacemi"),
         ("sync-clipboard-between-sessions-tip", "Text nebo obrázky zkopírované v jedné vzdálené relaci se odešlou i do schránky ostatních připojených relací."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Fortsæt"),
         ("Browser didn't open? Use the url below to sign in.", "Åbnede browseren ikke? Brug URL'en nedenfor til at logge ind."),
         ("Lock canvas", "Lås lærred"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Synkroniser udklipsholder mellem sessioner"),
         ("sync-clipboard-between-sessions-tip", "Tekst eller billeder, der kopieres i én fjernsession, sendes også til udklipsholderen i dine andre forbundne sessioner."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Weiter"),
         ("Browser didn't open? Use the url below to sign in.", "Hat sich der Browser nicht geöffnet? Melden Sie sich über die untenstehende URL an."),
         ("Lock canvas", "Sichtfeld sperren"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Zwischenablage zwischen Sitzungen synchronisieren"),
         ("sync-clipboard-between-sessions-tip", "In einer Remote-Sitzung kopierter Text oder kopierte Bilder werden auch an die Zwischenablage Ihrer anderen verbundenen Sitzungen gesendet."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Συνέχεια"),
         ("Browser didn't open? Use the url below to sign in.", "Δεν άνοιξε το πρόγραμμα περιήγησης; Χρησιμοποιήστε τον παρακάτω σύνδεσμο για να συνδεθείτε."),
         ("Lock canvas", "Κλείδωμα καμβά"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Συγχρονισμός προχείρου μεταξύ συνεδριών"),
         ("sync-clipboard-between-sessions-tip", "Κείμενο ή εικόνες που αντιγράφονται σε μία απομακρυσμένη συνεδρία αποστέλλονται και στο πρόχειρο των άλλων συνδεδεμένων συνεδριών σας."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -129,6 +129,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("hide_cm_tip", "Allow hiding only if accepting sessions via password and using permanent password"),
         ("wayland_experiment_tip", "Wayland support is in experimental stage, please use X11 if you require unattended access."),
         ("software_render_tip", "If you're using Nvidia graphics card under Linux and the remote window closes immediately after connecting, switching to the open-source Nouveau driver and choosing to use software rendering may help. A software restart is required."),
+        ("headless_display_tip", "When no monitor is attached, force a disconnected display output on so there is a screen to capture. Released again as soon as a monitor is plugged into another output."),
         ("config_input", "In order to control remote desktop with keyboard, you need to grant RustDesk \"Input Monitoring\" permissions."),
         ("config_microphone", "In order to speak remotely, you need to grant RustDesk \"Record Audio\" permissions."),
         ("request_elevation_tip", "You can also request elevation if there is someone on the remote side."),

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Daŭrigi"),
         ("Browser didn't open? Use the url below to sign in.", "Ĉu la retumilo ne malfermiĝis? Uzu la suban ligilon por ensaluti."),
         ("Lock canvas", "Ŝlosi kanvason"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sinkronigi poŝon inter seancoj"),
         ("sync-clipboard-between-sessions-tip", "Teksto aŭ bildoj kopiitaj en unu fora seanco ankaŭ sendiĝas al la poŝo de viaj aliaj konektitaj seancoj."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continuar"),
         ("Browser didn't open? Use the url below to sign in.", "¿No se abrió el navegador? Usa la URL de abajo para iniciar sesión."),
         ("Lock canvas", "Bloquear lienzo"),
+        ("Headless display", "Pantalla sin monitor"),
+        ("headless_display_tip", "Cuando no hay ningún monitor conectado, fuerza una salida de vídeo desconectada para que haya una pantalla que capturar. Se libera en cuanto se conecta un monitor en otra salida."),
         ("Sync clipboard between sessions", "Sincronizar portapapeles entre sesiones"),
         ("sync-clipboard-between-sessions-tip", "El texto o las imágenes copiados en una sesión remota también se envían al portapapeles de tus otras sesiones conectadas."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Jätka"),
         ("Browser didn't open? Use the url below to sign in.", "Brauser ei avanenud? Sisselogimiseks kasuta allolevat URL-i."),
         ("Lock canvas", "Lukusta lõuend"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sünkrooni lõikelaud seansside vahel"),
         ("sync-clipboard-between-sessions-tip", "Ühes kaugseansis kopeeritud tekst või pildid saadetakse ka teiste ühendatud seansside lõikelauale."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Jarraitu"),
         ("Browser didn't open? Use the url below to sign in.", "Nabigatzailea ez da ireki? Erabili beheko URLa saioa hasteko."),
         ("Lock canvas", "Blokeatu oihala"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sinkronizatu arbela saioen artean"),
         ("sync-clipboard-between-sessions-tip", "Urruneko saio batean kopiatutako testua edo irudiak konektatutako beste saioen arbelera ere bidaltzen dira."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "ادامه"),
         ("Browser didn't open? Use the url below to sign in.", "مرورگر باز نشد؟ برای ورود از نشانی زیر استفاده کنید."),
         ("Lock canvas", "قفل کردن صفحه"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "همگام‌سازی کلیپ‌بورد بین نشست‌ها"),
         ("sync-clipboard-between-sessions-tip", "متن یا تصاویری که در یک نشست راه دور کپی می‌شوند به کلیپ‌بورد سایر نشست‌های متصل شما نیز ارسال می‌شوند."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Jatka"),
         ("Browser didn't open? Use the url below to sign in.", "Eikö selain avautunut? Kirjaudu sisään alla olevan osoitteen kautta."),
         ("Lock canvas", "Lukitse näkymä"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Synkronoi leikepöytä istuntojen välillä"),
         ("sync-clipboard-between-sessions-tip", "Yhdessä etäistunnossa kopioitu teksti tai kuvat lähetetään myös muiden yhdistettyjen istuntojen leikepöydälle."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continuer"),
         ("Browser didn't open? Use the url below to sign in.", "Le navigateur ne s’est pas ouvert ? Utilisez l’URL ci-dessous pour vous connecter."),
         ("Lock canvas", "Verrouiller la vue"),
+        ("Headless display", "Écran sans moniteur"),
+        ("headless_display_tip", "Quand aucun écran n'est branché, force une sortie vidéo déconnectée afin qu'il y ait un écran à capturer. Elle est libérée dès qu'un écran est branché sur une autre sortie."),
         ("Sync clipboard between sessions", "Synchroniser le presse-papiers entre les sessions"),
         ("sync-clipboard-between-sessions-tip", "Le texte ou les images copiés dans une session distante sont également envoyés au presse-papiers de vos autres sessions connectées."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "გაგრძელება"),
         ("Browser didn't open? Use the url below to sign in.", "ბრაუზერი არ გაიხსნა? შესასვლელად გამოიყენეთ ქვემოთ მოცემული ბმული."),
         ("Lock canvas", "ტილოს დაბლოკვა"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "გაცვლის ბუფერის სინქრონიზაცია სესიებს შორის"),
         ("sync-clipboard-between-sessions-tip", "ერთ დაშორებულ სესიაში დაკოპირებული ტექსტი ან სურათები ასევე იგზავნება თქვენი სხვა დაკავშირებული სესიების გაცვლის ბუფერში."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "ચાલુ રાખો"),
         ("Browser didn't open? Use the url below to sign in.", "બ્રાઉઝર ખૂલ્યું નથી? લોગિન કરવા માટે નીચે આપેલ URL નો ઉપયોગ કરો."),
         ("Lock canvas", "કેનવાસ લોક કરો"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "સત્રો વચ્ચે ક્લિપબોર્ડ સિંક કરો"),
         ("sync-clipboard-between-sessions-tip", "એક રિમોટ સત્રમાં કૉપિ કરેલ ટેક્સ્ટ કે છબીઓ તમારા અન્ય જોડાયેલા સત્રોના ક્લિપબોર્ડ પર પણ મોકલવામાં આવે છે."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "המשך"),
         ("Browser didn't open? Use the url below to sign in.", "הדפדפן לא נפתח? השתמש בכתובת שלמטה כדי להתחבר."),
         ("Lock canvas", "נעל לוח ציור"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "סנכרן לוח בין סשנים"),
         ("sync-clipboard-between-sessions-tip", "טקסט או תמונות שהועתקו בסשן מרוחק אחד נשלחים גם ללוח של שאר הסשנים המחוברים שלך."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "जारी रखें"),
         ("Browser didn't open? Use the url below to sign in.", "ब्राउज़र नहीं खुला? लॉगिन करने के लिए नीचे दिए गए URL का उपयोग करें।"),
         ("Lock canvas", "कैनवास लॉक करें"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "सत्रों के बीच क्लिपबोर्ड सिंक करें"),
         ("sync-clipboard-between-sessions-tip", "एक रिमोट सत्र में कॉपी किए गए टेक्स्ट या चित्र आपके अन्य जुड़े सत्रों के क्लिपबोर्ड पर भी भेजे जाते हैं।"),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Nastavi"),
         ("Browser didn't open? Use the url below to sign in.", "Preglednik se nije otvorio? Za prijavu upotrijebite URL u nastavku."),
         ("Lock canvas", "Zaključaj pozadinu"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sinkroniziraj međuspremnik između sesija"),
         ("sync-clipboard-between-sessions-tip", "Tekst ili slike kopirani u jednoj udaljenoj sesiji šalju se i u međuspremnik vaših ostalih povezanih sesija."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Folytatás"),
         ("Browser didn't open? Use the url below to sign in.", "Nem nyílt meg a böngésző? A belépéshez használja az alábbi URL-címet."),
         ("Lock canvas", "Nézet zárolása"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Vágólap szinkronizálása a munkamenetek között"),
         ("sync-clipboard-between-sessions-tip", "Az egyik távoli munkamenetben másolt szöveg vagy kép a többi csatlakoztatott munkamenet vágólapjára is elküldésre kerül."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Lanjutkan"),
         ("Browser didn't open? Use the url below to sign in.", "Browser tidak terbuka? Gunakan URL di bawah ini untuk masuk."),
         ("Lock canvas", "Kunci kanvas"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sinkronkan papan klip antar sesi"),
         ("sync-clipboard-between-sessions-tip", "Teks atau gambar yang disalin di satu sesi jarak jauh juga dikirim ke papan klip sesi terhubung Anda yang lain."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continua"),
         ("Browser didn't open? Use the url below to sign in.", "Il browser non si è aperto? Usa l'URL qui sotto per accedere."),
         ("Lock canvas", "Blocca tela"),
+        ("Headless display", "Schermo senza monitor"),
+        ("headless_display_tip", "Quando non è collegato alcun monitor, forza l'accensione di un'uscita video scollegata così che ci sia uno schermo da catturare. Viene rilasciata appena si collega un monitor a un'altra uscita."),
         ("Sync clipboard between sessions", "Sincronizza appunti tra le sessioni"),
         ("sync-clipboard-between-sessions-tip", "Il testo o le immagini copiati in una sessione remota vengono inviati anche agli appunti delle altre sessioni connesse."),
         ("terminal-clipboard-write-tip", "Un'app nel terminale vuole copiare il testo negli appunti di questo dispositivo. Se concessa, questa autorizzazione si applica alle app terminali in tutte le connessioni finché non la disattivi in Impostazioni. Le operazioni di copia e incolla manuali non sono interessate."),

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "続行"),
         ("Browser didn't open? Use the url below to sign in.", "ブラウザが開きませんでしたか？下記の URL からログインしてください。"),
         ("Lock canvas", "キャンバスをロック"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "セッション間でクリップボードを同期"),
         ("sync-clipboard-between-sessions-tip", "1つのリモートセッションでコピーしたテキストや画像は、接続中の他のセッションのクリップボードにも送信されます。"),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "계속"),
         ("Browser didn't open? Use the url below to sign in.", "브라우저가 열리지 않았나요? 아래 URL로 로그인하세요."),
         ("Lock canvas", "캔버스 잠금"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "세션 간 클립보드 동기화"),
         ("sync-clipboard-between-sessions-tip", "하나의 원격 세션에서 복사한 텍스트나 이미지는 연결된 다른 세션의 클립보드에도 전송됩니다."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Жалғастыру"),
         ("Browser didn't open? Use the url below to sign in.", "Браузер ашылмады ма? Кіру үшін төмендегі сілтемені пайдаланыңыз."),
         ("Lock canvas", "Кенепті құлыптау"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Сеанстар арасында көшіру-тақтасын синхрондау"),
         ("sync-clipboard-between-sessions-tip", "Бір қашықтағы сеанста көшірілген мәтін немесе суреттер басқа қосылған сеанстардың көшіру-тақтасына да жіберіледі."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Tęsti"),
         ("Browser didn't open? Use the url below to sign in.", "Naršyklė neatsidarė? Prisijunkite naudodami toliau pateiktą URL."),
         ("Lock canvas", "Užrakinti drobę"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sinchronizuoti iškarpinę tarp seansų"),
         ("sync-clipboard-between-sessions-tip", "Viename nuotoliniame seanse nukopijuotas tekstas ar vaizdai taip pat siunčiami į kitų prijungtų seansų iškarpinę."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Turpināt"),
         ("Browser didn't open? Use the url below to sign in.", "Pārlūkprogramma neatvērās? Izmantojiet tālāk norādīto URL, lai pieslēgtos."),
         ("Lock canvas", "Bloķēt audeklu"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sinhronizēt starpliktuvi starp sesijām"),
         ("sync-clipboard-between-sessions-tip", "Vienā attālajā sesijā nokopētais teksts vai attēli tiek nosūtīti arī uz pārējo pievienoto sesiju starpliktuvi."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "തുടരുക"),
         ("Browser didn't open? Use the url below to sign in.", "ബ്രൗസർ തുറന്നില്ലേ? ലോഗിൻ ചെയ്യാൻ താഴെയുള്ള URL ഉപയോഗിക്കുക."),
         ("Lock canvas", "ക്യാൻവാസ് ലോക്ക് ചെയ്യുക"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "സെഷനുകൾക്കിടയിൽ ക്ലിപ്പ്ബോർഡ് സമന്വയിപ്പിക്കുക"),
         ("sync-clipboard-between-sessions-tip", "ഒരു റിമോട്ട് സെഷനിൽ പകർത്തിയ ടെക്സ്റ്റോ ചിത്രങ്ങളോ നിങ്ങളുടെ മറ്റ് കണക്റ്റുചെയ്ത സെഷനുകളുടെ ക്ലിപ്പ്ബോർഡിലേക്കും അയയ്ക്കപ്പെടും."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Fortsett"),
         ("Browser didn't open? Use the url below to sign in.", "Åpnet ikke nettleseren? Bruk URL-en nedenfor for å logge inn."),
         ("Lock canvas", "Lås lerret"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Synkroniser utklippstavlen mellom økter"),
         ("sync-clipboard-between-sessions-tip", "Tekst eller bilder som kopieres i én ekstern økt, sendes også til utklippstavlen i de andre tilkoblede øktene dine."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Doorgaan"),
         ("Browser didn't open? Use the url below to sign in.", "Is de browser niet geopend? Gebruik onderstaande URL om in te loggen."),
         ("Lock canvas", "Canvas vergrendelen"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Klembord synchroniseren tussen sessies"),
         ("sync-clipboard-between-sessions-tip", "Tekst of afbeeldingen die in één externe sessie worden gekopieerd, worden ook naar het klembord van uw andere verbonden sessies gestuurd."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Kontynuuj"),
         ("Browser didn't open? Use the url below to sign in.", "Przeglądarka się nie otworzyła? Użyj poniższego adresu URL, aby się zalogować."),
         ("Lock canvas", "Zablokuj ekran"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Synchronizuj schowek między sesjami"),
         ("sync-clipboard-between-sessions-tip", "Tekst lub obrazy skopiowane w jednej sesji zdalnej są wysyłane także do schowka pozostałych połączonych sesji."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continuar"),
         ("Browser didn't open? Use the url below to sign in.", "O navegador não abriu? Utilize o URL abaixo para iniciar sessão."),
         ("Lock canvas", "Bloquear tela"),
+        ("Headless display", "Ecrã sem monitor"),
+        ("headless_display_tip", "Quando nenhum monitor está ligado, força uma saída de vídeo desconectada para que haja um ecrã a capturar. É liberada assim que um monitor for ligado noutra saída."),
         ("Sync clipboard between sessions", "Sincronizar área de transferência entre sessões"),
         ("sync-clipboard-between-sessions-tip", "O texto ou as imagens copiados numa sessão remota também são enviados para a área de transferência das suas outras sessões ligadas."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continuar"),
         ("Browser didn't open? Use the url below to sign in.", "O navegador não foi aberto? Use a URL abaixo para fazer login."),
         ("Lock canvas", "Bloquear tela"),
+        ("Headless display", "Tela sem monitor"),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sincronizar área de transferência entre sessões"),
         ("sync-clipboard-between-sessions-tip", "Texto ou imagens copiados em uma sessão remota também são enviados para a área de transferência das suas outras sessões conectadas."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continuă"),
         ("Browser didn't open? Use the url below to sign in.", "Browserul nu s-a deschis? Folosește URL-ul de mai jos pentru a te conecta."),
         ("Lock canvas", "Blochează ecranul"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sincronizează clipboardul între sesiuni"),
         ("sync-clipboard-between-sessions-tip", "Textul sau imaginile copiate într-o sesiune la distanță sunt trimise și în clipboardul celorlalte sesiuni conectate."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Продолжить"),
         ("Browser didn't open? Use the url below to sign in.", "Браузер не открылся? Используйте ссылку ниже для входа."),
         ("Lock canvas", "Заблокировать холст"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Синхронизировать буфер обмена между сеансами"),
         ("sync-clipboard-between-sessions-tip", "Текст или изображения, скопированные в одном удалённом сеансе, также отправляются в буфер обмена других подключённых сеансов."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Sighi"),
         ("Browser didn't open? Use the url below to sign in.", "Non s'est abertu su navigadore? Imprea s'URL inoghe in suta pro intrare."),
         ("Lock canvas", "Bloca sa tela"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sincroniza sa punta de billete intre is sessiones"),
         ("sync-clipboard-between-sessions-tip", "Su testu o is immàgines copiadas in una sessione remota sunt imbiadas fintzas a sa punta de billete de is àteras sessiones connètidas."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Pokračovať"),
         ("Browser didn't open? Use the url below to sign in.", "Neotvoril sa prehliadač? Na prihlásenie použite URL nižšie."),
         ("Lock canvas", "Uzamknúť zobrazenie"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Synchronizovať schránku medzi reláciami"),
         ("sync-clipboard-between-sessions-tip", "Text alebo obrázky skopírované v jednej vzdialenej relácii sa odošlú aj do schránky ostatných pripojených relácií."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Nadaljuj"),
         ("Browser didn't open? Use the url below to sign in.", "Brskalnik se ni odprl? Za prijavo uporabite spodnji URL."),
         ("Lock canvas", "Zakleni platno"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sinhroniziraj odložišče med sejami"),
         ("sync-clipboard-between-sessions-tip", "Besedilo ali slike, kopirane v eni oddaljeni seji, se pošljejo tudi v odložišče vaših drugih povezanih sej."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Vazhdo"),
         ("Browser didn't open? Use the url below to sign in.", "Shfletuesi nuk u hap? Përdorni URL-në më poshtë për të hyrë."),
         ("Lock canvas", "Kyç canvas"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sinkronizo clipboard-in midis sesioneve"),
         ("sync-clipboard-between-sessions-tip", "Teksti ose imazhet e kopjuara në një sesion të largët dërgohen edhe në clipboard-in e sesioneve të tjera të lidhura."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Nastavi"),
         ("Browser didn't open? Use the url below to sign in.", "Pregledač se nije otvorio? Za prijavu koristite URL ispod."),
         ("Lock canvas", "Zaključaj pozadinu"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Sinhronizuj klipbord između sesija"),
         ("sync-clipboard-between-sessions-tip", "Tekst ili slike kopirane u jednoj udaljenoj sesiji šalju se i u klipbord vaših ostalih povezanih sesija."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Fortsätt"),
         ("Browser didn't open? Use the url below to sign in.", "Öppnades inte webbläsaren? Använd URL:en nedan för att logga in."),
         ("Lock canvas", "Lås canvas"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Synkronisera urklipp mellan sessioner"),
         ("sync-clipboard-between-sessions-tip", "Text eller bilder som kopieras i en fjärrsession skickas även till urklipp i dina andra anslutna sessioner."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "தொடர்க"),
         ("Browser didn't open? Use the url below to sign in.", "உலாவி திறக்கவில்லையா? உள்நுழைய கீழே உள்ள URL ஐப் பயன்படுத்தவும்."),
         ("Lock canvas", "கேன்வாஸைப் பூட்டு"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "அமர்வுகளுக்கு இடையே கிளிப்போர்டை ஒத்திசைக்கவும்"),
         ("sync-clipboard-between-sessions-tip", "ஒரு தொலை அமர்வில் நகலெடுக்கப்பட்ட உரை அல்லது படங்கள் உங்கள் பிற இணைக்கப்பட்ட அமர்வுகளின் கிளிப்போர்டுக்கும் அனுப்பப்படும்."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", ""),
         ("Browser didn't open? Use the url below to sign in.", ""),
         ("Lock canvas", ""),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", ""),
         ("sync-clipboard-between-sessions-tip", ""),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "ดำเนินการต่อ"),
         ("Browser didn't open? Use the url below to sign in.", "เบราว์เซอร์ไม่เปิดใช่ไหม? ใช้ URL ด้านล่างเพื่อเข้าสู่ระบบ"),
         ("Lock canvas", "ล็อคแคนวาส"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "ซิงค์คลิปบอร์ดระหว่างเซสชัน"),
         ("sync-clipboard-between-sessions-tip", "ข้อความหรือรูปภาพที่คัดลอกในเซสชันระยะไกลหนึ่งจะถูกส่งไปยังคลิปบอร์ดของเซสชันอื่นที่เชื่อมต่ออยู่ด้วย"),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Devam et"),
         ("Browser didn't open? Use the url below to sign in.", "Tarayıcı açılmadı mı? Giriş yapmak için aşağıdaki URL'yi kullanın."),
         ("Lock canvas", "Tuvali kilitle"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Oturumlar arasında panoyu senkronize et"),
         ("sync-clipboard-between-sessions-tip", "Bir uzak oturumda kopyalanan metin veya görseller, bağlı diğer oturumlarınızın panosuna da gönderilir."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "繼續"),
         ("Browser didn't open? Use the url below to sign in.", "瀏覽器未開啟？請使用下方網址登入。"),
         ("Lock canvas", "鎖定畫布"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "在工作階段間同步剪貼簿"),
         ("sync-clipboard-between-sessions-tip", "在一個遠端工作階段中複製的文字或圖片也會傳送到其他已連線工作階段的剪貼簿。"),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Продовжити"),
         ("Browser didn't open? Use the url below to sign in.", "Браузер не відкрився? Скористайтеся посиланням нижче, щоб увійти."),
         ("Lock canvas", "Блокування полотна"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Синхронізувати буфер обміну між сеансами"),
         ("sync-clipboard-between-sessions-tip", "Текст або зображення, скопійовані в одному віддаленому сеансі, також надсилаються до буфера обміну інших підключених сеансів."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -761,6 +761,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Tiếp tục"),
         ("Browser didn't open? Use the url below to sign in.", "Trình duyệt không mở được? Hãy dùng URL bên dưới để đăng nhập."),
         ("Lock canvas", "Khóa khung hình"),
+        ("Headless display", ""),
+        ("headless_display_tip", ""),
         ("Sync clipboard between sessions", "Đồng bộ clipboard giữa các phiên"),
         ("sync-clipboard-between-sessions-tip", "Văn bản hoặc hình ảnh được sao chép trong một phiên từ xa cũng được gửi đến clipboard của các phiên đã kết nối khác."),
         ("terminal-clipboard-write-tip", ""),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,4 +70,16 @@ pub mod privacy_mode;
 #[cfg(windows)]
 pub mod virtual_display_manager;
 
+// The Linux headless display lives under the same abstraction, but shares no code with the Windows
+// indirect-display driver: it forces an existing DRM connector on rather than adding a device. So it
+// is declared as a submodule here instead of making `virtual_display_manager.rs` cross-platform.
+//
+// The directory `src/virtual_display_manager/` therefore belongs to THIS module, not to the
+// same-named `src/virtual_display_manager.rs`, which uses inline submodules and owns no directory.
+// Adding a `src/virtual_display_manager/mod.rs` would break the Windows build.
+#[cfg(all(target_os = "linux", feature = "headless-display"))]
+pub mod virtual_display_manager {
+    pub mod linux;
+}
+
 mod kcp_stream;

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1097,6 +1097,11 @@ pub fn start_os_service() {
         );
     }
 
+    // Off unless the operator turned it on; the watcher checks that itself, every poll, so a toggle
+    // takes effect without a service restart.
+    #[cfg(feature = "headless-display")]
+    crate::virtual_display_manager::linux::start_watcher();
+
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
     let (mut display, mut xauth): (String, String) = ("".to_owned(), "".to_owned());

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -1375,6 +1375,11 @@ pub(super) fn warm_availability() {
             Ok(list) if !list.is_empty() => {
                 log::info!("drm: consumer cache warmed ({} displays) at startup", list.len());
                 publish_probe_state(&mut DRM_STATE.lock().unwrap(), ProbeState::Available(Instant::now(), list));
+                // Warm-up runs detached, so an empty probe can have armed the clock while it was
+                // querying. Retiring it AFTER the publish is what covers that: an empty observation
+                // from before this Available cannot be allowed to time out against it. The guard
+                // above is a temporary, so no lock is held here.
+                clear_empty_topology_clock();
                 return;
             }
             _ => std::thread::sleep(Duration::from_millis(300)),
@@ -1705,10 +1710,30 @@ fn normalize_connector(name: &str) -> String {
     }
 }
 
+/// A debounce clock armed before the verdict it would demote belongs to a topology that has since
+/// been proven non-empty. Every publisher of a non-empty topology retires the clock, but that is
+/// four call sites remembering; this makes a missed one cost a settle window rather than an
+/// immediate demote.
+fn clock_predates_verdict(armed_at: Option<Instant>, available_since: Option<Instant>) -> bool {
+    match (armed_at, available_since) {
+        (Some(armed), Some(available)) => armed < available,
+        _ => false,
+    }
+}
+
 fn swap_available_displays(list: Vec<DrmDisplayInfo>) {
+    // Read and released before the clock lock is taken: the two must never nest, and the order
+    // everywhere else is clock first.
+    let available_since = match &*DRM_STATE.lock().unwrap() {
+        ProbeState::Available(at, _) => Some(*at),
+        _ => None,
+    };
     // The empty debounce is resolved before DRM_STATE is taken so the two locks never nest.
     let empty_outlived_window = if list.is_empty() {
         let mut since = EMPTY_TOPOLOGY_SINCE.lock().unwrap();
+        if clock_predates_verdict(*since, available_since) {
+            *since = None;
+        }
         let was_first = since.is_none();
         let ready = empty_topology_ready(&mut *since, EMPTY_TOPOLOGY_DEMOTE_AFTER);
         if was_first {
@@ -2471,6 +2496,18 @@ mod drm_capturer_tests {
         assert!(!h.demoted(), "past the cooldown the display must be retried");
         h.demotes = 4;
         assert!(h.demoted(), "the backoff must still be holding it at demotion 4");
+    }
+
+    #[test]
+    fn a_clock_armed_before_the_current_verdict_cannot_demote_it() {
+        let armed = Instant::now();
+        let available = armed + Duration::from_millis(1);
+        assert!(clock_predates_verdict(Some(armed), Some(available)));
+        // Armed while this verdict already stood: it is about the current topology.
+        assert!(!clock_predates_verdict(Some(available), Some(armed)));
+        assert!(!clock_predates_verdict(None, Some(available)));
+        // Nothing to be stale against.
+        assert!(!clock_predates_verdict(Some(armed), None));
     }
 
     #[test]

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -1303,14 +1303,19 @@ fn refresh_available_async() {
                         _ => true,
                     };
                     publish_probe_state(&mut st, ProbeState::Available(Instant::now(), fresh));
+                    drop(st);
+                    // A restored list must also clear the empty-debounce clock, or the NEXT
+                    // empty push demotes instantly off a stale first-sighting.
+                    *EMPTY_TOPOLOGY_SINCE.lock().unwrap() = None;
                     if changed {
-                        drop(st);
                         scrap::wayland::display::clear_wayland_displays_cache();
                     }
                 }
                 RefreshOutcome::Unavailable => {
-                    log::info!("drm: refresh -> 0 displays, marking DRM unavailable");
-                    publish_probe_state(&mut st, ProbeState::Unavailable(Instant::now()));
+                    // Through the shared debounce, DRM_STATE dropped first (the two locks never
+                    // nest): the refresh path must not demote faster than the hotplug path does.
+                    drop(st);
+                    swap_available_displays(Vec::new());
                 }
                 // Only the TTL stamp moves, so this does NOT go through publish_probe_state.
                 RefreshOutcome::Restamp => {

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -1002,6 +1002,12 @@ fn empty_topology_ready(since: &mut Option<Instant>, window: Duration) -> bool {
     }
 }
 
+/// A non-empty observation retires the debounce clock. Callers must hold no `DRM_STATE` guard:
+/// `swap_available_displays` takes that lock first, so the two must never nest.
+fn clear_empty_topology_clock() {
+    *EMPTY_TOPOLOGY_SINCE.lock().unwrap() = None;
+}
+
 /// Runs on a throwaway thread: a nested `#[tokio::main]` panics if called from inside a runtime.
 fn query_displays() -> ResultType<Vec<DrmDisplayInfo>> {
     let (tx, rx) = std::sync::mpsc::channel();
@@ -1210,6 +1216,10 @@ fn probe_and_publish() -> Availability {
         }
     };
     drop(st);
+    // A successful probe is a non-empty observation, so it retires any pending debounce clock.
+    if answer == Availability::Available {
+        clear_empty_topology_clock();
+    }
     answer
 }
 
@@ -1253,6 +1263,7 @@ fn refresh_unavailable_async() {
                     DRM_PROBE_FAILURES.store(0, Ordering::Relaxed);
                     publish_probe_state(&mut st, ProbeState::Available(Instant::now(), list));
                     drop(st);
+                    clear_empty_topology_clock();
                     scrap::wayland::display::clear_wayland_displays_cache();
                 }
                 _ => {
@@ -1407,6 +1418,7 @@ pub(super) async fn refresh_displays_for_login() {
                     _ => return,
                 }
             };
+            clear_empty_topology_clock();
             if changed {
                 scrap::wayland::display::clear_wayland_displays_cache();
             }

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -1305,7 +1305,9 @@ fn refresh_available_async() {
                     publish_probe_state(&mut st, ProbeState::Available(Instant::now(), fresh));
                     drop(st);
                     // A restored list must also clear the empty-debounce clock, or the NEXT
-                    // empty push demotes instantly off a stale first-sighting.
+                    // empty push demotes instantly off a stale first-sighting. Racing a hotplug
+                    // empty push in the gap is benign (its recheck re-arms within a TTL) and the
+                    // gap is what keeps the two locks un-nested - do not move this under st.
                     *EMPTY_TOPOLOGY_SINCE.lock().unwrap() = None;
                     if changed {
                         scrap::wayland::display::clear_wayland_displays_cache();
@@ -1314,6 +1316,8 @@ fn refresh_available_async() {
                 RefreshOutcome::Unavailable => {
                     // Through the shared debounce, DRM_STATE dropped first (the two locks never
                     // nest): the refresh path must not demote faster than the hotplug path does.
+                    // A publish landing in the gap is re-read by swap under its own lock and the
+                    // worst case is one spurious first-sighting - benign, so no gen re-check.
                     drop(st);
                     swap_available_displays(Vec::new());
                 }
@@ -1706,12 +1710,14 @@ fn swap_available_displays(list: Vec<DrmDisplayInfo>) {
         false
     };
     let mut st = DRM_STATE.lock().unwrap();
+    let mut demoted = false;
     match &*st {
         ProbeState::Available(..) => {
             if list.is_empty() {
                 if empty_outlived_window {
                     log::info!("drm: topology empty past the settle window, marking DRM unavailable");
                     publish_probe_state(&mut st, ProbeState::Unavailable(Instant::now()));
+                    demoted = true;
                 } else {
                     log::info!("drm: hotplug refresh -> 0 displays; keeping the last list while the topology settles");
                 }
@@ -1734,6 +1740,13 @@ fn swap_available_displays(list: Vec<DrmDisplayInfo>) {
             publish_probe_state(&mut st, ProbeState::Available(Instant::now(), list));
         }
         _ => {}
+    }
+    drop(st);
+    // A landed demote retires its clock (locks never nest, so after DRM_STATE drops): recovery
+    // can arrive through publishers that know nothing of the debounce, and a stale first-sighting
+    // would make the NEXT transient empty demote instantly.
+    if demoted {
+        *EMPTY_TOPOLOGY_SINCE.lock().unwrap() = None;
     }
 }
 

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -1668,14 +1668,30 @@ fn normalize_connector(name: &str) -> String {
 
 fn swap_available_displays(list: Vec<DrmDisplayInfo>) {
     let mut st = DRM_STATE.lock().unwrap();
-    if matches!(&*st, ProbeState::Available(..)) {
-        if list.is_empty() {
-            log::info!("drm: hotplug refresh -> 0 displays, marking DRM unavailable");
-            publish_probe_state(&mut st, ProbeState::Unavailable(Instant::now()));
-        } else {
-            log::info!("drm: hotplug refresh -> {} display(s)", list.len());
+    match &*st {
+        ProbeState::Available(..) => {
+            if list.is_empty() {
+                log::info!("drm: hotplug refresh -> 0 displays, marking DRM unavailable");
+                publish_probe_state(&mut st, ProbeState::Unavailable(Instant::now()));
+            } else {
+                log::info!("drm: hotplug refresh -> {} display(s)", list.len());
+                publish_probe_state(&mut st, ProbeState::Available(Instant::now(), list));
+            }
+        }
+        // A hotplug that finds displays lifts a negative verdict, which is the rule
+        // `refresh_unavailable_async` already documents: only a non-empty list flips it. Without this
+        // arm the verdict could only be revised by that TTL re-probe, so a topology that went empty
+        // for an instant and came back cost the session the whole NEGATIVE_TTL on the portal even
+        // though the correct list had already arrived. A modeset takes long enough after a connector
+        // reports itself that the enumeration in between genuinely sees nothing.
+        ProbeState::Unavailable(..) if !list.is_empty() => {
+            log::info!(
+                "drm: hotplug refresh -> {} display(s), DRM is available again",
+                list.len()
+            );
             publish_probe_state(&mut st, ProbeState::Available(Instant::now(), list));
         }
+        _ => {}
     }
 }
 

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -984,6 +984,24 @@ static DRM_STATE: Mutex<ProbeState> = Mutex::new(ProbeState::Unknown);
 const NEGATIVE_TTL: Duration = Duration::from_secs(30);
 const POSITIVE_TTL: Duration = Duration::from_secs(15);
 
+/// First moment a hotplug refresh reported an empty topology; None while displays exist.
+static EMPTY_TOPOLOGY_SINCE: Mutex<Option<Instant>> = Mutex::new(None);
+/// A monitor unplug opens a measured 5-7 s zero-display gap before the headless force (or the
+/// compositor) restores scanout; demoting inside it hands a live session to the PipeWire portal,
+/// which a headless box can never answer.
+const EMPTY_TOPOLOGY_DEMOTE_AFTER: Duration = Duration::from_secs(10);
+
+/// True once the empty topology has outlived the settle window; records the first sighting.
+fn empty_topology_ready(since: &mut Option<Instant>, window: Duration) -> bool {
+    match *since {
+        Some(t) => t.elapsed() >= window,
+        None => {
+            *since = Some(Instant::now());
+            false
+        }
+    }
+}
+
 /// Runs on a throwaway thread: a nested `#[tokio::main]` panics if called from inside a runtime.
 fn query_displays() -> ResultType<Vec<DrmDisplayInfo>> {
     let (tx, rx) = std::sync::mpsc::channel();
@@ -1667,12 +1685,31 @@ fn normalize_connector(name: &str) -> String {
 }
 
 fn swap_available_displays(list: Vec<DrmDisplayInfo>) {
+    // The empty debounce is resolved before DRM_STATE is taken so the two locks never nest.
+    let empty_outlived_window = if list.is_empty() {
+        let mut since = EMPTY_TOPOLOGY_SINCE.lock().unwrap();
+        let was_first = since.is_none();
+        let ready = empty_topology_ready(&mut *since, EMPTY_TOPOLOGY_DEMOTE_AFTER);
+        if was_first {
+            // A single empty push may be the last event a dead topology ever sends, so re-ask
+            // after the window instead of waiting for a hotplug that may never come.
+            schedule_empty_topology_recheck();
+        }
+        ready
+    } else {
+        *EMPTY_TOPOLOGY_SINCE.lock().unwrap() = None;
+        false
+    };
     let mut st = DRM_STATE.lock().unwrap();
     match &*st {
         ProbeState::Available(..) => {
             if list.is_empty() {
-                log::info!("drm: hotplug refresh -> 0 displays, marking DRM unavailable");
-                publish_probe_state(&mut st, ProbeState::Unavailable(Instant::now()));
+                if empty_outlived_window {
+                    log::info!("drm: topology empty past the settle window, marking DRM unavailable");
+                    publish_probe_state(&mut st, ProbeState::Unavailable(Instant::now()));
+                } else {
+                    log::info!("drm: hotplug refresh -> 0 displays; keeping the last list while the topology settles");
+                }
             } else {
                 log::info!("drm: hotplug refresh -> {} display(s)", list.len());
                 publish_probe_state(&mut st, ProbeState::Available(Instant::now(), list));
@@ -1692,6 +1729,24 @@ fn swap_available_displays(list: Vec<DrmDisplayInfo>) {
             publish_probe_state(&mut st, ProbeState::Available(Instant::now(), list));
         }
         _ => {}
+    }
+}
+
+fn schedule_empty_topology_recheck() {
+    let spawned = std::thread::Builder::new()
+        .name("drm-empty-recheck".into())
+        .spawn(|| {
+            std::thread::sleep(EMPTY_TOPOLOGY_DEMOTE_AFTER + Duration::from_millis(200));
+            if EMPTY_TOPOLOGY_SINCE.lock().unwrap().is_none() {
+                return;
+            }
+            match query_displays() {
+                Ok(list) => swap_available_displays(list),
+                Err(err) => log::debug!("drm: empty-topology recheck failed: {err}"),
+            }
+        });
+    if let Err(err) = spawned {
+        log::warn!("drm: could not spawn the empty-topology recheck: {err}");
     }
 }
 
@@ -2386,6 +2441,19 @@ mod drm_capturer_tests {
         assert!(!h.demoted(), "past the cooldown the display must be retried");
         h.demotes = 4;
         assert!(h.demoted(), "the backoff must still be holding it at demotion 4");
+    }
+
+    #[test]
+    fn an_empty_topology_blip_does_not_demote() {
+        // The unplug-to-force gap, measured at 5-7 s on the RPi5: the first empty sighting only
+        // starts the clock, and inside the window the verdict must hold.
+        let mut since = None;
+        assert!(!empty_topology_ready(&mut since, EMPTY_TOPOLOGY_DEMOTE_AFTER));
+        assert!(since.is_some(), "the first sighting must start the clock");
+        assert!(!empty_topology_ready(&mut since, EMPTY_TOPOLOGY_DEMOTE_AFTER));
+        // Past the window the same state demotes.
+        since = Some(Instant::now() - EMPTY_TOPOLOGY_DEMOTE_AFTER - Duration::from_secs(1));
+        assert!(empty_topology_ready(&mut since, EMPTY_TOPOLOGY_DEMOTE_AFTER));
     }
 
     #[test]

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -1749,12 +1749,20 @@ fn swap_available_displays(list: Vec<DrmDisplayInfo>) {
     let mut st = DRM_STATE.lock().unwrap();
     let mut demoted = false;
     match &*st {
-        ProbeState::Available(..) => {
+        ProbeState::Available(at, _) => {
+            // The verdict sampled above can have been replaced while the clock was being
+            // resolved: a non-empty publisher can install a newer Available in between, and an
+            // empty push that then acted on the OLD verdict's clock would demote the new one and
+            // clearing the clock afterwards would not bring it back. Only the verdict that was
+            // sampled may be demoted.
+            let same_verdict = available_since == Some(*at);
             if list.is_empty() {
-                if empty_outlived_window {
+                if empty_outlived_window && same_verdict {
                     log::info!("drm: topology empty past the settle window, marking DRM unavailable");
                     publish_probe_state(&mut st, ProbeState::Unavailable(Instant::now()));
                     demoted = true;
+                } else if !same_verdict {
+                    log::info!("drm: hotplug refresh -> 0 displays; a newer verdict landed meanwhile, keeping it");
                 } else {
                     log::info!("drm: hotplug refresh -> 0 displays; keeping the last list while the topology settles");
                 }

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -105,11 +105,11 @@ fn connectors() -> Vec<Connector> {
     // One render-node lookup per card, not per connector: a machine with eight connectors on one
     // card would otherwise walk the same directory eight times every poll.
     let mut renderable_cache: HashMap<String, bool> = HashMap::new();
-    // Ownership cannot rest on the EDID alone. If the kernel forced the connector on but never
-    // loaded the override, the connector reads `connected` with somebody else's EDID or none, and
-    // treating that as a display the operator plugged in leaves the feature inert while holding a
-    // connector it can no longer manage. Our own `edid_firmware` entry names it either way.
     let named = connectors_named_by_our_entries();
+    // Two passes, because the name fallback needs to know whether a name is unique in the topology
+    // before trusting it (`connector_is_ours`).
+    let mut raw = Vec::new();
+    let mut name_count: HashMap<String, usize> = HashMap::new();
     for e in entries.flatten() {
         let dir = e.path();
         let sysfs = e.file_name().to_string_lossy().into_owned();
@@ -121,6 +121,10 @@ fn connectors() -> Vec<Connector> {
             Some((card, name)) => (card.to_owned(), name.to_owned()),
             None => continue,
         };
+        *name_count.entry(name.clone()).or_default() += 1;
+        raw.push((dir, sysfs, card, name));
+    }
+    for (dir, sysfs, card, name) in raw {
         let connected = read_trim(&dir.join("status")).as_deref() == Some("connected");
         let renderable = *renderable_cache
             .entry(card)
@@ -131,6 +135,7 @@ fn connectors() -> Vec<Connector> {
                 &std::fs::read(dir.join("edid")).unwrap_or_default(),
                 &name,
                 &named,
+                name_count.get(&name).copied().unwrap_or(1) == 1,
             ),
             name,
             sysfs,
@@ -288,8 +293,17 @@ fn detailed_timing_1080p() -> [u8; 18] {
 /// loading our override - in which case the connector reads `connected` carrying nothing of ours,
 /// and calling that a display the operator plugged in would leave the feature inert while still
 /// holding a connector it can no longer release.
-fn connector_is_ours(connected: bool, edid: &[u8], name: &str, named: &[String]) -> bool {
-    connected && (edid_bytes_are_ours(edid) || named.iter().any(|n| n == name))
+///
+/// The name fallback only counts when the name is unique in the topology: with a DP-1 on two cards,
+/// claiming both would hide a real display behind our own and the release would never fire.
+fn connector_is_ours(
+    connected: bool,
+    edid: &[u8],
+    name: &str,
+    named: &[String],
+    name_unique: bool,
+) -> bool {
+    connected && (edid_bytes_are_ours(edid) || (name_unique && named.iter().any(|n| n == name)))
 }
 
 #[allow(dead_code)]
@@ -879,15 +893,20 @@ mod tests {
         let named = vec!["HDMI-A-1".to_owned()];
 
         // The ordinary case: our EDID came back, and the name is not even needed.
-        assert!(connector_is_ours(true, &mine, "HDMI-A-1", &[]));
+        assert!(connector_is_ours(true, &mine, "HDMI-A-1", &[], true));
         // The case this exists for: forced on, override never loaded, so the connector reports
         // nothing of ours. Only our own edid_firmware entry still names it.
-        assert!(connector_is_ours(true, &[], "HDMI-A-1", &named));
+        assert!(connector_is_ours(true, &[], "HDMI-A-1", &named, true));
         // A real monitor on a connector we never named is never ours, either way round.
-        assert!(!connector_is_ours(true, &[], "DP-2", &named));
-        assert!(!connector_is_ours(true, &[], "DP-2", &[]));
+        assert!(!connector_is_ours(true, &[], "DP-2", &named, true));
+        assert!(!connector_is_ours(true, &[], "DP-2", &[], true));
         // And a disconnected connector is nobody's, whatever the parameter says.
-        assert!(!connector_is_ours(false, &mine, "HDMI-A-1", &named));
+        assert!(!connector_is_ours(false, &mine, "HDMI-A-1", &named, true));
+        // A duplicated name claims nothing by name alone: with DP-1 on two cards, the fallback
+        // would mark both ours and a real display behind one of them would never release ours.
+        assert!(!connector_is_ours(true, &[], "HDMI-A-1", &named, false));
+        // The EDID still decides when it does read back, duplicated name or not.
+        assert!(connector_is_ours(true, &mine, "HDMI-A-1", &named, false));
     }
 
     #[test]

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -6,8 +6,8 @@
 //
 // Deliberately conservative, because this writes to sysfs from the root service:
 //   - off unless the operator turns it on, on every build including the unattended one;
-//   - only a connector that currently reports no display is ever forced, on a card that has a
-//     render node, so the output is one a compositor can actually draw on;
+//   - only a connector that currently reports no display is ever forced, and only where a
+//     compositor can actually drive it (`promote_split_topology` for what that means per card);
 //   - an `edid_firmware` entry someone else configured is preserved, and if theirs already covers
 //     the connector we would have picked, we force nothing at all;
 //   - the release path gives back the connector this process forced, plus any connector still
@@ -73,8 +73,9 @@ struct Connector {
     connected: bool,
     /// The connector is reporting our own synthetic EDID, so this is one we forced.
     ours: bool,
-    /// Its card exposes a render node, so a compositor can actually draw on this device.
-    renderable: bool,
+    /// A compositor can actually drive this output: its card has a render node, or the whole
+    /// machine splits scanout and rendering between cards (`promote_split_topology`).
+    drivable: bool,
 }
 
 fn read_trim(p: &Path) -> Option<String> {
@@ -126,7 +127,7 @@ fn connectors() -> Vec<Connector> {
     }
     for (dir, sysfs, card, name) in raw {
         let connected = read_trim(&dir.join("status")).as_deref() == Some("connected");
-        let renderable = *renderable_cache
+        let drivable = *renderable_cache
             .entry(card)
             .or_insert_with_key(|c| card_is_renderable(c));
         out.push(Connector {
@@ -140,11 +141,35 @@ fn connectors() -> Vec<Connector> {
             name,
             sysfs,
             connected,
-            renderable,
+            drivable,
         });
     }
+    promote_split_topology(&mut out, system_has_render_node());
     out.sort_by(|a, b| a.sysfs.cmp(&b.sysfs));
     out
+}
+
+/// A Raspberry Pi-style SoC splits the work between two DRM devices: every connector sits on a
+/// display card with no render node (vc4) and the GPU has no connectors (v3d). There the
+/// display-only card is not a Touch Bar-like dead end but the machine's one scanout path, so as
+/// long as something in the system can render at all its connectors are drivable. On a machine
+/// where any connector already sits on a card with a render node this changes nothing.
+fn promote_split_topology(all: &mut [Connector], system_has_render_node: bool) {
+    if system_has_render_node && !all.iter().any(|c| c.drivable) {
+        for c in all.iter_mut() {
+            c.drivable = true;
+        }
+    }
+}
+
+fn system_has_render_node() -> bool {
+    std::fs::read_dir(DRM_CLASS)
+        .map(|entries| {
+            entries
+                .flatten()
+                .any(|e| e.file_name().to_string_lossy().starts_with("renderD"))
+        })
+        .unwrap_or(false)
 }
 
 /// True when nothing reports a display an operator could work on. A connector we forced does not
@@ -158,7 +183,7 @@ fn no_real_output(all: &[Connector]) -> bool {
 }
 
 fn is_real_output(c: &Connector) -> bool {
-    c.connected && !c.ours && c.renderable
+    c.connected && !c.ours && c.drivable
 }
 
 pub fn is_supported() -> bool {
@@ -469,7 +494,7 @@ fn pick_connector(all: &[Connector]) -> Option<&Connector> {
         *per_name.entry(c.name.as_str()).or_default() += 1;
     }
     let usable = |c: &&Connector| {
-        !c.connected && c.renderable && PREFERENCE.iter().any(|k| c.name.starts_with(k))
+        !c.connected && c.drivable && PREFERENCE.iter().any(|k| c.name.starts_with(k))
     };
     for kind in PREFERENCE {
         let mut of_kind: Vec<&Connector> = all
@@ -778,11 +803,7 @@ pub fn status_text(enabled: bool) -> String {
                 "disconnected"
             },
             if c.ours { " (rustdesk)" } else { "" },
-            if c.renderable {
-                ""
-            } else {
-                " (no render node)"
-            },
+            if c.drivable { "" } else { " (no render node)" },
         ));
     }
     s
@@ -928,13 +949,13 @@ mod tests {
             sysfs: sysfs.to_owned(),
             connected,
             ours,
-            renderable: true,
+            drivable: true,
         }
     }
 
     fn unrenderable(sysfs: &str, name: &str, connected: bool) -> Connector {
         Connector {
-            renderable: false,
+            drivable: false,
             ..c(sysfs, name, connected, false)
         }
     }
@@ -1032,7 +1053,7 @@ mod tests {
         // the feature must arm and pick an HDMI on a card something can render to.
         let mut all = macbook_pro_2018();
         for x in all.iter_mut() {
-            if x.renderable {
+            if x.drivable {
                 x.connected = false;
             }
         }
@@ -1040,6 +1061,58 @@ mod tests {
         assert_eq!(
             pick_connector(&all).map(|c| c.sysfs.as_str()),
             Some("card1-HDMI-A-1")
+        );
+    }
+
+    /// The measured topology of a Raspberry Pi 5 (Ubuntu 25.10, kernel 6.17): `card0` is the v3d
+    /// GPU with a render node and no connectors, `card1` is vc4 with every connector and no render
+    /// node. Nothing here owns both, which is what `promote_split_topology` exists for.
+    fn raspberry_pi_5(monitor_attached: bool) -> Vec<Connector> {
+        vec![
+            unrenderable("card1-HDMI-A-1", "HDMI-A-1", false),
+            unrenderable("card1-HDMI-A-2", "HDMI-A-2", monitor_attached),
+            unrenderable("card1-Writeback-1", "Writeback-1", false),
+            unrenderable("card1-Writeback-2", "Writeback-2", false),
+        ]
+    }
+
+    #[test]
+    fn a_split_soc_counts_its_display_card() {
+        // With a monitor attached the machine has real output and must be left alone.
+        let mut all = raspberry_pi_5(true);
+        promote_split_topology(&mut all, true);
+        assert!(!no_real_output(&all));
+        // Headless it arms, and the forceable connector is on the display-only card.
+        let mut all = raspberry_pi_5(false);
+        promote_split_topology(&mut all, true);
+        assert!(no_real_output(&all));
+        assert_eq!(
+            pick_connector(&all).map(|c| c.name.as_str()),
+            Some("HDMI-A-1")
+        );
+    }
+
+    #[test]
+    fn a_machine_with_no_render_node_at_all_is_not_promoted() {
+        let mut all = raspberry_pi_5(false);
+        promote_split_topology(&mut all, false);
+        assert!(pick_connector(&all).is_none());
+    }
+
+    #[test]
+    fn promotion_leaves_a_machine_with_hybrid_cards_alone() {
+        // The Touch Bar case: real GPUs own connectors here, so nothing gets promoted even in the
+        // arming state where every display is gone.
+        let mut all = macbook_pro_2018();
+        for x in all.iter_mut() {
+            if x.drivable {
+                x.connected = false;
+            }
+        }
+        promote_split_topology(&mut all, true);
+        assert!(
+            all.iter().any(|c| !c.drivable),
+            "the Touch Bar must stay display-only"
         );
     }
 

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -105,6 +105,11 @@ fn connectors() -> Vec<Connector> {
     // One render-node lookup per card, not per connector: a machine with eight connectors on one
     // card would otherwise walk the same directory eight times every poll.
     let mut renderable_cache: HashMap<String, bool> = HashMap::new();
+    // Ownership cannot rest on the EDID alone. If the kernel forced the connector on but never
+    // loaded the override, the connector reads `connected` with somebody else's EDID or none, and
+    // treating that as a display the operator plugged in leaves the feature inert while holding a
+    // connector it can no longer manage. Our own `edid_firmware` entry names it either way.
+    let named = connectors_named_by_our_entries();
     for e in entries.flatten() {
         let dir = e.path();
         let sysfs = e.file_name().to_string_lossy().into_owned();
@@ -121,7 +126,12 @@ fn connectors() -> Vec<Connector> {
             .entry(card)
             .or_insert_with_key(|c| card_is_renderable(c));
         out.push(Connector {
-            ours: connected && edid_is_ours(&dir.join("edid")),
+            ours: connector_is_ours(
+                connected,
+                &std::fs::read(dir.join("edid")).unwrap_or_default(),
+                &name,
+                &named,
+            ),
             name,
             sysfs,
             connected,
@@ -203,7 +213,7 @@ fn synthetic_edid() -> Vec<u8> {
     e[22] = 30; // 30 cm high
     e[23] = 0x78; // gamma 2.2
     e[24] = 0x0A; // RGB 4:4:4 + YCrCb 4:4:4, first detailed descriptor is the preferred timing
-    // Chromaticity, roughly sRGB. Cosmetic, but a parser dislikes an all-zero block.
+                  // Chromaticity, roughly sRGB. Cosmetic, but a parser dislikes an all-zero block.
     e[25..35].copy_from_slice(&[0xEE, 0x91, 0xA3, 0x54, 0x4C, 0x99, 0x26, 0x0F, 0x50, 0x54]);
     // Established timings: 640x480@60, 800x600@60, 1024x768@60.
     e[35] = 0x21;
@@ -271,6 +281,18 @@ fn detailed_timing_1080p() -> [u8; 18] {
     ]
 }
 
+/// Is this connector one we forced? Two independent records, because either can be missing.
+///
+/// The EDID is the one that survives a service restart and a process that never knew about the
+/// force. The name is the one that survives a kernel that forced the connector on without ever
+/// loading our override - in which case the connector reads `connected` carrying nothing of ours,
+/// and calling that a display the operator plugged in would leave the feature inert while still
+/// holding a connector it can no longer release.
+fn connector_is_ours(connected: bool, edid: &[u8], name: &str, named: &[String]) -> bool {
+    connected && (edid_bytes_are_ours(edid) || named.iter().any(|n| n == name))
+}
+
+#[allow(dead_code)]
 fn edid_is_ours(edid: &Path) -> bool {
     std::fs::read(edid)
         .map(|bytes| edid_bytes_are_ours(&bytes))
@@ -299,7 +321,10 @@ fn edid_path() -> PathBuf {
 /// be parsed rather than compared: a bare `ends_with` on our own file name reads a list that merely
 /// *ends* with our entry as entirely ours, and would then overwrite everything before it.
 fn edid_entries(v: &str) -> Vec<&str> {
-    v.split(',').map(str::trim).filter(|e| !e.is_empty()).collect()
+    v.split(',')
+        .map(str::trim)
+        .filter(|e| !e.is_empty())
+        .collect()
 }
 
 fn entry_is_ours(entry: &str) -> bool {
@@ -343,10 +368,7 @@ fn write_edid_param(value: &str) -> ResultType<()> {
 fn install_edid(connector: &str) -> ResultType<()> {
     let existing = read_edid_param();
     let entries = edid_entries(&existing);
-    if let Some(theirs) = entries
-        .iter()
-        .find(|e| foreign_entry_covers(e, connector))
-    {
+    if let Some(theirs) = entries.iter().find(|e| foreign_entry_covers(e, connector)) {
         bail!("edid_firmware entry '{theirs}' already covers {connector}, leaving it alone");
     }
     std::fs::create_dir_all(EDID_DIR)?;
@@ -370,10 +392,7 @@ fn uninstall_edid() {
     if !entries.iter().any(|e| entry_is_ours(e)) {
         return;
     }
-    let keep: Vec<&str> = entries
-        .into_iter()
-        .filter(|e| !entry_is_ours(e))
-        .collect();
+    let keep: Vec<&str> = entries.into_iter().filter(|e| !entry_is_ours(e)).collect();
     if let Err(e) = write_edid_param(&keep.join(",")) {
         log::warn!("headless display: cannot clear our edid_firmware entry: {e}");
         return;
@@ -436,9 +455,7 @@ fn pick_connector(all: &[Connector]) -> Option<&Connector> {
         *per_name.entry(c.name.as_str()).or_default() += 1;
     }
     let usable = |c: &&Connector| {
-        !c.connected
-            && c.renderable
-            && PREFERENCE.iter().any(|k| c.name.starts_with(k))
+        !c.connected && c.renderable && PREFERENCE.iter().any(|k| c.name.starts_with(k))
     };
     for kind in PREFERENCE {
         let mut of_kind: Vec<&Connector> = all
@@ -447,7 +464,12 @@ fn pick_connector(all: &[Connector]) -> Option<&Connector> {
             .filter(|c| c.name.starts_with(kind))
             .collect();
         // Stable and deterministic: unique names first, then sysfs order.
-        of_kind.sort_by_key(|c| (per_name.get(c.name.as_str()).copied().unwrap_or(1) > 1, &c.sysfs));
+        of_kind.sort_by_key(|c| {
+            (
+                per_name.get(c.name.as_str()).copied().unwrap_or(1) > 1,
+                &c.sysfs,
+            )
+        });
         if let Some(c) = of_kind.first() {
             return Some(c);
         }
@@ -570,6 +592,10 @@ fn disable(state: &mut State) -> ResultType<()> {
         // override already gone.
         if let Err(e) = write_status(sysfs, "detect") {
             log::warn!("headless display: cannot release {sysfs}: {e}");
+            // Put the marker back. By this point the parameter entry is already gone and, for a
+            // force whose override never loaded, so is the `ours` flag - so without this the last
+            // record of the connector disappears with the failed write and nothing ever retries.
+            state.forced.get_or_insert_with(|| sysfs.clone());
             last_err = Some(e);
         }
     }
@@ -655,12 +681,7 @@ fn tick(state: &mut State) {
             state.real_since = None;
             return;
         }
-        if state
-            .real_since
-            .get_or_insert_with(Instant::now)
-            .elapsed()
-            < REAL_OUTPUT_STABLE
-        {
+        if state.real_since.get_or_insert_with(Instant::now).elapsed() < REAL_OUTPUT_STABLE {
             return;
         }
         state.real_since = None;
@@ -743,7 +764,11 @@ pub fn status_text(enabled: bool) -> String {
                 "disconnected"
             },
             if c.ours { " (rustdesk)" } else { "" },
-            if c.renderable { "" } else { " (no render node)" },
+            if c.renderable {
+                ""
+            } else {
+                " (no render node)"
+            },
         ));
     }
     s
@@ -849,6 +874,23 @@ mod tests {
     }
 
     #[test]
+    fn a_force_whose_edid_never_loaded_is_still_ours() {
+        let mine = synthetic_edid();
+        let named = vec!["HDMI-A-1".to_owned()];
+
+        // The ordinary case: our EDID came back, and the name is not even needed.
+        assert!(connector_is_ours(true, &mine, "HDMI-A-1", &[]));
+        // The case this exists for: forced on, override never loaded, so the connector reports
+        // nothing of ours. Only our own edid_firmware entry still names it.
+        assert!(connector_is_ours(true, &[], "HDMI-A-1", &named));
+        // A real monitor on a connector we never named is never ours, either way round.
+        assert!(!connector_is_ours(true, &[], "DP-2", &named));
+        assert!(!connector_is_ours(true, &[], "DP-2", &[]));
+        // And a disconnected connector is nobody's, whatever the parameter says.
+        assert!(!connector_is_ours(false, &mine, "HDMI-A-1", &named));
+    }
+
+    #[test]
     fn a_foreign_entry_that_covers_our_connector_blocks_us() {
         assert!(foreign_entry_covers("HDMI-A-1:edid/theirs.bin", "HDMI-A-1"));
         assert!(!foreign_entry_covers("DP-1:edid/theirs.bin", "HDMI-A-1"));
@@ -880,17 +922,34 @@ mod tests {
 
     #[test]
     fn what_counts_as_real_output() {
-        assert!(no_real_output(&[c("card0-HDMI-A-1", "HDMI-A-1", false, false)]));
+        assert!(no_real_output(&[c(
+            "card0-HDMI-A-1",
+            "HDMI-A-1",
+            false,
+            false
+        )]));
         assert!(
             no_real_output(&[c("card0-HDMI-A-1", "HDMI-A-1", true, true)]),
             "our own display must not stop the tick from releasing it"
         );
-        assert!(!no_real_output(&[c("card0-HDMI-A-1", "HDMI-A-1", true, false)]));
-        assert!(!no_real_output(&[]), "no connectors at all is not the headless case");
+        assert!(!no_real_output(&[c(
+            "card0-HDMI-A-1",
+            "HDMI-A-1",
+            true,
+            false
+        )]));
+        assert!(
+            !no_real_output(&[]),
+            "no connectors at all is not the headless case"
+        );
         // The MacBook Touch Bar is permanently connected on a card with no render node. Counting it
         // as real output would stop the feature from ever arming there, and would make it release a
         // working forced display in favour of an output nothing can draw on.
-        assert!(no_real_output(&[unrenderable("card0-USB-1", "USB-1", true)]));
+        assert!(no_real_output(&[unrenderable(
+            "card0-USB-1",
+            "USB-1",
+            true
+        )]));
     }
 
     #[test]
@@ -901,7 +960,10 @@ mod tests {
             c("card0-VGA-1", "VGA-1", false, false),
             c("card0-HDMI-A-2", "HDMI-A-2", false, false),
         ];
-        assert_eq!(pick_connector(&all).map(|c| c.name.as_str()), Some("HDMI-A-2"));
+        assert_eq!(
+            pick_connector(&all).map(|c| c.name.as_str()),
+            Some("HDMI-A-2")
+        );
 
         // Nothing forceable: an internal panel and a writeback are not outputs to offer.
         assert!(pick_connector(&[
@@ -974,7 +1036,10 @@ mod tests {
             c("card1-DP-9", "DP-9", false, false),
             c("card2-DP-1", "DP-1", false, false),
         ];
-        assert_eq!(pick_connector(&all).map(|c| c.sysfs.as_str()), Some("card1-DP-9"));
+        assert_eq!(
+            pick_connector(&all).map(|c| c.sysfs.as_str()),
+            Some("card1-DP-9")
+        );
         // But a duplicated name is still better than no display at all.
         let only_dupes = vec![
             c("card1-DP-1", "DP-1", false, false),

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -746,6 +746,17 @@ fn tick(state: &mut State) {
         return;
     }
 
+    // Reaching here with our firmware entry still present means ownership could not be attributed
+    // to ANY connector: not by EDID, not by a unique name, not by this process's record (a restart
+    // cleared it, and a rebind can have twinned the name since). An unattributable hold cannot be
+    // managed - left alone it counts as a real output and wedges both arming and release - so give
+    // it back; the next tick re-forces cleanly if the machine is truly headless.
+    if state.forced.is_none() && !connectors_named_by_our_entries().is_empty() {
+        log::info!("headless display: releasing a hold this process cannot attribute");
+        let _ = disable(state);
+        return;
+    }
+
     match state.last_failure {
         Some(t) if t.elapsed() < RETRY_AFTER_FAILURE => return,
         Some(_) => state.last_failure = None,

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -183,7 +183,9 @@ fn no_real_output(all: &[Connector]) -> bool {
 }
 
 fn is_real_output(c: &Connector) -> bool {
-    c.connected && !c.ours && c.drivable
+    // A writeback connector can read `connected` (a capture sink, not a display anyone watches),
+    // and counting it would both block arming and prematurely release a held connector.
+    c.connected && !c.ours && c.drivable && !c.name.starts_with("Writeback")
 }
 
 pub fn is_supported() -> bool {
@@ -483,10 +485,9 @@ fn wait_for(sysfs: &str, connected: bool) -> bool {
 /// only a kind of output a headless machine plausibly has a cable for - `Writeback` is not an output
 /// at all, and an internal panel has nothing behind it.
 ///
-/// Among equals it prefers a name that appears on only one card, because `edid_firmware` matches a
-/// bare connector name with no card qualifier. That is insurance rather than a measured fix: on the
-/// multi-GPU machine to hand the two cards number their DisplayPort connectors DP-1..DP-3 and
-/// DP-4..DP-7, so nothing collides.
+/// A name duplicated across cards is REFUSED outright, not deprioritized: `edid_firmware` matches
+/// the bare name, so forcing one twin puts our EDID on the other card's connector at its next
+/// probe, and a monitor plugged there would classify as ours and never trigger the release.
 fn pick_connector(all: &[Connector]) -> Option<&Connector> {
     const PREFERENCE: &[&str] = &["HDMI", "DP-", "DVI", "VGA"];
     let mut per_name: HashMap<&str, usize> = HashMap::new();
@@ -494,7 +495,10 @@ fn pick_connector(all: &[Connector]) -> Option<&Connector> {
         *per_name.entry(c.name.as_str()).or_default() += 1;
     }
     let usable = |c: &&Connector| {
-        !c.connected && c.drivable && PREFERENCE.iter().any(|k| c.name.starts_with(k))
+        !c.connected
+            && c.drivable
+            && per_name.get(c.name.as_str()).copied().unwrap_or(1) == 1
+            && PREFERENCE.iter().any(|k| c.name.starts_with(k))
     };
     for kind in PREFERENCE {
         let mut of_kind: Vec<&Connector> = all
@@ -502,13 +506,7 @@ fn pick_connector(all: &[Connector]) -> Option<&Connector> {
             .filter(usable)
             .filter(|c| c.name.starts_with(kind))
             .collect();
-        // Stable and deterministic: unique names first, then sysfs order.
-        of_kind.sort_by_key(|c| {
-            (
-                per_name.get(c.name.as_str()).copied().unwrap_or(1) > 1,
-                &c.sysfs,
-            )
-        });
+        of_kind.sort_by_key(|c| &c.sysfs);
         if let Some(c) = of_kind.first() {
             return Some(c);
         }
@@ -700,6 +698,21 @@ pub fn start_watcher() {
 /// config and the user `--server` syncs it to this process over `ipc_service` in well under a second,
 /// and `--headless-display` pushes it here itself, so the in-memory value is the one that reflects
 /// what the operator just asked for.
+/// Overlay the process's own record of what it forced onto the sysfs view: while the connector
+/// settles - or when the override never loaded on it - sysfs cannot name it ours, and without
+/// this the tick would re-force it and count it as a real output. Matched by the card-qualified
+/// sysfs name, never the bare one.
+fn adopt_forced(all: &mut [Connector], forced: Option<&str>) {
+    let Some(forced) = forced else {
+        return;
+    };
+    for c in all.iter_mut() {
+        if c.sysfs == forced {
+            c.ours = true;
+        }
+    }
+}
+
 fn tick(state: &mut State) {
     if !is_enabled() {
         // Turned off, or never on. Give back anything we are still holding, then stay out of sysfs.
@@ -708,10 +721,14 @@ fn tick(state: &mut State) {
         }
         state.no_output_since = None;
         state.last_failure = None;
+        // A release timer started before the toggle must not survive it, or a later re-enable
+        // skips the stability delay.
+        state.real_since = None;
         return;
     }
 
-    let all = connectors();
+    let mut all = connectors();
+    adopt_forced(&mut all, state.forced.as_deref());
     if all.iter().any(|c| c.ours) {
         // A real display takes precedence over ours: release it, and the machine goes back to the
         // output the operator actually plugged in. Only visible for a connector other than the one we
@@ -1117,12 +1134,11 @@ mod tests {
     }
 
     #[test]
-    fn a_name_that_exists_on_two_cards_loses_to_a_unique_one() {
-        // `edid_firmware` matches a bare connector name with no card qualifier, so forcing a
-        // duplicated name would put our EDID on whichever card the kernel probes first. This is
-        // insurance, not a fix for something measured: the multi-GPU machine to hand numbers its
-        // DisplayPort connectors DP-1..DP-3 on one card and DP-4..DP-7 on the other, so no collision
-        // occurs there.
+    fn a_name_that_exists_on_two_cards_is_refused_outright() {
+        // `edid_firmware` matches a bare connector name with no card qualifier: forcing one twin
+        // puts our EDID on the other card's connector at its next probe, and a monitor plugged
+        // there would classify as ours and never trigger the release. So a duplicated name is not
+        // deprioritized, it is unusable - even when the alternative is forcing nothing.
         let all = vec![
             c("card1-DP-1", "DP-1", false, false),
             c("card1-DP-9", "DP-9", false, false),
@@ -1132,14 +1148,36 @@ mod tests {
             pick_connector(&all).map(|c| c.sysfs.as_str()),
             Some("card1-DP-9")
         );
-        // But a duplicated name is still better than no display at all.
         let only_dupes = vec![
             c("card1-DP-1", "DP-1", false, false),
             c("card2-DP-1", "DP-1", false, false),
         ];
-        assert_eq!(
-            pick_connector(&only_dupes).map(|c| c.sysfs.as_str()),
-            Some("card1-DP-1")
-        );
+        assert!(pick_connector(&only_dupes).is_none());
+    }
+
+    #[test]
+    fn a_connected_writeback_neither_blocks_arming_nor_releases_a_hold() {
+        // vc4 writebacks can read `connected`; a capture sink is not a display anyone watches.
+        let wb = c("card1-Writeback-1", "Writeback-1", true, false);
+        assert!(no_real_output(&[wb]));
+    }
+
+    #[test]
+    fn the_forced_record_outranks_sysfs() {
+        // While the forced connector settles (or when its override never loaded), sysfs cannot
+        // call it ours; the process's own record must, or the tick re-forces and miscounts it.
+        let mut all = vec![
+            c("card1-HDMI-A-1", "HDMI-A-1", true, false),
+            c("card1-HDMI-A-2", "HDMI-A-2", false, false),
+        ];
+        adopt_forced(&mut all, Some("card1-HDMI-A-1"));
+        assert!(all[0].ours, "the held connector is adopted by sysfs name");
+        assert!(!all[1].ours);
+        // And the bare name must not match: the record is card-qualified.
+        let mut all2 = vec![c("card1-HDMI-A-1", "HDMI-A-1", true, false)];
+        adopt_forced(&mut all2, Some("HDMI-A-1"));
+        assert!(!all2[0].ours);
+        adopt_forced(&mut all2, None);
+        assert!(!all2[0].ours);
     }
 }

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -59,6 +59,10 @@ const SETTLE_STEP: Duration = Duration::from_millis(50);
 /// CRTC-bound: on single-CRTC hardware the compositor cannot bind it until ours is released, so that
 /// condition would never come true.
 const REAL_OUTPUT_STABLE: Duration = Duration::from_secs(2);
+
+/// How often a held connector is re-probed to see whether a display has been plugged into it.
+/// Bounds how long such a display stays invisible; see `real_display_probe_due`.
+const HELD_CONNECTOR_PROBE_INTERVAL: Duration = Duration::from_secs(300);
 /// Backoff after a failed attempt. Nothing that makes `enable` fail is transient - a topology with
 /// no forceable connector stays that way - so retrying on the next poll would only produce a warning
 /// every few seconds for the life of the service.
@@ -671,6 +675,9 @@ struct State {
     /// When a real display was first seen while we were holding a connector. The release waits for
     /// it, see `REAL_OUTPUT_STABLE`.
     real_since: Option<Instant>,
+    /// When the held connector was last re-probed for a display of its own, see
+    /// `real_display_probe_due`.
+    last_probe: Option<Instant>,
 }
 
 /// One connector this process holds, with everything needed to recognise it again. The sysfs
@@ -961,6 +968,54 @@ fn adopt_forced(all: &mut [Connector], forced: &[Held]) {
     }
 }
 
+/// Whether the held connector is due a probe of its own.
+///
+/// Never while a capture is open: the probe drops the force for a moment, and on a single-output
+/// machine that empties the topology, which restarts the video service of whoever is watching. So
+/// this waits for a machine nobody is looking at - which is also exactly when it matters, since the
+/// display it is looking for is no use to anybody while a remote session is already running.
+fn real_display_probe_due(last: Option<Instant>, capture_active: bool) -> bool {
+    if capture_active {
+        return false;
+    }
+    match last {
+        None => true,
+        Some(t) => t.elapsed() >= HELD_CONNECTOR_PROBE_INTERVAL,
+    }
+}
+
+/// Drop the force on each held connector for one probe and see what it says on its own.
+///
+/// Only the FORCE comes off; the override stays installed, so a connector with a display on it
+/// comes back `connected` and one with nothing comes back `disconnected`. That is the whole
+/// question, and it is answered without touching the parameter, so nothing else has to be undone if
+/// this fails halfway.
+fn probe_held_connectors(state: &mut State) {
+    let held: Vec<String> = connectors()
+        .into_iter()
+        .filter(|c| c.ours)
+        .map(|c| c.sysfs)
+        .collect();
+    for sysfs in held {
+        if let Err(e) = write_status(&sysfs, "detect") {
+            log::warn!("headless display: cannot probe {sysfs} for a display of its own: {e}");
+            continue;
+        }
+        let connected = wait_for(&sysfs, true);
+        if connected {
+            log::info!(
+                "headless display: {sysfs} reports a display of its own; giving the connector back"
+            );
+            let _ = disable(state);
+            return;
+        }
+        // Nothing there. Put the force back; the override never came off, so this is one write.
+        if let Err(e) = write_status(&sysfs, "on") {
+            log::warn!("headless display: cannot re-force {sysfs} after probing it: {e}");
+        }
+    }
+}
+
 /// Bring the markers back in line with the machine, in one pass with enumerated outcomes.
 ///
 /// Two things go wrong on their own. A marker can name a connector INSTANCE that no longer exists:
@@ -1069,8 +1124,10 @@ fn tick(state: &mut State) {
         state.no_output_since = None;
         state.last_failure = None;
         // A release timer started before the toggle must not survive it, or a later re-enable
-        // skips the stability delay.
+        // skips the stability delay. The probe clock goes with it, so a re-enable looks at once
+        // rather than waiting out an interval that started under the old setting.
         state.real_since = None;
+        state.last_probe = None;
         return;
     }
 
@@ -1081,10 +1138,18 @@ fn tick(state: &mut State) {
     adopt_forced(&mut all, &state.forced);
     if all.iter().any(|c| c.ours) {
         // A real display takes precedence over ours: release it, and the machine goes back to the
-        // output the operator actually plugged in. Only visible for a connector other than the one we
-        // are holding, because ours is what that connector reports.
+        // output the operator actually plugged in. A connector OTHER than the one we hold shows
+        // that by itself; the one we hold cannot, because the kernel serves our override for it -
+        // so a monitor plugged into that port would stay invisible for the rest of the boot, and on
+        // a machine with one output, which is the machine this feature is for, that is its only
+        // display. Measured on such a box: it had a monitor attached the whole time and our EDID
+        // was what everything read. So the held connector gets re-probed on its own.
         if !all.iter().any(is_real_output) {
             state.real_since = None;
+            if real_display_probe_due(state.last_probe, crate::ipc::drm_capture_active()) {
+                state.last_probe = Some(Instant::now());
+                probe_held_connectors(state);
+            }
             return;
         }
         if state.real_since.get_or_insert_with(Instant::now).elapsed() < REAL_OUTPUT_STABLE {
@@ -1358,6 +1423,24 @@ mod tests {
             marker_action("DP-9", &Marker::Legacy, &live),
             MarkerAction::Drop { reprobe: false }
         );
+    }
+
+    // rustdesk#15908: the connector we hold is the one place a display can appear without us being
+    // able to see it, because the kernel serves our override for it. So it gets probed - but never
+    // while somebody is capturing, since the probe empties the topology for a moment and that
+    // restarts their video service.
+    #[test]
+    fn the_held_connector_is_probed_only_while_nobody_is_watching() {
+        let long_ago = Instant::now() - HELD_CONNECTOR_PROBE_INTERVAL;
+        // Never probed: look now.
+        assert!(real_display_probe_due(None, false));
+        // ...but not with a capture open, however overdue it is.
+        assert!(!real_display_probe_due(None, true));
+        assert!(!real_display_probe_due(Some(long_ago), true));
+        // Interval elapsed on an idle machine: look.
+        assert!(real_display_probe_due(Some(long_ago), false));
+        // Just looked: leave it alone, or every poll would blip the topology.
+        assert!(!real_display_probe_due(Some(Instant::now()), false));
     }
 
     // rustdesk#15908: a device identity has to survive being put in a file name without two

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -73,9 +73,12 @@ struct Connector {
     connected: bool,
     /// The connector is reporting our own synthetic EDID, so this is one we forced.
     ours: bool,
-    /// The card's stable bus identity, see `device_id`. Ownership is recorded against this and
-    /// not against the connector name alone, which the kernel re-issues after a rebind.
-    device: String,
+    /// The card's stable bus identity, see `device_id`. `None` when sysfs does not say, and a
+    /// connector with no identity is never claimed.
+    device: Option<String>,
+    /// The connector's KMS object id, see `connector_instance_id`. With `device` it names the
+    /// connector INSTANCE; the pair is what a marker records.
+    id: Option<String>,
     /// A compositor can actually drive this output: its card has a render node, or the whole
     /// machine splits scanout and rendering between cards (`promote_split_topology`).
     drivable: bool,
@@ -100,28 +103,39 @@ fn card_is_renderable(card: &str) -> bool {
         .any(|e| e.file_name().to_string_lossy().starts_with("renderD"))
 }
 
-/// The stable identity of the DRM device a card sits on: the name of the bus device it hangs off
-/// (`0000:01:00.0` on PCI, `fec00000.v3d` on a SoC), sanitised so it can live in a file name.
+/// A stable identity for the DRM device a card sits on, as a short token that can live in a file
+/// name. The FULL symlink target is hashed rather than trimmed: two different bus paths can share a
+/// basename, and a lossy transformation would let them collide into one identity.
+///
+/// `None` when sysfs does not say. A hold is then refused rather than recorded against an identity
+/// that other cards could share.
+///
 /// `cardN` cannot play this role - the minor comes from an allocator that recycles, measured on a
 /// MacBook whose Touch Bar connector was `card0-USB-1` one boot and `card3-USB-2` the next.
-///
-/// `unknown` when sysfs does not say. Two such cards then share an identity, which is the
-/// unqualified behaviour rather than a refusal to work.
-fn device_id(card: &str) -> String {
-    let sanitised = std::fs::read_link(Path::new(DRM_CLASS).join(card).join("device"))
-        .ok()
-        .and_then(|t| t.file_name().map(|n| n.to_string_lossy().into_owned()))
-        .map(|n| {
-            n.chars()
-                .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-                .collect::<String>()
-        })
-        .unwrap_or_default();
-    if sanitised.is_empty() {
-        "unknown".to_owned()
-    } else {
-        sanitised
+fn device_id(card: &str) -> Option<String> {
+    let target = std::fs::read_link(Path::new(DRM_CLASS).join(card).join("device")).ok()?;
+    Some(fnv1a(target.to_string_lossy().as_bytes()))
+}
+
+/// FNV-1a, written out because the marker has to be readable by a LATER build: `DefaultHasher` is
+/// explicitly not stable across releases, so a hold recorded with it would stop being recognised
+/// after an upgrade.
+fn fnv1a(bytes: &[u8]) -> String {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in bytes {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
     }
+    format!("{h:016x}")
+}
+
+/// The connector's KMS object id - the number `drmModeGetConnector` takes, exposed as
+/// `connector_id` in sysfs. This is what identifies the connector INSTANCE: the kernel returns a
+/// connector's name to its type allocator when the connector goes, so a later connector on the same
+/// card can carry the same name, and the device id alone would not tell them apart. Measured on an
+/// Iris Xe: 508/518/528 for the three connectors, unchanged across a re-probe.
+fn connector_instance_id(sysfs: &str) -> Option<String> {
+    read_trim(&Path::new(DRM_CLASS).join(sysfs).join("connector_id")).filter(|s| !s.is_empty())
 }
 
 /// Every connector of every card, with the facts the rest of this module decides on.
@@ -152,7 +166,7 @@ fn connectors() -> Vec<Connector> {
         *name_count.entry(name.clone()).or_default() += 1;
         raw.push((dir, sysfs, card, name));
     }
-    let mut device_cache: HashMap<String, String> = HashMap::new();
+    let mut device_cache: HashMap<String, Option<String>> = HashMap::new();
     for (dir, sysfs, card, name) in raw {
         let connected = read_trim(&dir.join("status")).as_deref() == Some("connected");
         let drivable = *renderable_cache
@@ -162,12 +176,14 @@ fn connectors() -> Vec<Connector> {
             .entry(card)
             .or_insert_with_key(|c| device_id(c))
             .clone();
+        let id = connector_instance_id(&sysfs);
         out.push(Connector {
             ours: connector_is_ours(
                 connected,
                 &std::fs::read(dir.join("edid")).unwrap_or_default(),
                 &name,
-                &device,
+                device.as_deref(),
+                id.as_deref(),
                 &named,
                 name_count.get(&name).copied().unwrap_or(1) == 1,
             ),
@@ -175,6 +191,7 @@ fn connectors() -> Vec<Connector> {
             sysfs,
             connected,
             device,
+            id,
             drivable,
         });
     }
@@ -361,8 +378,9 @@ fn connector_is_ours(
     connected: bool,
     edid: &[u8],
     name: &str,
-    device: &str,
-    named: &[(String, String)],
+    device: Option<&str>,
+    id: Option<&str>,
+    named: &[(String, Marker)],
     name_unique: bool,
 ) -> bool {
     connected
@@ -370,7 +388,7 @@ fn connector_is_ours(
             || (name_unique
                 && named
                     .iter()
-                    .any(|(n, d)| n == name && (d.is_empty() || d == device))))
+                    .any(|(n, m)| n == name && m.claims(device, id))))
 }
 
 #[allow(dead_code)]
@@ -394,22 +412,13 @@ fn edid_bytes_are_ours(bytes: &[u8]) -> bool {
         && bytes[d + 5..].starts_with(EDID_MONITOR_NAME)
 }
 
-/// One firmware file per device, so the entry itself says which device the hold is on. The bare
-/// name is what an earlier build wrote; it is still ours, it just carries no device.
-fn edid_file_name(device: &str) -> String {
-    if device.is_empty() {
-        format!("{EDID_NAME_PREFIX}.bin")
-    } else {
-        format!("{EDID_NAME_PREFIX}-{device}.bin")
-    }
+/// One firmware file per connector instance, so the entry itself says what the hold is on.
+fn edid_firmware_ref(marker: &Marker) -> String {
+    format!("{EDID_DIR_REF}{}", marker.file_name())
 }
 
-fn edid_firmware_ref(device: &str) -> String {
-    format!("{EDID_DIR_REF}{}", edid_file_name(device))
-}
-
-fn edid_path(device: &str) -> PathBuf {
-    Path::new(EDID_DIR).join(edid_file_name(device))
+fn edid_path(marker: &Marker) -> PathBuf {
+    Path::new(EDID_DIR).join(marker.file_name())
 }
 
 /// `edid_firmware` is a comma-separated list of `[<connector>:]<file>` entries, so the value has to
@@ -431,20 +440,58 @@ fn entry_connector(entry: &str) -> Option<&str> {
     entry.split_once(':').map(|(target, _)| target)
 }
 
-/// The device an entry records the hold against, or `None` when the entry is not ours at all.
-/// `Some("")` is the unqualified form an earlier build wrote: ours, but not device-checkable.
-fn entry_device(entry: &str) -> Option<&str> {
-    let file = entry_file(entry).strip_prefix(EDID_DIR_REF)?;
-    let rest = file.strip_prefix(EDID_NAME_PREFIX)?.strip_suffix(".bin")?;
-    match rest.strip_prefix('-') {
-        Some(device) if !device.is_empty() => Some(device),
-        _ if rest.is_empty() => Some(""),
-        _ => None,
+/// What one of our markers records about the connector it holds.
+///
+/// `Legacy` is the unqualified form an earlier build wrote. It is still ours, so a machine upgraded
+/// mid-hold can still give the connector back, but it names no instance - so the first pass that
+/// can attribute it rewrites it, and a pass that cannot drops it. It is never left standing as a
+/// permanent wildcard.
+#[derive(Clone, Debug, PartialEq)]
+enum Marker {
+    Legacy,
+    Instance { device: String, id: String },
+}
+
+impl Marker {
+    /// Does this marker claim the connector with this identity? A connector that cannot state its
+    /// own identity is claimed by nothing.
+    fn claims(&self, device: Option<&str>, id: Option<&str>) -> bool {
+        match self {
+            Marker::Legacy => true,
+            Marker::Instance { device: d, id: i } => {
+                device == Some(d.as_str()) && id == Some(i.as_str())
+            }
+        }
+    }
+
+    fn file_name(&self) -> String {
+        match self {
+            Marker::Legacy => format!("{EDID_NAME_PREFIX}.bin"),
+            Marker::Instance { device, id } => format!("{EDID_NAME_PREFIX}-{device}-{id}.bin"),
+        }
     }
 }
 
+/// The marker an entry carries, or `None` when the entry is not ours at all.
+fn entry_marker(entry: &str) -> Option<Marker> {
+    let file = entry_file(entry).strip_prefix(EDID_DIR_REF)?;
+    let rest = file.strip_prefix(EDID_NAME_PREFIX)?.strip_suffix(".bin")?;
+    if rest.is_empty() {
+        return Some(Marker::Legacy);
+    }
+    // `<device>-<id>`: both halves are our own alphanumeric tokens, so the LAST dash splits them.
+    let (device, id) = rest.strip_prefix('-')?.rsplit_once('-')?;
+    if device.is_empty() || id.is_empty() {
+        return None;
+    }
+    Some(Marker::Instance {
+        device: device.to_owned(),
+        id: id.to_owned(),
+    })
+}
+
 fn entry_is_ours(entry: &str) -> bool {
-    entry_device(entry).is_some()
+    entry_marker(entry).is_some()
 }
 
 /// Does an entry we did not write already govern this connector? An entry with no `<connector>:`
@@ -481,15 +528,15 @@ fn write_edid_param(value: &str) -> ResultType<()> {
 /// Add our entry for one connector, keeping every entry somebody else put there. Refuses if a
 /// foreign entry already governs this connector: overriding it would change what that connector
 /// reports, which is not ours to do.
-fn install_edid(connector: &str, device: &str) -> ResultType<()> {
+fn install_edid(connector: &str, marker: &Marker) -> ResultType<()> {
     let existing = read_edid_param();
     let entries = edid_entries(&existing);
     if let Some(theirs) = entries.iter().find(|e| foreign_entry_covers(e, connector)) {
         bail!("edid_firmware entry '{theirs}' already covers {connector}, leaving it alone");
     }
     std::fs::create_dir_all(EDID_DIR)?;
-    std::fs::write(edid_path(device), synthetic_edid())?;
-    let mine = format!("{connector}:{}", edid_firmware_ref(device));
+    std::fs::write(edid_path(marker), synthetic_edid())?;
+    let mine = format!("{connector}:{}", edid_firmware_ref(marker));
     // Only our entry for THIS connector is replaced. A release that fails on several connectors
     // has to be able to record every one of them, and dropping the rest here would lose all but
     // the last.
@@ -519,14 +566,14 @@ fn drop_our_entries(mut which: impl FnMut(&str) -> bool) {
         return;
     }
     for e in &mine {
-        let Some(device) = entry_device(e) else {
+        let Some(marker) = entry_marker(e) else {
             continue;
         };
         // Another entry of ours can still point at the same file.
-        if keep.iter().any(|k| entry_device(k) == Some(device)) {
+        if keep.iter().any(|k| entry_marker(k).as_ref() == Some(&marker)) {
             continue;
         }
-        let _ = std::fs::remove_file(edid_path(device));
+        let _ = std::fs::remove_file(edid_path(&marker));
     }
 }
 
@@ -539,13 +586,10 @@ fn uninstall_edid() {
 /// This is the only record left of a force whose EDID never actually loaded: the connector reads
 /// `connected` either way, so nothing marks it as ours, and `State` is empty after a service
 /// restart. Reading it back before the entries are removed is what keeps such a force releasable.
-fn connectors_named_by_our_entries() -> Vec<(String, String)> {
+fn connectors_named_by_our_entries() -> Vec<(String, Marker)> {
     edid_entries(&read_edid_param())
         .into_iter()
-        .filter_map(|e| {
-            let device = entry_device(e)?;
-            Some((entry_connector(e)?.to_owned(), device.to_owned()))
-        })
+        .filter_map(|e| Some((entry_connector(e)?.to_owned(), entry_marker(e)?)))
         .collect()
 }
 
@@ -617,8 +661,9 @@ struct State {
     /// The connectors this process forced, so a release does not depend only on the kernel still
     /// reporting our EDID. If a driver drops the override, the marker goes with it and nothing else
     /// would remember which connector to give back. A list, because a release that fails on more
-    /// than one must not remember only the first.
-    forced: Vec<String>,
+    /// than one must not remember only the first, and each entry carries the full identity: the
+    /// sysfs name alone is recycled, so a bare record would re-adopt a stranger.
+    forced: Vec<Held>,
     /// When the machine first reported no output, which is what the stable period is measured from.
     no_output_since: Option<Instant>,
     /// When forcing last failed, so a host where it cannot work is not retried every poll.
@@ -626,6 +671,26 @@ struct State {
     /// When a real display was first seen while we were holding a connector. The release waits for
     /// it, see `REAL_OUTPUT_STABLE`.
     real_since: Option<Instant>,
+}
+
+/// One connector this process holds, with everything needed to recognise it again. The sysfs
+/// directory is what a write targets, the name is what `edid_firmware` matches, and the marker is
+/// what says WHICH connector instance - both halves of it get recycled on their own.
+#[derive(Clone, Debug, PartialEq)]
+struct Held {
+    sysfs: String,
+    name: String,
+    marker: Marker,
+}
+
+/// The identity of a live connector, or `None` when it cannot state one. A connector that cannot be
+/// identified is never forced and never adopted: a marker recorded against a shared identity would
+/// follow the name onto a stranger, which is the whole failure the marker exists to prevent.
+fn marker_of(c: &Connector) -> Option<Marker> {
+    Some(Marker::Instance {
+        device: c.device.clone()?,
+        id: c.id.clone()?,
+    })
 }
 
 /// Install our EDID on one connector and force it on. No policy: the caller has already decided.
@@ -638,8 +703,9 @@ struct State {
 /// `status == connected` is as far as this can go. Binding a CRTC to the connector is the
 /// compositor's decision, and there is no sysfs attribute to wait on for it, so the log says what
 /// was forced and not that anything is being scanned out.
-fn force_on(state: &mut State, name: &str, sysfs: &str, device: &str) -> ResultType<()> {
-    install_edid(name, device)?;
+fn force_on(state: &mut State, held: &Held) -> ResultType<()> {
+    let (name, sysfs) = (held.name.as_str(), held.sysfs.as_str());
+    install_edid(name, &held.marker)?;
     if let Err(e) = write_status(sysfs, "on") {
         // Roll back, or the override outlives the attempt: nothing would be forced, so nothing would
         // look like ours, and a monitor later plugged into that connector would be described by an
@@ -647,7 +713,7 @@ fn force_on(state: &mut State, name: &str, sysfs: &str, device: &str) -> ResultT
         uninstall_edid();
         return Err(e);
     }
-    state.forced = vec![sysfs.to_owned()];
+    state.forced = vec![held.clone()];
     let settled = wait_for(sysfs, true);
     log::info!(
         "headless display: forced {sysfs} on with a 1920x1080 edid{}",
@@ -665,7 +731,7 @@ fn force_on(state: &mut State, name: &str, sysfs: &str, device: &str) -> ResultT
             "headless display: {sysfs} is on but is not reporting our edid, so the kernel did not \
              load {} (check the firmware search path). The display works with the kernel default \
              modes; releasing it relies on the edid_firmware entry instead.",
-            edid_firmware_ref(device)
+            edid_firmware_ref(&held.marker)
         );
     }
     Ok(())
@@ -678,20 +744,35 @@ fn enable(state: &mut State) -> ResultType<String> {
         bail!("no DRM connectors on this machine");
     }
     if let Some(c) = all.iter().find(|c| c.ours) {
-        state.forced = vec![c.sysfs.clone()];
+        if let Some(marker) = marker_of(c) {
+            state.forced = vec![Held {
+                sysfs: c.sysfs.clone(),
+                name: c.name.clone(),
+                marker,
+            }];
+        }
         return Ok(c.sysfs.clone());
     }
     if all.iter().any(is_real_output) {
         bail!("a display is already attached, nothing to force");
     }
     let target = pick_connector(&all).ok_or_else(|| anyhow!("no connector to force"))?;
-    let (name, sysfs, device) = (
-        target.name.clone(),
-        target.sysfs.clone(),
-        target.device.clone(),
-    );
-    force_on(state, &name, &sysfs, &device)?;
-    Ok(sysfs)
+    // A connector that cannot state its identity is not forced at all: the marker would have to be
+    // written against something other cards could share, and it would then follow the name onto a
+    // stranger after a rebind.
+    let marker = marker_of(target).ok_or_else(|| {
+        anyhow!(
+            "{} cannot be identified (no device link or connector_id in sysfs), refusing to force it",
+            target.sysfs
+        )
+    })?;
+    let held = Held {
+        sysfs: target.sysfs.clone(),
+        name: target.name.clone(),
+        marker,
+    };
+    force_on(state, &held)?;
+    Ok(held.sysfs)
 }
 
 /// Release what we forced, and only that: connectors still carrying our EDID, plus the one this
@@ -703,26 +784,25 @@ fn disable(state: &mut State) -> ResultType<()> {
     for c in all.iter().filter(|c| c.ours) {
         add_target(&mut targets, &all, &c.sysfs);
     }
-    for sysfs in std::mem::take(&mut state.forced) {
-        add_target(&mut targets, &all, &sysfs);
+    for h in std::mem::take(&mut state.forced) {
+        add_target(&mut targets, &all, &h.sysfs);
     }
     // Read the parameter while it still exists. A force whose EDID never loaded leaves no other
     // trace, and the entries below are about to go - which would leave the connector forced for the
-    // rest of the boot with nothing able to name it. The name resolves against the live list, and
-    // connector indices come from a per-type ida that is global to drm.ko, so two live connectors
-    // never share a name; the device qualifier is what keeps a name the kernel re-issued after a
-    // rebind from resolving to somebody else's connector.
-    for (name, device) in connectors_named_by_our_entries() {
+    // rest of the boot with nothing able to name it. A marker only resolves to the connector it
+    // actually names: both the card minor and the connector name get recycled, so the device and
+    // the KMS object id are what keep it from landing on somebody else's connector.
+    for (name, marker) in connectors_named_by_our_entries() {
         for c in all
             .iter()
-            .filter(|c| c.name == name && (device.is_empty() || c.device == device))
+            .filter(|c| c.name == name && marker.claims(c.device.as_deref(), c.id.as_deref()))
         {
             add_target(&mut targets, &all, &c.sysfs);
         }
     }
     let mut last_err = None;
     let mut released: Vec<String> = Vec::new();
-    let mut held: Vec<String> = Vec::new();
+    let mut still_held: Vec<String> = Vec::new();
     for t in &targets {
         // The override comes off before the unforce, or the re-probe would read our EDID straight
         // back and a real monitor on that connector would keep being described by it. One entry at
@@ -732,17 +812,31 @@ fn disable(state: &mut State) -> ResultType<()> {
         if let Err(e) = write_status(&t.sysfs, "detect") {
             log::warn!("headless display: cannot release {}: {e}", t.sysfs);
             // Put the marker back. The parameter entry is what survives this process and, for a
-            // force whose override never loaded, it is the only record there is. If this write
-            // fails too the hold lives on in `state.forced` alone and a restart loses it, which is
-            // as far as a machine refusing both writes can be carried.
-            if let Err(e) = install_edid(&t.name, &t.device) {
-                log::warn!(
-                    "headless display: cannot re-record the hold on {}: {e}",
+            // force whose override never loaded, it is the only record there is. A target whose
+            // connector is gone has no identity to record, and an unqualified marker would follow
+            // the name onto whatever appears next, so that one is left to the process record alone.
+            match &t.marker {
+                Some(marker) => {
+                    if let Err(e) = install_edid(&t.name, marker) {
+                        log::warn!(
+                            "headless display: cannot re-record the hold on {}: {e}",
+                            t.sysfs
+                        );
+                    } else {
+                        still_held.push(t.name.clone());
+                    }
+                    state.forced.push(Held {
+                        sysfs: t.sysfs.clone(),
+                        name: t.name.clone(),
+                        marker: marker.clone(),
+                    });
+                }
+                None => log::warn!(
+                    "headless display: {} could not be released and is gone from sysfs, so there \
+                     is nothing left to record the hold against",
                     t.sysfs
-                );
+                ),
             }
-            state.forced.push(t.sysfs.clone());
-            held.push(t.name.clone());
             last_err = Some(e);
         } else {
             released.push(t.sysfs.clone());
@@ -751,7 +845,7 @@ fn disable(state: &mut State) -> ResultType<()> {
     // Whatever is left of ours names no connector this pass could act on - an override orphaned by
     // an earlier failure, or one whose card is gone - and it would keep painting our EDID on the
     // next probe of that name.
-    drop_our_entries(|e| !entry_connector(e).is_some_and(|c| held.iter().any(|h| h == c)));
+    drop_our_entries(|e| !entry_connector(e).is_some_and(|c| still_held.iter().any(|h| h == c)));
     if !released.is_empty() {
         log::info!("headless display: released {}", released.join(", "));
     }
@@ -762,10 +856,11 @@ fn disable(state: &mut State) -> ResultType<()> {
 }
 
 /// One connector a release has to act on, carried with the facts needed to put its marker back.
+/// `marker` is `None` for a connector that is gone from sysfs: there is nothing left to identify.
 struct Target {
     sysfs: String,
     name: String,
-    device: String,
+    marker: Option<Marker>,
 }
 
 fn add_target(targets: &mut Vec<Target>, all: &[Connector], sysfs: &str) {
@@ -776,17 +871,17 @@ fn add_target(targets: &mut Vec<Target>, all: &[Connector], sysfs: &str) {
         Some(c) => targets.push(Target {
             sysfs: c.sysfs.clone(),
             name: c.name.clone(),
-            device: c.device.clone(),
+            marker: marker_of(c),
         }),
-        // Gone from sysfs since the record was made. Still worth the write, and the sysfs directory
-        // name carries the connector name; the device is no longer knowable.
+        // Gone from sysfs since the record was made. Still worth the write - the connector may be
+        // forced on with nothing else able to name it - but no marker can be written for it.
         None => targets.push(Target {
             sysfs: sysfs.to_owned(),
             name: sysfs
                 .split_once('-')
                 .map(|(_, name)| name.to_owned())
                 .unwrap_or_default(),
-            device: String::new(),
+            marker: None,
         }),
     }
 }
@@ -851,48 +946,118 @@ pub fn start_watcher() {
 /// connector reads disconnected means the kernel-side force was lost (GPU reset, an operator's
 /// detect), and adopting it would park the tick in the release-watch branch instead of letting
 /// the arming path re-force.
-fn adopt_forced(all: &mut [Connector], forced: &[String]) {
+fn adopt_forced(all: &mut [Connector], forced: &[Held]) {
     for c in all.iter_mut() {
-        if c.connected && forced.iter().any(|f| *f == c.sysfs) {
+        // The full identity, not the sysfs name: both the card minor and the connector name are
+        // recycled, so a name-only record would re-adopt whatever appeared in the old one's place
+        // and then hide it from `is_real_output`.
+        if c.connected
+            && forced.iter().any(|h| {
+                h.sysfs == c.sysfs && h.marker.claims(c.device.as_deref(), c.id.as_deref())
+            })
+        {
             c.ours = true;
         }
     }
 }
 
-/// Drop a marker whose device is not the one that connector sits on now, and re-probe what it named.
+/// Bring the markers back in line with the machine, in one pass with enumerated outcomes.
 ///
-/// Connector names are unique among LIVE connectors, but `drm_connector_cleanup()` frees the index,
-/// so an unbind and rebind can hand `DP-3` to a different card. `edid_firmware` has no card syntax,
-/// so the entry would follow the name onto that stranger, paint our EDID on it and make it look
-/// like ours - which hides a real display behind our own. The `detect` write is what stops it
-/// reporting our EDID; without it the connector keeps the blob it already probed.
+/// Two things go wrong on their own. A marker can name a connector INSTANCE that no longer exists:
+/// `drm_connector_cleanup()` returns the name to its allocator, so a later connector - on another
+/// card, or on the same one - can carry it, and `edid_firmware` has no syntax to say which. Such a
+/// marker is dropped and whatever now holds that name is re-probed, because without the `detect`
+/// write it keeps serving the blob it already read. And a marker written by an older build carries
+/// no identity at all; leaving it would make it a permanent wildcard, so it is either rewritten
+/// against the one connector it can be attributed to, or dropped like any other unattributable
+/// hold.
 ///
-/// Returns whether anything was dropped, so the caller can re-read a topology this just changed.
-fn prune_foreign_markers(all: &[Connector]) -> bool {
-    let stale: Vec<(String, String)> = connectors_named_by_our_entries()
-        .into_iter()
-        .filter(|(name, device)| {
-            !device.is_empty() && !all.iter().any(|c| &c.name == name && &c.device == device)
-        })
-        .collect();
-    if stale.is_empty() {
+/// Returns whether anything changed, so the caller can re-read a topology this just moved.
+fn reconcile_markers(all: &[Connector]) -> bool {
+    let mut drop_names: Vec<String> = Vec::new();
+    let mut reprobe: Vec<String> = Vec::new();
+    let mut upgrade: Vec<(String, Marker)> = Vec::new();
+    for (name, marker) in connectors_named_by_our_entries() {
+        match marker_action(&name, &marker, all) {
+            MarkerAction::Keep => {}
+            MarkerAction::Upgrade(m) => upgrade.push((name, m)),
+            MarkerAction::Drop { reprobe: probe } => {
+                log::info!("headless display: dropping the hold on {name} ({marker:?})");
+                if probe {
+                    reprobe.push(name.clone());
+                }
+                drop_names.push(name);
+            }
+        }
+    }
+    if drop_names.is_empty() && upgrade.is_empty() {
         return false;
     }
-    for (name, device) in &stale {
-        log::info!("headless display: dropping the hold on {name}, no longer on {device}");
+    if !drop_names.is_empty() {
+        drop_our_entries(|e| entry_connector(e).is_some_and(|c| drop_names.iter().any(|n| n == c)));
     }
-    drop_our_entries(|e| {
-        entry_connector(e).is_some_and(|c| stale.iter().any(|(name, _)| name == c))
-    });
+    for (name, marker) in &upgrade {
+        if let Err(e) = install_edid(name, marker) {
+            log::warn!("headless display: cannot re-record the hold on {name}: {e}");
+        } else {
+            log::info!("headless display: the hold on {name} now records which connector it is");
+        }
+    }
     for c in all
         .iter()
-        .filter(|c| stale.iter().any(|(name, _)| *name == c.name))
+        .filter(|c| reprobe.iter().any(|name| *name == c.name))
     {
         if let Err(e) = write_status(&c.sysfs, "detect") {
             log::warn!("headless display: cannot re-probe {}: {e}", c.sysfs);
         }
     }
     true
+}
+
+/// What has to happen to one marker. Four outcomes and no fifth, which is the point of naming them:
+/// the bug this replaced came from a marker that fell through every branch and stayed forever.
+#[derive(Debug, PartialEq)]
+enum MarkerAction {
+    Keep,
+    /// A marker from an older build, attributed to exactly one connector that can identify itself.
+    Upgrade(Marker),
+    /// Give the hold back. `reprobe` when a live connector still carries the name: it is serving
+    /// the EDID the kernel already handed it, and only a `detect` write makes it read the wire.
+    Drop {
+        reprobe: bool,
+    },
+}
+
+fn marker_action(name: &str, marker: &Marker, all: &[Connector]) -> MarkerAction {
+    match marker {
+        // No identity at all. Left alone it would claim any connector that ever carries this name,
+        // which is the failure the qualified form exists to prevent, so it does not survive a pass.
+        Marker::Legacy => {
+            let mut candidates = all.iter().filter(|c| c.name == name);
+            match (candidates.next(), candidates.next()) {
+                (Some(c), None) => match marker_of(c) {
+                    Some(m) => MarkerAction::Upgrade(m),
+                    None => MarkerAction::Drop { reprobe: true },
+                },
+                // None: nothing to attribute it to. Several: attributing it would be a guess.
+                (found, _) => MarkerAction::Drop {
+                    reprobe: found.is_some(),
+                },
+            }
+        }
+        Marker::Instance { .. } => {
+            if all
+                .iter()
+                .any(|c| c.name == name && marker.claims(c.device.as_deref(), c.id.as_deref()))
+            {
+                MarkerAction::Keep
+            } else {
+                MarkerAction::Drop {
+                    reprobe: all.iter().any(|c| c.name == name),
+                }
+            }
+        }
+    }
 }
 
 fn tick(state: &mut State) {
@@ -910,7 +1075,7 @@ fn tick(state: &mut State) {
     }
 
     let mut all = connectors();
-    if prune_foreign_markers(&all) {
+    if reconcile_markers(&all) {
         all = connectors();
     }
     adopt_forced(&mut all, &state.forced);
@@ -995,7 +1160,10 @@ pub fn status_text(enabled: bool) -> String {
             "forced by rustdesk: {} (our edid did not load; released by name)\n",
             named
                 .iter()
-                .map(|(name, device)| format!("{name} on {device}"))
+                .map(|(name, marker)| match marker {
+                    Marker::Legacy => format!("{name} (recorded by an older build)"),
+                    Marker::Instance { device, id } => format!("{name} on {device} #{id}"),
+                })
                 .collect::<Vec<_>>()
                 .join(", ")
         )),
@@ -1101,98 +1269,165 @@ mod tests {
     fn our_entries_name_the_connectors_a_release_has_to_reach() {
         // The parse behind the only recovery path for a force whose EDID never loaded. It has to
         // survive a foreign entry, either ordering, and an entry with no connector prefix.
-        let dev = "0000-01-00-0";
-        let mine = |c: &str| format!("{c}:edid/rustdesk-headless-{dev}.bin");
+        let inst = |d: &str, i: &str| Marker::Instance {
+            device: d.to_owned(),
+            id: i.to_owned(),
+        };
+        let mine = |c: &str, d: &str, i: &str| format!("{c}:edid/rustdesk-headless-{d}-{i}.bin");
         let names = |v: &str| {
             edid_entries(v)
                 .into_iter()
-                .filter_map(|e| Some((entry_connector(e)?.to_owned(), entry_device(e)?.to_owned())))
+                .filter_map(|e| Some((entry_connector(e)?.to_owned(), entry_marker(e)?)))
                 .collect::<Vec<_>>()
         };
+        let d = "a1b2c3d4e5f60718";
         assert_eq!(
-            names(&format!("DP-1:edid/theirs.bin,{}", mine("HDMI-A-1"))),
-            vec![("HDMI-A-1".to_owned(), dev.to_owned())]
+            names(&format!("DP-1:edid/theirs.bin,{}", mine("HDMI-A-1", d, "508"))),
+            vec![("HDMI-A-1".to_owned(), inst(d, "508"))]
         );
         assert_eq!(
-            names(&format!("{},DP-1:edid/theirs.bin", mine("HDMI-A-1"))),
-            vec![("HDMI-A-1".to_owned(), dev.to_owned())]
+            names(&format!("{},DP-1:edid/theirs.bin", mine("HDMI-A-1", d, "508"))),
+            vec![("HDMI-A-1".to_owned(), inst(d, "508"))]
         );
         // Two of ours, which is what a machine that forced one connector and then another leaves.
         assert_eq!(
-            names(&format!("{},{}", mine("HDMI-A-1"), mine("DP-2"))),
+            names(&format!(
+                "{},{}",
+                mine("HDMI-A-1", d, "508"),
+                mine("DP-2", d, "528")
+            )),
             vec![
-                ("HDMI-A-1".to_owned(), dev.to_owned()),
-                ("DP-2".to_owned(), dev.to_owned())
+                ("HDMI-A-1".to_owned(), inst(d, "508")),
+                ("DP-2".to_owned(), inst(d, "528"))
             ]
         );
         assert!(names("DP-1:edid/theirs.bin").is_empty());
         assert!(names("").is_empty());
-        // What an earlier build wrote: still ours, so still releasable, with no device to check.
+        // What an earlier build wrote: still ours, so still releasable, with no identity to check.
         assert_eq!(
             names("HDMI-A-1:edid/rustdesk-headless.bin"),
-            vec![("HDMI-A-1".to_owned(), String::new())]
+            vec![("HDMI-A-1".to_owned(), Marker::Legacy)]
         );
         // A file that merely starts like ours is not ours.
         assert!(names("HDMI-A-1:edid/rustdesk-headless-thing.png").is_empty());
+    }
+
+    // rustdesk#15908: every marker has to leave one pass with a decision. The bug this replaces was
+    // a marker that matched no branch and stayed valid for the rest of the boot.
+    #[test]
+    fn every_marker_leaves_a_pass_with_a_decision() {
+        let inst = |d: &str, i: &str| Marker::Instance {
+            device: d.to_owned(),
+            id: i.to_owned(),
+        };
+        let live = vec![c("card1-HDMI-A-1", "HDMI-A-1", true, false)];
+        let mine = marker_of(&live[0]).unwrap();
+
+        // The connector it names is there: nothing to do.
+        assert_eq!(
+            marker_action("HDMI-A-1", &mine, &live),
+            MarkerAction::Keep
+        );
+        // Same name, another connector instance: give it back AND re-probe, because that connector
+        // is already serving the EDID the kernel handed it.
+        assert_eq!(
+            marker_action("HDMI-A-1", &inst("card1", "card1-HDMI-A-9"), &live),
+            MarkerAction::Drop { reprobe: true }
+        );
+        // The connector is gone entirely: give it back, with nothing to re-probe.
+        assert_eq!(
+            marker_action("DP-4", &inst("card9", "card9-DP-4"), &live),
+            MarkerAction::Drop { reprobe: false }
+        );
+        // An older build's marker, attributable to exactly one connector: record what it is.
+        assert_eq!(
+            marker_action("HDMI-A-1", &Marker::Legacy, &live),
+            MarkerAction::Upgrade(mine)
+        );
+        // The same marker with the name on two cards cannot be attributed, so it is not kept.
+        let twins = vec![
+            c("card1-DP-1", "DP-1", true, false),
+            c("card2-DP-1", "DP-1", true, false),
+        ];
+        assert_eq!(
+            marker_action("DP-1", &Marker::Legacy, &twins),
+            MarkerAction::Drop { reprobe: true }
+        );
+        // And one that names nothing live is dropped rather than left as a wildcard.
+        assert_eq!(
+            marker_action("DP-9", &Marker::Legacy, &live),
+            MarkerAction::Drop { reprobe: false }
+        );
+    }
+
+    // rustdesk#15908: a device identity has to survive being put in a file name without two
+    // different devices ever landing on the same value.
+    #[test]
+    fn two_devices_never_share_an_identity() {
+        // Same basename, different bus path: trimming to the basename would have merged these.
+        let a = fnv1a(b"../../devices/pci0000:00/0000:00:02.0");
+        let b = fnv1a(b"../../devices/pci0000:80/0000:00:02.0");
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 16);
+        // Stable, because a marker written by one build is read by the next.
+        assert_eq!(a, fnv1a(b"../../devices/pci0000:00/0000:00:02.0"));
     }
 
     // rustdesk#15908: the kernel frees a connector's name when the connector goes, so a rebind can
     // hand `HDMI-A-1` to a different card - and `edid_firmware` has no card syntax to stop our
     // entry following it there. The device the entry records is what refuses the stranger.
     #[test]
-    fn a_marker_does_not_follow_its_name_onto_another_device() {
-        let named = vec![("HDMI-A-1".to_owned(), "0000-01-00-0".to_owned())];
-        assert!(connector_is_ours(
-            true,
-            &[],
-            "HDMI-A-1",
-            "0000-01-00-0",
-            &named,
-            true
-        ));
-        // Same connector name, different card: not ours.
-        assert!(!connector_is_ours(
-            true,
-            &[],
-            "HDMI-A-1",
-            "0000-02-00-0",
-            &named,
-            true
-        ));
-        // An unqualified entry from an earlier build still resolves by name alone, or a machine
-        // upgraded mid-hold could never give the connector back.
-        let legacy = vec![("HDMI-A-1".to_owned(), String::new())];
-        assert!(connector_is_ours(
-            true,
-            &[],
-            "HDMI-A-1",
-            "0000-02-00-0",
-            &legacy,
-            true
-        ));
+    fn a_marker_does_not_follow_its_name_onto_another_connector() {
+        let inst = |d: &str, i: &str| Marker::Instance {
+            device: d.to_owned(),
+            id: i.to_owned(),
+        };
+        let named = vec![("HDMI-A-1".to_owned(), inst("devA", "508"))];
+        let ours = |device, id, named: &[(String, Marker)]| {
+            connector_is_ours(true, &[], "HDMI-A-1", device, id, named, true)
+        };
+        assert!(ours(Some("devA"), Some("508"), &named));
+        // Same name, another card: the device half refuses it.
+        assert!(!ours(Some("devB"), Some("508"), &named));
+        // Same name and the SAME card, but a connector created later - the kernel returns a
+        // connector's name to its allocator when it goes, so the device alone would accept this.
+        assert!(!ours(Some("devA"), Some("531"), &named));
+        // A connector that cannot state its own identity is claimed by nothing.
+        assert!(!ours(None, Some("508"), &named));
+        assert!(!ours(Some("devA"), None, &named));
+        // An entry from an earlier build carries no identity, so it still resolves by name - it is
+        // rewritten or dropped by `reconcile_markers`, never left standing as a wildcard.
+        let legacy = vec![("HDMI-A-1".to_owned(), Marker::Legacy)];
+        assert!(ours(Some("devB"), Some("999"), &legacy));
     }
 
     #[test]
     fn a_force_whose_edid_never_loaded_is_still_ours() {
         let mine = synthetic_edid();
-        let dev = "0000-01-00-0";
-        let named = vec![("HDMI-A-1".to_owned(), dev.to_owned())];
+        let (dev, id) = (Some("devA"), Some("508"));
+        let named = vec![(
+            "HDMI-A-1".to_owned(),
+            Marker::Instance {
+                device: "devA".to_owned(),
+                id: "508".to_owned(),
+            },
+        )];
 
         // The ordinary case: our EDID came back, and the name is not even needed.
-        assert!(connector_is_ours(true, &mine, "HDMI-A-1", dev, &[], true));
+        assert!(connector_is_ours(true, &mine, "HDMI-A-1", dev, id, &[], true));
         // The case this exists for: forced on, override never loaded, so the connector reports
         // nothing of ours. Only our own edid_firmware entry still names it.
-        assert!(connector_is_ours(true, &[], "HDMI-A-1", dev, &named, true));
+        assert!(connector_is_ours(true, &[], "HDMI-A-1", dev, id, &named, true));
         // A real monitor on a connector we never named is never ours, either way round.
-        assert!(!connector_is_ours(true, &[], "DP-2", dev, &named, true));
-        assert!(!connector_is_ours(true, &[], "DP-2", dev, &[], true));
+        assert!(!connector_is_ours(true, &[], "DP-2", dev, id, &named, true));
+        assert!(!connector_is_ours(true, &[], "DP-2", dev, id, &[], true));
         // And a disconnected connector is nobody's, whatever the parameter says.
-        assert!(!connector_is_ours(false, &mine, "HDMI-A-1", dev, &named, true));
+        assert!(!connector_is_ours(false, &mine, "HDMI-A-1", dev, id, &named, true));
         // A duplicated name claims nothing by name alone: with DP-1 on two cards, the fallback
         // would mark both ours and a real display behind one of them would never release ours.
-        assert!(!connector_is_ours(true, &[], "HDMI-A-1", dev, &named, false));
+        assert!(!connector_is_ours(true, &[], "HDMI-A-1", dev, id, &named, false));
         // The EDID still decides when it does read back, duplicated name or not.
-        assert!(connector_is_ours(true, &mine, "HDMI-A-1", dev, &named, false));
+        assert!(connector_is_ours(true, &mine, "HDMI-A-1", dev, id, &named, false));
     }
 
     #[test]
@@ -1214,13 +1449,27 @@ mod tests {
     }
 
     fn c(sysfs: &str, name: &str, connected: bool, ours: bool) -> Connector {
+        // The card stands in for the device identity and the sysfs name for the instance id, so a
+        // test connector is as distinguishable as a real one.
         Connector {
             name: name.to_owned(),
             sysfs: sysfs.to_owned(),
             connected,
             ours,
-            device: sysfs.split_once('-').map(|(card, _)| card).unwrap_or("").to_owned(),
+            device: sysfs.split_once('-').map(|(card, _)| card.to_owned()),
+            id: Some(sysfs.to_owned()),
             drivable: true,
+        }
+    }
+
+    fn held(sysfs: &str, name: &str) -> Held {
+        Held {
+            sysfs: sysfs.to_owned(),
+            name: name.to_owned(),
+            marker: Marker::Instance {
+                device: sysfs.split_once('-').map(|(card, _)| card).unwrap_or("").to_owned(),
+                id: sysfs.to_owned(),
+            },
         }
     }
 
@@ -1424,19 +1673,19 @@ mod tests {
             c("card1-HDMI-A-1", "HDMI-A-1", true, false),
             c("card1-HDMI-A-2", "HDMI-A-2", false, false),
         ];
-        adopt_forced(&mut all, &["card1-HDMI-A-1".to_owned()]);
+        adopt_forced(&mut all, &[held("card1-HDMI-A-1", "HDMI-A-1")]);
         assert!(all[0].ours, "the held connector is adopted by sysfs name");
         assert!(!all[1].ours);
         // And the bare name must not match: the record is card-qualified.
         let mut all2 = vec![c("card1-HDMI-A-1", "HDMI-A-1", true, false)];
-        adopt_forced(&mut all2, &["HDMI-A-1".to_owned()]);
+        adopt_forced(&mut all2, &[held("HDMI-A-1", "HDMI-A-1")]);
         assert!(!all2[0].ours);
         adopt_forced(&mut all2, &[]);
         assert!(!all2[0].ours);
         // A disconnected forced record means the kernel-side force was lost: not adopted, so the
         // arming path can re-force instead of the tick parking in the release watch.
         let mut all3 = vec![c("card1-HDMI-A-1", "HDMI-A-1", false, false)];
-        adopt_forced(&mut all3, &["card1-HDMI-A-1".to_owned()]);
+        adopt_forced(&mut all3, &[held("card1-HDMI-A-1", "HDMI-A-1")]);
         assert!(!all3[0].ours);
         // A release that failed on two connectors remembers both, or the second is never retried.
         let mut all4 = vec![
@@ -1445,7 +1694,7 @@ mod tests {
         ];
         adopt_forced(
             &mut all4,
-            &["card1-HDMI-A-1".to_owned(), "card1-DP-2".to_owned()],
+            &[held("card1-HDMI-A-1", "HDMI-A-1"), held("card1-DP-2", "DP-2")],
         );
         assert!(all4.iter().all(|c| c.ours));
     }

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -1,0 +1,988 @@
+// A Linux box with nothing plugged in has no enabled connector, so there is no CRTC, no scanout,
+// and nothing for capture to read: the session falls back to the portal, which asks for consent on
+// a screen nobody is looking at. The kernel can force a disconnected connector on, which hands the
+// compositor an ordinary output on the device it is already driving, so capture takes its normal
+// path with no virtual driver involved.
+//
+// Deliberately conservative, because this writes to sysfs from the root service:
+//   - off unless the operator turns it on, on every build including the unattended one;
+//   - only a connector that currently reports no display is ever forced, on a card that has a
+//     render node, so the output is one a compositor can actually draw on;
+//   - an `edid_firmware` entry someone else configured is preserved, and if theirs already covers
+//     the connector we would have picked, we force nothing at all;
+//   - the release path gives back the connector this process forced, plus any connector still
+//     carrying our EDID from a previous run of the service, and nothing else.
+//
+// Known limit, stated because sysfs cannot express it: the kernel has no attribute that reports
+// `connector->force`, so a connector an operator forced *off* by hand is indistinguishable from one
+// with nothing plugged into it, and this code may force it back on. There is also no way to see a
+// monitor plugged into the connector we are holding, because our own EDID override is what that
+// connector reports; plugging into any other connector is noticed within a poll.
+
+use hbb_common::{anyhow::anyhow, bail, config::Config, log, ResultType};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+/// User-facing switch, kept in this crate the same way `enable-drm-display-wake` is: it belongs to
+/// a compile-gated Linux backend rather than to the shared config vocabulary.
+///
+/// `allow-` and not `enable-` is load-bearing. `option2bool` reads an `enable-` key as `value != "N"`
+/// - an absent value would default this ON - and an `allow-` key as `value == "Y"`, which is off
+/// until somebody says otherwise. The prefix is what decides it, so the key does not have to be
+/// registered anywhere for that to hold.
+pub const OPTION_ALLOW_HEADLESS_DISPLAY: &str = "allow-headless-display";
+
+const DRM_CLASS: &str = "/sys/class/drm";
+const EDID_PARAM: &str = "/sys/module/drm/parameters/edid_firmware";
+const EDID_DIR: &str = "/lib/firmware/edid";
+const EDID_NAME: &str = "rustdesk-headless.bin";
+/// The relative name the kernel resolves under the firmware search path.
+const EDID_FIRMWARE_REF: &str = "edid/rustdesk-headless.bin";
+
+/// How long the machine must report no output before a connector is forced. Short enough that a
+/// headless boot is remotable quickly, long enough that a monitor waking up, a KVM switching back
+/// or a driver rebinding wins the race and nothing is forced at all.
+const NO_OUTPUT_STABLE: Duration = Duration::from_secs(5);
+/// sysfs re-read interval. The service loop ticks twice a second; this feature does not need to.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// How long to wait for a forced connector to report a display before saying so in the log.
+const SETTLE_TIMEOUT: Duration = Duration::from_millis(1500);
+const SETTLE_STEP: Duration = Duration::from_millis(50);
+/// How long a real display has to keep reporting itself before ours is released. A connector flips
+/// its sysfs `status` within milliseconds of the hotplug, but the compositor needs longer to commit
+/// a mode on it, and releasing in between publishes a topology where the new display has no CRTC yet
+/// and ours is already gone - which reads downstream as "this machine has no displays" and drops a
+/// live session to the portal. Deliberately a delay and not a wait for the new connector to be
+/// CRTC-bound: on single-CRTC hardware the compositor cannot bind it until ours is released, so that
+/// condition would never come true.
+const REAL_OUTPUT_STABLE: Duration = Duration::from_secs(2);
+/// Backoff after a failed attempt. Nothing that makes `enable` fail is transient - a topology with
+/// no forceable connector stays that way - so retrying on the next poll would only produce a warning
+/// every few seconds for the life of the service.
+const RETRY_AFTER_FAILURE: Duration = Duration::from_secs(300);
+
+struct Connector {
+    /// Kernel connector name, e.g. `HDMI-A-1`. This is what `edid_firmware` matches on, and it
+    /// carries no card qualifier: the parameter has no syntax for one.
+    name: String,
+    /// `<card>-<connector>`, the sysfs directory name.
+    sysfs: String,
+    connected: bool,
+    /// The connector is reporting our own synthetic EDID, so this is one we forced.
+    ours: bool,
+    /// Its card exposes a render node, so a compositor can actually draw on this device.
+    renderable: bool,
+}
+
+fn read_trim(p: &Path) -> Option<String> {
+    std::fs::read_to_string(p).ok().map(|s| s.trim().to_owned())
+}
+
+/// Does this card have a render node? A display-only DRM device can scan out but nothing can render
+/// to it, so an output forced there is one no compositor will drive - and an output already present
+/// there is not one an operator can work on either. Measured on a 2018 MacBook Pro, where `card0` is
+/// the Touch Bar (`card0-USB-1`, no render node) and the two GPUs are `card1` and `card2`.
+fn card_is_renderable(card: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir(Path::new(DRM_CLASS).join(card).join("device/drm")) else {
+        // No such directory means we cannot tell. Treat that as usable rather than refusing to work
+        // on a driver that lays sysfs out differently.
+        return true;
+    };
+    entries
+        .flatten()
+        .any(|e| e.file_name().to_string_lossy().starts_with("renderD"))
+}
+
+/// Every connector of every card, with the facts the rest of this module decides on.
+fn connectors() -> Vec<Connector> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(DRM_CLASS) else {
+        return out;
+    };
+    // One render-node lookup per card, not per connector: a machine with eight connectors on one
+    // card would otherwise walk the same directory eight times every poll.
+    let mut renderable_cache: HashMap<String, bool> = HashMap::new();
+    for e in entries.flatten() {
+        let dir = e.path();
+        let sysfs = e.file_name().to_string_lossy().into_owned();
+        // cardN-CONNECTOR. cardN itself, renderD* and the version node have no status file.
+        if !dir.join("status").exists() {
+            continue;
+        }
+        let (card, name) = match sysfs.split_once('-') {
+            Some((card, name)) => (card.to_owned(), name.to_owned()),
+            None => continue,
+        };
+        let connected = read_trim(&dir.join("status")).as_deref() == Some("connected");
+        let renderable = *renderable_cache
+            .entry(card)
+            .or_insert_with_key(|c| card_is_renderable(c));
+        out.push(Connector {
+            ours: connected && edid_is_ours(&dir.join("edid")),
+            name,
+            sysfs,
+            connected,
+            renderable,
+        });
+    }
+    out.sort_by(|a, b| a.sysfs.cmp(&b.sysfs));
+    out
+}
+
+/// True when nothing reports a display an operator could work on. A connector we forced does not
+/// count, or the tick could never tell that its own output is all there is. Neither does a
+/// display-only card, for the same reason `pick_connector` will not force one.
+///
+/// Deliberately not "no scanout": a display that is merely asleep still reports connected, and
+/// waking it is a different job.
+fn no_real_output(all: &[Connector]) -> bool {
+    !all.is_empty() && !all.iter().any(is_real_output)
+}
+
+fn is_real_output(c: &Connector) -> bool {
+    c.connected && !c.ours && c.renderable
+}
+
+pub fn is_supported() -> bool {
+    Path::new(DRM_CLASS).exists() && !connectors().is_empty()
+}
+
+fn is_enabled() -> bool {
+    Config::get_bool_option(OPTION_ALLOW_HEADLESS_DISPLAY)
+}
+
+// ---------------------------------------------------------------------------------------------
+// The synthetic EDID
+//
+// Two jobs. Without an EDID the kernel invents a default mode list that tops out at 1024x768, so
+// this one carries a real mode list. And because it is ours and recognisable, it doubles as the
+// record of which connector was forced by an earlier run of this service - a connector released by
+// hand or by a reboot stops looking like ours in the same instant, with no state file to go stale.
+//
+// Generated rather than shipped: a real monitor's EDID carries that monitor's vendor id and serial
+// number and is not ours to redistribute.
+// ---------------------------------------------------------------------------------------------
+
+/// 5-bit-packed "RDK".
+const EDID_MFG: u16 = ((b'R' as u16 - 64) << 10) | ((b'D' as u16 - 64) << 5) | (b'K' as u16 - 64);
+const EDID_PRODUCT: u16 = 0x0001;
+const EDID_MONITOR_NAME: &[u8] = b"RustDesk VD";
+/// Offset of the second 18-byte descriptor, which holds the monitor name.
+const EDID_NAME_DESCRIPTOR: usize = 72;
+
+/// One standard-timing entry: `(hactive, aspect_code, refresh)`. Aspect codes are the EDID ones:
+/// 0 = 16:10, 1 = 4:3, 2 = 5:4, 3 = 16:9.
+const STD_TIMINGS: [(u16, u8, u8); 8] = [
+    (1680, 0, 60),
+    (1600, 3, 60),
+    (1440, 0, 60),
+    (1280, 2, 60),
+    (1280, 3, 60),
+    (1152, 1, 60),
+    (1024, 1, 60),
+    (800, 1, 60),
+];
+
+fn synthetic_edid() -> Vec<u8> {
+    let mut e = vec![0u8; 128];
+    e[0..8].copy_from_slice(&[0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00]);
+    e[8] = (EDID_MFG >> 8) as u8;
+    e[9] = (EDID_MFG & 0xFF) as u8;
+    e[10] = (EDID_PRODUCT & 0xFF) as u8;
+    e[11] = (EDID_PRODUCT >> 8) as u8;
+    // Serial number left at zero, which EDID defines as unspecified. We are not inventing one.
+    e[16] = 1; // week
+    e[17] = 36; // year 1990 + 36
+    e[18] = 1; // EDID 1.4
+    e[19] = 4;
+    e[20] = 0x80; // digital input
+    e[21] = 53; // 53 cm wide
+    e[22] = 30; // 30 cm high
+    e[23] = 0x78; // gamma 2.2
+    e[24] = 0x0A; // RGB 4:4:4 + YCrCb 4:4:4, first detailed descriptor is the preferred timing
+    // Chromaticity, roughly sRGB. Cosmetic, but a parser dislikes an all-zero block.
+    e[25..35].copy_from_slice(&[0xEE, 0x91, 0xA3, 0x54, 0x4C, 0x99, 0x26, 0x0F, 0x50, 0x54]);
+    // Established timings: 640x480@60, 800x600@60, 1024x768@60.
+    e[35] = 0x21;
+    e[36] = 0x08;
+    e[37] = 0x00;
+    for (i, (h, aspect, refresh)) in STD_TIMINGS.iter().enumerate() {
+        e[38 + i * 2] = ((h / 8) - 31) as u8;
+        e[39 + i * 2] = (aspect << 6) | (refresh - 60);
+    }
+    // Descriptor 1: 1920x1080 @ 60 Hz, 148.5 MHz - the CEA-861 timing every display understands.
+    e[54..72].copy_from_slice(&detailed_timing_1080p());
+    // Descriptor 2: the monitor name, so it shows up as something readable in a display panel. The
+    // spec terminates a short string with 0x0A and pads with spaces.
+    let d = EDID_NAME_DESCRIPTOR;
+    e[d + 3] = 0xFC; // monitor name tag
+    e[d + 5..d + 5 + EDID_MONITOR_NAME.len()].copy_from_slice(EDID_MONITOR_NAME);
+    e[d + 5 + EDID_MONITOR_NAME.len()] = 0x0A;
+    for b in e[d + 6 + EDID_MONITOR_NAME.len()..d + 18].iter_mut() {
+        *b = 0x20;
+    }
+    // Descriptors 3 and 4: unused, which EDID spells as a dummy descriptor rather than zeros.
+    for base in [90usize, 108] {
+        e[base + 3] = 0x10;
+    }
+    e[126] = 0; // no extension blocks
+    let sum = e[..127].iter().fold(0u8, |a, b| a.wrapping_add(*b));
+    e[127] = 0u8.wrapping_sub(sum);
+    e
+}
+
+fn detailed_timing_1080p() -> [u8; 18] {
+    const CLOCK_10KHZ: u16 = 14850;
+    const H_ACTIVE: u16 = 1920;
+    const H_BLANK: u16 = 280;
+    const V_ACTIVE: u16 = 1080;
+    const V_BLANK: u16 = 45;
+    const H_SYNC_OFF: u16 = 88;
+    const H_SYNC_W: u16 = 44;
+    const V_SYNC_OFF: u16 = 4;
+    const V_SYNC_W: u16 = 5;
+    const H_MM: u16 = 531;
+    const V_MM: u16 = 299;
+    [
+        (CLOCK_10KHZ & 0xFF) as u8,
+        (CLOCK_10KHZ >> 8) as u8,
+        (H_ACTIVE & 0xFF) as u8,
+        (H_BLANK & 0xFF) as u8,
+        (((H_ACTIVE >> 8) << 4) | (H_BLANK >> 8)) as u8,
+        (V_ACTIVE & 0xFF) as u8,
+        (V_BLANK & 0xFF) as u8,
+        (((V_ACTIVE >> 8) << 4) | (V_BLANK >> 8)) as u8,
+        (H_SYNC_OFF & 0xFF) as u8,
+        (H_SYNC_W & 0xFF) as u8,
+        (((V_SYNC_OFF & 0xF) << 4) | (V_SYNC_W & 0xF)) as u8,
+        (((H_SYNC_OFF >> 8) << 6)
+            | ((H_SYNC_W >> 8) << 4)
+            | ((V_SYNC_OFF >> 4) << 2)
+            | (V_SYNC_W >> 4)) as u8,
+        (H_MM & 0xFF) as u8,
+        (V_MM & 0xFF) as u8,
+        (((H_MM >> 8) << 4) | (V_MM >> 8)) as u8,
+        0,    // no horizontal border
+        0,    // no vertical border
+        0x1E, // digital separate sync, both polarities positive, non-interlaced
+    ]
+}
+
+fn edid_is_ours(edid: &Path) -> bool {
+    std::fs::read(edid)
+        .map(|bytes| edid_bytes_are_ours(&bytes))
+        .unwrap_or(false)
+}
+
+/// Vendor id, product code AND the monitor-name descriptor. Any one of those alone is something a
+/// real monitor's firmware could plausibly carry - product code `0x0001` especially - and this
+/// predicate is what decides whether a connector may be released, so it should not be a coin flip.
+fn edid_bytes_are_ours(bytes: &[u8]) -> bool {
+    let d = EDID_NAME_DESCRIPTOR;
+    bytes.len() >= d + 18
+        && bytes[8] == (EDID_MFG >> 8) as u8
+        && bytes[9] == (EDID_MFG & 0xFF) as u8
+        && bytes[10] == (EDID_PRODUCT & 0xFF) as u8
+        && bytes[11] == (EDID_PRODUCT >> 8) as u8
+        && bytes[d + 3] == 0xFC
+        && bytes[d + 5..].starts_with(EDID_MONITOR_NAME)
+}
+
+fn edid_path() -> PathBuf {
+    Path::new(EDID_DIR).join(EDID_NAME)
+}
+
+/// `edid_firmware` is a comma-separated list of `[<connector>:]<file>` entries, so the value has to
+/// be parsed rather than compared: a bare `ends_with` on our own file name reads a list that merely
+/// *ends* with our entry as entirely ours, and would then overwrite everything before it.
+fn edid_entries(v: &str) -> Vec<&str> {
+    v.split(',').map(str::trim).filter(|e| !e.is_empty()).collect()
+}
+
+fn entry_is_ours(entry: &str) -> bool {
+    entry.rsplit(':').next().unwrap_or(entry) == EDID_FIRMWARE_REF
+}
+
+/// Does an entry we did not write already govern this connector? An entry with no `<connector>:`
+/// prefix applies to every connector, so it governs any of them.
+fn foreign_entry_covers(entry: &str, connector: &str) -> bool {
+    !entry_is_ours(entry)
+        && match entry.split_once(':') {
+            Some((target, _)) => target == connector,
+            None => true,
+        }
+}
+
+fn read_edid_param() -> String {
+    read_trim(Path::new(EDID_PARAM)).unwrap_or_default()
+}
+
+/// Writing the parameter needs care in both directions. A zero-length write to this sysfs attribute
+/// is a silent no-op that leaves the old value in place - measured, and it is why this always writes
+/// at least a newline and reads the value back instead of trusting the write.
+fn write_edid_param(value: &str) -> ResultType<()> {
+    let payload = if value.is_empty() {
+        "\n".to_owned()
+    } else {
+        format!("{value}\n")
+    };
+    std::fs::write(EDID_PARAM, payload)?;
+    let now = read_edid_param();
+    if now != value {
+        bail!("edid_firmware still reads '{now}' after being set to '{value}'");
+    }
+    Ok(())
+}
+
+/// Add our entry for one connector, keeping every entry somebody else put there. Refuses if a
+/// foreign entry already governs this connector: overriding it would change what that connector
+/// reports, which is not ours to do.
+fn install_edid(connector: &str) -> ResultType<()> {
+    let existing = read_edid_param();
+    let entries = edid_entries(&existing);
+    if let Some(theirs) = entries
+        .iter()
+        .find(|e| foreign_entry_covers(e, connector))
+    {
+        bail!("edid_firmware entry '{theirs}' already covers {connector}, leaving it alone");
+    }
+    std::fs::create_dir_all(EDID_DIR)?;
+    std::fs::write(edid_path(), synthetic_edid())?;
+    let mine = format!("{connector}:{EDID_FIRMWARE_REF}");
+    let mut wanted: Vec<String> = entries
+        .iter()
+        .filter(|e| !entry_is_ours(e))
+        .map(|e| (*e).to_owned())
+        .collect();
+    wanted.push(mine);
+    write_edid_param(&wanted.join(","))
+}
+
+/// Drop our entries, keeping everyone else's, so the next probe of those connectors reads whatever
+/// is really on the wire. The firmware file goes only once the parameter no longer points at it: a
+/// pointer to a missing file would make the kernel fail the load on every probe.
+fn uninstall_edid() {
+    let existing = read_edid_param();
+    let entries = edid_entries(&existing);
+    if !entries.iter().any(|e| entry_is_ours(e)) {
+        return;
+    }
+    let keep: Vec<&str> = entries
+        .into_iter()
+        .filter(|e| !entry_is_ours(e))
+        .collect();
+    if let Err(e) = write_edid_param(&keep.join(",")) {
+        log::warn!("headless display: cannot clear our edid_firmware entry: {e}");
+        return;
+    }
+    let _ = std::fs::remove_file(edid_path());
+}
+
+/// The connector names our own `edid_firmware` entries refer to.
+///
+/// This is the only record left of a force whose EDID never actually loaded: the connector reads
+/// `connected` either way, so nothing marks it as ours, and `State` is empty after a service
+/// restart. Reading it back before the entries are removed is what keeps such a force releasable.
+fn connectors_named_by_our_entries() -> Vec<String> {
+    edid_entries(&read_edid_param())
+        .into_iter()
+        .filter(|e| entry_is_ours(e))
+        .filter_map(|e| e.split_once(':').map(|(name, _)| name.to_owned()))
+        .collect()
+}
+
+fn write_status(sysfs: &str, value: &str) -> ResultType<()> {
+    let p = Path::new(DRM_CLASS).join(sysfs).join("status");
+    std::fs::write(&p, value).map_err(|e| {
+        anyhow!(
+            "cannot write {} ({e}); forcing a connector needs the root service",
+            p.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// Poll one connector until its status matches, so a caller does not hand a topology that is still
+/// being probed to whatever asks next. Returns whether it got there.
+fn wait_for(sysfs: &str, connected: bool) -> bool {
+    let p = Path::new(DRM_CLASS).join(sysfs).join("status");
+    let deadline = Instant::now() + SETTLE_TIMEOUT;
+    loop {
+        if (read_trim(&p).as_deref() == Some("connected")) == connected {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(SETTLE_STEP);
+    }
+}
+
+/// Which connector to force. Only a disconnected one, only on a card something can render to, and
+/// only a kind of output a headless machine plausibly has a cable for - `Writeback` is not an output
+/// at all, and an internal panel has nothing behind it.
+///
+/// Among equals it prefers a name that appears on only one card, because `edid_firmware` matches a
+/// bare connector name with no card qualifier. That is insurance rather than a measured fix: on the
+/// multi-GPU machine to hand the two cards number their DisplayPort connectors DP-1..DP-3 and
+/// DP-4..DP-7, so nothing collides.
+fn pick_connector(all: &[Connector]) -> Option<&Connector> {
+    const PREFERENCE: &[&str] = &["HDMI", "DP-", "DVI", "VGA"];
+    let mut per_name: HashMap<&str, usize> = HashMap::new();
+    for c in all {
+        *per_name.entry(c.name.as_str()).or_default() += 1;
+    }
+    let usable = |c: &&Connector| {
+        !c.connected
+            && c.renderable
+            && PREFERENCE.iter().any(|k| c.name.starts_with(k))
+    };
+    for kind in PREFERENCE {
+        let mut of_kind: Vec<&Connector> = all
+            .iter()
+            .filter(usable)
+            .filter(|c| c.name.starts_with(kind))
+            .collect();
+        // Stable and deterministic: unique names first, then sysfs order.
+        of_kind.sort_by_key(|c| (per_name.get(c.name.as_str()).copied().unwrap_or(1) > 1, &c.sysfs));
+        if let Some(c) = of_kind.first() {
+            return Some(c);
+        }
+    }
+    None
+}
+
+/// Everything this watcher remembers between polls. A local rather than a set of statics, because
+/// exactly one thread runs the loop: a global would need poison handling for state no other thread
+/// can see.
+#[derive(Default)]
+struct State {
+    /// The connector this process forced, so a release does not depend only on the kernel still
+    /// reporting our EDID. If a driver drops the override, the marker goes with it and nothing else
+    /// would remember which connector to give back.
+    forced: Option<String>,
+    /// When the machine first reported no output, which is what the stable period is measured from.
+    no_output_since: Option<Instant>,
+    /// When forcing last failed, so a host where it cannot work is not retried every poll.
+    last_failure: Option<Instant>,
+    /// When a real display was first seen while we were holding a connector. The release waits for
+    /// it, see `REAL_OUTPUT_STABLE`.
+    real_since: Option<Instant>,
+}
+
+/// Install our EDID on one connector and force it on. No policy: the caller has already decided.
+///
+/// The EDID goes first. Forcing the connector on is what triggers the probe that reads it, so doing
+/// it the other way round would need an unforce/force cycle - and that cycle publishes a topology
+/// with no displays at all. Verified on a headless box: `edid_firmware` then `on`, with no `detect`
+/// in between, brings the connector up carrying our EDID.
+///
+/// `status == connected` is as far as this can go. Binding a CRTC to the connector is the
+/// compositor's decision, and there is no sysfs attribute to wait on for it, so the log says what
+/// was forced and not that anything is being scanned out.
+fn force_on(state: &mut State, name: &str, sysfs: &str) -> ResultType<()> {
+    install_edid(name)?;
+    if let Err(e) = write_status(sysfs, "on") {
+        // Roll back, or the override outlives the attempt: nothing would be forced, so nothing would
+        // look like ours, and a monitor later plugged into that connector would be described by an
+        // EDID we left behind with no owner.
+        uninstall_edid();
+        return Err(e);
+    }
+    state.forced = Some(sysfs.to_owned());
+    let settled = wait_for(sysfs, true);
+    log::info!(
+        "headless display: forced {sysfs} on with a 1920x1080 edid{}",
+        if settled {
+            ""
+        } else {
+            ", but it has not come up yet"
+        }
+    );
+    // A forced connector reads `connected` whether or not the override loaded, so success above says
+    // nothing about the EDID. Saying so matters: without our EDID the connector still works as a
+    // scanout but falls back to the kernel's 1024x768 mode list, and nothing marks it as ours.
+    if settled && !edid_is_ours(&Path::new(DRM_CLASS).join(sysfs).join("edid")) {
+        log::warn!(
+            "headless display: {sysfs} is on but is not reporting our edid, so the kernel did not \
+             load {EDID_FIRMWARE_REF} (check the firmware search path). The display works with the \
+             kernel default modes; releasing it relies on the edid_firmware entry instead."
+        );
+    }
+    Ok(())
+}
+
+/// Force a connector on so this machine has a scanout. Returns the connector forced.
+fn enable(state: &mut State) -> ResultType<String> {
+    let all = connectors();
+    if all.is_empty() {
+        bail!("no DRM connectors on this machine");
+    }
+    if let Some(c) = all.iter().find(|c| c.ours) {
+        state.forced = Some(c.sysfs.clone());
+        return Ok(c.sysfs.clone());
+    }
+    if all.iter().any(is_real_output) {
+        bail!("a display is already attached, nothing to force");
+    }
+    let target = pick_connector(&all).ok_or_else(|| anyhow!("no connector to force"))?;
+    let (name, sysfs) = (target.name.clone(), target.sysfs.clone());
+    force_on(state, &name, &sysfs)?;
+    Ok(sysfs)
+}
+
+/// Release what we forced, and only that: connectors still carrying our EDID, plus the one this
+/// process forced even if its EDID has since been dropped. A connector forced by someone else does
+/// not appear in either set.
+fn disable(state: &mut State) -> ResultType<()> {
+    let all = connectors();
+    let mut targets: Vec<String> = all
+        .iter()
+        .filter(|c| c.ours)
+        .map(|c| c.sysfs.clone())
+        .collect();
+    if let Some(sysfs) = state.forced.take() {
+        if !targets.contains(&sysfs) {
+            targets.push(sysfs);
+        }
+    }
+    // Read the parameter while it still exists. A force whose EDID never loaded leaves no other
+    // trace, and `uninstall_edid` below is about to erase this one - which would leave the connector
+    // forced for the rest of the boot with nothing able to name it. Writing `detect` to a connector
+    // that turns out not to have been forced is a no-op, so a name that matches on two cards is free.
+    for name in connectors_named_by_our_entries() {
+        for c in all.iter().filter(|c| c.name == name) {
+            if !targets.contains(&c.sysfs) {
+                targets.push(c.sysfs.clone());
+            }
+        }
+    }
+    // The override comes off before the unforce, or the re-probe would read our EDID straight back
+    // and a real monitor on that connector would keep being described by it. It also runs when no
+    // connector is left to release, so an override orphaned by an earlier failure still gets cleaned.
+    uninstall_edid();
+    let mut last_err = None;
+    for sysfs in &targets {
+        // Every connector gets its write attempted; one failure must not strand the others with the
+        // override already gone.
+        if let Err(e) = write_status(sysfs, "detect") {
+            log::warn!("headless display: cannot release {sysfs}: {e}");
+            last_err = Some(e);
+        }
+    }
+    if !targets.is_empty() {
+        log::info!("headless display: released {}", targets.join(", "));
+    }
+    match last_err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// Is there anything of ours left to give back, including an override orphaned by a failed attempt?
+///
+/// The connector walk is the last of the three checks because the first two answer instantly when we
+/// are holding something, but with the feature off none of them short-circuits, so a disabled host
+/// does pay the walk every poll: a readdir plus a `status` and an `edid` read per connector. That is
+/// deliberate - the walk is the only thing that finds a connector left forced by an earlier run whose
+/// parameter entry is already gone, and it costs a few page-cached kernfs reads against a service
+/// loop that reads seat0 twice a second anyway.
+fn holding_something(state: &State) -> bool {
+    state.forced.is_some()
+        || edid_entries(&read_edid_param())
+            .iter()
+            .any(|e| entry_is_ours(e))
+        || connectors().iter().any(|c| c.ours)
+}
+
+/// Start the watcher. Called once from the root service, which is the process that holds the
+/// privilege to write sysfs.
+///
+/// Its own thread rather than the service loop, because forcing a connector waits for it to come up
+/// and that must not delay `--server` supervision. Built with `Builder` for the same reason the DRM
+/// producer is: `thread::spawn` panics if the thread cannot be created, and that panic would unwind
+/// out of the service startup and take the whole root service with it, for a feature whose failure
+/// should cost nothing but this feature.
+pub fn start_watcher() {
+    let spawned = std::thread::Builder::new()
+        .name("headless-display".into())
+        .spawn(|| {
+            let mut state = State::default();
+            loop {
+                // A panic inside one pass must not kill the watcher for the rest of the boot: that
+                // would leave whatever is forced forced, with nothing left running to give it back.
+                // `AssertUnwindSafe` because the state is ours alone and a half-updated timestamp
+                // costs at most one extra poll.
+                let pass = std::panic::AssertUnwindSafe(|| tick(&mut state));
+                if let Err(e) = std::panic::catch_unwind(pass) {
+                    log::error!("headless display: a poll panicked ({e:?}); continuing");
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+        });
+    if let Err(e) = spawned {
+        log::warn!("headless display: cannot start the watcher thread: {e}");
+    }
+}
+
+/// One pass. Silent unless something changes; see `holding_something` for what it costs when the
+/// feature is off.
+///
+/// The option is read from `Config` rather than from disk on purpose. A UI toggle writes the user's
+/// config and the user `--server` syncs it to this process over `ipc_service` in well under a second,
+/// and `--headless-display` pushes it here itself, so the in-memory value is the one that reflects
+/// what the operator just asked for.
+fn tick(state: &mut State) {
+    if !is_enabled() {
+        // Turned off, or never on. Give back anything we are still holding, then stay out of sysfs.
+        if holding_something(state) {
+            let _ = disable(state);
+        }
+        state.no_output_since = None;
+        state.last_failure = None;
+        return;
+    }
+
+    let all = connectors();
+    if all.iter().any(|c| c.ours) {
+        // A real display takes precedence over ours: release it, and the machine goes back to the
+        // output the operator actually plugged in. Only visible for a connector other than the one we
+        // are holding, because ours is what that connector reports.
+        if !all.iter().any(is_real_output) {
+            state.real_since = None;
+            return;
+        }
+        if state
+            .real_since
+            .get_or_insert_with(Instant::now)
+            .elapsed()
+            < REAL_OUTPUT_STABLE
+        {
+            return;
+        }
+        state.real_since = None;
+        log::info!("headless display: a real display was attached");
+        let _ = disable(state);
+        return;
+    }
+
+    match state.last_failure {
+        Some(t) if t.elapsed() < RETRY_AFTER_FAILURE => return,
+        Some(_) => state.last_failure = None,
+        None => {}
+    }
+
+    if !no_real_output(&all) {
+        state.no_output_since = None;
+        return;
+    }
+    if state
+        .no_output_since
+        .get_or_insert_with(Instant::now)
+        .elapsed()
+        < NO_OUTPUT_STABLE
+    {
+        return;
+    }
+    state.no_output_since = None;
+
+    match enable(state) {
+        Ok(c) => log::info!("headless display: {c} is now the scanout for this machine"),
+        Err(e) => {
+            // Backed off rather than retried every poll: a topology with no forceable connector does
+            // not become forceable a second later, and the warning would repeat for the whole boot.
+            state.last_failure = Some(Instant::now());
+            log::warn!(
+                "headless display: not forcing a connector: {e}; retrying in {} s",
+                RETRY_AFTER_FAILURE.as_secs()
+            );
+        }
+    }
+}
+
+/// What `--headless-display status` prints. `enabled` is passed in rather than read here: the CLI
+/// asks the running server over IPC, the way `--option` does, so a normal user does not get told
+/// about their own config while the root service acts on a different one.
+pub fn status_text(enabled: bool) -> String {
+    let all = connectors();
+    let mut s = format!(
+        "headless display: {}\n",
+        if enabled { "enabled" } else { "disabled" }
+    );
+    let named = connectors_named_by_our_entries();
+    match all.iter().find(|c| c.ours) {
+        Some(c) => s.push_str(&format!("forced by rustdesk: {}\n", c.sysfs)),
+        // A connector our own entry names but whose EDID does not read back is a force whose
+        // override never loaded. Printing it is the difference between a diagnosable state and a
+        // machine that looks untouched while holding a connector on.
+        None if !named.is_empty() => s.push_str(&format!(
+            "forced by rustdesk: {} (our edid did not load; released by name)\n",
+            named.join(", ")
+        )),
+        None => s.push_str("forced by rustdesk: none\n"),
+    }
+    let param = read_edid_param();
+    if !param.is_empty() {
+        s.push_str(&format!("edid_firmware: {param}\n"));
+    }
+    if all.is_empty() {
+        s.push_str("no DRM connectors on this machine\n");
+        return s;
+    }
+    s.push_str("connectors:\n");
+    for c in &all {
+        s.push_str(&format!(
+            "  {:<20} {}{}{}\n",
+            c.sysfs,
+            if c.connected {
+                "connected"
+            } else {
+                "disconnected"
+            },
+            if c.ours { " (rustdesk)" } else { "" },
+            if c.renderable { "" } else { " (no render node)" },
+        ));
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_synthetic_edid_is_structurally_valid() {
+        let e = synthetic_edid();
+        assert_eq!(e.len(), 128);
+        assert_eq!(&e[0..8], &[0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00]);
+        assert_eq!(e[126], 0, "one block, so no extensions");
+        // The whole block must sum to zero mod 256; it is the one check every parser does.
+        assert_eq!(e.iter().fold(0u8, |a, b| a.wrapping_add(*b)), 0);
+        // Serial number stays unspecified rather than invented.
+        assert_eq!(&e[12..16], &[0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn the_edid_carries_the_1080p_timing_and_a_mode_list() {
+        let e = synthetic_edid();
+        let clock = u16::from_le_bytes([e[54], e[55]]) as u32 * 10_000;
+        assert_eq!(clock, 148_500_000);
+        let hactive = ((e[58] as u16 & 0xF0) << 4) | e[56] as u16;
+        let vactive = ((e[61] as u16 & 0xF0) << 4) | e[59] as u16;
+        assert_eq!((hactive, vactive), (1920, 1080));
+        let modes = (0..8)
+            .filter(|i| e[38 + i * 2] != 0x01)
+            .map(|i| (e[38 + i * 2] as u16 + 31) * 8)
+            .collect::<Vec<_>>();
+        assert!(modes.contains(&1280), "{modes:?}");
+        assert!(modes.contains(&1024), "{modes:?}");
+    }
+
+    #[test]
+    fn our_own_edid_is_recognised_and_a_near_miss_is_not() {
+        let e = synthetic_edid();
+        assert!(edid_bytes_are_ours(&e));
+
+        // Same block with a different vendor id. 0x10AC is DEL, which is what the real monitor EDID
+        // on the headless test box carries, so this is the exact confusion to rule out.
+        let mut dell = e.clone();
+        dell[8] = 0x10;
+        dell[9] = 0xAC;
+        assert!(!edid_bytes_are_ours(&dell));
+
+        // Our vendor and product but somebody else's name: product code 0x0001 is common enough that
+        // the name has to count too.
+        let mut renamed = e.clone();
+        renamed[EDID_NAME_DESCRIPTOR + 5] = b'X';
+        assert!(!edid_bytes_are_ours(&renamed));
+
+        // An empty or truncated read is not ours either.
+        assert!(!edid_bytes_are_ours(&[]));
+        assert!(!edid_bytes_are_ours(&e[..64]));
+    }
+
+    #[test]
+    fn a_foreign_edid_firmware_entry_survives_and_ours_is_told_apart() {
+        // A list is a list: a value that merely *ends* with our file is not entirely ours.
+        let mixed = "DP-1:edid/theirs.bin,HDMI-A-1:edid/rustdesk-headless.bin";
+        let entries = edid_entries(mixed);
+        assert_eq!(entries.len(), 2);
+        assert!(!entry_is_ours(entries[0]));
+        assert!(entry_is_ours(entries[1]));
+
+        // And the other order, which a suffix test would call foreign and then never clean up.
+        let other_order = "HDMI-A-1:edid/rustdesk-headless.bin,DP-1:edid/theirs.bin";
+        assert!(edid_entries(other_order).iter().any(|e| entry_is_ours(e)));
+
+        assert!(edid_entries("").is_empty());
+    }
+
+    #[test]
+    fn our_entries_name_the_connectors_a_release_has_to_reach() {
+        // The parse behind the only recovery path for a force whose EDID never loaded. It has to
+        // survive a foreign entry, either ordering, and an entry with no connector prefix.
+        let names = |v: &str| {
+            edid_entries(v)
+                .into_iter()
+                .filter(|e| entry_is_ours(e))
+                .filter_map(|e| e.split_once(':').map(|(n, _)| n.to_owned()))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            names("DP-1:edid/theirs.bin,HDMI-A-1:edid/rustdesk-headless.bin"),
+            vec!["HDMI-A-1"]
+        );
+        assert_eq!(
+            names("HDMI-A-1:edid/rustdesk-headless.bin,DP-1:edid/theirs.bin"),
+            vec!["HDMI-A-1"]
+        );
+        // Two of ours, which is what a machine that forced one connector and then another leaves.
+        assert_eq!(
+            names("HDMI-A-1:edid/rustdesk-headless.bin,DP-2:edid/rustdesk-headless.bin"),
+            vec!["HDMI-A-1", "DP-2"]
+        );
+        assert!(names("DP-1:edid/theirs.bin").is_empty());
+        assert!(names("").is_empty());
+    }
+
+    #[test]
+    fn a_foreign_entry_that_covers_our_connector_blocks_us() {
+        assert!(foreign_entry_covers("HDMI-A-1:edid/theirs.bin", "HDMI-A-1"));
+        assert!(!foreign_entry_covers("DP-1:edid/theirs.bin", "HDMI-A-1"));
+        // No connector prefix means every connector, so it covers whatever we would pick.
+        assert!(foreign_entry_covers("edid/theirs.bin", "HDMI-A-1"));
+        // Our own entry never blocks us.
+        assert!(!foreign_entry_covers(
+            "HDMI-A-1:edid/rustdesk-headless.bin",
+            "HDMI-A-1"
+        ));
+    }
+
+    fn c(sysfs: &str, name: &str, connected: bool, ours: bool) -> Connector {
+        Connector {
+            name: name.to_owned(),
+            sysfs: sysfs.to_owned(),
+            connected,
+            ours,
+            renderable: true,
+        }
+    }
+
+    fn unrenderable(sysfs: &str, name: &str, connected: bool) -> Connector {
+        Connector {
+            renderable: false,
+            ..c(sysfs, name, connected, false)
+        }
+    }
+
+    #[test]
+    fn what_counts_as_real_output() {
+        assert!(no_real_output(&[c("card0-HDMI-A-1", "HDMI-A-1", false, false)]));
+        assert!(
+            no_real_output(&[c("card0-HDMI-A-1", "HDMI-A-1", true, true)]),
+            "our own display must not stop the tick from releasing it"
+        );
+        assert!(!no_real_output(&[c("card0-HDMI-A-1", "HDMI-A-1", true, false)]));
+        assert!(!no_real_output(&[]), "no connectors at all is not the headless case");
+        // The MacBook Touch Bar is permanently connected on a card with no render node. Counting it
+        // as real output would stop the feature from ever arming there, and would make it release a
+        // working forced display in favour of an output nothing can draw on.
+        assert!(no_real_output(&[unrenderable("card0-USB-1", "USB-1", true)]));
+    }
+
+    #[test]
+    fn connector_choice() {
+        let all = vec![
+            c("card0-Writeback-1", "Writeback-1", false, false),
+            c("card0-eDP-1", "eDP-1", false, false),
+            c("card0-VGA-1", "VGA-1", false, false),
+            c("card0-HDMI-A-2", "HDMI-A-2", false, false),
+        ];
+        assert_eq!(pick_connector(&all).map(|c| c.name.as_str()), Some("HDMI-A-2"));
+
+        // Nothing forceable: an internal panel and a writeback are not outputs to offer.
+        assert!(pick_connector(&[
+            c("card0-Writeback-1", "Writeback-1", false, false),
+            c("card0-eDP-1", "eDP-1", false, false),
+        ])
+        .is_none());
+        // A connected connector is never forced.
+        assert!(pick_connector(&[c("card0-HDMI-A-1", "HDMI-A-1", true, false)]).is_none());
+        // Nor is a connector on a display-only card.
+        assert!(pick_connector(&[unrenderable("card0-USB-1", "USB-1", false)]).is_none());
+        // An unknown connector kind is left alone rather than forced as a last resort.
+        assert!(pick_connector(&[c("card0-DSI-1", "DSI-1", false, false)]).is_none());
+    }
+
+    /// The real topology of a 2018 MacBook Pro, read off the machine: three DRM devices, `card0`
+    /// being the Touch Bar with no render node and a connector that is permanently `connected`.
+    /// It is here because that permanently-connected non-renderable output is what an earlier
+    /// revision counted as real output, which stopped the feature from ever arming on this hardware.
+    fn macbook_pro_2018() -> Vec<Connector> {
+        vec![
+            unrenderable("card0-USB-1", "USB-1", true),
+            c("card1-DP-1", "DP-1", false, false),
+            c("card1-DP-2", "DP-2", false, false),
+            c("card1-DP-3", "DP-3", false, false),
+            c("card1-HDMI-A-1", "HDMI-A-1", false, false),
+            c("card1-HDMI-A-2", "HDMI-A-2", false, false),
+            c("card1-HDMI-A-3", "HDMI-A-3", false, false),
+            c("card2-DP-4", "DP-4", false, false),
+            c("card2-DP-5", "DP-5", false, false),
+            c("card2-DP-6", "DP-6", true, false),
+            c("card2-DP-7", "DP-7", false, false),
+            c("card2-eDP-1", "eDP-1", true, false),
+        ]
+    }
+
+    #[test]
+    fn a_machine_with_its_own_displays_is_left_alone() {
+        // DP-6 and the internal panel are both connected on a renderable card, so this machine has
+        // output and the feature must do nothing at all here.
+        assert!(!no_real_output(&macbook_pro_2018()));
+    }
+
+    #[test]
+    fn the_touch_bar_alone_does_not_count_as_output() {
+        // Same machine with every real display gone: only the non-renderable Touch Bar is left, and
+        // the feature must arm and pick an HDMI on a card something can render to.
+        let mut all = macbook_pro_2018();
+        for x in all.iter_mut() {
+            if x.renderable {
+                x.connected = false;
+            }
+        }
+        assert!(no_real_output(&all));
+        assert_eq!(
+            pick_connector(&all).map(|c| c.sysfs.as_str()),
+            Some("card1-HDMI-A-1")
+        );
+    }
+
+    #[test]
+    fn a_name_that_exists_on_two_cards_loses_to_a_unique_one() {
+        // `edid_firmware` matches a bare connector name with no card qualifier, so forcing a
+        // duplicated name would put our EDID on whichever card the kernel probes first. This is
+        // insurance, not a fix for something measured: the multi-GPU machine to hand numbers its
+        // DisplayPort connectors DP-1..DP-3 on one card and DP-4..DP-7 on the other, so no collision
+        // occurs there.
+        let all = vec![
+            c("card1-DP-1", "DP-1", false, false),
+            c("card1-DP-9", "DP-9", false, false),
+            c("card2-DP-1", "DP-1", false, false),
+        ];
+        assert_eq!(pick_connector(&all).map(|c| c.sysfs.as_str()), Some("card1-DP-9"));
+        // But a duplicated name is still better than no display at all.
+        let only_dupes = vec![
+            c("card1-DP-1", "DP-1", false, false),
+            c("card2-DP-1", "DP-1", false, false),
+        ];
+        assert_eq!(
+            pick_connector(&only_dupes).map(|c| c.sysfs.as_str()),
+            Some("card1-DP-1")
+        );
+    }
+}

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -701,13 +701,16 @@ pub fn start_watcher() {
 /// Overlay the process's own record of what it forced onto the sysfs view: while the connector
 /// settles - or when the override never loaded on it - sysfs cannot name it ours, and without
 /// this the tick would re-force it and count it as a real output. Matched by the card-qualified
-/// sysfs name, never the bare one.
+/// sysfs name, never the bare one. Only a CONNECTED connector is adopted: a forced record whose
+/// connector reads disconnected means the kernel-side force was lost (GPU reset, an operator's
+/// detect), and adopting it would park the tick in the release-watch branch instead of letting
+/// the arming path re-force.
 fn adopt_forced(all: &mut [Connector], forced: Option<&str>) {
     let Some(forced) = forced else {
         return;
     };
     for c in all.iter_mut() {
-        if c.sysfs == forced {
+        if c.connected && c.sysfs == forced {
             c.ours = true;
         }
     }
@@ -1190,5 +1193,10 @@ mod tests {
         assert!(!all2[0].ours);
         adopt_forced(&mut all2, None);
         assert!(!all2[0].ours);
+        // A disconnected forced record means the kernel-side force was lost: not adopted, so the
+        // arming path can re-force instead of the tick parking in the release watch.
+        let mut all3 = vec![c("card1-HDMI-A-1", "HDMI-A-1", false, false)];
+        adopt_forced(&mut all3, Some("card1-HDMI-A-1"));
+        assert!(!all3[0].ours);
     }
 }

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -38,9 +38,9 @@ pub const OPTION_ALLOW_HEADLESS_DISPLAY: &str = "allow-headless-display";
 const DRM_CLASS: &str = "/sys/class/drm";
 const EDID_PARAM: &str = "/sys/module/drm/parameters/edid_firmware";
 const EDID_DIR: &str = "/lib/firmware/edid";
-const EDID_NAME: &str = "rustdesk-headless.bin";
+const EDID_NAME_PREFIX: &str = "rustdesk-headless";
 /// The relative name the kernel resolves under the firmware search path.
-const EDID_FIRMWARE_REF: &str = "edid/rustdesk-headless.bin";
+const EDID_DIR_REF: &str = "edid/";
 
 /// How long the machine must report no output before a connector is forced. Short enough that a
 /// headless boot is remotable quickly, long enough that a monitor waking up, a KVM switching back
@@ -73,6 +73,9 @@ struct Connector {
     connected: bool,
     /// The connector is reporting our own synthetic EDID, so this is one we forced.
     ours: bool,
+    /// The card's stable bus identity, see `device_id`. Ownership is recorded against this and
+    /// not against the connector name alone, which the kernel re-issues after a rebind.
+    device: String,
     /// A compositor can actually drive this output: its card has a render node, or the whole
     /// machine splits scanout and rendering between cards (`promote_split_topology`).
     drivable: bool,
@@ -95,6 +98,30 @@ fn card_is_renderable(card: &str) -> bool {
     entries
         .flatten()
         .any(|e| e.file_name().to_string_lossy().starts_with("renderD"))
+}
+
+/// The stable identity of the DRM device a card sits on: the name of the bus device it hangs off
+/// (`0000:01:00.0` on PCI, `fec00000.v3d` on a SoC), sanitised so it can live in a file name.
+/// `cardN` cannot play this role - the minor comes from an allocator that recycles, measured on a
+/// MacBook whose Touch Bar connector was `card0-USB-1` one boot and `card3-USB-2` the next.
+///
+/// `unknown` when sysfs does not say. Two such cards then share an identity, which is the
+/// unqualified behaviour rather than a refusal to work.
+fn device_id(card: &str) -> String {
+    let sanitised = std::fs::read_link(Path::new(DRM_CLASS).join(card).join("device"))
+        .ok()
+        .and_then(|t| t.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .map(|n| {
+            n.chars()
+                .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+                .collect::<String>()
+        })
+        .unwrap_or_default();
+    if sanitised.is_empty() {
+        "unknown".to_owned()
+    } else {
+        sanitised
+    }
 }
 
 /// Every connector of every card, with the facts the rest of this module decides on.
@@ -125,22 +152,29 @@ fn connectors() -> Vec<Connector> {
         *name_count.entry(name.clone()).or_default() += 1;
         raw.push((dir, sysfs, card, name));
     }
+    let mut device_cache: HashMap<String, String> = HashMap::new();
     for (dir, sysfs, card, name) in raw {
         let connected = read_trim(&dir.join("status")).as_deref() == Some("connected");
         let drivable = *renderable_cache
-            .entry(card)
+            .entry(card.clone())
             .or_insert_with_key(|c| card_is_renderable(c));
+        let device = device_cache
+            .entry(card)
+            .or_insert_with_key(|c| device_id(c))
+            .clone();
         out.push(Connector {
             ours: connector_is_ours(
                 connected,
                 &std::fs::read(dir.join("edid")).unwrap_or_default(),
                 &name,
+                &device,
                 &named,
                 name_count.get(&name).copied().unwrap_or(1) == 1,
             ),
             name,
             sysfs,
             connected,
+            device,
             drivable,
         });
     }
@@ -327,10 +361,16 @@ fn connector_is_ours(
     connected: bool,
     edid: &[u8],
     name: &str,
-    named: &[String],
+    device: &str,
+    named: &[(String, String)],
     name_unique: bool,
 ) -> bool {
-    connected && (edid_bytes_are_ours(edid) || (name_unique && named.iter().any(|n| n == name)))
+    connected
+        && (edid_bytes_are_ours(edid)
+            || (name_unique
+                && named
+                    .iter()
+                    .any(|(n, d)| n == name && (d.is_empty() || d == device))))
 }
 
 #[allow(dead_code)]
@@ -354,8 +394,22 @@ fn edid_bytes_are_ours(bytes: &[u8]) -> bool {
         && bytes[d + 5..].starts_with(EDID_MONITOR_NAME)
 }
 
-fn edid_path() -> PathBuf {
-    Path::new(EDID_DIR).join(EDID_NAME)
+/// One firmware file per device, so the entry itself says which device the hold is on. The bare
+/// name is what an earlier build wrote; it is still ours, it just carries no device.
+fn edid_file_name(device: &str) -> String {
+    if device.is_empty() {
+        format!("{EDID_NAME_PREFIX}.bin")
+    } else {
+        format!("{EDID_NAME_PREFIX}-{device}.bin")
+    }
+}
+
+fn edid_firmware_ref(device: &str) -> String {
+    format!("{EDID_DIR_REF}{}", edid_file_name(device))
+}
+
+fn edid_path(device: &str) -> PathBuf {
+    Path::new(EDID_DIR).join(edid_file_name(device))
 }
 
 /// `edid_firmware` is a comma-separated list of `[<connector>:]<file>` entries, so the value has to
@@ -368,8 +422,29 @@ fn edid_entries(v: &str) -> Vec<&str> {
         .collect()
 }
 
+fn entry_file(entry: &str) -> &str {
+    entry.rsplit(':').next().unwrap_or(entry)
+}
+
+/// The connector an entry targets, or `None` for one that applies to every connector.
+fn entry_connector(entry: &str) -> Option<&str> {
+    entry.split_once(':').map(|(target, _)| target)
+}
+
+/// The device an entry records the hold against, or `None` when the entry is not ours at all.
+/// `Some("")` is the unqualified form an earlier build wrote: ours, but not device-checkable.
+fn entry_device(entry: &str) -> Option<&str> {
+    let file = entry_file(entry).strip_prefix(EDID_DIR_REF)?;
+    let rest = file.strip_prefix(EDID_NAME_PREFIX)?.strip_suffix(".bin")?;
+    match rest.strip_prefix('-') {
+        Some(device) if !device.is_empty() => Some(device),
+        _ if rest.is_empty() => Some(""),
+        _ => None,
+    }
+}
+
 fn entry_is_ours(entry: &str) -> bool {
-    entry.rsplit(':').next().unwrap_or(entry) == EDID_FIRMWARE_REF
+    entry_device(entry).is_some()
 }
 
 /// Does an entry we did not write already govern this connector? An entry with no `<connector>:`
@@ -406,18 +481,21 @@ fn write_edid_param(value: &str) -> ResultType<()> {
 /// Add our entry for one connector, keeping every entry somebody else put there. Refuses if a
 /// foreign entry already governs this connector: overriding it would change what that connector
 /// reports, which is not ours to do.
-fn install_edid(connector: &str) -> ResultType<()> {
+fn install_edid(connector: &str, device: &str) -> ResultType<()> {
     let existing = read_edid_param();
     let entries = edid_entries(&existing);
     if let Some(theirs) = entries.iter().find(|e| foreign_entry_covers(e, connector)) {
         bail!("edid_firmware entry '{theirs}' already covers {connector}, leaving it alone");
     }
     std::fs::create_dir_all(EDID_DIR)?;
-    std::fs::write(edid_path(), synthetic_edid())?;
-    let mine = format!("{connector}:{EDID_FIRMWARE_REF}");
+    std::fs::write(edid_path(device), synthetic_edid())?;
+    let mine = format!("{connector}:{}", edid_firmware_ref(device));
+    // Only our entry for THIS connector is replaced. A release that fails on several connectors
+    // has to be able to record every one of them, and dropping the rest here would lose all but
+    // the last.
     let mut wanted: Vec<String> = entries
         .iter()
-        .filter(|e| !entry_is_ours(e))
+        .filter(|e| !(entry_is_ours(e) && entry_connector(e) == Some(connector)))
         .map(|e| (*e).to_owned())
         .collect();
     wanted.push(mine);
@@ -427,18 +505,33 @@ fn install_edid(connector: &str) -> ResultType<()> {
 /// Drop our entries, keeping everyone else's, so the next probe of those connectors reads whatever
 /// is really on the wire. The firmware file goes only once the parameter no longer points at it: a
 /// pointer to a missing file would make the kernel fail the load on every probe.
-fn uninstall_edid() {
+fn drop_our_entries(mut which: impl FnMut(&str) -> bool) {
     let existing = read_edid_param();
     let entries = edid_entries(&existing);
-    if !entries.iter().any(|e| entry_is_ours(e)) {
+    let (mine, keep): (Vec<&str>, Vec<&str>) = entries
+        .into_iter()
+        .partition(|e| entry_is_ours(e) && which(e));
+    if mine.is_empty() {
         return;
     }
-    let keep: Vec<&str> = entries.into_iter().filter(|e| !entry_is_ours(e)).collect();
     if let Err(e) = write_edid_param(&keep.join(",")) {
         log::warn!("headless display: cannot clear our edid_firmware entry: {e}");
         return;
     }
-    let _ = std::fs::remove_file(edid_path());
+    for e in &mine {
+        let Some(device) = entry_device(e) else {
+            continue;
+        };
+        // Another entry of ours can still point at the same file.
+        if keep.iter().any(|k| entry_device(k) == Some(device)) {
+            continue;
+        }
+        let _ = std::fs::remove_file(edid_path(device));
+    }
+}
+
+fn uninstall_edid() {
+    drop_our_entries(|_| true)
 }
 
 /// The connector names our own `edid_firmware` entries refer to.
@@ -446,11 +539,13 @@ fn uninstall_edid() {
 /// This is the only record left of a force whose EDID never actually loaded: the connector reads
 /// `connected` either way, so nothing marks it as ours, and `State` is empty after a service
 /// restart. Reading it back before the entries are removed is what keeps such a force releasable.
-fn connectors_named_by_our_entries() -> Vec<String> {
+fn connectors_named_by_our_entries() -> Vec<(String, String)> {
     edid_entries(&read_edid_param())
         .into_iter()
-        .filter(|e| entry_is_ours(e))
-        .filter_map(|e| e.split_once(':').map(|(name, _)| name.to_owned()))
+        .filter_map(|e| {
+            let device = entry_device(e)?;
+            Some((entry_connector(e)?.to_owned(), device.to_owned()))
+        })
         .collect()
 }
 
@@ -519,10 +614,11 @@ fn pick_connector(all: &[Connector]) -> Option<&Connector> {
 /// can see.
 #[derive(Default)]
 struct State {
-    /// The connector this process forced, so a release does not depend only on the kernel still
+    /// The connectors this process forced, so a release does not depend only on the kernel still
     /// reporting our EDID. If a driver drops the override, the marker goes with it and nothing else
-    /// would remember which connector to give back.
-    forced: Option<String>,
+    /// would remember which connector to give back. A list, because a release that fails on more
+    /// than one must not remember only the first.
+    forced: Vec<String>,
     /// When the machine first reported no output, which is what the stable period is measured from.
     no_output_since: Option<Instant>,
     /// When forcing last failed, so a host where it cannot work is not retried every poll.
@@ -542,8 +638,8 @@ struct State {
 /// `status == connected` is as far as this can go. Binding a CRTC to the connector is the
 /// compositor's decision, and there is no sysfs attribute to wait on for it, so the log says what
 /// was forced and not that anything is being scanned out.
-fn force_on(state: &mut State, name: &str, sysfs: &str) -> ResultType<()> {
-    install_edid(name)?;
+fn force_on(state: &mut State, name: &str, sysfs: &str, device: &str) -> ResultType<()> {
+    install_edid(name, device)?;
     if let Err(e) = write_status(sysfs, "on") {
         // Roll back, or the override outlives the attempt: nothing would be forced, so nothing would
         // look like ours, and a monitor later plugged into that connector would be described by an
@@ -551,7 +647,7 @@ fn force_on(state: &mut State, name: &str, sysfs: &str) -> ResultType<()> {
         uninstall_edid();
         return Err(e);
     }
-    state.forced = Some(sysfs.to_owned());
+    state.forced = vec![sysfs.to_owned()];
     let settled = wait_for(sysfs, true);
     log::info!(
         "headless display: forced {sysfs} on with a 1920x1080 edid{}",
@@ -567,8 +663,9 @@ fn force_on(state: &mut State, name: &str, sysfs: &str) -> ResultType<()> {
     if settled && !edid_is_ours(&Path::new(DRM_CLASS).join(sysfs).join("edid")) {
         log::warn!(
             "headless display: {sysfs} is on but is not reporting our edid, so the kernel did not \
-             load {EDID_FIRMWARE_REF} (check the firmware search path). The display works with the \
-             kernel default modes; releasing it relies on the edid_firmware entry instead."
+             load {} (check the firmware search path). The display works with the kernel default \
+             modes; releasing it relies on the edid_firmware entry instead.",
+            edid_firmware_ref(device)
         );
     }
     Ok(())
@@ -581,15 +678,19 @@ fn enable(state: &mut State) -> ResultType<String> {
         bail!("no DRM connectors on this machine");
     }
     if let Some(c) = all.iter().find(|c| c.ours) {
-        state.forced = Some(c.sysfs.clone());
+        state.forced = vec![c.sysfs.clone()];
         return Ok(c.sysfs.clone());
     }
     if all.iter().any(is_real_output) {
         bail!("a display is already attached, nothing to force");
     }
     let target = pick_connector(&all).ok_or_else(|| anyhow!("no connector to force"))?;
-    let (name, sysfs) = (target.name.clone(), target.sysfs.clone());
-    force_on(state, &name, &sysfs)?;
+    let (name, sysfs, device) = (
+        target.name.clone(),
+        target.sysfs.clone(),
+        target.device.clone(),
+    );
+    force_on(state, &name, &sysfs, &device)?;
     Ok(sysfs)
 }
 
@@ -598,64 +699,95 @@ fn enable(state: &mut State) -> ResultType<String> {
 /// not appear in either set.
 fn disable(state: &mut State) -> ResultType<()> {
     let all = connectors();
-    let mut targets: Vec<String> = all
-        .iter()
-        .filter(|c| c.ours)
-        .map(|c| c.sysfs.clone())
-        .collect();
-    if let Some(sysfs) = state.forced.take() {
-        if !targets.contains(&sysfs) {
-            targets.push(sysfs);
-        }
+    let mut targets: Vec<Target> = Vec::new();
+    for c in all.iter().filter(|c| c.ours) {
+        add_target(&mut targets, &all, &c.sysfs);
+    }
+    for sysfs in std::mem::take(&mut state.forced) {
+        add_target(&mut targets, &all, &sysfs);
     }
     // Read the parameter while it still exists. A force whose EDID never loaded leaves no other
-    // trace, and `uninstall_edid` below is about to erase this one - which would leave the connector
-    // forced for the rest of the boot with nothing able to name it. The name resolves against the
-    // live list, and connector indices come from a per-type ida that is global to drm.ko, so two
-    // live connectors never share a name and this matches the one connector we forced.
-    for name in connectors_named_by_our_entries() {
-        for c in all.iter().filter(|c| c.name == name) {
-            if !targets.contains(&c.sysfs) {
-                targets.push(c.sysfs.clone());
-            }
+    // trace, and the entries below are about to go - which would leave the connector forced for the
+    // rest of the boot with nothing able to name it. The name resolves against the live list, and
+    // connector indices come from a per-type ida that is global to drm.ko, so two live connectors
+    // never share a name; the device qualifier is what keeps a name the kernel re-issued after a
+    // rebind from resolving to somebody else's connector.
+    for (name, device) in connectors_named_by_our_entries() {
+        for c in all
+            .iter()
+            .filter(|c| c.name == name && (device.is_empty() || c.device == device))
+        {
+            add_target(&mut targets, &all, &c.sysfs);
         }
     }
-    // The override comes off before the unforce, or the re-probe would read our EDID straight back
-    // and a real monitor on that connector would keep being described by it. It also runs when no
-    // connector is left to release, so an override orphaned by an earlier failure still gets cleaned.
-    uninstall_edid();
     let mut last_err = None;
     let mut released: Vec<String> = Vec::new();
-    for sysfs in &targets {
-        // Every connector gets its write attempted; one failure must not strand the others with the
-        // override already gone.
-        if let Err(e) = write_status(sysfs, "detect") {
-            log::warn!("headless display: cannot release {sysfs}: {e}");
-            // Put the marker back. By this point the parameter entry is already gone and, for a
-            // force whose override never loaded, so is the `ours` flag - so without this the last
-            // record of the connector disappears with the failed write and nothing ever retries.
-            state.forced.get_or_insert_with(|| sysfs.clone());
+    let mut held: Vec<String> = Vec::new();
+    for t in &targets {
+        // The override comes off before the unforce, or the re-probe would read our EDID straight
+        // back and a real monitor on that connector would keep being described by it. One entry at
+        // a time: every connector gets its write attempted, and a failure must not strand the
+        // others with their override already gone.
+        drop_our_entries(|e| entry_connector(e) == Some(t.name.as_str()));
+        if let Err(e) = write_status(&t.sysfs, "detect") {
+            log::warn!("headless display: cannot release {}: {e}", t.sysfs);
+            // Put the marker back. The parameter entry is what survives this process and, for a
+            // force whose override never loaded, it is the only record there is. If this write
+            // fails too the hold lives on in `state.forced` alone and a restart loses it, which is
+            // as far as a machine refusing both writes can be carried.
+            if let Err(e) = install_edid(&t.name, &t.device) {
+                log::warn!(
+                    "headless display: cannot re-record the hold on {}: {e}",
+                    t.sysfs
+                );
+            }
+            state.forced.push(t.sysfs.clone());
+            held.push(t.name.clone());
             last_err = Some(e);
         } else {
-            released.push(sysfs.clone());
+            released.push(t.sysfs.clone());
         }
     }
-    // The parameter entry is what survives this process, so a connector still forced needs it back.
-    // After the loop, not per failure: `install_edid` keeps only the last of our entries, and this
-    // way the parameter and `state.forced` name the same connector.
-    if let Some(stuck) = state.forced.as_deref() {
-        if let Some((_, name)) = stuck.split_once('-') {
-            if let Err(e) = install_edid(name) {
-                log::warn!("headless display: cannot re-record the hold on {stuck}: {e}");
-            }
-        }
-    }
+    // Whatever is left of ours names no connector this pass could act on - an override orphaned by
+    // an earlier failure, or one whose card is gone - and it would keep painting our EDID on the
+    // next probe of that name.
+    drop_our_entries(|e| !entry_connector(e).is_some_and(|c| held.iter().any(|h| h == c)));
     if !released.is_empty() {
         log::info!("headless display: released {}", released.join(", "));
     }
     match last_err {
         Some(e) => Err(e),
         None => Ok(()),
+    }
+}
+
+/// One connector a release has to act on, carried with the facts needed to put its marker back.
+struct Target {
+    sysfs: String,
+    name: String,
+    device: String,
+}
+
+fn add_target(targets: &mut Vec<Target>, all: &[Connector], sysfs: &str) {
+    if targets.iter().any(|t| t.sysfs == sysfs) {
+        return;
+    }
+    match all.iter().find(|c| c.sysfs == sysfs) {
+        Some(c) => targets.push(Target {
+            sysfs: c.sysfs.clone(),
+            name: c.name.clone(),
+            device: c.device.clone(),
+        }),
+        // Gone from sysfs since the record was made. Still worth the write, and the sysfs directory
+        // name carries the connector name; the device is no longer knowable.
+        None => targets.push(Target {
+            sysfs: sysfs.to_owned(),
+            name: sysfs
+                .split_once('-')
+                .map(|(_, name)| name.to_owned())
+                .unwrap_or_default(),
+            device: String::new(),
+        }),
     }
 }
 
@@ -668,7 +800,7 @@ fn disable(state: &mut State) -> ResultType<()> {
 /// parameter entry is already gone, and it costs a few page-cached kernfs reads against a service
 /// loop that reads seat0 twice a second anyway.
 fn holding_something(state: &State) -> bool {
-    state.forced.is_some()
+    !state.forced.is_empty()
         || edid_entries(&read_edid_param())
             .iter()
             .any(|e| entry_is_ours(e))
@@ -719,15 +851,48 @@ pub fn start_watcher() {
 /// connector reads disconnected means the kernel-side force was lost (GPU reset, an operator's
 /// detect), and adopting it would park the tick in the release-watch branch instead of letting
 /// the arming path re-force.
-fn adopt_forced(all: &mut [Connector], forced: Option<&str>) {
-    let Some(forced) = forced else {
-        return;
-    };
+fn adopt_forced(all: &mut [Connector], forced: &[String]) {
     for c in all.iter_mut() {
-        if c.connected && c.sysfs == forced {
+        if c.connected && forced.iter().any(|f| *f == c.sysfs) {
             c.ours = true;
         }
     }
+}
+
+/// Drop a marker whose device is not the one that connector sits on now, and re-probe what it named.
+///
+/// Connector names are unique among LIVE connectors, but `drm_connector_cleanup()` frees the index,
+/// so an unbind and rebind can hand `DP-3` to a different card. `edid_firmware` has no card syntax,
+/// so the entry would follow the name onto that stranger, paint our EDID on it and make it look
+/// like ours - which hides a real display behind our own. The `detect` write is what stops it
+/// reporting our EDID; without it the connector keeps the blob it already probed.
+///
+/// Returns whether anything was dropped, so the caller can re-read a topology this just changed.
+fn prune_foreign_markers(all: &[Connector]) -> bool {
+    let stale: Vec<(String, String)> = connectors_named_by_our_entries()
+        .into_iter()
+        .filter(|(name, device)| {
+            !device.is_empty() && !all.iter().any(|c| &c.name == name && &c.device == device)
+        })
+        .collect();
+    if stale.is_empty() {
+        return false;
+    }
+    for (name, device) in &stale {
+        log::info!("headless display: dropping the hold on {name}, no longer on {device}");
+    }
+    drop_our_entries(|e| {
+        entry_connector(e).is_some_and(|c| stale.iter().any(|(name, _)| name == c))
+    });
+    for c in all
+        .iter()
+        .filter(|c| stale.iter().any(|(name, _)| *name == c.name))
+    {
+        if let Err(e) = write_status(&c.sysfs, "detect") {
+            log::warn!("headless display: cannot re-probe {}: {e}", c.sysfs);
+        }
+    }
+    true
 }
 
 fn tick(state: &mut State) {
@@ -745,7 +910,10 @@ fn tick(state: &mut State) {
     }
 
     let mut all = connectors();
-    adopt_forced(&mut all, state.forced.as_deref());
+    if prune_foreign_markers(&all) {
+        all = connectors();
+    }
+    adopt_forced(&mut all, &state.forced);
     if all.iter().any(|c| c.ours) {
         // A real display takes precedence over ours: release it, and the machine goes back to the
         // output the operator actually plugged in. Only visible for a connector other than the one we
@@ -768,7 +936,7 @@ fn tick(state: &mut State) {
     // cleared it, and a rebind can have twinned the name since). An unattributable hold cannot be
     // managed - left alone it counts as a real output and wedges both arming and release - so give
     // it back; the next tick re-forces cleanly if the machine is truly headless.
-    if state.forced.is_none() && !connectors_named_by_our_entries().is_empty() {
+    if state.forced.is_empty() && !connectors_named_by_our_entries().is_empty() {
         log::info!("headless display: releasing a hold this process cannot attribute");
         let _ = disable(state);
         return;
@@ -825,7 +993,11 @@ pub fn status_text(enabled: bool) -> String {
         // machine that looks untouched while holding a connector on.
         None if !named.is_empty() => s.push_str(&format!(
             "forced by rustdesk: {} (our edid did not load; released by name)\n",
-            named.join(", ")
+            named
+                .iter()
+                .map(|(name, device)| format!("{name} on {device}"))
+                .collect::<Vec<_>>()
+                .join(", ")
         )),
         None => s.push_str("forced by rustdesk: none\n"),
     }
@@ -929,50 +1101,98 @@ mod tests {
     fn our_entries_name_the_connectors_a_release_has_to_reach() {
         // The parse behind the only recovery path for a force whose EDID never loaded. It has to
         // survive a foreign entry, either ordering, and an entry with no connector prefix.
+        let dev = "0000-01-00-0";
+        let mine = |c: &str| format!("{c}:edid/rustdesk-headless-{dev}.bin");
         let names = |v: &str| {
             edid_entries(v)
                 .into_iter()
-                .filter(|e| entry_is_ours(e))
-                .filter_map(|e| e.split_once(':').map(|(n, _)| n.to_owned()))
+                .filter_map(|e| Some((entry_connector(e)?.to_owned(), entry_device(e)?.to_owned())))
                 .collect::<Vec<_>>()
         };
         assert_eq!(
-            names("DP-1:edid/theirs.bin,HDMI-A-1:edid/rustdesk-headless.bin"),
-            vec!["HDMI-A-1"]
+            names(&format!("DP-1:edid/theirs.bin,{}", mine("HDMI-A-1"))),
+            vec![("HDMI-A-1".to_owned(), dev.to_owned())]
         );
         assert_eq!(
-            names("HDMI-A-1:edid/rustdesk-headless.bin,DP-1:edid/theirs.bin"),
-            vec!["HDMI-A-1"]
+            names(&format!("{},DP-1:edid/theirs.bin", mine("HDMI-A-1"))),
+            vec![("HDMI-A-1".to_owned(), dev.to_owned())]
         );
         // Two of ours, which is what a machine that forced one connector and then another leaves.
         assert_eq!(
-            names("HDMI-A-1:edid/rustdesk-headless.bin,DP-2:edid/rustdesk-headless.bin"),
-            vec!["HDMI-A-1", "DP-2"]
+            names(&format!("{},{}", mine("HDMI-A-1"), mine("DP-2"))),
+            vec![
+                ("HDMI-A-1".to_owned(), dev.to_owned()),
+                ("DP-2".to_owned(), dev.to_owned())
+            ]
         );
         assert!(names("DP-1:edid/theirs.bin").is_empty());
         assert!(names("").is_empty());
+        // What an earlier build wrote: still ours, so still releasable, with no device to check.
+        assert_eq!(
+            names("HDMI-A-1:edid/rustdesk-headless.bin"),
+            vec![("HDMI-A-1".to_owned(), String::new())]
+        );
+        // A file that merely starts like ours is not ours.
+        assert!(names("HDMI-A-1:edid/rustdesk-headless-thing.png").is_empty());
+    }
+
+    // rustdesk#15908: the kernel frees a connector's name when the connector goes, so a rebind can
+    // hand `HDMI-A-1` to a different card - and `edid_firmware` has no card syntax to stop our
+    // entry following it there. The device the entry records is what refuses the stranger.
+    #[test]
+    fn a_marker_does_not_follow_its_name_onto_another_device() {
+        let named = vec![("HDMI-A-1".to_owned(), "0000-01-00-0".to_owned())];
+        assert!(connector_is_ours(
+            true,
+            &[],
+            "HDMI-A-1",
+            "0000-01-00-0",
+            &named,
+            true
+        ));
+        // Same connector name, different card: not ours.
+        assert!(!connector_is_ours(
+            true,
+            &[],
+            "HDMI-A-1",
+            "0000-02-00-0",
+            &named,
+            true
+        ));
+        // An unqualified entry from an earlier build still resolves by name alone, or a machine
+        // upgraded mid-hold could never give the connector back.
+        let legacy = vec![("HDMI-A-1".to_owned(), String::new())];
+        assert!(connector_is_ours(
+            true,
+            &[],
+            "HDMI-A-1",
+            "0000-02-00-0",
+            &legacy,
+            true
+        ));
     }
 
     #[test]
     fn a_force_whose_edid_never_loaded_is_still_ours() {
         let mine = synthetic_edid();
-        let named = vec!["HDMI-A-1".to_owned()];
+        let dev = "0000-01-00-0";
+        let named = vec![("HDMI-A-1".to_owned(), dev.to_owned())];
 
         // The ordinary case: our EDID came back, and the name is not even needed.
-        assert!(connector_is_ours(true, &mine, "HDMI-A-1", &[], true));
+        assert!(connector_is_ours(true, &mine, "HDMI-A-1", dev, &[], true));
         // The case this exists for: forced on, override never loaded, so the connector reports
         // nothing of ours. Only our own edid_firmware entry still names it.
-        assert!(connector_is_ours(true, &[], "HDMI-A-1", &named, true));
+        assert!(connector_is_ours(true, &[], "HDMI-A-1", dev, &named, true));
         // A real monitor on a connector we never named is never ours, either way round.
-        assert!(!connector_is_ours(true, &[], "DP-2", &named, true));
-        assert!(!connector_is_ours(true, &[], "DP-2", &[], true));
+        assert!(!connector_is_ours(true, &[], "DP-2", dev, &named, true));
+        assert!(!connector_is_ours(true, &[], "DP-2", dev, &[], true));
         // And a disconnected connector is nobody's, whatever the parameter says.
-        assert!(!connector_is_ours(false, &mine, "HDMI-A-1", &named, true));
+        assert!(!connector_is_ours(false, &mine, "HDMI-A-1", dev, &named, true));
         // A duplicated name claims nothing by name alone: with DP-1 on two cards, the fallback
         // would mark both ours and a real display behind one of them would never release ours.
-        assert!(!connector_is_ours(true, &[], "HDMI-A-1", &named, false));
+        assert!(!connector_is_ours(true, &[], "HDMI-A-1", dev, &named, false));
         // The EDID still decides when it does read back, duplicated name or not.
-        assert!(connector_is_ours(true, &mine, "HDMI-A-1", &named, false));
+        assert!(connector_is_ours(true, &mine, "HDMI-A-1", dev, &named, false));
     }
 
     #[test]
@@ -982,6 +1202,11 @@ mod tests {
         // No connector prefix means every connector, so it covers whatever we would pick.
         assert!(foreign_entry_covers("edid/theirs.bin", "HDMI-A-1"));
         // Our own entry never blocks us.
+        assert!(!foreign_entry_covers(
+            "HDMI-A-1:edid/rustdesk-headless-0000-01-00-0.bin",
+            "HDMI-A-1"
+        ));
+        // And the unqualified form an earlier build wrote is still ours, not a stranger's.
         assert!(!foreign_entry_covers(
             "HDMI-A-1:edid/rustdesk-headless.bin",
             "HDMI-A-1"
@@ -994,6 +1219,7 @@ mod tests {
             sysfs: sysfs.to_owned(),
             connected,
             ours,
+            device: sysfs.split_once('-').map(|(card, _)| card).unwrap_or("").to_owned(),
             drivable: true,
         }
     }
@@ -1198,19 +1424,29 @@ mod tests {
             c("card1-HDMI-A-1", "HDMI-A-1", true, false),
             c("card1-HDMI-A-2", "HDMI-A-2", false, false),
         ];
-        adopt_forced(&mut all, Some("card1-HDMI-A-1"));
+        adopt_forced(&mut all, &["card1-HDMI-A-1".to_owned()]);
         assert!(all[0].ours, "the held connector is adopted by sysfs name");
         assert!(!all[1].ours);
         // And the bare name must not match: the record is card-qualified.
         let mut all2 = vec![c("card1-HDMI-A-1", "HDMI-A-1", true, false)];
-        adopt_forced(&mut all2, Some("HDMI-A-1"));
+        adopt_forced(&mut all2, &["HDMI-A-1".to_owned()]);
         assert!(!all2[0].ours);
-        adopt_forced(&mut all2, None);
+        adopt_forced(&mut all2, &[]);
         assert!(!all2[0].ours);
         // A disconnected forced record means the kernel-side force was lost: not adopted, so the
         // arming path can re-force instead of the tick parking in the release watch.
         let mut all3 = vec![c("card1-HDMI-A-1", "HDMI-A-1", false, false)];
-        adopt_forced(&mut all3, Some("card1-HDMI-A-1"));
+        adopt_forced(&mut all3, &["card1-HDMI-A-1".to_owned()]);
         assert!(!all3[0].ours);
+        // A release that failed on two connectors remembers both, or the second is never retried.
+        let mut all4 = vec![
+            c("card1-HDMI-A-1", "HDMI-A-1", true, false),
+            c("card1-DP-2", "DP-2", true, false),
+        ];
+        adopt_forced(
+            &mut all4,
+            &["card1-HDMI-A-1".to_owned(), "card1-DP-2".to_owned()],
+        );
+        assert!(all4.iter().all(|c| c.ours));
     }
 }

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -811,27 +811,16 @@ fn disable(state: &mut State) -> ResultType<()> {
     let mut released: Vec<String> = Vec::new();
     let mut still_held: Vec<String> = Vec::new();
     for t in &targets {
-        // The override comes off before the unforce, or the re-probe would read our EDID straight
-        // back and a real monitor on that connector would keep being described by it. One entry at
-        // a time: every connector gets its write attempted, and a failure must not strand the
-        // others with their override already gone.
-        drop_our_entries(|e| entry_connector(e) == Some(t.name.as_str()));
+        // The unforce comes FIRST, with our override still installed. A `detect` that fails then
+        // has touched nothing, so there is no marker to put back and no window in which a second
+        // failure could lose the record - the parameter entry simply stays, as it was. Only once
+        // the connector is off the force does the entry come off, and one more `detect` makes it
+        // read the wire instead of the EDID it already holds.
         if let Err(e) = write_status(&t.sysfs, "detect") {
             log::warn!("headless display: cannot release {}: {e}", t.sysfs);
-            // Put the marker back. The parameter entry is what survives this process and, for a
-            // force whose override never loaded, it is the only record there is. A target whose
-            // connector is gone has no identity to record, and an unqualified marker would follow
-            // the name onto whatever appears next, so that one is left to the process record alone.
             match &t.marker {
                 Some(marker) => {
-                    if let Err(e) = install_edid(&t.name, marker) {
-                        log::warn!(
-                            "headless display: cannot re-record the hold on {}: {e}",
-                            t.sysfs
-                        );
-                    } else {
-                        still_held.push(t.name.clone());
-                    }
+                    still_held.push(t.name.clone());
                     state.forced.push(Held {
                         sysfs: t.sysfs.clone(),
                         name: t.name.clone(),
@@ -845,9 +834,15 @@ fn disable(state: &mut State) -> ResultType<()> {
                 ),
             }
             last_err = Some(e);
-        } else {
-            released.push(t.sysfs.clone());
+            continue;
         }
+        drop_our_entries(|e| entry_connector(e) == Some(t.name.as_str()));
+        if let Err(e) = write_status(&t.sysfs, "detect") {
+            // Released, but it may still report the override it probed a moment ago; the next
+            // pass sees a connector carrying our EDID with no marker and re-probes it.
+            log::warn!("headless display: {} released, but the re-probe failed: {e}", t.sysfs);
+        }
+        released.push(t.sysfs.clone());
     }
     // Whatever is left of ours names no connector this pass could act on - an override orphaned by
     // an earlier failure, or one whose card is gone - and it would keep painting our EDID on the

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -625,6 +625,7 @@ fn disable(state: &mut State) -> ResultType<()> {
     // connector is left to release, so an override orphaned by an earlier failure still gets cleaned.
     uninstall_edid();
     let mut last_err = None;
+    let mut released: Vec<String> = Vec::new();
     for sysfs in &targets {
         // Every connector gets its write attempted; one failure must not strand the others with the
         // override already gone.
@@ -635,10 +636,22 @@ fn disable(state: &mut State) -> ResultType<()> {
             // record of the connector disappears with the failed write and nothing ever retries.
             state.forced.get_or_insert_with(|| sysfs.clone());
             last_err = Some(e);
+        } else {
+            released.push(sysfs.clone());
         }
     }
-    if !targets.is_empty() {
-        log::info!("headless display: released {}", targets.join(", "));
+    // The parameter entry is what survives this process, so a connector still forced needs it back.
+    // After the loop, not per failure: `install_edid` keeps only the last of our entries, and this
+    // way the parameter and `state.forced` name the same connector.
+    if let Some(stuck) = state.forced.as_deref() {
+        if let Some((_, name)) = stuck.split_once('-') {
+            if let Err(e) = install_edid(name) {
+                log::warn!("headless display: cannot re-record the hold on {stuck}: {e}");
+            }
+        }
+    }
+    if !released.is_empty() {
+        log::info!("headless display: released {}", released.join(", "));
     }
     match last_err {
         Some(e) => Err(e),

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -1147,8 +1147,12 @@ fn tick(state: &mut State) {
         if !all.iter().any(is_real_output) {
             state.real_since = None;
             if real_display_probe_due(state.last_probe, crate::ipc::drm_capture_active()) {
-                state.last_probe = Some(Instant::now());
-                probe_held_connectors(state);
+                // The gate is what makes the activity check above binding: a capture cannot be
+                // admitted between it and the writes below.
+                if let Some(_gate) = crate::ipc::begin_held_connector_probe() {
+                    state.last_probe = Some(Instant::now());
+                    probe_held_connectors(state);
+                }
             }
             return;
         }

--- a/src/virtual_display_manager/linux/mod.rs
+++ b/src/virtual_display_manager/linux/mod.rs
@@ -610,8 +610,9 @@ fn disable(state: &mut State) -> ResultType<()> {
     }
     // Read the parameter while it still exists. A force whose EDID never loaded leaves no other
     // trace, and `uninstall_edid` below is about to erase this one - which would leave the connector
-    // forced for the rest of the boot with nothing able to name it. Writing `detect` to a connector
-    // that turns out not to have been forced is a no-op, so a name that matches on two cards is free.
+    // forced for the rest of the boot with nothing able to name it. The name resolves against the
+    // live list, and connector indices come from a per-type ida that is global to drm.ko, so two
+    // live connectors never share a name and this matches the one connector we forced.
     for name in connectors_named_by_our_entries() {
         for c in all.iter().filter(|c| c.name == name) {
             if !targets.contains(&c.sysfs) {


### PR DESCRIPTION
follows the design you laid out in #15907.

## what it does

a linux box with nothing plugged in has no enabled connector, so no CRTC, so nothing to capture. the
session falls back to the portal and asks for consent on a screen nobody is looking at. this forces a
disconnected connector on, which gives the compositor an ordinary output on the device it is already
driving, so capture takes its normal path. no virtual driver, no kernel module.

## where it lives

`src/virtual_display_manager/linux/`, as you asked. `virtual_display_manager.rs` is untouched and
still `#[cfg(windows)]`; the linux submodule is declared separately in `lib.rs` because the two share
no code - windows adds a device, linux forces an existing connector on.

## two switches, and both are off

- a cargo feature `headless-display`, which implies `drm`. the same reasoning the tree already applies
  to `drm-wake`: everything else in that backend reads, this one writes, and a switch that removes it
  from the binary is worth having. it implies `drm` because the caches that have to be invalidated
  when a connector appears mid-session are only wired up on the drm path.
- a runtime option `allow-headless-display`, off unless the operator turns it on, on every build
  including the unattended one. `allow-` and not `enable-` on purpose: `option2bool` reads an
  `enable-` key as `value != "N"`, so an absent value would default the feature ON. the key lives in
  this crate rather than in hbb_common, the same way `enable-drm-display-wake` does, so nothing here
  needs a submodule bump. say the word if you would rather have it in `KEYS_SETTINGS` so a custom
  client can preset it, that is a one-line addition on the other side.

exposed as `rustdesk --headless-display enable|disable|status` and as a checkbox in settings, shown
only on linux and only when the machine has DRM connectors at all.

## what it will and will not touch

- only a connector that reports no display is forced, and only on a card that has a render node. a
  display-only DRM device can scan out but nothing can render to it. measured on a 2018 MacBook Pro,
  where `card0` is the Touch Bar (`card0-USB-1`, no render node, permanently `connected`) and the two
  GPUs are `card1` and `card2`. that permanently-connected non-renderable output is also why the
  "does this machine have output" test has to skip such cards, or the feature could never arm there.
- `Writeback` and internal panels are skipped, and an unknown connector kind is left alone rather
  than forced as a last resort.
- `edid_firmware` is a comma-separated list, so entries someone else put there are parsed and kept.
  if a foreign entry already governs the connector we would have picked, nothing is forced at all.
- the release path gives back the connector this process forced plus any connector still carrying our
  EDID from an earlier run of the service, and nothing else.

## the EDID

generated at runtime, not shipped: a real monitor's EDID carries that monitor's vendor id and serial
number and is not ours to redistribute. without any EDID the kernel invents a mode list that tops out
at 1024x768, so this one carries 1920x1080 as the preferred detailed timing plus a standard-timing
list down to 640x480. `edid-decode` reads it clean.

it doubles as the record of which connector was forced. vendor `RDK`, product `0x0001` and the
monitor-name descriptor together, because `0x0001` alone is something a real monitor could carry and
this predicate is what decides whether a connector may be released.

## ordering, which is the part that took the measurements

- force is `edid_firmware` then `on`, with no `detect` in between. the probe that `on` triggers is
  what reads the EDID, and a `detect` first would publish a topology with no displays. measured: `on`
  alone does apply a freshly written `edid_firmware`.
- release is the other way round: the override comes off first, then `detect`. going the other way
  would have the re-probe read our EDID straight back, and a real monitor on that connector would keep
  being described by it.
- clearing `edid_firmware` writes a newline and reads the value back. a zero-length write to that
  attribute is a silent no-op that leaves the old value in place, and taking it for success meant
  deleting the firmware file while the parameter still pointed at it - which the kernel then logs as
  `Requesting EDID firmware ... failed (err=-2)` on every probe of that connector.
- the firmware file is removed only after the parameter no longer refers to it.

## releasing it again

- the option going off releases it, and also cleans up an override orphaned by a failed attempt.
- a real display appearing on any other connector releases it, which the poll sees by reading sysfs.
- a monitor plugged into the connector we hold is noticed too (2fc604a75). the held connector is re-probed on its own every 5 minutes while no drm capture is open, with only the force lifted and the override kept. an earlier attempt at it was a drm-uevent listener of the feature's own, removed before the pr opened: our own sysfs writes make the kernel emit drm uevents, so it looped on its own work.
  turning the option off and on again releases and re-picks.

## what it does not solve

a machine with a monitor attached but no compositor running, and a machine whose connectors cannot be
forced. it assumes a running compositor and a forceable connector, as you said. `status == connected`
is also as far as the code can go: binding a CRTC is the compositor's decision and there is no sysfs
attribute to wait on for it, so the log says what was forced, not that anything is being scanned out.

## what a headless box actually does, since it decides the shape of this

two boots of the same machine with nothing plugged in, one with the option off and one with it on:

- **it gets a full session either way.** gdm autologins six seconds after boot with zero connected
  connectors, gnome-shell and Xwayland run, and rustdesk listens on 21118. so the box is reachable and
  has nothing to capture, which is the whole problem. i had assumed the session would not come up at
  all and that was wrong.
- **the compositor adopts the forced output even though the session was already running headless.**
  the session opened at 06:58:28 with no output, the connector was forced at 06:58:34, and
  gnome-shell allocated a 1920x1080 framebuffer on it. about twelve seconds from boot to a usable
  scanout, and exactly one force line - no cycle across a boot either.
- **the DRM card number is not stable across boots.** the same machine came up as `card1` one boot and
  `card0` the next. that is why this discovers the connector instead of being configured with one: a
  hand-written systemd unit doing `echo on > /sys/class/drm/card1-HDMI-A-1/status` was silently
  writing to a path that no longer existed after that reboot.

on a virtio-gpu VM both connectors report `connected`, so the feature never arms there. worth saying
because cloud VMs are the first thing a reviewer thinks of: they do not have this problem, their
virtual GPU already presents a connected output. this is for bare metal with a real GPU and no cable.

## measured

on a headless intel box, per step, each with a control:

| | |
|---|---|
| option off | does not touch sysfs at all |
| enable | forces by itself; vendor and monitor name read back from the kernel's own `edid` |
| modes offered | 1920x1080 1680x1050 1600x900 1280x1024 1440x900 1152x864 1280x720 1024x768 800x600 640x480 |
| CRTC | `crtc-pos=1920x1080+0+0`, framebuffer allocated by gnome-shell |
| no flap | 0 DRM uevents in 30 s and 0 re-forces, against ~15 before the listener was removed |
| foreign entry | preserved alongside ours, and after the release only theirs remains |
| release | parameter cleared, then the file removed; 0 kernel EDID errors |
| existing topology change handling | `drm: display cache refreshed (topology changed)` fires with no new code |
| release with a real display appearing | held for 3.86 s after the other connector came up (2 s debounce plus poll), never fewer than one connected output, no `marking DRM unavailable` |
| a force whose EDID never loaded | built by hand with the service stopped, then released by name on startup |

## tests

10 unit tests: EDID structure, checksum and the mode list; the ownership marker with a near-miss
control on both the vendor id and the monitor name; the `edid_firmware` list parsing in both entry
orders; a foreign entry that covers our connector; what counts as real output; connector choice
including the display-only card, the already-connected case and an unknown connector kind; and the
measured MacBook Pro topology, both as it is and with its real displays removed.

## one change outside the module

`swap_available_displays` in `src/server/drm_capturer.rs` only ever revised an `Available` verdict, so
once an empty enumeration latched `Unavailable` the correct list arriving a moment later was discarded
and the 30 s negative TTL was the only way out. `refresh_unavailable_async` two functions above
already documents the rule this was missing - "only a non-empty display list flips the verdict" - so
the new arm makes the hotplug path obey it. i am flagging it rather than burying it: it is
pre-existing, but releasing a forced connector is what makes an empty-then-non-empty enumeration a
routine event instead of a rarity, so it belongs with this change.

## one defensive measure i could not reproduce

`edid_firmware` matches a bare connector name with no card qualifier, so in principle a duplicated
name across two cards is ambiguous. among equal candidates the code prefers a name that appears on
only one card. i could not produce that collision on my hardware - the MacBook numbers its DisplayPort
connectors `DP-1`..`DP-3` on one GPU and `DP-4`..`DP-7` on the other - so treat it as insurance rather
than a fix for something i measured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux headless-display support for systems without a connected monitor.
  - Added desktop settings, command-line controls, hardware support detection, and status reporting.
  - Automatically creates a virtual 1920×1080 display when appropriate and releases it when a physical display is detected.
  - Synchronizes headless-display configuration with the service.

- **Bug Fixes**
  - Improved display hotplug handling with delayed rechecks and configuration persistence.

- **Localization**
  - Added headless-display labels and guidance across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->












































<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=54719356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 2/5</h2>

The PR is not yet safe to merge because configuration synchronization can roll back unrelated settings, and duplicate-name or failed-EDID connector paths can still lose persistent ownership and release behavior.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fvirtual_display_manager%2Flinux%2Fmod.rs%3A827-839%0AWhen%20both%20the%20%60detect%60%20release%20and%20the%20subsequent%20%60install_edid%60%20restoration%20fail%2C%20this%20branch%20retains%20ownership%20only%20in%20%60state.forced%60%20after%20the%20persistent%20marker%20was%20removed.%20A%20service%20restart%20clears%20that%20process-local%20state%2C%20so%20the%20still-forced%20connector%20is%20treated%20as%20an%20ordinary%20connected%20output%20and%20can%20no%20longer%20be%20automatically%20released%20or%20re-adopted.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fipc.rs%3A1904-1906%0AIf%20another%20process%20changes%20a%20setting%20after%20this%20CLI%20process%20starts%20but%20before%20this%20sync%20runs%2C%20%60Config%3A%3Aget%28%29%60%20and%20%60Config2%3A%3Aget%28%29%60%20omit%20that%20newer%20value.%20The%20service%20then%20replaces%20both%20complete%20configurations%20with%20these%20stale%20snapshots%2C%20so%20using%20%60--headless-display%20enable%7Cdisable%60%20can%20roll%20back%20an%20unrelated%20setting.%20Synchronize%20only%20the%20requested%20option%2C%20or%20merge%20it%20into%20the%20latest%20configuration%20without%20sending%20the%20encrypted-on-disk%20fields%20as%20blank%20plaintext%20values.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15908&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=7"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Failed release loses ownership** <a href="https://github.com/rustdesk/rustdesk/pull/15908#discussion_r3918663748">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Stale config overwrites settings** <a href="https://github.com/rustdesk/rustdesk/pull/15908#discussion_r3941326698">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/virtual_display_manager/linux/mod.rs:827-839
When both the `detect` release and the subsequent `install_edid` restoration fail, this branch retains ownership only in `state.forced` after the persistent marker was removed. A service restart clears that process-local state, so the still-forced connector is treated as an ordinary connected output and can no longer be automatically released or re-adopted.

### Issue 2
src/ipc.rs:1904-1906
If another process changes a setting after this CLI process starts but before this sync runs, `Config::get()` and `Config2::get()` omit that newer value. The service then replaces both complete configurations with these stale snapshots, so using `--headless-display enable|disable` can roll back an unrelated setting. Synchronize only the requested option, or merge it into the latest configuration without sending the encrypted-on-disk fields as blank plaintext values.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details open><summary>Summary</summary>

The PR adds an opt-in Linux headless-display facility that installs a generated EDID, forces a suitable DRM connector, exposes CLI and Flutter controls, and refreshes DRM capture state when topology changes.
- Adds connector discovery, ownership markers, forcing, release, and physical-display probing.
- Adds the `headless-display` Cargo feature and enables it in unattended DRM packages.
- Adds service configuration synchronization, UI controls, status reporting, and localization.
- Updates DRM display-cache handling for empty-to-nonempty topology transitions.
</details>

<details open><summary>Diagram</summary>

```mermaid
sequenceDiagram
    participant Operator
    participant CLI_UI as CLI/UI
    participant Service as Root service
    participant Manager as Headless manager
    participant Sysfs as DRM sysfs
    Operator->>CLI_UI: Enable headless display
    CLI_UI->>Service: Synchronize configuration
    Service->>Manager: Observe enabled option
    Manager->>Sysfs: Install generated EDID marker
    Manager->>Sysfs: "Write connector status=on"
    Sysfs-->>Manager: Connected synthetic output
    Manager->>Sysfs: Periodically probe held connector
    alt Physical display detected
        Manager->>Sysfs: Release forced connector
    else Still headless
        Manager->>Sysfs: "Restore status=on"
    end
```
</details>

<sub>Reviews (23) · Last reviewed commit: ["fix(drm): retry DRM across an empty topo..."](https://github.com/rustdesk/rustdesk/commit/ad73814a9ccf9c24e4ca0521a743cd3aab66d261)</sub>

<!-- /greptile_comment -->