### PR TITLE
Add Savol managed Windows client profile

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -2080,14 +2080,150 @@ pub fn rustdesk_interval(i: Interval) -> ThrottledInterval {
     ThrottledInterval::new(i)
 }
 
+#[cfg(target_os = "windows")]
+fn load_savol_profile() {
+    /*
+     * Savol managed RustDesk agent.
+     *
+     * Все параметры ниже загружаются как Override Settings.
+     * Пользовательские настройки не должны иметь над ними приоритет.
+     */
+    let settings = json!({
+        // ============================================================
+        // SAVOL RUSTDESK SERVER
+        // ============================================================
+
+        "custom-rendezvous-server": "rustdesk.savol-fmark.com",
+        "key": "UnB6n9PTIhW47OTHpBTH0oDSVx99iZbTfFeVzXDB6wI=",
+
+        // Relay не задаём специально.
+        // hbbr находится на том же сервере и используется автоматически.
+
+
+        // ============================================================
+        // VIDEO / CAPTURE
+        // ============================================================
+
+        "enable-hwcodec": "Y",
+        "enable-directx-capture": "Y",
+        "enable-udp-punch": "Y",
+        "enable-abr": "Y",
+        "keep-awake-during-incoming-sessions": "Y",
+
+
+        // ============================================================
+        // UNATTENDED ACCESS
+        // ============================================================
+
+        "approve-mode": "password",
+        "verification-method": "use-permanent-password",
+        "allow-only-conn-window-open": "N",
+
+
+        // ============================================================
+        // PERMISSIONS
+        // ============================================================
+
+        "access-mode": "custom",
+
+        "enable-keyboard": "Y",
+        "enable-clipboard": "Y",
+        "enable-file-transfer": "Y",
+        "enable-remote-restart": "Y",
+
+        // Обычный Terminal +
+        // Terminal (Administrator) (beta).
+        "enable-terminal": "Y",
+
+        "enable-camera": "N",
+        "enable-remote-printer": "N",
+        "enable-audio": "N",
+        "enable-tunnel": "N",
+
+
+        // ============================================================
+        // SECURITY / LOCKDOWN
+        // ============================================================
+
+        "allow-remote-config-modification": "N",
+        "allow-auto-update": "N",
+
+        // Это именно builtin-настройки.
+        "hide-tray": "Y",
+        "hide-stop-service": "Y",
+
+        "disable-change-permanent-password": "Y",
+        "disable-change-id": "Y",
+
+
+        // ============================================================
+        // UI LOCKDOWN
+        // ============================================================
+
+        // Сотруднику эти разделы вообще не нужны.
+        "hide-network-settings": "Y",
+        "hide-server-settings": "Y"
+    });
+
+    /*
+     * RustDesk делит настройки по нескольким внутренним namespaces.
+     * Формируем те же lookup maps, которые использует официальный
+     * механизм Custom Client.
+     */
+    let mut map_display_settings = HashMap::new();
+
+    for s in keys::KEYS_DISPLAY_SETTINGS {
+        map_display_settings.insert(s.replace("_", "-"), s);
+    }
+
+    let mut map_local_settings = HashMap::new();
+
+    for s in keys::KEYS_LOCAL_SETTINGS {
+        map_local_settings.insert(s.replace("_", "-"), s);
+    }
+
+    let mut map_settings = HashMap::new();
+
+    for s in keys::KEYS_SETTINGS {
+        map_settings.insert(s.replace("_", "-"), s);
+    }
+
+    let mut map_builtin_settings = HashMap::new();
+
+    for s in keys::KEYS_BUILDIN_SETTINGS {
+        map_builtin_settings.insert(s.replace("_", "-"), s);
+    }
+
+    /*
+     * true = Override Settings.
+     *
+     * Это принципиально:
+     *
+     * Override
+     *   >
+     * Strategy
+     *   >
+     * User
+     *   >
+     * Default
+     */
+    read_custom_client_advanced_settings(
+        settings,
+        &map_display_settings,
+        &map_local_settings,
+        &map_settings,
+        &map_builtin_settings,
+        true,
+    );
+}
+
 pub fn load_custom_client() {
+    #[cfg(target_os = "windows")]
+    load_savol_profile();
+
     #[cfg(debug_assertions)]
     if let Ok(data) = std::fs::read_to_string("./custom.txt") {
         read_custom_client(data.trim());
-        return;
-    }
-    let Some(path) = std::env::current_exe().map_or(None, |x| x.parent().map(|x| x.to_path_buf()))
-    else {
         return;
     };
     #[cfg(target_os = "macos")]

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -430,10 +430,6 @@ pub fn core_main() -> Option<Vec<String>> {
             }
             return None;
         } else if args[0] == "--password" {
-            if is_cli_setting_change_disabled() {
-                println!("Settings are disabled!");
-                return None;
-            }
             if config::Config::is_disable_change_permanent_password() {
                 println!("Changing permanent password is disabled!");
                 return None;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Windows installations now apply a standardized Savol connection and security profile automatically.
  - The profile configures connection routing, video and capture behavior, unattended access, permissions, and interface restrictions.

- **Bug Fixes**
  - Permanent password changes from the command line now correctly follow the configured password-change policy, allowing updates when permitted and blocking them when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a hard-coded Savol managed-client profile for Windows and changes permanent-password CLI policy handling.
- Applies Savol rendezvous, access, permission, and lockdown settings through the override-settings mechanism.
- Removes the global CLI-settings guard from the `--password` command.
- Accidentally removes the executable-path binding still required by custom-client file discovery.
</details>


<details><summary><h3>Confidence Score: 1/5</h3></summary>

This PR is not safe to merge because it breaks compilation, applies a tenant-specific profile to all Windows clients, and weakens the permanent-password command policy.

The removed path binding leaves unconditional unresolved references, normal Windows startup installs Savol-specific override settings without product gating, and the password command can mutate security-sensitive configuration despite the broader CLI lockdown.

**Files Needing Attention:** src/common.rs and src/core_main.rs
</details>


<details open><summary><h3>Security Review</h3></summary>

The `--password` command can now bypass the global command-line settings lockdown when the narrower permanent-password flag is not enabled. A privileged local invocation can therefore replace the unattended-access password despite that administrative policy.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/common.rs | Adds an unconditional tenant-specific Windows override profile and removes a required path binding, causing broad misconfiguration and a compile failure. |
| src/core_main.rs | Removes the broad CLI-settings policy guard from permanent-password changes, leaving only the narrower password-specific control. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Application startup] --> B[load_custom_client]
    B -->|Windows| C[load_savol_profile]
    C --> D[Install Savol override settings]
    D --> E[Use Savol server, key, permissions, and lockdown]
    B --> F[Resolve custom.txt path]
    F --> G[Unbound path reference]
    G --> H[Compilation failure]
    I[Root invokes --password] --> J{Permanent-password change disabled?}
    J -->|No| K[Set permanent password]
    K --> L[Global CLI-settings policy bypassed]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/common.rs`, line 2229-2231 ([link](https://github.com/rustdesk/rustdesk/blob/1b394eb6a2ab4aecad501e830453af37ebacce3e/src/common.rs#L2229-L2231)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Removed binding breaks compilation**

   The executable-directory `path` binding was removed, but both statements here still reference it, causing every target to fail compilation with `cannot find value 'path' in this scope`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/common.rs
   Line: 2229-2231

   Comment:
   **Removed binding breaks compilation**

   The executable-directory `path` binding was removed, but both statements here still reference it, causing every target to fail compilation with `cannot find value 'path' in this scope`.

   

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcommon.rs%0ALine%3A%202229-2231%0A%0AComment%3A%0A**Removed%20binding%20breaks%20compilation**%0A%0AThe%20executable-directory%20%60path%60%20binding%20was%20removed%2C%20but%20both%20statements%20here%20still%20reference%20it%2C%20causing%20every%20target%20to%20fail%20compilation%20with%20%60cannot%20find%20value%20'path'%20in%20this%20scope%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20Some%28path%29%20%3D%20std%3A%3Aenv%3A%3Acurrent_exe%28%29.map_or%28None%2C%20%7Cx%7C%20x.parent%28%29.map%28%7Cx%7C%20x.to_path_buf%28%29%29%29%0A%20%20%20%20else%20%7B%0A%20%20%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%3B%0A%20%20%20%20%23%5Bcfg%28target_os%20%3D%20%22macos%22%29%5D%0A%20%20%20%20let%20path%20%3D%20path.join%28%22..%2FResources%22%29%3B%0A%20%20%20%20let%20path%20%3D%20path.join%28%22custom.txt%22%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15994&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22savol-1.4.9%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22savol-1.4.9%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcommon.rs%0ALine%3A%202229-2231%0A%0AComment%3A%0A**Removed%20binding%20breaks%20compilation**%0A%0AThe%20executable-directory%20%60path%60%20binding%20was%20removed%2C%20but%20both%20statements%20here%20still%20reference%20it%2C%20causing%20every%20target%20to%20fail%20compilation%20with%20%60cannot%20find%20value%20'path'%20in%20this%20scope%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20Some%28path%29%20%3D%20std%3A%3Aenv%3A%3Acurrent_exe%28%29.map_or%28None%2C%20%7Cx%7C%20x.parent%28%29.map%28%7Cx%7C%20x.to_path_buf%28%29%29%29%0A%20%20%20%20else%20%7B%0A%20%20%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%3B%0A%20%20%20%20%23%5Bcfg%28target_os%20%3D%20%22macos%22%29%5D%0A%20%20%20%20let%20path%20%3D%20path.join%28%22..%2FResources%22%29%3B%0A%20%20%20%20let%20path%20%3D%20path.join%28%22custom.txt%22%29%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15994&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


2. `src/core_main.rs`, line 432-436 ([link](https://github.com/rustdesk/rustdesk/blob/1b394eb6a2ab4aecad501e830453af37ebacce3e/src/core_main.rs#L432-L436)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Password command bypasses CLI lockdown**

   When settings and command-line changes are disabled but the narrower permanent-password flag is false, an installed-system root invocation of `--password` now reaches `set_permanent_password`, changing the unattended-access password despite the administrator's broader lockdown.

   **How this was verified:** The removed global guard remains on sibling setting-changing commands, while this branch proceeds from its narrower guard to the permanent-password IPC setter.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/core_main.rs
   Line: 432-436

   Comment:
   **Password command bypasses CLI lockdown**

   When settings and command-line changes are disabled but the narrower permanent-password flag is false, an installed-system root invocation of `--password` now reaches `set_permanent_password`, changing the unattended-access password despite the administrator's broader lockdown.

   **How this was verified:** The removed global guard remains on sibling setting-changing commands, while this branch proceeds from its narrower guard to the permanent-password IPC setter.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcore_main.rs%0ALine%3A%20432-436%0A%0AComment%3A%0A**Password%20command%20bypasses%20CLI%20lockdown**%0A%0AWhen%20settings%20and%20command-line%20changes%20are%20disabled%20but%20the%20narrower%20permanent-password%20flag%20is%20false%2C%20an%20installed-system%20root%20invocation%20of%20%60--password%60%20now%20reaches%20%60set_permanent_password%60%2C%20changing%20the%20unattended-access%20password%20despite%20the%20administrator's%20broader%20lockdown.%0A%0A**How%20this%20was%20verified%3A**%20The%20removed%20global%20guard%20remains%20on%20sibling%20setting-changing%20commands%2C%20while%20this%20branch%20proceeds%20from%20its%20narrower%20guard%20to%20the%20permanent-password%20IPC%20setter.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15994&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22savol-1.4.9%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22savol-1.4.9%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcore_main.rs%0ALine%3A%20432-436%0A%0AComment%3A%0A**Password%20command%20bypasses%20CLI%20lockdown**%0A%0AWhen%20settings%20and%20command-line%20changes%20are%20disabled%20but%20the%20narrower%20permanent-password%20flag%20is%20false%2C%20an%20installed-system%20root%20invocation%20of%20%60--password%60%20now%20reaches%20%60set_permanent_password%60%2C%20changing%20the%20unattended-access%20password%20despite%20the%20administrator's%20broader%20lockdown.%0A%0A**How%20this%20was%20verified%3A**%20The%20removed%20global%20guard%20remains%20on%20sibling%20setting-changing%20commands%2C%20while%20this%20branch%20proceeds%20from%20its%20narrower%20guard%20to%20the%20permanent-password%20IPC%20setter.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15994&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2315994%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=15994&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fcommon.rs%3A2229-2231%0A**Removed%20binding%20breaks%20compilation**%0A%0AThe%20executable-directory%20%60path%60%20binding%20was%20removed%2C%20but%20both%20statements%20here%20still%20reference%20it%2C%20causing%20every%20target%20to%20fail%20compilation%20with%20%60cannot%20find%20value%20'path'%20in%20this%20scope%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20Some%28path%29%20%3D%20std%3A%3Aenv%3A%3Acurrent_exe%28%29.map_or%28None%2C%20%7Cx%7C%20x.parent%28%29.map%28%7Cx%7C%20x.to_path_buf%28%29%29%29%0A%20%20%20%20else%20%7B%0A%20%20%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%3B%0A%20%20%20%20%23%5Bcfg%28target_os%20%3D%20%22macos%22%29%5D%0A%20%20%20%20let%20path%20%3D%20path.join%28%22..%2FResources%22%29%3B%0A%20%20%20%20let%20path%20%3D%20path.join%28%22custom.txt%22%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Asrc%2Fcommon.rs%3A2221-2222%0A**Savol%20profile%20affects%20every%20client**%0A%0AEvery%20ordinary%20Windows%20startup%20now%20installs%20Savol's%20rendezvous%20server%2C%20key%2C%20permissions%2C%20and%20lockdown%20options%20as%20override%20settings%20because%20this%20call%20has%20no%20managed-client%20gate%2C%20causing%20standard%20Windows%20clients%20to%20use%20Savol%20infrastructure%20and%20preventing%20users%20or%20administrators%20from%20retaining%20their%20intended%20configuration.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fcore_main.rs%3A432-436%0A**Password%20command%20bypasses%20CLI%20lockdown**%0A%0AWhen%20settings%20and%20command-line%20changes%20are%20disabled%20but%20the%20narrower%20permanent-password%20flag%20is%20false%2C%20an%20installed-system%20root%20invocation%20of%20%60--password%60%20now%20reaches%20%60set_permanent_password%60%2C%20changing%20the%20unattended-access%20password%20despite%20the%20administrator's%20broader%20lockdown.%0A%0A**How%20this%20was%20verified%3A**%20The%20removed%20global%20guard%20remains%20on%20sibling%20setting-changing%20commands%2C%20while%20this%20branch%20proceeds%20from%20its%20narrower%20guard%20to%20the%20permanent-password%20IPC%20setter.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15994&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22savol-1.4.9%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22savol-1.4.9%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcommon.rs%3A2229-2231%0A**Removed%20binding%20breaks%20compilation**%0A%0AThe%20executable-directory%20%60path%60%20binding%20was%20removed%2C%20but%20both%20statements%20here%20still%20reference%20it%2C%20causing%20every%20target%20to%20fail%20compilation%20with%20%60cannot%20find%20value%20'path'%20in%20this%20scope%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20let%20Some%28path%29%20%3D%20std%3A%3Aenv%3A%3Acurrent_exe%28%29.map_or%28None%2C%20%7Cx%7C%20x.parent%28%29.map%28%7Cx%7C%20x.to_path_buf%28%29%29%29%0A%20%20%20%20else%20%7B%0A%20%20%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%3B%0A%20%20%20%20%23%5Bcfg%28target_os%20%3D%20%22macos%22%29%5D%0A%20%20%20%20let%20path%20%3D%20path.join%28%22..%2FResources%22%29%3B%0A%20%20%20%20let%20path%20%3D%20path.join%28%22custom.txt%22%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Asrc%2Fcommon.rs%3A2221-2222%0A**Savol%20profile%20affects%20every%20client**%0A%0AEvery%20ordinary%20Windows%20startup%20now%20installs%20Savol's%20rendezvous%20server%2C%20key%2C%20permissions%2C%20and%20lockdown%20options%20as%20override%20settings%20because%20this%20call%20has%20no%20managed-client%20gate%2C%20causing%20standard%20Windows%20clients%20to%20use%20Savol%20infrastructure%20and%20preventing%20users%20or%20administrators%20from%20retaining%20their%20intended%20configuration.%0A%0A%23%23%23%20Issue%203%0Asrc%2Fcore_main.rs%3A432-436%0A**Password%20command%20bypasses%20CLI%20lockdown**%0A%0AWhen%20settings%20and%20command-line%20changes%20are%20disabled%20but%20the%20narrower%20permanent-password%20flag%20is%20false%2C%20an%20installed-system%20root%20invocation%20of%20%60--password%60%20now%20reaches%20%60set_permanent_password%60%2C%20changing%20the%20unattended-access%20password%20despite%20the%20administrator's%20broader%20lockdown.%0A%0A**How%20this%20was%20verified%3A**%20The%20removed%20global%20guard%20remains%20on%20sibling%20setting-changing%20commands%2C%20while%20this%20branch%20proceeds%20from%20its%20narrower%20guard%20to%20the%20permanent-password%20IPC%20setter.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=15994&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/common.rs:2229-2231
**Removed binding breaks compilation**

The executable-directory `path` binding was removed, but both statements here still reference it, causing every target to fail compilation with `cannot find value 'path' in this scope`.

```suggestion
    let Some(path) = std::env::current_exe().map_or(None, |x| x.parent().map(|x| x.to_path_buf()))
    else {
        return;
    };
    #[cfg(target_os = "macos")]
    let path = path.join("../Resources");
    let path = path.join("custom.txt");
```

### Issue 2
src/common.rs:2221-2222
**Savol profile affects every client**

Every ordinary Windows startup now installs Savol's rendezvous server, key, permissions, and lockdown options as override settings because this call has no managed-client gate, causing standard Windows clients to use Savol infrastructure and preventing users or administrators from retaining their intended configuration.

### Issue 3
src/core_main.rs:432-436
**Password command bypasses CLI lockdown**

When settings and command-line changes are disabled but the narrower permanent-password flag is false, an installed-system root invocation of `--password` now reaches `set_permanent_password`, changing the unattended-access password despite the administrator's broader lockdown.

**How this was verified:** The removed global guard remains on sibling setting-changing commands, while this branch proceeds from its narrower guard to the permanent-password IPC setter.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Savol managed Windows client profile"](https://github.com/rustdesk/rustdesk/commit/1b394eb6a2ab4aecad501e830453af37ebacce3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57902178)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->