### PR TITLE
fix: dialog, trackpad speed, buttons (close -> ok, cancel)

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -1900,25 +1900,43 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
 }
 
 trackpadSpeedDialog(SessionID sessionId, FFI ffi) async {
-  int initSpeed = ffi.inputModel.trackpadSpeed;
+  final initSpeed = ffi.inputModel.trackpadSpeed;
   final curSpeed = SimpleWrapper(initSpeed);
-  final btnClose = dialogButton('Close', onPressed: () async {
-    if (curSpeed.value <= kMaxTrackpadSpeed &&
-        curSpeed.value >= kMinTrackpadSpeed &&
-        curSpeed.value != initSpeed) {
-      await bind.sessionSetTrackpadSpeed(
-          sessionId: sessionId, value: curSpeed.value);
-      await ffi.inputModel.updateTrackpadSpeed();
+  ffi.dialogManager.show((setState, close, context) {
+    submit() async {
+      if (curSpeed.value <= kMaxTrackpadSpeed &&
+          curSpeed.value >= kMinTrackpadSpeed &&
+          curSpeed.value != initSpeed) {
+        await bind.sessionSetTrackpadSpeed(
+            sessionId: sessionId, value: curSpeed.value);
+        await ffi.inputModel.updateTrackpadSpeed();
+      }
+      close();
     }
-    ffi.dialogManager.dismissAll();
-  });
-  msgBoxCommon(
-      ffi.dialogManager,
-      'Trackpad speed',
-      TrackpadSpeedWidget(
-        value: curSpeed,
+
+    return CustomAlertDialog(
+      title: Text(
+        translate('Trackpad speed'),
+        style: TextStyle(fontSize: 21),
       ),
-      [btnClose]);
+      content: TrackpadSpeedWidget(value: curSpeed),
+      actions: [
+        dialogButton(
+          'Cancel',
+          icon: Icon(Icons.close_rounded),
+          onPressed: close,
+          isOutline: true,
+        ),
+        dialogButton(
+          'OK',
+          icon: Icon(Icons.done_rounded),
+          onPressed: submit,
+        ),
+      ],
+      onSubmit: submit,
+      onCancel: close,
+    );
+  });
 }
 
 void deleteConfirmDialog(Function onSubmit, String title) async {

--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -1960,10 +1960,11 @@ void trackpadSpeedDialog(SessionID sessionId, FFI ffi) {
   var speedText = initSpeed.toString();
   var isSubmitting = false;
   ffi.dialogManager.show((setState, close, context) {
-    Future<void> submit() async {
+    Future<void> submit([String? submittedText]) async {
       if (isSubmitting) {
         return;
       }
+      speedText = submittedText ?? speedText;
       final speed = _validateTrackpadSpeed(speedText);
       if (speed == null) {
         return;
@@ -1991,6 +1992,7 @@ void trackpadSpeedDialog(SessionID sessionId, FFI ffi) {
       content: TrackpadSpeedWidget(
         value: curSpeed,
         onTextChanged: (text) => speedText = text,
+        onTextSubmitted: submit,
       ),
       actions: _trackpadSpeedDialogActions(
         isSubmitting: isSubmitting,

--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -1899,19 +1899,88 @@ customImageQualityDialog(SessionID sessionId, String id, FFI ffi) async {
   msgBoxCommon(ffi.dialogManager, 'Custom Image Quality', content, [btnClose]);
 }
 
-trackpadSpeedDialog(SessionID sessionId, FFI ffi) async {
+int? _validateTrackpadSpeed(String text) {
+  final speed = int.tryParse(text);
+  if (speed == null || speed < kMinTrackpadSpeed || speed > kMaxTrackpadSpeed) {
+    BotToast.showText(
+      text:
+          '${translate('Invalid format')}: $kMinTrackpadSpeed-$kMaxTrackpadSpeed',
+      contentColor: Colors.red,
+    );
+    return null;
+  }
+  return speed;
+}
+
+Future<void> _saveTrackpadSpeed({
+  required SessionID sessionId,
+  required FFI ffi,
+  required int initSpeed,
+  required int speed,
+}) async {
+  if (speed == initSpeed) {
+    return;
+  }
+  await bind.sessionSetTrackpadSpeed(sessionId: sessionId, value: speed);
+  await ffi.inputModel.updateTrackpadSpeed();
+}
+
+void _showTrackpadSpeedSaveError(Object error, StackTrace stackTrace) {
+  debugPrint('Failed to save trackpad speed: $error');
+  debugPrintStack(stackTrace: stackTrace);
+  BotToast.showText(
+    text: translate('Failed'),
+    contentColor: Colors.red,
+  );
+}
+
+List<Widget> _trackpadSpeedDialogActions({
+  required bool isSubmitting,
+  required VoidCallback close,
+  required VoidCallback submit,
+}) {
+  return [
+    dialogButton(
+      'Cancel',
+      icon: Icon(Icons.close_rounded),
+      onPressed: isSubmitting ? null : close,
+      isOutline: true,
+    ),
+    dialogButton(
+      'OK',
+      icon: Icon(Icons.done_rounded),
+      onPressed: isSubmitting ? null : submit,
+    ),
+  ];
+}
+
+void trackpadSpeedDialog(SessionID sessionId, FFI ffi) {
   final initSpeed = ffi.inputModel.trackpadSpeed;
   final curSpeed = SimpleWrapper(initSpeed);
+  var speedText = initSpeed.toString();
+  var isSubmitting = false;
   ffi.dialogManager.show((setState, close, context) {
-    submit() async {
-      if (curSpeed.value <= kMaxTrackpadSpeed &&
-          curSpeed.value >= kMinTrackpadSpeed &&
-          curSpeed.value != initSpeed) {
-        await bind.sessionSetTrackpadSpeed(
-            sessionId: sessionId, value: curSpeed.value);
-        await ffi.inputModel.updateTrackpadSpeed();
+    Future<void> submit() async {
+      if (isSubmitting) {
+        return;
       }
-      close();
+      final speed = _validateTrackpadSpeed(speedText);
+      if (speed == null) {
+        return;
+      }
+      setState(() => isSubmitting = true);
+      try {
+        await _saveTrackpadSpeed(
+          sessionId: sessionId,
+          ffi: ffi,
+          initSpeed: initSpeed,
+          speed: speed,
+        );
+        close();
+      } catch (error, stackTrace) {
+        _showTrackpadSpeedSaveError(error, stackTrace);
+        setState(() => isSubmitting = false);
+      }
     }
 
     return CustomAlertDialog(
@@ -1919,22 +1988,17 @@ trackpadSpeedDialog(SessionID sessionId, FFI ffi) async {
         translate('Trackpad speed'),
         style: TextStyle(fontSize: 21),
       ),
-      content: TrackpadSpeedWidget(value: curSpeed),
-      actions: [
-        dialogButton(
-          'Cancel',
-          icon: Icon(Icons.close_rounded),
-          onPressed: close,
-          isOutline: true,
-        ),
-        dialogButton(
-          'OK',
-          icon: Icon(Icons.done_rounded),
-          onPressed: submit,
-        ),
-      ],
-      onSubmit: submit,
-      onCancel: close,
+      content: TrackpadSpeedWidget(
+        value: curSpeed,
+        onTextChanged: (text) => speedText = text,
+      ),
+      actions: _trackpadSpeedDialogActions(
+        isSubmitting: isSubmitting,
+        close: close,
+        submit: submit,
+      ),
+      onSubmit: isSubmitting ? null : submit,
+      onCancel: isSubmitting ? null : close,
     );
   });
 }

--- a/flutter/lib/common/widgets/setting_widgets.dart
+++ b/flutter/lib/common/widgets/setting_widgets.dart
@@ -253,8 +253,14 @@ class TrackpadSpeedWidget extends StatefulWidget {
   final SimpleWrapper<int> value;
   // If null, no debouncer will be applied.
   final Function(int)? onDebouncer;
+  final ValueChanged<String>? onTextChanged;
 
-  TrackpadSpeedWidget({Key? key, required this.value, this.onDebouncer});
+  TrackpadSpeedWidget({
+    Key? key,
+    required this.value,
+    this.onDebouncer,
+    this.onTextChanged,
+  });
 
   @override
   TrackpadSpeedWidgetState createState() => TrackpadSpeedWidgetState();
@@ -276,6 +282,18 @@ class TrackpadSpeedWidgetState extends State<TrackpadSpeedWidget> {
         debouncerSpeed.setValue(value);
       }
     });
+    widget.onTextChanged?.call(_controller.text);
+  }
+
+  void submitTextValue(String text) {
+    if (widget.onTextChanged != null) {
+      return;
+    }
+    final newValue = int.tryParse(text);
+    if (newValue == null) {
+      return;
+    }
+    updateValue(newValue);
   }
 
   @override
@@ -315,12 +333,8 @@ class TrackpadSpeedWidgetState extends State<TrackpadSpeedWidget> {
                     controller: _controller,
                     keyboardType: TextInputType.number,
                     textAlign: TextAlign.center,
-                    onSubmitted: (text) {
-                      int? v = int.tryParse(text);
-                      if (v != null) {
-                        updateValue(v);
-                      }
-                    },
+                    onChanged: widget.onTextChanged,
+                    onSubmitted: submitTextValue,
                     style: const TextStyle(fontSize: 13),
                     decoration: InputDecoration(
                       contentPadding:

--- a/flutter/lib/common/widgets/setting_widgets.dart
+++ b/flutter/lib/common/widgets/setting_widgets.dart
@@ -254,12 +254,16 @@ class TrackpadSpeedWidget extends StatefulWidget {
   // If null, no debouncer will be applied.
   final Function(int)? onDebouncer;
   final ValueChanged<String>? onTextChanged;
+  // IME actions call TextField.onSubmitted without reaching the dialog's
+  // raw Enter handler, so the dialog needs a separate submission callback.
+  final ValueChanged<String>? onTextSubmitted;
 
   TrackpadSpeedWidget({
     Key? key,
     required this.value,
     this.onDebouncer,
     this.onTextChanged,
+    this.onTextSubmitted,
   });
 
   @override
@@ -285,7 +289,23 @@ class TrackpadSpeedWidgetState extends State<TrackpadSpeedWidget> {
     widget.onTextChanged?.call(_controller.text);
   }
 
+  void updateTextValue(String text) {
+    widget.onTextChanged?.call(text);
+    final newValue = int.tryParse(text);
+    if (newValue == null ||
+        newValue < kMinTrackpadSpeed ||
+        newValue > kMaxTrackpadSpeed) {
+      return;
+    }
+    setState(() => value = newValue);
+  }
+
   void submitTextValue(String text) {
+    final onTextSubmitted = widget.onTextSubmitted;
+    if (onTextSubmitted != null) {
+      onTextSubmitted(text);
+      return;
+    }
     if (widget.onTextChanged != null) {
       return;
     }
@@ -333,7 +353,7 @@ class TrackpadSpeedWidgetState extends State<TrackpadSpeedWidget> {
                     controller: _controller,
                     keyboardType: TextInputType.number,
                     textAlign: TextAlign.center,
-                    onChanged: widget.onTextChanged,
+                    onChanged: updateTextValue,
                     onSubmitted: submitTextValue,
                     style: const TextStyle(fontSize: 13),
                     decoration: InputDecoration(


### PR DESCRIPTION
Change the dialog buttons from "Close" to "Ok" and "Cancel". To make the function clear.

"Custom image quality" dialog is not changed because it needs a live preview.

## Preview

<img width="450" alt="before" src="https://github.com/user-attachments/assets/dc7d41b7-7142-4645-9a9e-26b3fdf4f5b8" />

<img width="450" alt="after" src="https://github.com/user-attachments/assets/230983e7-937b-4ada-92be-1428fd9f1380" />

<img width="500" alt="other" src="https://github.com/user-attachments/assets/0e820bf6-7367-416a-870d-e96322d497d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated the trackpad speed dialog with clearer Cancel and OK actions.
  * Added validation for trackpad speed input and clearer handling of invalid values.
  * Dialog actions are temporarily disabled while changes are being saved.
  * Valid, changed values are saved and reflected in the input controls.
  * Save failures now provide an error notification, while unchanged values are not applied.
  * Improved text entry and submission handling for trackpad speed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces the trackpad-speed dialog’s single Close action with explicit Cancel and OK actions and makes saving validation-aware and asynchronous.
- Adds range validation, save-error feedback, and duplicate-submission prevention.
- Extends `TrackpadSpeedWidget` to report text changes and IME submissions.
- Keeps slider and text-entry values synchronized with the dialog’s submission state.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| flutter/lib/common/widgets/dialog.dart | Reworks the trackpad-speed dialog around explicit cancellation, validated submission, asynchronous persistence, and save-error handling. |
| flutter/lib/common/widgets/setting_widgets.dart | Adds text-change and submission callbacks while preserving the existing standalone widget behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(flutter): sync trackpad speed input ..."](https://github.com/rustdesk/rustdesk/commit/d23f35507a81255d375888c7c4c4c7639ebc6f7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55070736)</sub>

<!-- /greptile_comment -->