### PR TITLE
fix(linux): Set AppIndicator ID for tray-icon

### DIFF
--- a/src/tray.rs
+++ b/src/tray.rs
@@ -153,7 +153,7 @@ fn make_tray() -> hbb_common::ResultType<()> {
             // We create the icon once the event loop is actually running
             // to prevent issues like https://github.com/tauri-apps/tray-icon/issues/90
             let mut builder = TrayIconBuilder::new()
-                .with_id("rustdesk")
+                .with_id(create::get_app_name().to_lowercase())
                 .with_menu(Box::new(tray_menu.clone()))
                 .with_tooltip(tooltip(0))
                 .with_icon(icon.clone());

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -153,6 +153,7 @@ fn make_tray() -> hbb_common::ResultType<()> {
             // We create the icon once the event loop is actually running
             // to prevent issues like https://github.com/tauri-apps/tray-icon/issues/90
             let mut builder = TrayIconBuilder::new()
+                .with_id("rustdesk")
                 .with_menu(Box::new(tray_menu.clone()))
                 .with_tooltip(tooltip(0))
                 .with_icon(icon.clone());


### PR DESCRIPTION
This PR amends changes made in #14530 (which was reverted and later re-implemented in e3b6e4eaf).

This issue was discussed in the following discussion: https://github.com/rustdesk/rustdesk/discussions/15208

The changes as made in commit e3b6e4eaf cause the tray-icon create to "randomly" create the tray icon based on the service's current PID. This prevents DEs, such as KDE, from persisting the user's configuration (eg. hiding the tray icon, always showing it, always hiding it). Every restart of the system/service/process cause it to generate a new tray icon in the format `tray-icon tray-app PID-1`. This change sets the AppIndicator ID to a persistent value of "rustdesk", which should prevent it from conflicting with other applications, as intended by the changes made in #14530 


Details:
The issue is caused by rustdesk allowing the tauri-apps/tray-icon crate to determine its AppIndicator ID. KDE's show/hide tray configuration uses them. Each time the Rustdesk service is started (manually or by system reboot), it generates a new PID-based identifier. Here's an excerpt from my `.config/plasma-org.kde.plasma.desktop-appletsrc` *before* the patch.
```
hiddenItems=Arch-Update,tray-icon tray app,chrome_status_icon_1,Easy Effects,steam,org.kde.plasma.brightness,tray-icon tray app 61965-1,tray-icon tray app 1457169-1
```
Note the numerous instances of `tray-icon tray app <pid>`; each one of those is a RustDesk instance I had configured KDE to "show only in popup". After restarting the rustdesk service, the AppIndicator ID changed to the new PID and put it back in my tray, as if I had never configured it.

After the change:
```
hiddenItems=Arch-Update,tray-icon tray app,chrome_status_icon_1,Easy Effects,steam,org.kde.plasma.brightness,tray-icon tray app rustdesk
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved tray icon identification by deriving its identifier consistently from the application name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Assigns the tray icon a stable, lowercase application-derived identifier so desktop environments can persist tray visibility preferences.
- Adds an explicit identifier during `TrayIconBuilder` initialization.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/tray.rs | Adds an explicit application-derived ID to tray icon construction; no follow-up-eligible finding was identified. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Update tray.rs"](https://github.com/rustdesk/rustdesk/commit/d67d3d99e75c5fc0bb209f9f656e419e0a274c57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57224326)</sub>

<!-- /greptile_comment -->