### PR TITLE
fix: support iOS soft keyboard input in VM consoles

### DIFF
--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -45,15 +45,8 @@ class RawKeyFocusScope extends StatelessWidget {
                 : null,
             onKeyEvent: useRawKeyEvents
                 ? null
-                : (FocusNode node, KeyEvent event) {
-                    if (isIOS &&
-                        inputModel.vmKeyboardMode &&
-                        inputModel.peerPlatform == kPeerPlatformWindows &&
-                        !node.hasPrimaryFocus) {
-                      return KeyEventResult.skipRemainingHandlers;
-                    }
-                    return inputModel.handleKeyEvent(event);
-                  },
+                : (FocusNode node, KeyEvent event) =>
+                    inputModel.handleKeyEvent(event),
             child: child));
   }
 }

--- a/flutter/lib/common/widgets/remote_input.dart
+++ b/flutter/lib/common/widgets/remote_input.dart
@@ -45,8 +45,15 @@ class RawKeyFocusScope extends StatelessWidget {
                 : null,
             onKeyEvent: useRawKeyEvents
                 ? null
-                : (FocusNode node, KeyEvent event) =>
-                    inputModel.handleKeyEvent(event),
+                : (FocusNode node, KeyEvent event) {
+                    if (isIOS &&
+                        inputModel.vmKeyboardMode &&
+                        inputModel.peerPlatform == kPeerPlatformWindows &&
+                        !node.hasPrimaryFocus) {
+                      return KeyEventResult.skipRemainingHandlers;
+                    }
+                    return inputModel.handleKeyEvent(event);
+                  },
             child: child));
   }
 }

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -314,12 +314,16 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
 
     // Delete the different part in the old value.
     for (i = 0; i < subOldValue.length - common; ++i) {
-      inputModel.inputKey('VK_BACK');
+      if (!inputModel.inputVmKeyboardText('\b')) {
+        inputModel.inputKey('VK_BACK');
+      }
     }
 
     // Input the new string.
     if (newStr.length > 1) {
-      bind.sessionInputString(sessionId: sessionId, value: newStr);
+      if (!inputModel.inputVmKeyboardText(newStr)) {
+        bind.sessionInputString(sessionId: sessionId, value: newStr);
+      }
     } else {
       inputChar(newStr);
     }
@@ -380,6 +384,9 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
 
   void inputChar(String char) {
     if (!inputModel.keyboardInputAllowed) {
+      return;
+    }
+    if (inputModel.inputVmKeyboardText(char)) {
       return;
     }
     if (char == '\n') {
@@ -1006,6 +1013,12 @@ class _KeyHelpToolsState extends State<KeyHelpTools> {
       }, active: inputModel.command),
     ];
     final keys = <Widget>[
+      if (isIOS && isWin)
+        wrap('VM', () {
+          setState(() {
+            inputModel.vmKeyboardMode = !inputModel.vmKeyboardMode;
+          });
+        }, active: inputModel.vmKeyboardMode),
       wrap(
           ' Fn ',
           () => setState(

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -1068,13 +1068,15 @@ class InputModel {
     }
 
     for (final stroke in strokes) {
-      if (stroke.shift) {
-        sendPhysicalKey(vmLeftShiftUsbHid, true);
-      }
-      sendPhysicalKey(stroke.usbHid, true);
-      sendPhysicalKey(stroke.usbHid, false);
-      if (stroke.shift) {
-        sendPhysicalKey(vmLeftShiftUsbHid, false);
+      final events = vmKeyEventsForStroke(
+        stroke,
+        ctrl: ctrl,
+        shift: shift,
+        alt: alt,
+        command: command,
+      );
+      for (final event in events) {
+        sendPhysicalKey(event.usbHid, event.down);
       }
     }
     return true;

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -18,6 +18,7 @@ import '../../models/platform_model.dart';
 import '../../models/state_model.dart';
 import 'input_modifier_utils.dart';
 import 'relative_mouse_model.dart';
+import 'vm_keyboard_utils.dart';
 import '../common.dart';
 import '../consts.dart';
 
@@ -407,6 +408,9 @@ class InputModel {
 
   final WeakReference<FFI> parent;
   String keyboardMode = '';
+  // Physical US-key input is opt-in because normal host input should keep its
+  // Unicode and IME behavior.
+  bool vmKeyboardMode = false;
 
   // keyboard
   var shift = false;
@@ -1038,6 +1042,42 @@ class InputModel {
         ctrl: ctrl,
         shift: shift,
         command: command);
+  }
+
+  /// Sends supported iOS soft-keyboard text as physical keys in VM mode.
+  /// Returns false when the caller should use the normal text-input path.
+  bool inputVmKeyboardText(String text) {
+    if (!vmKeyboardMode ||
+        !isIOS ||
+        peerPlatform != kPeerPlatformWindows ||
+        !keyboardPerm ||
+        isViewCamera) {
+      return false;
+    }
+
+    final strokes = vmKeyStrokesForText(text);
+    if (strokes == null) return false;
+
+    void sendPhysicalKey(int usbHid, bool down) {
+      bind.sessionHandleFlutterKeyEvent(
+          sessionId: sessionId,
+          character: 'flutter_key_map',
+          usbHid: usbHid,
+          lockModes: 0,
+          downOrUp: down);
+    }
+
+    for (final stroke in strokes) {
+      if (stroke.shift) {
+        sendPhysicalKey(vmLeftShiftUsbHid, true);
+      }
+      sendPhysicalKey(stroke.usbHid, true);
+      sendPhysicalKey(stroke.usbHid, false);
+      if (stroke.shift) {
+        sendPhysicalKey(vmLeftShiftUsbHid, false);
+      }
+    }
+    return true;
   }
 
   static Map<String, dynamic> getMouseEventMove() => {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -1044,7 +1044,8 @@ class InputModel {
         command: command);
   }
 
-  /// Sends supported iOS soft-keyboard text as physical keys in VM mode.
+  /// Sends supported iOS soft-keyboard text as physical US-layout keys in VM
+  /// mode. The guest keyboard layout must be US-compatible.
   /// Returns false when the caller should use the normal text-input path.
   bool inputVmKeyboardText(String text) {
     if (!vmKeyboardMode ||
@@ -1059,12 +1060,9 @@ class InputModel {
     if (strokes == null) return false;
 
     void sendPhysicalKey(int usbHid, bool down) {
-      bind.sessionHandleFlutterKeyEvent(
-          sessionId: sessionId,
-          character: 'flutter_key_map',
-          usbHid: usbHid,
-          lockModes: 0,
-          downOrUp: down);
+      // Reuse the normal physical-key dispatch entry point. The sentinel only
+      // overrides the Rust-side keyboard mode for this explicit VM event.
+      newKeyboardMode('flutter_key_map', usbHid, down, false);
     }
 
     for (final stroke in strokes) {

--- a/flutter/lib/models/input_model.dart
+++ b/flutter/lib/models/input_model.dart
@@ -300,6 +300,17 @@ class ToReleaseKeys {
   KeyEvent? lastRCommandKeyEvent;
   KeyEvent? lastSuperKeyEvent;
 
+  bool get hasCtrlKeyDown =>
+      lastLCtrlKeyEvent != null || lastRCtrlKeyEvent != null;
+  bool get hasShiftKeyDown =>
+      lastLShiftKeyEvent != null || lastRShiftKeyEvent != null;
+  bool get hasAltKeyDown =>
+      lastLAltKeyEvent != null || lastRAltKeyEvent != null;
+  bool get hasCommandKeyDown =>
+      lastLCommandKeyEvent != null ||
+      lastRCommandKeyEvent != null ||
+      lastSuperKeyEvent != null;
+
   reset() {
     lastLShiftKeyEvent = null;
     lastRShiftKeyEvent = null;
@@ -637,7 +648,7 @@ class InputModel {
       if (!alt) {
         alt = true;
       }
-      toReleaseKeys.lastLAltKeyEvent = upEvent(e);
+      toReleaseKeys.lastRAltKeyEvent = upEvent(e);
     } else if (e.logicalKey == LogicalKeyboardKey.controlLeft) {
       if (!ctrl) {
         ctrl = true;
@@ -1072,6 +1083,10 @@ class InputModel {
         shift: shift,
         alt: alt,
         command: command,
+        ctrlAlreadyDown: toReleaseKeys.hasCtrlKeyDown,
+        shiftAlreadyDown: toReleaseKeys.hasShiftKeyDown,
+        altAlreadyDown: toReleaseKeys.hasAltKeyDown,
+        commandAlreadyDown: toReleaseKeys.hasCommandKeyDown,
       );
       for (final event in events) {
         sendPhysicalKey(event.usbHid, event.down);

--- a/flutter/lib/models/vm_keyboard_utils.dart
+++ b/flutter/lib/models/vm_keyboard_utils.dart
@@ -45,19 +45,24 @@ class VmKeyEvent {
       'VmKeyEvent(usbHid: 0x${usbHid.toRadixString(16)}, down: $down)';
 }
 
-/// Builds a balanced physical event sequence with active toolbar modifiers.
+/// Builds a balanced physical event sequence without releasing modifiers that
+/// are already held by a physical keyboard.
 List<VmKeyEvent> vmKeyEventsForStroke(
   VmKeyStroke stroke, {
   required bool ctrl,
   required bool shift,
   required bool alt,
   required bool command,
+  bool ctrlAlreadyDown = false,
+  bool shiftAlreadyDown = false,
+  bool altAlreadyDown = false,
+  bool commandAlreadyDown = false,
 }) {
   final modifiers = <int>[
-    if (ctrl) vmLeftControlUsbHid,
-    if (shift || stroke.shift) vmLeftShiftUsbHid,
-    if (alt) vmLeftAltUsbHid,
-    if (command) vmLeftGuiUsbHid,
+    if (ctrl && !ctrlAlreadyDown) vmLeftControlUsbHid,
+    if ((shift || stroke.shift) && !shiftAlreadyDown) vmLeftShiftUsbHid,
+    if (alt && !altAlreadyDown) vmLeftAltUsbHid,
+    if (command && !commandAlreadyDown) vmLeftGuiUsbHid,
   ];
   return [
     for (final modifier in modifiers) VmKeyEvent(modifier, true),

--- a/flutter/lib/models/vm_keyboard_utils.dart
+++ b/flutter/lib/models/vm_keyboard_utils.dart
@@ -21,7 +21,51 @@ class VmKeyStroke {
 
 // USB HID usages from the Keyboard/Keypad usage page (0x07). Flutter's
 // PhysicalKeyboardKey.usbHidUsage exposes the same values in its low 16 bits.
+const vmLeftControlUsbHid = 0xE0;
 const vmLeftShiftUsbHid = 0xE1;
+const vmLeftAltUsbHid = 0xE2;
+const vmLeftGuiUsbHid = 0xE3;
+
+/// One physical key transition sent by VM keyboard mode.
+class VmKeyEvent {
+  const VmKeyEvent(this.usbHid, this.down);
+
+  final int usbHid;
+  final bool down;
+
+  @override
+  bool operator ==(Object other) =>
+      other is VmKeyEvent && other.usbHid == usbHid && other.down == down;
+
+  @override
+  int get hashCode => Object.hash(usbHid, down);
+
+  @override
+  String toString() =>
+      'VmKeyEvent(usbHid: 0x${usbHid.toRadixString(16)}, down: $down)';
+}
+
+/// Builds a balanced physical event sequence with active toolbar modifiers.
+List<VmKeyEvent> vmKeyEventsForStroke(
+  VmKeyStroke stroke, {
+  required bool ctrl,
+  required bool shift,
+  required bool alt,
+  required bool command,
+}) {
+  final modifiers = <int>[
+    if (ctrl) vmLeftControlUsbHid,
+    if (shift || stroke.shift) vmLeftShiftUsbHid,
+    if (alt) vmLeftAltUsbHid,
+    if (command) vmLeftGuiUsbHid,
+  ];
+  return [
+    for (final modifier in modifiers) VmKeyEvent(modifier, true),
+    VmKeyEvent(stroke.usbHid, true),
+    VmKeyEvent(stroke.usbHid, false),
+    for (final modifier in modifiers.reversed) VmKeyEvent(modifier, false),
+  ];
+}
 
 const Map<int, VmKeyStroke> _specialAsciiStrokes = {
   0x08: VmKeyStroke(0x2A),

--- a/flutter/lib/models/vm_keyboard_utils.dart
+++ b/flutter/lib/models/vm_keyboard_utils.dart
@@ -107,7 +107,10 @@ const Map<int, VmKeyStroke> _specialAsciiStrokes = {
   0x7E: VmKeyStroke(0x35, shift: true),
 };
 
-/// Converts an ASCII rune to a physical US keyboard stroke.
+/// Converts an ASCII rune to a physical US-layout keyboard stroke.
+///
+/// The receiving VM guest must use a US-compatible keyboard layout. Returning
+/// null leaves the character on the existing Unicode/IME input path.
 VmKeyStroke? vmKeyStrokeForRune(int rune) {
   if (rune >= 0x61 && rune <= 0x7A) {
     return VmKeyStroke(0x04 + rune - 0x61);

--- a/flutter/lib/models/vm_keyboard_utils.dart
+++ b/flutter/lib/models/vm_keyboard_utils.dart
@@ -1,0 +1,94 @@
+/// A physical USB HID keyboard stroke used by VM keyboard mode.
+class VmKeyStroke {
+  const VmKeyStroke(this.usbHid, {this.shift = false});
+
+  final int usbHid;
+  final bool shift;
+
+  @override
+  bool operator ==(Object other) =>
+      other is VmKeyStroke &&
+      other.usbHid == usbHid &&
+      other.shift == shift;
+
+  @override
+  int get hashCode => Object.hash(usbHid, shift);
+
+  @override
+  String toString() =>
+      'VmKeyStroke(usbHid: 0x${usbHid.toRadixString(16)}, shift: $shift)';
+}
+
+// USB HID usages from the Keyboard/Keypad usage page (0x07). Flutter's
+// PhysicalKeyboardKey.usbHidUsage exposes the same values in its low 16 bits.
+const vmLeftShiftUsbHid = 0xE1;
+
+const Map<int, VmKeyStroke> _specialAsciiStrokes = {
+  0x08: VmKeyStroke(0x2A),
+  0x09: VmKeyStroke(0x2B),
+  0x0A: VmKeyStroke(0x28),
+  0x0D: VmKeyStroke(0x28),
+  0x20: VmKeyStroke(0x2C),
+  0x21: VmKeyStroke(0x1E, shift: true),
+  0x22: VmKeyStroke(0x34, shift: true),
+  0x23: VmKeyStroke(0x20, shift: true),
+  0x24: VmKeyStroke(0x21, shift: true),
+  0x25: VmKeyStroke(0x22, shift: true),
+  0x26: VmKeyStroke(0x24, shift: true),
+  0x27: VmKeyStroke(0x34),
+  0x28: VmKeyStroke(0x26, shift: true),
+  0x29: VmKeyStroke(0x27, shift: true),
+  0x2A: VmKeyStroke(0x25, shift: true),
+  0x2B: VmKeyStroke(0x2E, shift: true),
+  0x2C: VmKeyStroke(0x36),
+  0x2D: VmKeyStroke(0x2D),
+  0x2E: VmKeyStroke(0x37),
+  0x2F: VmKeyStroke(0x38),
+  0x3A: VmKeyStroke(0x33, shift: true),
+  0x3B: VmKeyStroke(0x33),
+  0x3C: VmKeyStroke(0x36, shift: true),
+  0x3D: VmKeyStroke(0x2E),
+  0x3E: VmKeyStroke(0x37, shift: true),
+  0x3F: VmKeyStroke(0x38, shift: true),
+  0x40: VmKeyStroke(0x1F, shift: true),
+  0x5B: VmKeyStroke(0x2F),
+  0x5C: VmKeyStroke(0x31),
+  0x5D: VmKeyStroke(0x30),
+  0x5E: VmKeyStroke(0x23, shift: true),
+  0x5F: VmKeyStroke(0x2D, shift: true),
+  0x60: VmKeyStroke(0x35),
+  0x7B: VmKeyStroke(0x2F, shift: true),
+  0x7C: VmKeyStroke(0x31, shift: true),
+  0x7D: VmKeyStroke(0x30, shift: true),
+  0x7E: VmKeyStroke(0x35, shift: true),
+};
+
+/// Converts an ASCII rune to a physical US keyboard stroke.
+VmKeyStroke? vmKeyStrokeForRune(int rune) {
+  if (rune >= 0x61 && rune <= 0x7A) {
+    return VmKeyStroke(0x04 + rune - 0x61);
+  }
+  if (rune >= 0x41 && rune <= 0x5A) {
+    return VmKeyStroke(0x04 + rune - 0x41, shift: true);
+  }
+  if (rune >= 0x31 && rune <= 0x39) {
+    return VmKeyStroke(0x1E + rune - 0x31);
+  }
+  if (rune == 0x30) {
+    return const VmKeyStroke(0x27);
+  }
+  return _specialAsciiStrokes[rune];
+}
+
+/// Returns null when any character requires the normal Unicode/IME path.
+List<VmKeyStroke>? vmKeyStrokesForText(String text) {
+  if (text.isEmpty) return null;
+
+  final strokes = <VmKeyStroke>[];
+  for (final rune in text.runes) {
+    final stroke = vmKeyStrokeForRune(rune);
+    if (stroke == null) return null;
+    strokes.add(stroke);
+  }
+  return strokes;
+}

--- a/flutter/test/vm_keyboard_utils_test.dart
+++ b/flutter/test/vm_keyboard_utils_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_hbb/models/vm_keyboard_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('vmKeyStrokeForRune', () {
+    test('maps 12345 to USB HID usages instead of ASCII codes', () {
+      final usages = vmKeyStrokesForText('12345')!
+          .map((stroke) => stroke.usbHid)
+          .toList();
+
+      expect(usages, const [0x1E, 0x1F, 0x20, 0x21, 0x22]);
+      expect(usages, isNot(const [0x31, 0x32, 0x33, 0x34, 0x35]));
+    });
+
+    test('maps lowercase and uppercase letters', () {
+      expect(vmKeyStrokeForRune('a'.runes.single), const VmKeyStroke(0x04));
+      expect(vmKeyStrokeForRune('Z'.runes.single),
+          const VmKeyStroke(0x1D, shift: true));
+    });
+
+    test('maps editing keys used by the hidden iOS text field', () {
+      expect(vmKeyStrokeForRune('\b'.runes.single), const VmKeyStroke(0x2A));
+      expect(vmKeyStrokeForRune('\n'.runes.single), const VmKeyStroke(0x28));
+      expect(vmKeyStrokeForRune(' '.runes.single), const VmKeyStroke(0x2C));
+    });
+
+    test('leaves non-ASCII text on the Unicode path', () {
+      expect(vmKeyStrokeForRune('中'.runes.single), isNull);
+      expect(vmKeyStrokesForText('abc中'), isNull);
+    });
+
+    test('maps shifted number-row symbols', () {
+      expect(vmKeyStrokeForRune(r'$'.runes.single),
+          const VmKeyStroke(0x21, shift: true));
+      expect(vmKeyStrokeForRune('@'.runes.single),
+          const VmKeyStroke(0x1F, shift: true));
+    });
+  });
+}

--- a/flutter/test/vm_keyboard_utils_test.dart
+++ b/flutter/test/vm_keyboard_utils_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_hbb/models/vm_keyboard_utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('vmKeyStrokeForRune', () {
+  group('VM keyboard utilities', () {
     test('maps 12345 to USB HID usages instead of ASCII codes', () {
       final usages = vmKeyStrokesForText('12345')!
           .map((stroke) => stroke.usbHid)
@@ -34,6 +34,66 @@ void main() {
           const VmKeyStroke(0x21, shift: true));
       expect(vmKeyStrokeForRune('@'.runes.single),
           const VmKeyStroke(0x1F, shift: true));
+    });
+
+    test('wraps a VM stroke in active toolbar modifiers', () {
+      final events = vmKeyEventsForStroke(
+        const VmKeyStroke(0x06),
+        ctrl: true,
+        shift: false,
+        alt: false,
+        command: false,
+      );
+
+      expect(
+        events,
+        const [
+          VmKeyEvent(vmLeftControlUsbHid, true),
+          VmKeyEvent(0x06, true),
+          VmKeyEvent(0x06, false),
+          VmKeyEvent(vmLeftControlUsbHid, false),
+        ],
+      );
+    });
+
+    test('does not duplicate toolbar and character shift', () {
+      final events = vmKeyEventsForStroke(
+        const VmKeyStroke(0x1D, shift: true),
+        ctrl: false,
+        shift: true,
+        alt: false,
+        command: false,
+      );
+
+      expect(
+        events,
+        const [
+          VmKeyEvent(vmLeftShiftUsbHid, true),
+          VmKeyEvent(0x1D, true),
+          VmKeyEvent(0x1D, false),
+          VmKeyEvent(vmLeftShiftUsbHid, false),
+        ],
+      );
+    });
+
+    test('applies toolbar shift to an unshifted character', () {
+      final events = vmKeyEventsForStroke(
+        const VmKeyStroke(0x04),
+        ctrl: false,
+        shift: true,
+        alt: false,
+        command: false,
+      );
+
+      expect(
+        events,
+        const [
+          VmKeyEvent(vmLeftShiftUsbHid, true),
+          VmKeyEvent(0x04, true),
+          VmKeyEvent(0x04, false),
+          VmKeyEvent(vmLeftShiftUsbHid, false),
+        ],
+      );
     });
   });
 }

--- a/flutter/test/vm_keyboard_utils_test.dart
+++ b/flutter/test/vm_keyboard_utils_test.dart
@@ -159,33 +159,62 @@ void main() {
       );
     });
 
-    test('keeps a physical modifier held across a VM soft-key stroke', () {
-      final vmEvents = vmKeyEventsForStroke(
-        const VmKeyStroke(0x06),
-        ctrl: true,
-        shift: false,
-        alt: false,
-        command: false,
-        ctrlAlreadyDown: true,
-      );
+    for (final modifier in [
+      vmLeftControlUsbHid,
+      vmLeftShiftUsbHid,
+      vmLeftAltUsbHid,
+      vmLeftGuiUsbHid,
+    ]) {
+      test('keeps physical modifier $modifier held across VM input', () {
+        final vmEvents = vmKeyEventsForStroke(
+          const VmKeyStroke(0x06),
+          ctrl: modifier == vmLeftControlUsbHid,
+          shift: modifier == vmLeftShiftUsbHid,
+          alt: modifier == vmLeftAltUsbHid,
+          command: modifier == vmLeftGuiUsbHid,
+          ctrlAlreadyDown: modifier == vmLeftControlUsbHid,
+          shiftAlreadyDown: modifier == vmLeftShiftUsbHid,
+          altAlreadyDown: modifier == vmLeftAltUsbHid,
+          commandAlreadyDown: modifier == vmLeftGuiUsbHid,
+        );
 
-      final completeSequence = [
-        const VmKeyEvent(vmLeftControlUsbHid, true),
-        ...vmEvents,
-        const VmKeyEvent(0x1B, true),
-        const VmKeyEvent(0x1B, false),
-        const VmKeyEvent(vmLeftControlUsbHid, false),
-      ];
+        final completeSequence = [
+          VmKeyEvent(modifier, true),
+          ...vmEvents,
+          const VmKeyEvent(0x1B, true),
+          const VmKeyEvent(0x1B, false),
+          VmKeyEvent(modifier, false),
+        ];
 
+        expect(
+          completeSequence,
+          [
+            VmKeyEvent(modifier, true),
+            const VmKeyEvent(0x06, true),
+            const VmKeyEvent(0x06, false),
+            const VmKeyEvent(0x1B, true),
+            const VmKeyEvent(0x1B, false),
+            VmKeyEvent(modifier, false),
+          ],
+        );
+      });
+    }
+
+    test('synthesizes toolbar Shift while physical Ctrl stays held', () {
       expect(
-        completeSequence,
+        vmKeyEventsForStroke(
+          const VmKeyStroke(0x06),
+          ctrl: true,
+          shift: true,
+          alt: false,
+          command: false,
+          ctrlAlreadyDown: true,
+        ),
         const [
-          VmKeyEvent(vmLeftControlUsbHid, true),
+          VmKeyEvent(vmLeftShiftUsbHid, true),
           VmKeyEvent(0x06, true),
           VmKeyEvent(0x06, false),
-          VmKeyEvent(0x1B, true),
-          VmKeyEvent(0x1B, false),
-          VmKeyEvent(vmLeftControlUsbHid, false),
+          VmKeyEvent(vmLeftShiftUsbHid, false),
         ],
       );
     });

--- a/flutter/test/vm_keyboard_utils_test.dart
+++ b/flutter/test/vm_keyboard_utils_test.dart
@@ -56,6 +56,46 @@ void main() {
       );
     });
 
+    test('wraps a VM stroke in the active Alt modifier', () {
+      final events = vmKeyEventsForStroke(
+        const VmKeyStroke(0x2B),
+        ctrl: false,
+        shift: false,
+        alt: true,
+        command: false,
+      );
+
+      expect(
+        events,
+        const [
+          VmKeyEvent(vmLeftAltUsbHid, true),
+          VmKeyEvent(0x2B, true),
+          VmKeyEvent(0x2B, false),
+          VmKeyEvent(vmLeftAltUsbHid, false),
+        ],
+      );
+    });
+
+    test('wraps a VM stroke in the active Command or Win modifier', () {
+      final events = vmKeyEventsForStroke(
+        const VmKeyStroke(0x0F),
+        ctrl: false,
+        shift: false,
+        alt: false,
+        command: true,
+      );
+
+      expect(
+        events,
+        const [
+          VmKeyEvent(vmLeftGuiUsbHid, true),
+          VmKeyEvent(0x0F, true),
+          VmKeyEvent(0x0F, false),
+          VmKeyEvent(vmLeftGuiUsbHid, false),
+        ],
+      );
+    });
+
     test('does not duplicate toolbar and character shift', () {
       final events = vmKeyEventsForStroke(
         const VmKeyStroke(0x1D, shift: true),

--- a/flutter/test/vm_keyboard_utils_test.dart
+++ b/flutter/test/vm_keyboard_utils_test.dart
@@ -135,5 +135,59 @@ void main() {
         ],
       );
     });
+
+    test('does not synthesize modifiers already held by a physical keyboard',
+        () {
+      final events = vmKeyEventsForStroke(
+        const VmKeyStroke(0x04, shift: true),
+        ctrl: true,
+        shift: true,
+        alt: true,
+        command: true,
+        ctrlAlreadyDown: true,
+        shiftAlreadyDown: true,
+        altAlreadyDown: true,
+        commandAlreadyDown: true,
+      );
+
+      expect(
+        events,
+        const [
+          VmKeyEvent(0x04, true),
+          VmKeyEvent(0x04, false),
+        ],
+      );
+    });
+
+    test('keeps a physical modifier held across a VM soft-key stroke', () {
+      final vmEvents = vmKeyEventsForStroke(
+        const VmKeyStroke(0x06),
+        ctrl: true,
+        shift: false,
+        alt: false,
+        command: false,
+        ctrlAlreadyDown: true,
+      );
+
+      final completeSequence = [
+        const VmKeyEvent(vmLeftControlUsbHid, true),
+        ...vmEvents,
+        const VmKeyEvent(0x1B, true),
+        const VmKeyEvent(0x1B, false),
+        const VmKeyEvent(vmLeftControlUsbHid, false),
+      ];
+
+      expect(
+        completeSequence,
+        const [
+          VmKeyEvent(vmLeftControlUsbHid, true),
+          VmKeyEvent(0x06, true),
+          VmKeyEvent(0x06, false),
+          VmKeyEvent(0x1B, true),
+          VmKeyEvent(0x1B, false),
+          VmKeyEvent(vmLeftControlUsbHid, false),
+        ],
+      );
+    });
   });
 }

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -994,6 +994,16 @@ impl<T: InvokeUiSession> Session<T> {
     ) {
         if character == "flutter_key" {
             self._handle_key_flutter_simulation(keyboard_mode, usb_hid, down_or_up);
+        } else if character == "flutter_key_map" {
+            // VM consoles require physical map-mode events even when the
+            // surrounding session uses legacy Unicode input.
+            self._handle_key_non_flutter_simulation(
+                "map",
+                "",
+                usb_hid,
+                lock_modes,
+                down_or_up,
+            );
         } else {
             self._handle_key_non_flutter_simulation(
                 keyboard_mode,


### PR DESCRIPTION
## Summary

- Add an opt-in `VM` toolbar mode for iOS sessions connected to Windows peers.
- Send supported ASCII soft-keyboard text as physical USB HID key events, using the existing keyboard dispatch entry point.
- Preserve toolbar Ctrl/Shift/Alt/Command modifiers without releasing modifiers already held by a physical keyboard.
- Validate the whole text before emitting any events; unsupported text uses the existing Unicode/IME fallback.

## Problem and scope

In the reported VMware guest, iOS software-keyboard input is misinterpreted: `12345` becomes `nm,./`, and letters may produce no input. VM mode sends the physical number-row usages `0x1e` through `0x22` instead of character values `0x31` through `0x35`.

This is a physical US-layout workaround: the guest must use a US-compatible keyboard layout. VM mode is disabled by default and does not change the session's saved keyboard mode. The shared keyboard-focus path is unchanged.

Modifier handling reuses the existing `toReleaseKeys` tracking for both left and right physical modifiers. Only modifiers synthesized for a VM stroke receive matching key-up events; a physically held modifier remains down until its physical release. Right-Alt tracking is corrected so that this check also covers that key.

## Tests

`flutter/test/vm_keyboard_utils_test.dart` covers digits, letters, editing keys, shifted symbols, all-or-nothing Unicode fallback, toolbar modifiers, and avoiding duplicate Shift events. It also covers each of Ctrl/Shift/Alt/Command held across VM input and a subsequent physical key, plus toolbar Shift while physical Ctrl remains held.

Validation on Flutter 3.24.5 / Dart 3.5.4: all 16 tests pass in a minimal Flutter package containing byte-identical copies of the utility and test file, and `flutter analyze --no-pub` reports no issues for that package. `git diff --check` also passes.

These are utility/event-sequence tests, not full `InputModel` dispatch or hardware integration tests. Device validation of this master-based branch remains necessary; the earlier user-reported success was for the local 1.4.9 patch.

Fixes #16027

Related: discussion #15954
