### PR TITLE
fix: query online states from each peer's own rendezvous server

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -4160,8 +4160,12 @@ pub mod peer_online {
             }
             let mut onlines = Vec::new();
             let mut offlines = Vec::new();
-            for (server, ids) in groups {
-                match query_online_states_(&ids, &server, query_timeout).await {
+            let results = hbb_common::futures::future::join_all(groups.into_iter().map(
+                |(server, ids)| async move { query_online_states_(&ids, &server, query_timeout).await },
+            ))
+            .await;
+            for result in results {
+                match result {
                     Ok((on, off)) => {
                         onlines.extend(on);
                         offlines.extend(off);

--- a/src/client.rs
+++ b/src/client.rs
@@ -4150,20 +4150,43 @@ pub mod peer_online {
             f(onlines, offlines)
         } else {
             let query_timeout = std::time::Duration::from_millis(3_000);
-            match query_online_states_(&ids, query_timeout).await {
-                Ok((onlines, offlines)) => {
-                    f(onlines, offlines);
-                }
-                Err(e) => {
-                    log::debug!("query onlines, {}", &e);
+            // Peers may carry an "id@server" suffix pointing to another rendezvous
+            // server; query each server for its own peers, otherwise they always
+            // show as offline.
+            let mut groups: std::collections::HashMap<String, Vec<String>> = Default::default();
+            for id in ids {
+                let server = id.split_once('@').map(|(_, s)| s).unwrap_or("").to_owned();
+                groups.entry(server).or_default().push(id);
+            }
+            let mut onlines = Vec::new();
+            let mut offlines = Vec::new();
+            for (server, ids) in groups {
+                match query_online_states_(&ids, &server, query_timeout).await {
+                    Ok((on, off)) => {
+                        onlines.extend(on);
+                        offlines.extend(off);
+                    }
+                    Err(e) => {
+                        log::debug!("query onlines, {}", &e);
+                    }
                 }
             }
+            f(onlines, offlines);
         }
     }
 
-    async fn create_online_stream() -> ResultType<Stream> {
-        let (rendezvous_server, _servers, _contained) =
-            crate::get_rendezvous_server(READ_TIMEOUT).await;
+    async fn create_online_stream(server: &str) -> ResultType<Stream> {
+        let server = server.split('?').next().unwrap_or_default();
+        let rendezvous_server = if server.is_empty() {
+            crate::get_rendezvous_server(READ_TIMEOUT).await.0
+        } else if server == super::PUBLIC_SERVER {
+            crate::check_port(
+                hbb_common::config::RENDEZVOUS_SERVERS[0],
+                hbb_common::config::RENDEZVOUS_PORT,
+            )
+        } else {
+            crate::check_port(server, hbb_common::config::RENDEZVOUS_PORT)
+        };
         let tmp: Vec<&str> = rendezvous_server.split(":").collect();
         if tmp.len() != 2 {
             bail!("Invalid server address: {}", rendezvous_server);
@@ -4178,16 +4201,21 @@ pub mod peer_online {
 
     async fn query_online_states_(
         ids: &Vec<String>,
+        server: &str,
         timeout: std::time::Duration,
     ) -> ResultType<(Vec<String>, Vec<String>)> {
+        let query_ids: Vec<String> = ids
+            .iter()
+            .map(|id| id.split('@').next().unwrap_or(id).to_owned())
+            .collect();
         let mut msg_out = RendezvousMessage::new();
         msg_out.set_online_request(OnlineRequest {
             id: Config::get_id(),
-            peers: ids.clone(),
+            peers: query_ids,
             ..Default::default()
         });
 
-        let mut socket = match create_online_stream().await {
+        let mut socket = match create_online_stream(server).await {
             Ok(s) => s,
             Err(e) => {
                 log::debug!("Failed to create peers online stream, {e}");

--- a/src/client.rs
+++ b/src/client.rs
@@ -4222,8 +4222,7 @@ pub mod peer_online {
         let mut socket = match create_online_stream(server).await {
             Ok(s) => s,
             Err(e) => {
-                log::debug!("Failed to create peers online stream, {e}");
-                return Ok((vec![], ids.clone()));
+                bail!("Failed to create peers online stream, {e}");
             }
         };
         // TODO: Use long connections to avoid socket creation
@@ -4231,8 +4230,7 @@ pub mod peer_online {
         // we may face the following error:
         // An established connection was aborted by the software in your host machine. (os error 10053)
         if let Err(e) = socket.send(&msg_out).await {
-            log::debug!("Failed to send peers online states query, {e}");
-            return Ok((vec![], ids.clone()));
+            bail!("Failed to send peers online states query, {e}");
         }
         // Retry for 2 times to get the online response
         for _ in 0..2 {


### PR DESCRIPTION
## Problem

Peers connected via the `id@server` syntax are stored in the recent sessions list with that suffix, but the online-state indicator query (`peer_online::query_online_states`) always connects to the **currently configured** rendezvous server and sends the full `id@server` string as the peer id.

As a result, any peer that lives on a different rendezvous server is always shown as offline (gray dot) in the recent sessions / autocomplete lists, even though it is online and connecting to it works fine (the connection path does honor the `@server` suffix).

## Fix

- Group the queried ids by their `@server` suffix.
- Query each rendezvous server separately (its online port, i.e. rendezvous port − 1), sending only the bare ids.
- Map the results back to the original full id strings, so the UI matching by `peers[i].id` keeps working unchanged.
- Ids without a suffix keep the existing behavior (currently configured server); the `public` suffix maps to the public rendezvous server; a `?key=...` query part is ignored for addressing.

A server group that fails to answer is simply left out of the callback lists, so its peers keep their previous displayed state instead of flapping to offline on transient errors.

No Flutter-side changes needed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed online-status lookups for peers registered through different rendezvous servers.
  * Peer availability results are now retrieved from the appropriate server and combined into a consistent status view.
  * Improved responsiveness when checking multiple servers by processing requests concurrently.
  * Improved error reporting when online-status checks cannot be completed, instead of incorrectly showing all peers as offline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates online-state lookups to query each peer’s own rendezvous server while preserving full peer IDs in callback results.
- Groups peers by rendezvous-server suffix and queries those groups concurrently.
- Uses bare peer IDs in rendezvous requests and maps response states back to the original IDs.
- Omits failed server groups from callback results so transient errors preserve existing indicators.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; concurrent querying resolves the serialized latency issue, and every failed query path now omits the affected group so its prior displayed state is preserved.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/client.rs | Implements concurrent per-server online-state queries and correctly skips failed groups instead of marking their peers offline. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: skip a failed server group instead ..."](https://github.com/rustdesk/rustdesk/commit/c065bc5f0810938b252797f580e37246b6daa310) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58873483)</sub>

<!-- /greptile_comment -->