### PR TITLE
fix(linux): a Wayland session without XAUTHORITY is not incomplete

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1957,6 +1957,14 @@ mod desktop {
     const ENV_KEY_WAYLAND_DISPLAY: &str = "WAYLAND_DISPLAY";
     const ENV_KEY_DBUS_SESSION_BUS_ADDRESS: &str = "DBUS_SESSION_BUS_ADDRESS";
 
+    /// A compositor that runs Xwayland without exporting `XAUTHORITY` (wlroots, e.g. Hyprland)
+    /// still hands out a usable session through the Wayland side. Requiring xauth there never
+    /// succeeded, so every refresh ran the retry loop to the end, 240 shell pipelines at a time.
+    /// https://github.com/rustdesk/rustdesk/issues/15952
+    fn is_session_env_complete(display: &str, xauth: &str, wl_display: &str, dbus: &str) -> bool {
+        !display.is_empty() && (!xauth.is_empty() || (!wl_display.is_empty() && !dbus.is_empty()))
+    }
+
     #[derive(Debug, Clone, Default)]
     pub struct Desktop {
         pub sid: String,
@@ -2023,14 +2031,50 @@ mod desktop {
                     PLASMA_KDED,
                     tray.as_str(),
                 ];
+                self.display.clear();
+                self.xauth.clear();
+                self.wl_display.clear();
+                self.dbus.clear();
+                let mut kept = 0u8;
                 for proc in display_proc {
-                    self.display = get_env(ENV_KEY_DISPLAY, &self.uid, proc);
-                    self.xauth = get_env(ENV_KEY_XAUTHORITY, &self.uid, proc);
-                    self.wl_display = get_env(ENV_KEY_WAYLAND_DISPLAY, &self.uid, proc);
-                    self.dbus = get_env(ENV_KEY_DBUS_SESSION_BUS_ADDRESS, &self.uid, proc);
-                    if !self.display.is_empty() && !self.xauth.is_empty() {
+                    let display = get_env(ENV_KEY_DISPLAY, &self.uid, proc);
+                    let xauth = get_env(ENV_KEY_XAUTHORITY, &self.uid, proc);
+                    let wl_display = get_env(ENV_KEY_WAYLAND_DISPLAY, &self.uid, proc);
+                    let dbus = get_env(ENV_KEY_DBUS_SESSION_BUS_ADDRESS, &self.uid, proc);
+                    // Take a candidate whole and keep the best seen. Assigning each variable
+                    // unconditionally let a pattern that does not run on this desktop blank out
+                    // the values an earlier one had answered with, which is how a session with a
+                    // working portal ended up starting its `--server` with no compositor and no
+                    // bus at all. The Wayland-only rank is what a session whose Xwayland exports
+                    // no `XAUTHORITY` can still offer.
+                    let complete = is_session_env_complete(&display, &xauth, &wl_display, &dbus);
+                    let rank = if complete {
+                        3
+                    } else if !wl_display.is_empty() && !dbus.is_empty() {
+                        2
+                    } else if !display.is_empty() {
+                        1
+                    } else {
+                        0
+                    };
+                    if rank > kept {
+                        kept = rank;
+                        self.display = display;
+                        self.xauth = xauth;
+                        self.wl_display = wl_display;
+                        self.dbus = dbus;
+                    }
+                    if complete {
                         return;
                     }
+                }
+                // The Wayland pair on its own is a session the child server can be started
+                // against -- it is what `get_display_xauth_wayland` returns on. Retrying is for a
+                // session that has not finished coming up, and a compositor whose Xwayland starts
+                // on demand may never export a `DISPLAY` for this walk to find, so waiting ten
+                // more rounds for one costs the whole probe again on every refresh.
+                if kept >= 2 {
+                    break;
                 }
                 sleep_millis(300);
             }


### PR DESCRIPTION
Fixes #15952.

Hyprland runs Xwayland without exporting `XAUTHORITY`, and `get_display_xauth_xwayland` only returns once it has both `DISPLAY` and `XAUTHORITY`. On such a session that condition is never met, so every refresh runs the retry loop to the end: 10 rounds x 6 process patterns x 4 variables = 240 `get_env` calls, each a `sh -c` pipeline of ~12 processes starting with a full `ps -u <uid> -f`. That is ~2900 fork/exec per refresh, and the service loop repeats every 500 ms. The reporter measured a full core on a low-end laptop and ~60% of a core on a 13600KF.

The Wayland side answers for such a session, so accept `DISPLAY` together with either `XAUTHORITY` or `WAYLAND_DISPLAY` + `DBUS_SESSION_BUS_ADDRESS`. The portal answers on the first pattern, which ends the walk there, as it already did on desktops that do export an xauth.

The loop also assigned all four variables unconditionally per pattern, so the patterns that do not run on a given desktop blanked out what an earlier one had answered with -- the portal's valid `DISPLAY=:1` included. That is why the `--server` was then started with no `WAYLAND_DISPLAY` and no `DBUS_SESSION_BUS_ADDRESS`. Candidates are now taken from one pattern as a whole and ranked, so a later pattern replaces an earlier answer only by being better, and a session that can only offer a compositor and a bus still keeps them.

A compositor that starts Xwayland on demand shows the same shape from the other side: the portal came up before Xwayland did, so its environment carries a valid `WAYLAND_DISPLAY` and `DBUS_SESSION_BUS_ADDRESS` but no `DISPLAY`, and no pattern here may ever produce one. That pair alone is a session the child server can be started against -- it is exactly what `get_display_xauth_wayland` returns on -- so it outranks a bare `DISPLAY` and ends the retrying, while the rest of the round still looks for something that completes the session.

Not specific to the drm build: the function is not feature-gated, and the commit the report points at does not touch it.


Claude-Session: https://claude.ai/code/session_01Q5egQpH4q4GoXJiuMoTJ5t

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux session detection for Wayland and DBus environments.
  * Prevented stale or incomplete environment values from being reused.
  * Improved Xwayland environment discovery by selecting the most complete available session.
  * Recognized valid Wayland-only sessions without requiring Xauthority.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR revises Linux Xwayland session discovery so Wayland-capable sessions without `XAUTHORITY` or an eagerly created `DISPLAY` can terminate probing successfully.
- Adds a shared session-completeness predicate.
- Ranks complete, Wayland-only, display-only, and empty process-environment candidates.
- Preserves the best candidate across process patterns and avoids unnecessary retry rounds.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking concern that ranked session candidates should be collected from one process rather than four independent PID selections.

The new completion and retry behavior matches the existing Wayland environment contract, while the remaining concern requires process-pattern ambiguity or churn to combine fields from different sessions.

**Files Needing Attention:** src/platform/linux.rs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/platform/linux.rs | Improves Xwayland environment selection and retry termination, but independently retrieving each field can still create an incoherent ranked candidate when a pattern matches multiple processes. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Probe process pattern] --> B[Read DISPLAY, XAUTHORITY, WAYLAND_DISPLAY, DBUS]
    B --> C{Candidate rank}
    C -->|Complete| D[Keep candidate and return]
    C -->|Wayland plus DBUS| E[Keep rank 2 candidate]
    C -->|DISPLAY only| F[Keep rank 1 candidate]
    C -->|Empty| G[Keep prior candidate]
    E --> H{All patterns checked?}
    F --> H
    G --> H
    H -->|Rank at least 2| I[Stop retrying]
    H -->|Lower rank| J[Sleep and retry]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2315978%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=15978&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fplatform%2Flinux.rs%3A2040-2043%0A**Candidate%20spans%20multiple%20processes**%0A%0AIf%20a%20pattern%20matches%20multiple%20processes%20or%20its%20selected%20PID%20changes%20between%20calls%2C%20the%20four%20independent%20%60get_env%60%20lookups%20can%20combine%20values%20from%20different%20sessions%20into%20one%20highly%20ranked%20candidate%2C%20causing%20the%20child%20server%20to%20use%20mismatched%20display%20or%20session-bus%20endpoints.%20Collecting%20all%20four%20variables%20from%20one%20selected%20process%20would%20preserve%20candidate%20coherence.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15978&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix-xwayland-env-without-xauthority%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-xwayland-env-without-xauthority%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fplatform%2Flinux.rs%3A2040-2043%0A**Candidate%20spans%20multiple%20processes**%0A%0AIf%20a%20pattern%20matches%20multiple%20processes%20or%20its%20selected%20PID%20changes%20between%20calls%2C%20the%20four%20independent%20%60get_env%60%20lookups%20can%20combine%20values%20from%20different%20sessions%20into%20one%20highly%20ranked%20candidate%2C%20causing%20the%20child%20server%20to%20use%20mismatched%20display%20or%20session-bus%20endpoints.%20Collecting%20all%20four%20variables%20from%20one%20selected%20process%20would%20preserve%20candidate%20coherence.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15978&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(linux): a Wayland session without XA..."](https://github.com/rustdesk/rustdesk/commit/bb00fbb0029f18e3cb80d67cf8418b127630def2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57015298)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->