### PR TITLE
fix: correct terminal mouse selection and scroll coordinates

### DIFF
--- a/flutter/lib/desktop/pages/terminal_page.dart
+++ b/flutter/lib/desktop/pages/terminal_page.dart
@@ -5,7 +5,7 @@ import 'package:flutter_hbb/common.dart';
 import 'package:flutter_hbb/desktop/widgets/tabbar_widget.dart';
 import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/terminal_model.dart';
-import 'package:xterm/xterm.dart';
+import 'package:flutter_hbb/models/terminal_mouse_handler.dart';
 import 'terminal_connection_manager.dart';
 
 class TerminalPage extends StatefulWidget {
@@ -197,7 +197,7 @@ class _TerminalPageState extends State<TerminalPage>
       body: LayoutBuilder(
         builder: (context, constraints) {
           final heightPx = constraints.maxHeight;
-          return TerminalView(
+          return TerminalMouseInteraction(
             _terminalModel.terminal,
             controller: _terminalModel.terminalController,
             focusNode: _terminalFocusNode,

--- a/flutter/lib/models/terminal_mouse_drag_reporter.dart
+++ b/flutter/lib/models/terminal_mouse_drag_reporter.dart
@@ -1,0 +1,235 @@
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:xterm/xterm.dart';
+
+const _cellIndexOffset = 1;
+const _legacyCodeOffset = 32;
+const _leftButtonCode = 0;
+const _motionButtonCode = 32;
+const _releaseButtonCode = 3;
+const _shiftModifierCode = 4;
+const _metaModifierCode = 8;
+const _controlModifierCode = 16;
+const _modifierCodeMask =
+    _shiftModifierCode | _metaModifierCode | _controlModifierCode;
+const _normalCoordinateLimit = 223;
+const _utfCoordinateLimit = 2015;
+
+String encodeTerminalMouseReport(
+  MouseReportMode mode,
+  int button,
+  CellOffset position, {
+  bool release = false,
+}) {
+  final x = position.x + _cellIndexOffset;
+  final y = position.y + _cellIndexOffset;
+  final reportedButton =
+      release ? _releaseButtonCode | (button & _modifierCodeMask) : button;
+  switch (mode) {
+    case MouseReportMode.normal:
+    case MouseReportMode.utf:
+      final limit = mode == MouseReportMode.normal
+          ? _normalCoordinateLimit
+          : _utfCoordinateLimit;
+      final encodedButton =
+          String.fromCharCode(_legacyCodeOffset + reportedButton);
+      return '\x1b[M$encodedButton${_legacyCoordinate(x, limit)}'
+          '${_legacyCoordinate(y, limit)}';
+    case MouseReportMode.sgr:
+      final suffix = release ? 'm' : 'M';
+      return '\x1b[<$button;$x;$y$suffix';
+    case MouseReportMode.urxvt:
+      return '\x1b[${_legacyCodeOffset + reportedButton};$x;${y}M';
+  }
+}
+
+String _legacyCoordinate(int value, int limit) =>
+    value > limit ? '\x00' : String.fromCharCode(_legacyCodeOffset + value);
+
+int _activeModifierCode() {
+  final keyboard = HardwareKeyboard.instance;
+  return (keyboard.isShiftPressed ? _shiftModifierCode : 0) |
+      (keyboard.isAltPressed ? _metaModifierCode : 0) |
+      (keyboard.isControlPressed ? _controlModifierCode : 0);
+}
+
+class TerminalMouseDragReporter {
+  int? _pointerId;
+  TerminalController? _controller;
+  late CellOffset _lastReportedPosition;
+  var _ownsControllerSuspension = false;
+  var _releasePending = false;
+  var _reporting = false;
+
+  bool handleDown(
+    PointerDownEvent event,
+    Terminal terminal,
+    TerminalViewState? terminalView,
+  ) {
+    if (!_isPrimaryMouse(event) || !_reportsDrag(terminal.mouseMode)) {
+      return false;
+    }
+    if (terminalView == null || terminalView.widget.readOnly) return false;
+    final controller = terminalView.widget.controller;
+    if (controller == null ||
+        controller.suspendedPointerInputs ||
+        !controller.pointerInput.inputs.contains(PointerInput.tap)) {
+      return false;
+    }
+
+    cancel();
+    _pointerId = event.pointer;
+    _controller = controller;
+    _ownsControllerSuspension = true;
+    _releasePending = true;
+    _reporting = true;
+    controller.setSuspendPointerInput(true);
+    _clearSelection(controller);
+    final position = _cellAt(event, terminalView);
+    _lastReportedPosition = position;
+    terminal.textInput(
+      _report(terminal.mouseReportMode, position),
+    );
+    return true;
+  }
+
+  bool handleMove(
+    PointerMoveEvent event,
+    Terminal terminal,
+    TerminalViewState? terminalView,
+  ) {
+    if (event.pointer != _pointerId) return false;
+    if (terminalView == null) {
+      cancel();
+      return true;
+    }
+    final reportsDrag = _reportsDrag(terminal.mouseMode);
+    if (!_isPrimaryMouse(event)) {
+      if (_releasePending && reportsDrag) {
+        _reportRelease(
+          terminal,
+          _reporting ? _cellAt(event, terminalView) : _lastReportedPosition,
+        );
+      }
+      cancel();
+      return true;
+    }
+    if (!_reporting || !reportsDrag) {
+      if (!reportsDrag) _releasePending = false;
+      _reporting = false;
+      // Keep ownership until the matching end event to suppress local selection.
+      final controller = _controller;
+      scheduleMicrotask(() => _clearSelection(controller));
+      return true;
+    }
+
+    final position = _cellAt(event, terminalView);
+    _lastReportedPosition = position;
+    terminal.textInput(
+      _report(terminal.mouseReportMode, position, motion: true),
+    );
+    final controller = _controller;
+    scheduleMicrotask(() => _clearSelection(controller));
+    return true;
+  }
+
+  bool handleEnd(
+    PointerEvent event,
+    Terminal terminal,
+    TerminalViewState? terminalView,
+  ) {
+    if (event.pointer != _pointerId) return false;
+    if (terminalView != null &&
+        _releasePending &&
+        _reportsDrag(terminal.mouseMode)) {
+      _reportRelease(
+        terminal,
+        _reporting ? _cellAt(event, terminalView) : _lastReportedPosition,
+      );
+    }
+    _clearSelection(_controller);
+    final controller = _controller;
+    _pointerId = null;
+    // Keep xterm's tap recognizer suspended for this pointer event.
+    scheduleMicrotask(() {
+      if (_pointerId == null && identical(_controller, controller)) {
+        _clearSelection(controller);
+        cancel();
+      }
+    });
+    return true;
+  }
+
+  void cancel() {
+    final controller = _controller;
+    if (_ownsControllerSuspension) {
+      controller?.setSuspendPointerInput(false);
+    }
+    _pointerId = null;
+    _controller = null;
+    _ownsControllerSuspension = false;
+    _releasePending = false;
+    _reporting = false;
+  }
+
+  void updateController(TerminalController controller) {
+    final oldController = _controller;
+    if (_pointerId == null || oldController == null) {
+      cancel();
+      return;
+    }
+    if (identical(oldController, controller)) return;
+    if (_ownsControllerSuspension) {
+      oldController.setSuspendPointerInput(false);
+    }
+    final acceptsPointerInput = !controller.suspendedPointerInputs &&
+        controller.pointerInput.inputs.contains(PointerInput.tap);
+    _controller = controller;
+    _ownsControllerSuspension = acceptsPointerInput;
+    _reporting = _reporting && acceptsPointerInput;
+    if (_ownsControllerSuspension) controller.setSuspendPointerInput(true);
+    _clearSelection(controller);
+  }
+
+  void _reportRelease(Terminal terminal, CellOffset position) {
+    terminal.textInput(
+      _report(
+        terminal.mouseReportMode,
+        position,
+        release: true,
+      ),
+    );
+  }
+
+  CellOffset _cellAt(PointerEvent event, TerminalViewState terminalView) {
+    final renderTerminal = terminalView.renderTerminal;
+    return renderTerminal.getCellOffset(
+      renderTerminal.globalToLocal(event.position),
+    );
+  }
+
+  bool _isPrimaryMouse(PointerEvent event) =>
+      event.kind == PointerDeviceKind.mouse &&
+      (event.buttons & kPrimaryMouseButton) == kPrimaryMouseButton;
+
+  bool _reportsDrag(MouseMode mode) =>
+      mode == MouseMode.upDownScrollDrag || mode == MouseMode.upDownScrollMove;
+
+  void _clearSelection(TerminalController? controller) {
+    if (controller == null || controller.selection == null) return;
+    controller.clearSelection();
+  }
+
+  String _report(
+    MouseReportMode mode,
+    CellOffset position, {
+    bool release = false,
+    bool motion = false,
+  }) {
+    final baseButton = motion ? _motionButtonCode : _leftButtonCode;
+    final button = baseButton | _activeModifierCode();
+    return encodeTerminalMouseReport(mode, button, position, release: release);
+  }
+}

--- a/flutter/lib/models/terminal_mouse_handler.dart
+++ b/flutter/lib/models/terminal_mouse_handler.dart
@@ -1,10 +1,18 @@
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
 import 'package:xterm/xterm.dart';
+
+import 'terminal_mouse_drag_reporter.dart';
 
 /// xterm 4.0.0 encodes wheel buttons as 68..71; the extra bit reads as a Shift
 /// modifier, so strict full-screen apps ignore the report and never scroll.
 /// Upstream fix: TerminalStudio/xterm.dart#238.
 class WheelButtonFixMouseHandler implements TerminalMouseHandler {
-  const WheelButtonFixMouseHandler();
+  const WheelButtonFixMouseHandler({this.positionProvider});
+
+  final CellOffset? Function()? positionProvider;
 
   @override
   String? call(TerminalMouseEvent event) {
@@ -23,20 +31,268 @@ class WheelButtonFixMouseHandler implements TerminalMouseHandler {
   String _reportWheel(TerminalMouseEvent event) {
     // Wheel buttons 4..7 go on the wire as 64..67, but `id` is 64 + 4..7.
     final button = event.button.id - 4;
-    final x = event.position.x + 1;
-    final y = event.position.y + 1;
-    switch (event.state.mouseReportMode) {
-      case MouseReportMode.normal:
-      case MouseReportMode.utf:
-        final limit =
-            event.state.mouseReportMode == MouseReportMode.normal ? 223 : 2015;
-        final col = x > limit ? '\x00' : String.fromCharCode(32 + x);
-        final row = y > limit ? '\x00' : String.fromCharCode(32 + y);
-        return '\x1b[M${String.fromCharCode(32 + button)}$col$row';
-      case MouseReportMode.sgr:
-        return '\x1b[<$button;$x;${y}M';
-      case MouseReportMode.urxvt:
-        return '\x1b[${32 + button};$x;${y}M';
+    final position = positionProvider?.call() ?? event.position;
+    return encodeTerminalMouseReport(
+      event.state.mouseReportMode,
+      button,
+      position,
+    );
+  }
+}
+
+class TerminalMouseInteraction extends StatefulWidget {
+  const TerminalMouseInteraction(
+    this.terminal, {
+    super.key,
+    required this.controller,
+    this.focusNode,
+    this.backgroundOpacity = 1,
+    this.padding,
+    this.onSecondaryTapDown,
+  });
+
+  final Terminal terminal;
+  final TerminalController controller;
+  final FocusNode? focusNode;
+  final double backgroundOpacity;
+  final EdgeInsets? padding;
+  final void Function(TapDownDetails, CellOffset)? onSecondaryTapDown;
+
+  @override
+  State<TerminalMouseInteraction> createState() =>
+      _TerminalMouseInteractionState();
+}
+
+class _TerminalMouseInteractionState extends State<TerminalMouseInteraction> {
+  static const _selectionScrollInterval = Duration(milliseconds: 50);
+  static const _noScroll = 0;
+  static const _scrollUp = -1;
+  static const _scrollDown = 1;
+
+  final _terminalViewKey = GlobalKey<TerminalViewState>();
+  final _scrollController = ScrollController();
+  final _mouseDrag = TerminalMouseDragReporter();
+  late final WheelButtonFixMouseHandler _mouseHandler;
+  TerminalMouseHandler? _previousMouseHandler;
+  Offset? _pointerPosition;
+  Offset? _selectionPointer;
+  CellAnchor? _selectionBase;
+  Buffer? _selectionBuffer;
+  int? _selectionPointerId;
+  Timer? _selectionScrollTimer;
+  var _selectionHasScrolled = false;
+  var _scrollDirection = _noScroll;
+  TerminalViewState? get _terminalView => _terminalViewKey.currentState;
+
+  @override
+  void initState() {
+    super.initState();
+    _mouseHandler = WheelButtonFixMouseHandler(
+      positionProvider: _cellAtPointer,
+    );
+    _installMouseHandler(widget.terminal);
+  }
+
+  @override
+  void didUpdateWidget(TerminalMouseInteraction oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final terminalChanged = !identical(oldWidget.terminal, widget.terminal);
+    final controllerChanged =
+        !identical(oldWidget.controller, widget.controller);
+    if (!terminalChanged && !controllerChanged) return;
+    if (controllerChanged && !terminalChanged) {
+      _mouseDrag.updateController(widget.controller);
+    } else {
+      _mouseDrag.cancel();
     }
+    _clearSelectionDrag();
+    if (!terminalChanged) return;
+    _restoreMouseHandler(oldWidget.terminal);
+    _installMouseHandler(widget.terminal);
+  }
+
+  void _installMouseHandler(Terminal terminal) {
+    _previousMouseHandler = terminal.mouseHandler;
+    terminal.mouseHandler = _mouseHandler;
+  }
+
+  void _restoreMouseHandler(Terminal terminal) {
+    if (identical(terminal.mouseHandler, _mouseHandler)) {
+      terminal.mouseHandler = _previousMouseHandler;
+    }
+  }
+
+  CellOffset? _cellAtPointer() {
+    final terminalView = _terminalView;
+    final pointerPosition = _pointerPosition;
+    if (terminalView == null || pointerPosition == null) return null;
+    final renderTerminal = terminalView.renderTerminal;
+    return renderTerminal.getCellOffset(
+      renderTerminal.globalToLocal(pointerPosition),
+    );
+  }
+
+  void _updatePointerPosition(PointerEvent event) =>
+      _pointerPosition = event.position;
+
+  void _handlePointerDown(PointerDownEvent event) {
+    _updatePointerPosition(event);
+    if (_mouseDrag.handleDown(event, widget.terminal, _terminalView)) {
+      _clearSelectionDrag();
+      return;
+    }
+    if (event.kind != PointerDeviceKind.mouse ||
+        (event.buttons & kPrimaryMouseButton) != kPrimaryMouseButton) {
+      return;
+    }
+    _clearSelectionDrag();
+    final terminalView = _terminalView;
+    if (terminalView == null) return;
+    final renderTerminal = terminalView.renderTerminal;
+    final localPosition = renderTerminal.globalToLocal(event.position);
+    final selectionBuffer = widget.terminal.buffer;
+    _selectionPointerId = event.pointer;
+    _selectionBase = selectionBuffer.createAnchorFromOffset(
+      renderTerminal.getCellOffset(localPosition),
+    );
+    _selectionBuffer = selectionBuffer;
+    _selectionPointer = localPosition;
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    _updatePointerPosition(event);
+    if (_mouseDrag.handleMove(event, widget.terminal, _terminalView)) return;
+    if (event.pointer != _selectionPointerId) return;
+    if (event.kind != PointerDeviceKind.mouse ||
+        (event.buttons & kPrimaryMouseButton) != kPrimaryMouseButton) {
+      _clearSelectionDrag();
+      return;
+    }
+    final terminalView = _terminalView;
+    if (terminalView == null || _selectionBase == null) return;
+    final renderTerminal = terminalView.renderTerminal;
+    final localPosition = renderTerminal.globalToLocal(event.position);
+    _selectionPointer = localPosition;
+    _setScrollDirection(
+      _directionFor(localPosition, renderTerminal.paintBounds),
+    );
+    if (_selectionHasScrolled) {
+      scheduleMicrotask(() => _scrollSelection(scroll: false));
+    }
+  }
+
+  int _directionFor(Offset position, Rect bounds) {
+    if (position.dy < bounds.top) return _scrollUp;
+    if (position.dy >= bounds.bottom) return _scrollDown;
+    return _noScroll;
+  }
+
+  void _setScrollDirection(int direction) {
+    if (_scrollDirection == direction) return;
+    _stopAutoScroll();
+    _scrollDirection = direction;
+    if (direction == _noScroll) return;
+    _scrollSelection();
+    if (_scrollDirection != _noScroll) {
+      _selectionScrollTimer = Timer.periodic(
+        _selectionScrollInterval,
+        (_) => _scrollSelection(),
+      );
+    }
+  }
+
+  void _scrollSelection({bool scroll = true}) {
+    final terminalView = _terminalView;
+    final selectionBase = _selectionBase;
+    final selectionBuffer = _selectionBuffer;
+    final selectionPointer = _selectionPointer;
+    if (terminalView == null ||
+        selectionBase == null ||
+        selectionBuffer == null ||
+        selectionPointer == null ||
+        !_scrollController.hasClients) {
+      return;
+    }
+    if (!identical(selectionBuffer, widget.terminal.buffer) ||
+        !selectionBase.attached) {
+      _clearSelectionDrag();
+      return;
+    }
+    final renderTerminal = terminalView.renderTerminal;
+    if (scroll) {
+      final position = _scrollController.position;
+      final target =
+          (position.pixels + renderTerminal.lineHeight * _scrollDirection)
+              .clamp(position.minScrollExtent, position.maxScrollExtent)
+              .toDouble();
+      if (target == position.pixels) {
+        _stopAutoScroll();
+      } else {
+        position.jumpTo(target);
+        _selectionHasScrolled = true;
+      }
+    }
+    renderTerminal.selectCharacters(
+      renderTerminal.getOffset(selectionBase.offset),
+      selectionPointer,
+    );
+  }
+
+  void _handlePointerEnd(PointerEvent event) {
+    _updatePointerPosition(event);
+    if (!_mouseDrag.handleEnd(event, widget.terminal, _terminalView) &&
+        event.pointer != _selectionPointerId) return;
+    if (_selectionHasScrolled) _scrollSelection(scroll: false);
+    _clearSelectionDrag();
+  }
+
+  void _clearSelectionDrag() {
+    _selectionPointerId = null;
+    _selectionBase?.dispose();
+    _selectionBase = null;
+    _selectionBuffer = null;
+    _selectionPointer = null;
+    _selectionHasScrolled = false;
+    _stopAutoScroll();
+  }
+
+  void _stopAutoScroll() {
+    _selectionScrollTimer?.cancel();
+    _selectionScrollTimer = null;
+    _scrollDirection = _noScroll;
+  }
+
+  @override
+  void dispose() {
+    _mouseDrag.cancel();
+    _clearSelectionDrag();
+    _restoreMouseHandler(widget.terminal);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: _handlePointerDown,
+      onPointerMove: _handlePointerMove,
+      onPointerUp: _handlePointerEnd,
+      onPointerHover: _updatePointerPosition,
+      onPointerCancel: _handlePointerEnd,
+      onPointerSignal: _updatePointerPosition,
+      onPointerPanZoomStart: _updatePointerPosition,
+      onPointerPanZoomUpdate: _updatePointerPosition,
+      onPointerPanZoomEnd: _updatePointerPosition,
+      child: TerminalView(
+        widget.terminal,
+        key: _terminalViewKey,
+        controller: widget.controller,
+        scrollController: _scrollController,
+        focusNode: widget.focusNode,
+        backgroundOpacity: widget.backgroundOpacity,
+        padding: widget.padding,
+        onSecondaryTapDown: widget.onSecondaryTapDown,
+      ),
+    );
   }
 }

--- a/flutter/test/terminal_mouse_handler_test.dart
+++ b/flutter/test/terminal_mouse_handler_test.dart
@@ -1,6 +1,32 @@
 import 'package:flutter_hbb/models/terminal_mouse_handler.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xterm/xterm.dart';
+
+const _terminalSize = Size(400, 120);
+
+Widget _terminalHarness(
+  Terminal terminal,
+  TerminalController controller,
+) =>
+    MaterialApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: _terminalSize.width,
+          height: _terminalSize.height,
+          child: TerminalMouseInteraction(
+            terminal,
+            controller: controller,
+          ),
+        ),
+      ),
+    );
+
+void _writeLines(Terminal terminal, int count) => terminal.write(
+      List.generate(count, (index) => 'line $index\r\n').join(),
+    );
 
 void main() {
   late Terminal terminal;
@@ -110,5 +136,134 @@ void main() {
       report(TerminalMouseButton.wheelDown, TerminalMouseButtonState.up),
       isNull,
     );
+  });
+
+  testWidgets('dragging below scrolls and extends selection', (tester) async {
+    final controller = TerminalController();
+    _writeLines(terminal, 80);
+    await tester.pumpWidget(_terminalHarness(terminal, controller));
+    final terminalView =
+        tester.state<TerminalViewState>(find.byType(TerminalView));
+    final scrollController = terminalView.widget.scrollController!;
+    scrollController.jumpTo(0);
+    await tester.pump();
+    final renderTerminal = terminalView.renderTerminal;
+    const localStart = Offset(20, 20);
+    final startCell = renderTerminal.getCellOffset(localStart);
+    final mouse = TestPointer(1, PointerDeviceKind.mouse);
+    final outside = Offset(20, renderTerminal.size.height);
+    await tester.handlePointerEventRecord([
+      PointerEventRecord(Duration.zero, [
+        mouse.down(renderTerminal.localToGlobal(localStart)),
+        mouse.move(renderTerminal.localToGlobal(outside)),
+      ]),
+      PointerEventRecord(const Duration(milliseconds: 150), [
+        mouse.move(
+          renderTerminal.localToGlobal(outside + const Offset(1, 1)),
+        ),
+        mouse.up(),
+      ]),
+    ]);
+
+    expect(scrollController.offset, greaterThan(0));
+    expect(controller.selection!.begin, startCell);
+    expect(controller.selection!.end.y, greaterThan(startCell.y));
+    final releasedOffset = scrollController.offset;
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(scrollController.offset, releasedOffset);
+  });
+
+  testWidgets('tmux mouse input is reported without local selection',
+      (tester) async {
+    final controller = TerminalController();
+    terminal.write('\x1b[?1049h\x1b[?1002h\x1b[?1006hword');
+    await tester.pumpWidget(_terminalHarness(terminal, controller));
+    final renderTerminal = tester
+        .state<TerminalViewState>(find.byType(TerminalView))
+        .renderTerminal;
+    const wheel = Offset(120, 40);
+    await tester.sendEventToBinding(
+      PointerScrollEvent(
+        position: renderTerminal.localToGlobal(wheel),
+        scrollDelta: const Offset(0, 40),
+      ),
+    );
+    await tester.pump();
+    final wheelCell = renderTerminal.getCellOffset(wheel);
+    expect(output.first, '\x1b[<65;${wheelCell.x + 1};${wheelCell.y + 1}M');
+    output.clear();
+    final clickPosition =
+        renderTerminal.getOffset(const CellOffset(0, 0)) + const Offset(1, 1);
+    final clickCell = renderTerminal.getCellOffset(clickPosition);
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.down(renderTerminal.localToGlobal(clickPosition));
+    await mouse.up();
+    await tester.pump();
+    await mouse.down(renderTerminal.localToGlobal(clickPosition));
+    await mouse.up();
+    await tester.pump(kDoubleTapTimeout);
+    expect(output, [
+      '\x1b[<0;${clickCell.x + 1};${clickCell.y + 1}M',
+      '\x1b[<0;${clickCell.x + 1};${clickCell.y + 1}m',
+      '\x1b[<0;${clickCell.x + 1};${clickCell.y + 1}M',
+      '\x1b[<0;${clickCell.x + 1};${clickCell.y + 1}m',
+    ]);
+    expect(controller.selection, isNull);
+    expect(controller.suspendedPointerInputs, isFalse);
+    output.clear();
+    const start = Offset(40, 40);
+    const end = Offset(240, 80);
+    final startCell = renderTerminal.getCellOffset(start);
+    final endCell = renderTerminal.getCellOffset(end);
+    await mouse.down(renderTerminal.localToGlobal(start));
+    await mouse.moveTo(renderTerminal.localToGlobal(end));
+    await tester.pump();
+
+    expect(output, [
+      '\x1b[<0;${startCell.x + 1};${startCell.y + 1}M',
+      '\x1b[<32;${endCell.x + 1};${endCell.y + 1}M',
+    ]);
+    expect(controller.selection, isNull);
+    await mouse.up();
+    expect(output.last, '\x1b[<0;${endCell.x + 1};${endCell.y + 1}m');
+    expect(controller.suspendedPointerInputs, isFalse);
+  });
+
+  testWidgets('tmux drag stays suppressed after mouse mode is disabled',
+      (tester) async {
+    final controller = TerminalController();
+    terminal.write('\x1b[?1049h\x1b[?1002h\x1b[?1006hword');
+    await tester.pumpWidget(_terminalHarness(terminal, controller));
+    final renderTerminal = tester
+        .state<TerminalViewState>(find.byType(TerminalView))
+        .renderTerminal;
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    final start = renderTerminal.localToGlobal(const Offset(40, 40));
+    final end = renderTerminal.localToGlobal(const Offset(240, 80));
+    await mouse.down(start);
+    output.clear();
+    terminal.write('\x1b[?1002l');
+    await mouse.moveTo(end);
+
+    expect(output, isEmpty);
+    expect(controller.selection, isNull);
+    expect(controller.suspendedPointerInputs, isTrue);
+    terminal.write('\x1b[?1002h');
+    await mouse.moveTo(start);
+    expect(output, isEmpty);
+    expect(controller.selection, isNull);
+    await mouse.up();
+    expect(output, isEmpty);
+    expect(controller.suspendedPointerInputs, isFalse);
+
+    await mouse.down(start);
+    output.clear();
+    terminal.write('\x1b[?1002l');
+    await mouse.up();
+    await tester.pump(kDoubleTapTimeout);
+
+    expect(output, isEmpty);
+    expect(controller.selection, isNull);
+    expect(controller.suspendedPointerInputs, isFalse);
   });
 }


### PR DESCRIPTION
## Preview

### Before

https://github.com/user-attachments/assets/f53bb74c-2d85-474f-aa88-9345177ff263

### After

https://github.com/user-attachments/assets/e6bd6f90-7bb3-48f0-b46e-f57a812cab6c

## Changes

- Scroll the terminal while dragging a text selection above or below the visible area, and keep extending the same selection as the viewport moves.
- Send tmux mouse press, drag, release, and wheel events using the pointer's actual terminal cell. This fixes the incorrect x-coordinate and keeps tmux selection inside the active pane.
- Prevent xterm's local selection and tap handling from producing duplicate mouse reports while application mouse mode is active.


## Tests

- [x] Windows/Linux/macOS -> Linux



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal mouse interaction support, including dragging, selection, auto-scrolling, and modifier-aware mouse reporting.
  * Added compatibility with multiple terminal mouse-reporting modes.
  * Preserved clipboard actions and terminal focus behavior.

* **Bug Fixes**
  * Improved handling of mouse wheel and click events in terminal sessions.
  * Prevented local text selection when terminal mouse mode is active, with proper reset when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR wraps the terminal view with custom pointer handling to extend selections during viewport auto-scroll and to report actual pointer cells to mouse-aware terminal applications.
- Adds periodic selection scrolling while dragging above or below the viewport.
- Adds explicit tmux press, motion, release, and wheel report encoding.
- Suppresses xterm's local selection handling while application mouse reporting owns a drag.
- Adds widget tests for scrolling selection and tmux mouse interactions.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The wheel-coordinate ordering defect should be fixed before merging because it can still send scrolling input to the wrong terminal cell or tmux pane.

The new wheel handler prefers wrapper-maintained pointer state, but that state is refreshed by an ancestor pointer-signal callback after TerminalView can invoke the handler for the current signal.

**Files Needing Attention:** flutter/lib/models/terminal_mouse_handler.dart and flutter/test/terminal_mouse_handler_test.dart
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/models/terminal_mouse_handler.dart | Adds the interaction wrapper and auto-scroll behavior, but the wheel handler can consume the previous pointer position before the current signal updates it. |
| flutter/lib/models/terminal_mouse_drag_reporter.dart | Adds mouse protocol encoding and drag lifecycle management; no independently publishable defect was established. |
| flutter/lib/desktop/pages/terminal_page.dart | Replaces TerminalView with the new interaction wrapper while preserving the existing terminal configuration. |
| flutter/test/terminal_mouse_handler_test.dart | Covers selection scrolling and tmux reporting, but the wheel test only exercises the null-provider fallback and misses a pre-populated stale position. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant OS as Pointer system
    participant TV as TerminalView
    participant MH as Wheel mouse handler
    participant L as Parent Listener
    participant App as tmux/application
    OS->>TV: PointerScrollEvent at current cell
    TV->>MH: Handle wheel report
    MH->>MH: Read previously stored pointer position
    MH->>App: Report wheel at stale cell
    OS->>L: Dispatch signal to ancestor
    L->>L: Store current pointer position
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2315915%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=15915&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aflutter%2Flib%2Fmodels%2Fterminal_mouse_handler.dart%3A35%0A**Wheel%20reports%20use%20stale%20coordinates**%0A%0AWhen%20a%20wheel%20signal%20occurs%20at%20a%20different%20cell%20from%20the%20last%20retained%20pointer%20event%2C%20%60positionProvider%60%20reads%20the%20previous%20position%20because%20the%20child%20%60TerminalView%60%20handles%20the%20signal%20before%20the%20wrapping%20Listener%20updates%20%60_pointerPosition%60%2C%20causing%20tmux%20or%20another%20mouse-aware%20application%20to%20receive%20the%20wheel%20event%20for%20the%20wrong%20cell%20or%20pane.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15915&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix%2Fterminal-mouse-selection%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fterminal-mouse-selection%22.%0A%0A%23%23%23%20Issue%201%0Aflutter%2Flib%2Fmodels%2Fterminal_mouse_handler.dart%3A35%0A**Wheel%20reports%20use%20stale%20coordinates**%0A%0AWhen%20a%20wheel%20signal%20occurs%20at%20a%20different%20cell%20from%20the%20last%20retained%20pointer%20event%2C%20%60positionProvider%60%20reads%20the%20previous%20position%20because%20the%20child%20%60TerminalView%60%20handles%20the%20signal%20before%20the%20wrapping%20Listener%20updates%20%60_pointerPosition%60%2C%20causing%20tmux%20or%20another%20mouse-aware%20application%20to%20receive%20the%20wheel%20event%20for%20the%20wrong%20cell%20or%20pane.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15915&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
flutter/lib/models/terminal_mouse_handler.dart:35
**Wheel reports use stale coordinates**

When a wheel signal occurs at a different cell from the last retained pointer event, `positionProvider` reads the previous position because the child `TerminalView` handles the signal before the wrapping Listener updates `_pointerPosition`, causing tmux or another mouse-aware application to receive the wheel event for the wrong cell or pane.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: correct terminal mouse selection an..."](https://github.com/rustdesk/rustdesk/commit/e0f57480782f1324e67df6931b7d4035ae622717) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55019135)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->