### PR TITLE
Keep the login when switching between servers

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3633,10 +3633,8 @@ Future<bool> setServerConfig(
   await bind.mainSetOption(key: 'api-server', value: config.apiServer);
   await bind.mainSetOption(key: 'key', value: config.key);
   final newApiServer = await bind.mainGetApiServer();
-  if (oldApiServer.isNotEmpty &&
-      oldApiServer != newApiServer &&
-      gFFI.userModel.isLogin) {
-    gFFI.userModel.logOut(apiServer: oldApiServer);
+  if (oldApiServer.isNotEmpty && oldApiServer != newApiServer) {
+    await gFFI.userModel.switchApiServer(oldApiServer, newApiServer);
   }
   return true;
 }

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -167,6 +167,51 @@ class UserModel {
     ]);
   }
 
+  // Sessions parked per API server while another server is in use, so that
+  // switching back restores the login instead of requiring a new one.
+  static const String _kParkedSessions = 'parked_sessions';
+
+  /// Called when the API server changes: park the session of the server being
+  /// left (the token is not invalidated, unlike [logOut]) and restore the one
+  /// parked for the server being switched to, if any.
+  Future<void> switchApiServer(
+      String oldApiServer, String newApiServer) async {
+    Map<String, dynamic> parked = {};
+    final raw = bind.mainGetLocalOption(key: _kParkedSessions);
+    if (raw.isNotEmpty) {
+      try {
+        parked = json.decode(raw);
+      } catch (e) {
+        debugPrint('Failed to decode parked sessions: $e');
+      }
+    }
+    final token = bind.mainGetLocalOption(key: 'access_token');
+    if (token.isNotEmpty) {
+      parked[oldApiServer] = {
+        'access_token': token,
+        'user_info': bind.mainGetLocalOption(key: 'user_info'),
+      };
+    } else {
+      parked.remove(oldApiServer);
+    }
+    final restored = parked.remove(newApiServer);
+    // Park before clearing the active session, so a crash in between cannot
+    // leave the session nowhere.
+    await bind.mainSetLocalOption(
+        key: _kParkedSessions, value: json.encode(parked));
+    await reset(resetOther: true);
+    if (restored is Map) {
+      await bind.mainSetLocalOption(
+          key: 'access_token',
+          value: (restored['access_token'] ?? '').toString());
+      await bind.mainSetLocalOption(
+          key: 'user_info', value: (restored['user_info'] ?? '').toString());
+      // An expired or revoked token comes back 401 here, which resets the
+      // session, so a stale parked login cleans itself up.
+      refreshCurrentUser();
+    }
+  }
+
   Future<void> logOut({String? apiServer}) async {
     final tag = gFFI.dialogManager.showLoading(translate('Waiting'));
     try {

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -119,6 +119,11 @@ class UserModel {
       }
     } finally {
       refreshingUser = false;
+      if (epoch != _sessionEpoch) {
+        // A refresh for the session that took over meanwhile was suppressed
+        // by refreshingUser while this one ran, so issue it now.
+        refreshCurrentUser();
+      }
       await updateOtherModels();
     }
   }

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -205,9 +205,10 @@ class UserModel {
     } else {
       parked.remove(oldApiServer);
     }
-    final restored = parked.remove(newApiServer);
-    // Park before clearing the active session, so a crash in between cannot
-    // leave the session nowhere.
+    final restored = parked[newApiServer];
+    // Park before clearing the active session, and unpark only after the
+    // restored one is active again, so a crash in between cannot leave
+    // either session nowhere.
     await bind.mainSetLocalOption(
         key: _kParkedSessions, value: json.encode(parked));
     await reset(resetOther: true);
@@ -217,6 +218,9 @@ class UserModel {
           value: (restored['access_token'] ?? '').toString());
       await bind.mainSetLocalOption(
           key: 'user_info', value: (restored['user_info'] ?? '').toString());
+      parked.remove(newApiServer);
+      await bind.mainSetLocalOption(
+          key: _kParkedSessions, value: json.encode(parked));
       // An expired or revoked token comes back 401 here, which resets the
       // session, so a stale parked login cleans itself up.
       refreshCurrentUser();

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -95,7 +95,13 @@ class UserModel {
       }
       final status = response.statusCode;
       if (status == 401 || status == 400) {
-        reset(resetOther: status == 401);
+        // Queued behind a server switch in progress and re-checked, so a
+        // reset that began before the switch cannot clear the session the
+        // switch restores.
+        _serializeSessionWrite(() async {
+          if (epoch != _sessionEpoch) return;
+          await reset(resetOther: status == 401);
+        });
         return;
       }
       final data = json.decode(decode_http_response(response));
@@ -188,10 +194,24 @@ class UserModel {
   // switching back restores the login instead of requiring a new one.
   static const String _kParkedSessions = 'parked_sessions';
 
+  // Writes to the active session are serialized, so that a switch and a
+  // 401 reset cannot interleave their multi-step storage updates.
+  Future<void> _sessionWrites = Future.value();
+
+  Future<T> _serializeSessionWrite<T>(Future<T> Function() write) {
+    final result = _sessionWrites.then((_) => write());
+    _sessionWrites = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
   /// Called when the API server changes: park the session of the server being
   /// left (the token is not invalidated, unlike [logOut]) and restore the one
   /// parked for the server being switched to, if any.
-  Future<void> switchApiServer(
+  Future<void> switchApiServer(String oldApiServer, String newApiServer) =>
+      _serializeSessionWrite(
+          () => _switchApiServer(oldApiServer, newApiServer));
+
+  Future<void> _switchApiServer(
       String oldApiServer, String newApiServer) async {
     _sessionEpoch++;
     Map<String, dynamic> parked = {};

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -50,8 +50,13 @@ class UserModel {
     });
   }
 
+  // Bumped on every server switch, so a refresh that was in flight against
+  // the previous server cannot apply its late response to the new session.
+  int _sessionEpoch = 0;
+
   void refreshCurrentUser() async {
     if (bind.isDisableAccount()) return;
+    final epoch = _sessionEpoch;
     networkError.value = '';
     networkErrorFromServer.value = false;
     final token = bind.mainGetLocalOption(key: 'access_token');
@@ -81,6 +86,11 @@ class UserModel {
         rethrow;
       }
       refreshingUser = false;
+      if (epoch != _sessionEpoch) {
+        // The response belongs to the session this refresh started with,
+        // not to the one now active.
+        return;
+      }
       final status = response.statusCode;
       if (status == 401 || status == 400) {
         reset(resetOther: status == 401);
@@ -176,6 +186,7 @@ class UserModel {
   /// parked for the server being switched to, if any.
   Future<void> switchApiServer(
       String oldApiServer, String newApiServer) async {
+    _sessionEpoch++;
     Map<String, dynamic> parked = {};
     final raw = bind.mainGetLocalOption(key: _kParkedSessions);
     if (raw.isNotEmpty) {

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -82,7 +82,9 @@ class UserModel {
             },
             body: json.encode(body));
       } catch (e) {
-        networkError.value = e.toString();
+        if (epoch == _sessionEpoch) {
+          networkError.value = e.toString();
+        }
         rethrow;
       }
       refreshingUser = false;
@@ -114,7 +116,7 @@ class UserModel {
       // retry. Anything not flagged above -- transport errors, non-JSON or
       // unexpected-schema bodies (e.g. a filter's block page) -- keeps the
       // check-your-network tip.
-      if (networkError.value.isEmpty) {
+      if (epoch == _sessionEpoch && networkError.value.isEmpty) {
         networkError.value = e.toString();
       }
     } finally {

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -219,6 +219,12 @@ class UserModel {
     await bind.mainSetLocalOption(
         key: _kParkedSessions, value: json.encode(parked));
     await reset(resetOther: true);
+    // Bump again now that the old token is gone: a refresh that a stale one
+    // re-issued while this was awaiting saw the new server with the old token,
+    // and its 401 must not reset the session restored below. Bumping before
+    // the restore, rather than after, leaves no moment in which a refresh can
+    // hold the final epoch together with that token.
+    _sessionEpoch++;
     if (restored is Map) {
       await bind.mainSetLocalOption(
           key: 'access_token',
@@ -228,12 +234,6 @@ class UserModel {
       parked.remove(newApiServer);
       await bind.mainSetLocalOption(
           key: _kParkedSessions, value: json.encode(parked));
-    }
-    // Bump again now that the switch is complete: a refresh that a stale one
-    // re-issued while this was awaiting saw the new server with the old token,
-    // and its 401 must not reset the session restored here.
-    _sessionEpoch++;
-    if (restored is Map) {
       // An expired or revoked token comes back 401 here, which resets the
       // session, so a stale parked login cleans itself up.
       refreshCurrentUser();

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -56,6 +56,9 @@ class UserModel {
 
   void refreshCurrentUser() async {
     if (bind.isDisableAccount()) return;
+    // Wait out a server switch in progress, so that the token read below is
+    // never the previous server's while the API server is already the new one.
+    await _sessionWrites;
     final epoch = _sessionEpoch;
     networkError.value = '';
     networkErrorFromServer.value = false;

--- a/flutter/lib/models/user_model.dart
+++ b/flutter/lib/models/user_model.dart
@@ -226,6 +226,12 @@ class UserModel {
       parked.remove(newApiServer);
       await bind.mainSetLocalOption(
           key: _kParkedSessions, value: json.encode(parked));
+    }
+    // Bump again now that the switch is complete: a refresh that a stale one
+    // re-issued while this was awaiting saw the new server with the old token,
+    // and its 401 must not reset the session restored here.
+    _sessionEpoch++;
+    if (restored is Map) {
       // An expired or revoked token comes back 401 here, which resets the
       // session, so a stale parked login cleans itself up.
       refreshCurrentUser();


### PR DESCRIPTION
## What this does

Changing the ID/API server currently logs the user out (`setServerConfig` posts `/api/logout` to the old server and clears the local token), because the stored access token belongs to a single API server. Anyone who alternates between two servers — e.g. a self-hosted server and the public one — has to log in again after every switch.

With this change, switching servers parks the session (access token + user info) of the server being left in a per-API-server map in the local config, and restores the session parked for the server being switched to, if there is one. So logging in on server A, switching to server B, and switching back to A leaves you logged in on A again.

## Notes

- The old server's token is intentionally no longer invalidated on switch — keeping it valid is what allows resuming the session later. An explicit logout still invalidates it as before.
- A restored token is refreshed against the server right away (`refreshCurrentUser`); an expired or revoked one comes back 401 and resets the session, so stale parked logins clean themselves up.
- The session is parked before the active one is cleared, so a crash in between cannot lose it.
- Restoring also runs when the user is currently logged out, so the `isLogin` condition at the call site is gone.

## Testing

- Log in on the public server, set a self-hosted server: no logout request is sent, the account UI shows logged out on the new server.
- Clear the server config back to public: the previous login reappears and `/api/currentUser` succeeds.
- Log in on both sides and alternate: each side keeps its own account.
- Restore a session whose token was revoked server-side: the 401 resets to logged out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Switching between API servers preserves the active session for the server being left.
  - Previously saved sessions are restored automatically when returning to an API server.
  - Restored sessions are refreshed to confirm they remain valid.

- **Bug Fixes**
  - Users are no longer unnecessarily logged out when changing API server settings.
  - Outdated session refreshes cannot affect the newly selected server session or display incorrect network errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->











<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR preserves separate authenticated sessions while switching API servers and adds epoch and write-serialization safeguards around refreshes. The current synchronization boundary still permits a cross-server bearer-token request during the API-option transition.
- Parks access tokens and user information under their API-server address.
- Restores and validates a parked session when returning to its server.
- Serializes switching and invalid-token resets while discarding stale refresh responses.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because an API-server switch can disclose the previous server's bearer token to the newly selected server.

The synchronization added for the previously reported token leak starts only inside `switchApiServer`, after the API-server option has already changed; `refreshCurrentUser` can therefore read the old token and the new URL and transmit them together.

**Files Needing Attention:** flutter/lib/common.dart and flutter/lib/models/user_model.dart
</details>


<details open><summary><h3>Security Review</h3></summary>

A refresh can capture the old session token and the newly configured API URL because the API-server option is updated outside the serialized session-switch boundary. This can disclose a valid bearer token to a different server.

**How this was verified:** The changed flow updates the API-server option before acquiring the session-write chain, while `refreshCurrentUser` reads the token before asynchronously reading and requesting the current API URL.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| flutter/lib/common.dart | Changes server switching from logout to session preservation, but updates the API-server option before entering the synchronization boundary used by session migration. |
| flutter/lib/models/user_model.dart | Adds parked sessions, epoch validation, and serialized writes, but refresh can still combine the previous token with the newly selected server URL. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as refreshCurrentUser
    participant C as setServerConfig
    participant O as Local options
    participant B as New API server
    R->>O: Read old server access_token
    C->>O: Set api-server to new server
    R->>O: Read current API URL
    Note over C,R: switchApiServer serialization has not started yet
    R->>B: POST /api/currentUser with old bearer token
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `flutter/lib/models/user_model.dart`, line 61-71 ([link](https://github.com/rustdesk/rustdesk/blob/34caf4fb05dbc60566bff0d47f3d327e3af342b6/flutter/lib/models/user_model.dart#L61-L71)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Bearer token crosses servers**

   If a refresh overlaps an API-server change, `refreshCurrentUser` can read the previous server's token before `setServerConfig` updates the server option, then read the new URL before `switchApiServer` enters the serialized session-write chain. The resulting `/api/currentUser` request discloses the still-valid bearer token to the newly selected server.

   **How this was verified:** The API-server option is updated before the session-write chain starts, while the refresh reads the token before asynchronously reading and requesting the current API URL.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: flutter/lib/models/user_model.dart
   Line: 61-71

   Comment:
   **Bearer token crosses servers**

   If a refresh overlaps an API-server change, `refreshCurrentUser` can read the previous server's token before `setServerConfig` updates the server option, then read the new URL before `switchApiServer` enters the serialized session-write chain. The resulting `/api/currentUser` request discloses the still-valid bearer token to the newly selected server.

   **How this was verified:** The API-server option is updated before the session-write chain starts, while the refresh reads the token before asynchronously reading and requesting the current API URL.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20flutter%2Flib%2Fmodels%2Fuser_model.dart%0ALine%3A%2061-71%0A%0AComment%3A%0A**Bearer%20token%20crosses%20servers**%0A%0AIf%20a%20refresh%20overlaps%20an%20API-server%20change%2C%20%60refreshCurrentUser%60%20can%20read%20the%20previous%20server's%20token%20before%20%60setServerConfig%60%20updates%20the%20server%20option%2C%20then%20read%20the%20new%20URL%20before%20%60switchApiServer%60%20enters%20the%20serialized%20session-write%20chain.%20The%20resulting%20%60%2Fapi%2FcurrentUser%60%20request%20discloses%20the%20still-valid%20bearer%20token%20to%20the%20newly%20selected%20server.%0A%0A**How%20this%20was%20verified%3A**%20The%20API-server%20option%20is%20updated%20before%20the%20session-write%20chain%20starts%2C%20while%20the%20refresh%20reads%20the%20token%20before%20asynchronously%20reading%20and%20requesting%20the%20current%20API%20URL.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16030&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22feat%2Fkeep-login-across-server-switch%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fkeep-login-across-server-switch%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20flutter%2Flib%2Fmodels%2Fuser_model.dart%0ALine%3A%2061-71%0A%0AComment%3A%0A**Bearer%20token%20crosses%20servers**%0A%0AIf%20a%20refresh%20overlaps%20an%20API-server%20change%2C%20%60refreshCurrentUser%60%20can%20read%20the%20previous%20server's%20token%20before%20%60setServerConfig%60%20updates%20the%20server%20option%2C%20then%20read%20the%20new%20URL%20before%20%60switchApiServer%60%20enters%20the%20serialized%20session-write%20chain.%20The%20resulting%20%60%2Fapi%2FcurrentUser%60%20request%20discloses%20the%20still-valid%20bearer%20token%20to%20the%20newly%20selected%20server.%0A%0A**How%20this%20was%20verified%3A**%20The%20API-server%20option%20is%20updated%20before%20the%20session-write%20chain%20starts%2C%20while%20the%20refresh%20reads%20the%20token%20before%20asynchronously%20reading%20and%20requesting%20the%20current%20API%20URL.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16030&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2316030%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=16030&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aflutter%2Flib%2Fmodels%2Fuser_model.dart%3A61-71%0A**Bearer%20token%20crosses%20servers**%0A%0AIf%20a%20refresh%20overlaps%20an%20API-server%20change%2C%20%60refreshCurrentUser%60%20can%20read%20the%20previous%20server's%20token%20before%20%60setServerConfig%60%20updates%20the%20server%20option%2C%20then%20read%20the%20new%20URL%20before%20%60switchApiServer%60%20enters%20the%20serialized%20session-write%20chain.%20The%20resulting%20%60%2Fapi%2FcurrentUser%60%20request%20discloses%20the%20still-valid%20bearer%20token%20to%20the%20newly%20selected%20server.%0A%0A**How%20this%20was%20verified%3A**%20The%20API-server%20option%20is%20updated%20before%20the%20session-write%20chain%20starts%2C%20while%20the%20refresh%20reads%20the%20token%20before%20asynchronously%20reading%20and%20requesting%20the%20current%20API%20URL.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16030&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22feat%2Fkeep-login-across-server-switch%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fkeep-login-across-server-switch%22.%0A%0A%23%23%23%20Issue%201%0Aflutter%2Flib%2Fmodels%2Fuser_model.dart%3A61-71%0A**Bearer%20token%20crosses%20servers**%0A%0AIf%20a%20refresh%20overlaps%20an%20API-server%20change%2C%20%60refreshCurrentUser%60%20can%20read%20the%20previous%20server's%20token%20before%20%60setServerConfig%60%20updates%20the%20server%20option%2C%20then%20read%20the%20new%20URL%20before%20%60switchApiServer%60%20enters%20the%20serialized%20session-write%20chain.%20The%20resulting%20%60%2Fapi%2FcurrentUser%60%20request%20discloses%20the%20still-valid%20bearer%20token%20to%20the%20newly%20selected%20server.%0A%0A**How%20this%20was%20verified%3A**%20The%20API-server%20option%20is%20updated%20before%20the%20session-write%20chain%20starts%2C%20while%20the%20refresh%20reads%20the%20token%20before%20asynchronously%20reading%20and%20requesting%20the%20current%20API%20URL.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16030&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
flutter/lib/models/user_model.dart:61-71
**Bearer token crosses servers**

If a refresh overlaps an API-server change, `refreshCurrentUser` can read the previous server's token before `setServerConfig` updates the server option, then read the new URL before `switchApiServer` enters the serialized session-write chain. The resulting `/api/currentUser` request discloses the still-valid bearer token to the newly selected server.

**How this was verified:** The API-server option is updated before the session-write chain starts, while the refresh reads the token before asynchronously reading and requesting the current API URL.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(account): do not start a user refres..."](https://github.com/rustdesk/rustdesk/commit/34caf4fb05dbc60566bff0d47f3d327e3af342b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59368430)</sub>

<!-- /greptile_comment -->