### PR TITLE
fix(clipboard): avoid receiver lock contention on reconnect

### DIFF
--- a/libs/clipboard/src/lib.rs
+++ b/libs/clipboard/src/lib.rs
@@ -146,7 +146,9 @@ struct MsgChannel {
 }
 
 lazy_static::lazy_static! {
+    // TODO: A stalled client I/O loop leaves its channel registered indefinitely.
     static ref VEC_MSG_CHANNEL: RwLock<Vec<MsgChannel>> = Default::default();
+    // TODO: Client IDs may collide with independently generated server IDs in this shared table.
     static ref CLIENT_CONN_ID_COUNTER: Mutex<i32> = Mutex::new(0);
 }
 
@@ -173,6 +175,7 @@ pub fn get_client_conn_id(peer_id: &str) -> Option<i32> {
         .read()
         .unwrap()
         .iter()
+        .rev()
         .find(|x| x.peer_id == peer_id)
         .map(|x| x.conn_id)
 }
@@ -187,23 +190,18 @@ pub fn get_rx_cliprdr_client(
     peer_id: &str,
 ) -> (i32, Arc<TokioMutex<UnboundedReceiver<ClipboardFile>>>) {
     let mut lock = VEC_MSG_CHANNEL.write().unwrap();
-    match lock.iter().find(|x| x.peer_id == peer_id) {
-        Some(msg_channel) => (msg_channel.conn_id, msg_channel.receiver.clone()),
-        None => {
-            let (sender, receiver) = unbounded_channel();
-            let receiver = Arc::new(TokioMutex::new(receiver));
-            let receiver2 = receiver.clone();
-            let conn_id = get_conn_id();
-            let msg_channel = MsgChannel {
-                peer_id: peer_id.to_owned(),
-                conn_id,
-                sender,
-                receiver,
-            };
-            lock.push(msg_channel);
-            (conn_id, receiver2)
-        }
-    }
+    let (sender, receiver) = unbounded_channel();
+    let receiver = Arc::new(TokioMutex::new(receiver));
+    let receiver2 = receiver.clone();
+    let conn_id = get_conn_id();
+    let msg_channel = MsgChannel {
+        peer_id: peer_id.to_owned(),
+        conn_id,
+        sender,
+        receiver,
+    };
+    lock.push(msg_channel);
+    (conn_id, receiver2)
 }
 
 pub fn get_rx_cliprdr_server(conn_id: i32) -> Arc<TokioMutex<UnboundedReceiver<ClipboardFile>>> {
@@ -287,12 +285,4 @@ fn send_data_to_all(data: ClipboardFile) {
     for msg_channel in VEC_MSG_CHANNEL.read().unwrap().iter() {
         allow_err!(msg_channel.sender.send(data.clone()));
     }
-}
-
-#[cfg(test)]
-mod tests {
-    // #[test]
-    // fn test_cliprdr_run() {
-    //     super::cliprdr_run();
-    // }
 }


### PR DESCRIPTION
Prevent a new connection from freezing when a previous session to the same peer has not completed shutdown and still holds the clipboard receiver lock.

This is a fallback/containment fix. It prevents the stale session from blocking a new session, but it does not address why the previous session failed to exit.

Therefore, I'm submitting it as a draft and may close it if it turns out to be unnecessary.

## User-submitted log evidence

  The following excerpt is sanitized to remove peer and network information:

  ```text
  [2026-08-19 13:00:26.804] Session <peer> start
  [2026-08-19 13:00:27.088] 26.3037ms used to establish Relay connection
  [2026-08-19 13:00:27.310] get cliprdr client for conn_id 1
  [2026-08-19 13:00:27.720] handling cliprdr msg from server peer
  [2026-08-19 13:00:27.720] Process clipboard message from server peer

  [2026-08-19 13:06:56.574] Session <same-peer> start
  [2026-08-19 13:06:56.853] 22.1827ms used to establish Relay connection
  [2026-08-19 13:06:57.077] get cliprdr client for conn_id 1

  [2026-08-19 13:08:56.308] Session <same-peer> start
  [2026-08-19 13:08:56.598] 22.8919ms used to establish Relay connection
  [2026-08-19 13:08:56.821] get cliprdr client for conn_id 1
```

The initial session continues past clipboard initialization. Both later sessions establish the relay connection, reuse clipboard connection ID 1, and stop producing normal session logs immediately afterward.

There is also no Exit io_loop record for the previous session between these connection attempts.

## Root cause of the freeze

`get_rx_cliprdr_client()` previously reused the same clipboard channel and receiver for connections to the same peer.

The previous io_loop retained the receiver mutex guard for its lifetime. A new io_loop therefore received the same  `Arc<TokioMutex<...>>` and waited indefinitely at:

`rx_clip_client_holder.0.lock().await`

This await occurs before the main network event loop and its timeout handling, making the connection appear frozen.

## Changes

  - Allocate an independent clipboard channel, receiver, and connection ID for every client session.
  - Select the newest registered clipboard connection for the current peer.
  - Remove channels by their captured connection ID, so delayed cleanup from an old session does not remove the new session.
  - Document the remaining session-lifecycle and connection-ID namespace risks.

## Tests

- [x] Windows -> Linux/Windows/macOS, file/text clipboard

## Scope and remaining investigation

This PR is not a complete session-lifecycle fix.

The reconnect path sends Data::Close, but immediately starts a new thread without joining the previous one because the previous thread is expected to exit automatically. The submitted log shows that this expectation was not met, but it does not contain enough shutdown-stage information to determine why.

A separate lifecycle investigation is still required to confirm:

  - Whether Data::Close reached the previous io_loop.
  - Where the previous io_loop remained blocked or delayed.
  - Why Exit io_loop and clipboard channel cleanup were not reached.

Until that cause is confirmed, this change should be considered a fallback that keeps new connections usable despite an incomplete previous shutdown.



