### PR TITLE
fix: convert X11 depth-30 root windows to BGRA instead of mislabeling…

### DIFF
--- a/libs/scrap/src/common/mod.rs
+++ b/libs/scrap/src/common/mod.rs
@@ -235,6 +235,8 @@ pub enum Pixfmt {
     BGRA,
     RGBA,
     RGB565LE,
+    // X11 depth 30: xRGB2101010, little endian (libyuv's AR30).
+    AR30,
     I420,
     NV12,
     I444,
@@ -243,7 +245,7 @@ pub enum Pixfmt {
 impl Pixfmt {
     pub fn bpp(&self) -> usize {
         match self {
-            Pixfmt::BGRA | Pixfmt::RGBA => 32,
+            Pixfmt::BGRA | Pixfmt::RGBA | Pixfmt::AR30 => 32,
             Pixfmt::RGB565LE => 16,
             Pixfmt::I420 | Pixfmt::NV12 => 12,
             Pixfmt::I444 => 24,

--- a/libs/scrap/src/common/x11.rs
+++ b/libs/scrap/src/common/x11.rs
@@ -23,7 +23,7 @@ impl TraitCapturer for Capturer {
     fn frame<'a>(&'a mut self, _timeout: Duration) -> io::Result<Frame<'a>> {
         let width = self.width();
         let height = self.height();
-        let pixfmt = self.0.display().pixfmt();
+        let pixfmt = self.0.pixfmt();
         Ok(Frame::PixelBuffer(PixelBuffer::new(
             self.0.frame()?,
             pixfmt,

--- a/libs/scrap/src/x11/capturer.rs
+++ b/libs/scrap/src/x11/capturer.rs
@@ -1,5 +1,6 @@
 use super::ffi::*;
 use super::Display;
+use crate::Pixfmt;
 use hbb_common::libc;
 use std::{io, ptr, slice};
 
@@ -11,6 +12,7 @@ pub struct Capturer {
 
     size: usize,
     saved_raw_data: Vec<u8>, // for faster compare and copy
+    converted: Vec<u8>,
 }
 
 impl Capturer {
@@ -64,6 +66,7 @@ impl Capturer {
             buffer,
             size,
             saved_raw_data: Vec::new(),
+            converted: Vec::new(),
         };
         Ok(c)
     }
@@ -93,11 +96,79 @@ impl Capturer {
         }
     }
 
+    /// Format of the frames `frame` returns; a depth-30 root is handed out as BGRA.
+    pub fn pixfmt(&self) -> Pixfmt {
+        match self.display.pixfmt() {
+            Pixfmt::AR30 => Pixfmt::BGRA,
+            pixfmt => pixfmt,
+        }
+    }
+
     pub fn frame<'b>(&'b mut self) -> std::io::Result<&'b [u8]> {
         self.get_image();
         let result = unsafe { slice::from_raw_parts(self.buffer, self.size) };
         crate::would_block_if_equal(&mut self.saved_raw_data, result)?;
+        if self.display.pixfmt() == Pixfmt::AR30 {
+            return self.ar30_to_bgra(result);
+        }
         Ok(result)
+    }
+
+    fn ar30_to_bgra(&mut self, ar30: &[u8]) -> io::Result<&[u8]> {
+        let rect = self.display.rect();
+        ar30_to_bgra(ar30, rect.w as _, rect.h as _, &mut self.converted)?;
+        Ok(&self.converted)
+    }
+}
+
+/// xRGB2101010 (libyuv's AR30) to BGRA. The top two bits are padding, not
+/// alpha, so the output alpha is forced opaque; libyuv has no XR30 conversion
+/// and would expand them to 0/85/170/255.
+fn ar30_to_bgra(ar30: &[u8], width: usize, height: usize, bgra: &mut Vec<u8>) -> io::Result<()> {
+    let stride = width * 4;
+    bgra.resize(stride * height, 0);
+    let ret = unsafe {
+        crate::common::AR30ToARGB(
+            ar30.as_ptr(),
+            stride as _,
+            bgra.as_mut_ptr(),
+            stride as _,
+            width as _,
+            height as _,
+        )
+    };
+    if ret != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("AR30ToARGB failed: {ret}"),
+        ));
+    }
+    for px in bgra.chunks_exact_mut(4) {
+        px[3] = 0xff;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ar30_to_bgra_drops_padding_bits() {
+        // (padding, r, g, b) packed as X11 xRGB2101010, little endian.
+        let px =
+            |x: u32, r: u32, g: u32, b: u32| ((x << 30) | (r << 20) | (g << 10) | b).to_le_bytes();
+        let src = [
+            px(0, 1023, 0, 0),
+            px(1, 0, 1023, 0),
+            px(2, 0, 0, 1023),
+            px(3, 512, 256, 128),
+        ]
+        .concat();
+        let mut dst = Vec::new();
+        super::ar30_to_bgra(&src, 4, 1, &mut dst).unwrap();
+        assert_eq!(
+            dst,
+            [0, 0, 255, 255, 0, 255, 0, 255, 255, 0, 0, 255, 32, 64, 128, 255]
+        );
     }
 }
 

--- a/libs/scrap/src/x11/iter.rs
+++ b/libs/scrap/src/x11/iter.rs
@@ -132,6 +132,7 @@ unsafe fn get_pixfmt(conn: *mut xcb_connection_t, root: xcb_window_t) -> Option<
     // https://github.com/FFmpeg/FFmpeg/blob/a9c05eb657d0d05f3ac79fe9973581a41b265a5e/libavdevice/xcbgrab.c#L519
     match depth {
         16 => Some(Pixfmt::RGB565LE),
+        30 => Some(Pixfmt::AR30),
         32 => Some(Pixfmt::BGRA),
         _ => None,
     }


### PR DESCRIPTION
## Fix X11 depth-30 root windows being captured as BGRA

On a 10-bit X11 desktop (`DefaultDepth 30`, or NVIDIA "30-bit color") the root window is xRGB2101010. `get_pixfmt` only knows depths 16 and 32, and the `unwrap_or(Pixfmt::BGRA)` after it silently labels the 10-bit pixels as 8-bit BGRA, so the controller sees scrambled colours.

### Change

- Add `Pixfmt::AR30`, libyuv's name for X11's little-endian xRGB2101010 (blue in bits 0–9, red in 20–29), and map depth 30 to it.
- `x11::Capturer` converts each changed AR30 frame to BGRA with libyuv `AR30ToARGB` into an owned buffer, so encoders, screenshots and everything downstream still see BGRA.
- The top two bits of the source are padding, not alpha; libyuv expands them to 0/85/170/255, so the output alpha is forced to 255. This matters for the screenshot feature, which writes the BGRA buffer straight into a PNG. A unit test pins the conversion for all four padding values.

### Blast radius

Four files, +76/-2. Only depth-30 roots take a new code path; every other depth executes the same code as before. An earlier revision of this PR also validated the pixmap format, byte order and root visual masks and refused unknown layouts. That ran new xcb FFI code for every X11 user and turned a wrong-colour bug into a no-picture failure, so it was dropped: depth 30 is already a hand-configured setup, and the little-endian assumption matches what this file already documents for the other depths.

### Testing

- Verified libyuv's AR30 layout against X11's with a real call into libyuv.
- `cargo check` of the x11 module for a Linux target; the unit test lives in the Linux-only capturer file and passed on macOS when it was in the shared conversion module.
- Not yet run on a real depth-30 X server. Testers: `DefaultDepth 30` in xorg.conf or NVIDIA "30-bit color", then compare colours and take a screenshot from the controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLb1dNdhFqUQExJPANjo1F