### PR TITLE
feat(linux): add direct GNOME Mutter backend and GDM handoff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ hwcodec = ["scrap/hwcodec"]
 vram = ["scrap/vram"]
 mediacodec = ["scrap/mediacodec"]
 drm = ["scrap/drm"]
+gnome-mutter = ["scrap/gnome-mutter"]
 # The display wake, as its OWN compile gate on top of `drm`. Everything else in the drm backend
 # READS (it captures a scanout); the wake WRITES, injecting one synthetic pointer event from the
 # root service so a compositor that idle-disabled its outputs re-enables them. That is a different

--- a/build.py
+++ b/build.py
@@ -146,6 +146,12 @@ def make_parser():
              'dlopen-ed in-process by the root service). Off by default.'
     )
     parser.add_argument(
+        '--gnome-mutter',
+        action='store_true',
+        help='Linux only: build direct GNOME Mutter ScreenCast/RemoteDesktop support. '
+             'Runtime opt-in; falls back to XDG Portal.'
+    )
+    parser.add_argument(
         '--print-features',
         action='store_true',
         help='Print the cargo feature list these flags select, and exit without building. For a '
@@ -322,6 +328,10 @@ def get_features(args):
         features.append('flutter')
     if args.unix_file_copy_paste:
         features.append('unix-file-copy-paste')
+    if args.gnome_mutter:
+        if windows or osx:
+            raise Exception('--gnome-mutter is Linux only')
+        features.append('gnome-mutter')
     if args.drm:
         # Say so rather than quietly handing back a stock build: the backend is Linux-only, so on
         # any other host the flag cannot be honoured and the resulting binary would look like a

--- a/libs/scrap/Cargo.toml
+++ b/libs/scrap/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2018"
 
 [features]
 wayland = ["gstreamer", "gstreamer-app", "gstreamer-video", "dbus", "tracing", "zbus"]
+# Direct integration with GNOME Mutter's private ScreenCast/RemoteDesktop API.
+# Runtime-gated and falls back to the XDG portal when the API is unavailable.
+gnome-mutter = ["wayland"]
 # `drm` is a pure runtime-dlopen backend: rustdesk loads `libdrmtap.so.0` at runtime (`drmtap_dl.rs`)
 # and NEVER link-time links it, so the graceful PipeWire fallback when the .so or EGL is absent is
 # preserved and the drm build pulls in no libdrm/seccomp/cap/EGL link-time deps. The .so is pinned by
@@ -75,4 +78,3 @@ optional = true
 
 [target.'cfg(any(target_os = "windows", target_os = "linux"))'.dependencies]
 nokhwa = { git = "https://github.com/rustdesk-org/nokhwa.git", branch = "fix_from_raw_parts", features = ["input-native"] }
-

--- a/libs/scrap/src/wayland.rs
+++ b/libs/scrap/src/wayland.rs
@@ -1,6 +1,8 @@
 pub mod capturable;
-pub mod pipewire;
 pub mod display;
-mod screencast_portal;
-mod request_portal;
+#[cfg(feature = "gnome-mutter")]
+pub mod mutter;
+pub mod pipewire;
 pub mod remote_desktop_portal;
+mod request_portal;
+mod screencast_portal;

--- a/libs/scrap/src/wayland/mutter.rs
+++ b/libs/scrap/src/wayland/mutter.rs
@@ -1,0 +1,201 @@
+//! Direct GNOME Mutter ScreenCast/RemoteDesktop integration.
+//!
+//! Mutter explicitly labels these D-Bus interfaces private, so every use is
+//! version-gated and the caller must retain the regular XDG portal fallback.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use dbus::{
+    arg::{PropMap, RefArg, Variant},
+    blocking::{stdintf::org_freedesktop_dbus::Properties, SyncConnection},
+    message::MatchRule,
+    Path,
+};
+use hbb_common::{anyhow, bail, config::Config, ResultType};
+
+use super::{
+    display::get_displays,
+    pipewire::{PwStreamInfo, RdpInputBackend, RdpSessionInfo},
+};
+
+pub const CONFIG_OPTION: &str = "enable-gnome-mutter";
+
+pub const SCREEN_CAST_NAME: &str = "org.gnome.Mutter.ScreenCast";
+pub const SCREEN_CAST_PATH: &str = "/org/gnome/Mutter/ScreenCast";
+pub const SCREEN_CAST_IFACE: &str = "org.gnome.Mutter.ScreenCast";
+pub const SCREEN_CAST_SESSION_IFACE: &str = "org.gnome.Mutter.ScreenCast.Session";
+pub const SCREEN_CAST_STREAM_IFACE: &str = "org.gnome.Mutter.ScreenCast.Stream";
+
+pub const REMOTE_DESKTOP_NAME: &str = "org.gnome.Mutter.RemoteDesktop";
+pub const REMOTE_DESKTOP_PATH: &str = "/org/gnome/Mutter/RemoteDesktop";
+pub const REMOTE_DESKTOP_IFACE: &str = "org.gnome.Mutter.RemoteDesktop";
+pub const REMOTE_DESKTOP_SESSION_IFACE: &str = "org.gnome.Mutter.RemoteDesktop.Session";
+
+const MIN_SCREEN_CAST_VERSION: i32 = 4;
+const MIN_REMOTE_DESKTOP_VERSION: i32 = 1;
+const REQUIRED_DEVICE_TYPES: u32 = 1 | 2; // keyboard | pointer
+const DBUS_TIMEOUT: Duration = Duration::from_secs(3);
+const STREAM_TIMEOUT: Duration = Duration::from_secs(8);
+
+#[inline]
+pub fn option_enabled() -> bool {
+    Config::get_option(CONFIG_OPTION) == "Y"
+}
+
+fn pair_i32(value: &dyn RefArg) -> Option<(i32, i32)> {
+    let values = value
+        .as_iter()?
+        .filter_map(|item| item.as_i64())
+        .collect::<Vec<_>>();
+    if values.len() == 2 {
+        Some((values[0] as i32, values[1] as i32))
+    } else {
+        None
+    }
+}
+
+fn check_api(conn: &SyncConnection) -> ResultType<()> {
+    let screen_cast = conn.with_proxy(SCREEN_CAST_NAME, SCREEN_CAST_PATH, DBUS_TIMEOUT);
+    let screen_cast_version: i32 = screen_cast.get(SCREEN_CAST_IFACE, "Version")?;
+    if screen_cast_version < MIN_SCREEN_CAST_VERSION {
+        bail!(
+            "Mutter ScreenCast API {} is older than required {}",
+            screen_cast_version,
+            MIN_SCREEN_CAST_VERSION
+        );
+    }
+
+    let remote_desktop = conn.with_proxy(REMOTE_DESKTOP_NAME, REMOTE_DESKTOP_PATH, DBUS_TIMEOUT);
+    let remote_desktop_version: i32 = remote_desktop.get(REMOTE_DESKTOP_IFACE, "Version")?;
+    if remote_desktop_version < MIN_REMOTE_DESKTOP_VERSION {
+        bail!(
+            "Mutter RemoteDesktop API {} is older than required {}",
+            remote_desktop_version,
+            MIN_REMOTE_DESKTOP_VERSION
+        );
+    }
+    let device_types: u32 = remote_desktop.get(REMOTE_DESKTOP_IFACE, "SupportedDeviceTypes")?;
+    if device_types & REQUIRED_DEVICE_TYPES != REQUIRED_DEVICE_TYPES {
+        bail!("Mutter RemoteDesktop lacks keyboard/pointer support ({device_types:#x})");
+    }
+    Ok(())
+}
+
+pub fn request_session() -> ResultType<RdpSessionInfo> {
+    let conn = SyncConnection::new_session()?;
+    check_api(&conn)?;
+
+    let displays = get_displays();
+    let connectors = displays
+        .displays
+        .iter()
+        .filter(|display| !display.name.is_empty())
+        .map(|display| display.name.clone())
+        .collect::<Vec<_>>();
+    if connectors.is_empty() {
+        bail!("Mutter backend found no named active monitor connectors");
+    }
+
+    let remote_manager = conn.with_proxy(REMOTE_DESKTOP_NAME, REMOTE_DESKTOP_PATH, DBUS_TIMEOUT);
+    let (remote_session_path,): (Path<'static>,) =
+        remote_manager.method_call(REMOTE_DESKTOP_IFACE, "CreateSession", ())?;
+    let remote_session = conn.with_proxy(
+        REMOTE_DESKTOP_NAME,
+        remote_session_path.clone(),
+        DBUS_TIMEOUT,
+    );
+    let session_id: String = remote_session.get(REMOTE_DESKTOP_SESSION_IFACE, "SessionId")?;
+
+    let mut session_properties = PropMap::new();
+    session_properties.insert(
+        "remote-desktop-session-id".into(),
+        Variant(Box::new(session_id)),
+    );
+    let screen_manager = conn.with_proxy(SCREEN_CAST_NAME, SCREEN_CAST_PATH, DBUS_TIMEOUT);
+    let (screen_session_path,): (Path<'static>,) =
+        screen_manager.method_call(SCREEN_CAST_IFACE, "CreateSession", (session_properties,))?;
+    let screen_session = conn.with_proxy(SCREEN_CAST_NAME, screen_session_path, DBUS_TIMEOUT);
+
+    let pending_paths = Arc::new(Mutex::new(HashMap::<String, u32>::new()));
+    let mut stream_paths = Vec::<(String, Path<'static>)>::new();
+    let mut _match_tokens = Vec::new();
+
+    for connector in connectors {
+        let mut properties = PropMap::new();
+        properties.insert("cursor-mode".into(), Variant(Box::new(0u32)));
+        properties.insert("is-recording".into(), Variant(Box::new(false)));
+        let (stream_path,): (Path<'static>,) = screen_session.method_call(
+            SCREEN_CAST_SESSION_IFACE,
+            "RecordMonitor",
+            (connector.clone(), properties),
+        )?;
+
+        let path_key = stream_path.to_string();
+        let nodes = pending_paths.clone();
+        let mut rule = MatchRule::new_signal(SCREEN_CAST_STREAM_IFACE, "PipeWireStreamAdded");
+        rule.path = Some(stream_path.clone());
+        _match_tokens.push(conn.add_match(rule, move |(node_id,): (u32,), _, _| {
+            nodes.lock().unwrap().insert(path_key.clone(), node_id);
+            true
+        })?);
+        stream_paths.push((connector, stream_path));
+    }
+
+    let _: () = remote_session.method_call(REMOTE_DESKTOP_SESSION_IFACE, "Start", ())?;
+
+    let deadline = Instant::now() + STREAM_TIMEOUT;
+    while pending_paths.lock().unwrap().len() < stream_paths.len() && Instant::now() < deadline {
+        conn.process(Duration::from_millis(50))?;
+    }
+    if pending_paths.lock().unwrap().len() != stream_paths.len() {
+        bail!(
+            "Mutter announced {}/{} PipeWire streams before timeout",
+            pending_paths.lock().unwrap().len(),
+            stream_paths.len()
+        );
+    }
+
+    let mut streams = Vec::with_capacity(stream_paths.len());
+    for (connector, object_path) in stream_paths {
+        let object_path_key = object_path.to_string();
+        let node_id = pending_paths
+            .lock()
+            .unwrap()
+            .get(&object_path_key)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("missing PipeWire node for {connector}"))?;
+        let stream_proxy = conn.with_proxy(SCREEN_CAST_NAME, object_path.clone(), DBUS_TIMEOUT);
+        let parameters: PropMap = stream_proxy.get(SCREEN_CAST_STREAM_IFACE, "Parameters")?;
+        let position = parameters
+            .get("position")
+            .and_then(|value| pair_i32(value.0.as_ref()))
+            .unwrap_or((0, 0));
+        let size = parameters
+            .get("size")
+            .and_then(|value| pair_i32(value.0.as_ref()))
+            .filter(|(width, height)| *width > 0 && *height > 0)
+            .map(|(width, height)| (width as usize, height as usize))
+            .ok_or_else(|| anyhow::anyhow!("Mutter stream {connector} has no size"))?;
+        streams.push(PwStreamInfo::new_mutter(
+            node_id as u64,
+            object_path,
+            position,
+            size,
+        ));
+    }
+
+    Ok(RdpSessionInfo {
+        conn: Arc::new(conn),
+        streams,
+        fd: None,
+        session: remote_session_path,
+        input_backend: RdpInputBackend::Mutter,
+        close_when_idle: true,
+        is_support_restore_token: false,
+        resolution: Arc::new(Mutex::new(None)),
+    })
+}

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -23,7 +23,7 @@ use gstreamer_app::AppSink;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
-use hbb_common::{bail, config, platform::linux::CMD_SH, serde_json, tokio, ResultType};
+use hbb_common::{bail, config, platform::linux::CMD_SH, serde_json, ResultType};
 
 use super::capturable::PixelProvider;
 use super::capturable::{Capturable, Recorder};
@@ -84,7 +84,7 @@ pub fn try_close_session() {
     let mut close = false;
     if let Some(rdp_info) = &*rdp_info {
         // If is server running and restore token is supported, there's no need to keep the session.
-        if is_server_running() && rdp_info.is_support_restore_token {
+        if is_server_running() && (rdp_info.is_support_restore_token || rdp_info.close_when_idle) {
             close = true;
         }
     }
@@ -98,17 +98,27 @@ pub fn try_close_session() {
 pub struct RdpSessionInfo {
     pub conn: Arc<SyncConnection>,
     pub streams: Vec<PwStreamInfo>,
-    pub fd: OwnedFd,
+    pub fd: Option<OwnedFd>,
     pub session: dbus::Path<'static>,
+    pub input_backend: RdpInputBackend,
+    pub close_when_idle: bool,
     pub is_support_restore_token: bool,
     pub resolution: Arc<Mutex<Option<(usize, usize)>>>,
 }
-#[derive(Debug, Clone, Copy)]
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RdpInputBackend {
+    Portal,
+    Mutter,
+}
+
+#[derive(Debug, Clone)]
 pub struct PwStreamInfo {
     pub path: u64,
     source_type: u64,
     position: (i32, i32),
     size: (usize, usize),
+    mutter_path: Option<dbus::Path<'static>>,
 }
 
 impl PwStreamInfo {
@@ -119,6 +129,36 @@ impl PwStreamInfo {
     pub fn get_position(&self) -> (i32, i32) {
         self.position
     }
+
+    pub fn get_mutter_path(&self) -> Option<&dbus::Path<'static>> {
+        self.mutter_path.as_ref()
+    }
+
+    #[cfg(feature = "gnome-mutter")]
+    pub(super) fn new_mutter(
+        node_id: u64,
+        object_path: dbus::Path<'static>,
+        position: (i32, i32),
+        size: (usize, usize),
+    ) -> Self {
+        Self {
+            path: node_id,
+            source_type: 1,
+            position,
+            size,
+            mutter_path: Some(object_path),
+        }
+    }
+}
+
+#[inline]
+pub fn is_mutter_session() -> bool {
+    RDP_SESSION_INFO
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|session| session.input_backend == RdpInputBackend::Mutter)
+        .unwrap_or(false)
 }
 
 #[derive(Debug)]
@@ -149,7 +189,7 @@ impl Error for GStreamerError {}
 pub struct PipeWireCapturable {
     // connection needs to be kept alive for recording
     dbus_conn: Arc<SyncConnection>,
-    fd: OwnedFd,
+    fd: Option<OwnedFd>,
     path: u64,
     source_type: u64,
     pub primary: bool,
@@ -161,7 +201,7 @@ pub struct PipeWireCapturable {
 impl PipeWireCapturable {
     fn new(
         conn: Arc<SyncConnection>,
-        fd: OwnedFd,
+        fd: Option<OwnedFd>,
         resolution: Arc<Mutex<Option<(usize, usize)>>>,
         stream: &PwStreamInfo,
     ) -> Self {
@@ -198,7 +238,7 @@ impl std::fmt::Debug for PipeWireCapturable {
             f,
             "PipeWireCapturable {{dbus: {}, fd: {}, path: {}, source_type: {}}}",
             self.dbus_conn.unique_name(),
-            self.fd.as_raw_fd(),
+            self.fd.as_ref().map(AsRawFd::as_raw_fd).unwrap_or(-1),
             self.path,
             self.source_type
         )
@@ -265,10 +305,16 @@ pub struct PipeWireRecorder {
 
 impl PipeWireRecorder {
     pub fn new(capturable: PipeWireCapturable) -> ResultType<Self> {
-        let pipeline = gst::Pipeline::new(None);
+        // The portal path initializes GStreamer while opening its session, but
+        // the direct Mutter path intentionally bypasses that portal call. Keep
+        // initialization at the pipeline boundary so every capture backend is
+        // safe, including a freshly started server's first Mutter connection.
+        let pipeline = new_initialized_pipeline()?;
 
         let src = gst::ElementFactory::make("pipewiresrc", None)?;
-        src.set_property("fd", &capturable.fd.as_raw_fd())?;
+        if let Some(fd) = capturable.fd.as_ref() {
+            src.set_property("fd", &fd.as_raw_fd())?;
+        }
         src.set_property("path", &format!("{}", capturable.path))?;
         src.set_property("keepalive_time", &1_000.as_raw_fd())?;
 
@@ -313,7 +359,7 @@ impl PipeWireRecorder {
         // Adding a short sleep period can also reduce the probability of crashes.
         debug!(
             "[gstreamer] Setting pipeline {} to PLAYING state...",
-            capturable.fd.as_raw_fd()
+            capturable.fd.as_ref().map(AsRawFd::as_raw_fd).unwrap_or(-1)
         );
         pipeline.set_state(gst::State::Playing)?;
 
@@ -327,13 +373,13 @@ impl PipeWireRecorder {
                 (Ok(_), gst::State::Playing, _) => {
                     debug!(
                         "[gstreamer] Pipeline {} state confirmed as PLAYING.",
-                        capturable.fd.as_raw_fd()
+                        capturable.fd.as_ref().map(AsRawFd::as_raw_fd).unwrap_or(-1)
                     );
                 }
                 (result, state, pending) => {
                     warn!(
                     "[gstreamer] Pipeline {} state change incomplete: result={:?}, state={:?}, pending={:?}",
-                    capturable.fd.as_raw_fd(), result, state, pending
+                    capturable.fd.as_ref().map(AsRawFd::as_raw_fd).unwrap_or(-1), result, state, pending
                 );
                 }
             }
@@ -352,6 +398,13 @@ impl PipeWireRecorder {
             saved_raw_data: Vec::new(),
         })
     }
+}
+
+fn new_initialized_pipeline() -> ResultType<gst::Pipeline> {
+    // gst_init_check is thread-safe and idempotent. Calling it here also removes
+    // the data race from the former process-global `static mut INIT` guard.
+    gst::init()?;
+    Ok(gst::Pipeline::new(None))
 }
 
 impl Recorder for PipeWireRecorder {
@@ -565,6 +618,7 @@ fn streams_from_response(response: OrgFreedesktopPortalRequestResponse) -> Vec<P
                             .map_or(Some(0), |v| v.as_u64())?,
                         position: (0, 0),
                         size: (0, 0),
+                        mutter_path: None,
                     };
                     let v = attributes
                         .get("size")?
@@ -610,7 +664,6 @@ fn streams_from_response(response: OrgFreedesktopPortalRequestResponse) -> Vec<P
     .unwrap_or_default()
 }
 
-static mut INIT: bool = false;
 const RESTORE_TOKEN: &str = "restore_token";
 const RESTORE_TOKEN_CONF_KEY: &str = "wayland-restore-token";
 const PIPEWIRE_DISPLAY_OFFSET_CONF_KEY: &str = "wayland-pipewire-display-offset";
@@ -631,12 +684,7 @@ pub fn request_remote_desktop(
     dbus::Path<'static>,
     bool,
 )> {
-    unsafe {
-        if !INIT {
-            gstreamer::init()?;
-            INIT = true;
-        }
-    }
+    gst::init()?;
     let conn = SyncConnection::new_session()?;
     let portal = get_portal(&conn);
     let mut args: PropMap = HashMap::new();
@@ -960,18 +1008,39 @@ pub fn get_capturables() -> Result<Vec<PipeWireCapturable>, Box<dyn Error>> {
     };
 
     if rdp_connection.is_none() {
-        let (conn, fd, streams, session, is_support_restore_token) = request_remote_desktop(false)?;
-        let conn = Arc::new(conn);
+        #[cfg(feature = "gnome-mutter")]
+        if is_server_running() && super::mutter::option_enabled() {
+            match super::mutter::request_session() {
+                Ok(rdp_info) => {
+                    HAS_POSITION_ATTR.store(true, Ordering::SeqCst);
+                    *rdp_connection = Some(rdp_info);
+                    debug!("Using direct GNOME Mutter ScreenCast/RemoteDesktop session");
+                }
+                Err(err) => {
+                    warn!(
+                        "Direct GNOME Mutter session is unavailable, falling back to XDG Portal: {err}"
+                    );
+                }
+            }
+        }
 
-        let rdp_info = RdpSessionInfo {
-            conn,
-            streams,
-            fd,
-            session,
-            is_support_restore_token,
-            resolution: Arc::new(Mutex::new(None)),
-        };
-        *rdp_connection = Some(rdp_info);
+        if rdp_connection.is_none() {
+            let (conn, fd, streams, session, is_support_restore_token) =
+                request_remote_desktop(false)?;
+            let conn = Arc::new(conn);
+
+            let rdp_info = RdpSessionInfo {
+                conn,
+                streams,
+                fd: Some(fd),
+                session,
+                input_backend: RdpInputBackend::Portal,
+                close_when_idle: false,
+                is_support_restore_token,
+                resolution: Arc::new(Mutex::new(None)),
+            };
+            *rdp_connection = Some(rdp_info);
+        }
     }
 
     let rdp_info = match rdp_connection.as_mut() {
@@ -1255,6 +1324,19 @@ fn save_positions_to_cache(displays: &Arc<Displays>, shared_displays: &Vec<crate
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::new_initialized_pipeline;
+
+    #[test]
+    fn pipeline_constructor_initializes_gstreamer_and_is_idempotent() {
+        let first = new_initialized_pipeline().expect("first pipeline should initialize GStreamer");
+        let second = new_initialized_pipeline().expect("repeated initialization should be safe");
+
+        drop((first, second));
+    }
+}
+
 fn compare_left_up_corner(w: usize, d1: &[u8], d2: &[u8]) -> bool {
     if w == 0 {
         return false;
@@ -1424,7 +1506,7 @@ fn fill_multi_matched_positions_cursor(
 
                 let mut rec = PipeWireRecorder::new(PipeWireCapturable {
                     dbus_conn: conn.clone(),
-                    fd: fd.clone(),
+                    fd: Some(fd.clone()),
                     path: pw_stream_with_cursor.path,
                     source_type: pw_stream_with_cursor.source_type,
                     primary: false,

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -398,12 +398,20 @@ pub fn core_main() -> Option<Vec<String>> {
             #[cfg(target_os = "linux")]
             {
                 hbb_common::allow_err!(crate::platform::check_autostart_config());
-                std::process::Command::new("pkill")
-                    .arg("-f")
-                    .arg(&format!("{} --tray", crate::get_app_name().to_lowercase()))
-                    .status()
-                    .ok();
-                hbb_common::allow_err!(crate::run_me(vec!["--tray"]));
+                #[cfg(feature = "drm")]
+                let login_server = crate::platform::linux::is_login_server_process();
+                #[cfg(not(feature = "drm"))]
+                let login_server = false;
+                if !login_server {
+                    std::process::Command::new("pkill")
+                        .arg("-f")
+                        .arg(&format!("{} --tray", crate::get_app_name().to_lowercase()))
+                        .status()
+                        .ok();
+                    hbb_common::allow_err!(crate::run_me(vec!["--tray"]));
+                } else {
+                    log::info!("login-screen server: graphical tray is disabled");
+                }
             }
             #[cfg(windows)]
             crate::privacy_mode::restore_reg_connectivity(true, false);
@@ -709,6 +717,13 @@ pub fn core_main() -> Option<Vec<String>> {
                 }
             }
             return None;
+        } else if args[0] == "--cm-headless" {
+            #[cfg(target_os = "linux")]
+            {
+                log::info!("start headless connection manager");
+                crate::ui_cm_interface::start_headless_cm();
+            }
+            return None;
         } else if args[0] == "--cm" {
             // call connection manager to establish connections
             // meanwhile, return true to call flutter window to show control panel
@@ -940,6 +955,7 @@ mod tests {
             "--server",
             "--tray",
             "--cm",
+            "--cm-headless",
             "--check-hwcodec-config",
             "--connect",
         ] {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -494,7 +494,7 @@ pub enum Data {
     #[cfg(target_os = "windows")]
     PortForwardSessionCount(Option<usize>),
     SocksWs(Option<Box<(Option<config::Socks5Server>, String)>>),
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     HasNoActiveConns(Option<bool>),
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     Whiteboard((String, crate::whiteboard::CustomEvent)),
@@ -1089,7 +1089,7 @@ async fn handle(data: Data, stream: &mut Connection) {
                     .await
             );
         }
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         Data::HasNoActiveConns(None) => {
             allow_err!(
                 stream

--- a/src/ipc/auth.rs
+++ b/src/ipc/auth.rs
@@ -165,10 +165,28 @@ fn is_allowed_windows_portable_service_peer(
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[inline]
-pub(crate) fn is_allowed_service_peer_uid(peer_uid: u32, active_uid: Option<u32>) -> bool {
+fn service_peer_uid_allowed(
+    peer_uid: u32,
+    active_uid: Option<u32>,
+    login_handoff_uid: Option<u32>,
+) -> bool {
     // Root is allowed at the UID gate because the service side may run as root.
-    // Callers still enforce executable matching before accepting service-scoped peers.
-    peer_uid == 0 || active_uid.is_some_and(|uid| uid == peer_uid)
+    peer_uid == 0 || active_uid == Some(peer_uid) || login_handoff_uid == Some(peer_uid)
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[inline]
+pub(crate) fn is_allowed_service_peer_uid(peer_uid: u32, active_uid: Option<u32>) -> bool {
+    // During a GDM -> desktop handoff the preserved greeter server may have to reopen DRM and
+    // uinput channels after Mutter changes the output topology. Admit only that exact remembered
+    // greeter UID while the handoff is active. Callers still require the peer to be the same
+    // installed executable before accepting a service-scoped connection.
+    #[cfg(all(target_os = "linux", feature = "drm"))]
+    let login_handoff_uid = crate::platform::linux::login_handoff_uid();
+    #[cfg(not(all(target_os = "linux", feature = "drm")))]
+    let login_handoff_uid = None;
+
+    service_peer_uid_allowed(peer_uid, active_uid, login_handoff_uid)
 }
 
 #[cfg(target_os = "macos")]
@@ -949,10 +967,13 @@ mod tests {
     #[test]
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn test_service_peer_uid_policy() {
-        assert!(super::is_allowed_service_peer_uid(0, None));
-        assert!(super::is_allowed_service_peer_uid(501, Some(501)));
-        assert!(!super::is_allowed_service_peer_uid(502, Some(501)));
-        assert!(!super::is_allowed_service_peer_uid(501, None));
+        let allowed = super::service_peer_uid_allowed;
+        assert!(allowed(0, None, None));
+        assert!(allowed(501, Some(501), None));
+        assert!(allowed(60_590, Some(1_000), Some(60_590)));
+        assert!(!allowed(502, Some(501), None));
+        assert!(!allowed(501, None, None));
+        assert!(!allowed(60_591, Some(1_000), Some(60_590)));
     }
 
     #[test]

--- a/src/ipc/drm.rs
+++ b/src/ipc/drm.rs
@@ -726,10 +726,14 @@ fn drm_auth_admitted(prev_in_flight: usize) -> bool {
     prev_in_flight < MAX_DRM_AUTH_IN_FLIGHT
 }
 
-fn drm_peer_authorized(peer_uid: Option<u32>, active_uid: Option<u32>) -> bool {
+fn drm_peer_authorized(
+    peer_uid: Option<u32>,
+    active_uid: Option<u32>,
+    login_handoff_uid: Option<u32>,
+) -> bool {
     match peer_uid {
         Some(0) => true,
-        Some(uid) => active_uid == Some(uid),
+        Some(uid) => active_uid == Some(uid) || login_handoff_uid == Some(uid),
         None => false,
     }
 }
@@ -887,7 +891,11 @@ async fn handle_drm_conn(stream: Connection) -> ResultType<()> {
         // Re-authorize per frame with the CACHE-ONLY active uid: a fresh lookup forks `loginctl` and
         // would stall every stream on this single-threaded runtime. A miss is fail-closed for a non-root peer
             // (root stays authorized; see `drm_peer_authorized`).
-        let peer_ok = drm_peer_authorized(peer_uid, active_uid_cached());
+        let peer_ok = drm_peer_authorized(
+            peer_uid,
+            active_uid_cached(),
+            crate::platform::linux::login_handoff_uid(),
+        );
         if !peer_ok {
             log::warn!("drm: _drm peer no longer matches the active session (or it is unknown); closing");
             break;
@@ -1728,13 +1736,14 @@ mod drm_conn_tests {
 
     #[test]
     fn drm_peer_authorized_matrix() {
-        assert!(drm_peer_authorized(Some(0), Some(1000)));
-        assert!(drm_peer_authorized(Some(0), None));
-        assert!(drm_peer_authorized(Some(1000), Some(1000)));
-        assert!(!drm_peer_authorized(Some(1000), Some(1001)));
-        assert!(!drm_peer_authorized(Some(1000), None));
-        assert!(!drm_peer_authorized(None, Some(1000)));
-        assert!(!drm_peer_authorized(None, None));
+        assert!(drm_peer_authorized(Some(0), Some(1000), None));
+        assert!(drm_peer_authorized(Some(0), None, None));
+        assert!(drm_peer_authorized(Some(1000), Some(1000), None));
+        assert!(drm_peer_authorized(Some(60589), Some(1000), Some(60589)));
+        assert!(!drm_peer_authorized(Some(1000), Some(1001), None));
+        assert!(!drm_peer_authorized(Some(1000), None, None));
+        assert!(!drm_peer_authorized(None, Some(1000), Some(60589)));
+        assert!(!drm_peer_authorized(None, None, None));
     }
 
     #[test]

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -65,7 +65,7 @@ const NO_LOGIN_HANDOFF_UID: u32 = u32::MAX;
 #[cfg(feature = "drm")]
 static LOGIN_HANDOFF_UID: AtomicU32 = AtomicU32::new(NO_LOGIN_HANDOFF_UID);
 
-#[cfg(feature = "drm")]
+#[cfg(any(feature = "drm", feature = "gnome-mutter"))]
 lazy_static::lazy_static! {
     /// Only for per-frame callers; see `is_login_screen_wayland_cached`.
     /// Own block because `#[cfg]` on one item inside a shared one breaks the macro.
@@ -422,7 +422,7 @@ pub fn is_x11_for_drm() -> bool {
 ///
 /// Only from the per-session `--server`: it is spawned after the session is identified, so the
 /// answer is settled. Anything that can run mid-boot must use the uncached form.
-#[cfg(feature = "drm")]
+#[cfg(any(feature = "drm", feature = "gnome-mutter"))]
 #[inline]
 pub fn is_login_screen_wayland_cached() -> bool {
     *IS_LOGIN_SCREEN_WAYLAND

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -22,6 +22,8 @@ use hbb_common::{
     users::{get_user_by_name, os::unix::UserExt},
 };
 use libxdo_sys::{self, xdo_t, Window};
+#[cfg(feature = "drm")]
+use std::sync::atomic::AtomicU32;
 use std::{
     cell::RefCell,
     ffi::{OsStr, OsString},
@@ -51,6 +53,17 @@ const SHELL_PROCESSES: [&str; 4] = ["bash", "zsh", "fish", "sh"];
 const TERM_XTERM_256COLOR: &str = "xterm-256color";
 const TERM_SCREEN_256COLOR: &str = "screen-256color";
 const TERM_XTERM: &str = "xterm";
+
+#[cfg(feature = "drm")]
+const LOGIN_SERVER_ENV: &str = "RUSTDESK_LOGIN_SERVER";
+
+#[cfg(feature = "drm")]
+const NO_LOGIN_HANDOFF_UID: u32 = u32::MAX;
+
+/// UID of the greeter `--server` that is temporarily allowed to keep consuming DRM frames while
+/// an already-authorized remote connection crosses from GDM into the user's desktop.
+#[cfg(feature = "drm")]
+static LOGIN_HANDOFF_UID: AtomicU32 = AtomicU32::new(NO_LOGIN_HANDOFF_UID);
 
 #[cfg(feature = "drm")]
 lazy_static::lazy_static! {
@@ -374,9 +387,17 @@ pub struct xcb_xfixes_get_cursor_image {
 }
 
 #[inline]
+fn is_login_manager_user(username: &str) -> bool {
+    // Current GDM releases use a dynamically-created `gdm-greeter` account, while older
+    // installations use `gdm`. Keep hbb_common's SDDM handling and recognize both GDM forms.
+    username == "gdm-greeter" || is_gdm_user(username)
+}
+
+#[inline]
 pub fn is_login_screen_wayland() -> bool {
     let values = get_values_of_seat0_with_gdm_wayland(&[0, 2]);
-    is_gdm_user(&values[1]) && get_display_server_of_session(&values[0]) == DISPLAY_SERVER_WAYLAND
+    is_login_manager_user(&values[1])
+        && get_display_server_of_session(&values[0]) == DISPLAY_SERVER_WAYLAND
 }
 
 /// An explicit `RUSTDESK_FORCED_DISPLAY_SERVER` is an operator override, and the root service
@@ -405,6 +426,27 @@ pub fn is_x11_for_drm() -> bool {
 #[inline]
 pub fn is_login_screen_wayland_cached() -> bool {
     *IS_LOGIN_SCREEN_WAYLAND
+}
+
+/// Stable for the lifetime of a per-session server. The live seat0 answer changes immediately
+/// after a successful login, so it cannot by itself tell the outgoing greeter server that it was
+/// born for the login screen.
+#[cfg(feature = "drm")]
+pub fn is_login_server_process() -> bool {
+    std::env::var(LOGIN_SERVER_ENV).as_deref() == Ok("1") || is_login_screen_wayland_cached()
+}
+
+#[cfg(feature = "drm")]
+pub(crate) fn set_login_handoff_uid(uid: Option<u32>) {
+    LOGIN_HANDOFF_UID.store(uid.unwrap_or(NO_LOGIN_HANDOFF_UID), Ordering::Release);
+}
+
+#[cfg(feature = "drm")]
+pub(crate) fn login_handoff_uid() -> Option<u32> {
+    match LOGIN_HANDOFF_UID.load(Ordering::Acquire) {
+        NO_LOGIN_HANDOFF_UID => None,
+        uid => Some(uid),
+    }
 }
 
 #[inline]
@@ -895,15 +937,14 @@ fn try_start_server_(desktop: Option<&Desktop>) -> ResultType<Option<Child>> {
             if !desktop.dbus.is_empty() {
                 envs.push(("DBUS_SESSION_BUS_ADDRESS", desktop.dbus.clone()));
             }
-            if let Ok(forced_display_server) =
-                std::env::var("RUSTDESK_FORCED_DISPLAY_SERVER")
-            {
+            if let Ok(forced_display_server) = std::env::var("RUSTDESK_FORCED_DISPLAY_SERVER") {
                 if !forced_display_server.is_empty() {
-                    envs.push((
-                        "RUSTDESK_FORCED_DISPLAY_SERVER",
-                        forced_display_server,
-                    ));
+                    envs.push(("RUSTDESK_FORCED_DISPLAY_SERVER", forced_display_server));
                 }
+            }
+            #[cfg(feature = "drm")]
+            if desktop.is_login_wayland() {
+                envs.push((LOGIN_SERVER_ENV, "1".to_owned()));
             }
             envs.push((
                 "TERM",
@@ -1065,6 +1106,88 @@ fn force_stop_server() {
     sleep_millis(super::SERVICE_INTERVAL);
 }
 
+#[cfg(feature = "drm")]
+fn child_is_running(server: &mut Option<Child>) -> bool {
+    let Some(child) = server.as_mut() else {
+        return false;
+    };
+    match child.try_wait() {
+        Ok(None) => true,
+        Ok(Some(status)) => {
+            log::info!("login-screen --server exited during handoff: {status}");
+            *server = None;
+            false
+        }
+        Err(err) => {
+            log::warn!("could not inspect login-screen --server during handoff: {err}");
+            true
+        }
+    }
+}
+
+#[cfg(feature = "drm")]
+fn login_server_has_active_connections(uid: u32) -> ResultType<bool> {
+    const IPC_TIMEOUT_MS: u64 = 300;
+    let runtime = hbb_common::tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(async {
+        let mut connection = crate::ipc::connect_for_uid(IPC_TIMEOUT_MS, uid, "").await?;
+        connection
+            .send(&crate::ipc::Data::HasNoActiveConns(None))
+            .await?;
+        match connection.next_timeout(IPC_TIMEOUT_MS).await? {
+            Some(crate::ipc::Data::HasNoActiveConns(Some(has_none))) => Ok(!has_none),
+            _ => bail!("login-screen --server returned no connection-state reply"),
+        }
+    })
+}
+
+/// Keep the greeter server only while it has a live remote session. An IPC failure is treated as
+/// active for a short grace so a transient socket race cannot cut the session at the exact login
+/// boundary, but it cannot pin a dead greeter process forever.
+#[cfg(feature = "drm")]
+fn should_keep_login_server_for_handoff(
+    server: &mut Option<Child>,
+    query_failed_since: &mut Option<Instant>,
+) -> bool {
+    const QUERY_FAILURE_GRACE: Duration = Duration::from_secs(5);
+    if !child_is_running(server) {
+        *query_failed_since = None;
+        return false;
+    }
+    let Some(uid) = login_handoff_uid() else {
+        *query_failed_since = None;
+        return false;
+    };
+    match login_server_has_active_connections(uid) {
+        Ok(true) => {
+            *query_failed_since = None;
+            true
+        }
+        Ok(false) => {
+            *query_failed_since = None;
+            false
+        }
+        Err(err) => {
+            let failed_since = query_failed_since.get_or_insert_with(|| {
+                log::warn!(
+                    "could not query login-screen connection state; preserving it for {QUERY_FAILURE_GRACE:?}: {err}"
+                );
+                Instant::now()
+            });
+            if failed_since.elapsed() < QUERY_FAILURE_GRACE {
+                true
+            } else {
+                log::warn!(
+                    "login-screen connection-state query failed for {QUERY_FAILURE_GRACE:?}; ending handoff"
+                );
+                false
+            }
+        }
+    }
+}
+
 pub fn start_os_service() {
     check_if_stop_service();
     stop_rustdesk_servers();
@@ -1105,6 +1228,10 @@ pub fn start_os_service() {
     let mut uid = "".to_owned();
     let mut server: Option<Child> = None;
     let mut user_server: Option<Child> = None;
+    #[cfg(feature = "drm")]
+    let mut handoff_query_failed_since: Option<Instant> = None;
+    #[cfg(feature = "drm")]
+    let mut handoff_logged = false;
     if let Err(err) = ctrlc::set_handler(move || {
         r.store(false, Ordering::SeqCst);
     }) {
@@ -1119,6 +1246,11 @@ pub fn start_os_service() {
 
         // Duplicate logic here with should_start_server.
         if desktop.username == "root" || desktop.is_login_wayland() {
+            #[cfg(feature = "drm")]
+            {
+                handoff_query_failed_since = None;
+                handoff_logged = false;
+            }
             // try kill subprocess "--server"
             stop_server(&mut user_server);
             // try start subprocess "--server"
@@ -1166,28 +1298,69 @@ pub fn start_os_service() {
                     start_server(None, &mut server);
                 }
             }
+            #[cfg(feature = "drm")]
+            if server.is_some() {
+                let server_uid = if desktop.username == "root" {
+                    Some(0)
+                } else {
+                    desktop.uid.parse::<u32>().ok()
+                };
+                set_login_handoff_uid(server_uid);
+            }
         } else if desktop.username != "" {
-            // try kill subprocess "--server"
-            stop_server(&mut server);
+            #[cfg(feature = "drm")]
+            let keep_login_server =
+                should_keep_login_server_for_handoff(&mut server, &mut handoff_query_failed_since);
+            #[cfg(not(feature = "drm"))]
+            let keep_login_server = false;
 
-            let is_display_changed = desktop.display != display || desktop.xauth != xauth;
-            display = desktop.display.clone();
-            xauth = desktop.xauth.clone();
+            if keep_login_server {
+                // The established phone connection owns this greeter server. Its DRM and uinput
+                // channels remain valid across the login boundary, so replacing the process here
+                // would only turn a working handoff into an avoidable TCP reset.
+                stop_server(&mut user_server);
+                #[cfg(feature = "drm")]
+                if !handoff_logged {
+                    log::info!(
+                        "preserving active login-screen connection across the desktop handoff"
+                    );
+                    handoff_logged = true;
+                }
+            } else {
+                #[cfg(feature = "drm")]
+                if handoff_logged {
+                    log::info!(
+                        "login-screen connection ended; switching to the user Wayland server"
+                    );
+                    handoff_logged = false;
+                }
 
-            // try start subprocess "--server"
-            if should_start_server(
-                !desktop.is_wayland(),
-                is_display_changed,
-                &mut uid,
-                &desktop,
-                &mut cm0,
-                &mut last_restart,
-                &mut user_server,
-            ) {
-                force_stop_server();
-                start_server(Some(&desktop), &mut user_server);
+                // try kill subprocess "--server"
+                stop_server(&mut server);
+                #[cfg(feature = "drm")]
+                set_login_handoff_uid(None);
+
+                let is_display_changed = desktop.display != display || desktop.xauth != xauth;
+                display = desktop.display.clone();
+                xauth = desktop.xauth.clone();
+
+                // try start subprocess "--server"
+                if should_start_server(
+                    !desktop.is_wayland(),
+                    is_display_changed,
+                    &mut uid,
+                    &desktop,
+                    &mut cm0,
+                    &mut last_restart,
+                    &mut user_server,
+                ) {
+                    force_stop_server();
+                    start_server(Some(&desktop), &mut user_server);
+                }
             }
         } else {
+            #[cfg(feature = "drm")]
+            set_login_handoff_uid(None);
             force_stop_server();
             stop_server(&mut user_server);
             stop_server(&mut server);
@@ -1209,6 +1382,8 @@ pub fn start_os_service() {
     if let Some(ps) = server.take().as_mut() {
         allow_err!(ps.kill());
     }
+    #[cfg(feature = "drm")]
+    set_login_handoff_uid(None);
     log::info!("Exit");
 }
 
@@ -1986,7 +2161,7 @@ mod desktop {
 
         #[inline]
         pub fn is_login_wayland(&self) -> bool {
-            super::is_gdm_user(&self.username) && self.protocol == DISPLAY_SERVER_WAYLAND
+            super::is_login_manager_user(&self.username) && self.protocol == DISPLAY_SERVER_WAYLAND
         }
 
         fn get_display_xauth_wayland(&mut self) {
@@ -2338,11 +2513,8 @@ mod desktop {
                 // which is the entire reason it works at a login screen. `try_start_server_` skips
                 // empty entries, so the greeter child simply does not get them.
                 //
-                // `is_login_wayland` needs `is_gdm_user(username)`, and a current GDM runs its
-                // greeter as `gdm-greeter`, which that helper does not match -- measured on the
-                // test host, where the greeter server therefore takes the branch below and gets a
-                // fully populated environment. This is for the display managers whose greeter user
-                // does match.
+                // `is_login_wayland` accepts both GDM's legacy `gdm` account and the current
+                // dynamically-created `gdm-greeter` account, as well as SDDM's greeter account.
                 #[cfg(feature = "drm")]
                 self.get_home();
                 return;
@@ -2365,6 +2537,14 @@ mod desktop {
     #[cfg(test)]
     mod tests {
         use super::*;
+
+        #[test]
+        fn recognizes_current_and_legacy_gdm_greeter_users() {
+            assert!(super::super::is_login_manager_user("gdm"));
+            assert!(super::super::is_login_manager_user("gdm-greeter"));
+            assert!(super::super::is_login_manager_user("sddm"));
+            assert!(!super::super::is_login_manager_user("greeter"));
+        }
 
         #[test]
         fn test_desktop_env() {
@@ -2443,11 +2623,8 @@ impl SessionIdleInhibit {
         let mut refused = Vec::new();
         for target in SESSION_INHIBIT_TARGETS {
             let res: Result<(u32,), dbus::Error> = {
-                let proxy = conn.with_proxy(
-                    target.dest,
-                    target.path,
-                    std::time::Duration::from_secs(3),
-                );
+                let proxy =
+                    conn.with_proxy(target.dest, target.path, std::time::Duration::from_secs(3));
                 if target.gnome_shape {
                     // Inhibit(s app_id, u xid, s reason, u flags) -> u cookie; xid 0 = no window.
                     proxy.method_call(

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -6017,18 +6017,29 @@ async fn start_ipc(
 ) -> ResultType<()> {
     use hbb_common::anyhow::anyhow;
 
-    loop {
-        if !crate::platform::is_prelogin() {
-            break;
+    #[cfg(all(target_os = "linux", feature = "drm"))]
+    let login_server = crate::platform::linux::is_login_server_process();
+    #[cfg(not(all(target_os = "linux", feature = "drm")))]
+    let login_server = false;
+
+    if !login_server {
+        loop {
+            if !crate::platform::is_prelogin() {
+                break;
+            }
+            sleep(1.).await;
         }
-        sleep(1.).await;
     }
     let mut stream = None;
     if let Ok(s) = crate::ipc::connect(1000, "_cm").await {
         stream = Some(s);
     }
     if stream.is_none() {
-        let args = vec!["--cm"];
+        let args = if login_server {
+            vec!["--cm-headless"]
+        } else {
+            vec!["--cm"]
+        };
         let run_done;
         if crate::platform::is_root() {
             let mut res = Ok(None);

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -345,7 +345,7 @@ fn check_get_displays_changed_msg() -> Option<Message> {
             // from the DRM display list here. Without this the display service broadcasts an empty
             // list that overwrites the login peer-info displays and the client shows "No displays".
             #[cfg(feature = "drm")]
-            if super::drm_capturer::is_available_cached() {
+            if super::drm_capturer::should_use_cached() {
                 let synced = !SYNC_DISPLAYS.lock().unwrap().displays.is_empty();
                 let stamped_before = scrap::wayland::display::wayland_failure_stamped();
                 // With nothing published yet, even the unaugmented DRM list beats the empty

--- a/src/server/drm_capturer.rs
+++ b/src/server/drm_capturer.rs
@@ -5,8 +5,8 @@ use crate::ipc::{connect_drm, Data, DrmDisplayInfo};
 use hbb_common::{anyhow::anyhow, bail, log, message_proto::DisplayInfo, tokio, ResultType};
 use scrap::drm_render::RenderConverter;
 use scrap::drmtap_dl::drmtap_dmabuf_desc;
-use scrap::{Frame, Pixfmt, PixelBuffer, TraitCapturer};
-use std::collections::BTreeMap;
+use scrap::{Frame, PixelBuffer, Pixfmt, TraitCapturer};
+use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 use std::os::fd::{AsRawFd, RawFd};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -21,7 +21,7 @@ const DISPLAY_LIST_TIMEOUT_MS: u64 = HANDSHAKE_TIMEOUT_MS + 4000;
 /// (first byte, then body). The render-node open and the DrmStart send can still overrun it.
 const HANDSHAKE_WAIT_MS: u64 = DRM_CONNECT_TIMEOUT_MS + DISPLAY_LIST_TIMEOUT_MS * 2 + 500;
 /// Only the header read rechecks `stop`, so bound the body read here rather than relying on
-    /// `next_raw_into`'s own cap.
+/// `next_raw_into`'s own cap.
 const BODY_READ_TIMEOUT: Duration = Duration::from_secs(5);
 
 struct FrameSlot {
@@ -85,7 +85,7 @@ fn display_info_of(display: i32) -> Option<DrmDisplayInfo> {
 }
 
 /// A delivered frame resets the streak verdicts (`zero_frame_streak`, `demotes`, `since`) and
-    /// nothing else.
+/// nothing else.
 #[derive(Clone, Copy)]
 struct DisplayHealth {
     zero_frame_streak: u32,
@@ -185,7 +185,8 @@ fn render_node_count() -> usize {
 }
 
 static UINPUT_REFRESH_GEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-static UINPUT_REFRESH_BUSY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static UINPUT_REFRESH_BUSY: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 impl IpcDrmCapturer {
     /// The service resolves indices against ITS OWN enumeration, so the receive thread re-resolves
@@ -480,7 +481,8 @@ async fn recv_thread(
                     match recv_fd.as_ref() {
                         Some(f) => f.as_raw_fd(),
                         None => {
-                            break "dma-buf frame set has_fd but carried no SCM_RIGHTS fd".to_owned()
+                            break "dma-buf frame set has_fd but carried no SCM_RIGHTS fd"
+                                .to_owned()
                         }
                     }
                 } else {
@@ -629,35 +631,35 @@ async fn recv_thread(
                     let spawned = std::thread::Builder::new()
                         .name("drm-uinput-refresh".into())
                         .spawn(move || {
-                        let rt = match tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                        {
-                            Ok(rt) => rt,
-                            Err(err) => {
-                                log::warn!(
+                            let rt = match tokio::runtime::Builder::new_current_thread()
+                                .enable_all()
+                                .build()
+                            {
+                                Ok(rt) => rt,
+                                Err(err) => {
+                                    log::warn!(
                                     "drm: uinput refresh worker could not build a runtime: {err}"
                                 );
-                                return; // the guard hands the slot back
+                                    return; // the guard hands the slot back
+                                }
+                            };
+                            let mut served = 0u64;
+                            loop {
+                                let g = UINPUT_REFRESH_GEN.load(Ordering::Acquire);
+                                if g != served {
+                                    served = g;
+                                    rt.block_on(super::wayland::update_uinput_resolution());
+                                    continue;
+                                }
+                                busy.release();
+                                if UINPUT_REFRESH_GEN.load(Ordering::Acquire) == served {
+                                    break;
+                                }
+                                if !busy.retake() {
+                                    break; // another handler already started a fresh worker
+                                }
                             }
-                        };
-                        let mut served = 0u64;
-                        loop {
-                            let g = UINPUT_REFRESH_GEN.load(Ordering::Acquire);
-                            if g != served {
-                                served = g;
-                                rt.block_on(super::wayland::update_uinput_resolution());
-                                continue;
-                            }
-                            busy.release();
-                            if UINPUT_REFRESH_GEN.load(Ordering::Acquire) == served {
-                                break;
-                            }
-                            if !busy.retake() {
-                                break; // another handler already started a fresh worker
-                            }
-                        }
-                    });
+                        });
                     if let Err(err) = spawned {
                         log::error!("drm: could not spawn the uinput refresh worker: {err}");
                     }
@@ -743,6 +745,12 @@ enum ProbeState {
 }
 
 static DRM_STATE: Mutex<ProbeState> = Mutex::new(ProbeState::Unknown);
+/// A preserved login-screen server cannot open the user's Mutter socket after GDM exits. Keep the
+/// last compositor layout that this same process successfully observed, so connector origins and
+/// the uinput desktop range do not collapse to DRM's ambiguous all-at-(0,0) geometry mid-handoff.
+static LOGIN_SERVER_WAYLAND_LAYOUT: Mutex<Option<Arc<scrap::wayland::display::Displays>>> =
+    Mutex::new(None);
+static LOGIN_SERVER_LAYOUT_FALLBACK_LOGGED: AtomicBool = AtomicBool::new(false);
 const NEGATIVE_TTL: Duration = Duration::from_secs(30);
 const POSITIVE_TTL: Duration = Duration::from_secs(15);
 
@@ -779,13 +787,14 @@ const DRM_PROBE_MAX_FAILURES: u32 = 5;
 static DRM_REFRESH_FAILURES: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 const DRM_REFRESH_MAX_FAILURES: u32 = 3;
 // Single-flight, so is_available() never calls query_displays() (~4s of IPC) holding DRM_STATE.
-static DRM_PROBE_IN_FLIGHT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+static DRM_PROBE_IN_FLIGHT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 /// Advanced by every publish, so a slow UNLOCKED probe can tell a newer verdict landed meanwhile.
 static DRM_STATE_GEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// EVERY verdict change to DRM_STATE goes through here so the generation stays truthful; the TTL
-    /// restamp in `refresh_available_async` is the one direct write.
+/// restamp in `refresh_available_async` is the one direct write.
 #[inline]
 fn publish_probe_state(st: &mut ProbeState, next: ProbeState) {
     *st = next;
@@ -825,6 +834,30 @@ impl Drop for UinputRefreshGuard {
 /// enumeration, where seconds of IPC would trip "deadline has elapsed".
 pub(crate) fn is_available_cached() -> bool {
     matches!(&*DRM_STATE.lock().unwrap(), ProbeState::Available(..))
+}
+
+#[inline]
+fn prefer_drm_for_session(login_screen: bool, mutter_requested: bool) -> bool {
+    login_screen || !mutter_requested
+}
+
+#[inline]
+fn prefer_drm_for_current_session() -> bool {
+    #[cfg(feature = "gnome-mutter")]
+    let mutter_requested = scrap::wayland::mutter::option_enabled();
+    #[cfg(not(feature = "gnome-mutter"))]
+    let mutter_requested = false;
+
+    prefer_drm_for_session(
+        crate::platform::linux::is_login_screen_wayland_cached(),
+        mutter_requested,
+    )
+}
+
+/// Non-blocking capture-routing gate. A configured GNOME user session uses Mutter; the Wayland
+/// greeter still uses DRM because it has no user session bus or portal.
+pub(crate) fn should_use_cached() -> bool {
+    prefer_drm_for_current_session() && is_available_cached()
 }
 
 /// A tri-state assessment of DRM capture availability.
@@ -934,7 +967,10 @@ fn probe_and_publish() -> Availability {
             Availability::Available
         }
         Ok(_) => {
-            log::info!("drm: availability probe -> no displays in {:?}", t.elapsed());
+            log::info!(
+                "drm: availability probe -> no displays in {:?}",
+                t.elapsed()
+            );
             publish_probe_state(&mut st, ProbeState::Unavailable(Instant::now()));
             Availability::Unavailable
         }
@@ -961,6 +997,12 @@ fn probe_and_publish() -> Availability {
 /// route the same way (into the non-DRM fallback).
 pub(crate) fn is_available() -> bool {
     availability() == Availability::Available
+}
+
+/// Blocking capture-build gate. This mirrors `should_use_cached`, but may settle a cold DRM probe
+/// on the plain video thread.
+pub(crate) fn should_use() -> bool {
+    prefer_drm_for_current_session() && is_available()
 }
 
 /// The negative mirror of `refresh_available_async`: re-verify a stale Unavailable without ever
@@ -1097,8 +1139,14 @@ pub(super) fn warm_availability() {
         }
         match query_displays() {
             Ok(list) if !list.is_empty() => {
-                log::info!("drm: consumer cache warmed ({} displays) at startup", list.len());
-                publish_probe_state(&mut DRM_STATE.lock().unwrap(), ProbeState::Available(Instant::now(), list));
+                log::info!(
+                    "drm: consumer cache warmed ({} displays) at startup",
+                    list.len()
+                );
+                publish_probe_state(
+                    &mut DRM_STATE.lock().unwrap(),
+                    ProbeState::Available(Instant::now(), list),
+                );
                 return;
             }
             _ => std::thread::sleep(Duration::from_millis(300)),
@@ -1206,18 +1254,156 @@ fn primary_index_from_assignment(assignment: &[Option<usize>], primary: usize) -
         .unwrap_or(0)
 }
 
+fn xml_element_blocks<'a>(xml: &'a str, tag: &str) -> Vec<&'a str> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let mut blocks = Vec::new();
+    let mut cursor = 0;
+    while let Some(open_offset) = xml[cursor..].find(&open) {
+        let content_start = cursor + open_offset + open.len();
+        let Some(close_offset) = xml[content_start..].find(&close) else {
+            break;
+        };
+        let content_end = content_start + close_offset;
+        blocks.push(&xml[content_start..content_end]);
+        cursor = content_end + close.len();
+    }
+    blocks
+}
+
+fn first_xml_element_text<'a>(xml: &'a str, tag: &str) -> Option<&'a str> {
+    xml_element_blocks(xml, tag)
+        .into_iter()
+        .next()
+        .map(str::trim)
+}
+
+/// GDM's Wayland session is deliberately not exposed to the login `--server` through D-Bus or a
+/// compositor socket, so Mutter's `GetCurrentState` primary lookup cannot work there. Read the
+/// persisted monitor profile instead, but only accept a configuration whose complete set of active
+/// connectors matches the DRM snapshot. That prevents a stale profile for a dock or a different
+/// monitor set from selecting the wrong physical output.
+fn primary_index_from_monitors_xml(xml: &str, drm: &[DrmDisplayInfo]) -> Option<usize> {
+    let active: BTreeSet<String> = drm
+        .iter()
+        .map(|display| normalize_connector(&display.name))
+        .collect();
+    if active.is_empty() {
+        return None;
+    }
+
+    for configuration in xml_element_blocks(xml, "configuration") {
+        let mut configured = BTreeSet::new();
+        let mut primary_connector = None;
+        for logical_monitor in xml_element_blocks(configuration, "logicalmonitor") {
+            let connectors: Vec<&str> = xml_element_blocks(logical_monitor, "connector")
+                .into_iter()
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .collect();
+            configured.extend(connectors.iter().map(|name| normalize_connector(name)));
+            if first_xml_element_text(logical_monitor, "primary") == Some("yes") {
+                // A mirrored logical monitor can name more than one physical connector. Pick the
+                // first one that is actually present in this DRM snapshot.
+                primary_connector = connectors
+                    .into_iter()
+                    .find(|name| active.contains(&normalize_connector(name)))
+                    .map(str::to_owned);
+            }
+        }
+        if configured == active {
+            if let Some(primary_connector) = primary_connector {
+                let primary = normalize_connector(&primary_connector);
+                if let Some(index) = drm
+                    .iter()
+                    .position(|display| normalize_connector(&display.name) == primary)
+                {
+                    return Some(index);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn gdm_primary_index(drm: &[DrmDisplayInfo]) -> Option<usize> {
+    if !crate::platform::linux::is_login_server_process() {
+        return None;
+    }
+    // GDM 50 uses a per-seat persistent config for its dynamic greeter uid; older GDM releases use
+    // the account's traditional ~/.config. Both paths are fixed system locations and the parser
+    // above still requires an exact connector-set match before trusting either file.
+    const CANDIDATES: [&str; 4] = [
+        "/var/lib/gdm/seat0/config/monitors.xml",
+        "/var/lib/gdm/.config/monitors.xml",
+        "/var/lib/gdm3/seat0/config/monitors.xml",
+        "/var/lib/gdm3/.config/monitors.xml",
+    ];
+    for path in CANDIDATES {
+        let Ok(xml) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if let Some(primary) = primary_index_from_monitors_xml(&xml, drm) {
+            log::info!(
+                "drm: selecting GDM primary connector {} from its persisted monitor profile",
+                drm[primary].name
+            );
+            return Some(primary);
+        }
+    }
+    None
+}
+
+fn select_wayland_layout_for_login_handoff(
+    live: Arc<scrap::wayland::display::Displays>,
+    login_server: bool,
+    saved: &mut Option<Arc<scrap::wayland::display::Displays>>,
+) -> (Arc<scrap::wayland::display::Displays>, bool) {
+    if !login_server {
+        return (live, false);
+    }
+    if !live.displays.is_empty() {
+        *saved = Some(live.clone());
+        return (live, false);
+    }
+    match saved.as_ref() {
+        Some(saved) => (saved.clone(), true),
+        None => (live, false),
+    }
+}
+
+fn wayland_layout_for_drm_augmentation() -> Arc<scrap::wayland::display::Displays> {
+    let live = scrap::wayland::display::get_displays();
+    let (layout, used_saved) = select_wayland_layout_for_login_handoff(
+        live,
+        crate::platform::linux::is_login_server_process(),
+        &mut LOGIN_SERVER_WAYLAND_LAYOUT.lock().unwrap(),
+    );
+    if used_saved {
+        if !LOGIN_SERVER_LAYOUT_FALLBACK_LOGGED.swap(true, Ordering::Relaxed) {
+            log::info!(
+                "drm: GDM compositor is gone; preserving its last display geometry for handoff"
+            );
+        }
+    } else {
+        LOGIN_SERVER_LAYOUT_FALLBACK_LOGGED.store(false, Ordering::Relaxed);
+    }
+    layout
+}
+
 /// Releases DRM_STATE before taking the Wayland and health locks.
 pub(super) fn get_display_infos_and_primary() -> Option<(Vec<DisplayInfo>, usize)> {
     let list = match &*DRM_STATE.lock().unwrap() {
         ProbeState::Available(_, list) => list.clone(),
         _ => return None,
     };
-    let wl = scrap::wayland::display::get_displays();
+    let wl = wayland_layout_for_drm_augmentation();
     let assignment = assign_wayland_outputs(&list, &wl.displays);
     let mut infos = augment_with_wayland_geometry_from(&list, &wl, &assignment);
     mark_demoted_displays(&list, &mut infos);
     // Primary and geometry must use the same connector assignment snapshot.
-    let primary = primary_index_from_assignment(&assignment, wl.primary);
+    let primary = gdm_primary_index(&list)
+        .unwrap_or_else(|| primary_index_from_assignment(&assignment, wl.primary));
     Some((infos, primary))
 }
 
@@ -1238,7 +1424,7 @@ pub(super) fn get_display_infos() -> Option<Vec<DisplayInfo>> {
 /// cannot answer, the list comes back empty and everything stays unaugmented, which is what the
 /// old is-login-screen gate produced unconditionally.
 fn augment_with_wayland_geometry(drm: &[DrmDisplayInfo]) -> Vec<DisplayInfo> {
-    let wl = scrap::wayland::display::get_displays();
+    let wl = wayland_layout_for_drm_augmentation();
     let assignment = assign_wayland_outputs(drm, &wl.displays);
     augment_with_wayland_geometry_from(drm, &wl, &assignment)
 }
@@ -1308,10 +1494,9 @@ fn assign_wayland_outputs(
         if matched[i].is_some() {
             continue;
         }
-        let free_same_size = wl
-            .iter()
-            .enumerate()
-            .position(|(j, w)| !taken[j] && w.width == d.width as i32 && w.height == d.height as i32);
+        let free_same_size = wl.iter().enumerate().position(|(j, w)| {
+            !taken[j] && w.width == d.width as i32 && w.height == d.height as i32
+        });
         let Some(j) = free_same_size.or_else(|| taken.iter().position(|t| !t)) else {
             continue; // more connectors than outputs; leave the rest unaugmented
         };
@@ -1358,7 +1543,8 @@ fn match_wayland_display(
 /// Only a *letter* folds: a single *digit* is an MST port index, so "DP-1-2" is not "DP-2".
 fn normalize_connector(name: &str) -> String {
     let parts: Vec<&str> = name.split('-').collect();
-    if parts.len() == 3 && parts[1].len() == 1 && parts[1].chars().all(|c| c.is_ascii_alphabetic()) {
+    if parts.len() == 3 && parts[1].len() == 1 && parts[1].chars().all(|c| c.is_ascii_alphabetic())
+    {
         format!("{}-{}", parts[0], parts[2])
     } else {
         name.to_string()
@@ -1379,8 +1565,11 @@ fn swap_available_displays(list: Vec<DrmDisplayInfo>) {
 }
 
 fn display_info_from_drm(d: &DrmDisplayInfo) -> DisplayInfo {
-    let original_resolution =
-        super::display_service::get_original_resolution(&d.name, d.width as usize, d.height as usize);
+    let original_resolution = super::display_service::get_original_resolution(
+        &d.name,
+        d.width as usize,
+        d.height as usize,
+    );
     DisplayInfo {
         x: d.x,
         y: d.y,
@@ -1467,6 +1656,14 @@ pub(super) fn get_capturer_info(
 mod drm_capturer_tests {
     use super::*;
 
+    #[test]
+    fn mutter_is_used_only_for_a_logged_in_user_session() {
+        assert!(!prefer_drm_for_session(false, true));
+        assert!(prefer_drm_for_session(true, true));
+        assert!(prefer_drm_for_session(false, false));
+        assert!(prefer_drm_for_session(true, false));
+    }
+
     fn capturer_with(session: Option<(usize, usize)>) -> IpcDrmCapturer {
         capturer_named(session, None)
     }
@@ -1506,7 +1703,13 @@ mod drm_capturer_tests {
     }
 
     fn put_frame(c: &IpcDrmCapturer, w: usize, h: usize) {
-        let mut buf = c.shared.slot.lock().unwrap().take_free().unwrap_or_default();
+        let mut buf = c
+            .shared
+            .slot
+            .lock()
+            .unwrap()
+            .take_free()
+            .unwrap_or_default();
         buf.clear();
         buf.resize(w * h * 4, 0);
         let mut slot = c.shared.slot.lock().unwrap();
@@ -1533,16 +1736,23 @@ mod drm_capturer_tests {
         // process-wide DRM_DISPLAY_HEALTH poisons the mutex for every sibling test.
         let h = {
             let map = DRM_DISPLAY_HEALTH.lock().unwrap();
-            *map.get(key).expect("the entry must SURVIVE a delivered frame")
+            *map.get(key)
+                .expect("the entry must SURVIVE a delivered frame")
         };
-        assert_eq!(h.zero_frame_streak, 0, "a delivered frame refutes the zero-frame streak");
+        assert_eq!(
+            h.zero_frame_streak, 0,
+            "a delivered frame refutes the zero-frame streak"
+        );
         assert_eq!(h.demotes, 0, "and the demotion count that streak drove");
         assert_eq!(
             h.rapid_builds, 3,
             "but it says NOTHING about the rebuild cadence: keeping it is what lets the flap guard \
              reach RAPID_REBUILD_MAX for a display that delivers a first frame and then fails"
         );
-        assert!(h.last_build.is_some(), "same for the timestamp the cadence is measured from");
+        assert!(
+            h.last_build.is_some(),
+            "same for the timestamp the cadence is measured from"
+        );
         assert!(
             h.prefer_cpu,
             "and nothing about which GPU exports the scanout: only a topology change may clear it"
@@ -1590,8 +1800,13 @@ mod drm_capturer_tests {
             Err(e) => e,
             Ok(_) => panic!("a first frame off the advertised geometry must be a hard error"),
         };
-        assert!(err.to_string().contains("never matched its advertised geometry"));
-        assert!(!c.got_frame, "no frame reached the encoder, so none was produced");
+        assert!(err
+            .to_string()
+            .contains("never matched its advertised geometry"));
+        assert!(
+            !c.got_frame,
+            "no frame reached the encoder, so none was produced"
+        );
         assert_eq!(
             zero_frame_streak_of(&c),
             1,
@@ -1645,6 +1860,63 @@ mod drm_capturer_tests {
         }
     }
 
+    fn wl_layout(
+        displays: Vec<hbb_common::platform::linux::WaylandDisplayInfo>,
+    ) -> Arc<scrap::wayland::display::Displays> {
+        Arc::new(scrap::wayland::display::Displays {
+            primary: 0,
+            displays,
+        })
+    }
+
+    #[test]
+    fn login_handoff_keeps_the_last_nonempty_compositor_layout() {
+        let original = wl_layout(vec![
+            wl_display("DP-1", 0, 0, 1920, 1080),
+            wl_display("DP-2", 1920, 0, 1920, 1080),
+            wl_display("DP-3", 3840, 0, 1920, 1080),
+        ]);
+        let mut saved = None;
+        let (selected, used_saved) =
+            select_wayland_layout_for_login_handoff(original.clone(), true, &mut saved);
+        assert!(Arc::ptr_eq(&selected, &original));
+        assert!(!used_saved);
+
+        let missing = wl_layout(Vec::new());
+        let (selected, used_saved) =
+            select_wayland_layout_for_login_handoff(missing, true, &mut saved);
+        assert!(used_saved);
+        assert_eq!(selected.displays.len(), 3);
+        assert_eq!(selected.displays[2].x, 3840);
+
+        let drm = [
+            drm_display("DP-1", 1920, 1080),
+            drm_display("DP-2", 1920, 1080),
+            drm_display("DP-3", 1920, 1080),
+        ];
+        let assignment = assign_wayland_outputs(&drm, &selected.displays);
+        let infos = augment_with_wayland_geometry_from(&drm, &selected, &assignment);
+        assert_eq!(
+            infos.iter().map(|display| display.x).collect::<Vec<_>>(),
+            vec![0, 1920, 3840]
+        );
+        assert_eq!(
+            infos.iter().map(|display| display.x + display.width).max(),
+            Some(5760)
+        );
+    }
+
+    #[test]
+    fn ordinary_session_does_not_reuse_a_login_layout() {
+        let remembered = wl_layout(vec![wl_display("DP-1", 0, 0, 1920, 1080)]);
+        let mut saved = Some(remembered);
+        let missing = wl_layout(Vec::new());
+        let (selected, used_saved) =
+            select_wayland_layout_for_login_handoff(missing.clone(), false, &mut saved);
+        assert!(Arc::ptr_eq(&selected, &missing));
+        assert!(!used_saved);
+    }
+
     #[test]
     fn one_connector_assignment_drives_geometry_and_primary() {
         let drm = [
@@ -1663,6 +1935,70 @@ mod drm_capturer_tests {
         let infos = augment_with_wayland_geometry_from(&drm, &wl, &assignment);
         assert_eq!((infos[0].x, infos[1].x), (0, 1920));
         assert_eq!(primary_index_from_assignment(&assignment, wl.primary), 1);
+    }
+
+    #[test]
+    fn gdm_monitor_profile_selects_the_declared_primary_connector() {
+        let drm = [
+            drm_display("DP-1", 1920, 1080),
+            drm_display("DP-2", 1920, 1080),
+            drm_display("DP-3", 1920, 1080),
+        ];
+        let xml = r#"
+            <monitors version="2">
+              <configuration>
+                <logicalmonitor>
+                  <x>3840</x>
+                  <monitor><monitorspec><connector>DP-1</connector></monitorspec></monitor>
+                </logicalmonitor>
+                <logicalmonitor>
+                  <x>0</x>
+                  <monitor><monitorspec><connector>DP-2</connector></monitorspec></monitor>
+                </logicalmonitor>
+                <logicalmonitor>
+                  <x>1920</x>
+                  <primary>yes</primary>
+                  <monitor><monitorspec><connector>DP-3</connector></monitorspec></monitor>
+                </logicalmonitor>
+              </configuration>
+            </monitors>
+        "#;
+
+        assert_eq!(primary_index_from_monitors_xml(xml, &drm), Some(2));
+    }
+
+    #[test]
+    fn gdm_monitor_profile_ignores_a_stale_connector_set() {
+        let drm = [
+            drm_display("DP-1", 1920, 1080),
+            drm_display("DP-2", 1920, 1080),
+            drm_display("DP-3", 1920, 1080),
+        ];
+        let xml = r#"
+            <monitors version="2">
+              <configuration>
+                <logicalmonitor>
+                  <primary>yes</primary>
+                  <monitor><monitorspec><connector>HDMI-1</connector></monitorspec></monitor>
+                </logicalmonitor>
+              </configuration>
+              <configuration>
+                <logicalmonitor>
+                  <monitor><monitorspec><connector>DP-1</connector></monitorspec></monitor>
+                </logicalmonitor>
+                <logicalmonitor>
+                  <monitor><monitorspec><connector>DP-2</connector></monitorspec></monitor>
+                </logicalmonitor>
+                <logicalmonitor>
+                  <primary>yes</primary>
+                  <monitor><monitorspec><connector>DP-3</connector></monitorspec></monitor>
+                </logicalmonitor>
+              </configuration>
+            </monitors>
+        "#;
+
+        assert_eq!(primary_index_from_monitors_xml(xml, &drm), Some(2));
+        assert_eq!(primary_index_from_monitors_xml(xml, &drm[..2]), None);
     }
 
     #[test]
@@ -1697,7 +2033,13 @@ mod drm_capturer_tests {
         );
         assert!(matches!(c.frame(Duration::from_millis(50)), Ok(_)));
         assert!(
-            c.shared.slot.lock().unwrap().free.iter().any(|b| b.is_some()),
+            c.shared
+                .slot
+                .lock()
+                .unwrap()
+                .free
+                .iter()
+                .any(|b| b.is_some()),
             "the buffer the encoder finished with must be handed back to the receive path"
         );
     }
@@ -1727,15 +2069,24 @@ mod drm_capturer_tests {
 
     #[test]
     fn outputs_are_matched_by_name_across_the_drm_naming_difference() {
-        let drm = [drm_display("HDMI-A-1", 1920, 1080), drm_display("DP-1", 2560, 1440)];
-        let wl = [wl_display("DP-1", 1920, 0, 2560, 1440), wl_display("HDMI-1", 0, 0, 1920, 1080)];
+        let drm = [
+            drm_display("HDMI-A-1", 1920, 1080),
+            drm_display("DP-1", 2560, 1440),
+        ];
+        let wl = [
+            wl_display("DP-1", 1920, 0, 2560, 1440),
+            wl_display("HDMI-1", 0, 0, 1920, 1080),
+        ];
         assert_eq!(assign_wayland_outputs(&drm, &wl), vec![Some(1), Some(0)]);
     }
 
     // The M10 case: same model and resolution, names that do not normalize to the compositor's.
     #[test]
     fn identical_monitors_that_match_no_name_take_layout_order() {
-        let drm = [drm_display("DP-1", 1920, 1080), drm_display("DP-2", 1920, 1080)];
+        let drm = [
+            drm_display("DP-1", 1920, 1080),
+            drm_display("DP-2", 1920, 1080),
+        ];
         let wl = [
             wl_display("Unknown-1", 0, 0, 1920, 1080),
             wl_display("Unknown-2", 1920, 0, 1920, 1080),
@@ -1745,7 +2096,10 @@ mod drm_capturer_tests {
 
     #[test]
     fn one_output_is_never_claimed_by_two_connectors() {
-        let drm = [drm_display("DP-1", 1920, 1080), drm_display("DP-2", 1920, 1080)];
+        let drm = [
+            drm_display("DP-1", 1920, 1080),
+            drm_display("DP-2", 1920, 1080),
+        ];
         let wl = [
             wl_display("Unknown-1", 0, 0, 1920, 1080),
             wl_display("Unknown-2", 1920, 0, 3840, 2160),
@@ -1757,7 +2111,10 @@ mod drm_capturer_tests {
 
     #[test]
     fn a_name_match_beats_the_positional_fallback() {
-        let drm = [drm_display("DP-1", 1920, 1080), drm_display("HDMI-A-1", 1920, 1080)];
+        let drm = [
+            drm_display("DP-1", 1920, 1080),
+            drm_display("HDMI-A-1", 1920, 1080),
+        ];
         let wl = [
             wl_display("Unknown-1", 0, 0, 1920, 1080),
             wl_display("HDMI-1", 1920, 0, 1920, 1080),
@@ -1776,7 +2133,10 @@ mod drm_capturer_tests {
             wl_display("Unknown-1", 0, 0, 1920, 1080),
             wl_display("Unknown-2", 1920, 0, 1920, 1080),
         ];
-        assert_eq!(assign_wayland_outputs(&drm, &wl), vec![Some(0), Some(1), None]);
+        assert_eq!(
+            assign_wayland_outputs(&drm, &wl),
+            vec![Some(0), Some(1), None]
+        );
     }
 
     #[test]
@@ -1817,14 +2177,23 @@ mod drm_capturer_tests {
         let mut h = DisplayHealth::new();
         assert!(!h.demoted(), "a fresh display is not demoted");
         h.zero_frame_streak = DRM_GRAB_MAX_FAILURES - 1;
-        assert!(!h.demoted(), "one session short of the threshold is not demoted");
+        assert!(
+            !h.demoted(),
+            "one session short of the threshold is not demoted"
+        );
         h.zero_frame_streak = DRM_GRAB_MAX_FAILURES;
         h.demotes = 1;
         assert!(h.demoted(), "at the threshold, inside the cooldown");
         h.since = Instant::now() - demote_cooldown(h.demotes) - Duration::from_secs(1);
-        assert!(!h.demoted(), "past the cooldown the display must be retried");
+        assert!(
+            !h.demoted(),
+            "past the cooldown the display must be retried"
+        );
         h.demotes = 4;
-        assert!(h.demoted(), "the backoff must still be holding it at demotion 4");
+        assert!(
+            h.demoted(),
+            "the backoff must still be holding it at demotion 4"
+        );
     }
 
     #[test]

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -675,14 +675,34 @@ pub async fn setup_uinput(minx: i32, maxx: i32, miny: i32, maxy: i32) -> ResultT
 }
 
 #[cfg(target_os = "linux")]
-pub async fn setup_rdp_input() -> ResultType<(), Box<dyn std::error::Error>> {
-    let mut en = ENIGO.lock()?;
+pub fn is_uinput_active() -> bool {
+    ENIGO
+        .lock()
+        .unwrap()
+        .get_custom_mouse()
+        .as_ref()
+        .is_some_and(|mouse| mouse.as_any().is::<super::uinput::client::UInputMouse>())
+}
+
+#[cfg(target_os = "linux")]
+fn setup_rdp_input_sync() -> ResultType<()> {
+    let mut en = ENIGO
+        .lock()
+        .map_err(|_| hbb_common::anyhow::anyhow!("ENIGO mutex is poisoned"))?;
     // Same as `setup_uinput`: the caller is gated on `wayland_use_rdp_input()`.
     en.set_is_x11(false);
-    let rdp_info_lock = RDP_SESSION_INFO.lock()?;
-    let rdp_info = rdp_info_lock.as_ref().ok_or("RDP session is None")?;
+    let rdp_info_lock = RDP_SESSION_INFO
+        .lock()
+        .map_err(|_| hbb_common::anyhow::anyhow!("RDP session mutex is poisoned"))?;
+    let rdp_info = rdp_info_lock
+        .as_ref()
+        .ok_or_else(|| hbb_common::anyhow::anyhow!("RDP session is None"))?;
 
-    let keyboard = RdpInputKeyboard::new(rdp_info.conn.clone(), rdp_info.session.clone())?;
+    let keyboard = RdpInputKeyboard::new(
+        rdp_info.conn.clone(),
+        rdp_info.session.clone(),
+        rdp_info.input_backend,
+    )?;
     en.set_custom_keyboard(Box::new(keyboard));
     log::info!("RdpInput keyboard created");
 
@@ -695,7 +715,8 @@ pub async fn setup_rdp_input() -> ResultType<(), Box<dyn std::error::Error>> {
         let mouse = RdpInputMouse::new(
             rdp_info.conn.clone(),
             rdp_info.session.clone(),
-            stream,
+            rdp_info.input_backend,
+            rdp_info.streams.clone(),
             resolution,
         )?;
         en.set_custom_mouse(Box::new(mouse));
@@ -703,6 +724,46 @@ pub async fn setup_rdp_input() -> ResultType<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+async fn run_blocking_input_switch<F>(switch: F) -> ResultType<()>
+where
+    F: FnOnce() -> ResultType<()> + Send + 'static,
+{
+    tokio::task::spawn_blocking(switch).await?
+}
+
+#[cfg(target_os = "linux")]
+pub async fn setup_rdp_input() -> ResultType<()> {
+    // The currently installed uinput keyboard and mouse each own a Tokio runtime. Replacing
+    // them drops those runtimes, which Tokio explicitly forbids on an async worker thread.
+    // Keep the complete ENIGO backend swap on a blocking worker so both old devices are dropped
+    // outside the connection runtime.
+    run_blocking_input_switch(setup_rdp_input_sync).await
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod rdp_input_switch_tests {
+    use super::run_blocking_input_switch;
+
+    #[test]
+    fn blocking_input_switch_can_drop_owned_tokio_runtime() {
+        let outer = hbb_common::tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        outer.block_on(async {
+            let owned_runtime = hbb_common::tokio::runtime::Runtime::new().unwrap();
+            run_blocking_input_switch(move || {
+                drop(owned_runtime);
+                Ok(())
+            })
+            .await
+            .unwrap();
+        });
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -2377,13 +2438,26 @@ async fn send_sas() -> ResultType<()> {
 #[inline]
 #[cfg(target_os = "linux")]
 pub fn wayland_use_uinput() -> bool {
-    !crate::platform::is_x11() && crate::is_server()
+    #[cfg(feature = "gnome-mutter")]
+    let login_screen = crate::platform::linux::is_login_screen_wayland_cached();
+    #[cfg(not(feature = "gnome-mutter"))]
+    let login_screen = false;
+
+    !crate::platform::is_x11()
+        && crate::is_server()
+        && (login_screen || !scrap::wayland::pipewire::is_mutter_session())
 }
 
 #[inline]
 #[cfg(target_os = "linux")]
 pub fn wayland_use_rdp_input() -> bool {
-    !crate::platform::is_x11() && !crate::is_server()
+    #[cfg(feature = "gnome-mutter")]
+    let login_screen = crate::platform::linux::is_login_screen_wayland_cached();
+    #[cfg(not(feature = "gnome-mutter"))]
+    let login_screen = false;
+
+    !crate::platform::is_x11()
+        && (!crate::is_server() || (!login_screen && scrap::wayland::pipewire::is_mutter_session()))
 }
 
 #[cfg(target_os = "linux")]

--- a/src/server/rdp_input.rs
+++ b/src/server/rdp_input.rs
@@ -3,10 +3,11 @@ use crate::uinput::service::{can_input_via_keysym, char_to_keysym, map_key};
 use dbus::{blocking::SyncConnection, Path};
 use enigo::{Key, KeyboardControllable, MouseButton, MouseControllable};
 use hbb_common::{log, ResultType};
-use scrap::wayland::pipewire::{get_portal, PwStreamInfo};
+use scrap::wayland::pipewire::{get_portal, PwStreamInfo, RdpInputBackend};
 use scrap::wayland::remote_desktop_portal::OrgFreedesktopPortalRemoteDesktop as remote_desktop_portal;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub mod client {
     use hbb_common::platform::linux::{DISPLAY_DESKTOP_KDE, XDG_CURRENT_DESKTOP};
@@ -19,6 +20,11 @@ pub mod client {
 
     const PRESSED_DOWN_STATE: u32 = 1;
     const PRESSED_UP_STATE: u32 = 0;
+
+    const MUTTER_REMOTE_DESKTOP_NAME: &str = "org.gnome.Mutter.RemoteDesktop";
+    const MUTTER_REMOTE_DESKTOP_SESSION_IFACE: &str = "org.gnome.Mutter.RemoteDesktop.Session";
+    const MUTTER_POINTER_MOTION_RELATIVE_METHOD: &str = "NotifyPointerMotionRelative";
+    const DBUS_TIMEOUT: Duration = Duration::from_secs(3);
 
     /// Modifier key state tracking for RDP input.
     /// Portal API doesn't provide a way to query key state, so we track it ourselves.
@@ -78,14 +84,20 @@ pub mod client {
     pub struct RdpInputKeyboard {
         conn: Arc<SyncConnection>,
         session: Path<'static>,
+        backend: RdpInputBackend,
         modifier_state: ModifierState,
     }
 
     impl RdpInputKeyboard {
-        pub fn new(conn: Arc<SyncConnection>, session: Path<'static>) -> ResultType<Self> {
+        pub fn new(
+            conn: Arc<SyncConnection>,
+            session: Path<'static>,
+            backend: RdpInputBackend,
+        ) -> ResultType<Self> {
             Ok(Self {
                 conn,
                 session,
+                backend,
                 modifier_state: ModifierState::default(),
             })
         }
@@ -131,7 +143,7 @@ pub mod client {
                 can_input_via_keysym(c, keysym)
             });
             if !ascii_only {
-                input_text_via_clipboard(s, self.conn.clone(), &self.session);
+                input_text_via_clipboard(s, self.conn.clone(), &self.session, self.backend);
                 return;
             }
 
@@ -139,10 +151,18 @@ pub mod client {
                 let keysym = char_to_keysym(c);
                 // ASCII characters: use keysym
                 if can_input_via_keysym(c, keysym) {
-                    if let Err(e) = send_keysym(keysym, true, self.conn.clone(), &self.session) {
+                    if let Err(e) =
+                        send_keysym(keysym, true, self.conn.clone(), &self.session, self.backend)
+                    {
                         log::error!("Failed to send keysym down: {:?}", e);
                     }
-                    if let Err(e) = send_keysym(keysym, false, self.conn.clone(), &self.session) {
+                    if let Err(e) = send_keysym(
+                        keysym,
+                        false,
+                        self.conn.clone(),
+                        &self.session,
+                        self.backend,
+                    ) {
                         log::error!("Failed to send keysym up: {:?}", e);
                     }
                 }
@@ -154,13 +174,24 @@ pub mod client {
                 let keysym = char_to_keysym(chr);
                 // ASCII characters: use keysym
                 if can_input_via_keysym(chr, keysym) {
-                    send_keysym(keysym, true, self.conn.clone(), &self.session)?;
+                    send_keysym(keysym, true, self.conn.clone(), &self.session, self.backend)?;
                 } else {
                     // Non-ASCII: use clipboard (complete key press in key_down)
-                    input_text_via_clipboard(&chr.to_string(), self.conn.clone(), &self.session);
+                    input_text_via_clipboard(
+                        &chr.to_string(),
+                        self.conn.clone(),
+                        &self.session,
+                        self.backend,
+                    );
                 }
             } else {
-                handle_key(true, key.clone(), self.conn.clone(), &self.session)?;
+                handle_key(
+                    true,
+                    key.clone(),
+                    self.conn.clone(),
+                    &self.session,
+                    self.backend,
+                )?;
                 // Update modifier state only after successful send —
                 // if handle_key fails, we don't want stale "pressed" state
                 // affecting subsequent key event decisions.
@@ -181,14 +212,22 @@ pub mod client {
                 // ASCII characters: send keysym up if we also sent it on key_down
                 let keysym = char_to_keysym(chr);
                 if can_input_via_keysym(chr, keysym) {
-                    if let Err(e) = send_keysym(keysym, false, self.conn.clone(), &self.session) {
+                    if let Err(e) = send_keysym(
+                        keysym,
+                        false,
+                        self.conn.clone(),
+                        &self.session,
+                        self.backend,
+                    ) {
                         log::error!("Failed to send keysym up: {:?}", e);
                     }
                 }
                 // Non-ASCII: already handled completely in key_down via clipboard paste,
                 // no corresponding release needed (clipboard paste is an atomic operation)
             } else {
-                if let Err(e) = handle_key(false, key, self.conn.clone(), &self.session) {
+                if let Err(e) =
+                    handle_key(false, key, self.conn.clone(), &self.session, self.backend)
+                {
                     log::error!("Failed to handle key up: {:?}", e);
                 }
             }
@@ -199,18 +238,37 @@ pub mod client {
                 let keysym = char_to_keysym(chr);
                 // ASCII characters: use keysym
                 if can_input_via_keysym(chr, keysym) {
-                    if let Err(e) = send_keysym(keysym, true, self.conn.clone(), &self.session) {
+                    if let Err(e) =
+                        send_keysym(keysym, true, self.conn.clone(), &self.session, self.backend)
+                    {
                         log::error!("Failed to send keysym down: {:?}", e);
                     }
-                    if let Err(e) = send_keysym(keysym, false, self.conn.clone(), &self.session) {
+                    if let Err(e) = send_keysym(
+                        keysym,
+                        false,
+                        self.conn.clone(),
+                        &self.session,
+                        self.backend,
+                    ) {
                         log::error!("Failed to send keysym up: {:?}", e);
                     }
                 } else {
                     // Non-ASCII: use clipboard
-                    input_text_via_clipboard(&chr.to_string(), self.conn.clone(), &self.session);
+                    input_text_via_clipboard(
+                        &chr.to_string(),
+                        self.conn.clone(),
+                        &self.session,
+                        self.backend,
+                    );
                 }
             } else {
-                if let Err(e) = handle_key(true, key.clone(), self.conn.clone(), &self.session) {
+                if let Err(e) = handle_key(
+                    true,
+                    key.clone(),
+                    self.conn.clone(),
+                    &self.session,
+                    self.backend,
+                ) {
                     log::error!("Failed to handle key down: {:?}", e);
                 } else {
                     // Only mark modifier as pressed if key-down was actually delivered
@@ -218,7 +276,9 @@ pub mod client {
                 }
                 // Always mark as released to avoid stuck-modifier state
                 self.modifier_state.update(&key, false);
-                if let Err(e) = handle_key(false, key, self.conn.clone(), &self.session) {
+                if let Err(e) =
+                    handle_key(false, key, self.conn.clone(), &self.session, self.backend)
+                {
                     log::error!("Failed to handle key up: {:?}", e);
                 }
             }
@@ -229,7 +289,12 @@ pub mod client {
     /// Shift+Insert is more universal than Ctrl+V, works in both GUI apps and terminals.
     ///
     /// Note: Clipboard content is NOT restored after paste - see `set_clipboard_for_paste_sync` for rationale.
-    fn input_text_via_clipboard(text: &str, conn: Arc<SyncConnection>, session: &Path<'static>) {
+    fn input_text_via_clipboard(
+        text: &str,
+        conn: Arc<SyncConnection>,
+        session: &Path<'static>,
+        backend: RdpInputBackend,
+    ) {
         if text.is_empty() {
             return;
         }
@@ -237,53 +302,35 @@ pub mod client {
             return;
         }
 
-        let portal = get_portal(&conn);
         let shift_keycode = evdev::Key::KEY_LEFTSHIFT.code() as i32;
         let insert_keycode = evdev::Key::KEY_INSERT.code() as i32;
 
         // Send Shift+Insert (universal paste shortcut)
-        if let Err(e) = remote_desktop_portal::notify_keyboard_keycode(
-            &portal,
-            session,
-            HashMap::new(),
-            shift_keycode,
-            PRESSED_DOWN_STATE,
-        ) {
+        if let Err(e) = notify_keyboard_keycode(backend, &conn, session, shift_keycode, true) {
             log::error!("input_text_via_clipboard: failed to press Shift: {:?}", e);
             return;
         }
 
         // Press Insert
-        if let Err(e) = remote_desktop_portal::notify_keyboard_keycode(
-            &portal,
-            session,
-            HashMap::new(),
-            insert_keycode,
-            PRESSED_DOWN_STATE,
-        ) {
+        if let Err(e) = notify_keyboard_keycode(backend, &conn, session, insert_keycode, true) {
             log::error!("input_text_via_clipboard: failed to press Insert: {:?}", e);
             // Still try to release Shift.
             // Note: clipboard has already been set by set_clipboard_for_paste_sync but paste
             // never happened. We don't attempt to restore the previous clipboard contents
             // because reading the clipboard on Wayland requires focus/permission.
-            let _ = remote_desktop_portal::notify_keyboard_keycode(
-                &portal,
-                session,
-                HashMap::new(),
-                shift_keycode,
-                PRESSED_UP_STATE,
-            );
+            if let Err(release_err) =
+                notify_keyboard_keycode(backend, &conn, session, shift_keycode, false)
+            {
+                log::warn!(
+                    "input_text_via_clipboard: failed to release Shift after Insert error: {:?}",
+                    release_err
+                );
+            }
             return;
         }
 
         // Release Insert
-        if let Err(e) = remote_desktop_portal::notify_keyboard_keycode(
-            &portal,
-            session,
-            HashMap::new(),
-            insert_keycode,
-            PRESSED_UP_STATE,
-        ) {
+        if let Err(e) = notify_keyboard_keycode(backend, &conn, session, insert_keycode, false) {
             log::error!(
                 "input_text_via_clipboard: failed to release Insert: {:?}",
                 e
@@ -291,13 +338,7 @@ pub mod client {
         }
 
         // Release Shift
-        if let Err(e) = remote_desktop_portal::notify_keyboard_keycode(
-            &portal,
-            session,
-            HashMap::new(),
-            shift_keycode,
-            PRESSED_UP_STATE,
-        ) {
+        if let Err(e) = notify_keyboard_keycode(backend, &conn, session, shift_keycode, false) {
             log::error!("input_text_via_clipboard: failed to release Shift: {:?}", e);
         }
     }
@@ -315,22 +356,48 @@ pub mod client {
                 .unwrap_or(false);
     }
 
+    fn select_stream_rect(
+        rects: impl IntoIterator<Item = ((i32, i32), (usize, usize))>,
+        x: f64,
+        y: f64,
+    ) -> Option<(usize, f64, f64)> {
+        let mut first = None;
+        for (index, (position, size)) in rects.into_iter().enumerate() {
+            let local_x = (x - position.0 as f64).clamp(0.0, size.0.saturating_sub(1) as f64);
+            let local_y = (y - position.1 as f64).clamp(0.0, size.1.saturating_sub(1) as f64);
+            first.get_or_insert((index, local_x, local_y));
+            if x >= position.0 as f64
+                && y >= position.1 as f64
+                && x < position.0 as f64 + size.0 as f64
+                && y < position.1 as f64 + size.1 as f64
+            {
+                return Some((index, local_x, local_y));
+            }
+        }
+        first
+    }
+
     pub struct RdpInputMouse {
         conn: Arc<SyncConnection>,
         session: Path<'static>,
-        stream: PwStreamInfo,
-        resolution: (usize, usize),
+        backend: RdpInputBackend,
+        streams: Vec<PwStreamInfo>,
         scale: Option<f64>,
         position: (f64, f64),
+        motion_error_logged: bool,
     }
 
     impl RdpInputMouse {
         pub fn new(
             conn: Arc<SyncConnection>,
             session: Path<'static>,
-            stream: PwStreamInfo,
+            backend: RdpInputBackend,
+            streams: Vec<PwStreamInfo>,
             resolution: (usize, usize),
         ) -> ResultType<Self> {
+            let stream = streams
+                .first()
+                .ok_or_else(|| hbb_common::anyhow::anyhow!("RDP input has no PipeWire stream"))?;
             // https://github.com/rustdesk/rustdesk/pull/9019#issuecomment-2295252388
             // There may be a bug in Rdp input on Gnome util Ubuntu 24.04 (Gnome 46)
             //
@@ -340,7 +407,7 @@ pub mod client {
             // For Ubuntu 24.04(Gnome 46), (x,y) is restricted from (0,0) to (400,300), but the actual range in screen is:
             // Logic coordinate from (0,0) to (200x150).
             // Or physical coordinate from (0,0) to (400,300).
-            let scale = if *SHOULD_SCALE_POINTER_COORDINATES {
+            let scale = if backend == RdpInputBackend::Portal && *SHOULD_SCALE_POINTER_COORDINATES {
                 if resolution.0 == 0 || stream.get_size().0 == 0 {
                     Some(1.0f64)
                 } else {
@@ -353,17 +420,43 @@ pub mod client {
             Ok(Self {
                 conn,
                 session,
-                stream,
-                resolution,
+                backend,
+                streams,
                 scale,
                 position: (pos.0 as f64, pos.1 as f64),
+                motion_error_logged: false,
             })
+        }
+
+        fn mutter_stream_at(&self, x: f64, y: f64) -> Option<(&PwStreamInfo, f64, f64)> {
+            let (index, local_x, local_y) = select_stream_rect(
+                self.streams
+                    .iter()
+                    .map(|stream| (stream.get_position(), stream.get_size())),
+                x,
+                y,
+            )?;
+            Some((self.streams.get(index)?, local_x, local_y))
+        }
+
+        fn report_motion_result(&mut self, kind: &str, result: ResultType<()>) {
+            match result {
+                Ok(()) => self.motion_error_logged = false,
+                Err(err) if !self.motion_error_logged => {
+                    log::error!("Failed to send {kind} pointer motion: {err:#}");
+                    self.motion_error_logged = true;
+                }
+                Err(_) => {}
+            }
         }
     }
 
     #[cfg(test)]
     mod tests {
-        use super::desktop_is_niri;
+        use super::{
+            desktop_is_niri, mutter_stream_name, select_stream_rect,
+            MUTTER_POINTER_MOTION_RELATIVE_METHOD,
+        };
 
         #[test]
         fn detects_niri_in_desktop_list() {
@@ -371,6 +464,79 @@ pub mod client {
             assert!(desktop_is_niri("NIRI"));
             assert!(desktop_is_niri("GNOME:niri"));
             assert!(!desktop_is_niri("GNOME"));
+        }
+
+        #[test]
+        fn maps_global_pointer_to_the_correct_mutter_monitor() {
+            let rects = [
+                ((0, 0), (1920, 1080)),
+                ((1920, 0), (1920, 1080)),
+                ((3840, 0), (1920, 1080)),
+            ];
+            assert_eq!(
+                select_stream_rect(rects, 100.0, 50.0),
+                Some((0, 100.0, 50.0))
+            );
+            assert_eq!(
+                select_stream_rect(rects, 2000.0, 60.0),
+                Some((1, 80.0, 60.0))
+            );
+            assert_eq!(
+                select_stream_rect(rects, 5000.0, 1079.0),
+                Some((2, 1160.0, 1079.0))
+            );
+        }
+
+        #[test]
+        fn clamps_an_out_of_layout_pointer_to_the_fallback_stream() {
+            let rects = [((-1920, 0), (1920, 1080)), ((0, 0), (1920, 1080))];
+            assert_eq!(
+                select_stream_rect(rects, 9000.0, -20.0),
+                Some((0, 1919.0, 0.0))
+            );
+        }
+
+        #[test]
+        fn matches_mutter_pointer_motion_wire_contract() {
+            assert_eq!(
+                MUTTER_POINTER_MOTION_RELATIVE_METHOD,
+                "NotifyPointerMotionRelative"
+            );
+            let path = dbus::Path::new("/org/gnome/Mutter/ScreenCast/Stream/u1").unwrap();
+            let stream_name: String = mutter_stream_name(&path);
+            assert_eq!(stream_name, "/org/gnome/Mutter/ScreenCast/Stream/u1");
+        }
+
+        #[test]
+        #[cfg(feature = "gnome-mutter")]
+        #[ignore = "requires an active GNOME Wayland session and moves the local pointer"]
+        fn live_mutter_pointer_methods_match_the_session_contract() {
+            let session = scrap::wayland::mutter::request_session().unwrap();
+            super::notify_pointer_motion(
+                scrap::wayland::pipewire::RdpInputBackend::Mutter,
+                &session.conn,
+                &session.session,
+                0.0,
+                0.0,
+            )
+            .unwrap();
+
+            let stream = session
+                .streams
+                .iter()
+                .find(|stream| stream.get_position() == (1920, 0))
+                .or_else(|| session.streams.first())
+                .unwrap();
+            let size = stream.get_size();
+            super::notify_pointer_motion_absolute(
+                scrap::wayland::pipewire::RdpInputBackend::Mutter,
+                &session.conn,
+                &session.session,
+                stream,
+                size.0 as f64 / 2.0,
+                size.1 as f64 / 2.0,
+            )
+            .unwrap();
         }
     }
 
@@ -384,6 +550,22 @@ pub mod client {
         }
 
         fn mouse_move_to(&mut self, x: i32, y: i32) {
+            if self.backend == RdpInputBackend::Mutter {
+                if let Some((stream, local_x, local_y)) = self.mutter_stream_at(x as f64, y as f64)
+                {
+                    let result = notify_pointer_motion_absolute(
+                        self.backend,
+                        &self.conn,
+                        &self.session,
+                        stream,
+                        local_x,
+                        local_y,
+                    );
+                    self.report_motion_result("absolute", result);
+                }
+                return;
+            }
+
             let x = if let Some(s) = self.scale {
                 x as f64 / s
             } else {
@@ -396,15 +578,17 @@ pub mod client {
             };
             let x = x - self.position.0;
             let y = y - self.position.1;
-            let portal = get_portal(&self.conn);
-            let _ = remote_desktop_portal::notify_pointer_motion_absolute(
-                &portal,
-                &self.session,
-                HashMap::new(),
-                self.stream.path as u32,
-                x,
-                y,
-            );
+            if let Some(stream) = self.streams.first() {
+                let result = notify_pointer_motion_absolute(
+                    self.backend,
+                    &self.conn,
+                    &self.session,
+                    stream,
+                    x,
+                    y,
+                );
+                self.report_motion_result("absolute", result);
+            }
         }
         fn mouse_move_relative(&mut self, x: i32, y: i32) {
             let x = if let Some(s) = self.scale {
@@ -417,73 +601,251 @@ pub mod client {
             } else {
                 y as f64
             };
-            let portal = get_portal(&self.conn);
-            let _ = remote_desktop_portal::notify_pointer_motion(
-                &portal,
-                &self.session,
-                HashMap::new(),
-                x,
-                y,
-            );
+            let result = notify_pointer_motion(self.backend, &self.conn, &self.session, x, y);
+            self.report_motion_result("relative", result);
         }
         fn mouse_down(&mut self, button: MouseButton) -> enigo::ResultType {
-            handle_mouse(true, button, self.conn.clone(), &self.session);
+            if let Err(err) =
+                handle_mouse(true, button, self.conn.clone(), &self.session, self.backend)
+            {
+                log::error!("Failed to send pointer button down: {err:#}");
+            }
             Ok(())
         }
         fn mouse_up(&mut self, button: MouseButton) {
-            handle_mouse(false, button, self.conn.clone(), &self.session);
+            if let Err(err) = handle_mouse(
+                false,
+                button,
+                self.conn.clone(),
+                &self.session,
+                self.backend,
+            ) {
+                log::error!("Failed to send pointer button up: {err:#}");
+            }
         }
         fn mouse_click(&mut self, button: MouseButton) {
-            handle_mouse(true, button, self.conn.clone(), &self.session);
-            handle_mouse(false, button, self.conn.clone(), &self.session);
+            if let Err(err) =
+                handle_mouse(true, button, self.conn.clone(), &self.session, self.backend)
+            {
+                log::error!("Failed to send pointer click down: {err:#}");
+            }
+            if let Err(err) = handle_mouse(
+                false,
+                button,
+                self.conn.clone(),
+                &self.session,
+                self.backend,
+            ) {
+                log::error!("Failed to send pointer click up: {err:#}");
+            }
         }
         fn mouse_scroll_x(&mut self, length: i32) {
-            let portal = get_portal(&self.conn);
-            let _ = remote_desktop_portal::notify_pointer_axis(
-                &portal,
-                &self.session,
-                HashMap::new(),
-                length as f64,
-                0 as f64,
-            );
+            if let Err(err) =
+                notify_pointer_axis(self.backend, &self.conn, &self.session, length as f64, 0.0)
+            {
+                log::error!("Failed to send horizontal pointer scroll: {err:#}");
+            }
         }
         fn mouse_scroll_y(&mut self, length: i32) {
-            let portal = get_portal(&self.conn);
-            let _ = remote_desktop_portal::notify_pointer_axis(
-                &portal,
-                &self.session,
-                HashMap::new(),
-                0 as f64,
-                length as f64,
-            );
+            if let Err(err) =
+                notify_pointer_axis(self.backend, &self.conn, &self.session, 0.0, length as f64)
+            {
+                log::error!("Failed to send vertical pointer scroll: {err:#}");
+            }
         }
     }
 
-    /// Send a keysym via RemoteDesktop portal.
+    fn notify_keyboard_keycode(
+        backend: RdpInputBackend,
+        conn: &SyncConnection,
+        session: &Path<'static>,
+        keycode: i32,
+        down: bool,
+    ) -> ResultType<()> {
+        match backend {
+            RdpInputBackend::Portal => {
+                let portal = get_portal(conn);
+                let state = if down {
+                    PRESSED_DOWN_STATE
+                } else {
+                    PRESSED_UP_STATE
+                };
+                remote_desktop_portal::notify_keyboard_keycode(
+                    &portal,
+                    session,
+                    HashMap::new(),
+                    keycode,
+                    state,
+                )?;
+            }
+            RdpInputBackend::Mutter => {
+                let proxy =
+                    conn.with_proxy(MUTTER_REMOTE_DESKTOP_NAME, session.clone(), DBUS_TIMEOUT);
+                let _: () = proxy.method_call(
+                    MUTTER_REMOTE_DESKTOP_SESSION_IFACE,
+                    "NotifyKeyboardKeycode",
+                    (keycode as u32, down),
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn notify_keyboard_keysym(
+        backend: RdpInputBackend,
+        conn: &SyncConnection,
+        session: &Path<'static>,
+        keysym: i32,
+        down: bool,
+    ) -> ResultType<()> {
+        match backend {
+            RdpInputBackend::Portal => {
+                let portal = get_portal(conn);
+                let state = if down {
+                    PRESSED_DOWN_STATE
+                } else {
+                    PRESSED_UP_STATE
+                };
+                remote_desktop_portal::notify_keyboard_keysym(
+                    &portal,
+                    session,
+                    HashMap::new(),
+                    keysym,
+                    state,
+                )?;
+            }
+            RdpInputBackend::Mutter => {
+                let proxy =
+                    conn.with_proxy(MUTTER_REMOTE_DESKTOP_NAME, session.clone(), DBUS_TIMEOUT);
+                let _: () = proxy.method_call(
+                    MUTTER_REMOTE_DESKTOP_SESSION_IFACE,
+                    "NotifyKeyboardKeysym",
+                    (keysym as u32, down),
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn notify_pointer_motion_absolute(
+        backend: RdpInputBackend,
+        conn: &SyncConnection,
+        session: &Path<'static>,
+        stream: &PwStreamInfo,
+        x: f64,
+        y: f64,
+    ) -> ResultType<()> {
+        match backend {
+            RdpInputBackend::Portal => {
+                let portal = get_portal(conn);
+                remote_desktop_portal::notify_pointer_motion_absolute(
+                    &portal,
+                    session,
+                    HashMap::new(),
+                    stream.path as u32,
+                    x,
+                    y,
+                )?;
+            }
+            RdpInputBackend::Mutter => {
+                let stream_path = stream.get_mutter_path().ok_or_else(|| {
+                    hbb_common::anyhow::anyhow!("Mutter stream is missing its D-Bus object path")
+                })?;
+                let stream_name = mutter_stream_name(stream_path);
+                let proxy =
+                    conn.with_proxy(MUTTER_REMOTE_DESKTOP_NAME, session.clone(), DBUS_TIMEOUT);
+                let _: () = proxy.method_call(
+                    MUTTER_REMOTE_DESKTOP_SESSION_IFACE,
+                    "NotifyPointerMotionAbsolute",
+                    (stream_name, x, y),
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn notify_pointer_motion(
+        backend: RdpInputBackend,
+        conn: &SyncConnection,
+        session: &Path<'static>,
+        x: f64,
+        y: f64,
+    ) -> ResultType<()> {
+        match backend {
+            RdpInputBackend::Portal => {
+                let portal = get_portal(conn);
+                remote_desktop_portal::notify_pointer_motion(
+                    &portal,
+                    session,
+                    HashMap::new(),
+                    x,
+                    y,
+                )?;
+            }
+            RdpInputBackend::Mutter => {
+                let proxy =
+                    conn.with_proxy(MUTTER_REMOTE_DESKTOP_NAME, session.clone(), DBUS_TIMEOUT);
+                let _: () = proxy.method_call(
+                    MUTTER_REMOTE_DESKTOP_SESSION_IFACE,
+                    MUTTER_POINTER_MOTION_RELATIVE_METHOD,
+                    (x, y),
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    fn mutter_stream_name(stream_path: &Path<'_>) -> String {
+        // Mutter's private RemoteDesktop API intentionally declares this argument as D-Bus
+        // string (`s`), even though its value is a ScreenCast object path. Passing Path would
+        // encode it as object-path (`o`) and make every absolute motion call fail validation.
+        stream_path.to_string()
+    }
+
+    fn notify_pointer_axis(
+        backend: RdpInputBackend,
+        conn: &SyncConnection,
+        session: &Path<'static>,
+        x: f64,
+        y: f64,
+    ) -> ResultType<()> {
+        match backend {
+            RdpInputBackend::Portal => {
+                let portal = get_portal(conn);
+                remote_desktop_portal::notify_pointer_axis(&portal, session, HashMap::new(), x, y)?;
+            }
+            RdpInputBackend::Mutter => {
+                let proxy =
+                    conn.with_proxy(MUTTER_REMOTE_DESKTOP_NAME, session.clone(), DBUS_TIMEOUT);
+                let _: () = proxy.method_call(
+                    MUTTER_REMOTE_DESKTOP_SESSION_IFACE,
+                    "NotifyPointerAxis",
+                    (x, y, 0u32),
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Send a keysym through the active remote-desktop backend.
     fn send_keysym(
         keysym: i32,
         down: bool,
         conn: Arc<SyncConnection>,
         session: &Path<'static>,
+        backend: RdpInputBackend,
     ) -> ResultType<()> {
         let state: u32 = if down {
             PRESSED_DOWN_STATE
         } else {
             PRESSED_UP_STATE
         };
-        let portal = get_portal(&conn);
         log::trace!(
             "send_keysym: calling notify_keyboard_keysym, keysym={:#x}, state={}",
             keysym,
             state
         );
-        match remote_desktop_portal::notify_keyboard_keysym(
-            &portal,
-            session,
-            HashMap::new(),
-            keysym,
-            state,
-        ) {
+        match notify_keyboard_keysym(backend, &conn, session, keysym, down) {
             Ok(_) => {
                 log::trace!("send_keysym: notify_keyboard_keysym succeeded");
                 Ok(())
@@ -507,23 +869,12 @@ pub mod client {
         key: Key,
         conn: Arc<SyncConnection>,
         session: &Path<'static>,
+        backend: RdpInputBackend,
     ) -> ResultType<()> {
-        let state: u32 = if down {
-            PRESSED_DOWN_STATE
-        } else {
-            PRESSED_UP_STATE
-        };
-        let portal = get_portal(&conn);
         match key {
             Key::Raw(key) => {
                 let key = get_raw_evdev_keycode(key);
-                remote_desktop_portal::notify_keyboard_keycode(
-                    &portal,
-                    &session,
-                    HashMap::new(),
-                    key,
-                    state,
-                )?;
+                notify_keyboard_keycode(backend, &conn, session, key, down)?;
             }
             _ => {
                 if let Ok((key, is_shift)) = map_key(&key) {
@@ -531,33 +882,33 @@ pub mod client {
                     if down {
                         // Press: Shift down first, then key down
                         if is_shift {
-                            if let Err(e) = remote_desktop_portal::notify_keyboard_keycode(
-                                &portal,
-                                &session,
-                                HashMap::new(),
+                            if let Err(e) = notify_keyboard_keycode(
+                                backend,
+                                &conn,
+                                session,
                                 shift_keycode,
-                                state,
+                                true,
                             ) {
                                 log::error!("handle_key: failed to press Shift: {:?}", e);
                                 return Err(e.into());
                             }
                         }
-                        if let Err(e) = remote_desktop_portal::notify_keyboard_keycode(
-                            &portal,
-                            &session,
-                            HashMap::new(),
+                        if let Err(e) = notify_keyboard_keycode(
+                            backend,
+                            &conn,
+                            session,
                             key.code() as i32,
-                            state,
+                            true,
                         ) {
                             log::error!("handle_key: failed to press key: {:?}", e);
                             // Best-effort: release Shift if it was pressed
                             if is_shift {
-                                if let Err(e) = remote_desktop_portal::notify_keyboard_keycode(
-                                    &portal,
-                                    &session,
-                                    HashMap::new(),
+                                if let Err(e) = notify_keyboard_keycode(
+                                    backend,
+                                    &conn,
+                                    session,
                                     shift_keycode,
-                                    PRESSED_UP_STATE,
+                                    false,
                                 ) {
                                     log::warn!(
                                         "handle_key: best-effort Shift release also failed: {:?}",
@@ -569,22 +920,22 @@ pub mod client {
                         }
                     } else {
                         // Release: key up first, then Shift up
-                        if let Err(e) = remote_desktop_portal::notify_keyboard_keycode(
-                            &portal,
-                            &session,
-                            HashMap::new(),
+                        if let Err(e) = notify_keyboard_keycode(
+                            backend,
+                            &conn,
+                            session,
                             key.code() as i32,
-                            PRESSED_UP_STATE,
+                            false,
                         ) {
                             log::error!("handle_key: failed to release key: {:?}", e);
                             // Best-effort: still try to release Shift
                             if is_shift {
-                                if let Err(e) = remote_desktop_portal::notify_keyboard_keycode(
-                                    &portal,
-                                    &session,
-                                    HashMap::new(),
+                                if let Err(e) = notify_keyboard_keycode(
+                                    backend,
+                                    &conn,
+                                    session,
                                     shift_keycode,
-                                    PRESSED_UP_STATE,
+                                    false,
                                 ) {
                                     log::warn!(
                                         "handle_key: best-effort Shift release also failed: {:?}",
@@ -595,12 +946,12 @@ pub mod client {
                             return Err(e.into());
                         }
                         if is_shift {
-                            if let Err(e) = remote_desktop_portal::notify_keyboard_keycode(
-                                &portal,
-                                &session,
-                                HashMap::new(),
+                            if let Err(e) = notify_keyboard_keycode(
+                                backend,
+                                &conn,
+                                session,
                                 shift_keycode,
-                                PRESSED_UP_STATE,
+                                false,
                             ) {
                                 log::error!("handle_key: failed to release Shift: {:?}", e);
                                 return Err(e.into());
@@ -618,27 +969,40 @@ pub mod client {
         button: MouseButton,
         conn: Arc<SyncConnection>,
         session: &Path<'static>,
-    ) {
-        let portal = get_portal(&conn);
+        backend: RdpInputBackend,
+    ) -> ResultType<()> {
         let but_key = match button {
             MouseButton::Left => EVDEV_MOUSE_LEFT,
             MouseButton::Right => EVDEV_MOUSE_RIGHT,
             MouseButton::Middle => EVDEV_MOUSE_MIDDLE,
-            _ => {
-                return;
+            _ => return Ok(()),
+        };
+        match backend {
+            RdpInputBackend::Portal => {
+                let portal = get_portal(&conn);
+                let state = if down {
+                    PRESSED_DOWN_STATE
+                } else {
+                    PRESSED_UP_STATE
+                };
+                remote_desktop_portal::notify_pointer_button(
+                    &portal,
+                    session,
+                    HashMap::new(),
+                    but_key,
+                    state,
+                )?;
             }
-        };
-        let state: u32 = if down {
-            PRESSED_DOWN_STATE
-        } else {
-            PRESSED_UP_STATE
-        };
-        let _ = remote_desktop_portal::notify_pointer_button(
-            &portal,
-            &session,
-            HashMap::new(),
-            but_key,
-            state,
-        );
+            RdpInputBackend::Mutter => {
+                let proxy =
+                    conn.with_proxy(MUTTER_REMOTE_DESKTOP_NAME, session.clone(), DBUS_TIMEOUT);
+                let _: () = proxy.method_call(
+                    MUTTER_REMOTE_DESKTOP_SESSION_IFACE,
+                    "NotifyPointerButton",
+                    (but_key, down),
+                )?;
+            }
+        }
+        Ok(())
     }
 }

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -1,5 +1,5 @@
 use super::*;
-use hbb_common::{allow_err, anyhow, platform::linux::DISTRO};
+use hbb_common::{anyhow, platform::linux::DISTRO};
 use scrap::{
     is_cursor_embedded, set_map_err,
     wayland::pipewire::{fill_displays, try_fix_logical_size},
@@ -192,18 +192,22 @@ pub(super) async fn update_uinput_resolution() {
     // Reprogram the device only when the range actually changes. A display stuck in a rebuild loop
     // calls this about once a second, and reapplying an identical range is an IPC roundtrip plus a
     // uinput device reconfiguration under a user who may be at the console.
-    if super::display_service::wayland_uinput_rect() == Some(rect) {
+    let uinput_is_active = input_service::is_uinput_active();
+    if uinput_is_active && super::display_service::wayland_uinput_rect() == Some(rect) {
         snapshot_layout();
         return;
     }
     let (minx, maxx, miny, maxy) = rect;
     log::info!("update mouse resolution: ({minx}, {maxx}), ({miny}, {maxy})");
-    match timeout(
-        3_000,
-        input_service::update_mouse_resolution(minx, maxx, miny, maxy),
-    )
-    .await
-    {
+    let configure_uinput = async {
+        if uinput_is_active {
+            input_service::update_mouse_resolution(minx, maxx, miny, maxy).await
+        } else {
+            log::info!("restoring uinput after leaving a Mutter user session");
+            input_service::setup_uinput(minx, maxx, miny, maxy).await
+        }
+    };
+    match timeout(3_000, configure_uinput).await {
         // Record the rect only after a successful apply, so a transient failure is retried on the
         // next call instead of being remembered as applied.
         Ok(Ok(())) => {
@@ -221,7 +225,7 @@ pub(super) async fn ensure_inited() -> ResultType<()> {
     // IPC, so there is no PipeWire recorder to initialize here. But we still must set the uinput
     // desktop rect (check_init does this on the PipeWire path, and the DRM path skips check_init).
     #[cfg(feature = "drm")]
-    if super::drm_capturer::is_available_cached() {
+    if super::drm_capturer::should_use_cached() {
         update_uinput_resolution().await;
         return Ok(());
     }
@@ -233,7 +237,7 @@ pub(super) fn is_inited() -> Option<Message> {
         None
     } else {
         #[cfg(feature = "drm")]
-        if super::drm_capturer::is_available_cached() {
+        if super::drm_capturer::should_use_cached() {
             return None;
         }
         if CAP_DISPLAY_INFO.read().unwrap().is_empty() {
@@ -357,13 +361,19 @@ pub(super) async fn check_init() -> ResultType<()> {
                 }
             }
         }
+
+        if scrap::wayland::pipewire::is_mutter_session() {
+            if let Err(err) = input_service::setup_rdp_input().await {
+                log::warn!("Failed to activate Mutter remote input: {err}");
+            }
+        }
     }
     Ok(())
 }
 
 pub(super) async fn get_displays_and_primary() -> ResultType<(Vec<DisplayInfo>, usize)> {
     #[cfg(feature = "drm")]
-    if super::drm_capturer::is_available_cached() {
+    if super::drm_capturer::should_use_cached() {
         // This function runs once per login (update_get_sync_displays_on_login is its only
         // caller), and login is the moment the client is PROMISED a display list -- so refresh
         // that list over a live `_drm` handshake first. The service wakes sleeping displays and
@@ -407,7 +417,7 @@ pub fn clear() {
     // against STALE geometry after a monitor hotplug/rotation/scale change. Invalidate it on teardown
     // so the next session re-reads fresh geometry (lazily, on the next enumeration) and self-heals.
     #[cfg(feature = "drm")]
-    if super::drm_capturer::is_available_cached() {
+    if super::drm_capturer::should_use_cached() {
         scrap::wayland::display::clear_wayland_displays_cache();
     }
     // NOTE: intentionally do NOT reset the DRM probe cache here. `clear()` runs on every capturer
@@ -459,7 +469,7 @@ pub(super) fn get_capturer_for_display(
     // gives up after its attempts, so if EVERY gate were cache-only a --server that started
     // before the root service would never see DRM again for the rest of its life.
     #[cfg(feature = "drm")]
-    if super::drm_capturer::is_available() {
+    if super::drm_capturer::should_use() {
         match super::drm_capturer::get_capturer_info(display_idx) {
             Ok(info) => return Ok(info),
             Err(e) => {
@@ -479,7 +489,7 @@ pub(super) fn get_capturer_for_display(
     // across that roundtrip would stall every concurrent teardown for its duration, and the value
     // does not depend on anything inside the guard.
     #[cfg(feature = "drm")]
-    let drm_advertised = if super::drm_capturer::is_available_cached() {
+    let drm_advertised = if super::drm_capturer::should_use_cached() {
         match super::drm_capturer::get_display_infos() {
             Some(list) => Some((list.get(display_idx).cloned(), list.len() == 1)),
             None => Some((None, false)),

--- a/src/ui_cm_interface.rs
+++ b/src/ui_cm_interface.rs
@@ -198,6 +198,72 @@ pub trait InvokeUiCM: Send + Clone + 'static + Sized {
     fn file_transfer_log(&self, action: &str, log: &str);
 }
 
+/// A connection manager without a compositor-bound window.
+///
+/// The GDM Wayland compositor is destroyed as soon as login completes. A Flutter CM that was
+/// created inside that greeter then loses its EGL context and aborts, even though the unattended
+/// connection itself does not need an approval window. Keep the CM IPC/state machine alive for
+/// password-authorized greeter sessions, but deliberately attach no graphical UI to it.
+#[cfg(target_os = "linux")]
+#[derive(Clone, Default)]
+struct HeadlessUiCM;
+
+#[cfg(target_os = "linux")]
+impl InvokeUiCM for HeadlessUiCM {
+    fn add_connection(&self, _client: &Client) {}
+
+    fn remove_connection(&self, _id: i32, _close: bool) {}
+
+    fn new_message(&self, _id: i32, _text: String) {}
+
+    fn change_theme(&self, _dark: String) {}
+
+    fn change_language(&self) {}
+
+    fn show_elevation(&self, _show: bool) {}
+
+    fn update_voice_call_state(&self, _client: &Client) {}
+
+    fn file_transfer_log(&self, _action: &str, _log: &str) {}
+}
+
+/// Run the CM IPC loop on Linux without initializing Flutter, GTK, EGL, PulseAudio, or a tray.
+#[cfg(target_os = "linux")]
+pub fn start_headless_cm() {
+    // This process is spawned and owned by the login-screen `--server`. The root service stops
+    // that server with SIGKILL after the remote session ends, which skips Rust destructors and
+    // would otherwise leave the headless CM orphaned under the transient GDM uid. Ask the kernel
+    // to terminate us when that exact parent disappears; the second getppid closes the race where
+    // the parent exits immediately before PR_SET_PDEATHSIG is armed.
+    // SAFETY: `getppid` has no pointer arguments and no preconditions.
+    let parent_pid = unsafe { hbb_common::libc::getppid() };
+    if parent_pid > 1 {
+        // SAFETY: PR_SET_PDEATHSIG accepts a signal number as its only variadic argument.
+        let result = unsafe {
+            hbb_common::libc::prctl(
+                hbb_common::libc::PR_SET_PDEATHSIG,
+                hbb_common::libc::SIGTERM,
+            )
+        };
+        if result != 0 {
+            log::warn!(
+                "failed to arm headless CM parent-death signal: {}",
+                std::io::Error::last_os_error()
+            );
+        // SAFETY: `getppid` has no pointer arguments and no preconditions.
+        } else if unsafe { hbb_common::libc::getppid() } != parent_pid {
+            log::info!("headless CM parent exited while parent-death signal was being armed");
+            return;
+        }
+    } else {
+        log::warn!("headless CM started without a live owning server process");
+    }
+
+    start_ipc(ConnectionManager {
+        ui_handler: HeadlessUiCM,
+    });
+}
+
 impl<T: InvokeUiCM> Deref for ConnectionManager<T> {
     type Target = T;
 


### PR DESCRIPTION
## Summary

- add an opt-in `gnome-mutter` build feature that creates GNOME ScreenCast and RemoteDesktop sessions directly through Mutter's private D-Bus APIs
- capture every active monitor as an independent PipeWire stream and route keyboard, buttons, scrolling, relative motion, and monitor-local absolute motion through the same Mutter session
- keep the XDG Desktop Portal as the automatic fallback when the Mutter API is unavailable or incompatible
- preserve an already-authenticated GDM Wayland connection across login with a headless connection manager, bounded greeter-UID authorization, and parent-death cleanup
- retain GDM monitor geometry during compositor handoff and select its persisted primary connector, including the current dynamic `gdm-greeter` account

## Runtime gating

The direct GNOME path is disabled unless both gates are enabled:

1. build with `--gnome-mutter` (or Cargo feature `gnome-mutter`)
2. set the custom option `enable-gnome-mutter=Y`

The user session then prefers Mutter and falls back to the portal. A Wayland login screen continues to use the existing opt-in DRM/uinput backend because GDM has no user session bus available to the server.

The handoff authorization does not admit arbitrary stale users: it remembers only the exact greeter UID that owns the preserved server, while the existing same-executable check remains required.

## Manual validation

Validated from an Android client against CachyOS, GNOME Shell 50.4 on Wayland, NVIDIA RTX 3090 Ti, and three 1920x1080 monitors:

- all three user-session monitors are enumerated and switch independently
- keyboard, buttons, scrolling, relative pointer motion, and absolute pointer motion work
- absolute input selects the correct Mutter stream and reaches the final pixel row, so GNOME's bottom-edge Dock trigger works
- GDM exposes the configured primary monitor, accepts remote keyboard and pointer input, and completes login without dropping the authenticated RustDesk connection

Known limitation: a connection established at GDM deliberately remains on its DRM/uinput session through the login handoff; reconnecting after login moves it to the direct Mutter backend. A short visual interruption was observable while the GDM compositor was replaced.

## Automated validation

- `cargo test --lib`: 97 passed
- `cargo test --features gnome-mutter --lib`: 97 passed, 1 ignored live Mutter test
- `cargo test --features drm --lib`: 135 passed
- `cargo test --features drm,gnome-mutter --lib`: 135 passed, 1 ignored live Mutter test
- the first GDM-only commit was also tested independently with `--features drm`: 126 passed
- `git diff --check`: passed

The local GCC toolchain required temporary `CXXFLAGS=-include cstdint` for the pinned upstream `rust-webm` source. No dependency or source workaround for that unrelated build issue is included here.

Related context: #15791, #13012.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional direct GNOME Mutter screen capture and remote input support on Linux.
  * Added a headless connection-manager mode for login-screen sessions.
* **Bug Fixes**
  * Improved display and input handling during transitions from the login screen to the desktop.
  * Improved support for GDM and SDDM login environments, including monitor selection.
  * Enhanced session authorization during login handoffs.
* **Improvements**
  * Improved multi-monitor pointer mapping and capture backend selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds an opt-in direct GNOME Mutter capture and input backend with portal fallback, plus preservation of authenticated GDM sessions across login.

- Adds private Mutter ScreenCast and RemoteDesktop session creation with per-monitor PipeWire streams.
- Routes keyboard and pointer input through the selected portal or Mutter backend.
- Adds GDM server handoff state, bounded greeter-UID authorization, headless connection management, and persisted display geometry.
- Adjusts DRM routing so configured user sessions prefer Mutter while login sessions continue using DRM.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking runtime-management issue in the GDM handoff polling path.

The accepted issue is limited to repeated synchronous Tokio runtime construction during handoff polling; no concrete capture, input-routing, authorization, or session-lifecycle failure was established.

**Files Needing Attention:** src/platform/linux.rs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/scrap/src/wayland/mutter.rs | Introduces direct Mutter session creation, monitor recording, and PipeWire stream discovery with portal fallback handled by its caller. |
| libs/scrap/src/wayland/pipewire.rs | Generalizes PipeWire sessions for portal and Mutter backends and initializes GStreamer at recorder construction. |
| src/server/rdp_input.rs | Adds backend-specific Mutter keyboard, pointer, scrolling, and multi-monitor absolute-motion dispatch. |
| src/platform/linux.rs | Implements GDM handoff ownership and display persistence, but the connection-state poll constructs and blocks a fresh Tokio runtime. |
| src/ipc/auth.rs | Extends service-peer UID authorization to the exact greeter UID remembered during an active handoff. |
| src/ui_cm_interface.rs | Adds a compositor-independent headless connection manager with Linux parent-death cleanup. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Greeter as GDM RustDesk Server
    participant Service as Root Service
    participant CM as Headless CM
    participant User as User Session Server
    Client->>Greeter: Establish authenticated session
    Greeter->>CM: Start --cm-headless
    Service->>Greeter: Query HasNoActiveConns
    alt Remote session remains active
        Service->>Service: Preserve greeter server and UID handoff
        Greeter-->>Client: Continue DRM/uinput session
    else Session ends or query grace expires
        Service->>Greeter: Stop greeter server
        Service->>Service: Clear handoff UID
        Service->>User: Start user-session server
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2315988%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=15988&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fplatform%2Flinux.rs%3A1131-1134%0A**Repeated%20runtime%20construction**%0A%0AEvery%20active%20GDM%20handoff%20poll%20constructs%20a%20new%20Tokio%20runtime%20and%20synchronously%20calls%20%60block_on%60%2C%20contrary%20to%20the%20repository's%20runtime-management%20rules.%20This%20repeatedly%20blocks%20the%20service%20loop%20and%20adds%20avoidable%20executor%20and%20thread-resource%20churn%20to%20the%20login%20transition%3B%20please%20reuse%20an%20existing%20runtime%20or%20move%20this%20work%20to%20a%20dedicated%20asynchronous%20worker.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15988&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22codex%2Fgnome-wayland-backend%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fgnome-wayland-backend%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fplatform%2Flinux.rs%3A1131-1134%0A**Repeated%20runtime%20construction**%0A%0AEvery%20active%20GDM%20handoff%20poll%20constructs%20a%20new%20Tokio%20runtime%20and%20synchronously%20calls%20%60block_on%60%2C%20contrary%20to%20the%20repository's%20runtime-management%20rules.%20This%20repeatedly%20blocks%20the%20service%20loop%20and%20adds%20avoidable%20executor%20and%20thread-resource%20churn%20to%20the%20login%20transition%3B%20please%20reuse%20an%20existing%20runtime%20or%20move%20this%20work%20to%20a%20dedicated%20asynchronous%20worker.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15988&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/platform/linux.rs:1131-1134
**Repeated runtime construction**

Every active GDM handoff poll constructs a new Tokio runtime and synchronously calls `block_on`, contrary to the repository's runtime-management rules. This repeatedly blocks the service loop and adds avoidable executor and thread-resource churn to the login transition; please reuse an existing runtime or move this work to a dedicated asynchronous worker.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(linux): add direct GNOME Mutter rem..."](https://github.com/rustdesk/rustdesk/commit/1521761d32dba00d2cf9c5f3ac067c98c2fdec71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57524685)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/rustdesk/rustdesk/blob/master/CLAUDE.md))

<!-- /greptile_comment -->