### PR TITLE
feat(windows): expose RDP session sharing through the CLI

### DIFF
--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -331,6 +331,33 @@ pub fn core_main() -> Option<Vec<String>> {
                     log::info!("Remote printer uninstalled");
                 }
                 return None;
+            } else if args[0] == "--share-rdp" {
+                if !platform::is_installed() {
+                    eprintln!("Installation required!");
+                    std::process::exit(1);
+                }
+                match parse_share_rdp_arg(&args) {
+                    Ok(None) => println!("{}", platform::windows::is_share_rdp()),
+                    Ok(Some(enable)) => {
+                        if is_cli_setting_change_disabled() {
+                            eprintln!("Settings are disabled!");
+                            std::process::exit(1);
+                        }
+                        if !is_root() {
+                            eprintln!("Administrative privileges required!");
+                            std::process::exit(1);
+                        }
+                        if let Err(err) = platform::windows::set_share_rdp(enable) {
+                            eprintln!("Failed to update RDP session sharing: {err}");
+                            std::process::exit(1);
+                        }
+                    }
+                    Err(err) => {
+                        eprintln!("{err}");
+                        std::process::exit(1);
+                    }
+                }
+                return None;
             }
         }
         #[cfg(target_os = "macos")]
@@ -912,6 +939,16 @@ fn parse_silent_install_args(args: &[String]) -> (Option<bool>, bool) {
     (printer_override, debug)
 }
 
+#[cfg(any(windows, test))]
+fn parse_share_rdp_arg(args: &[String]) -> Result<Option<bool>, &'static str> {
+    match args {
+        [_] => Ok(None),
+        [_, value] if value == "true" => Ok(Some(true)),
+        [_, value] if value == "false" => Ok(Some(false)),
+        _ => Err("Usage: rustdesk --share-rdp [true|false]"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -945,6 +982,21 @@ mod tests {
         ] {
             assert!(!is_user_main_ipc_scope_cli_command(&args(&[command])));
         }
+    }
+
+    #[test]
+    fn share_rdp_argument_is_optional_and_strict() {
+        assert_eq!(parse_share_rdp_arg(&args(&["--share-rdp"])), Ok(None));
+        assert_eq!(
+            parse_share_rdp_arg(&args(&["--share-rdp", "true"])),
+            Ok(Some(true))
+        );
+        assert_eq!(
+            parse_share_rdp_arg(&args(&["--share-rdp", "false"])),
+            Ok(Some(false))
+        );
+        assert!(parse_share_rdp_arg(&args(&["--share-rdp", "yes"])).is_err());
+        assert!(parse_share_rdp_arg(&args(&["--share-rdp", "true", "extra"])).is_err());
     }
 }
 

--- a/src/core_main.rs
+++ b/src/core_main.rs
@@ -332,13 +332,20 @@ pub fn core_main() -> Option<Vec<String>> {
                 }
                 return None;
             } else if args[0] == "--share-rdp" {
+                let enable = match parse_share_rdp_arg(&args) {
+                    Ok(enable) => enable,
+                    Err(err) => {
+                        eprintln!("{err}");
+                        std::process::exit(1);
+                    }
+                };
                 if !platform::is_installed() {
                     eprintln!("Installation required!");
                     std::process::exit(1);
                 }
-                match parse_share_rdp_arg(&args) {
-                    Ok(None) => println!("{}", platform::windows::is_share_rdp()),
-                    Ok(Some(enable)) => {
+                match enable {
+                    None => println!("{}", platform::windows::is_share_rdp()),
+                    Some(enable) => {
                         if is_cli_setting_change_disabled() {
                             eprintln!("Settings are disabled!");
                             std::process::exit(1);
@@ -351,10 +358,6 @@ pub fn core_main() -> Option<Vec<String>> {
                             eprintln!("Failed to update RDP session sharing: {err}");
                             std::process::exit(1);
                         }
-                    }
-                    Err(err) => {
-                        eprintln!("{err}");
-                        std::process::exit(1);
                     }
                 }
                 return None;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1071,7 +1071,7 @@ pub fn is_share_rdp() -> bool {
 
 fn share_rdp_reg_command(subkey: &str, enable: bool) -> String {
     format!(
-        "reg add {} /f /v share_rdp /t REG_SZ /d \"{}\"",
+        "reg add {} /f /v share_rdp /t REG_SZ /d \"{}\" || exit /b 1",
         subkey,
         if enable { "true" } else { "false" }
     )
@@ -4863,11 +4863,11 @@ mod tests {
         let subkey = r"HKEY_LOCAL_MACHINE\Software\RustDesk";
         assert_eq!(
             share_rdp_reg_command(subkey, true),
-            format!(r#"reg add {subkey} /f /v share_rdp /t REG_SZ /d "true""#)
+            format!(r#"reg add {subkey} /f /v share_rdp /t REG_SZ /d "true" || exit /b 1"#)
         );
         assert_eq!(
             share_rdp_reg_command(subkey, false),
-            format!(r#"reg add {subkey} /f /v share_rdp /t REG_SZ /d "false""#)
+            format!(r#"reg add {subkey} /f /v share_rdp /t REG_SZ /d "false" || exit /b 1"#)
         );
     }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1069,14 +1069,17 @@ pub fn is_share_rdp() -> bool {
     share_rdp() == TRUE
 }
 
-pub fn set_share_rdp(enable: bool) {
-    let (subkey, _, _, _) = get_install_info();
-    let cmd = format!(
+fn share_rdp_reg_command(subkey: &str, enable: bool) -> String {
+    format!(
         "reg add {} /f /v share_rdp /t REG_SZ /d \"{}\"",
         subkey,
         if enable { "true" } else { "false" }
-    );
-    run_cmds(cmd, false, "share_rdp").ok();
+    )
+}
+
+pub fn set_share_rdp(enable: bool) -> ResultType<()> {
+    let (subkey, _, _, _) = get_install_info();
+    run_cmds(share_rdp_reg_command(&subkey, enable), false, "share_rdp")
 }
 
 pub fn get_current_process_session_id() -> Option<u32> {
@@ -4853,6 +4856,19 @@ mod tests {
                 "unsafe application name was accepted: {app_name}"
             );
         }
+    }
+
+    #[test]
+    fn share_rdp_registry_command_uses_requested_state() {
+        let subkey = r"HKEY_LOCAL_MACHINE\Software\RustDesk";
+        assert_eq!(
+            share_rdp_reg_command(subkey, true),
+            format!(r#"reg add {subkey} /f /v share_rdp /t REG_SZ /d "true""#)
+        );
+        assert_eq!(
+            share_rdp_reg_command(subkey, false),
+            format!(r#"reg add {subkey} /f /v share_rdp /t REG_SZ /d "false""#)
+        );
     }
 
     #[test]

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -557,7 +557,9 @@ pub fn is_share_rdp() -> bool {
 #[inline]
 pub fn set_share_rdp(_enable: bool) {
     #[cfg(windows)]
-    crate::platform::windows::set_share_rdp(_enable);
+    if let Err(err) = crate::platform::windows::set_share_rdp(_enable) {
+        log::error!("Failed to update RDP session sharing: {err}");
+    }
 }
 
 #[inline]


### PR DESCRIPTION
inayayousfi directed the work and made every decision.
gpt-5.6-sol, running in OpenCode, carried inayayousfi's decisions out.

## Summary

This adds `rustdesk --share-rdp` on Windows. Calling it without a value prints the current state as `true` or `false`. Passing `true` or `false` updates the setting, while invalid or extra arguments return a usage error.

The command requires an installed client. Updates also respect the CLI settings lock and require administrator privileges. Registry write failures now return a nonzero exit code, and the existing UI path logs those failures instead of discarding them.

Unit tests cover argument parsing and registry command construction.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid `--share-rdp` values now show a usage error before installation checks.
  * Failures while enabling or disabling Windows Remote Desktop sharing are now reported instead of being silently ignored.
  * Registry update failures now correctly surface as errors.
  * Valid commands continue to support checking the current sharing status and enabling or disabling sharing when required permissions and settings are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a Windows CLI command for reading and updating RDP session sharing and propagates registry-write failures to both CLI and UI callers.
- Parses strict optional `true` or `false` values for `--share-rdp`.
- Enforces installation, settings-lock, and administrator requirements before updates.
- Preserves failed `reg add` exit statuses and reports them to callers.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/core_main.rs | Adds strict `--share-rdp` argument handling and the required installation, settings-lock, privilege, and failure-reporting paths. |
| src/platform/windows.rs | Changes the RDP registry setter to preserve command failures and return them to callers; the prior masking issue is resolved. |
| src/ui_interface.rs | Handles the setter’s new result by logging registry-update failures from the existing UI path. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[--share-rdp invocation] --> B{Argument valid?}
    B -- No --> C[Print usage and exit nonzero]
    B -- Yes --> D{Client installed?}
    D -- No --> E[Print installation error and exit nonzero]
    D -- Yes --> F{Value supplied?}
    F -- No --> G[Print current state]
    F -- Yes --> H{Settings unlocked and administrator?}
    H -- No --> I[Print permission error and exit nonzero]
    H -- Yes --> J[Run registry update]
    J --> K{Registry command succeeded?}
    K -- Yes --> L[Return success]
    K -- No --> M[Propagate error to CLI or UI logger]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(windows): preserve share RDP CLI err..."](https://github.com/rustdesk/rustdesk/commit/276399b6f058186319c36541142fd520d44491a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59697321)</sub>

<!-- /greptile_comment -->