### PR TITLE
Add Alt+` keyboard shortcut to switch remote displays

### DIFF
--- a/flutter/lib/models/display_utils.dart
+++ b/flutter/lib/models/display_utils.dart
@@ -1,0 +1,10 @@
+import '../consts.dart';
+
+/// Compute the next individual display index in a round-robin cycle.
+///
+/// The "All displays" pseudo-monitor (`kAllDisplayValue`) is skipped: cycling
+/// from it wraps to the first individual display. Callers must ensure
+/// `total > 1`; with fewer displays there is nothing to cycle between.
+int nextDisplayIndex(int current, int total) {
+  return current == kAllDisplayValue ? 0 : (current + 1) % total;
+}

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -778,7 +778,10 @@ class InputModel {
 
   // Invoked from the Rust rdev grab loop ("Input source 1") when Alt+` is
   // pressed; the Flutter key path handles "Input source 2" above.
-  void switchToNextDisplay() => _cycleToNextDisplay();
+  void switchToNextDisplay() {
+    if (!isDesktop || !keyboardPerm || isViewOnly || isViewCamera) return;
+    _cycleToNextDisplay();
+  }
 
   KeyEventResult handleRawKeyEvent(RawKeyEvent e) {
     if (isViewOnly) return KeyEventResult.handled;

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -16,6 +16,7 @@ import 'package:get/get.dart';
 import '../../models/model.dart';
 import '../../models/platform_model.dart';
 import '../../models/state_model.dart';
+import 'display_utils.dart';
 import 'input_modifier_utils.dart';
 import 'relative_mouse_model.dart';
 import '../common.dart';
@@ -735,6 +736,50 @@ class InputModel {
     }
   }
 
+  // Alt+` (physical backquote key) cycles to the next individual remote
+  // display, skipping the "All displays" pseudo-monitor. Mirrors the
+  // relative-mouse exit shortcut: intercept locally and never forward.
+  bool _displaySwitchShortcutDown = false;
+
+  bool _handleDisplaySwitchShortcut({
+    required PhysicalKeyboardKey physicalKey,
+    required bool isKeyUp,
+    required bool isKeyDown,
+    required bool isRepeat,
+    required bool altPressed,
+  }) {
+    if (!isDesktop || !keyboardPerm || isViewCamera) return false;
+    if (physicalKey != PhysicalKeyboardKey.backquote) return false;
+
+    // Once held, swallow every backquote event until release so the remote
+    // never sees an orphan down/repeat/up it did not initiate.
+    if (_displaySwitchShortcutDown) {
+      if (isKeyUp) _displaySwitchShortcutDown = false;
+      return true;
+    }
+
+    if (!isKeyDown || isRepeat || !altPressed) return false;
+
+    _displaySwitchShortcutDown = true;
+    _cycleToNextDisplay();
+    return true;
+  }
+
+  void _cycleToNextDisplay() {
+    final ffi = parent.target;
+    if (ffi == null) return;
+    final pi = ffi.ffiModel.pi;
+    final total = pi.displays.length;
+    if (total <= 1) return;
+
+    final next = nextDisplayIndex(pi.currentDisplay, total);
+    openMonitorInTheSameTab(next, ffi, pi);
+  }
+
+  // Invoked from the Rust rdev grab loop ("Input source 1") when Alt+` is
+  // pressed; the Flutter key path handles "Input source 2" above.
+  void switchToNextDisplay() => _cycleToNextDisplay();
+
   KeyEventResult handleRawKeyEvent(RawKeyEvent e) {
     if (isViewOnly) return KeyEventResult.handled;
     if (isViewCamera) return KeyEventResult.handled;
@@ -747,6 +792,16 @@ class InputModel {
     }
 
     if (_relativeMouse.handleRawKeyEvent(e)) {
+      return KeyEventResult.handled;
+    }
+
+    if (_handleDisplaySwitchShortcut(
+      physicalKey: e.physicalKey,
+      isKeyUp: e is RawKeyUpEvent,
+      isKeyDown: e is RawKeyDownEvent,
+      isRepeat: e is RawKeyDownEvent && e.repeat,
+      altPressed: e.isAltPressed,
+    )) {
       return KeyEventResult.handled;
     }
 
@@ -844,6 +899,16 @@ class InputModel {
       shiftPressed: shift,
       altPressed: alt,
       commandPressed: command,
+    )) {
+      return KeyEventResult.handled;
+    }
+
+    if (_handleDisplaySwitchShortcut(
+      physicalKey: e.physicalKey,
+      isKeyUp: e is KeyUpEvent,
+      isKeyDown: e is KeyDownEvent,
+      isRepeat: e is KeyRepeatEvent,
+      altPressed: HardwareKeyboard.instance.isAltPressed,
     )) {
       return KeyEventResult.handled;
     }

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -474,6 +474,9 @@ class FfiModel with ChangeNotifier {
       } else if (name == 'exit_relative_mouse_mode') {
         // Handle exit shortcut from rdev grab loop (Ctrl+Alt on Win/Linux, Cmd+G on macOS)
         parent.target?.inputModel.exitRelativeMouseModeWithKeyRelease();
+      } else if (name == 'switch_display_shortcut') {
+        // Handle Alt+` display-switch shortcut from rdev grab loop ("Input source 1")
+        parent.target?.inputModel.switchToNextDisplay();
       } else {
         debugPrint('Event is not handled in the fixed branch: $name');
       }

--- a/flutter/test/display_utils_test.dart
+++ b/flutter/test/display_utils_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_hbb/consts.dart';
+import 'package:flutter_hbb/models/display_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('nextDisplayIndex', () {
+    test('advances to the next display', () {
+      expect(nextDisplayIndex(0, 3), 1);
+      expect(nextDisplayIndex(1, 3), 2);
+    });
+
+    test('wraps around after the last display', () {
+      expect(nextDisplayIndex(2, 3), 0);
+    });
+
+    test('skips the "All displays" pseudo-monitor and starts at the first', () {
+      expect(nextDisplayIndex(kAllDisplayValue, 3), 0);
+    });
+
+    test('cycles through all individual displays and back to the start', () {
+      const total = 4;
+      var current = 0;
+      final order = <int>[];
+      for (var i = 0; i < total; i++) {
+        current = nextDisplayIndex(current, total);
+        order.add(current);
+      }
+      expect(order, [1, 2, 3, 0]);
+    });
+  });
+}

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -42,6 +42,23 @@ static KEYBOARD_HOOKED: AtomicBool = AtomicBool::new(false);
 #[cfg(all(feature = "flutter", any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 static EXIT_SHORTCUT_KEY_DOWN: AtomicBool = AtomicBool::new(false);
 
+// Track the backquote key for the Alt+` display-switch shortcut, so the
+// matching key-up is swallowed and the switch only triggers on the initial
+// press (not OS auto-repeat).
+#[cfg(all(feature = "flutter", any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+static DISPLAY_SWITCH_KEY_DOWN: AtomicBool = AtomicBool::new(false);
+
+// The Alt key-down is buffered instead of forwarded immediately, so an Alt+`
+// shortcut leaves no "lone Alt" on the remote (which would focus the menu bar
+// and break a subsequent Alt+Tab).
+#[cfg(all(feature = "flutter", any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+static BUFFERED_ALT: Mutex<Option<Event>> = Mutex::new(None);
+
+// Set when a buffered Alt was consumed by the shortcut, so the real Alt key-up
+// is swallowed too (the Alt-down was never forwarded).
+#[cfg(all(feature = "flutter", any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+static ALT_CONSUMED: AtomicBool = AtomicBool::new(false);
+
 // Track whether relative mouse mode is currently active.
 // This is set by Flutter via set_relative_mouse_mode_state() and checked
 // by the rdev grab loop to determine if exit shortcuts should be processed.
@@ -531,6 +548,14 @@ fn notify_exit_relative_mouse_mode() {
     flutter::push_session_event(&session_id, "exit_relative_mouse_mode", vec![]);
 }
 
+/// Notify Flutter to cycle to the next individual remote display.
+#[cfg(feature = "flutter")]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn notify_switch_display() {
+    let session_id = flutter::get_cur_session_id();
+    flutter::push_session_event(&session_id, "switch_display_shortcut", vec![]);
+}
+
 /// Handle relative mouse mode shortcuts in the rdev grab loop.
 /// Returns true if the event should be blocked from being sent to the peer.
 #[cfg(feature = "flutter")]
@@ -609,6 +634,70 @@ fn should_block_relative_mouse_shortcut(key: Key, is_press: bool) -> bool {
     false
 }
 
+/// Handle the Alt+` (backquote) display-switch shortcut in the rdev grab loop.
+/// Returns true if the event should be blocked from being sent to the peer.
+///
+/// The Alt key-down is buffered rather than forwarded immediately, so an Alt+`
+/// shortcut never leaves a "lone Alt" on the remote (which would focus the
+/// menu bar and break a subsequent Alt+Tab). If the next key is not BackQuote,
+/// the buffered Alt-down is replayed before that key so Alt+Tab and other
+/// chords still reach the remote.
+#[cfg(feature = "flutter")]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[inline]
+fn should_block_display_switch_shortcut(key: Key, is_press: bool, event: &Event) -> bool {
+    if !KEYBOARD_HOOKED.load(Ordering::SeqCst) {
+        return false;
+    }
+
+    let is_alt = key == Key::Alt || key == Key::AltGr;
+    if is_alt {
+        if is_press {
+            // Buffer the Alt-down; forward it once the next key is known.
+            *BUFFERED_ALT.lock().unwrap() = Some(event.clone());
+            return true;
+        }
+        // Swallow the key-up if the Alt-down was buffered and never forwarded.
+        if BUFFERED_ALT.lock().unwrap().take().is_some() {
+            return true;
+        }
+        // Swallow the key-up if the Alt-down was consumed by the shortcut.
+        if ALT_CONSUMED.swap(false, Ordering::SeqCst) {
+            return true;
+        }
+        return false;
+    }
+
+    // Swallow backquote repeat/up while the shortcut key is held.
+    if key == Key::BackQuote && DISPLAY_SWITCH_KEY_DOWN.load(Ordering::SeqCst) {
+        if !is_press {
+            DISPLAY_SWITCH_KEY_DOWN.store(false, Ordering::SeqCst);
+        }
+        return true;
+    }
+
+    let buffered_alt = BUFFERED_ALT.lock().unwrap().take();
+    let had_alt = buffered_alt.is_some();
+
+    if key == Key::BackQuote && is_press && had_alt {
+        // Alt + BackQuote: switch display, consume the buffered Alt.
+        ALT_CONSUMED.store(true, Ordering::SeqCst);
+        DISPLAY_SWITCH_KEY_DOWN.store(true, Ordering::SeqCst);
+        notify_switch_display();
+        return true;
+    }
+
+    if had_alt {
+        // Alt + <other key>: replay the buffered Alt-down, then let this key
+        // through normally (the grab loop forwards it after we return false).
+        if let Some(alt_event) = buffered_alt {
+            client::process_event(&get_keyboard_mode(), &alt_event, None);
+        }
+    }
+
+    false
+}
+
 fn start_grab_loop() {
     std::env::set_var("KEYBOARD_ONLY", "y");
     #[cfg(any(target_os = "windows", target_os = "macos"))]
@@ -624,6 +713,10 @@ fn start_grab_loop() {
 
             #[cfg(feature = "flutter")]
             if should_block_relative_mouse_shortcut(key, is_press) {
+                return None;
+            }
+            #[cfg(feature = "flutter")]
+            if should_block_display_switch_shortcut(key, is_press, &event) {
                 return None;
             }
 
@@ -692,6 +785,10 @@ fn start_grab_loop() {
             } else {
                 #[cfg(feature = "flutter")]
                 if should_block_relative_mouse_shortcut(key, is_press) {
+                    return None;
+                }
+                #[cfg(feature = "flutter")]
+                if should_block_display_switch_shortcut(key, is_press, &event) {
                     return None;
                 }
                 client::process_event(&get_keyboard_mode(), &event, None);

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -649,16 +649,38 @@ fn should_block_display_switch_shortcut(key: Key, is_press: bool, event: &Event)
     if !KEYBOARD_HOOKED.load(Ordering::SeqCst) {
         return false;
     }
+    // Never buffer Alt while relative mouse mode is active: the Ctrl+Alt exit
+    // shortcut relies on MODIFIERS_STATE seeing the Alt, which buffering would
+    // hide.
+    if RELATIVE_MOUSE_MODE_ACTIVE.load(Ordering::SeqCst) {
+        return false;
+    }
 
-    let is_alt = key == Key::Alt || key == Key::AltGr;
-    if is_alt {
+    // Only left Alt triggers the shortcut. AltGr is a distinct key used for
+    // special characters (e.g. @, #, [ on European layouts) and must pass
+    // through normally.
+    if key == Key::Alt {
         if is_press {
             // Buffer the Alt-down; forward it once the next key is known.
-            *BUFFERED_ALT.lock().unwrap() = Some(event.clone());
+            let mut buf = match BUFFERED_ALT.lock() {
+                Ok(g) => g,
+                Err(e) => {
+                    log::error!("display-switch: BUFFERED_ALT poisoned: {}", e);
+                    return false;
+                }
+            };
+            *buf = Some(event.clone());
             return true;
         }
         // Swallow the key-up if the Alt-down was buffered and never forwarded.
-        if BUFFERED_ALT.lock().unwrap().take().is_some() {
+        let buffered = match BUFFERED_ALT.lock() {
+            Ok(mut g) => g.take().is_some(),
+            Err(e) => {
+                log::error!("display-switch: BUFFERED_ALT poisoned: {}", e);
+                return false;
+            }
+        };
+        if buffered {
             return true;
         }
         // Swallow the key-up if the Alt-down was consumed by the shortcut.
@@ -676,7 +698,13 @@ fn should_block_display_switch_shortcut(key: Key, is_press: bool, event: &Event)
         return true;
     }
 
-    let buffered_alt = BUFFERED_ALT.lock().unwrap().take();
+    let buffered_alt = match BUFFERED_ALT.lock() {
+        Ok(mut g) => g.take(),
+        Err(e) => {
+            log::error!("display-switch: BUFFERED_ALT poisoned: {}", e);
+            return false;
+        }
+    };
     let had_alt = buffered_alt.is_some();
 
     if key == Key::BackQuote && is_press && had_alt {


### PR DESCRIPTION
## Summary

Adds an `Alt+`` (backquote — the physical key before `1`) shortcut to cycle through the individual remote displays during a session, matching the existing display menu in the floating toolbar.

## Motivation

Switching displays today requires clicking the toolbar's display menu. A keyboard shortcut makes navigating multi-monitor remote sessions much faster.

## Why Alt+`

- Uses the *physical* backquote key (`PhysicalKeyboardKey.backquote` / rdev `Key::BackQuote`), so it works on any keyboard layout (e.g. Spanish `º`), not just US `` ` ``.
- `Ctrl+`` collides with VS Code's terminal toggle, so `Alt` was chosen instead.

## Implementation

Two layers, mirroring the existing `Ctrl+Alt` relative-mouse exit shortcut:

1. **Rust (`src/keyboard.rs`)** — on desktop the client captures keys in the rdev grab loop ("Input source 1" by default), not in Flutter. `should_block_display_switch_shortcut` detects the chord and emits a `switch_display_shortcut` session event. The Alt key-down is **buffered** and only replayed when the next key is not BackQuote, so the shortcut never leaves a lone Alt on the remote (a lone Alt focuses the menu bar and breaks a following Alt+Tab).

2. **Flutter (`input_model.dart`, `model.dart`, `display_utils.dart`)** — handles the event and cycles to the next individual display (skipping "All displays"), reusing `openMonitorInTheSameTab`. The round-robin index computation is extracted into a pure `nextDisplayIndex` helper for testability.

## Tests

`flutter/test/display_utils_test.dart` covers advancing, wrap-around, and skipping "All displays".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Alt+Backquote shortcut to cycle through individual remote displays.
  * Automatically wraps from the last display back to the first.
  * Skips the “All displays” view during switching.
  * Prevents shortcut keystrokes from being forwarded to the remote session.
  * Display switching respects desktop, permission, view-only, and camera-view restrictions.

* **Tests**
  * Added coverage for display cycling, wrapping, and skipping the “All displays” view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an Alt+Backquote shortcut for cycling through individual remote displays.

- Intercepts the shortcut in the Rust desktop keyboard-grab path and emits a session event.
- Handles both Rust and Flutter keyboard sources and reuses the existing monitor-opening flow.
- Adds a helper and tests for round-robin display selection while skipping the “All displays” entry.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because lone Alt input remains lost and buffered shortcut state can survive a session-ownership transition.

The current keyboard path still blocks both halves of a standalone Alt gesture, and its process-global buffered and consumed-key state is not reset when grab ownership changes, allowing stale input to affect a later active session.

**Files Needing Attention:** src/keyboard.rs
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/keyboard.rs | Adds shortcut interception and process-global key buffering; the two previously reported input-state failures remain present. |
| flutter/lib/models/input_model.dart | Handles the shortcut from Flutter and Rust event sources and delegates display switching to the existing monitor flow. |
| flutter/lib/models/model.dart | Routes the new Rust session event to the input model. |
| flutter/lib/models/display_utils.dart | Adds the round-robin display-index helper. |
| flutter/test/display_utils_test.dart | Covers advancement, wrap-around, and exclusion of the all-displays pseudo-monitor. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(flutter): validate session permissio..."](https://github.com/rustdesk/rustdesk/commit/156ce974b647fc2cff19e6eddf7a9f9744678504) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54929536)</sub>

<!-- /greptile_comment -->