### PR TITLE
Fix/msi install no reboot dialog

### DIFF
--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -9,7 +9,6 @@
 				<File Id="App.exe" Name="$(var.Product).exe" KeyPath="yes" Checksum="yes">
 					<!--<fire:FirewallException Id="AppEx" Name="$(var.Product) Service" Scope="any" IgnoreFailure="yes" />-->
 				</File>
-				<ServiceControl Id="StopRustDeskService" Name="$(var.Product)" Stop="install" Wait="yes" />
 			</Component>
 		</DirectoryRef>
 

--- a/res/msi/Package/Components/RustDesk.wxs
+++ b/res/msi/Package/Components/RustDesk.wxs
@@ -9,6 +9,7 @@
 				<File Id="App.exe" Name="$(var.Product).exe" KeyPath="yes" Checksum="yes">
 					<!--<fire:FirewallException Id="AppEx" Name="$(var.Product) Service" Scope="any" IgnoreFailure="yes" />-->
 				</File>
+				<ServiceControl Id="StopRustDeskService" Name="$(var.Product)" Stop="install" Wait="yes" />
 			</Component>
 		</DirectoryRef>
 

--- a/res/msi/Package/Package.wxs
+++ b/res/msi/Package/Package.wxs
@@ -11,13 +11,10 @@
 		<!--<PropertyRef Id="UpgradesFile" />-->
 
 		<PropertyRef Id="AddRemovePropertiesFile" />
-		<Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
 		<Media Id="1" Cabinet="cab1.cab" EmbedCab="yes" CompressionLevel="high" />
 		<Icon Id="AppIcon" SourceFile="Resources\icon.ico" />
 		<CustomAction Id="BlockSelfInstalledApp" Error="!(loc.AnotherAppDialogDescription)" />
-		<util:CloseApplication Id="CloseRustDeskBeforeInstallValidate" Target="$(var.Product).exe" CloseMessage="yes" EndSessionMessage="yes" RebootPrompt="no" Sequence="1" Condition="NOT Installed AND WIX_UPGRADE_DETECTED" />
-		<util:CloseApplication Id="CloseRuntimeBrokerBeforeInstallValidate" Target="RuntimeBroker_rustdesk.exe" CloseMessage="yes" EndSessionMessage="yes" RebootPrompt="no" Sequence="2" Condition="NOT Installed AND WIX_UPGRADE_DETECTED" />
 
 		<!-- User Interface -->
 		<WixVariable Id="WixUILicenseRtf" Value="License.rtf" />
@@ -31,17 +28,12 @@
 
 		<InstallExecuteSequence>
 			<Custom Action="BlockSelfInstalledApp" After="AppSearch" Condition="NOT Installed AND (APP_WINDOWS_INSTALLER=&quot;#0&quot; OR APP_WINDOWS_INSTALLER32=&quot;#0&quot;)" />
-			<?if $(sys.BUILDARCH) = arm64 ?>
-				<Custom Action="Wix4CloseApplications_A64" Before="InstallValidate" Condition="VersionNT &gt; 400" />
-			<?else?>
-				<Custom Action="Wix4CloseApplications_X64" Before="InstallValidate" Condition="VersionNT &gt; 400" />
-			<?endif?>
 			<InstallExecute After="RemoveExistingProducts" />
 
 			<!--Only do InstallValidate if is not Uninstall-->
 			<!--<InstallValidate Condition="NOT (Installed AND REMOVE AND NOT UPGRADINGPRODUCTCODE )" />-->
-			<!--Only do InstallValidate if is Install-->
-			<InstallValidate Condition="NOT Installed" />
+			<!--Only validate fresh installs, not major upgrades-->
+			<InstallValidate Condition="NOT Installed AND NOT WIX_UPGRADE_DETECTED" />
 
 		</InstallExecuteSequence>
 

--- a/res/msi/Package/Package.wxs
+++ b/res/msi/Package/Package.wxs
@@ -11,10 +11,13 @@
 		<!--<PropertyRef Id="UpgradesFile" />-->
 
 		<PropertyRef Id="AddRemovePropertiesFile" />
+		<Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
 		<Media Id="1" Cabinet="cab1.cab" EmbedCab="yes" CompressionLevel="high" />
 		<Icon Id="AppIcon" SourceFile="Resources\icon.ico" />
 		<CustomAction Id="BlockSelfInstalledApp" Error="!(loc.AnotherAppDialogDescription)" />
+		<util:CloseApplication Id="CloseRustDeskBeforeInstallValidate" Target="$(var.Product).exe" CloseMessage="yes" EndSessionMessage="yes" RebootPrompt="no" Sequence="1" Condition="NOT Installed AND WIX_UPGRADE_DETECTED" />
+		<util:CloseApplication Id="CloseRuntimeBrokerBeforeInstallValidate" Target="RuntimeBroker_rustdesk.exe" CloseMessage="yes" EndSessionMessage="yes" RebootPrompt="no" Sequence="2" Condition="NOT Installed AND WIX_UPGRADE_DETECTED" />
 
 		<!-- User Interface -->
 		<WixVariable Id="WixUILicenseRtf" Value="License.rtf" />
@@ -28,6 +31,11 @@
 
 		<InstallExecuteSequence>
 			<Custom Action="BlockSelfInstalledApp" After="AppSearch" Condition="NOT Installed AND (APP_WINDOWS_INSTALLER=&quot;#0&quot; OR APP_WINDOWS_INSTALLER32=&quot;#0&quot;)" />
+			<?if $(sys.BUILDARCH) = arm64 ?>
+				<Custom Action="Wix4CloseApplications_A64" Before="InstallValidate" Condition="VersionNT &gt; 400" />
+			<?else?>
+				<Custom Action="Wix4CloseApplications_X64" Before="InstallValidate" Condition="VersionNT &gt; 400" />
+			<?endif?>
 			<InstallExecute After="RemoveExistingProducts" />
 
 			<!--Only do InstallValidate if is not Uninstall-->


### PR DESCRIPTION
Avoid show the reboot prompt dialog.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/6060d67d-cff9-4a32-82bb-259cbea69d06" />


## Tests

- [x] `msiexec /i "rustdesk-1.4.9-x86_64.msi" REBOOT=ReallySuppress /norestart  /l*v "rustdesk-msi.log"`
- [x] `msiexec /i "rustdesk-1.4.9-x86_64.msi" /qn LAUNCH_TRAY_APP=N REBOOT=ReallySuppress /norestart  /l*v "rustdesk-msi.log"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade installation behavior by preventing unnecessary validation during major upgrades.
  * Fresh installations continue to receive the standard installation validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR suppresses the MSI reboot prompt during detected major upgrades by conditionally skipping InstallValidate.
- Adds WIX_UPGRADE_DETECTED to the InstallValidate condition.
- Leaves validation enabled for fresh installations.
- Also removes disk-space validation from the major-upgrade path.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until major upgrades retain disk-space validation while suppressing the unwanted reboot prompt through a narrower mechanism.

Detected major upgrades now bypass InstallValidate entirely, so insufficient disk space is discovered only after the destructive upgrade sequence has begun.

**Files Needing Attention:** res/msi/Package/Package.wxs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| res/msi/Package/Package.wxs | Changes MSI upgrade sequencing to skip InstallValidate, suppressing its prompt but also omitting required pre-execution disk-space validation. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2316021%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=16021&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ares%2Fmsi%2FPackage%2FPackage.wxs%3A35%0A**Upgrade%20disk%20validation%20is%20skipped**%0A%0AWhen%20a%20major%20upgrade%20is%20detected%20and%20the%20target%20volume%20lacks%20sufficient%20free%20space%2C%20this%20condition%20skips%20%60InstallValidate%60%2C%20causing%20the%20installation%20to%20fail%20and%20roll%20back%20only%20after%20the%20existing%20product%20has%20entered%20the%20major-upgrade%20removal%20sequence.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16021&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix%2Fmsi-install-no-reboot-dialog%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmsi-install-no-reboot-dialog%22.%0A%0A%23%23%23%20Issue%201%0Ares%2Fmsi%2FPackage%2FPackage.wxs%3A35%0A**Upgrade%20disk%20validation%20is%20skipped**%0A%0AWhen%20a%20major%20upgrade%20is%20detected%20and%20the%20target%20volume%20lacks%20sufficient%20free%20space%2C%20this%20condition%20skips%20%60InstallValidate%60%2C%20causing%20the%20installation%20to%20fail%20and%20roll%20back%20only%20after%20the%20existing%20product%20has%20entered%20the%20major-upgrade%20removal%20sequence.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16021&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
res/msi/Package/Package.wxs:35
**Upgrade disk validation is skipped**

When a major upgrade is detected and the target volume lacks sufficient free space, this condition skips `InstallValidate`, causing the installation to fail and roll back only after the existing product has entered the major-upgrade removal sequence.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(msi): suppress reboot prompt during ..."](https://github.com/rustdesk/rustdesk/commit/a940387866c86f0fbfd55eea7d95121a493c2dbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59021832)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->