### PR TITLE
fix(ci): install CMake 4.3 for ARM64 vcpkg builds

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -43,6 +43,7 @@ env:
   #  https://github.com/rustdesk/rustdesk/actions/runs/14414119794/job/40427970174
   # 2. Update the `VCPKG_COMMIT_ID` in `ci.yml` and `playground.yml`.
   VCPKG_COMMIT_ID: "9e593bb18ea69cc5095e012465dcd675a822ed0d"
+  VCPKG_CMAKE_VERSION: "4.3.0"
   ARMV7_VCPKG_COMMIT_ID: "6f29f12e82a8293156836ad81cc9bf5af41fe836" # 2025.01.13, got "/opt/artifacts/vcpkg/vcpkg: No such file or directory" with latest version
   VERSION: "1.5.0"
   NDK_VERSION: "r28c"
@@ -1570,6 +1571,15 @@ jobs:
         with:
           name: bridge-artifact
           path: ./
+
+      # vcpkg 2026.07.29's SPDX scripts require CMake 4.3+, but this ARM64 runner selects CMake 3.31.
+      - name: Install CMake for vcpkg on Linux ARM64
+        if: matrix.job.arch == 'aarch64' && env.UPLOAD_ARTIFACT == 'true'
+        run: |
+          python3 -m pip install --user "cmake==${VCPKG_CMAKE_VERSION}"
+          user_base="$(python3 -m site --user-base)"
+          "${user_base}/bin/cmake" --version
+          echo "${user_base}/bin" >> "${GITHUB_PATH}"
 
       - name: Setup vcpkg with Github Actions binary cache
         if: matrix.job.arch == 'x86_64' || env.UPLOAD_ARTIFACT == 'true'


### PR DESCRIPTION
fix: https://github.com/rustdesk/rustdesk/actions/runs/33699437638/job/100476975520

test: https://github.com/fufesou/rustdesk/actions/runs/33719859737/job/100538249151

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes ARM64 vcpkg CI setup by installing a pinned CMake 4.3 release before dependency provisioning.
- Adds `VCPKG_CMAKE_VERSION` to the workflow environment.
- Installs and verifies CMake 4.3.0 for ARM64 artifact builds.
- Prepends the user installation directory to subsequent steps through `GITHUB_PATH`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed workflow.

The new setup is limited to ARM64 artifact builds, verifies the installed CMake executable before use, and updates PATH for the subsequent host-side vcpkg steps.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/flutter-build.yml | Adds a narrowly gated, pinned CMake installation for ARM64 vcpkg builds; no actionable defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): install CMake 4.3 for ARM64 vcp..."](https://github.com/rustdesk/rustdesk/commit/254e74cea1d2674249f456f7943ff87e06945a42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59855715)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux ARM64 build processing to use the required CMake version when publishing artifacts.
  * Improved compatibility for dependency packaging on ARM64 build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->