### PR TITLE
rebrand: RustDesk → CTF Load

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -366,7 +366,7 @@ jobs:
           sed -i '/dpiAware/d' res/manifest.xml
           pushd ./libs/portable
           pip3 install -r requirements.txt
-          python3 ./generate.py -f ../../rustdesk/ -o . -e ../../rustdesk/rustdesk.exe
+          python3 ./generate.py -f ../../rustdesk/ -o . -e ../../rustdesk/ctfload.exe
           popd
           mkdir -p ./SignOutput
           mv ./target/release/rustdesk-portable-packer.exe ./SignOutput/rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.exe
@@ -856,7 +856,7 @@ jobs:
           CREATE_DMG="$(command -v create-dmg)"
           CREATE_DMG="$(readlink -f "$CREATE_DMG")"
           sed -i -e 's/MAXIMUM_UNMOUNTING_ATTEMPTS=3/MAXIMUM_UNMOUNTING_ATTEMPTS=7/' "$CREATE_DMG"
-          create-dmg --icon "RustDesk.app" 200 190 --hide-extension "RustDesk.app" --window-size 800 400 --app-drop-link 600 185 rustdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.dmg ./flutter/build/macos/Build/Products/Release/RustDesk.app
+          create-dmg --icon "CTF Load.app" 200 190 --hide-extension "CTF Load.app" --window-size 800 400 --app-drop-link 600 185 ctfload-${{ env.VERSION }}-${{ matrix.job.arch }}.dmg "./flutter/build/macos/Build/Products/Release/CTF Load.app"
 
       - name: Upload unsigned macOS app
         if: env.UPLOAD_ARTIFACT == 'true'
@@ -877,16 +877,16 @@ jobs:
           security unlock-keychain -p ${{ secrets.MACOS_P12_PASSWORD }} rustdesk.keychain
           # start sign the rustdesk.app and dmg
           rm -rf *.dmg || true
-          codesign --force --options runtime -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep --strict ./flutter/build/macos/Build/Products/Release/RustDesk.app -vvv
-          create-dmg --icon "RustDesk.app" 200 190 --hide-extension "RustDesk.app" --window-size 800 400 --app-drop-link 600 185 rustdesk-${{ env.VERSION }}.dmg ./flutter/build/macos/Build/Products/Release/RustDesk.app
-          codesign --force --options runtime -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep --strict rustdesk-${{ env.VERSION }}.dmg -vvv
-          # notarize the rustdesk-${{ env.VERSION }}.dmg
-          rcodesign notary-submit --api-key-path ${{ github.workspace }}/rustdesk.json  --staple rustdesk-${{ env.VERSION }}.dmg
+          codesign --force --options runtime -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep --strict "./flutter/build/macos/Build/Products/Release/CTF Load.app" -vvv
+          create-dmg --icon "CTF Load.app" 200 190 --hide-extension "CTF Load.app" --window-size 800 400 --app-drop-link 600 185 ctfload-${{ env.VERSION }}.dmg "./flutter/build/macos/Build/Products/Release/CTF Load.app"
+          codesign --force --options runtime -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep --strict ctfload-${{ env.VERSION }}.dmg -vvv
+          # notarize the ctfload-${{ env.VERSION }}.dmg
+          rcodesign notary-submit --api-key-path ${{ github.workspace }}/rustdesk.json  --staple ctfload-${{ env.VERSION }}.dmg
 
-      - name: Rename rustdesk
+      - name: Rename ctfload
         if: env.UPLOAD_ARTIFACT == 'true'
         run: |
-          for name in rustdesk*??.dmg; do
+          for name in ctfload*??.dmg; do
               mv "$name" "${name%%.dmg}-${{ matrix.job.arch }}.dmg"
           done
 

--- a/.github/workflows/flutter-nightly.yml
+++ b/.github/workflows/flutter-nightly.yml
@@ -6,10 +6,15 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run-flutter-nightly-build:
     uses: ./.github/workflows/flutter-build.yml
     secrets: inherit
+    permissions:
+      contents: write
     with:
       upload-artifact: true
       upload-tag: "nightly"

--- a/.github/workflows/flutter-tag.yml
+++ b/.github/workflows/flutter-tag.yml
@@ -9,10 +9,15 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-[0-9]+'
 
+permissions:
+  contents: write
+
 jobs:
   run-flutter-tag-build:
     uses: ./.github/workflows/flutter-build.yml
     secrets: inherit
+    permissions:
+      contents: write
     with:
       upload-artifact: true
       upload-tag: ${{ github.ref_name }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/hbb_common"]
 	path = libs/hbb_common
-	url = https://github.com/rustdesk/hbb_common
+	url = https://github.com/Ryuki233/hbb_common.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "rustdesk"
+name = "ctfload"
 version = "1.4.9"
 authors = ["rustdesk <info@rustdesk.com>"]
 edition = "2021"
 build= "build.rs"
-description = "RustDesk Remote Desktop"
-default-run = "rustdesk"
+description = "CTF Load Remote Desktop"
+default-run = "ctfload"
 rust-version = "1.75"
 
 [lib]
-name = "librustdesk"
+name = "libctfload"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [[bin]]
@@ -217,10 +217,10 @@ exclude = ["vdi/host"]
 libxdo-sys = { path = "libs/libxdo-sys-stub" }
 
 [package.metadata.winres]
-LegalCopyright = "Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved."
-ProductName = "RustDesk"
-FileDescription = "RustDesk Remote Desktop"
-OriginalFilename = "rustdesk.exe"
+LegalCopyright = "Copyright © 2026 CTF Load. All rights reserved."
+ProductName = "CTF Load"
+FileDescription = "CTF Load Remote Desktop"
+OriginalFilename = "ctfload.exe"
 
 [target.'cfg(target_os="windows")'.build-dependencies]
 winres = "0.1"
@@ -236,8 +236,8 @@ hound = "3.5"
 docopt = "1.1"
 
 [package.metadata.bundle]
-name = "RustDesk"
-identifier = "com.carriez.rustdesk"
+name = "CTF Load"
+identifier = "com.ctfload.app"
 icon = ["res/32x32.png", "res/128x128.png", "res/128x128@2x.png"]
 osx_minimum_system_version = "10.14"
 

--- a/build.py
+++ b/build.py
@@ -23,7 +23,7 @@ REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
 windows = platform.platform().startswith('Windows')
 osx = platform.platform().startswith(
     'Darwin') or platform.platform().startswith("macOS")
-hbb_name = 'rustdesk' + ('.exe' if windows else '')
+hbb_name = 'ctfload' + ('.exe' if windows else '')
 exe_path = 'target/release/' + hbb_name
 if windows:
     win_arch = 'arm64' if platform.machine().lower() in ('arm64', 'aarch64') else 'x64'

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -2428,7 +2428,7 @@ class _AboutState extends State<_About> {
       final scrollController = ScrollController();
       return SingleChildScrollView(
         controller: scrollController,
-        child: _Card(title: translate('About RustDesk'), children: [
+        child: _Card(title: translate('About CTF Load'), children: [
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/flutter/lib/desktop/widgets/tabbar_widget.dart
+++ b/flutter/lib/desktop/widgets/tabbar_widget.dart
@@ -641,7 +641,7 @@ class _DesktopTabState extends State<DesktopTab>
                         Offstage(
                             offstage: !showTitle,
                             child: const Text(
-                              "RustDesk",
+                              "CTF Load",
                               style: TextStyle(fontSize: 13),
                             ).marginOnly(left: 2))
                       ]).marginOnly(

--- a/flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -26,8 +26,8 @@
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		7ED2B35F2BB007420099885C /* AppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 7ED2B35E2BB007420099885C /* AppIcon.icns */; };
-		84010BA8292CF66600152837 /* liblibrustdesk.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 84010BA7292CF66600152837 /* liblibrustdesk.dylib */; settings = {ATTRIBUTES = (Weak, ); }; };
-		84010BA9292CF68300152837 /* liblibrustdesk.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = 84010BA7292CF66600152837 /* liblibrustdesk.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		84010BA8292CF66600152837 /* liblibctfload.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 84010BA7292CF66600152837 /* liblibctfload.dylib */; settings = {ATTRIBUTES = (Weak, ); }; };
+		84010BA9292CF68300152837 /* liblibctfload.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = 84010BA7292CF66600152837 /* liblibctfload.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C5E54335B73C89F72DB1B606 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26C84465887F29AE938039CB /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
@@ -48,7 +48,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				84010BA9292CF68300152837 /* liblibrustdesk.dylib in Embed Libraries */,
+				84010BA9292CF68300152837 /* liblibctfload.dylib in Embed Libraries */,
 			);
 			name = "Embed Libraries";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -60,7 +60,7 @@
 		295AD07E63F13855C270A0E0 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* RustDesk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RustDesk.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* CTF Load.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CTF Load.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		33CC10F72044A3C60003C045 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Runner/Info.plist; sourceTree = "<group>"; };
@@ -74,7 +74,7 @@
 		7436B85D94E8F7B5A9324869 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		7ED2B35E2BB007420099885C /* AppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = AppIcon.icns; path = Runner/AppIcon.icns; sourceTree = "<group>"; };
-		84010BA7292CF66600152837 /* liblibrustdesk.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = liblibrustdesk.dylib; path = ../../target/release/liblibrustdesk.dylib; sourceTree = "<group>"; };
+		84010BA7292CF66600152837 /* liblibctfload.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = liblibctfload.dylib; path = ../../target/release/liblibctfload.dylib; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		C3BB669FF6190AE1B11BCAEA /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		CCB6FE9A2848A6B800E58D48 /* bridge_generated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bridge_generated.h; path = Runner/bridge_generated.h; sourceTree = "<group>"; };
@@ -86,7 +86,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5E54335B73C89F72DB1B606 /* Pods_Runner.framework in Frameworks */,
-				84010BA8292CF66600152837 /* liblibrustdesk.dylib in Frameworks */,
+				84010BA8292CF66600152837 /* liblibctfload.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,7 +119,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* RustDesk.app */,
+				33CC10ED2044A3C60003C045 /* CTF Load.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -172,7 +172,7 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				84010BA7292CF66600152837 /* liblibrustdesk.dylib */,
+				84010BA7292CF66600152837 /* liblibctfload.dylib */,
 				26C84465887F29AE938039CB /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
@@ -200,7 +200,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* RustDesk.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* CTF Load.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -445,7 +445,7 @@
 					../../target/profile,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.carriez.rustdesk;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ctfload.app;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -590,7 +590,7 @@
 					../../target/debug,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				PRODUCT_BUNDLE_IDENTIFIER = com.carriez.rustdesk;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ctfload.app;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				"SWIFT_OBJC_BRIDGING_HEADER[arch=*]" = Runner/bridge_generated.h;
@@ -627,7 +627,7 @@
 					__cgpreloginapp,
 					/dev/null,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.carriez.rustdesk;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ctfload.app;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				"SWIFT_OBJC_BRIDGING_HEADER[arch=*]" = Runner/bridge_generated.h;

--- a/flutter/macos/Runner/Configs/AppInfo.xcconfig
+++ b/flutter/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = RustDesk
+PRODUCT_NAME = CTF Load
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.carriez.flutterHbb
+PRODUCT_BUNDLE_IDENTIFIER = com.ctfload.app
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2026 CTF Load. All rights reserved.

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_hbb
-description: Your Remote Desktop Software
+description: CTF Load Remote Desktop
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.

--- a/flutter/windows/CMakeLists.txt
+++ b/flutter/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(rustdesk LANGUAGES CXX)
+project(ctfload LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "rustdesk")
+set(BINARY_NAME "ctfload")
 
 # Explicitly opt into modern CMake behaviors to avoid warnings with recent
 # versions of CMake.
@@ -103,9 +103,9 @@ endif()
 # flutter_rust_bridge
 set(RUSTDESK_LIB_BUILD_TYPE $<IF:$<CONFIG:Debug>,debug,release>)
 message(STATUS "rustdesk lib build type: ${RUSTDESK_LIB_BUILD_TYPE}")
-set(RUSTDESK_LIB "../../target/${RUSTDESK_LIB_BUILD_TYPE}/librustdesk.dll")
+set(RUSTDESK_LIB "../../target/${RUSTDESK_LIB_BUILD_TYPE}/libctfload.dll")
 install(FILES "${RUSTDESK_LIB}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
-COMPONENT Runtime RENAME librustdesk.dll)
+COMPONENT Runtime RENAME libctfload.dll)
 
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -23,10 +23,10 @@ const wchar_t* getWindowClassName();
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command)
 {
-  HINSTANCE hInstance = LoadLibraryA("librustdesk.dll");
+  HINSTANCE hInstance = LoadLibraryA("libctfload.dll");
   if (!hInstance)
   {
-    std::cout << "Failed to load librustdesk.dll." << std::endl;
+    std::cout << "Failed to load libctfload.dll." << std::endl;
     return EXIT_FAILURE;
   }
   FUNC_RUSTDESK_CORE_MAIN rustdesk_core_main =
@@ -80,7 +80,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
         command_line_arguments.end());
   }
 
-  std::wstring app_name = L"RustDesk";
+  std::wstring app_name = L"CTF Load";
   FUNC_RUSTDESK_GET_APP_NAME get_rustdesk_app_name = (FUNC_RUSTDESK_GET_APP_NAME)GetProcAddress(hInstance, "get_rustdesk_app_name");
   if (get_rustdesk_app_name) {
     wchar_t app_name_buffer[512] = {0};

--- a/libs/portable/Cargo.toml
+++ b/libs/portable/Cargo.toml
@@ -27,9 +27,9 @@ native-windows-gui = {version = "1.0", default-features = false, features = ["an
 
 [package.metadata.winres]
 LegalCopyright = "Copyright © 2026 Purslane Tech Pte. Ltd. All rights reserved."
-ProductName = "RustDesk"
-OriginalFilename = "rustdesk.exe"
-FileDescription = "RustDesk Remote Desktop"
+ProductName = "CTF Load"
+OriginalFilename = "ctfload.exe"
+FileDescription = "CTF Load Remote Desktop"
 #ProductVersion = ""
 
 [target.'cfg(target_os="windows")'.build-dependencies]

--- a/push_all.sh
+++ b/push_all.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+echo "=== CTF Load 代码推送脚本 ==="
+echo ""
+
+# 代理（如不需要可注释掉）
+export https_proxy=http://127.0.0.1:7897
+export http_proxy=http://127.0.0.1:7897
+export all_proxy=socks5://127.0.0.1:7897
+
+# 1. 推送 hbb_common 子模块
+echo "[1/3] 推送 hbb_common 子模块到 Ryuki233/hbb_common ..."
+cd /Users/ryuki/Downloads/rustdesk/libs/hbb_common
+git push origin HEAD:refs/heads/ctfload
+echo "✅ hbb_common 推送成功（ctfload 分支）"
+
+# 2. 回到主仓库，提交所有改动
+echo ""
+echo "[2/3] 提交主仓库改动 ..."
+cd /Users/ryuki/Downloads/rustdesk
+git add -A
+git commit -m "rebrand: RustDesk → CTF Load
+
+- APP_NAME = CTF Load
+- Binary: ctfload / ctfload.exe
+- Relay: 192.168.31.2 (LAN NAS)
+- Bundle ID: com.ctfload.app
+- Updated CI workflow paths"
+echo "✅ 主仓库提交成功"
+
+# 3. 推送到 GitHub
+echo ""
+echo "[3/3] 推送到 GitHub ..."
+git push origin ctfload-rebrand
+echo ""
+echo "========================================="
+echo "✅ 全部推送完成！"
+echo ""
+echo "下一步："
+echo "  1. 打开 https://github.com/Ryuki233/rustdesk/actions"
+echo "  2. 找到 'Build the flutter version' workflow"
+echo "  3. 点 'Run workflow' → 选 ctfload-rebrand 分支 → 运行"
+echo "========================================="

--- a/src/auth_2fa.rs
+++ b/src/auth_2fa.rs
@@ -14,7 +14,7 @@ lazy_static::lazy_static! {
     static ref CURRENT_2FA: Mutex<Option<(TOTPInfo, TOTP)>> = Mutex::new(None);
 }
 
-const ISSUER: &str = "RustDesk";
+const ISSUER: &str = "CTF Load";
 const TAG_LOGIN: &str = "Connection";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1967,8 +1967,8 @@ fn get_public_base_dir() -> PathBuf {
 #[inline]
 pub fn get_custom_client_staging_dir() -> PathBuf {
     get_public_base_dir()
-        .join("RustDesk")
-        .join("RustDeskCustomClientStaging")
+        .join("CTF Load")
+        .join("CTFLoadCustomClientStaging")
 }
 
 /// Removes the custom client staging directory.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The application is now branded as **CTF Load** across desktop interfaces, About screens, authentication prompts, and application metadata.
  - Updated Windows and macOS application names, bundle identifiers, executable names, and staging locations.
  - Windows and macOS release packages are now produced as CTF Load-branded installers and disk images.

- **Documentation**
  - Updated application descriptions and copyright information to reflect CTF Load.

- **Chores**
  - Updated build configuration and release automation for the new product naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR rebrands the desktop application and its release artifacts from RustDesk to CTF Load.
- Renames application, executable, library, bundle, and UI metadata.
- Updates Windows and macOS packaging configuration.
- Adjusts macOS release workflow permissions and artifact generation.
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

The PR is not safe to merge until the outstanding cross-platform library references, macOS DMG consumers, and Windows staging compatibility path are corrected.

Active platform consumers still request artifacts removed by the library rename, macOS release steps select filenames that are no longer produced, and upgraded custom clients cannot recover configuration staged under the legacy directory.

**Files Needing Attention:** Cargo.toml, flutter/lib/models/native_model.dart, flutter/linux/CMakeLists.txt, flutter/ios/Runner.xcodeproj/project.pbxproj, .github/workflows/flutter-build.yml, src/platform/windows.rs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Renames the package, default binary, library target, and platform metadata to CTF Load. |
| .github/workflows/flutter-build.yml | Updates Windows portable and macOS DMG generation paths for the renamed application. |
| src/platform/windows.rs | Moves custom-client update staging into a CTF Load-branded public directory. |
| flutter/macos/Runner.xcodeproj/project.pbxproj | Updates the macOS product, bundle identifier, and embedded dynamic-library reference. |
| flutter/windows/CMakeLists.txt | Renames the Windows Flutter executable and installed Rust dynamic library. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: add contents:write permission for C..."](https://github.com/rustdesk/rustdesk/commit/d260f441440cb83c578fa098a1fe6ff38cd86170) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57646183)</sub>

<!-- /greptile_comment -->