### PR TITLE
fix: reuse the dxgi staging texture instead of one per frame (wait for issue OP verify)

### DIFF
--- a/libs/scrap/src/dxgi/mod.rs
+++ b/libs/scrap/src/dxgi/mod.rs
@@ -357,10 +357,10 @@ impl Capturer {
     // copy from GPU memory to system memory
     unsafe fn ohgodwhat(&mut self, frame: *mut IDXGIResource) -> io::Result<()> {
         let mut texture: *mut ID3D11Texture2D = ptr::null_mut();
-        (*frame).QueryInterface(
+        wrap_hresult((*frame).QueryInterface(
             &IID_ID3D11Texture2D,
             &mut texture as *mut *mut _ as *mut *mut _,
-        );
+        ))?;
         let texture = ComPtr(texture);
 
         #[allow(invalid_value)]
@@ -500,10 +500,10 @@ impl Capturer {
             }
 
             let mut texture: *mut ID3D11Texture2D = ptr::null_mut();
-            (*frame.0).QueryInterface(
+            wrap_hresult((*frame.0).QueryInterface(
                 &IID_ID3D11Texture2D,
                 &mut texture as *mut *mut _ as *mut *mut _,
-            );
+            ))?;
             let texture = ComPtr(texture);
             self.texture = texture;
 

--- a/libs/scrap/src/dxgi/mod.rs
+++ b/libs/scrap/src/dxgi/mod.rs
@@ -48,6 +48,7 @@ pub struct Capturer {
     duplication: ComPtr<IDXGIOutputDuplication>,
     fastlane: bool,
     surface: ComPtr<IDXGISurface>,
+    readable: ComPtr<ID3D11Texture2D>,
     texture: ComPtr<ID3D11Texture2D>,
     width: usize,
     height: usize,
@@ -163,6 +164,7 @@ impl Capturer {
             duplication: ComPtr(duplication),
             fastlane: desc.DesktopImageInSystemMemory == TRUE,
             surface: ComPtr(ptr::null_mut()),
+            readable: ComPtr(ptr::null_mut()),
             texture: ComPtr(ptr::null_mut()),
             width: display.width() as usize,
             height: display.height() as usize,
@@ -346,14 +348,14 @@ impl Capturer {
         if self.fastlane {
             wrap_hresult((*self.duplication.0).MapDesktopSurface(&mut rect))?;
         } else {
-            self.surface = ComPtr(self.ohgodwhat(frame.0)?);
+            self.ohgodwhat(frame.0)?;
             wrap_hresult((*self.surface.0).Map(&mut rect, DXGI_MAP_READ))?;
         }
         Ok((rect.pBits, rect.Pitch))
     }
 
     // copy from GPU memory to system memory
-    unsafe fn ohgodwhat(&mut self, frame: *mut IDXGIResource) -> io::Result<*mut IDXGISurface> {
+    unsafe fn ohgodwhat(&mut self, frame: *mut IDXGIResource) -> io::Result<()> {
         let mut texture: *mut ID3D11Texture2D = ptr::null_mut();
         (*frame).QueryInterface(
             &IID_ID3D11Texture2D,
@@ -370,24 +372,37 @@ impl Capturer {
         texture_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
         texture_desc.MiscFlags = 0;
 
-        let mut readable = ptr::null_mut();
-        wrap_hresult((*self.device.0).CreateTexture2D(
-            &mut texture_desc,
-            ptr::null(),
-            &mut readable,
-        ))?;
-        (*readable).SetEvictionPriority(DXGI_RESOURCE_PRIORITY_MAXIMUM);
-        let readable = ComPtr(readable);
+        // Avoid per-frame staging texture allocation and the kernel allocation churn it causes.
+        let mut current: D3D11_TEXTURE2D_DESC = mem::zeroed();
+        if !self.surface.is_null() {
+            (*self.readable.0).GetDesc(&mut current);
+        }
+        if current.Width != texture_desc.Width
+            || current.Height != texture_desc.Height
+            || current.Format != texture_desc.Format
+        {
+            let mut readable = ptr::null_mut();
+            wrap_hresult((*self.device.0).CreateTexture2D(
+                &mut texture_desc,
+                ptr::null(),
+                &mut readable,
+            ))?;
+            (*readable).SetEvictionPriority(DXGI_RESOURCE_PRIORITY_MAXIMUM);
+            let readable = ComPtr(readable);
 
-        let mut surface = ptr::null_mut();
-        (*readable.0).QueryInterface(
-            &IID_IDXGISurface,
-            &mut surface as *mut *mut _ as *mut *mut _,
-        );
+            let mut surface = ptr::null_mut();
+            wrap_hresult((*readable.0).QueryInterface(
+                &IID_IDXGISurface,
+                &mut surface as *mut *mut _ as *mut *mut _,
+            ))?;
 
-        (*self.context.0).CopyResource(readable.0 as *mut _, texture.0 as *mut _);
+            self.readable = readable;
+            self.surface = ComPtr(surface);
+        }
 
-        Ok(surface)
+        (*self.context.0).CopyResource(self.readable.0 as *mut _, texture.0 as *mut _);
+
+        Ok(())
     }
 
     pub fn frame<'a>(&'a mut self, timeout: UINT) -> io::Result<Frame<'a>> {


### PR DESCRIPTION
ohgodwhat() created a full screen D3D11_USAGE_STAGING texture for every captured frame and pinned each one with SetEvictionPriority(MAXIMUM). Because D3D11 resource destruction may be deferred, that per-frame churn can accumulate a large amount of graphics kernel paged pool on affected drivers. Keep a single staging texture and rebuild it only when the desktop image changes shape.

Also check the HRESULT of the QueryInterface calls in dxgi capture: the IDXGISurface cast could leave surface null while readable holds a valid texture, and the pre-existing IDXGIResource -> ID3D11Texture2D casts fed a null pointer to GetDesc() / the vram encoder.

Reported in #15945.


Claude-Session: https://claude.ai/code/session_018vpiLqteCBiTiuNYMka9LU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved DXGI screen capture efficiency by reusing capture resources between frames.
  * Reduced unnecessary resource creation during ongoing capture sessions, supporting smoother and more consistent capture performance.

* **Bug Fixes**
  * Capture resources now refresh automatically when screen dimensions or formats change, improving reliability during display or configuration changes.
  * Improved handling of changing capture conditions to help prevent interruptions during active screen capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->








<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR caches the DXGI staging texture across captured frames and recreates it when the captured image dimensions or format change. It also checks texture and surface QueryInterface results before using the returned COM pointers.
- Adds persistent staging-texture ownership to the DXGI capturer.
- Rebuilds the cached staging texture when width, height, or format changes.
- Propagates failed COM interface queries instead of dereferencing null results.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/scrap/src/dxgi/mod.rs | Reuses a cached DXGI staging texture and adds HRESULT propagation for the changed COM interface-query paths. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Acquire DXGI frame] --> B[Query ID3D11Texture2D]
    B --> C[Read frame descriptor]
    C --> D{Cached staging texture matches?}
    D -- No --> E[Create staging texture]
    E --> F[Query IDXGISurface]
    F --> G[Cache texture and surface]
    D -- Yes --> H[Reuse cached resources]
    G --> I[Copy frame into staging texture]
    H --> I
    I --> J[Map cached surface]
    J --> K[Return pixel buffer]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: check the frame QueryInterface resu..."](https://github.com/rustdesk/rustdesk/commit/9343affe0bf90110a494134a8076c4060d41bbd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56210940)</sub>

<!-- /greptile_comment -->