### PR TITLE
feat(terminal): use platform-native copy and paste shortcuts

### DIFF
--- a/flutter/lib/models/terminal_copy_shortcut.dart
+++ b/flutter/lib/models/terminal_copy_shortcut.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:xterm/xterm.dart';
+
+const _controlShiftVPasteShortcut = SingleActivator(
+  LogicalKeyboardKey.keyV,
+  control: true,
+  shift: true,
+);
+
+Future<void> writeTerminalClipboard(String text) async {
+  try {
+    await Clipboard.setData(ClipboardData(text: text));
+  } catch (error) {
+    debugPrint('[Terminal] Failed to write clipboard: $error');
+  }
+}
+
+Map<ShortcutActivator, Intent>? platformTerminalShortcuts() {
+  if (defaultTargetPlatform != TargetPlatform.linux) return null;
+  return {
+    for (final entry in defaultTerminalShortcuts.entries)
+      if (!_isControlVShortcut(entry.key)) entry.key: entry.value,
+    _controlShiftVPasteShortcut:
+        const PasteTextIntent(SelectionChangedCause.keyboard),
+  };
+}
+
+bool _isControlVShortcut(ShortcutActivator shortcut) =>
+    shortcut is SingleActivator &&
+    shortcut.trigger == LogicalKeyboardKey.keyV &&
+    shortcut.control &&
+    !shortcut.shift &&
+    !shortcut.alt &&
+    !shortcut.meta;
+
+FocusOnKeyEventCallback terminalCopyHandler(
+  Terminal terminal,
+  TerminalController controller,
+) =>
+    (_, event) {
+      if (!_isWindowsCopyShortcut(event)) return KeyEventResult.ignored;
+      final selection = controller.selection;
+      if (selection == null || selection.isCollapsed) {
+        return KeyEventResult.ignored;
+      }
+      if (event is KeyDownEvent) {
+        final text = terminal.buffer.getText(selection);
+        unawaited(writeTerminalClipboard(text));
+      }
+      return KeyEventResult.handled;
+    };
+
+bool _isWindowsCopyShortcut(KeyEvent event) {
+  final keyboard = HardwareKeyboard.instance;
+  return defaultTargetPlatform == TargetPlatform.windows &&
+      (event is KeyDownEvent || event is KeyRepeatEvent) &&
+      event.logicalKey == LogicalKeyboardKey.keyC &&
+      keyboard.isControlPressed &&
+      !keyboard.isShiftPressed &&
+      !keyboard.isAltPressed &&
+      !keyboard.isMetaPressed;
+}

--- a/flutter/lib/models/terminal_mouse_handler.dart
+++ b/flutter/lib/models/terminal_mouse_handler.dart
@@ -4,6 +4,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:xterm/xterm.dart';
 
+import 'terminal_copy_shortcut.dart';
 import 'terminal_mouse_drag_reporter.dart';
 
 /// xterm 4.0.0 encodes wheel buttons as 68..71; the extra bit reads as a Shift
@@ -291,6 +292,8 @@ class _TerminalMouseInteractionState extends State<TerminalMouseInteraction> {
         focusNode: widget.focusNode,
         backgroundOpacity: widget.backgroundOpacity,
         padding: widget.padding,
+        shortcuts: platformTerminalShortcuts(),
+        onKeyEvent: terminalCopyHandler(widget.terminal, widget.controller),
         onSecondaryTapDown: widget.onSecondaryTapDown,
       ),
     );

--- a/flutter/test/terminal_mouse_handler_test.dart
+++ b/flutter/test/terminal_mouse_handler_test.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_hbb/models/terminal_mouse_handler.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xterm/xterm.dart';
 
@@ -36,6 +38,34 @@ void main() {
     output = <String>[];
     terminal = Terminal(mouseHandler: const WheelButtonFixMouseHandler())
       ..onOutput = output.add;
+  });
+
+  testWidgets('Linux Ctrl+V is not paste', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      final messenger = tester.binding.defaultBinaryMessenger;
+      messenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (_) async => {'text': 'clipboard'},
+      );
+      final controller = TerminalController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(_terminalHarness(terminal, controller));
+      await tester.tap(find.byType(TerminalView));
+      await tester.pump(kDoubleTapTimeout);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyV);
+      final controlVOutput = List.of(output);
+      output.clear();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyV);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      expect(controlVOutput, ['\x16']);
+      expect(output, ['clipboard']);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 
   String? report(


### PR DESCRIPTION
RustDesk's terminal currently inherits the same xterm.dart shortcuts on Windows and Linux.

This makes selection copy awkward on Windows and consumes `Ctrl+V` as paste on Linux, where terminal applications expect it as `0x16`.

This PR adjusts the local shortcuts without changing the remote terminal protocol or configuration.

| Local platform | Shortcut | Behavior |
| --- | --- | --- |
| Windows | `Ctrl+C` with a selection | Copy the selected text |
| Windows | `Ctrl+C` without a selection | Send `0x03` to the remote terminal |
| Windows | `Ctrl+V` | Paste from the local clipboard |
| Linux | `Ctrl+Shift+C` | Copy the selected text |
| Linux | `Ctrl+C` | Send `0x03` to the remote terminal |
| Linux | `Ctrl+Shift+V` | Paste from the local clipboard |
| Linux | `Ctrl+V` | Send `0x16` to the remote terminal |

Clipboard write failures are logged instead of surfacing as unhandled asynchronous errors.

## Broken

- Windows. Copy shortcuts ~~`Ctrl+Shift+C`~~ to `Ctrl+C`
- Linux. Paste shortcuts ~~`Ctrl+V`~~ to `Ctrl+Shift+V`


## Tests

- [x] Windows
  - [x] `Ctrl+C` & `Ctrl+V` 
- Linux
  - [x] `Ctrl+Shift+C` & `Ctrl+Shift+V` 
  - [x] `Ctrl+V` -> `0x16`
     1. `od -An -t x1`
     2. Double Ctrl+V, then Enter, then Ctrl+D
     3. The output contains `16 0a`

- macOS 
  - [x] `Cmd+C` & `Cmd+V` 
  - [x] `Ctrl+V` -> `0x16`
     1. `od -An -t x1`
     2. Double Ctrl+V, then Enter, then Ctrl+D
     3. The output contains `16 0a`

## Scope

This PR covers only manual copy-and-paste shortcuts.

It does not handle OSC 52 or tmux automatic clipboard writes, as we need some options to guard automatic clipboard pastes for security reasons.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added platform-specific terminal clipboard shortcuts.
  - On Linux, use **Ctrl+Shift+V** to paste clipboard text into the terminal.
  - On Windows, use **Ctrl+C** to copy selected terminal text.

- **Bug Fixes**
  - Prevented repeated key events from copying terminal selections multiple times.
  - Added handling for clipboard write failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR introduces platform-native terminal copy and paste shortcuts without changing the remote protocol.
- Adds selection-aware Windows Ctrl+C clipboard handling while preserving Ctrl+C terminal input when no selection exists.
- Replaces Linux Ctrl+V paste with Ctrl+Shift+V so Ctrl+V reaches the remote terminal as `0x16`.
- Logs clipboard write failures and adds Linux shortcut-routing coverage.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The shortcut changes are narrowly platform-scoped, preserve normal terminal input when copy conditions do not apply, handle clipboard failures, and include direct coverage of the altered Linux Ctrl+V and Ctrl+Shift+V routing.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| flutter/lib/models/terminal_copy_shortcut.dart | Defines Linux shortcut overrides, selection-aware Windows copying, and guarded asynchronous clipboard writes. |
| flutter/lib/models/terminal_mouse_handler.dart | Connects the platform shortcut map and Windows copy event handler to TerminalView. |
| flutter/test/terminal_mouse_handler_test.dart | Verifies that Linux Ctrl+V emits `0x16` while Ctrl+Shift+V pastes clipboard text. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  K[Keyboard event] --> P{Local platform}
  P -->|Windows Ctrl+C| S{Selection exists?}
  S -->|Yes| C[Copy selection to local clipboard]
  S -->|No| R[Forward Ctrl+C to remote terminal]
  P -->|Linux Ctrl+Shift+V| V[Paste local clipboard into terminal]
  P -->|Linux Ctrl+V| X[Forward 0x16 to remote terminal]
  P -->|Other input| N[Use normal terminal key handling]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(terminal): use platform-native copy..."](https://github.com/rustdesk/rustdesk/commit/3cda91644cd6675117478479803d44fb6af24958) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55550426)</sub>

<!-- /greptile_comment -->