### PR TITLE
feat(server): toggle between the personal and the public server

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3591,7 +3591,27 @@ importConfig(List<TextEditingController>? controllers, List<RxString>? errMsgs,
   }
 }
 
+// Writing a server config touches several options one by one, so overlapping
+// writes could interleave and park an empty config over a valid one, losing the
+// personal server settings altogether. Serialize them all, wherever they start:
+// the settings dialog, a config import, or the personal server switch.
+Future<void> _serverConfigQueue = Future.value();
+
+Future<T> _serializeServerConfigWrite<T>(Future<T> Function() write) {
+  final result = _serverConfigQueue.then((_) => write());
+  _serverConfigQueue = result.then((_) {}, onError: (_) {});
+  return result;
+}
+
 Future<bool> setServerConfig(
+  List<TextEditingController>? controllers,
+  List<RxString>? errMsgs,
+  ServerConfig config,
+) =>
+    _serializeServerConfigWrite(
+        () => _setServerConfig(controllers, errMsgs, config));
+
+Future<bool> _setServerConfig(
   List<TextEditingController>? controllers,
   List<RxString>? errMsgs,
   ServerConfig config,
@@ -3705,17 +3725,8 @@ Future<void> _stashServerConfig(ServerConfig config) async {
 
 /// Switch between the personal server and the public one, parking the personal
 /// config aside while the public server is used so it can be restored as is.
-Future<bool> usePersonalServer(bool use) {
-  // The switches must not interleave: the options are written one by one, so
-  // two overlapping switches could park an empty config and lose the personal
-  // server settings altogether.
-  final result =
-      _pendingPersonalServerSwitch.then((_) => _usePersonalServer(use));
-  _pendingPersonalServerSwitch = result.then((_) => true, onError: (_) => false);
-  return result;
-}
-
-Future<bool> _pendingPersonalServerSwitch = Future.value(true);
+Future<bool> usePersonalServer(bool use) =>
+    _serializeServerConfigWrite(() => _usePersonalServer(use));
 
 Future<bool> _usePersonalServer(bool use) async {
   if (use) {
@@ -3724,7 +3735,7 @@ Future<bool> _usePersonalServer(bool use) async {
       return false;
     }
     // It was validated when it was entered, so no need to test it again here.
-    return await setServerConfig(null, null, stashed);
+    return await _setServerConfig(null, null, stashed);
   }
   final current = ServerConfig(
     idServer: bind.mainGetOptionSync(key: kOptionCustomRendezvousServer),
@@ -3735,7 +3746,7 @@ Future<bool> _usePersonalServer(bool use) async {
   if (current.idServer.isEmpty) {
     return false;
   }
-  if (!await setServerConfig(null, null, ServerConfig())) {
+  if (!await _setServerConfig(null, null, ServerConfig())) {
     return false;
   }
   await _stashServerConfig(current);

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3705,7 +3705,19 @@ Future<void> _stashServerConfig(ServerConfig config) async {
 
 /// Switch between the personal server and the public one, parking the personal
 /// config aside while the public server is used so it can be restored as is.
-Future<bool> usePersonalServer(bool use) async {
+Future<bool> usePersonalServer(bool use) {
+  // The switches must not interleave: the options are written one by one, so
+  // two overlapping switches could park an empty config and lose the personal
+  // server settings altogether.
+  final result =
+      _pendingPersonalServerSwitch.then((_) => _usePersonalServer(use));
+  _pendingPersonalServerSwitch = result.then((_) => true, onError: (_) => false);
+  return result;
+}
+
+Future<bool> _pendingPersonalServerSwitch = Future.value(true);
+
+Future<bool> _usePersonalServer(bool use) async {
   if (use) {
     final stashed = getStashedServerConfig();
     if (stashed.idServer.isEmpty) {

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3746,11 +3746,11 @@ Future<bool> _usePersonalServer(bool use) async {
   if (current.idServer.isEmpty) {
     return false;
   }
-  if (!await _setServerConfig(null, null, ServerConfig())) {
-    return false;
-  }
+  // Park it before clearing the active options, so that a crash in between
+  // cannot leave the personal config nowhere. Clearing does not drop the parked
+  // one, it is only dropped when a personal server is entered.
   await _stashServerConfig(current);
-  return true;
+  return await _setServerConfig(null, null, ServerConfig());
 }
 
 ColorFilter? svgColor(Color? color) {

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3642,16 +3642,91 @@ Future<bool> setServerConfig(
 
   // should set one by one
   await bind.mainSetOption(
-      key: 'custom-rendezvous-server', value: config.idServer);
-  await bind.mainSetOption(key: 'relay-server', value: config.relayServer);
-  await bind.mainSetOption(key: 'api-server', value: config.apiServer);
-  await bind.mainSetOption(key: 'key', value: config.key);
+      key: kOptionCustomRendezvousServer, value: config.idServer);
+  await bind.mainSetOption(key: kOptionRelayServer, value: config.relayServer);
+  await bind.mainSetOption(key: kOptionApiServer, value: config.apiServer);
+  await bind.mainSetOption(key: kOptionServerKey, value: config.key);
+  if (config.idServer.isNotEmpty) {
+    // A newly entered personal server replaces whatever was parked before.
+    await _stashServerConfig(ServerConfig());
+  }
   final newApiServer = await bind.mainGetApiServer();
   if (oldApiServer.isNotEmpty &&
       oldApiServer != newApiServer &&
       gFFI.userModel.isLogin) {
     gFFI.userModel.logOut(apiServer: oldApiServer);
   }
+  return true;
+}
+
+/// The personal (self-hosted) server, and whether it is the one in use.
+/// It stays configured while the public server is used, see [usePersonalServer].
+class PersonalServerState {
+  final bool inUse;
+  final String idServer;
+
+  const PersonalServerState(this.inUse, this.idServer);
+
+  bool get isConfigured => idServer.isNotEmpty;
+}
+
+PersonalServerState getPersonalServerState() {
+  final idServer = bind.mainGetOptionSync(key: kOptionCustomRendezvousServer);
+  if (idServer.isNotEmpty) {
+    return PersonalServerState(true, idServer);
+  }
+  return PersonalServerState(false, getStashedServerConfig().idServer);
+}
+
+ServerConfig getStashedServerConfig() => ServerConfig(
+      idServer: bind.mainGetOptionSync(
+          key: '$kStashedServerConfigPrefix$kOptionCustomRendezvousServer'),
+      relayServer: bind.mainGetOptionSync(
+          key: '$kStashedServerConfigPrefix$kOptionRelayServer'),
+      apiServer: bind.mainGetOptionSync(
+          key: '$kStashedServerConfigPrefix$kOptionApiServer'),
+      key: bind.mainGetOptionSync(
+          key: '$kStashedServerConfigPrefix$kOptionServerKey'),
+    );
+
+Future<void> _stashServerConfig(ServerConfig config) async {
+  await bind.mainSetOption(
+      key: '$kStashedServerConfigPrefix$kOptionCustomRendezvousServer',
+      value: config.idServer);
+  await bind.mainSetOption(
+      key: '$kStashedServerConfigPrefix$kOptionRelayServer',
+      value: config.relayServer);
+  await bind.mainSetOption(
+      key: '$kStashedServerConfigPrefix$kOptionApiServer',
+      value: config.apiServer);
+  await bind.mainSetOption(
+      key: '$kStashedServerConfigPrefix$kOptionServerKey', value: config.key);
+}
+
+/// Switch between the personal server and the public one, parking the personal
+/// config aside while the public server is used so it can be restored as is.
+Future<bool> usePersonalServer(bool use) async {
+  if (use) {
+    final stashed = getStashedServerConfig();
+    if (stashed.idServer.isEmpty) {
+      return false;
+    }
+    // It was validated when it was entered, so no need to test it again here.
+    return await setServerConfig(null, null, stashed);
+  }
+  final current = ServerConfig(
+    idServer: bind.mainGetOptionSync(key: kOptionCustomRendezvousServer),
+    relayServer: bind.mainGetOptionSync(key: kOptionRelayServer),
+    apiServer: bind.mainGetOptionSync(key: kOptionApiServer),
+    key: bind.mainGetOptionSync(key: kOptionServerKey),
+  );
+  if (current.idServer.isEmpty) {
+    return false;
+  }
+  if (!await setServerConfig(null, null, ServerConfig())) {
+    return false;
+  }
+  await _stashServerConfig(current);
   return true;
 }
 

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -179,6 +179,13 @@ const String kOptionEnableShowTerminalExtraKeys = "enable-show-terminal-extra-ke
 const String kOptionShowTerminalCtrlKeys = "show-terminal-extra-ctrl-keys";
 
 // network options
+const String kOptionCustomRendezvousServer = "custom-rendezvous-server";
+const String kOptionRelayServer = "relay-server";
+const String kOptionApiServer = "api-server";
+const String kOptionServerKey = "key";
+// The personal server config is parked under these keys while the public
+// server is in use, so that switching back does not require retyping it.
+const String kStashedServerConfigPrefix = "stashed-";
 const String kOptionAllowWebSocket = "allow-websocket";
 const String kOptionAllowInsecureTLSFallback = "allow-insecure-tls-fallback";
 const String kOptionDisableUdp = "disable-udp";

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -1748,6 +1748,7 @@ class _NetworkState extends State<_Network> with AutomaticKeepAliveClientMixin {
         );
 
     final outgoingOnly = bind.isOutgoingOnly();
+    final personalServer = getPersonalServerState();
 
     final divider = const Divider(height: 1, indent: 16, endIndent: 16);
     return _Card(
@@ -1763,6 +1764,25 @@ class _NetworkState extends State<_Network> with AutomaticKeepAliveClientMixin {
                   title: 'ID/Relay Server',
                   onTap: () => showServerSettings(gFFI.dialogManager, setState),
                 ),
+              if (!hideServer && personalServer.isConfigured) ...[
+                divider,
+                listTile(
+                  icon: Icons.swap_horiz_outlined,
+                  title: 'Use personal server',
+                  showTooltip: true,
+                  tooltipMessage: 'use-personal-server-tip',
+                  trailing: Switch(
+                    value: personalServer.inUse,
+                    onChanged:
+                        locked || isOptionFixed(kOptionCustomRendezvousServer)
+                            ? null
+                            : (value) async {
+                                await usePersonalServer(value);
+                                setState(() {});
+                              },
+                  ),
+                ),
+              ],
               if (!hideProxy && !hideServer) divider,
               if (!hideProxy)
                 listTile(

--- a/flutter/lib/mobile/pages/settings_page.dart
+++ b/flutter/lib/mobile/pages/settings_page.dart
@@ -102,6 +102,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
   var _disableUdp = false;
   var _enableIpv6Punch = false;
   var _isUsingPublicServer = false;
+  var _personalServer = const PersonalServerState(false, '');
   var _allowAskForNoteAtEndOfConnection = false;
   var _preventSleepWhileConnected = true;
 
@@ -149,6 +150,7 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
         mainGetLocalBoolOptionSync(kOptionKeepAwakeDuringOutgoingSessions);
     _showTerminalExtraKeys =
         mainGetLocalBoolOptionSync(kOptionEnableShowTerminalExtraKeys);
+    _personalServer = getPersonalServerState();
   }
 
   @override
@@ -751,9 +753,29 @@ class _SettingsState extends State<SettingsPage> with WidgetsBindingObserver {
                 onPressed: (context) {
                   showServerSettings(gFFI.dialogManager, (callback) async {
                     _isUsingPublicServer = await bind.mainIsUsingPublicServer();
+                    _personalServer = getPersonalServerState();
                     setState(callback);
                   });
                 }),
+          if (!disabledSettings &&
+              !_hideNetwork &&
+              !_hideServer &&
+              _personalServer.isConfigured)
+            SettingsTile.switchTile(
+              title: Text(translate('Use personal server')),
+              initialValue: _personalServer.inUse,
+              onToggle: isOptionFixed(kOptionCustomRendezvousServer)
+                  ? null
+                  : (v) async {
+                      await usePersonalServer(v);
+                      final isUsingPublicServer =
+                          await bind.mainIsUsingPublicServer();
+                      setState(() {
+                        _isUsingPublicServer = isUsingPublicServer;
+                        _personalServer = getPersonalServerState();
+                      });
+                    },
+            ),
           if (!_hideNetwork && !_hideProxy)
             SettingsTile(
                 title: Text(translate('Socks5/Http(s) Proxy')),

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "متابعة"),
         ("Browser didn't open? Use the url below to sign in.", "لم يفتح المتصفح؟ استخدم الرابط أدناه لتسجيل الدخول."),
         ("Lock canvas", "قفل اللوحة"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Працягнуць"),
         ("Browser didn't open? Use the url below to sign in.", "Браўзер не адкрыўся? Скарыстайцеся спасылкай ніжэй, каб увайсці."),
         ("Lock canvas", "Заблакіраваць палатно"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Продължи"),
         ("Browser didn't open? Use the url below to sign in.", "Браузърът не се отвори? Използвайте URL адреса по-долу, за да се впишете."),
         ("Lock canvas", "Заключване на платното"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continua"),
         ("Browser didn't open? Use the url below to sign in.", "No s'ha obert el navegador? Utilitzeu l'URL de sota per iniciar la sessió."),
         ("Lock canvas", "Bloca el llenç"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "继续"),
         ("Browser didn't open? Use the url below to sign in.", "浏览器未打开？请使用下方网址登录。"),
         ("Lock canvas", "锁定画布"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Pokračovat"),
         ("Browser didn't open? Use the url below to sign in.", "Neotevřel se prohlížeč? Pro přihlášení použijte URL níže."),
         ("Lock canvas", "Zamknout zobrazení"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Fortsæt"),
         ("Browser didn't open? Use the url below to sign in.", "Åbnede browseren ikke? Brug URL'en nedenfor til at logge ind."),
         ("Lock canvas", "Lås lærred"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Weiter"),
         ("Browser didn't open? Use the url below to sign in.", "Hat sich der Browser nicht geöffnet? Melden Sie sich über die untenstehende URL an."),
         ("Lock canvas", "Sichtfeld sperren"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Συνέχεια"),
         ("Browser didn't open? Use the url below to sign in.", "Δεν άνοιξε το πρόγραμμα περιήγησης; Χρησιμοποιήστε τον παρακάτω σύνδεσμο για να συνδεθείτε."),
         ("Lock canvas", "Κλείδωμα καμβά"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -275,5 +275,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("id_whitelist_caveat_tip", "The ID is reported by the connecting client. This whitelist reduces exposure and does not replace the password or 2FA."),
         ("whitelist_cidr_tip", "CIDR notation is supported, e.g. 192.168.1.0/24"),
         ("Your ip is blocked by the peer", "Your IP is blocked by the peer"),
+        ("use-personal-server-tip", "Switch back to the public server without losing your personal server settings; they are kept and restored when you turn this on again."),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Daŭrigi"),
         ("Browser didn't open? Use the url below to sign in.", "Ĉu la retumilo ne malfermiĝis? Uzu la suban ligilon por ensaluti."),
         ("Lock canvas", "Ŝlosi kanvason"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continuar"),
         ("Browser didn't open? Use the url below to sign in.", "¿No se abrió el navegador? Usa la URL de abajo para iniciar sesión."),
         ("Lock canvas", "Bloquear lienzo"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Jätka"),
         ("Browser didn't open? Use the url below to sign in.", "Brauser ei avanenud? Sisselogimiseks kasuta allolevat URL-i."),
         ("Lock canvas", "Lukusta lõuend"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Jarraitu"),
         ("Browser didn't open? Use the url below to sign in.", "Nabigatzailea ez da ireki? Erabili beheko URLa saioa hasteko."),
         ("Lock canvas", "Blokeatu oihala"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "ادامه"),
         ("Browser didn't open? Use the url below to sign in.", "مرورگر باز نشد؟ برای ورود از نشانی زیر استفاده کنید."),
         ("Lock canvas", "قفل کردن صفحه"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Jatka"),
         ("Browser didn't open? Use the url below to sign in.", "Eikö selain avautunut? Kirjaudu sisään alla olevan osoitteen kautta."),
         ("Lock canvas", "Lukitse näkymä"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continuer"),
         ("Browser didn't open? Use the url below to sign in.", "Le navigateur ne s’est pas ouvert ? Utilisez l’URL ci-dessous pour vous connecter."),
         ("Lock canvas", "Verrouiller la vue"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "გაგრძელება"),
         ("Browser didn't open? Use the url below to sign in.", "ბრაუზერი არ გაიხსნა? შესასვლელად გამოიყენეთ ქვემოთ მოცემული ბმული."),
         ("Lock canvas", "ტილოს დაბლოკვა"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "ચાલુ રાખો"),
         ("Browser didn't open? Use the url below to sign in.", "બ્રાઉઝર ખૂલ્યું નથી? લોગિન કરવા માટે નીચે આપેલ URL નો ઉપયોગ કરો."),
         ("Lock canvas", "કેનવાસ લોક કરો"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "המשך"),
         ("Browser didn't open? Use the url below to sign in.", "הדפדפן לא נפתח? השתמש בכתובת שלמטה כדי להתחבר."),
         ("Lock canvas", "נעל לוח ציור"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -758,7 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "המשך"),
         ("Browser didn't open? Use the url below to sign in.", "הדפדפן לא נפתח? השתמש בכתובת שלמטה כדי להתחבר."),
         ("Lock canvas", "נעל לוח ציור"),
-        ("Use personal server", ""),
-        ("use-personal-server-tip", ""),
+        ("Use personal server", "השתמש בשרת אישי"),
+        ("use-personal-server-tip", "מעבר חזרה לשרת הציבורי בלי לאבד את הגדרות השרת האישי; הן נשמרות ומשוחזרות כשמדליקים את המתג שוב."),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "जारी रखें"),
         ("Browser didn't open? Use the url below to sign in.", "ब्राउज़र नहीं खुला? लॉगिन करने के लिए नीचे दिए गए URL का उपयोग करें।"),
         ("Lock canvas", "कैनवास लॉक करें"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Nastavi"),
         ("Browser didn't open? Use the url below to sign in.", "Preglednik se nije otvorio? Za prijavu upotrijebite URL u nastavku."),
         ("Lock canvas", "Zaključaj pozadinu"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Folytatás"),
         ("Browser didn't open? Use the url below to sign in.", "Nem nyílt meg a böngésző? A belépéshez használja az alábbi URL-címet."),
         ("Lock canvas", "Nézet zárolása"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Lanjutkan"),
         ("Browser didn't open? Use the url below to sign in.", "Browser tidak terbuka? Gunakan URL di bawah ini untuk masuk."),
         ("Lock canvas", "Kunci kanvas"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continua"),
         ("Browser didn't open? Use the url below to sign in.", "Il browser non si è aperto? Usa l'URL qui sotto per accedere."),
         ("Lock canvas", "Blocca tela"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "続行"),
         ("Browser didn't open? Use the url below to sign in.", "ブラウザが開きませんでしたか？下記の URL からログインしてください。"),
         ("Lock canvas", "キャンバスをロック"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "계속"),
         ("Browser didn't open? Use the url below to sign in.", "브라우저가 열리지 않았나요? 아래 URL로 로그인하세요."),
         ("Lock canvas", "캔버스 잠금"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Жалғастыру"),
         ("Browser didn't open? Use the url below to sign in.", "Браузер ашылмады ма? Кіру үшін төмендегі сілтемені пайдаланыңыз."),
         ("Lock canvas", "Кенепті құлыптау"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Tęsti"),
         ("Browser didn't open? Use the url below to sign in.", "Naršyklė neatsidarė? Prisijunkite naudodami toliau pateiktą URL."),
         ("Lock canvas", "Užrakinti drobę"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Turpināt"),
         ("Browser didn't open? Use the url below to sign in.", "Pārlūkprogramma neatvērās? Izmantojiet tālāk norādīto URL, lai pieslēgtos."),
         ("Lock canvas", "Bloķēt audeklu"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "തുടരുക"),
         ("Browser didn't open? Use the url below to sign in.", "ബ്രൗസർ തുറന്നില്ലേ? ലോഗിൻ ചെയ്യാൻ താഴെയുള്ള URL ഉപയോഗിക്കുക."),
         ("Lock canvas", "ക്യാൻവാസ് ലോക്ക് ചെയ്യുക"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Fortsett"),
         ("Browser didn't open? Use the url below to sign in.", "Åpnet ikke nettleseren? Bruk URL-en nedenfor for å logge inn."),
         ("Lock canvas", "Lås lerret"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Doorgaan"),
         ("Browser didn't open? Use the url below to sign in.", "Is de browser niet geopend? Gebruik onderstaande URL om in te loggen."),
         ("Lock canvas", "Canvas vergrendelen"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Kontynuuj"),
         ("Browser didn't open? Use the url below to sign in.", "Przeglądarka się nie otworzyła? Użyj poniższego adresu URL, aby się zalogować."),
         ("Lock canvas", "Zablokuj ekran"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continuar"),
         ("Browser didn't open? Use the url below to sign in.", "O navegador não abriu? Utilize o URL abaixo para iniciar sessão."),
         ("Lock canvas", "Bloquear tela"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continuar"),
         ("Browser didn't open? Use the url below to sign in.", "O navegador não foi aberto? Use a URL abaixo para fazer login."),
         ("Lock canvas", "Bloquear tela"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continuă"),
         ("Browser didn't open? Use the url below to sign in.", "Browserul nu s-a deschis? Folosește URL-ul de mai jos pentru a te conecta."),
         ("Lock canvas", "Blochează ecranul"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Продолжить"),
         ("Browser didn't open? Use the url below to sign in.", "Браузер не открылся? Используйте ссылку ниже для входа."),
         ("Lock canvas", "Заблокировать холст"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Sighi"),
         ("Browser didn't open? Use the url below to sign in.", "Non s'est abertu su navigadore? Imprea s'URL inoghe in suta pro intrare."),
         ("Lock canvas", "Bloca sa tela"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Pokračovať"),
         ("Browser didn't open? Use the url below to sign in.", "Neotvoril sa prehliadač? Na prihlásenie použite URL nižšie."),
         ("Lock canvas", "Uzamknúť zobrazenie"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Nadaljuj"),
         ("Browser didn't open? Use the url below to sign in.", "Brskalnik se ni odprl? Za prijavo uporabite spodnji URL."),
         ("Lock canvas", "Zakleni platno"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Vazhdo"),
         ("Browser didn't open? Use the url below to sign in.", "Shfletuesi nuk u hap? Përdorni URL-në më poshtë për të hyrë."),
         ("Lock canvas", "Kyç canvas"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Nastavi"),
         ("Browser didn't open? Use the url below to sign in.", "Pregledač se nije otvorio? Za prijavu koristite URL ispod."),
         ("Lock canvas", "Zaključaj pozadinu"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Fortsätt"),
         ("Browser didn't open? Use the url below to sign in.", "Öppnades inte webbläsaren? Använd URL:en nedan för att logga in."),
         ("Lock canvas", "Lås canvas"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "தொடர்க"),
         ("Browser didn't open? Use the url below to sign in.", "உலாவி திறக்கவில்லையா? உள்நுழைய கீழே உள்ள URL ஐப் பயன்படுத்தவும்."),
         ("Lock canvas", "கேன்வாஸைப் பூட்டு"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", ""),
         ("Browser didn't open? Use the url below to sign in.", ""),
         ("Lock canvas", ""),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "ดำเนินการต่อ"),
         ("Browser didn't open? Use the url below to sign in.", "เบราว์เซอร์ไม่เปิดใช่ไหม? ใช้ URL ด้านล่างเพื่อเข้าสู่ระบบ"),
         ("Lock canvas", "ล็อคแคนวาส"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Devam et"),
         ("Browser didn't open? Use the url below to sign in.", "Tarayıcı açılmadı mı? Giriş yapmak için aşağıdaki URL'yi kullanın."),
         ("Lock canvas", "Tuvali kilitle"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "繼續"),
         ("Browser didn't open? Use the url below to sign in.", "瀏覽器未開啟？請使用下方網址登入。"),
         ("Lock canvas", "鎖定畫布"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Продовжити"),
         ("Browser didn't open? Use the url below to sign in.", "Браузер не відкрився? Скористайтеся посиланням нижче, щоб увійти."),
         ("Lock canvas", "Блокування полотна"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ur.rs
+++ b/src/lang/ur.rs
@@ -745,6 +745,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "display-name"),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }
 

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -758,5 +758,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Tiếp tục"),
         ("Browser didn't open? Use the url below to sign in.", "Trình duyệt không mở được? Hãy dùng URL bên dưới để đăng nhập."),
         ("Lock canvas", "Khóa khung hình"),
+        ("Use personal server", ""),
+        ("use-personal-server-tip", ""),
     ].iter().cloned().collect();
 }


### PR DESCRIPTION
## Problem

Only one ID server can be active at a time. When a personal (self-hosted)
server is configured and you need to reach a peer that is registered on the
public server, the only way is to clear the ID / relay / API / key fields by
hand and type them all back in afterwards — the key in particular is easy to
lose.

## Change

A **Use personal server** switch in Settings → Network, right below
*ID/Relay Server*. It is only shown when a personal server is actually
configured, so users on the public server see nothing new.

- Off: the four values are parked under `stashed-*` option keys and the client
  moves to the public server.
- On: they are restored exactly as they were, without re-running the server
  tests (they were validated when entered).
- Entering a new personal server in the dialog drops whatever was parked, so no
  stale config can come back.

Switching goes through the existing `setServerConfig()`, so the API-server
change still logs the account out as before. On desktop the switch sits inside
the locked network card and is disabled while locked or when the server is fixed
by a built-in option; the mobile settings page gets the same tile.

No new FFI functions — it is built on the existing option get/set, so no bridge
regeneration is needed.

## Notes

- `Use personal server` and `use-personal-server-tip` were added to
  `template.rs`, all locale files (empty) and `en.rs` (the tip).
- `flutter analyze` reports no new issues on the changed files.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Use personal server** switch to network settings on desktop and mobile.
  * Easily switch between a configured personal server and the public server.
  * Personal server settings are preserved and restored when switching back.

* **Bug Fixes**
  * Improved reliability when changing server settings quickly or repeatedly, preventing configuration changes from overwriting one another.

* **Documentation**
  * Added explanatory text for the personal-server switching option, with localization support across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds desktop and mobile controls for switching between personal and public servers while preserving the personal configuration.
- Serializes server configuration changes from toggles, settings saves, and imports through one shared queue.
- Parks and restores the ID, relay, API, and key options when changing server modes.
- Adds the switch to desktop and mobile network settings with localization entries.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| flutter/lib/common.dart | Adds shared serialization and the active/stashed personal-server state transitions; the fixes cover the previously reported overlapping writers. |
| flutter/lib/desktop/pages/desktop_setting_page.dart | Adds the personal-server switch to the locked desktop network card and routes changes through the serialized helper. |
| flutter/lib/mobile/pages/settings_page.dart | Adds and refreshes mobile personal-server state while routing toggles through the same serialized helper. |
| flutter/lib/consts.dart | Centralizes active server option names and defines the prefix used for parked configuration. |
| src/lang/template.rs | Registers the new switch label and tooltip localization keys. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Desktop/Mobile UI
    participant Q as Server-config queue
    participant C as Config writer
    participant O as Option storage
    UI->>Q: setServerConfig(...) or usePersonalServer(...)
    Q->>Q: Wait for prior operation
    Q->>C: Execute serialized write
    alt Disable personal server
        C->>O: Stash personal configuration
        C->>O: Clear active server options
    else Enable personal server
        C->>O: Read stashed configuration
        C->>O: Restore active server options
        C->>O: Clear stale stash
    else Save/import configuration
        C->>O: Write active server options
        C->>O: Clear stale stash
    end
    C-->>UI: Complete
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(server): park the personal config be..."](https://github.com/rustdesk/rustdesk/commit/c409422c2105b746a112d226b79874dbe8eb9748) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57888679)</sub>

<!-- /greptile_comment -->