### PR TITLE
fix: prevent stale clicks in iOS touch mode

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -199,23 +199,27 @@ class _RawTouchGestureDetectorRegionState
       return;
     }
     if (handleTouch) {
-      if (isIOS &&
-          (touchSequence == null ||
-              !_touchModeGestureTracker.shouldHandleTap(touchSequence))) {
-        return;
-      }
-      final isMoved =
-          await ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy);
-      if (isIOS &&
-          !_touchModeGestureTracker.shouldHandleTap(touchSequence!)) {
-        return;
-      }
-      if (isMoved) {
+      Future<void> sendTap() async {
         // If pan already handled 'down', don't send it again.
         if (lastTapDownDetails != null && !_touchModePanStarted) {
           await inputModel.tapDown(MouseButtons.left);
         }
         await inputModel.tapUp(MouseButtons.left);
+      }
+      if (isIOS) {
+        if (touchSequence == null) {
+          return;
+        }
+        await handleTrackedTap(
+          tracker: _touchModeGestureTracker,
+          sequence: touchSequence,
+          move: () =>
+              ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy),
+          sendTap: sendTap,
+        );
+      } else if (await ffi.cursorModel
+          .move(d.localPosition.dx, d.localPosition.dy)) {
+        await sendTap();
       }
     }
   }

--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -464,6 +464,7 @@ class _RawTouchGestureDetectorRegionState
     final isMoved = await ffi.cursorModel
         .move(panStartPosition.dx, panStartPosition.dy);
     if (!isMoved ||
+        panState.ended ||
         panState.cancelled ||
         panState.touchSequence != _touchModeGestureTracker.sequence) {
       return;
@@ -473,7 +474,8 @@ class _RawTouchGestureDetectorRegionState
       await inputModel.sendMouse('down', MouseButtons.left);
       panState.mouseDownSent = true;
     }
-    if (panState.cancelled ||
+    if (panState.ended ||
+        panState.cancelled ||
         panState.touchSequence != _touchModeGestureTracker.sequence) {
       return;
     }

--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -59,17 +59,6 @@ bool isSpecialHoldDragActive = false;
 // Cache the last focal point to calculate deltas in special hold-drag mode.
 Offset _lastSpecialHoldDragFocalPoint = Offset.zero;
 
-class _TouchModePanState {
-  _TouchModePanState(this.touchSequence);
-
-  final int touchSequence;
-  late final Future<void> startFuture;
-  bool ended = false;
-  bool cancelled = false;
-  bool mouseDownSent = false;
-  bool finishing = false;
-}
-
 class RawTouchGestureDetectorRegion extends StatefulWidget {
   final Widget child;
   final FFI ffi;
@@ -107,6 +96,7 @@ class _RawTouchGestureDetectorRegionState
 
   // Workaround tap down event when two fingers are used to scale(mobile)
   TapDownDetails? _lastTapDownDetails;
+  int? _lastTapDownSequence;
 
   PointerDeviceKind? lastDeviceKind;
 
@@ -116,7 +106,6 @@ class _RawTouchGestureDetectorRegionState
   bool _touchModePanStarted = false;
   final TouchModeGestureTracker _touchModeGestureTracker =
       TouchModeGestureTracker();
-  _TouchModePanState? _touchModePanState;
   Offset _doubleFinerTapPosition = Offset.zero;
 
   // For mouse mode, we need to block the events when the cursor is in a blocked area.
@@ -134,14 +123,18 @@ class _RawTouchGestureDetectorRegionState
 
   @override
   Widget build(BuildContext context) {
+    final detector = RawGestureDetector(
+      child: widget.child,
+      gestures: makeGestures(context),
+    );
+    if (!isIOS) {
+      return detector;
+    }
     return Listener(
       onPointerDown: _onTouchPointerDown,
       onPointerUp: _onTouchPointerEnd,
       onPointerCancel: _onTouchPointerEnd,
-      child: RawGestureDetector(
-        child: widget.child,
-        gestures: makeGestures(context),
-      ),
+      child: detector,
     );
   }
 
@@ -149,12 +142,7 @@ class _RawTouchGestureDetectorRegionState
     if (!kTouchBasedDeviceKinds.contains(event.kind)) {
       return;
     }
-    lastDeviceKind = event.kind;
-    final previousSequence = _touchModeGestureTracker.sequence;
     _touchModeGestureTracker.pointerDown(event.pointer);
-    if (_touchModeGestureTracker.sequence != previousSequence) {
-      _touchModePanStarted = false;
-    }
   }
 
   void _onTouchPointerEnd(PointerEvent event) {
@@ -185,19 +173,24 @@ class _RawTouchGestureDetectorRegionState
       _lastPosOfDoubleTapDown = d.localPosition;
       // Desktop or mobile "Touch mode"
       _lastTapDownDetails = d;
-      _touchModeGestureTracker.recordTapDown();
+      if (isIOS) {
+        _lastTapDownSequence = _touchModeGestureTracker.recordTapDown();
+      }
     } else {
       _lastTapDownPositionForMouseMode = d.localPosition;
     }
   }
 
   onTapUp(TapUpDetails d) async {
-    final touchSequence = _touchModeGestureTracker.sequence;
-    final TapDownDetails? lastTapDownDetails =
-        _touchModeGestureTracker.takeCurrentTapDown(touchSequence)
-            ? _lastTapDownDetails
-            : null;
-    _lastTapDownDetails = null;
+    final touchSequence =
+        isIOS ? _touchModeGestureTracker.takeNextTapDown() : null;
+    final TapDownDetails? lastTapDownDetails;
+    if (isIOS) {
+      lastTapDownDetails = _takeTapDownDetails(touchSequence);
+    } else {
+      lastTapDownDetails = _lastTapDownDetails;
+      _lastTapDownDetails = null;
+    }
     if (isNotTouchBasedDevice()) {
       return;
     }
@@ -206,12 +199,15 @@ class _RawTouchGestureDetectorRegionState
       return;
     }
     if (handleTouch) {
-      if (!_touchModeGestureTracker.shouldHandleTap(touchSequence)) {
+      if (isIOS &&
+          (touchSequence == null ||
+              !_touchModeGestureTracker.shouldHandleTap(touchSequence))) {
         return;
       }
       final isMoved =
           await ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy);
-      if (!_touchModeGestureTracker.shouldHandleTap(touchSequence)) {
+      if (isIOS &&
+          !_touchModeGestureTracker.shouldHandleTap(touchSequence!)) {
         return;
       }
       if (isMoved) {
@@ -222,6 +218,22 @@ class _RawTouchGestureDetectorRegionState
         await inputModel.tapUp(MouseButtons.left);
       }
     }
+  }
+
+  onTapCancel() {
+    if (isIOS) {
+      _touchModeGestureTracker.takeNextTapDown();
+    }
+  }
+
+  TapDownDetails? _takeTapDownDetails(int? touchSequence) {
+    if (touchSequence == null || _lastTapDownSequence != touchSequence) {
+      return null;
+    }
+    final details = _lastTapDownDetails;
+    _lastTapDownDetails = null;
+    _lastTapDownSequence = null;
+    return details;
   }
 
   onTap() async {
@@ -290,7 +302,6 @@ class _RawTouchGestureDetectorRegionState
         return;
       }
       _cacheLongPressPositionTs = DateTime.now().millisecondsSinceEpoch;
-      _touchModeGestureTracker.recordLongPress();
       if (ffiModel.isPeerMobile) {
         await ffi.cursorModel
             .move(_cacheLongPressPosition.dx, _cacheLongPressPosition.dy);
@@ -403,17 +414,26 @@ class _RawTouchGestureDetectorRegionState
   }
 
   onOneFingerPanStart(BuildContext context, DragStartDetails d) async {
-    final touchSequence = _touchModeGestureTracker.sequence;
-    final TapDownDetails? lastTapDownDetails =
-        _touchModeGestureTracker.takeCurrentTapDown(touchSequence)
-            ? _lastTapDownDetails
-            : null;
-    _lastTapDownDetails = null;
+    final touchSequence = isIOS ? _touchModeGestureTracker.sequence : null;
+    final TapDownDetails? lastTapDownDetails;
+    if (isIOS) {
+      lastTapDownDetails = _takeTapDownDetails(touchSequence);
+    } else {
+      lastTapDownDetails = _lastTapDownDetails;
+      _lastTapDownDetails = null;
+    }
     lastDeviceKind = d.kind ?? lastDeviceKind;
     if (isNotTouchBasedDevice()) {
       return;
     }
     if (handleTouch) {
+      if (isIOS) {
+        _touchModeGestureTracker.claimPan(touchSequence!);
+      }
+      if (lastTapDownDetails != null) {
+        await ffi.cursorModel.move(lastTapDownDetails.localPosition.dx,
+            lastTapDownDetails.localPosition.dy);
+      }
       if (ffi.cursorModel.shouldBlock(d.localPosition.dx, d.localPosition.dy)) {
         return;
       }
@@ -421,7 +441,7 @@ class _RawTouchGestureDetectorRegionState
         return;
       }
 
-      _touchModeGestureTracker.claimPan();
+      _touchModePanStarted = true;
       if (isDesktop || isWebDesktop) {
         ffi.cursorModel.trySetRemoteWindowCoords();
       }
@@ -431,21 +451,16 @@ class _RawTouchGestureDetectorRegionState
       // we consider to use the long press position as the start position.
       //
       // TODO: We should find a better way to send the first pan event as soon as possible.
-      final hasCurrentLongPressPosition =
-          _touchModeGestureTracker.isCurrentLongPress(touchSequence) &&
-              DateTime.now().millisecondsSinceEpoch -
-                      _cacheLongPressPositionTs <
-                  500;
-      final panStartPosition = hasCurrentLongPressPosition
-          ? _cacheLongPressPosition
-          : (lastTapDownDetails?.localPosition ?? d.localPosition);
-      final panState = _TouchModePanState(touchSequence);
-      _touchModePanState = panState;
-      // End/cancel awaits this future so an asynchronous start cannot leave a
-      // late mouse-down or an unmatched mouse-up behind.
-      panState.startFuture =
-          _startTouchModePan(panState, panStartPosition, d.localPosition);
-      await panState.startFuture;
+      if (DateTime.now().millisecondsSinceEpoch - _cacheLongPressPositionTs <
+          500) {
+        await ffi.cursorModel
+            .move(_cacheLongPressPosition.dx, _cacheLongPressPosition.dy);
+      }
+      // In relative mouse mode, skip mouse down - only send movement via sendMobileRelativeMouseMove
+      if (!inputModel.relativeMouseMode.value) {
+        await inputModel.sendMouse('down', MouseButtons.left);
+      }
+      await ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy);
     } else {
       final offset = ffi.cursorModel.offset;
       final cursorX = offset.dx;
@@ -456,35 +471,6 @@ class _RawTouchGestureDetectorRegionState
       if (!visible.contains(Offset(cursorX, cursorY))) {
         await ffi.cursorModel.move(size.width / 2, size.height / 2);
       }
-    }
-  }
-
-  Future<void> _startTouchModePan(_TouchModePanState panState,
-      Offset panStartPosition, Offset currentPosition) async {
-    final isMoved = await ffi.cursorModel
-        .move(panStartPosition.dx, panStartPosition.dy);
-    if (!isMoved ||
-        panState.ended ||
-        panState.cancelled ||
-        panState.touchSequence != _touchModeGestureTracker.sequence) {
-      return;
-    }
-
-    if (!inputModel.relativeMouseMode.value) {
-      await inputModel.sendMouse('down', MouseButtons.left);
-      panState.mouseDownSent = true;
-    }
-    if (panState.ended ||
-        panState.cancelled ||
-        panState.touchSequence != _touchModeGestureTracker.sequence) {
-      return;
-    }
-
-    if (!panState.ended) {
-      _touchModePanStarted = true;
-    }
-    if (panStartPosition != currentPosition) {
-      await ffi.cursorModel.move(currentPosition.dx, currentPosition.dy);
     }
   }
 
@@ -507,21 +493,18 @@ class _RawTouchGestureDetectorRegionState
   }
 
   onOneFingerPanEnd(DragEndDetails d) async {
-    final panState = _touchModePanState;
-    panState?.ended = true;
     _touchModePanStarted = false;
-    if (panState != null) {
-      if (isDesktop || isWebDesktop) {
-        ffi.cursorModel.clearRemoteWindowCoords();
-      }
-      await _finishTouchModePan(panState);
-      return;
-    }
     if (isNotTouchBasedDevice()) {
       return;
     }
     if (isDesktop || isWebDesktop) {
       ffi.cursorModel.clearRemoteWindowCoords();
+    }
+    if (handleTouch) {
+      // In relative mouse mode, skip mouse up - matches the skipped mouse down in onOneFingerPanStart
+      if (!inputModel.relativeMouseMode.value) {
+        await inputModel.sendMouse('up', MouseButtons.left);
+      }
     }
   }
 
@@ -529,42 +512,17 @@ class _RawTouchGestureDetectorRegionState
   // or rejected by the gesture arena. Without this, the flag can remain
   // stuck in the "started" state and cause issues such as the Magic Mouse
   // double-click problem on iPad with magic mouse.
-  onOneFingerPanCancel() async {
-    final panState = _touchModePanState;
-    panState?.cancelled = true;
+  onOneFingerPanCancel() {
     _touchModePanStarted = false;
-    if (panState != null) {
-      if (isDesktop || isWebDesktop) {
-        ffi.cursorModel.clearRemoteWindowCoords();
-      }
-      await _finishTouchModePan(panState);
-    }
-  }
-
-  Future<void> _finishTouchModePan(_TouchModePanState panState) async {
-    if (panState.finishing) {
-      return;
-    }
-    panState.finishing = true;
-    try {
-      await panState.startFuture;
-    } finally {
-      try {
-        if (panState.mouseDownSent) {
-          await inputModel.sendMouse('up', MouseButtons.left);
-        }
-      } finally {
-        if (identical(_touchModePanState, panState)) {
-          _touchModePanState = null;
-        }
-      }
-    }
   }
 
   // scale + pan event
   onTwoFingerScaleStart(ScaleStartDetails d) {
     _lastTapDownDetails = null;
-    _touchModeGestureTracker.clearTapDown();
+    _lastTapDownSequence = null;
+    if (isIOS) {
+      _touchModeGestureTracker.clearTapDowns();
+    }
     if (isNotTouchBasedDevice()) {
       return;
     }
@@ -655,6 +613,7 @@ class _RawTouchGestureDetectorRegionState
         instance
           ..onTapDown = onTapDown
           ..onTapUp = onTapUp
+          ..onTapCancel = onTapCancel
           ..onTap = onTap;
       }),
       DoubleTapGestureRecognizer:

--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -277,6 +277,12 @@ class _RawTouchGestureDetectorRegionState
     if (isNotTouchBasedDevice()) {
       return;
     }
+    if (isIOS) {
+      // A double tap can emit two tap-downs but only one tap-cancel.
+      _touchModeGestureTracker.clearTapDowns();
+      _lastTapDownDetails = null;
+      _lastTapDownSequence = null;
+    }
     if (ffiModel.touchMode && ffi.cursorModel.lastIsBlocked) {
       return;
     }

--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -12,6 +12,7 @@ import 'package:flutter_hbb/models/model.dart';
 import 'package:flutter_hbb/models/input_model.dart';
 
 import './gestures.dart';
+import './touch_mode_gesture_tracker.dart';
 
 class RawKeyFocusScope extends StatelessWidget {
   final FocusNode? focusNode;
@@ -58,6 +59,17 @@ bool isSpecialHoldDragActive = false;
 // Cache the last focal point to calculate deltas in special hold-drag mode.
 Offset _lastSpecialHoldDragFocalPoint = Offset.zero;
 
+class _TouchModePanState {
+  _TouchModePanState(this.touchSequence);
+
+  final int touchSequence;
+  late final Future<void> startFuture;
+  bool ended = false;
+  bool cancelled = false;
+  bool mouseDownSent = false;
+  bool finishing = false;
+}
+
 class RawTouchGestureDetectorRegion extends StatefulWidget {
   final Widget child;
   final FFI ffi;
@@ -102,6 +114,9 @@ class _RawTouchGestureDetectorRegionState
   // `onDoubleTap()` does not provide the position of the tap event.
   Offset _lastPosOfDoubleTapDown = Offset.zero;
   bool _touchModePanStarted = false;
+  final TouchModeGestureTracker _touchModeGestureTracker =
+      TouchModeGestureTracker();
+  _TouchModePanState? _touchModePanState;
   Offset _doubleFinerTapPosition = Offset.zero;
 
   // For mouse mode, we need to block the events when the cursor is in a blocked area.
@@ -119,10 +134,33 @@ class _RawTouchGestureDetectorRegionState
 
   @override
   Widget build(BuildContext context) {
-    return RawGestureDetector(
-      child: widget.child,
-      gestures: makeGestures(context),
+    return Listener(
+      onPointerDown: _onTouchPointerDown,
+      onPointerUp: _onTouchPointerEnd,
+      onPointerCancel: _onTouchPointerEnd,
+      child: RawGestureDetector(
+        child: widget.child,
+        gestures: makeGestures(context),
+      ),
     );
+  }
+
+  void _onTouchPointerDown(PointerDownEvent event) {
+    if (!kTouchBasedDeviceKinds.contains(event.kind)) {
+      return;
+    }
+    lastDeviceKind = event.kind;
+    final previousSequence = _touchModeGestureTracker.sequence;
+    _touchModeGestureTracker.pointerDown(event.pointer);
+    if (_touchModeGestureTracker.sequence != previousSequence) {
+      _touchModePanStarted = false;
+    }
+  }
+
+  void _onTouchPointerEnd(PointerEvent event) {
+    if (kTouchBasedDeviceKinds.contains(event.kind)) {
+      _touchModeGestureTracker.pointerEnd(event.pointer);
+    }
   }
 
   bool isNotTouchBasedDevice() {
@@ -147,13 +185,18 @@ class _RawTouchGestureDetectorRegionState
       _lastPosOfDoubleTapDown = d.localPosition;
       // Desktop or mobile "Touch mode"
       _lastTapDownDetails = d;
+      _touchModeGestureTracker.recordTapDown();
     } else {
       _lastTapDownPositionForMouseMode = d.localPosition;
     }
   }
 
   onTapUp(TapUpDetails d) async {
-    final TapDownDetails? lastTapDownDetails = _lastTapDownDetails;
+    final touchSequence = _touchModeGestureTracker.sequence;
+    final TapDownDetails? lastTapDownDetails =
+        _touchModeGestureTracker.takeCurrentTapDown(touchSequence)
+            ? _lastTapDownDetails
+            : null;
     _lastTapDownDetails = null;
     if (isNotTouchBasedDevice()) {
       return;
@@ -163,8 +206,14 @@ class _RawTouchGestureDetectorRegionState
       return;
     }
     if (handleTouch) {
+      if (!_touchModeGestureTracker.shouldHandleTap(touchSequence)) {
+        return;
+      }
       final isMoved =
           await ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy);
+      if (!_touchModeGestureTracker.shouldHandleTap(touchSequence)) {
+        return;
+      }
       if (isMoved) {
         // If pan already handled 'down', don't send it again.
         if (lastTapDownDetails != null && !_touchModePanStarted) {
@@ -241,6 +290,7 @@ class _RawTouchGestureDetectorRegionState
         return;
       }
       _cacheLongPressPositionTs = DateTime.now().millisecondsSinceEpoch;
+      _touchModeGestureTracker.recordLongPress();
       if (ffiModel.isPeerMobile) {
         await ffi.cursorModel
             .move(_cacheLongPressPosition.dx, _cacheLongPressPosition.dy);
@@ -353,17 +403,17 @@ class _RawTouchGestureDetectorRegionState
   }
 
   onOneFingerPanStart(BuildContext context, DragStartDetails d) async {
-    final TapDownDetails? lastTapDownDetails = _lastTapDownDetails;
+    final touchSequence = _touchModeGestureTracker.sequence;
+    final TapDownDetails? lastTapDownDetails =
+        _touchModeGestureTracker.takeCurrentTapDown(touchSequence)
+            ? _lastTapDownDetails
+            : null;
     _lastTapDownDetails = null;
     lastDeviceKind = d.kind ?? lastDeviceKind;
     if (isNotTouchBasedDevice()) {
       return;
     }
     if (handleTouch) {
-      if (lastTapDownDetails != null) {
-        await ffi.cursorModel.move(lastTapDownDetails.localPosition.dx,
-            lastTapDownDetails.localPosition.dy);
-      }
       if (ffi.cursorModel.shouldBlock(d.localPosition.dx, d.localPosition.dy)) {
         return;
       }
@@ -371,7 +421,7 @@ class _RawTouchGestureDetectorRegionState
         return;
       }
 
-      _touchModePanStarted = true;
+      _touchModeGestureTracker.claimPan();
       if (isDesktop || isWebDesktop) {
         ffi.cursorModel.trySetRemoteWindowCoords();
       }
@@ -381,16 +431,21 @@ class _RawTouchGestureDetectorRegionState
       // we consider to use the long press position as the start position.
       //
       // TODO: We should find a better way to send the first pan event as soon as possible.
-      if (DateTime.now().millisecondsSinceEpoch - _cacheLongPressPositionTs <
-          500) {
-        await ffi.cursorModel
-            .move(_cacheLongPressPosition.dx, _cacheLongPressPosition.dy);
-      }
-      // In relative mouse mode, skip mouse down - only send movement via sendMobileRelativeMouseMove
-      if (!inputModel.relativeMouseMode.value) {
-        await inputModel.sendMouse('down', MouseButtons.left);
-      }
-      await ffi.cursorModel.move(d.localPosition.dx, d.localPosition.dy);
+      final hasCurrentLongPressPosition =
+          _touchModeGestureTracker.isCurrentLongPress(touchSequence) &&
+              DateTime.now().millisecondsSinceEpoch -
+                      _cacheLongPressPositionTs <
+                  500;
+      final panStartPosition = hasCurrentLongPressPosition
+          ? _cacheLongPressPosition
+          : (lastTapDownDetails?.localPosition ?? d.localPosition);
+      final panState = _TouchModePanState(touchSequence);
+      _touchModePanState = panState;
+      // End/cancel awaits this future so an asynchronous start cannot leave a
+      // late mouse-down or an unmatched mouse-up behind.
+      panState.startFuture =
+          _startTouchModePan(panState, panStartPosition, d.localPosition);
+      await panState.startFuture;
     } else {
       final offset = ffi.cursorModel.offset;
       final cursorX = offset.dx;
@@ -401,6 +456,33 @@ class _RawTouchGestureDetectorRegionState
       if (!visible.contains(Offset(cursorX, cursorY))) {
         await ffi.cursorModel.move(size.width / 2, size.height / 2);
       }
+    }
+  }
+
+  Future<void> _startTouchModePan(_TouchModePanState panState,
+      Offset panStartPosition, Offset currentPosition) async {
+    final isMoved = await ffi.cursorModel
+        .move(panStartPosition.dx, panStartPosition.dy);
+    if (!isMoved ||
+        panState.cancelled ||
+        panState.touchSequence != _touchModeGestureTracker.sequence) {
+      return;
+    }
+
+    if (!inputModel.relativeMouseMode.value) {
+      await inputModel.sendMouse('down', MouseButtons.left);
+      panState.mouseDownSent = true;
+    }
+    if (panState.cancelled ||
+        panState.touchSequence != _touchModeGestureTracker.sequence) {
+      return;
+    }
+
+    if (!panState.ended) {
+      _touchModePanStarted = true;
+    }
+    if (panStartPosition != currentPosition) {
+      await ffi.cursorModel.move(currentPosition.dx, currentPosition.dy);
     }
   }
 
@@ -423,18 +505,21 @@ class _RawTouchGestureDetectorRegionState
   }
 
   onOneFingerPanEnd(DragEndDetails d) async {
+    final panState = _touchModePanState;
+    panState?.ended = true;
     _touchModePanStarted = false;
+    if (panState != null) {
+      if (isDesktop || isWebDesktop) {
+        ffi.cursorModel.clearRemoteWindowCoords();
+      }
+      await _finishTouchModePan(panState);
+      return;
+    }
     if (isNotTouchBasedDevice()) {
       return;
     }
     if (isDesktop || isWebDesktop) {
       ffi.cursorModel.clearRemoteWindowCoords();
-    }
-    if (handleTouch) {
-      // In relative mouse mode, skip mouse up - matches the skipped mouse down in onOneFingerPanStart
-      if (!inputModel.relativeMouseMode.value) {
-        await inputModel.sendMouse('up', MouseButtons.left);
-      }
     }
   }
 
@@ -442,13 +527,42 @@ class _RawTouchGestureDetectorRegionState
   // or rejected by the gesture arena. Without this, the flag can remain
   // stuck in the "started" state and cause issues such as the Magic Mouse
   // double-click problem on iPad with magic mouse.
-  onOneFingerPanCancel() {
+  onOneFingerPanCancel() async {
+    final panState = _touchModePanState;
+    panState?.cancelled = true;
     _touchModePanStarted = false;
+    if (panState != null) {
+      if (isDesktop || isWebDesktop) {
+        ffi.cursorModel.clearRemoteWindowCoords();
+      }
+      await _finishTouchModePan(panState);
+    }
+  }
+
+  Future<void> _finishTouchModePan(_TouchModePanState panState) async {
+    if (panState.finishing) {
+      return;
+    }
+    panState.finishing = true;
+    try {
+      await panState.startFuture;
+    } finally {
+      try {
+        if (panState.mouseDownSent) {
+          await inputModel.sendMouse('up', MouseButtons.left);
+        }
+      } finally {
+        if (identical(_touchModePanState, panState)) {
+          _touchModePanState = null;
+        }
+      }
+    }
   }
 
   // scale + pan event
   onTwoFingerScaleStart(ScaleStartDetails d) {
     _lastTapDownDetails = null;
+    _touchModeGestureTracker.clearTapDown();
     if (isNotTouchBasedDevice()) {
       return;
     }

--- a/flutter/lib/common/widgets/touch_mode_gesture_tracker.dart
+++ b/flutter/lib/common/widgets/touch_mode_gesture_tracker.dart
@@ -45,3 +45,22 @@ class TouchModeGestureTracker {
   bool shouldHandleTap(int sequence) =>
       sequence == _sequence && sequence != _panSequence;
 }
+
+/// Keeps tap delivery tied to the same physical touch across cursor movement.
+Future<void> handleTrackedTap({
+  required TouchModeGestureTracker tracker,
+  required int sequence,
+  required Future<bool> Function() move,
+  required Future<void> Function() sendTap,
+}) async {
+  if (!tracker.shouldHandleTap(sequence)) {
+    return;
+  }
+  if (!await move()) {
+    return;
+  }
+  if (!tracker.shouldHandleTap(sequence)) {
+    return;
+  }
+  await sendTap();
+}

--- a/flutter/lib/common/widgets/touch_mode_gesture_tracker.dart
+++ b/flutter/lib/common/widgets/touch_mode_gesture_tracker.dart
@@ -1,18 +1,17 @@
 /// Distinguishes callbacks from one physical touch sequence from stale ones.
 class TouchModeGestureTracker {
   final Set<int> _activePointers = <int>{};
+  final List<int> _pendingTapDowns = <int>[];
 
   int _sequence = 0;
-  int? _tapDownSequence;
-  int? _longPressSequence;
-  bool _panHandled = false;
+  int? _panSequence;
 
   int get sequence => _sequence;
 
   void pointerDown(int pointer) {
     if (_activePointers.isEmpty) {
       _sequence++;
-      _panHandled = false;
+      _panSequence = null;
     }
     _activePointers.add(pointer);
   }
@@ -21,30 +20,28 @@ class TouchModeGestureTracker {
     _activePointers.remove(pointer);
   }
 
-  void recordTapDown() {
-    _tapDownSequence = _sequence;
+  int recordTapDown() {
+    _pendingTapDowns.add(_sequence);
+    return _sequence;
   }
 
-  bool takeCurrentTapDown(int sequence) {
-    final isCurrent = _tapDownSequence == sequence;
-    _tapDownSequence = null;
-    return isCurrent;
+  int? takeNextTapDown() {
+    if (_pendingTapDowns.isEmpty) {
+      return null;
+    }
+    return _pendingTapDowns.removeAt(0);
   }
 
-  void clearTapDown() {
-    _tapDownSequence = null;
+  void clearTapDowns() {
+    _pendingTapDowns.clear();
   }
 
-  void recordLongPress() {
-    _longPressSequence = _sequence;
-  }
-
-  bool isCurrentLongPress(int sequence) => _longPressSequence == sequence;
-
-  void claimPan() {
-    _panHandled = true;
+  void claimPan(int sequence) {
+    if (sequence == _sequence) {
+      _panSequence = sequence;
+    }
   }
 
   bool shouldHandleTap(int sequence) =>
-      sequence == _sequence && !_panHandled;
+      sequence == _sequence && sequence != _panSequence;
 }

--- a/flutter/lib/common/widgets/touch_mode_gesture_tracker.dart
+++ b/flutter/lib/common/widgets/touch_mode_gesture_tracker.dart
@@ -1,0 +1,50 @@
+/// Distinguishes callbacks from one physical touch sequence from stale ones.
+class TouchModeGestureTracker {
+  final Set<int> _activePointers = <int>{};
+
+  int _sequence = 0;
+  int? _tapDownSequence;
+  int? _longPressSequence;
+  bool _panHandled = false;
+
+  int get sequence => _sequence;
+
+  void pointerDown(int pointer) {
+    if (_activePointers.isEmpty) {
+      _sequence++;
+      _panHandled = false;
+    }
+    _activePointers.add(pointer);
+  }
+
+  void pointerEnd(int pointer) {
+    _activePointers.remove(pointer);
+  }
+
+  void recordTapDown() {
+    _tapDownSequence = _sequence;
+  }
+
+  bool takeCurrentTapDown(int sequence) {
+    final isCurrent = _tapDownSequence == sequence;
+    _tapDownSequence = null;
+    return isCurrent;
+  }
+
+  void clearTapDown() {
+    _tapDownSequence = null;
+  }
+
+  void recordLongPress() {
+    _longPressSequence = _sequence;
+  }
+
+  bool isCurrentLongPress(int sequence) => _longPressSequence == sequence;
+
+  void claimPan() {
+    _panHandled = true;
+  }
+
+  bool shouldHandleTap(int sequence) =>
+      sequence == _sequence && !_panHandled;
+}

--- a/flutter/test/touch_mode_gesture_tracker_test.dart
+++ b/flutter/test/touch_mode_gesture_tracker_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_hbb/common/widgets/touch_mode_gesture_tracker.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -6,31 +8,54 @@ void main() {
     test('suppresses a late tap after the pan recognizer wins', () {
       final tracker = TouchModeGestureTracker();
       tracker.pointerDown(1);
-      final sequence = tracker.sequence;
-      tracker.recordTapDown();
+      final sequence = tracker.recordTapDown();
 
-      tracker.claimPan();
+      tracker.claimPan(sequence);
       tracker.pointerEnd(1);
 
-      expect(tracker.takeCurrentTapDown(sequence), isTrue);
+      expect(tracker.takeNextTapDown(), sequence);
       expect(tracker.shouldHandleTap(sequence), isFalse);
     });
 
-    test('a new physical touch invalidates cached gesture state', () {
+    test('a delayed callback does not consume a newer tap-down', () {
       final tracker = TouchModeGestureTracker();
       tracker.pointerDown(1);
-      final firstSequence = tracker.sequence;
-      tracker.recordTapDown();
-      tracker.recordLongPress();
+      final firstSequence = tracker.recordTapDown();
       tracker.pointerEnd(1);
 
       tracker.pointerDown(2);
-      final secondSequence = tracker.sequence;
+      final secondSequence = tracker.recordTapDown();
 
       expect(secondSequence, firstSequence + 1);
-      expect(tracker.takeCurrentTapDown(secondSequence), isFalse);
-      expect(tracker.isCurrentLongPress(secondSequence), isFalse);
+      expect(tracker.takeNextTapDown(), firstSequence);
+      expect(tracker.shouldHandleTap(firstSequence), isFalse);
+      expect(tracker.takeNextTapDown(), secondSequence);
       expect(tracker.shouldHandleTap(secondSequence), isTrue);
+    });
+
+    test('rejects a tap if a newer touch starts while work is pending',
+        () async {
+      final tracker = TouchModeGestureTracker();
+      tracker.pointerDown(1);
+      final firstSequence = tracker.recordTapDown();
+      final started = Completer<void>();
+      final resume = Completer<void>();
+
+      final result = () async {
+        if (!tracker.shouldHandleTap(firstSequence)) {
+          return false;
+        }
+        started.complete();
+        await resume.future;
+        return tracker.shouldHandleTap(firstSequence);
+      }();
+
+      await started.future;
+      tracker.pointerEnd(1);
+      tracker.pointerDown(2);
+      resume.complete();
+
+      expect(await result, isFalse);
     });
 
     test('additional pointers stay in the same touch sequence', () {

--- a/flutter/test/touch_mode_gesture_tracker_test.dart
+++ b/flutter/test/touch_mode_gesture_tracker_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_hbb/common/widgets/touch_mode_gesture_tracker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TouchModeGestureTracker', () {
+    test('suppresses a late tap after the pan recognizer wins', () {
+      final tracker = TouchModeGestureTracker();
+      tracker.pointerDown(1);
+      final sequence = tracker.sequence;
+      tracker.recordTapDown();
+
+      tracker.claimPan();
+      tracker.pointerEnd(1);
+
+      expect(tracker.takeCurrentTapDown(sequence), isTrue);
+      expect(tracker.shouldHandleTap(sequence), isFalse);
+    });
+
+    test('a new physical touch invalidates cached gesture state', () {
+      final tracker = TouchModeGestureTracker();
+      tracker.pointerDown(1);
+      final firstSequence = tracker.sequence;
+      tracker.recordTapDown();
+      tracker.recordLongPress();
+      tracker.pointerEnd(1);
+
+      tracker.pointerDown(2);
+      final secondSequence = tracker.sequence;
+
+      expect(secondSequence, firstSequence + 1);
+      expect(tracker.takeCurrentTapDown(secondSequence), isFalse);
+      expect(tracker.isCurrentLongPress(secondSequence), isFalse);
+      expect(tracker.shouldHandleTap(secondSequence), isTrue);
+    });
+
+    test('additional pointers stay in the same touch sequence', () {
+      final tracker = TouchModeGestureTracker();
+      tracker.pointerDown(1);
+      final sequence = tracker.sequence;
+
+      tracker.pointerDown(2);
+
+      expect(tracker.sequence, sequence);
+    });
+  });
+}

--- a/flutter/test/touch_mode_gesture_tracker_test.dart
+++ b/flutter/test/touch_mode_gesture_tracker_test.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_hbb/common/widgets/touch_mode_gesture_tracker.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -72,6 +74,66 @@ void main() {
       tracker.pointerDown(2);
 
       expect(tracker.sequence, sequence);
+    });
+
+    testWidgets('single taps work after a double tap wins the gesture arena',
+        (tester) async {
+      final tracker = TouchModeGestureTracker();
+      final callbacks = <String>[];
+      var clicks = 0;
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: Listener(
+          onPointerDown: (event) => tracker.pointerDown(event.pointer),
+          onPointerUp: (event) => tracker.pointerEnd(event.pointer),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTapDown: (_) {
+              callbacks.add('down');
+              tracker.recordTapDown();
+            },
+            onTapCancel: () {
+              callbacks.add('cancel');
+              tracker.takeNextTapDown();
+            },
+            onTapUp: (_) async {
+              final sequence = tracker.takeNextTapDown();
+              if (sequence == null) return;
+              await handleTrackedTap(
+                tracker: tracker,
+                sequence: sequence,
+                move: () async => true,
+                sendTap: () async => clicks++,
+              );
+            },
+            onDoubleTap: () {
+              callbacks.add('double');
+              tracker.clearTapDowns();
+            },
+            child: const SizedBox.expand(),
+          ),
+        ),
+      ));
+
+      final position = tester.getCenter(find.byType(GestureDetector));
+      // Hold each contact past the tap-down deadline. Flutter can then emit
+      // both tap-downs before the double-tap recognizer cancels only one tap.
+      for (var i = 0; i < 2; i++) {
+        final gesture = await tester.startGesture(position);
+        await tester.pump(kPressTimeout + const Duration(milliseconds: 1));
+        await gesture.up();
+        await tester.pump(kDoubleTapMinTime);
+      }
+      expect(callbacks, ['down', 'down', 'cancel', 'double']);
+      expect(clicks, 0);
+
+      // Both subsequent singles must be delivered; one successful tap is not
+      // enough to detect a queue that remains permanently one sequence behind.
+      for (var i = 1; i <= 2; i++) {
+        await tester.tapAt(position);
+        await tester.pump(kDoubleTapTimeout + const Duration(milliseconds: 1));
+        expect(clicks, i);
+      }
     });
   });
 }

--- a/flutter/test/touch_mode_gesture_tracker_test.dart
+++ b/flutter/test/touch_mode_gesture_tracker_test.dart
@@ -33,29 +33,35 @@ void main() {
       expect(tracker.shouldHandleTap(secondSequence), isTrue);
     });
 
-    test('rejects a tap if a newer touch starts while work is pending',
+    test('does not send a tap if a newer touch starts while move is pending',
         () async {
       final tracker = TouchModeGestureTracker();
       tracker.pointerDown(1);
       final firstSequence = tracker.recordTapDown();
       final started = Completer<void>();
       final resume = Completer<void>();
+      var clicks = 0;
 
-      final result = () async {
-        if (!tracker.shouldHandleTap(firstSequence)) {
-          return false;
-        }
-        started.complete();
-        await resume.future;
-        return tracker.shouldHandleTap(firstSequence);
-      }();
+      final result = handleTrackedTap(
+        tracker: tracker,
+        sequence: firstSequence,
+        move: () async {
+          started.complete();
+          await resume.future;
+          return true;
+        },
+        sendTap: () async {
+          clicks++;
+        },
+      );
 
       await started.future;
       tracker.pointerEnd(1);
       tracker.pointerDown(2);
       resume.complete();
 
-      expect(await result, isFalse);
+      await result;
+      expect(clicks, 0);
     });
 
     test('additional pointers stay in the same touch sequence', () {


### PR DESCRIPTION
## Summary

- Associate iOS tap-down state with the physical touch that created it.
- Mark a touch as pan-owned before the existing pan-start awaits, and reject stale taps before and after asynchronous cursor movement.
- Clear pending single-tap callbacks and cached tap-down details when a double tap wins, so subsequent single taps continue working.
- Keep existing long-press and pan start/update/end/cancel behavior unchanged.

## Problem and scope

In the reported iOS touch-mode case, a tap at a new location can first click the previous cursor position. Tap state must not be reused by a callback from another physical touch, or by a tap callback after pan recognition has claimed that touch.

The sequence tracking is limited to iOS. A double tap also needs explicit cleanup: Flutter 3.24.5 can deliver two tap-down callbacks followed by only one tap-cancel. Leaving the second entry pending causes later single taps to consume stale entries indefinitely. Cleanup happens synchronously in `onDoubleTap`, before its early returns and mouse events.

## Tests

`flutter/test/touch_mode_gesture_tracker_test.dart` covers:

- A late tap rejected after pan recognition.
- An older callback not consuming a newer tap's cached state.
- A new physical touch starting while cursor movement is deliberately paused.
- Multiple pointers belonging to the same physical touch sequence.
- Real Flutter tap/double-tap recognition delivering two tap-downs and one cancel, followed by two successful single taps.

Validation on Flutter 3.24.5 / Dart 3.5.4: all 5 tests pass in a minimal Flutter package containing byte-identical copies of the tracker and test file, and `flutter analyze --no-pub` reports no issues for that package. Removing double-tap cleanup in the test harness makes the new regression fail on the first subsequent single tap (expected 1 click, observed 0); restoring cleanup makes it pass. `git diff --check` also passes.

The widget regression uses a recognizer/tracker harness, not the full `RemoteInput` widget or a remote connection. Device validation of this master-based branch remains necessary; the earlier user-reported success was for the local 1.4.9 patch.

Fixes #16025


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents stale iOS touch-mode clicks by associating tap state with physical touch sequences.
- Tracks active pointers, pending tap-downs, and pan ownership on iOS.
- Revalidates tap ownership before and after asynchronous cursor movement.
- Clears residual tap state when double-tap or two-finger scale recognition supersedes a tap.
- Adds regression coverage for delayed callbacks, pan ownership, sequence transitions, and post-double-tap behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or repository-rule violations identified.

The sequence tracker validates taps both before and after cursor movement, synchronously records pan ownership, and cleans up double-tap state without exposing an interleaving that would discard a subsequent physical touch.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| flutter/lib/common/widgets/remote_input.dart | Integrates iOS pointer-sequence tracking into tap, pan, scale, cancellation, and double-tap gesture handling. |
| flutter/lib/common/widgets/touch_mode_gesture_tracker.dart | Adds a focused tracker that rejects stale or pan-owned tap callbacks around asynchronous cursor movement. |
| flutter/test/touch_mode_gesture_tracker_test.dart | Covers stale callbacks, pan ownership, multi-pointer sequencing, pending movement, and double-tap queue cleanup. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Pointer down] --> B[Start or join touch sequence]
  B --> C[Record tap-down sequence]
  C --> D{Pan claims sequence?}
  D -- Yes --> X[Suppress tap]
  D -- No --> E[Tap-up consumes queued sequence]
  E --> F{Sequence still current?}
  F -- No --> X
  F -- Yes --> G[Move remote cursor asynchronously]
  G --> H{Sequence still current and not pan-owned?}
  H -- No --> X
  H -- Yes --> I[Send mouse tap]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: clear pending iOS taps after double..."](https://github.com/rustdesk/rustdesk/commit/a112a123fa408bb232ce080c396a3164087ff319) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59359269)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS touch and gesture handling for overlapping, canceled, double-tap, and multi-touch interactions.
  * Prevented delayed or stale tap callbacks from triggering after a newer touch sequence or pan gesture.
  * Improved tap, pan, and two-finger scaling behavior with more reliable gesture completion and cleanup.
  * Ensured single taps are delivered correctly when a double-tap gesture takes precedence.

* **Tests**
  * Added coverage for gesture sequencing, delayed taps, pan transitions, cancellations, double taps, and multi-pointer interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->