### PR TITLE
chore(flutter): bump desktop_multi_window for show recovery

### DIFF
--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -340,7 +340,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: 533883bcb0ffe91a9afdb13b8bac9b14b3e054ba
+      resolved-ref: 8b774a66671cbb9bcb2631af6ac28f9bdd469ce3
       url: "https://github.com/rustdesk-org/rustdesk_desktop_multi_window"
     source: git
     version: "0.1.0"


### PR DESCRIPTION
Pick up rustdesk-org/rustdesk_desktop_multi_window#37, which re-arms the existing bounded redraw timer whenever a secondary window is shown, including when its first frame was generated while hidden but not presented.

This may perform one delayed child refresh on each show. It intentionally does not add a presentation-complete flag: Flutter reports frame generation rather than successful presentation, so recording success after a synthetic refresh could suppress later self-recovery without a reliable success signal.