### PR TITLE
fix: Privacy Mode 2 error on Windows when Auto Login (auto unlock, notest)

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1265,6 +1265,21 @@ pub fn is_locked() -> bool {
     unsafe { is_session_locked(session_id) == TRUE }
 }
 
+pub fn privacy_mode_wait_unlocked(
+    impl_key: &str,
+    waiting_since: Option<Instant>,
+) -> Option<Instant> {
+    const TIMEOUT: Duration = Duration::from_secs(15);
+    if impl_key != crate::privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY || !is_locked() {
+        return None;
+    }
+    let waiting_since = waiting_since.unwrap_or_else(Instant::now);
+    if waiting_since.elapsed() >= TIMEOUT {
+        return None;
+    }
+    Some(waiting_since)
+}
+
 #[inline]
 pub fn is_logon_ui() -> ResultType<bool> {
     let Some(current_sid) = get_current_process_session_id() else {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1265,23 +1265,61 @@ pub fn is_locked() -> bool {
     unsafe { is_session_locked(session_id) == TRUE }
 }
 
-pub fn privacy_mode_wait_unlocked(
-    impl_key: &str,
-    waiting_since: Option<Instant>,
-) -> Option<Instant> {
-    if impl_key != crate::privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY || !is_locked() {
-        return None;
-    }
-    let waiting_since = waiting_since.unwrap_or_else(Instant::now);
-    if privacy_mode_retry_expired(waiting_since) {
-        return None;
-    }
-    Some(waiting_since)
+const PRIVACY_MODE_DEFER_TIMEOUT: Duration = Duration::from_secs(15);
+
+pub struct PrivacyModeDeferredRequest {
+    impl_key: String,
+    since: Instant,
+    unlocked: bool,
 }
 
-pub fn privacy_mode_retry_expired(waiting_since: Instant) -> bool {
-    const TIMEOUT: Duration = Duration::from_secs(15);
-    waiting_since.elapsed() >= TIMEOUT
+impl PrivacyModeDeferredRequest {
+    #[inline]
+    pub fn impl_key(&self) -> &str {
+        &self.impl_key
+    }
+
+    #[inline]
+    pub fn expired(&self) -> bool {
+        self.since.elapsed() >= PRIVACY_MODE_DEFER_TIMEOUT
+    }
+}
+
+pub fn privacy_mode_defer_while_locked(
+    impl_key: &str,
+    pending: &mut Option<PrivacyModeDeferredRequest>,
+) -> bool {
+    privacy_mode_defer(impl_key, is_locked(), pending)
+}
+
+fn privacy_mode_defer(
+    impl_key: &str,
+    locked: bool,
+    pending: &mut Option<PrivacyModeDeferredRequest>,
+) -> bool {
+    if impl_key != crate::privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY {
+        return false;
+    }
+    if locked {
+        return match pending.as_ref() {
+            Some(p) => !p.expired(),
+            None => {
+                *pending = Some(PrivacyModeDeferredRequest {
+                    impl_key: impl_key.to_owned(),
+                    since: Instant::now(),
+                    unlocked: false,
+                });
+                true
+            }
+        };
+    }
+    if let Some(p) = pending.as_mut() {
+        if !p.unlocked {
+            p.unlocked = true;
+            p.since = Instant::now();
+        }
+    }
+    false
 }
 
 #[inline]
@@ -4724,6 +4762,55 @@ mod tests {
         };
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn privacy_mode_defer_restarts_deadline_after_unlock() {
+        let key = crate::privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY;
+        let mut pending = None;
+
+        assert!(privacy_mode_defer(key, true, &mut pending));
+        let locked_since = pending.as_ref().map(|p| p.since).expect("request is stored");
+        assert!(privacy_mode_defer(key, true, &mut pending));
+        assert_eq!(pending.as_ref().map(|p| p.since), Some(locked_since));
+
+        assert!(!privacy_mode_defer(key, false, &mut pending));
+        let unlocked_since = pending.as_ref().map(|p| p.since).expect("request is kept");
+        assert!(unlocked_since >= locked_since);
+        assert_eq!(
+            pending.as_ref().map(|p| p.impl_key().to_owned()),
+            Some(key.to_owned())
+        );
+
+        assert!(!privacy_mode_defer(key, false, &mut pending));
+        assert_eq!(pending.as_ref().map(|p| p.since), Some(unlocked_since));
+    }
+
+    #[test]
+    fn privacy_mode_defer_stops_when_locked_wait_expires() {
+        let key = crate::privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY;
+        let Some(expired_since) = Instant::now().checked_sub(PRIVACY_MODE_DEFER_TIMEOUT) else {
+            return;
+        };
+        let mut pending = Some(PrivacyModeDeferredRequest {
+            impl_key: key.to_owned(),
+            since: expired_since,
+            unlocked: false,
+        });
+
+        assert!(pending.as_ref().map_or(false, |p| p.expired()));
+        assert!(!privacy_mode_defer(key, true, &mut pending));
+    }
+
+    #[test]
+    fn privacy_mode_defer_ignores_other_impls() {
+        let mut pending = None;
+        assert!(!privacy_mode_defer(
+            "privacy_mode_impl_mag",
+            true,
+            &mut pending
+        ));
+        assert!(pending.is_none());
     }
 
     #[test]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1269,15 +1269,19 @@ pub fn privacy_mode_wait_unlocked(
     impl_key: &str,
     waiting_since: Option<Instant>,
 ) -> Option<Instant> {
-    const TIMEOUT: Duration = Duration::from_secs(15);
     if impl_key != crate::privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY || !is_locked() {
         return None;
     }
     let waiting_since = waiting_since.unwrap_or_else(Instant::now);
-    if waiting_since.elapsed() >= TIMEOUT {
+    if privacy_mode_retry_expired(waiting_since) {
         return None;
     }
     Some(waiting_since)
+}
+
+pub fn privacy_mode_retry_expired(waiting_since: Instant) -> bool {
+    const TIMEOUT: Duration = Duration::from_secs(15);
+    waiting_since.elapsed() >= TIMEOUT
 }
 
 #[inline]

--- a/src/privacy_mode.rs
+++ b/src/privacy_mode.rs
@@ -190,7 +190,7 @@ pub fn switch(impl_key: &str) {
     }
 }
 
-fn get_supported_impl(impl_key: &str) -> String {
+pub fn get_supported_impl(impl_key: &str) -> String {
     let supported_impls = get_supported_privacy_mode_impl();
     if supported_impls.iter().any(|(k, _)| k == &impl_key) {
         return impl_key.to_owned();

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -775,6 +775,10 @@ impl Connection {
                                     }
                                 }
                                 conn.privacy_mode = enabled;
+                                #[cfg(windows)]
+                                if !enabled {
+                                    conn.privacy_mode_locked_wait = None;
+                                }
                                 conn.send_permission(Permission::PrivacyMode, enabled).await;
                             }
                         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -271,7 +271,7 @@ pub struct Connection {
     block_input: bool,
     privacy_mode: bool,
     #[cfg(windows)]
-    privacy_mode_locked_wait: Option<Instant>,
+    privacy_mode_locked_wait: Option<(String, Instant)>,
     control_permissions: Option<ControlPermissions>,
     last_test_delay: Option<Instant>,
     network_delay: u32,
@@ -4824,13 +4824,15 @@ impl Connection {
 
         #[cfg(windows)]
         {
-            self.privacy_mode_locked_wait = crate::platform::privacy_mode_wait_unlocked(
-                &impl_key,
-                self.privacy_mode_locked_wait,
-            );
-            if self.privacy_mode_locked_wait.is_some() {
+            let effective_impl_key = privacy_mode::get_supported_impl(&impl_key);
+            let waiting_since = self.privacy_mode_locked_wait.as_ref().map(|(_, t)| *t);
+            if let Some(waiting_since) =
+                crate::platform::privacy_mode_wait_unlocked(&effective_impl_key, waiting_since)
+            {
+                self.privacy_mode_locked_wait = Some((impl_key, waiting_since));
                 return;
             }
+            self.privacy_mode_locked_wait = None;
         }
 
         let msg_out = if !privacy_mode::is_privacy_mode_supported() {
@@ -4914,9 +4916,8 @@ impl Connection {
 
     #[cfg(windows)]
     async fn turn_on_privacy_after_unlocked(&mut self) {
-        if self.privacy_mode_locked_wait.is_some() {
-            self.turn_on_privacy(privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY.to_owned())
-                .await;
+        if let Some((impl_key, _)) = self.privacy_mode_locked_wait.clone() {
+            self.turn_on_privacy(impl_key).await;
         }
     }
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -103,6 +103,9 @@ lazy_static::lazy_static! {
 #[cfg(target_os = "windows")]
 const TERMINAL_OS_LOGIN_FAILED_MSG: &str = "Incorrect username or password.";
 
+#[cfg(windows)]
+const PRIVACY_MODE_LOCKED_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
+
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;
@@ -270,6 +273,8 @@ pub struct Connection {
     recording: bool,
     block_input: bool,
     privacy_mode: bool,
+    #[cfg(windows)]
+    privacy_mode_locked_wait: Option<Instant>,
     control_permissions: Option<ControlPermissions>,
     last_test_delay: Option<Instant>,
     network_delay: u32,
@@ -481,6 +486,8 @@ impl Connection {
             recording: Self::permission(keys::OPTION_ENABLE_RECORD_SESSION, &control_permissions),
             block_input: Self::permission(keys::OPTION_ENABLE_BLOCK_INPUT, &control_permissions),
             privacy_mode: Self::permission(keys::OPTION_ENABLE_PRIVACY_MODE, &control_permissions),
+            #[cfg(windows)]
+            privacy_mode_locked_wait: None,
             control_permissions,
             last_test_delay: None,
             network_delay: 0,
@@ -1019,6 +1026,8 @@ impl Connection {
                 _ = second_timer.tick() => {
                     #[cfg(windows)]
                     conn.portable_check();
+                    #[cfg(windows)]
+                    conn.turn_on_privacy_after_unlocked().await;
                     raii::AuthedConnID::check_wake_lock_on_setting_changed();
                     if let Some((instant, minute)) = conn.auto_disconnect_timer.as_ref() {
                         if instant.elapsed().as_secs() > minute * 60 {
@@ -4812,6 +4821,11 @@ impl Connection {
             return;
         }
 
+        #[cfg(windows)]
+        if self.wait_unlocked_before_turn_on_privacy(&impl_key) {
+            return;
+        }
+
         let msg_out = if !privacy_mode::is_privacy_mode_supported() {
             crate::common::make_privacy_mode_msg_with_details(
                 back_notification::PrivacyModeState::PrvNotSupported,
@@ -4891,7 +4905,35 @@ impl Connection {
         self.send(msg_out).await;
     }
 
+    #[cfg(windows)]
+    fn wait_unlocked_before_turn_on_privacy(&mut self, impl_key: &str) -> bool {
+        let waiting_since = self.privacy_mode_locked_wait.take();
+        if impl_key != privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY
+            || !crate::platform::is_locked()
+        {
+            return false;
+        }
+        let waiting_since = waiting_since.unwrap_or_else(Instant::now);
+        if waiting_since.elapsed() >= PRIVACY_MODE_LOCKED_WAIT_TIMEOUT {
+            return false;
+        }
+        self.privacy_mode_locked_wait = Some(waiting_since);
+        true
+    }
+
+    #[cfg(windows)]
+    async fn turn_on_privacy_after_unlocked(&mut self) {
+        if self.privacy_mode_locked_wait.is_some() {
+            self.turn_on_privacy(privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY.to_owned())
+                .await;
+        }
+    }
+
     async fn turn_off_privacy(&mut self, impl_key: String) {
+        #[cfg(windows)]
+        {
+            self.privacy_mode_locked_wait = None;
+        }
         let msg_out = if !privacy_mode::is_privacy_mode_supported() {
             crate::common::make_privacy_mode_msg_with_details(
                 back_notification::PrivacyModeState::PrvNotSupported,

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -271,7 +271,7 @@ pub struct Connection {
     block_input: bool,
     privacy_mode: bool,
     #[cfg(windows)]
-    privacy_mode_locked_wait: Option<(String, std::time::Instant)>,
+    privacy_mode_deferred: Option<crate::platform::PrivacyModeDeferredRequest>,
     control_permissions: Option<ControlPermissions>,
     last_test_delay: Option<Instant>,
     network_delay: u32,
@@ -484,7 +484,7 @@ impl Connection {
             block_input: Self::permission(keys::OPTION_ENABLE_BLOCK_INPUT, &control_permissions),
             privacy_mode: Self::permission(keys::OPTION_ENABLE_PRIVACY_MODE, &control_permissions),
             #[cfg(windows)]
-            privacy_mode_locked_wait: None,
+            privacy_mode_deferred: None,
             control_permissions,
             last_test_delay: None,
             network_delay: 0,
@@ -774,7 +774,7 @@ impl Connection {
                                 conn.privacy_mode = enabled;
                                 #[cfg(windows)]
                                 if !enabled {
-                                    conn.privacy_mode_locked_wait = None;
+                                    conn.privacy_mode_deferred = None;
                                 }
                                 conn.send_permission(Permission::PrivacyMode, enabled).await;
                             }
@@ -4469,7 +4469,7 @@ impl Connection {
         if t.on {
             #[cfg(windows)]
             {
-                self.privacy_mode_locked_wait = None;
+                self.privacy_mode_deferred = None;
             }
             self.turn_on_privacy(t.impl_key).await;
         } else {
@@ -4732,7 +4732,7 @@ impl Connection {
                         BoolOption::Yes => {
                             #[cfg(windows)]
                             {
-                                self.privacy_mode_locked_wait = None;
+                                self.privacy_mode_deferred = None;
                             }
                             self.turn_on_privacy("".to_owned()).await;
                         }
@@ -4833,11 +4833,10 @@ impl Connection {
         #[cfg(windows)]
         {
             let effective_impl_key = privacy_mode::get_supported_impl(&impl_key);
-            let waiting_since = self.privacy_mode_locked_wait.as_ref().map(|(_, t)| *t);
-            if let Some(waiting_since) =
-                crate::platform::privacy_mode_wait_unlocked(&effective_impl_key, waiting_since)
-            {
-                self.privacy_mode_locked_wait = Some((impl_key, waiting_since));
+            if crate::platform::privacy_mode_defer_while_locked(
+                &effective_impl_key,
+                &mut self.privacy_mode_deferred,
+            ) {
                 return;
             }
         }
@@ -4927,12 +4926,12 @@ impl Connection {
 
     #[cfg(windows)]
     fn keep_privacy_mode_retry(&mut self) -> bool {
-        let Some(waiting_since) = self.privacy_mode_locked_wait.as_ref().map(|(_, t)| *t) else {
+        let Some(expired) = self.privacy_mode_deferred.as_ref().map(|p| p.expired()) else {
             return false;
         };
         let turned_on = privacy_mode::get_privacy_mode_conn_id() == Some(self.inner.id);
-        if turned_on || crate::platform::privacy_mode_retry_expired(waiting_since) {
-            self.privacy_mode_locked_wait = None;
+        if turned_on || expired {
+            self.privacy_mode_deferred = None;
             return false;
         }
         true
@@ -4940,7 +4939,11 @@ impl Connection {
 
     #[cfg(windows)]
     async fn turn_on_privacy_after_unlocked(&mut self) {
-        if let Some((impl_key, _)) = self.privacy_mode_locked_wait.clone() {
+        if let Some(impl_key) = self
+            .privacy_mode_deferred
+            .as_ref()
+            .map(|p| p.impl_key().to_owned())
+        {
             self.turn_on_privacy(impl_key).await;
         }
     }
@@ -4948,7 +4951,7 @@ impl Connection {
     async fn turn_off_privacy(&mut self, impl_key: String) {
         #[cfg(windows)]
         {
-            self.privacy_mode_locked_wait = None;
+            self.privacy_mode_deferred = None;
         }
         let msg_out = if !privacy_mode::is_privacy_mode_supported() {
             crate::common::make_privacy_mode_msg_with_details(

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -271,7 +271,7 @@ pub struct Connection {
     block_input: bool,
     privacy_mode: bool,
     #[cfg(windows)]
-    privacy_mode_locked_wait: Option<(String, Instant)>,
+    privacy_mode_locked_wait: Option<(String, std::time::Instant)>,
     control_permissions: Option<ControlPermissions>,
     last_test_delay: Option<Instant>,
     network_delay: u32,
@@ -4840,7 +4840,6 @@ impl Connection {
                 self.privacy_mode_locked_wait = Some((impl_key, waiting_since));
                 return;
             }
-            self.privacy_mode_locked_wait = None;
         }
 
         let msg_out = if !privacy_mode::is_privacy_mode_supported() {
@@ -4919,7 +4918,24 @@ impl Connection {
                 ),
             }
         };
+        #[cfg(windows)]
+        if self.keep_privacy_mode_retry() {
+            return;
+        }
         self.send(msg_out).await;
+    }
+
+    #[cfg(windows)]
+    fn keep_privacy_mode_retry(&mut self) -> bool {
+        let Some(waiting_since) = self.privacy_mode_locked_wait.as_ref().map(|(_, t)| *t) else {
+            return false;
+        };
+        let turned_on = privacy_mode::get_privacy_mode_conn_id() == Some(self.inner.id);
+        if turned_on || crate::platform::privacy_mode_retry_expired(waiting_since) {
+            self.privacy_mode_locked_wait = None;
+            return false;
+        }
+        true
     }
 
     #[cfg(windows)]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -4467,6 +4467,10 @@ impl Connection {
 
     async fn toggle_privacy_mode(&mut self, t: TogglePrivacyMode) {
         if t.on {
+            #[cfg(windows)]
+            {
+                self.privacy_mode_locked_wait = None;
+            }
             self.turn_on_privacy(t.impl_key).await;
         } else {
             self.turn_off_privacy(t.impl_key).await;
@@ -4726,6 +4730,10 @@ impl Connection {
                 if self.keyboard {
                     match q {
                         BoolOption::Yes => {
+                            #[cfg(windows)]
+                            {
+                                self.privacy_mode_locked_wait = None;
+                            }
                             self.turn_on_privacy("".to_owned()).await;
                         }
                         BoolOption::No => {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -103,9 +103,6 @@ lazy_static::lazy_static! {
 #[cfg(target_os = "windows")]
 const TERMINAL_OS_LOGIN_FAILED_MSG: &str = "Incorrect username or password.";
 
-#[cfg(windows)]
-const PRIVACY_MODE_LOCKED_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
-
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;
@@ -4826,8 +4823,14 @@ impl Connection {
         }
 
         #[cfg(windows)]
-        if self.wait_unlocked_before_turn_on_privacy(&impl_key) {
-            return;
+        {
+            self.privacy_mode_locked_wait = crate::platform::privacy_mode_wait_unlocked(
+                &impl_key,
+                self.privacy_mode_locked_wait,
+            );
+            if self.privacy_mode_locked_wait.is_some() {
+                return;
+            }
         }
 
         let msg_out = if !privacy_mode::is_privacy_mode_supported() {
@@ -4907,22 +4910,6 @@ impl Connection {
             }
         };
         self.send(msg_out).await;
-    }
-
-    #[cfg(windows)]
-    fn wait_unlocked_before_turn_on_privacy(&mut self, impl_key: &str) -> bool {
-        let waiting_since = self.privacy_mode_locked_wait.take();
-        if impl_key != privacy_mode::PRIVACY_MODE_IMPL_WIN_VIRTUAL_DISPLAY
-            || !crate::platform::is_locked()
-        {
-            return false;
-        }
-        let waiting_since = waiting_since.unwrap_or_else(Instant::now);
-        if waiting_since.elapsed() >= PRIVACY_MODE_LOCKED_WAIT_TIMEOUT {
-            return false;
-        }
-        self.privacy_mode_locked_wait = Some(waiting_since);
-        true
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
Fixes #14849

## Root cause

Privacy mode 2 is turned on while the Windows session is still locked

## Changes

- On Windows, defer a virtual-display (privacy mode 2) turn-on request while the session is locked and perform it from the existing per-second connection timer once the session is unlocked (bounded by a 15s timeout, after which the attempt proceeds so a real result is still reported). A pending deferral is cancelled when privacy mode is turned off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy-mode activation reliability on Windows virtual displays.
  * Activation now waits during system lock periods and retries automatically after unlocking, for up to 15 seconds.
  * Retry attempts retain the selected privacy implementation.
  * Pending activation is cleared when privacy mode is disabled, directly re-enabled, or the retry period expires.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR defers Windows virtual-display privacy-mode activation while the session is locked and retries it from the connection timer, while incorporating the requested follow-up fixes.
- Encapsulates Windows lock and timeout handling in the platform module.
- Preserves deferred implementation state across internal retries.
- Clears deferred state on permission revocation, explicit disable, and replacement activation requests.
- Adds unit coverage for lock, unlock, expiration, and unsupported implementation behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/platform/windows.rs | Adds the Windows-specific deferred-request state machine and focused tests for its timeout and unlock transitions. |
| src/privacy_mode.rs | Exposes implementation-key normalization so the connection layer can determine whether Windows virtual-display deferral applies. |
| src/server/connection.rs | Integrates deferred activation with the timer and clears pending state across revocation, replacement, disable, success, and expiration paths. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Privacy mode activation request] --> B{Windows virtual display?}
    B -- No --> F[Activate immediately]
    B -- Yes --> C{Session locked?}
    C -- Yes --> D[Store deferred request]
    D --> E[Connection timer retries]
    E --> C
    C -- No --> F
    D --> G{Permission revoked or mode disabled?}
    G -- Yes --> H[Clear deferred request]
    D --> I{Timeout expired?}
    I -- Yes --> F
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix: address review feedback"](https://github.com/rustdesk/rustdesk/commit/0b7f95fe675ac4e9ac01bd8c143277b2417e7f70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55654139)</sub>

<!-- /greptile_comment -->