### PR TITLE
 fix appimage : gdk-pixbuf PNG decode crash on remote cursors

### DIFF
--- a/appimage/AppImageBuilder-aarch64.yml
+++ b/appimage/AppImageBuilder-aarch64.yml
@@ -76,6 +76,8 @@ AppDir:
     env:
       GIO_MODULE_DIR: /lib64/gio/modules:/usr/lib/aarch64-linux-gnu/gio/modules:$APPDIR/usr/lib/aarch64-linux-gnu/gio/modules
       GDK_BACKEND: x11
+      # Append the XDG defaults: AppRun drops /usr/share when the host has XDG_DATA_DIRS unset, and gdk-pixbuf 2.43+ (Arch, Fedora) then finds no glycin loaders, so every PNG decode fails and the first remote cursor aborts the process.
+      XDG_DATA_DIRS: $APPDIR/usr/local/share:$APPDIR/usr/share:$XDG_DATA_DIRS:/usr/local/share:/usr/share
       APPDIR_LIBRARY_PATH: /lib64:/usr/lib/aarch64-linux-gnu:$APPDIR/lib/aarch64-linux-gnu:$APPDIR/lib/aarch64-linux-gnu/security:$APPDIR/lib/systemd:$APPDIR/usr/lib/aarch64-linux-gnu:$APPDIR/usr/lib/aarch64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders:$APPDIR/usr/lib/aarch64-linux-gnu/gstreamer-1.0:$APPDIR/usr/lib/aarch64-linux-gnu/gtk-3.0/3.0.0/immodules:$APPDIR/usr/lib/aarch64-linux-gnu/gtk-3.0/3.0.0/printbackends:$APPDIR/usr/lib/aarch64-linux-gnu/krb5/plugins/preauth:$APPDIR/usr/lib/aarch64-linux-gnu/libcanberra-0.30:$APPDIR/usr/lib/aarch64-linux-gnu/pulseaudio:$APPDIR/usr/lib/aarch64-linux-gnu/sasl2:$APPDIR/usr/lib/aarch64-linux-gnu/vdpau:$APPDIR/usr/share/rustdesk/lib:$APPDIR/lib/aarch64
       GST_PLUGIN_PATH: /lib64/gstreamer-1.0:/usr/lib/aarch64-linux-gnu/gstreamer-1.0:$APPDIR/usr/lib/aarch64-linux-gnu/gstreamer-1.0
       GST_PLUGIN_SYSTEM_PATH: /lib64/gstreamer-1.0:/usr/lib/aarch64-linux-gnu/gstreamer-1.0:$APPDIR/usr/lib/aarch64-linux-gnu/gstreamer-1.0

--- a/appimage/AppImageBuilder-x86_64.yml
+++ b/appimage/AppImageBuilder-x86_64.yml
@@ -79,6 +79,8 @@ AppDir:
     env:
       GIO_MODULE_DIR: /lib64/gio/modules:/usr/lib/x86_64-linux-gnu/gio/modules:$APPDIR/usr/lib/x86_64-linux-gnu/gio/modules
       GDK_BACKEND: x11
+      # Append the XDG defaults: AppRun drops /usr/share when the host has XDG_DATA_DIRS unset, and gdk-pixbuf 2.43+ (Arch, Fedora) then finds no glycin loaders, so every PNG decode fails and the first remote cursor aborts the process.
+      XDG_DATA_DIRS: $APPDIR/usr/local/share:$APPDIR/usr/share:$XDG_DATA_DIRS:/usr/local/share:/usr/share
       APPDIR_LIBRARY_PATH: /lib64:/usr/lib/x86_64-linux-gnu:$APPDIR/lib/x86_64-linux-gnu:$APPDIR/lib/x86_64-linux-gnu/security:$APPDIR/lib/systemd:$APPDIR/usr/lib/x86_64-linux-gnu:$APPDIR/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders:$APPDIR/usr/lib/x86_64-linux-gnu/gstreamer-1.0:$APPDIR/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules:$APPDIR/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/printbackends:$APPDIR/usr/lib/x86_64-linux-gnu/krb5/plugins/preauth:$APPDIR/usr/lib/x86_64-linux-gnu/libcanberra-0.30:$APPDIR/usr/lib/x86_64-linux-gnu/pulseaudio:$APPDIR/usr/lib/x86_64-linux-gnu/sasl2:$APPDIR/usr/lib/x86_64-linux-gnu/vdpau:$APPDIR/usr/share/rustdesk/lib:$APPDIR/lib/x86_64
       GST_PLUGIN_PATH: /lib64/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:$APPDIR/usr/lib/x86_64-linux-gnu/gstreamer-1.0
       GST_PLUGIN_SYSTEM_PATH: /lib64/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:$APPDIR/usr/lib/x86_64-linux-gnu/gstreamer-1.0


### PR DESCRIPTION
Hi,

This PR fixes the long-running pixbuf error that breaks the AppImage on Arch and Fedora.

(Refs #4565 #5457 #7013 #9164 #10563 #11499 #12257 #14305 #14405 #15625)

This took me about two weeks and a few wrong turns to pin down.  AppRun sets `XDG_DATA_DIRS` to the AppDir paths plus the host's value, so when the host doesn't set it at all like Arch does `/usr/share` drops off
the list entirely. On distros where gdk-pixbuf 2.43+ decodes PNG through glycin rather than a bundled loader module, that means no loaders are found, every PNG decode fails, and the first remote cursor takes the process down. The fix
appends the XDG defaults back so the host's loaders stay reachable.

I've confirmed the fix on CachyOS by connecting out to a Mint machine.  I haven't tested on a Debian-based host yet as i dont have one set up at the moment. I could set one up if more testing is needed for this PR. 

I used Claude Code as a debugging aid on this, as this was quite a difficult issue to track down and debug.. the diagnosis and patch are mine and I've verified both by hand. Below you will see a output from the final working session with claude going over the error in detail. 

### Problem

Every AppImage release since at least 1.2.2 aborts the moment the remote sends a
non-default mouse cursor:

```
flutter: Register custom cursor with key 1434141999_3695_240000000_240000000 (5.0,1.0)
(rustdesk:...): GdkPixbuf-CRITICAL **: gdk_pixbuf_copy: assertion 'GDK_IS_PIXBUF (pixbuf)' failed
(rustdesk:...): Gdk-CRITICAL **: gdk_cursor_new_from_pixbuf: assertion 'GDK_IS_PIXBUF (pixbuf)' failed
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
Aborted
```

Reported at least ten times over three years — #4565, #5457, #7013, #9164,
#10563, #11499, #12257, #14305, #14405, #15625 — and closed each time without a
diagnosis. Here is the mechanism.

`AppRun.env` sets

```
XDG_DATA_DIRS=$APPDIR/usr/local/share:$APPDIR/usr/share:$XDG_DATA_DIRS
```

When the host leaves `XDG_DATA_DIRS` unset — normal when the AppImage is started
from a file manager, a `.desktop` entry, or a plain terminal — the result ends in
a trailing colon and contains **no `/usr/share`**. An unset `XDG_DATA_DIRS` gets
the XDG default `/usr/local/share:/usr/share`; setting it to anything suppresses
that default.

gdk-pixbuf 2.43+ (Arch, CachyOS, Gentoo, Fedora, openSUSE) no longer ships PNG,
JPEG or WebP as loader modules. `libgdk_pixbuf` links `libglycin-2.so.0` and
decodes them through glycin, which finds its loaders in
`$XDG_DATA_DIRS/glycin-loaders/<ver>/conf.d/*.conf`. With `/usr/share` gone,
glycin finds none, and **every PNG decode inside the AppImage fails.**

RustDesk sends remote cursors to `flutter_custom_cursor` as PNG. That plugin
discards the `GError` from `gdk_pixbuf_loader_close()` and then returns `nullptr`
from a `std::string`-returning function, so a decode failure becomes `SIGABRT`
rather than a missing cursor.

### Diagnosis

Instrumented from inside a live crashing process by interposing the gdk-pixbuf
entry points (`LD_PRELOAD`, chain-loading the original `libapprun_hooks.so`):

```
[dump] header/runtime version   = 2.44.7
[dump] gdk_pixbuf_loader_write  -> /lib64/libgdk_pixbuf-2.0.so.0
[dump] #0 write len=800 ok=1 err=(none)
[dump] close ok=0 err=Unrecognized image file format -> pixbuf=NULL
[dump] (2)  loader_new_with_type("png") -> OK | no error
[dump] (2b) explicit-png decode        -> NULL | No image loaders are configured.
                                                 You might need to install a package like glycin-loaders.
[dump] (3)  get_file_info -> UNRECOGNISED (-1x-1)
[dump] (4)  png disabled=0
```

The captured buffer is a valid, complete 800-byte 24x24 RGBA PNG that the *same*
library decodes fine outside the AppImage. `write` succeeds because 800 bytes is
below gdk-pixbuf's 1024-byte sniff threshold, so detection is deferred to
`close` — which is where it fails.

Single-variable reproduction, same bytes, same library, same process, only
`XDG_DATA_DIRS` differing:

| `XDG_DATA_DIRS` | result |
|---|---|
| unset (XDG default applies) | decoded 24x24 |
| `$APPDIR/usr/local/share:$APPDIR/usr/share:` | **Unrecognized image file format** |
| the above + `/usr/local/share:/usr/share` | decoded 24x24 |

### Change

Three added lines per recipe, nothing modified or deleted:

```yaml
XDG_DATA_DIRS: $APPDIR/usr/local/share:$APPDIR/usr/share:$XDG_DATA_DIRS:/usr/local/share:/usr/share
```

`appimage-builder` lets a recipe's `runtime.env` override its generated default
(`apprun_2/apprun2.py`), so this is the whole fix.

The two defaults go **last**, so a session that sets `XDG_DATA_DIRS` properly
keeps its own precedence, the AppDir's own directories still win over the host's,
and appending is a no-op wherever those paths are already present.

### Testing

- CachyOS (gdk-pixbuf 2.44.7, glycin), stock 1.4.9 x86_64 AppImage extracted and
  re-run from the AppDir with **only** this variable changed, original
  `libapprun_hooks.so`, no other patch: full remote session against a Windows
  host, cursor moved over the remote screen repeatedly, no crash, remote cursor
  shapes render correctly. The unmodified AppDir from the same extraction aborts
  within seconds.
- Both recipes verified to parse and to place the key at
  `AppDir.runtime.env.XDG_DATA_DIRS`.
- `git diff --check` clean.

### Scope

This fixes the AppImage packaging only. Distributions whose gdk-pixbuf still
compiles PNG into the library (Debian, Ubuntu) never reach glycin, so the older
Debian reports (#5457, #10563) may have a different cause and I have not verified
those. The `flutter_custom_cursor` plugin turning any decode failure into a
`std::string` from `nullptr` is a separate robustness problem in
`Kingtous/flutter_custom_cursor`, not addressed here.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AppImage runtime integration by ensuring bundled and system data directories are detected correctly on both x86_64 and aarch64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores the standard XDG data directories in AppImage runtime environments so gdk-pixbuf can discover host glycin loaders when `XDG_DATA_DIRS` was initially unset.
- Adds the same `XDG_DATA_DIRS` override to the aarch64 AppImage recipe.
- Adds the corresponding override to the x86_64 AppImage recipe.
- Preserves AppDir and inherited session paths ahead of the appended XDG defaults.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with both AppImage recipes consistently restoring the standard XDG data directories.

The runtime environment values preserve AppDir and session precedence while making `/usr/local/share` and `/usr/share` available for glycin loader discovery, and no concrete regression was identified.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| appimage/AppImageBuilder-aarch64.yml | Appends the standard host XDG data directories after AppDir and inherited paths; no actionable issue identified. |
| appimage/AppImageBuilder-x86_64.yml | Applies the equivalent XDG data-directory correction to the x86_64 AppImage runtime; no actionable issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(appimage): keep the XDG default data..."](https://github.com/rustdesk/rustdesk/commit/3bab42228273a5fbd330654c1d6aa080e2b618f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55779630)</sub>

<!-- /greptile_comment -->