### PR TITLE
fix(flutter): align terminal shortcuts with platform conventions

### DIFF
--- a/flutter/lib/mobile/pages/terminal_page.dart
+++ b/flutter/lib/mobile/pages/terminal_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter_hbb/common/widgets/dialog.dart';
 import 'package:flutter_hbb/models/input_modifier_utils.dart';
 import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
+import 'package:flutter_hbb/models/terminal_copy_shortcut.dart';
 import 'package:flutter_hbb/models/terminal_model.dart';
 import 'package:flutter_hbb/mobile/terminal_keyboard_utils.dart';
 import 'package:flutter_hbb/web/dummy.dart'
@@ -244,7 +245,12 @@ class _TerminalPageState extends State<TerminalPage>
                     //
                     // Android works fine without this workaround.
                     deleteDetection: isIOS,
-                    onKeyEvent: _handleTerminalKeyEvent,
+                    shortcuts: platformTerminalShortcuts(),
+                    onKeyEvent: terminalCopyHandler(
+                      _terminalModel.terminal,
+                      _terminalModel.terminalController,
+                      fallback: _handleTerminalKeyEvent,
+                    ),
                     padding: _calculatePadding(heightPx),
                     onSecondaryTapDown: (details, offset) async {
                       final selection = _terminalModel.terminalController.selection;

--- a/flutter/lib/mobile/pages/terminal_page.dart
+++ b/flutter/lib/mobile/pages/terminal_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -191,6 +192,7 @@ class _TerminalPageState extends State<TerminalPage>
   KeyEventResult _handleTerminalKeyEvent(FocusNode _, KeyEvent event) {
     final hardwareKeyboard = HardwareKeyboard.instance;
     final shouldPaste = shouldHandleTerminalPasteShortcut(
+      platform: defaultTargetPlatform,
       logicalKey: event.logicalKey,
       isKeyDown: event is KeyDownEvent,
       isKeyRepeat: event is KeyRepeatEvent,

--- a/flutter/lib/models/input_modifier_utils.dart
+++ b/flutter/lib/models/input_modifier_utils.dart
@@ -117,10 +117,11 @@ String prepareTerminalInputPayload(
 
 /// Returns true when a hardware paste shortcut must bypass keyboard modifiers.
 ///
-/// xterm already handles hardware Ctrl/Cmd+V correctly in the common case. Only
-/// intercept while a virtual Ctrl/Alt lock is active, because xterm can emit a
-/// one-character paste as normal text when bracketed paste mode is disabled.
+/// xterm already handles each platform's paste shortcut in the common case.
+/// Only intercept while a virtual Ctrl/Alt lock is active, because xterm can
+/// emit a one-character paste as normal text when bracketed paste mode is off.
 bool shouldHandleTerminalPasteShortcut({
+  required TargetPlatform platform,
   required LogicalKeyboardKey logicalKey,
   required bool isKeyDown,
   required bool isKeyRepeat,
@@ -133,8 +134,18 @@ bool shouldHandleTerminalPasteShortcut({
   if (!modifierLockActive) return false;
   if (!isKeyDown && !isKeyRepeat) return false;
   if (logicalKey != LogicalKeyboardKey.keyV) return false;
-  if (altPressed || shiftPressed) return false;
-  return controlPressed != metaPressed;
+  if (altPressed) return false;
+  switch (platform) {
+    case TargetPlatform.linux:
+      return controlPressed && !metaPressed && shiftPressed;
+    case TargetPlatform.iOS:
+    case TargetPlatform.macOS:
+      return !controlPressed && metaPressed && !shiftPressed;
+    case TargetPlatform.android:
+    case TargetPlatform.fuchsia:
+    case TargetPlatform.windows:
+      return controlPressed && !metaPressed && !shiftPressed;
+  }
 }
 
 /// Returns true when collapsing Row3 should also clear hidden modifier state.

--- a/flutter/lib/models/terminal_copy_shortcut.dart
+++ b/flutter/lib/models/terminal_copy_shortcut.dart
@@ -20,43 +20,68 @@ Future<void> writeTerminalClipboard(String text) async {
 }
 
 Map<ShortcutActivator, Intent>? platformTerminalShortcuts() {
-  if (defaultTargetPlatform != TargetPlatform.linux) return null;
+  final platform = defaultTargetPlatform;
+  if (platform == TargetPlatform.linux) {
+    return {
+      for (final entry in defaultTerminalShortcuts.entries)
+        if (!_isControlShortcut(entry.key, LogicalKeyboardKey.keyV))
+          entry.key: entry.value,
+      _controlShiftVPasteShortcut:
+          const PasteTextIntent(SelectionChangedCause.keyboard),
+    };
+  }
+  if (platform != TargetPlatform.windows &&
+      platform != TargetPlatform.android) {
+    return null;
+  }
   return {
     for (final entry in defaultTerminalShortcuts.entries)
-      if (!_isControlVShortcut(entry.key)) entry.key: entry.value,
-    _controlShiftVPasteShortcut:
-        const PasteTextIntent(SelectionChangedCause.keyboard),
+      if (!_isControlShortcut(
+        entry.key,
+        LogicalKeyboardKey.keyC,
+        shift: true,
+      ))
+        entry.key: entry.value,
   };
 }
 
-bool _isControlVShortcut(ShortcutActivator shortcut) =>
+bool _isControlShortcut(
+  ShortcutActivator shortcut,
+  LogicalKeyboardKey key, {
+  bool shift = false,
+}) =>
     shortcut is SingleActivator &&
-    shortcut.trigger == LogicalKeyboardKey.keyV &&
+    shortcut.trigger == key &&
     shortcut.control &&
-    !shortcut.shift &&
+    shortcut.shift == shift &&
     !shortcut.alt &&
     !shortcut.meta;
 
 FocusOnKeyEventCallback terminalCopyHandler(
   Terminal terminal,
-  TerminalController controller,
-) =>
-    (_, event) {
-      if (!_isWindowsCopyShortcut(event)) return KeyEventResult.ignored;
-      final selection = controller.selection;
-      if (selection == null || selection.isCollapsed) {
-        return KeyEventResult.ignored;
+  TerminalController controller, {
+  FocusOnKeyEventCallback? fallback,
+}) =>
+    (focusNode, event) {
+      if (_isSelectionCopyShortcut(event)) {
+        final selection = controller.selection;
+        if (selection != null && !selection.isCollapsed) {
+          if (event is KeyDownEvent) {
+            final text = terminal.buffer.getText(selection);
+            unawaited(writeTerminalClipboard(text));
+          }
+          return KeyEventResult.handled;
+        }
       }
-      if (event is KeyDownEvent) {
-        final text = terminal.buffer.getText(selection);
-        unawaited(writeTerminalClipboard(text));
-      }
-      return KeyEventResult.handled;
+      return fallback?.call(focusNode, event) ?? KeyEventResult.ignored;
     };
 
-bool _isWindowsCopyShortcut(KeyEvent event) {
+bool _isSelectionCopyShortcut(KeyEvent event) {
   final keyboard = HardwareKeyboard.instance;
-  return defaultTargetPlatform == TargetPlatform.windows &&
+  final platform = defaultTargetPlatform;
+  final usesControlCopy =
+      platform == TargetPlatform.windows || platform == TargetPlatform.android;
+  return usesControlCopy &&
       (event is KeyDownEvent || event is KeyRepeatEvent) &&
       event.logicalKey == LogicalKeyboardKey.keyC &&
       keyboard.isControlPressed &&

--- a/flutter/test/input_modifier_utils_test.dart
+++ b/flutter/test/input_modifier_utils_test.dart
@@ -342,11 +342,43 @@ void main() {
   });
 
   group('shouldHandleTerminalPasteShortcut', () {
+    test('handles only Ctrl+Shift+V on Linux with a virtual lock', () {
+      expect(
+        shouldHandleTerminalPasteShortcut(
+          platform: TargetPlatform.linux,
+          logicalKey: LogicalKeyboardKey.keyV,
+          isKeyDown: true,
+          isKeyRepeat: false,
+          controlPressed: true,
+          metaPressed: false,
+          altPressed: false,
+          shiftPressed: true,
+          modifierLockActive: true,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldHandleTerminalPasteShortcut(
+          platform: TargetPlatform.linux,
+          logicalKey: LogicalKeyboardKey.keyV,
+          isKeyDown: true,
+          isKeyRepeat: false,
+          controlPressed: true,
+          metaPressed: false,
+          altPressed: false,
+          shiftPressed: false,
+          modifierLockActive: true,
+        ),
+        isFalse,
+      );
+    });
+
     test(
         'keeps default xterm paste behavior when virtual modifiers are inactive',
         () {
       expect(
         shouldHandleTerminalPasteShortcut(
+          platform: TargetPlatform.windows,
           logicalKey: LogicalKeyboardKey.keyV,
           isKeyDown: true,
           isKeyRepeat: false,
@@ -364,6 +396,7 @@ void main() {
         () {
       expect(
         shouldHandleTerminalPasteShortcut(
+          platform: TargetPlatform.windows,
           logicalKey: LogicalKeyboardKey.keyV,
           isKeyDown: true,
           isKeyRepeat: false,
@@ -377,6 +410,7 @@ void main() {
       );
       expect(
         shouldHandleTerminalPasteShortcut(
+          platform: TargetPlatform.macOS,
           logicalKey: LogicalKeyboardKey.keyV,
           isKeyDown: true,
           isKeyRepeat: false,
@@ -393,6 +427,7 @@ void main() {
     test('handles paste shortcut repeats while a virtual lock is active', () {
       expect(
         shouldHandleTerminalPasteShortcut(
+          platform: TargetPlatform.windows,
           logicalKey: LogicalKeyboardKey.keyV,
           isKeyDown: false,
           isKeyRepeat: true,
@@ -409,6 +444,7 @@ void main() {
     test('ignores key-up and unmodified V events', () {
       expect(
         shouldHandleTerminalPasteShortcut(
+          platform: TargetPlatform.windows,
           logicalKey: LogicalKeyboardKey.keyV,
           isKeyDown: false,
           isKeyRepeat: false,
@@ -422,6 +458,7 @@ void main() {
       );
       expect(
         shouldHandleTerminalPasteShortcut(
+          platform: TargetPlatform.windows,
           logicalKey: LogicalKeyboardKey.keyV,
           isKeyDown: true,
           isKeyRepeat: false,
@@ -444,6 +481,7 @@ void main() {
       ]) {
         expect(
           shouldHandleTerminalPasteShortcut(
+            platform: TargetPlatform.windows,
             logicalKey: LogicalKeyboardKey.keyV,
             isKeyDown: true,
             isKeyRepeat: false,
@@ -461,6 +499,7 @@ void main() {
     test('ignores non-V key events', () {
       expect(
         shouldHandleTerminalPasteShortcut(
+          platform: TargetPlatform.windows,
           logicalKey: LogicalKeyboardKey.keyC,
           isKeyDown: true,
           isKeyRepeat: false,


### PR DESCRIPTION
This is a follow-up to #15931.

The desktop terminal already used platform-specific shortcuts, but Flutter's `TerminalPage` did not pass them to xterm.dart. On Flutter web, copy was still `Ctrl+Shift+C` and paste was still `Ctrl+V` on both Windows and Linux.

This applies the same shortcut handling to the Flutter web/mobile terminal and adds selection-aware `Ctrl+C` handling for Android. It does not change the remote terminal protocol or configuration.

| Local platform | Shortcut | Behavior |
| --- | --- | --- |
| Windows / Android | `Ctrl+C` with a selection | Copy the selected text |
| Windows / Android | `Ctrl+C` without a selection | Send `0x03` to the remote terminal |
| Windows / Android | `Ctrl+V` | Paste from the local clipboard |
| Linux | `Ctrl+Shift+C` | Copy the selected text |
| Linux | `Ctrl+C` | Send `0x03` to the remote terminal |
| Linux | `Ctrl+Shift+V` | Paste from the local clipboard |
| Linux | `Ctrl+V` | Send `0x16` to the remote terminal |
| macOS / iOS | `Cmd+C` | Copy the selected text |
| macOS / iOS | `Cmd+V` | Paste from the local clipboard |
| macOS / iOS | `Ctrl+C` | Send `0x03` to the remote terminal |
| macOS / iOS | `Ctrl+V` | Send `0x16` to the remote terminal |

Android shortcuts:
https://android-dot-devsite-v2-prod.appspot.com/develop/ui/compose/touch-input/keyboard-input/commands#1

## Tests

- [x] Relevant Flutter terminal tests (`29 passed`)
- [x] `flutter analyze` on the changed files
- [x] Flutter web on Windows: `Ctrl+C` and `Ctrl+V`
- [x] Flutter web on Linux: `Ctrl+Shift+C`, `Ctrl+Shift+V`, and `Ctrl+V` -> `0x16`
- [x] Flutter web on macOS: `Cmd+C`, `Cmd+V`, and `Ctrl+V` -> `0x16`
- [x] Android terminal with a hardware keyboard: `Ctrl+C` and `Ctrl+V`
- [x] iOS terminal with a hardware keyboard: `Cmd+C` and `Cmd+V`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-specific terminal keyboard shortcut handling.
  * Added Linux support for pasting with Control-Shift-V.
  * Improved copy shortcuts across Windows and Android.
  * Added platform-aware handling for macOS, iOS, Linux, Android, Windows, and Fuchsia paste shortcuts.

* **Bug Fixes**
  * Unrecognized keyboard events now continue through existing terminal handling.
  * Improved detection of paste shortcuts when modifier keys are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns Flutter terminal copy and paste shortcuts with platform conventions while preserving terminal control-key behavior.
- Adds platform-aware shortcut maps for Linux, Windows, and Android.
- Adds selection-aware copy handling with fallback key-event processing.
- Makes modifier-locked paste interception platform-specific.
- Extends tests for platform-specific paste detection.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| flutter/lib/mobile/pages/terminal_page.dart | Wires platform shortcuts and composed copy/paste key handling into the mobile and web TerminalView. |
| flutter/lib/models/input_modifier_utils.dart | Makes modifier-locked paste interception follow each target platform's paste shortcut. |
| flutter/lib/models/terminal_copy_shortcut.dart | Defines platform-specific shortcut maps and selection-aware Ctrl+C handling for Windows and Android. |
| flutter/test/input_modifier_utils_test.dart | Adds coverage for Linux, Windows, and macOS paste combinations with virtual modifier locks. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(flutter): handle Linux terminal past..."](https://github.com/rustdesk/rustdesk/commit/c75787cd1942c03a27d5a5a7f686e0a63cbbe5d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56698051)</sub>

<!-- /greptile_comment -->