### PR TITLE
fix: show speed in desktop file transfer status

### DIFF
--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -278,22 +278,35 @@ class _FileManagerPageState extends State<FileManagerPage>
                                     item.state != JobState.inProgress,
                                 child: LinearPercentIndicator(
                                   animateFromLastPercent: true,
-                                  center: FittedBox(
-                                    fit: BoxFit.scaleDown,
-                                    child: Text.rich(
-                                      TextSpan(
-                                        text: item.percentText,
-                                        children: [
-                                          if (item.recvJobRes)
-                                            TextSpan(
-                                              text:
-                                                  ' ${readableFileSize(item.speed)}/s',
-                                              style: TextStyle(
-                                                fontSize: 12,
-                                                color: MyTheme.darkGray,
-                                              ),
-                                            ),
+                                  center: SizedBox.expand(
+                                    child: ShaderMask(
+                                      blendMode: BlendMode.srcATop,
+                                      shaderCallback: (bounds) =>
+                                          LinearGradient(
+                                        colors: [
+                                          Colors.white,
+                                          Colors.transparent,
                                         ],
+                                        stops: [item.percent, item.percent],
+                                      ).createShader(bounds),
+                                      child: FittedBox(
+                                        fit: BoxFit.scaleDown,
+                                        child: Text.rich(
+                                          TextSpan(
+                                            text: item.percentText,
+                                            children: [
+                                              if (item.recvJobRes)
+                                                TextSpan(
+                                                  text:
+                                                      ' ${readableFileSize(item.speed)}/s',
+                                                  style: TextStyle(
+                                                    fontSize: 12,
+                                                    color: MyTheme.darkGray,
+                                                  ),
+                                                ),
+                                            ],
+                                          ),
+                                        ),
                                       ),
                                     ),
                                   ),

--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -280,9 +280,22 @@ class _FileManagerPageState extends State<FileManagerPage>
                                   animateFromLastPercent: true,
                                   center: FittedBox(
                                     fit: BoxFit.scaleDown,
-                                    child: Text(item.recvJobRes
-                                        ? '${item.percentText} · ${readableFileSize(item.speed)}/s'
-                                        : item.percentText),
+                                    child: Text.rich(
+                                      TextSpan(
+                                        text: item.percentText,
+                                        children: [
+                                          if (item.recvJobRes)
+                                            TextSpan(
+                                              text:
+                                                  ' ${readableFileSize(item.speed)}/s',
+                                              style: TextStyle(
+                                                fontSize: 12,
+                                                color: MyTheme.darkGray,
+                                              ),
+                                            ),
+                                        ],
+                                      ),
+                                    ),
                                   ),
                                   barRadius: Radius.circular(15),
                                   percent: item.percent,

--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -278,16 +278,12 @@ class _FileManagerPageState extends State<FileManagerPage>
                                     item.state != JobState.inProgress,
                                 child: LinearPercentIndicator(
                                   animateFromLastPercent: true,
-                                  center: Text(item.percentText),
-                                  trailing: item.recvJobRes
-                                      ? Text(
-                                          '${readableFileSize(item.speed)}/s',
-                                          style: TextStyle(
-                                            fontSize: 12,
-                                            color: MyTheme.darkGray,
-                                          ),
-                                        )
-                                      : null,
+                                  center: FittedBox(
+                                    fit: BoxFit.scaleDown,
+                                    child: Text(item.recvJobRes
+                                        ? '${item.percentText} · ${readableFileSize(item.speed)}/s'
+                                        : item.percentText),
+                                  ),
                                   barRadius: Radius.circular(15),
                                   percent: item.percent,
                                   progressColor: MyTheme.accent,

--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -301,6 +301,7 @@ class _FileManagerPageState extends State<FileManagerPage>
                                                       ' ${readableFileSize(item.speed)}/s',
                                                   style: TextStyle(
                                                     fontSize: 12,
+                                                    fontWeight: FontWeight.w300,
                                                     color: MyTheme.darkGray,
                                                   ),
                                                 ),

--- a/flutter/lib/desktop/pages/file_manager_page.dart
+++ b/flutter/lib/desktop/pages/file_manager_page.dart
@@ -279,6 +279,15 @@ class _FileManagerPageState extends State<FileManagerPage>
                                 child: LinearPercentIndicator(
                                   animateFromLastPercent: true,
                                   center: Text(item.percentText),
+                                  trailing: item.recvJobRes
+                                      ? Text(
+                                          '${readableFileSize(item.speed)}/s',
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            color: MyTheme.darkGray,
+                                          ),
+                                        )
+                                      : null,
                                   barRadius: Radius.circular(15),
                                   percent: item.percent,
                                   progressColor: MyTheme.accent,

--- a/flutter/lib/mobile/pages/file_manager_page.dart
+++ b/flutter/lib/mobile/pages/file_manager_page.dart
@@ -366,8 +366,7 @@ class _FileManagerPageState extends State<FileManagerPage> {
           return BottomSheetBody(
             leading: CircularProgressIndicator(),
             title: translate("Waiting"),
-            text:
-                "${translate("Speed")}:  ${readableFileSize(activeJob.speed)}/s",
+            text: "${readableFileSize(activeJob.speed)}/s",
             onCanceled: () {
               model.jobController.cancelJob(activeJob.id);
               jobTable.clear();

--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -1733,9 +1733,6 @@ class JobProgress {
         }
         res += sizePercentStr;
       }
-      if (state == JobState.inProgress && recvJobRes) {
-        res += ", ${readableFileSize(speed)}/s";
-      }
       return res;
     }
     return '';

--- a/flutter/lib/models/file_model.dart
+++ b/flutter/lib/models/file_model.dart
@@ -1733,6 +1733,9 @@ class JobProgress {
         }
         res += sizePercentStr;
       }
+      if (state == JobState.inProgress && recvJobRes) {
+        res += ", ${readableFileSize(speed)}/s";
+      }
       return res;
     }
     return '';


### PR DESCRIPTION
Add speed for the desktop version; mobile is not affected.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/f18b2631-c46b-4294-83db-de60ea4dc12c" />

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/38095551-3db8-4e73-9cf4-77fb27afbbae" />

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/9e2df5b7-b741-4fae-a6dc-fadb90463bcc" />

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/53e3463e-5778-41d7-a62e-e031bf91606a" />



<img width="600" alt="image" src="https://github.com/user-attachments/assets/12b1f9e9-9d9d-4d84-b6f7-fe35152fe4d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* **Transfer Progress**
  * Improved desktop transfer indicators by overlaying percentage progress with a visual gradient.
  * Receive transfers now show the current readable speed directly within the progress indicator.
  * Simplified mobile transfer speed display by removing the “Speed” label and showing only the formatted value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds transfer-speed text to the desktop file-transfer progress indicator and refines the corresponding mobile status text.
- Displays received transfer speed alongside desktop progress.
- Uses a shader mask to adapt progress-label contrast.
- Simplifies the active-transfer speed text on mobile.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| flutter/lib/desktop/pages/file_manager_page.dart | Adds formatted receive-speed text and progress-aware masking to the desktop transfer indicator. |
| flutter/lib/mobile/pages/file_manager_page.dart | Simplifies the active-transfer bottom-sheet text to display only the formatted speed. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: adapt file transfer progress text c..."](https://github.com/rustdesk/rustdesk/commit/7e9a02748a04b99a2d865da48982055e689ca8d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57043119)</sub>

<!-- /greptile_comment -->