### PR TITLE
fix(windows): recover shown secondary Flutter windows

### DIFF
--- a/flutter/windows/runner/CMakeLists.txt
+++ b/flutter/windows/runner/CMakeLists.txt
@@ -33,7 +33,7 @@ target_compile_definitions(${BINARY_NAME} PRIVATE "NOMINMAX")
 
 # Add dependency libraries and include directories. Add any application-specific
 # dependencies here.
-target_link_libraries(${BINARY_NAME} PRIVATE flutter flutter_wrapper_app)
+target_link_libraries(${BINARY_NAME} PRIVATE flutter flutter_wrapper_app comctl32)
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 
 # Run the Flutter tool portions of the build. This must not be removed.

--- a/flutter/windows/runner/flutter_window.cpp
+++ b/flutter/windows/runner/flutter_window.cpp
@@ -12,6 +12,7 @@
 #include <flutter/method_channel.h>
 #include <flutter/standard_method_codec.h>
 
+#include <commctrl.h>
 #include <windows.h>
 
 #include <optional>
@@ -59,6 +60,9 @@ constexpr UINT kForceRedrawMaxTries = 25;
 // per call (each nudge re-enters the 100ms resize wait).
 constexpr UINT kForceRedrawCheapTries = 2;
 
+constexpr UINT_PTR kSecondaryWindowRefreshTimerId = 0xFB16;
+constexpr UINT_PTR kSecondaryWindowSubclassId = 0xFB16;
+
 // Re-enters the embedder's OnWindowSizeChanged by nudging the Flutter child
 // window by 1px and back: this resets the resize target and resends the window
 // metrics. Same as BaseFlutterWindow::ForceChildRefresh() on the
@@ -75,6 +79,26 @@ void ForceChildRefresh(HWND child) {
                SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOMOVE | SWP_FRAMECHANGED);
   SetWindowPos(child, nullptr, 0, 0, width, height,
                SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOMOVE | SWP_FRAMECHANGED);
+}
+
+LRESULT CALLBACK SecondaryWindowSubclassProc(HWND hwnd, UINT message,
+                                             WPARAM wparam, LPARAM lparam,
+                                             UINT_PTR subclass_id,
+                                             DWORD_PTR ref_data) {
+  if (message == WM_SHOWWINDOW && wparam == TRUE) {
+    SetTimer(hwnd, kSecondaryWindowRefreshTimerId, kForceRedrawIntervalMs,
+             nullptr);
+  } else if (message == WM_TIMER &&
+             wparam == kSecondaryWindowRefreshTimerId) {
+    KillTimer(hwnd, kSecondaryWindowRefreshTimerId);
+    ForceChildRefresh(reinterpret_cast<HWND>(ref_data));
+    return 0;
+  } else if (message == WM_NCDESTROY) {
+    KillTimer(hwnd, kSecondaryWindowRefreshTimerId);
+    RemoveWindowSubclass(hwnd, SecondaryWindowSubclassProc, subclass_id);
+  }
+
+  return DefSubclassProc(hwnd, message, wparam, lparam);
 }
 
 }  // namespace
@@ -150,6 +174,16 @@ bool FlutterWindow::OnCreate() {
         registry->GetRegistrarForPlugin("TextureRgbaRendererPlugin"));
     FlutterGpuTextureRendererPluginCApiRegisterWithRegistrar(
         registry->GetRegistrarForPlugin("FlutterGpuTextureRendererPluginCApi"));
+
+    HWND child = flutter_view_controller->view()->GetNativeWindow();
+    HWND window = GetParent(child);
+    if (!window ||
+        !SetWindowSubclass(window, SecondaryWindowSubclassProc,
+                           kSecondaryWindowSubclassId,
+                           reinterpret_cast<DWORD_PTR>(child))) {
+      OutputDebugStringA(
+          "rustdesk: Failed to install secondary window show recovery.\n");
+    }
   });
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 


### PR DESCRIPTION
## Summary
- refresh secondary Flutter child surfaces after their hidden parent is shown
- prevent black remote-session windows on very wide, negative-origin Windows display layouts
- link Comctl32 for the window subclass helper

## Root cause
The current multi-window first-frame callback can fire while a secondary window is hidden, even though that frame was not presented. The dependency then treats the window as rendered and does not re-arm its recovery timer on WM_SHOWWINDOW.

## Verification
- Windows Debug build succeeded
- Windows Release build succeeded
- reproduced before the change on an NVIDIA Surround 11520x2160 display
- connected to the same 1920x1080 peer twice after the change at window coordinates (-3102, -1720); the remote lock screen and RustDesk toolbar rendered immediately both times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when opening secondary windows on Windows.
  * Added automatic recovery to refresh window content if it fails to render correctly.
  * Improved cleanup when secondary windows are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds recovery for secondary Flutter windows whose first generated frame was not presented after being shown, and links the Windows common-controls library required for window subclassing.
- Subclasses secondary native parent windows and schedules a delayed Flutter child refresh on `WM_SHOWWINDOW`.
- Cleans up the refresh timer and subclass during native-window destruction.
- Links `comctl32` for the subclass helper APIs.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure established.

The secondary-window recovery is scoped to show notifications, cancels its one-shot timer before refreshing, and removes both timer and subclass state when the parent is destroyed; the associated Windows library is linked explicitly.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| flutter/windows/runner/flutter_window.cpp | Adds a parent-window subclass that refreshes secondary Flutter child surfaces shortly after they are shown, with timer and destruction cleanup. |
| flutter/windows/runner/CMakeLists.txt | Links the Windows common-controls library needed by `SetWindowSubclass`, `DefSubclassProc`, and `RemoveWindowSubclass`. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Plugin as DesktopMultiWindow
  participant Parent as Secondary parent HWND
  participant Subclass as SecondaryWindowSubclassProc
  participant Child as Flutter child HWND

  Plugin->>Subclass: Install subclass on parent
  Parent->>Subclass: WM_SHOWWINDOW(TRUE)
  Subclass->>Parent: SetTimer(200 ms)
  Parent->>Subclass: WM_TIMER
  Subclass->>Parent: KillTimer
  Subclass->>Child: ForceChildRefresh()
  Child->>Child: Resize +1 px, then restore
  Parent->>Subclass: WM_NCDESTROY
  Subclass->>Parent: KillTimer and remove subclass
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(windows): recover shown secondary Fl..."](https://github.com/rustdesk/rustdesk/commit/ca6fc0edfa73be3fc13dcc8846e203727f9baf7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56036736)</sub>

<!-- /greptile_comment -->