### PR TITLE
Fix #3762: expose WASAPI communications-role device as selectable loopback source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,10 +140,12 @@ windows = { version = "0.61", features = [
     "Win32_System_Registry",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",
+    "Win32_System_Variant",
     "Win32_UI_Shell",
+    "Win32_UI_Shell_PropertiesSystem",
     "Win32_UI_WindowsAndMessaging",
     "Win32_Media_Audio",
-    "Win32_Devices_Properties",
+    "Win32_Devices_FunctionDiscovery",
 ] }
 winreg = "0.11"
 windows-service = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ windows = { version = "0.61", features = [
     "Win32_Storage_FileSystem",
     "Win32_System",
     "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
     "Win32_System_Diagnostics",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Environment",
@@ -141,6 +142,8 @@ windows = { version = "0.61", features = [
     "Win32_System_Threading",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_Media_Audio",
+    "Win32_Devices_Properties",
 ] }
 winreg = "0.11"
 windows-service = "0.6"

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -112,11 +112,18 @@ mod comms_device {
     /// becomes a harmless duplicate of the normal default entry).
     pub fn get_default_comms_output_device_name() -> Option<String> {
         unsafe {
-            // CoInitializeEx may already have been called elsewhere in this
-            // process (e.g. by another Windows-only subsystem); ignore
-            // "already initialized" style results, only bail on hard errors
-            // inside the closure below via `?`.
-            let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+            // Only release a COM initialization reference we actually took
+            // out. `CoInitializeEx` returns `RPC_E_CHANGED_MODE` when this
+            // thread is already COM-initialized under a different
+            // concurrency model — in that case we added no reference, so
+            // calling `CoUninitialize()` unconditionally would incorrectly
+            // release one belonging to whoever initialized it first and can
+            // disrupt later COM operations on this thread. `S_OK` and
+            // `S_FALSE` (already initialized with the *same* model) both
+            // mean we hold a reference that we must release; anything else
+            // (e.g. `RPC_E_CHANGED_MODE`) means we don't.
+            let init_hr = CoInitializeEx(None, COINIT_MULTITHREADED);
+            let we_initialized = init_hr.is_ok();
 
             let name = (|| -> windows::core::Result<String> {
                 let enumerator: IMMDeviceEnumerator =
@@ -127,7 +134,10 @@ mod comms_device {
                 Ok(prop.to_string())
             })();
 
-            CoUninitialize();
+            if we_initialized {
+                CoUninitialize();
+            }
+
             match name {
                 Ok(n) if !n.is_empty() => Some(n),
                 Ok(_) => None,

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -22,6 +22,17 @@ pub const NAME: &'static str = "audio";
 pub const AUDIO_DATA_SIZE_U8: usize = 960 * 4; // 10ms in 48000 stereo
 static RESTARTING: AtomicBool = AtomicBool::new(false);
 
+// Suffix appended to the communications-role default output device when it
+// is surfaced in the UI's audio-input device list. See #3762: cpal's
+// `default_output_device()` on Windows only ever resolves the *console*
+// role via WASAPI, so users who have configured a different "Default
+// communication device" than "Default device" get silent loopback capture
+// unless they change their Windows-wide default. This suffix lets such a
+// user explicitly pick the communications-role device from within RustDesk
+// instead of changing system-wide settings.
+#[cfg(windows)]
+pub const COMMS_DEVICE_SUFFIX: &str = " (Communications)";
+
 lazy_static::lazy_static! {
     static ref VOICE_CALL_INPUT_DEVICE: Arc::<Mutex::<Option<String>>> = Default::default();
 }
@@ -74,6 +85,91 @@ pub fn restart() {
     }
     RESTARTING.store(true, Ordering::SeqCst);
 }
+
+// ---------------------------------------------------------------------
+// #3762 fix: expose the WASAPI *communications*-role default render
+// device so it can be selected explicitly as a loopback source, instead
+// of only ever being able to capture the *console*-role default device
+// (which is all cpal's `default_output_device()` can see on Windows).
+// ---------------------------------------------------------------------
+#[cfg(windows)]
+mod comms_device {
+    use windows::core::Interface;
+    use windows::Win32::Devices::Properties::DEVPKEY_Device_FriendlyName;
+    use windows::Win32::Media::Audio::{
+        eCommunications, eRender, IMMDeviceEnumerator, MMDeviceEnumerator,
+    };
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_MULTITHREADED,
+        STGM_READ,
+    };
+
+    /// Query the current system default *communications*-role render
+    /// (output) device's friendly name via WASAPI. Returns `None` if COM
+    /// setup fails, no such device is configured, or the name can't be
+    /// read (e.g. no communications-role device configured at all, in
+    /// which case Windows just returns the console-role device and this
+    /// becomes a harmless duplicate of the normal default entry).
+    pub fn get_default_comms_output_device_name() -> Option<String> {
+        unsafe {
+            // CoInitializeEx may already have been called elsewhere in this
+            // process (e.g. by another Windows-only subsystem); ignore
+            // "already initialized" style results, only bail on hard errors
+            // inside the closure below via `?`.
+            let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+
+            let name = (|| -> windows::core::Result<String> {
+                let enumerator: IMMDeviceEnumerator =
+                    CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)?;
+                let device = enumerator.GetDefaultAudioEndpoint(eRender, eCommunications)?;
+                let store = device.OpenPropertyStore(STGM_READ)?;
+                let prop = store.GetValue(&DEVPKEY_Device_FriendlyName)?;
+                Ok(prop.to_string())
+            })();
+
+            CoUninitialize();
+            match name {
+                Ok(n) if !n.is_empty() => Some(n),
+                Ok(_) => None,
+                Err(e) => {
+                    log::debug!("Failed to query default communications output device: {:?}", e);
+                    None
+                }
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+pub use comms_device::get_default_comms_output_device_name;
+
+/// Strip the `COMMS_DEVICE_SUFFIX` marker from a UI-facing device name,
+/// returning the underlying cpal device name that can be matched against
+/// `HOST.devices()`.
+#[cfg(windows)]
+#[inline]
+pub fn strip_comms_device_suffix(name: &str) -> &str {
+    name.strip_suffix(COMMS_DEVICE_SUFFIX).unwrap_or(name)
+}
+
+/// Append the communications-role default output device (if any, and if
+/// distinct from what's already listed) to a UI-facing device name list,
+/// suffixed with `COMMS_DEVICE_SUFFIX` so it round-trips through
+/// `strip_comms_device_suffix` / `get_device()` below. No-op on
+/// non-Windows platforms.
+#[cfg(windows)]
+pub fn append_comms_output_device(devices: &mut Vec<String>) {
+    if let Some(name) = get_default_comms_output_device_name() {
+        let labeled = format!("{}{}", name, COMMS_DEVICE_SUFFIX);
+        if !devices.contains(&labeled) {
+            devices.push(labeled);
+        }
+    }
+}
+
+#[cfg(not(windows))]
+#[inline]
+pub fn append_comms_output_device(_devices: &mut Vec<String>) {}
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod pa_impl {
@@ -287,10 +383,35 @@ mod cpal_impl {
         Ok((device, format))
     }
 
+    // ------------------------------------------------------------------
+    // #3762: if the user explicitly selected the communications-role
+    // default device (surfaced in the UI with `COMMS_DEVICE_SUFFIX`, see
+    // `append_comms_output_device` above), resolve it here by matching
+    // the stripped name against cpal's device enumeration. Falls through
+    // to the original console-role `default_output_device()` behavior in
+    // every other case, so existing users see no behavior change.
+    // ------------------------------------------------------------------
     #[cfg(windows)]
     fn get_device() -> ResultType<(Device, SupportedStreamConfig)> {
         let audio_input = super::get_audio_input();
         if !audio_input.is_empty() {
+            if let Some(stripped) = audio_input.strip_suffix(super::COMMS_DEVICE_SUFFIX) {
+                for d in HOST.devices().with_context(|| "Failed to get audio devices")? {
+                    if d.name().unwrap_or_default() == stripped {
+                        log::info!("Communications output device: {}", stripped);
+                        let format = d
+                            .default_output_config()
+                            .map_err(|e| anyhow!(e))
+                            .with_context(|| "Failed to get default output format")?;
+                        log::info!("Default output format: {:?}", format);
+                        return Ok((d, format));
+                    }
+                }
+                bail!(
+                    "Selected communications output device '{}' not found",
+                    stripped
+                );
+            }
             return get_audio_input(&audio_input);
         }
         let device = HOST

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -94,8 +94,8 @@ pub fn restart() {
 // ---------------------------------------------------------------------
 #[cfg(windows)]
 mod comms_device {
-    use windows::core::Interface;
-    use windows::Win32::Devices::Properties::DEVPKEY_Device_FriendlyName;
+    use hbb_common::log;
+    use windows::Win32::Devices::FunctionDiscovery::PKEY_Device_FriendlyName;
     use windows::Win32::Media::Audio::{
         eCommunications, eRender, IMMDeviceEnumerator, MMDeviceEnumerator,
     };
@@ -130,7 +130,7 @@ mod comms_device {
                     CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)?;
                 let device = enumerator.GetDefaultAudioEndpoint(eRender, eCommunications)?;
                 let store = device.OpenPropertyStore(STGM_READ)?;
-                let prop = store.GetValue(&DEVPKEY_Device_FriendlyName)?;
+                let prop = store.GetValue(&PKEY_Device_FriendlyName)?;
                 Ok(prop.to_string())
             })();
 
@@ -142,7 +142,10 @@ mod comms_device {
                 Ok(n) if !n.is_empty() => Some(n),
                 Ok(_) => None,
                 Err(e) => {
-                    log::debug!("Failed to query default communications output device: {:?}", e);
+                    log::debug!(
+                        "Failed to query default communications output device: {:?}",
+                        e
+                    );
                     None
                 }
             }
@@ -406,7 +409,10 @@ mod cpal_impl {
         let audio_input = super::get_audio_input();
         if !audio_input.is_empty() {
             if let Some(stripped) = audio_input.strip_suffix(super::COMMS_DEVICE_SUFFIX) {
-                for d in HOST.devices().with_context(|| "Failed to get audio devices")? {
+                for d in HOST
+                    .devices()
+                    .with_context(|| "Failed to get audio devices")?
+                {
                     if d.name().unwrap_or_default() == stripped {
                         log::info!("Communications output device: {}", stripped);
                         let format = d

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -846,6 +846,7 @@ fn get_sound_inputs() -> Vec<String> {
             }
         }
     }
+    crate::audio_service::append_comms_output_device(&mut out);
     out
 }
 

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -404,6 +404,7 @@ pub fn get_sound_inputs() -> Vec<String> {
             a.push(name);
         }
     }
+    crate::audio_service::append_comms_output_device(&mut a);
     a
 }
 


### PR DESCRIPTION
/claim #3762

## Summary

Fixes the root cause of #3762: on Windows, RustDesk's loopback audio
capture only ever resolves the WASAPI *console*-role default output
device via `cpal::Host::default_output_device()`. Users who have
configured a different "Default communication device" than "Default
device" in Windows Sound settings get silent loopback capture and
previously had no way to fix this without changing their system-wide
audio defaults.

## Problem

`src/server/audio_service.rs::get_device()` (Windows branch) calls:

    HOST.default_output_device()

which only queries the `eConsole` role. It has no way to see the
`eCommunications` role Windows also exposes. When the app producing
sound on the remote machine plays through the communications-role
device instead, RustDesk captures silence.

## Fix

- Added `get_default_comms_output_device_name()` in
  `src/server/audio_service.rs`, using the `windows` crate's Core Audio
  APIs (`IMMDeviceEnumerator::GetDefaultAudioEndpoint(eRender,
  eCommunications)`) to read the communications-role device's friendly
  name.
- Added `append_comms_output_device()` / `strip_comms_device_suffix()`
  helpers, and a `COMMS_DEVICE_SUFFIX` (`" (Communications)"`) marker
  so the device can round-trip through the existing `audio-input`
  config string.
- `get_device()` now checks for the suffix and resolves the matching
  cpal device before falling back to the original console-role default
  — **existing behavior is unchanged unless the user explicitly
  selects this new option**.
- Surfaced the new device in the Settings audio-input dropdown via one
  additional call each in `src/ui.rs` and `src/ui_interface.rs`.
- Added the required `windows` crate feature flags
  (`Win32_System_Com`, `Win32_System_Com_StructuredStorage`,
  `Win32_Media_Audio`, `Win32_Devices_Properties`) to `Cargo.toml`.

## Why this approach

Three prior attempts on this issue (#14512, #15232, #15805) tried to
add full ASIO support and were all closed unmerged — ASIO can't do
loopback capture the way WASAPI does, and none could be validated with
real ASIO hardware. This fix instead targets the actual bug reported
in #3762 (console vs. communications role mismatch) using plain WASAPI,
which needs no special drivers/SDK and is testable on any Windows
machine with two audio devices.

## Files changed

- `Cargo.toml`
- `src/server/audio_service.rs`
- `src/ui.rs`
- `src/ui_interface.rs`

## Testing

- [ ] `cargo check --target x86_64-pc-windows-msvc`
- [ ] `cargo fmt --check`
- [ ] Verified default (no selection) behavior unchanged when console
      and communications roles are the same device
- [ ] Verified the new "<name> (Communications)" entry appears in
      Settings → Audio when the two roles differ
- [ ] Verified selecting it captures audio from the correct device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows users can select the default communications output device as a loopback audio input.
  * The communications device appears in audio input lists with a clear “Communications” label.
  * Audio capture automatically resolves the selected communications device while preserving existing device selection behavior.
* **Bug Fixes**
  * Improved reliability when initializing and releasing Windows audio services during communications-device detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR exposes Windows’ communications-role output device as an explicitly selectable loopback source while preserving the existing default path.
- Queries the WASAPI communications endpoint and obtains its friendly name.
- Adds a labeled communications-device option to both audio settings interfaces.
- Resolves that selection through CPAL and adds the required Windows API features.
- Balances COM initialization references without releasing caller-owned apartment state.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported COM apartment cleanup imbalance is corrected by releasing COM only after successful initialization.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Enables the Windows API feature sets required for Core Audio endpoint discovery and friendly-name retrieval. |
| src/server/audio_service.rs | Adds communications-endpoint discovery, UI-label round-tripping, CPAL resolution, and balanced COM apartment cleanup. |
| src/ui.rs | Adds the communications-role output device to the Sciter audio-input options. |
| src/ui_interface.rs | Adds the communications-role output device to the alternative UI audio-input options. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Open audio input settings] --> B[Query CPAL devices]
    B --> C[Query WASAPI communications endpoint]
    C --> D[Append labeled communications option]
    D --> E{Selected communications option?}
    E -- Yes --> F[Strip label and resolve CPAL output device]
    E -- No --> G[Use existing audio-device selection path]
    F --> H[Start loopback capture]
    G --> H
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Fix WASAPI communications device compila..."](https://github.com/rustdesk/rustdesk/commit/ac7790e54013e6f0a2edf2c44b473459d6d18e16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57374805)</sub>

<!-- /greptile_comment -->