### PR TITLE
feat(lan): discover peers across Tailscale

### DIFF
--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -115,7 +115,21 @@ class _PeersViewState extends State<_PeersView>
   void initState() {
     windowManager.addListener(this);
     WidgetsBinding.instance.addObserver(this);
+    if (widget.peerTabIndex == PeerTabIndex.lan) {
+      bind.mainLoadLanPeers();
+      bind.mainDiscover();
+    }
     super.initState();
+  }
+
+  @override
+  void didUpdateWidget(covariant _PeersView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.peerTabIndex != PeerTabIndex.lan &&
+        widget.peerTabIndex == PeerTabIndex.lan) {
+      bind.mainLoadLanPeers();
+      bind.mainDiscover();
+    }
   }
 
   @override
@@ -187,6 +201,16 @@ class _PeersViewState extends State<_PeersView>
       child: Consumer<Peers>(builder: (context, peers, child) {
         if (peers.peers.isEmpty) {
           gFFI.peerTabModel.setCurrentTabCachedPeers([]);
+          if (widget.peerTabIndex == PeerTabIndex.lan) {
+            return LanDiscoveryResultView(
+              state: peers.discoveryState,
+              foundPeers: false,
+              firewallBlocked: peers.discoveryFirewallBlocked,
+              discoveryEnabled: peers.discoveryEnabled,
+              onRetry: bind.mainDiscover,
+              child: LanDiscoveryEmptyState(state: peers.discoveryState),
+            );
+          }
           return Center(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -209,7 +233,18 @@ class _PeersViewState extends State<_PeersView>
             ),
           );
         } else {
-          return _buildPeersView(peers);
+          final child = _buildPeersView(peers);
+          if (widget.peerTabIndex == PeerTabIndex.lan) {
+            return LanDiscoveryResultView(
+              state: peers.discoveryState,
+              foundPeers: peers.discoveryFoundPeers,
+              firewallBlocked: peers.discoveryFirewallBlocked,
+              discoveryEnabled: peers.discoveryEnabled,
+              onRetry: bind.mainDiscover,
+              child: child,
+            );
+          }
+          return child;
         }
       }),
     );
@@ -501,13 +536,155 @@ class DiscoveredPeersView extends BasePeersView {
             menuPadding: menuPadding,
           ),
         );
+}
+
+const _lanDiscoveryNoResponseMessage =
+    'No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.';
+const _lanDiscoveryFirewallBlockedMessage =
+    "This device's firewall blocked LAN discovery. Some available devices may not appear in this list.";
+const _lanDiscoveryDisabledMessage =
+    'This device will not answer LAN discovery requests because "Deny LAN discovery" is enabled. It can still discover other devices.';
+
+class LanDiscoveryResultView extends StatelessWidget {
+  const LanDiscoveryResultView({
+    required this.state,
+    required this.foundPeers,
+    required this.firewallBlocked,
+    required this.discoveryEnabled,
+    required this.onRetry,
+    required this.child,
+    this.translateText = translate,
+    super.key,
+  });
+
+  final DiscoveryState state;
+  final bool foundPeers;
+  final bool firewallBlocked;
+  final bool discoveryEnabled;
+  final VoidCallback onRetry;
+  final Widget child;
+  final F translateText;
 
   @override
   Widget build(BuildContext context) {
-    final widget = super.build(context);
-    bind.mainLoadLanPeers();
-    bind.mainDiscover();
-    return widget;
+    final messages = <String>[];
+    if (state == DiscoveryState.failed) {
+      messages.add('Failed');
+    } else if (firewallBlocked) {
+      messages.add(_lanDiscoveryFirewallBlockedMessage);
+    } else if (state == DiscoveryState.completed && !foundPeers) {
+      messages.add(_lanDiscoveryNoResponseMessage);
+    }
+    if (!discoveryEnabled) {
+      messages.add(_lanDiscoveryDisabledMessage);
+    }
+    if (messages.isEmpty) {
+      return child;
+    }
+    final canRetry = state == DiscoveryState.failed ||
+        firewallBlocked ||
+        (state == DiscoveryState.completed && !foundPeers);
+
+    return Column(
+      children: [
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final message = Row(
+              children: [
+                const Icon(Icons.info_outline_rounded, size: 20)
+                    .paddingOnly(right: 10),
+                Expanded(
+                  child: Text(messages.map(translateText).join('\n\n')),
+                ),
+              ],
+            );
+            final retry = canRetry
+                ? OutlinedButton(
+                    onPressed: onRetry,
+                    child: Text(translateText('Retry')),
+                  )
+                : null;
+            return Material(
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: retry == null
+                    ? message
+                    : constraints.maxWidth < 600
+                        ? Column(
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            children: [
+                              message,
+                              retry.paddingOnly(top: 8),
+                            ],
+                          )
+                        : Row(
+                            children: [
+                              Expanded(child: message),
+                              retry.paddingOnly(left: 12),
+                            ],
+                          ),
+              ),
+            );
+          },
+        ).paddingOnly(bottom: 12),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+
+class LanDiscoveryEmptyState extends StatelessWidget {
+  const LanDiscoveryEmptyState({
+    required this.state,
+    this.translateText = translate,
+    super.key,
+  });
+
+  final DiscoveryState state;
+  final F translateText;
+
+  @override
+  Widget build(BuildContext context) {
+    if (state == DiscoveryState.scanning) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const SizedBox(
+              width: 32,
+              height: 32,
+              child: CircularProgressIndicator(),
+            ).paddingOnly(bottom: 12),
+            Text(translateText('Waiting')),
+          ],
+        ),
+      );
+    }
+
+    return Center(
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.sentiment_very_dissatisfied_rounded,
+              color: Theme.of(context).tabBarTheme.labelColor,
+              size: 40,
+            ).paddingOnly(bottom: 10),
+            if (state == DiscoveryState.idle)
+              Text(
+                translateText('empty_lan_tip'),
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: Theme.of(context).tabBarTheme.labelColor,
+                ),
+              ).paddingSymmetric(horizontal: 24),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -3769,7 +3769,10 @@ class FFI {
         loadEvent: LoadEvent.favorite,
         getInitPeers: null);
     lanPeersModel = Peers(
-        name: PeersModelName.lan, loadEvent: LoadEvent.lan, getInitPeers: null);
+        name: PeersModelName.lan,
+        loadEvent: LoadEvent.lan,
+        discoveryEvent: 'update_lan_discovery',
+        getInitPeers: null);
   }
 
   /// Mobile reuse FFI

--- a/flutter/lib/models/peer_model.dart
+++ b/flutter/lib/models/peer_model.dart
@@ -169,11 +169,14 @@ class Peer {
 
 enum UpdateEvent { online, load }
 
+enum DiscoveryState { idle, scanning, completed, failed }
+
 typedef GetInitPeers = RxList<Peer> Function();
 
 class Peers extends ChangeNotifier {
   final String name;
   final String loadEvent;
+  final String? discoveryEvent;
   List<Peer> peers = List.empty(growable: true);
   // Part of the peers that are not in the rest peers list.
   // When there're too many peers, we may want to load the front 100 peers first,
@@ -182,12 +185,17 @@ class Peers extends ChangeNotifier {
   List<String> restPeerIds = List.empty(growable: true);
   final GetInitPeers? getInitPeers;
   UpdateEvent event = UpdateEvent.load;
+  DiscoveryState discoveryState = DiscoveryState.idle;
+  bool discoveryFoundPeers = false;
+  bool discoveryFirewallBlocked = false;
+  bool discoveryEnabled = true;
   static const _cbQueryOnlines = 'callback_query_onlines';
 
   Peers(
       {required this.name,
       required this.getInitPeers,
-      required this.loadEvent}) {
+      required this.loadEvent,
+      this.discoveryEvent}) {
     peers = getInitPeers?.call() ?? [];
     platformFFI.registerEventHandler(_cbQueryOnlines, name, (evt) async {
       _updateOnlineState(evt);
@@ -195,12 +203,29 @@ class Peers extends ChangeNotifier {
     platformFFI.registerEventHandler(loadEvent, name, (evt) async {
       _updatePeers(evt);
     });
+    if (discoveryEvent != null) {
+      platformFFI.registerEventHandler(discoveryEvent!, name, (evt) async {
+        discoveryState = switch (evt['status']) {
+          'scanning' => DiscoveryState.scanning,
+          'completed' => DiscoveryState.completed,
+          'failed' => DiscoveryState.failed,
+          _ => DiscoveryState.idle,
+        };
+        discoveryFoundPeers = evt['found_peers'] == 'true';
+        discoveryFirewallBlocked = evt['firewall_blocked'] == 'true';
+        discoveryEnabled = evt['discovery_enabled'] != 'false';
+        notifyListeners();
+      });
+    }
   }
 
   @override
   void dispose() {
     platformFFI.unregisterEventHandler(_cbQueryOnlines, name);
     platformFFI.unregisterEventHandler(loadEvent, name);
+    if (discoveryEvent != null) {
+      platformFFI.unregisterEventHandler(discoveryEvent!, name);
+    }
     super.dispose();
   }
 

--- a/flutter/test/lan_discovery_empty_state_test.dart
+++ b/flutter/test/lan_discovery_empty_state_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_hbb/common/widgets/peers_view.dart';
+import 'package:flutter_hbb/models/peer_model.dart';
+
+void main() {
+  Widget app(
+    DiscoveryState state,
+    VoidCallback onRetry, {
+    bool foundPeers = false,
+    bool firewallBlocked = false,
+    bool discoveryEnabled = true,
+    Widget? child,
+  }) {
+    return MaterialApp(
+      home: LanDiscoveryResultView(
+        state: state,
+        foundPeers: foundPeers,
+        firewallBlocked: firewallBlocked,
+        discoveryEnabled: discoveryEnabled,
+        onRetry: onRetry,
+        child: child ??
+            LanDiscoveryEmptyState(
+              state: state,
+              translateText: (text) => text,
+            ),
+        translateText: (text) => text,
+      ),
+    );
+  }
+
+  testWidgets('shows progress only while discovery is scanning',
+      (tester) async {
+    await tester.pumpWidget(app(DiscoveryState.scanning, () {}));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('Waiting'), findsOneWidget);
+    expect(find.text('Retry'), findsNothing);
+  });
+
+  testWidgets('shows guidance and retries after discovery completes',
+      (tester) async {
+    var retries = 0;
+    await tester.pumpWidget(app(DiscoveryState.completed, () => retries++));
+
+    expect(
+      find.text(
+        'No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.',
+      ),
+      findsOneWidget,
+    );
+    await tester.ensureVisible(find.text('Retry'));
+    await tester.tap(find.text('Retry'));
+
+    expect(retries, 1);
+  });
+
+  testWidgets('keeps cached peers visible when a scan gets no responses',
+      (tester) async {
+    var retries = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LanDiscoveryResultView(
+          state: DiscoveryState.completed,
+          foundPeers: false,
+          firewallBlocked: false,
+          discoveryEnabled: true,
+          onRetry: () => retries++,
+          translateText: (text) => text,
+          child: const Text('Cached peer'),
+        ),
+      ),
+    );
+
+    expect(find.text('Cached peer'), findsOneWidget);
+    expect(
+      find.text(
+        'No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.',
+      ),
+      findsOneWidget,
+    );
+    await tester.tap(find.text('Retry'));
+
+    expect(retries, 1);
+  });
+
+  testWidgets('reports a failed scan without claiming devices did not respond',
+      (tester) async {
+    await tester.pumpWidget(app(DiscoveryState.failed, () {}));
+
+    expect(find.text('Failed'), findsOneWidget);
+    expect(find.textContaining('No devices responded'), findsNothing);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('lays out the cached peer banner at narrow width',
+      (tester) async {
+    await tester.binding.setSurfaceSize(const Size(320, 600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LanDiscoveryResultView(
+          state: DiscoveryState.completed,
+          foundPeers: false,
+          firewallBlocked: false,
+          discoveryEnabled: true,
+          onRetry: () {},
+          translateText: (text) => text,
+          child: const Text('Cached peer'),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Cached peer'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('shows a firewall warning beside visible peers', (tester) async {
+    await tester.pumpWidget(app(
+      DiscoveryState.completed,
+      () {},
+      foundPeers: true,
+      firewallBlocked: true,
+      child: const Text('Tailnet peer'),
+    ));
+
+    expect(find.text('Tailnet peer'), findsOneWidget);
+    expect(
+      find.text(
+        "This device's firewall blocked LAN discovery. Some available devices may not appear in this list.",
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('No devices responded'), findsNothing);
+  });
+
+  testWidgets('explains disabled incoming discovery beside visible peers',
+      (tester) async {
+    await tester.pumpWidget(app(
+      DiscoveryState.completed,
+      () {},
+      foundPeers: true,
+      discoveryEnabled: false,
+      child: const Text('Tailnet peer'),
+    ));
+
+    expect(find.text('Tailnet peer'), findsOneWidget);
+    expect(
+      find.text(
+        'This device will not answer LAN discovery requests because "Deny LAN discovery" is enabled. It can still discover other devices.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Retry'), findsNothing);
+  });
+}

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1552,6 +1552,24 @@ pub fn main_load_lan_peers() {
     );
 }
 
+pub(crate) fn main_update_lan_discovery(status: &str, found_peers: bool, firewall_blocked: bool) {
+    let discovery_enabled = config::option2bool(
+        "enable-lan-discovery",
+        &config::Config::get_option("enable-lan-discovery"),
+    );
+    let data = HashMap::from([
+        ("name", "update_lan_discovery".to_owned()),
+        ("status", status.to_owned()),
+        ("found_peers", found_peers.to_string()),
+        ("firewall_blocked", firewall_blocked.to_string()),
+        ("discovery_enabled", discovery_enabled.to_string()),
+    ]);
+    let _res = flutter::push_global_event(
+        flutter::APP_TYPE_MAIN,
+        serde_json::ser::to_string(&data).unwrap_or_default(),
+    );
+}
+
 pub fn main_remove_discovered(id: String) {
     remove_discovered(id);
 }

--- a/src/lan.rs
+++ b/src/lan.rs
@@ -468,7 +468,7 @@ fn wait_response(
         if remaining.is_zero() {
             break;
         }
-        socket.set_read_timeout(Some(remaining.min(Duration::from_millis(10))))?;
+        socket.set_read_timeout(Some(remaining))?;
         let mut buf = [0; 2048];
         if let Ok((len, addr)) = socket.recv_from(&mut buf) {
             if let Ok(msg_in) = Message::parse_from_bytes(&buf[0..len]) {

--- a/src/lan.rs
+++ b/src/lan.rs
@@ -2,7 +2,7 @@
 use hbb_common::whoami;
 use hbb_common::{
     allow_err,
-    anyhow::bail,
+    anyhow::{anyhow, bail},
     config::Config,
     config::{self, RENDEZVOUS_PORT},
     log,
@@ -10,6 +10,7 @@ use hbb_common::{
     rendezvous_proto::*,
     tokio::{
         self,
+        io::AsyncReadExt,
         sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     },
     ResultType,
@@ -18,10 +19,44 @@ use hbb_common::{
 use std::{
     collections::{HashMap, HashSet},
     net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs, UdpSocket},
-    time::Instant,
+    process::Stdio,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime},
 };
 
 type Message = RendezvousMessage;
+
+pub struct DiscoveryResult {
+    pub found_peers: bool,
+    pub firewall_blocked: bool,
+}
+
+struct DiscoveryProbe {
+    socket: UdpSocket,
+    targets: Vec<SocketAddr>,
+}
+
+const DISCOVERY_SCAN_TIMEOUT: Duration = Duration::from_secs(15);
+const DISCOVERY_RETRY_BASE: Duration = Duration::from_millis(500);
+const DISCOVERY_RETRY_CAP: Duration = Duration::from_secs(8);
+const TAILSCALE_STATUS_MAX_BYTES: usize = 1024 * 1024;
+const TAILSCALE_STATUS_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+#[derive(serde::Deserialize)]
+struct TailscaleStatus {
+    #[serde(rename = "Peer", default)]
+    peers: HashMap<String, TailscalePeer>,
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+#[derive(serde::Deserialize)]
+struct TailscalePeer {
+    #[serde(rename = "TailscaleIPs", default)]
+    ips: Vec<IpAddr>,
+    #[serde(rename = "Online", default)]
+    online: bool,
+}
 
 #[cfg(not(target_os = "ios"))]
 pub(super) fn start_listening() -> ResultType<()> {
@@ -74,13 +109,28 @@ pub(super) fn start_listening() -> ResultType<()> {
 }
 
 #[tokio::main(flavor = "current_thread")]
-pub async fn discover() -> ResultType<()> {
-    let sockets = send_query()?;
-    let rx = spawn_wait_responses(sockets);
-    handle_received_peers(rx).await?;
+pub async fn discover(local_id: String) -> ResultType<DiscoveryResult> {
+    let local_ips = Arc::new(get_local_ips());
+    let (sockets, probes, query, scan_started, scan_deadline) =
+        send_query(&local_id, &local_ips).await?;
+    let response_ports = sockets
+        .iter()
+        .filter_map(|socket| socket.local_addr().ok().map(|addr| addr.port()))
+        .collect::<Vec<_>>();
+    spawn_query_retries(probes, query, scan_deadline);
+    let rx = spawn_wait_responses(sockets, local_id.clone(), local_ips, scan_deadline);
+    let found_peers = handle_received_peers(rx, &local_id).await?;
+    #[cfg(target_os = "linux")]
+    let firewall_blocked =
+        crate::platform::linux::lan_discovery_firewall_blocked(scan_started, &response_ports).await;
+    #[cfg(not(target_os = "linux"))]
+    let firewall_blocked = false;
 
     log::info!("discover ping done");
-    Ok(())
+    Ok(DiscoveryResult {
+        found_peers,
+        firewall_blocked,
+    })
 }
 
 pub fn send_wol(id: String) {
@@ -161,6 +211,28 @@ fn get_ipaddr_by_peer<A: ToSocketAddrs>(peer: A) -> Option<IpAddr> {
     };
 }
 
+fn get_local_ips() -> HashSet<IpAddr> {
+    #[cfg(not(target_os = "ios"))]
+    return default_net::get_interfaces()
+        .into_iter()
+        .flat_map(|interface| {
+            interface
+                .ipv4
+                .into_iter()
+                .map(|network| IpAddr::V4(network.addr))
+                .chain(
+                    interface
+                        .ipv6
+                        .into_iter()
+                        .map(|network| IpAddr::V6(network.addr)),
+                )
+        })
+        .collect();
+
+    #[cfg(target_os = "ios")]
+    HashSet::new()
+}
+
 fn create_broadcast_sockets() -> Vec<UdpSocket> {
     let mut ipv4s = Vec::new();
     // TODO: maybe we should use a better way to get ipv4 addresses.
@@ -185,46 +257,205 @@ fn create_broadcast_sockets() -> Vec<UdpSocket> {
     sockets
 }
 
-fn send_query() -> ResultType<Vec<UdpSocket>> {
-    let sockets = create_broadcast_sockets();
+async fn send_query(
+    local_id: &str,
+    local_ips: &HashSet<IpAddr>,
+) -> ResultType<(
+    Vec<UdpSocket>,
+    Vec<DiscoveryProbe>,
+    Vec<u8>,
+    SystemTime,
+    Instant,
+)> {
+    let mut sockets = create_broadcast_sockets();
     if sockets.is_empty() {
         bail!("Found no bindable ipv4 addresses");
     }
 
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    let targets = tailscale_targets(local_ips).await;
+
     let mut msg_out = Message::new();
     // We may not be able to get the mac address on mobile platforms.
     // So we need to use the id to avoid discovering ourselves.
-    #[cfg(any(target_os = "android", target_os = "ios"))]
-    let id = crate::ui_interface::get_id();
-    // `crate::ui_interface::get_id()` will cause error:
-    // `get_id()` uses async code with `current_thread`, which is not allowed in this context.
-    //
-    // No need to get id for desktop platforms.
-    // We can use the mac address to identify the device.
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    let id = "".to_owned();
     let peer = PeerDiscovery {
         cmd: "ping".to_owned(),
-        id,
+        id: local_id.to_owned(),
         ..Default::default()
     };
     msg_out.set_peer_discovery(peer);
     let out = msg_out.write_to_bytes()?;
+    let scan_started = SystemTime::now();
+    let scan_deadline = Instant::now() + DISCOVERY_SCAN_TIMEOUT;
     let maddr = SocketAddr::from(([255, 255, 255, 255], get_broadcast_port()));
+    let mut probes = Vec::new();
     for socket in &sockets {
         allow_err!(socket.send_to(&out, maddr));
+        probes.push(DiscoveryProbe {
+            socket: socket.try_clone()?,
+            targets: vec![maddr],
+        });
+    }
+
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    {
+        if !targets.is_empty() {
+            let socket = UdpSocket::bind(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))?;
+            for target in &targets {
+                allow_err!(socket.send_to(&out, target));
+            }
+            probes.push(DiscoveryProbe {
+                socket: socket.try_clone()?,
+                targets,
+            });
+            sockets.push(socket);
+        }
     }
     log::info!("discover ping sent");
-    Ok(sockets)
+    Ok((sockets, probes, out, scan_started, scan_deadline))
+}
+
+fn retry_ceiling(attempt: u32) -> Duration {
+    DISCOVERY_RETRY_BASE
+        .saturating_mul(2_u32.saturating_pow(attempt))
+        .min(DISCOVERY_RETRY_CAP)
+}
+
+fn full_jitter(ceiling: Duration) -> Duration {
+    use hbb_common::rand::Rng as _;
+
+    Duration::from_millis(hbb_common::rand::thread_rng().gen_range(0..=ceiling.as_millis() as u64))
+}
+
+fn retry_time(now: Instant, deadline: Instant, jitter: Duration) -> Option<Instant> {
+    now.checked_add(jitter).filter(|retry| *retry < deadline)
+}
+
+fn spawn_query_retries(probes: Vec<DiscoveryProbe>, query: Vec<u8>, deadline: Instant) {
+    std::thread::spawn(move || {
+        let mut attempt = 0;
+        loop {
+            let now = Instant::now();
+            let Some(retry) = retry_time(now, deadline, full_jitter(retry_ceiling(attempt))) else {
+                break;
+            };
+            std::thread::sleep(retry.saturating_duration_since(now));
+            if Instant::now() >= deadline {
+                break;
+            }
+            for probe in &probes {
+                for target in &probe.targets {
+                    allow_err!(probe.socket.send_to(&query, target));
+                }
+            }
+            attempt = attempt.saturating_add(1);
+        }
+    });
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn parse_tailscale_targets(
+    data: &[u8],
+    local_ips: &HashSet<IpAddr>,
+) -> ResultType<Vec<SocketAddr>> {
+    if data.len() > TAILSCALE_STATUS_MAX_BYTES {
+        bail!("Tailscale status output exceeds limit");
+    }
+    let status: TailscaleStatus = serde_json::from_slice(data)?;
+    let mut targets = HashSet::new();
+    for peer in status.peers.into_values().filter(|peer| peer.online) {
+        for ip in peer.ips {
+            if ip.is_ipv4() && !local_ips.contains(&ip) {
+                targets.insert(SocketAddr::new(ip, get_broadcast_port()));
+            }
+        }
+    }
+    Ok(targets.into_iter().collect())
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+async fn read_tailscale_status(command: &str) -> ResultType<Vec<u8>> {
+    let mut child = tokio::process::Command::new(command)
+        .args(["status", "--json"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()?;
+    let Some(stdout) = child.stdout.take() else {
+        bail!("Failed to read Tailscale status output");
+    };
+    let read = async {
+        let mut data = Vec::new();
+        stdout
+            .take((TAILSCALE_STATUS_MAX_BYTES + 1) as u64)
+            .read_to_end(&mut data)
+            .await?;
+        if data.len() > TAILSCALE_STATUS_MAX_BYTES {
+            child.kill().await.ok();
+            bail!("Tailscale status output exceeds limit");
+        }
+        let status = child.wait().await?;
+        if !status.success() {
+            bail!("Tailscale status command failed");
+        }
+        Ok(data)
+    };
+    match tokio::time::timeout(TAILSCALE_STATUS_TIMEOUT, read).await {
+        Ok(result) => result,
+        Err(_) => {
+            child.kill().await.ok();
+            Err(anyhow!("Tailscale status command timed out"))
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+async fn tailscale_targets(local_ips: &HashSet<IpAddr>) -> Vec<SocketAddr> {
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
+    let mut commands = vec!["tailscale"];
+    #[cfg(target_os = "macos")]
+    commands.push("/Applications/Tailscale.app/Contents/MacOS/Tailscale");
+
+    for command in commands {
+        match read_tailscale_status(command).await {
+            Ok(data) => match parse_tailscale_targets(&data, local_ips) {
+                Ok(targets) => return targets,
+                Err(err) => {
+                    log::debug!("Failed to parse Tailscale status: {err}");
+                    return Vec::new();
+                }
+            },
+            Err(err) => log::debug!("Failed to query Tailscale status with {command}: {err}"),
+        }
+    }
+    Vec::new()
+}
+
+fn is_usable_mac(mac: &str) -> bool {
+    !mac.is_empty() && mac != "00:00:00:00:00:00"
+}
+
+fn is_self_response(
+    local_id: &str,
+    local_ips: &HashSet<IpAddr>,
+    source_ip: IpAddr,
+    local_mac: &str,
+    peer: &PeerDiscovery,
+) -> bool {
+    (!local_id.is_empty() && peer.id == local_id)
+        || local_ips.contains(&source_ip)
+        || (is_usable_mac(local_mac)
+            && is_usable_mac(&peer.mac)
+            && local_mac.eq_ignore_ascii_case(&peer.mac))
 }
 
 fn wait_response(
     socket: UdpSocket,
-    timeout: Option<std::time::Duration>,
     tx: UnboundedSender<config::DiscoveryPeer>,
+    local_id: String,
+    local_ips: Arc<HashSet<IpAddr>>,
+    deadline: Instant,
 ) -> ResultType<()> {
-    let mut last_recv_time = Instant::now();
-
     let local_addr = socket.local_addr();
     let try_get_ip_by_peer = match local_addr.as_ref() {
         Err(..) => true,
@@ -232,14 +463,17 @@ fn wait_response(
     };
     let mut mac: Option<String> = None;
 
-    socket.set_read_timeout(timeout)?;
     loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        socket.set_read_timeout(Some(remaining.min(Duration::from_millis(10))))?;
         let mut buf = [0; 2048];
         if let Ok((len, addr)) = socket.recv_from(&mut buf) {
             if let Ok(msg_in) = Message::parse_from_bytes(&buf[0..len]) {
                 match msg_in.union {
                     Some(rendezvous_message::Union::PeerDiscovery(p)) => {
-                        last_recv_time = Instant::now();
                         if p.cmd == "pong" {
                             if !crate::common::is_valid_untrusted_peer_id(&p.id) {
                                 log::warn!(
@@ -270,7 +504,7 @@ fn wait_response(
                                 }
                             };
 
-                            if local_mac.is_empty() && p.mac.is_empty() || local_mac != p.mac {
+                            if !is_self_response(&local_id, &local_ips, addr.ip(), &local_mac, &p) {
                                 allow_err!(tx.send(config::DiscoveryPeer {
                                     id: p.id.clone(),
                                     ip_mac: HashMap::from([
@@ -288,30 +522,38 @@ fn wait_response(
                 }
             }
         }
-        if last_recv_time.elapsed().as_millis() > 3_000 {
-            break;
-        }
     }
     Ok(())
 }
 
-fn spawn_wait_responses(sockets: Vec<UdpSocket>) -> UnboundedReceiver<config::DiscoveryPeer> {
+fn spawn_wait_responses(
+    sockets: Vec<UdpSocket>,
+    local_id: String,
+    local_ips: Arc<HashSet<IpAddr>>,
+    deadline: Instant,
+) -> UnboundedReceiver<config::DiscoveryPeer> {
     let (tx, rx) = unbounded_channel::<_>();
     for socket in sockets {
         let tx_clone = tx.clone();
+        let local_id = local_id.clone();
+        let local_ips = local_ips.clone();
         std::thread::spawn(move || {
             allow_err!(wait_response(
-                socket,
-                Some(std::time::Duration::from_millis(10)),
-                tx_clone
+                socket, tx_clone, local_id, local_ips, deadline,
             ));
         });
     }
     rx
 }
 
-async fn handle_received_peers(mut rx: UnboundedReceiver<config::DiscoveryPeer>) -> ResultType<()> {
+async fn handle_received_peers(
+    mut rx: UnboundedReceiver<config::DiscoveryPeer>,
+    local_id: &str,
+) -> ResultType<bool> {
     let mut peers = config::LanPeers::load().peers;
+    if !local_id.is_empty() {
+        peers.retain(|peer| peer.id != local_id);
+    }
     peers.iter_mut().for_each(|peer| {
         peer.online = false;
     });
@@ -348,5 +590,117 @@ async fn handle_received_peers(mut rx: UnboundedReceiver<config::DiscoveryPeer>)
     config::LanPeers::store(&peers);
     #[cfg(feature = "flutter")]
     crate::flutter_ffi::main_load_lan_peers();
-    Ok(())
+    Ok(!response_set.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn peer(id: &str, mac: &str) -> PeerDiscovery {
+        PeerDiscovery {
+            id: id.to_owned(),
+            mac: mac.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn self_response_uses_id_ip_and_only_usable_macs() {
+        let local_ip: IpAddr = "100.64.0.1".parse().unwrap();
+        let remote_ip: IpAddr = "100.64.0.2".parse().unwrap();
+        let local_ips = HashSet::from([local_ip]);
+
+        assert!(is_self_response(
+            "123",
+            &local_ips,
+            remote_ip,
+            "",
+            &peer("123", "")
+        ));
+        assert!(is_self_response(
+            "123",
+            &local_ips,
+            local_ip,
+            "",
+            &peer("456", "")
+        ));
+        assert!(is_self_response(
+            "123",
+            &local_ips,
+            remote_ip,
+            "aa:bb:cc:dd:ee:ff",
+            &peer("456", "AA:BB:CC:DD:EE:FF")
+        ));
+        assert!(!is_self_response(
+            "123",
+            &local_ips,
+            remote_ip,
+            "",
+            &peer("456", "")
+        ));
+        assert!(!is_self_response(
+            "123",
+            &local_ips,
+            remote_ip,
+            "00:00:00:00:00:00",
+            &peer("456", "00:00:00:00:00:00")
+        ));
+    }
+
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    #[test]
+    fn parses_online_remote_tailscale_ipv4_targets() {
+        let local_ip: IpAddr = "100.64.0.1".parse().unwrap();
+        let data = br#"{
+            "Unknown": true,
+            "Peer": {
+                "a": {"Online": true, "TailscaleIPs": ["100.64.0.1", "100.64.0.2", "fd7a:115c:a1e0::1"]},
+                "b": {"Online": false, "TailscaleIPs": ["100.64.0.3"]},
+                "c": {"Online": true, "TailscaleIPs": ["100.64.0.2"]}
+            }
+        }"#;
+        let targets = parse_tailscale_targets(data, &HashSet::from([local_ip])).unwrap();
+
+        assert_eq!(targets, vec!["100.64.0.2:21119".parse().unwrap()]);
+    }
+
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    #[test]
+    fn rejects_invalid_or_oversized_tailscale_status() {
+        assert!(parse_tailscale_targets(b"not json", &HashSet::new()).is_err());
+        assert!(parse_tailscale_targets(
+            &vec![b' '; TAILSCALE_STATUS_MAX_BYTES + 1],
+            &HashSet::new()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn retry_backoff_doubles_and_caps() {
+        assert_eq!(retry_ceiling(0), Duration::from_millis(500));
+        assert_eq!(retry_ceiling(1), Duration::from_secs(1));
+        assert_eq!(retry_ceiling(2), Duration::from_secs(2));
+        assert_eq!(retry_ceiling(3), Duration::from_secs(4));
+        assert_eq!(retry_ceiling(4), Duration::from_secs(8));
+        assert_eq!(retry_ceiling(10), Duration::from_secs(8));
+    }
+
+    #[test]
+    fn retry_time_uses_jitter_and_stays_before_deadline() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_secs(15);
+        let ceiling = Duration::from_secs(4);
+
+        for _ in 0..100 {
+            assert!(full_jitter(ceiling) <= ceiling);
+        }
+
+        assert_eq!(
+            retry_time(now, deadline, Duration::from_millis(375)),
+            Some(now + Duration::from_millis(375))
+        );
+        assert_eq!(retry_time(now, deadline, Duration::from_secs(15)), None);
+        assert_eq!(retry_time(now, deadline, Duration::from_secs(16)), None);
+    }
 }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "قفل اللوحة"),
         ("Sync clipboard between sessions", "مزامنة الحافظة بين الجلسات"),
         ("sync-clipboard-between-sessions-tip", "النص أو الصور المنسوخة في جلسة بعيدة واحدة تُرسَل أيضًا إلى حافظة جلساتك المتصلة الأخرى."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Заблакіраваць палатно"),
         ("Sync clipboard between sessions", "Сінхранізаваць буфер абмену паміж сеансамі"),
         ("sync-clipboard-between-sessions-tip", "Тэкст або відарысы, скапіяваныя ў адным аддаленым сеансе, таксама адпраўляюцца ў буфер абмену іншых вашых падключаных сеансаў."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Заключване на платното"),
         ("Sync clipboard between sessions", "Синхронизиране на клипборда между сесиите"),
         ("sync-clipboard-between-sessions-tip", "Текст или изображения, копирани в една отдалечена сесия, се изпращат и към клипборда на другите ви свързани сесии."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Bloca el llenç"),
         ("Sync clipboard between sessions", "Sincronitza el porta-retalls entre sessions"),
         ("sync-clipboard-between-sessions-tip", "El text o les imatges copiats en una sessió remota també s'envien al porta-retalls de les altres sessions connectades."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "锁定画布"),
         ("Sync clipboard between sessions", "在会话间同步剪贴板"),
         ("sync-clipboard-between-sessions-tip", "在一个远程会话中复制的文本或图片也会发送到其他已连接会话的剪贴板。"),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Zamknout zobrazení"),
         ("Sync clipboard between sessions", "Synchronizovat schránku mezi relacemi"),
         ("sync-clipboard-between-sessions-tip", "Text nebo obrázky zkopírované v jedné vzdálené relaci se odešlou i do schránky ostatních připojených relací."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Lås lærred"),
         ("Sync clipboard between sessions", "Synkroniser udklipsholder mellem sessioner"),
         ("sync-clipboard-between-sessions-tip", "Tekst eller billeder, der kopieres i én fjernsession, sendes også til udklipsholderen i dine andre forbundne sessioner."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Sichtfeld sperren"),
         ("Sync clipboard between sessions", "Zwischenablage zwischen Sitzungen synchronisieren"),
         ("sync-clipboard-between-sessions-tip", "In einer Remote-Sitzung kopierter Text oder kopierte Bilder werden auch an die Zwischenablage Ihrer anderen verbundenen Sitzungen gesendet."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Κλείδωμα καμβά"),
         ("Sync clipboard between sessions", "Συγχρονισμός προχείρου μεταξύ συνεδριών"),
         ("sync-clipboard-between-sessions-tip", "Κείμενο ή εικόνες που αντιγράφονται σε μία απομακρυσμένη συνεδρία αποστέλλονται και στο πρόχειρο των άλλων συνδεδεμένων συνεδριών σας."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Ŝlosi kanvason"),
         ("Sync clipboard between sessions", "Sinkronigi poŝon inter seancoj"),
         ("sync-clipboard-between-sessions-tip", "Teksto aŭ bildoj kopiitaj en unu fora seanco ankaŭ sendiĝas al la poŝo de viaj aliaj konektitaj seancoj."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Bloquear lienzo"),
         ("Sync clipboard between sessions", "Sincronizar portapapeles entre sesiones"),
         ("sync-clipboard-between-sessions-tip", "El texto o las imágenes copiados en una sesión remota también se envían al portapapeles de tus otras sesiones conectadas."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Lukusta lõuend"),
         ("Sync clipboard between sessions", "Sünkrooni lõikelaud seansside vahel"),
         ("sync-clipboard-between-sessions-tip", "Ühes kaugseansis kopeeritud tekst või pildid saadetakse ka teiste ühendatud seansside lõikelauale."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Blokeatu oihala"),
         ("Sync clipboard between sessions", "Sinkronizatu arbela saioen artean"),
         ("sync-clipboard-between-sessions-tip", "Urruneko saio batean kopiatutako testua edo irudiak konektatutako beste saioen arbelera ere bidaltzen dira."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "قفل کردن صفحه"),
         ("Sync clipboard between sessions", "همگام‌سازی کلیپ‌بورد بین نشست‌ها"),
         ("sync-clipboard-between-sessions-tip", "متن یا تصاویری که در یک نشست راه دور کپی می‌شوند به کلیپ‌بورد سایر نشست‌های متصل شما نیز ارسال می‌شوند."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Lukitse näkymä"),
         ("Sync clipboard between sessions", "Synkronoi leikepöytä istuntojen välillä"),
         ("sync-clipboard-between-sessions-tip", "Yhdessä etäistunnossa kopioitu teksti tai kuvat lähetetään myös muiden yhdistettyjen istuntojen leikepöydälle."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Verrouiller la vue"),
         ("Sync clipboard between sessions", "Synchroniser le presse-papiers entre les sessions"),
         ("sync-clipboard-between-sessions-tip", "Le texte ou les images copiés dans une session distante sont également envoyés au presse-papiers de vos autres sessions connectées."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "ტილოს დაბლოკვა"),
         ("Sync clipboard between sessions", "გაცვლის ბუფერის სინქრონიზაცია სესიებს შორის"),
         ("sync-clipboard-between-sessions-tip", "ერთ დაშორებულ სესიაში დაკოპირებული ტექსტი ან სურათები ასევე იგზავნება თქვენი სხვა დაკავშირებული სესიების გაცვლის ბუფერში."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "કેનવાસ લોક કરો"),
         ("Sync clipboard between sessions", "સત્રો વચ્ચે ક્લિપબોર્ડ સિંક કરો"),
         ("sync-clipboard-between-sessions-tip", "એક રિમોટ સત્રમાં કૉપિ કરેલ ટેક્સ્ટ કે છબીઓ તમારા અન્ય જોડાયેલા સત્રોના ક્લિપબોર્ડ પર પણ મોકલવામાં આવે છે."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "נעל לוח ציור"),
         ("Sync clipboard between sessions", "סנכרן לוח בין סשנים"),
         ("sync-clipboard-between-sessions-tip", "טקסט או תמונות שהועתקו בסשן מרוחק אחד נשלחים גם ללוח של שאר הסשנים המחוברים שלך."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "कैनवास लॉक करें"),
         ("Sync clipboard between sessions", "सत्रों के बीच क्लिपबोर्ड सिंक करें"),
         ("sync-clipboard-between-sessions-tip", "एक रिमोट सत्र में कॉपी किए गए टेक्स्ट या चित्र आपके अन्य जुड़े सत्रों के क्लिपबोर्ड पर भी भेजे जाते हैं।"),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Zaključaj pozadinu"),
         ("Sync clipboard between sessions", "Sinkroniziraj međuspremnik između sesija"),
         ("sync-clipboard-between-sessions-tip", "Tekst ili slike kopirani u jednoj udaljenoj sesiji šalju se i u međuspremnik vaših ostalih povezanih sesija."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Nézet zárolása"),
         ("Sync clipboard between sessions", "Vágólap szinkronizálása a munkamenetek között"),
         ("sync-clipboard-between-sessions-tip", "Az egyik távoli munkamenetben másolt szöveg vagy kép a többi csatlakoztatott munkamenet vágólapjára is elküldésre kerül."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Kunci kanvas"),
         ("Sync clipboard between sessions", "Sinkronkan papan klip antar sesi"),
         ("sync-clipboard-between-sessions-tip", "Teks atau gambar yang disalin di satu sesi jarak jauh juga dikirim ke papan klip sesi terhubung Anda yang lain."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Blocca tela"),
         ("Sync clipboard between sessions", "Sincronizza gli appunti tra le sessioni"),
         ("sync-clipboard-between-sessions-tip", "Il testo o le immagini copiati in una sessione remota vengono inviati anche agli appunti delle altre sessioni connesse."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "キャンバスをロック"),
         ("Sync clipboard between sessions", "セッション間でクリップボードを同期"),
         ("sync-clipboard-between-sessions-tip", "1つのリモートセッションでコピーしたテキストや画像は、接続中の他のセッションのクリップボードにも送信されます。"),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "캔버스 잠금"),
         ("Sync clipboard between sessions", "세션 간 클립보드 동기화"),
         ("sync-clipboard-between-sessions-tip", "하나의 원격 세션에서 복사한 텍스트나 이미지는 연결된 다른 세션의 클립보드에도 전송됩니다."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Кенепті құлыптау"),
         ("Sync clipboard between sessions", "Сеанстар арасында көшіру-тақтасын синхрондау"),
         ("sync-clipboard-between-sessions-tip", "Бір қашықтағы сеанста көшірілген мәтін немесе суреттер басқа қосылған сеанстардың көшіру-тақтасына да жіберіледі."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Užrakinti drobę"),
         ("Sync clipboard between sessions", "Sinchronizuoti iškarpinę tarp seansų"),
         ("sync-clipboard-between-sessions-tip", "Viename nuotoliniame seanse nukopijuotas tekstas ar vaizdai taip pat siunčiami į kitų prijungtų seansų iškarpinę."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Bloķēt audeklu"),
         ("Sync clipboard between sessions", "Sinhronizēt starpliktuvi starp sesijām"),
         ("sync-clipboard-between-sessions-tip", "Vienā attālajā sesijā nokopētais teksts vai attēli tiek nosūtīti arī uz pārējo pievienoto sesiju starpliktuvi."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "ക്യാൻവാസ് ലോക്ക് ചെയ്യുക"),
         ("Sync clipboard between sessions", "സെഷനുകൾക്കിടയിൽ ക്ലിപ്പ്ബോർഡ് സമന്വയിപ്പിക്കുക"),
         ("sync-clipboard-between-sessions-tip", "ഒരു റിമോട്ട് സെഷനിൽ പകർത്തിയ ടെക്സ്റ്റോ ചിത്രങ്ങളോ നിങ്ങളുടെ മറ്റ് കണക്റ്റുചെയ്ത സെഷനുകളുടെ ക്ലിപ്പ്ബോർഡിലേക്കും അയയ്ക്കപ്പെടും."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Lås lerret"),
         ("Sync clipboard between sessions", "Synkroniser utklippstavlen mellom økter"),
         ("sync-clipboard-between-sessions-tip", "Tekst eller bilder som kopieres i én ekstern økt, sendes også til utklippstavlen i de andre tilkoblede øktene dine."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Canvas vergrendelen"),
         ("Sync clipboard between sessions", "Klembord synchroniseren tussen sessies"),
         ("sync-clipboard-between-sessions-tip", "Tekst of afbeeldingen die in één externe sessie worden gekopieerd, worden ook naar het klembord van uw andere verbonden sessies gestuurd."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Zablokuj ekran"),
         ("Sync clipboard between sessions", "Synchronizuj schowek między sesjami"),
         ("sync-clipboard-between-sessions-tip", "Tekst lub obrazy skopiowane w jednej sesji zdalnej są wysyłane także do schowka pozostałych połączonych sesji."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Bloquear tela"),
         ("Sync clipboard between sessions", "Sincronizar área de transferência entre sessões"),
         ("sync-clipboard-between-sessions-tip", "O texto ou as imagens copiados numa sessão remota também são enviados para a área de transferência das suas outras sessões ligadas."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Bloquear tela"),
         ("Sync clipboard between sessions", "Sincronizar área de transferência entre sessões"),
         ("sync-clipboard-between-sessions-tip", "Texto ou imagens copiados em uma sessão remota também são enviados para a área de transferência das suas outras sessões conectadas."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Blochează ecranul"),
         ("Sync clipboard between sessions", "Sincronizează clipboardul între sesiuni"),
         ("sync-clipboard-between-sessions-tip", "Textul sau imaginile copiate într-o sesiune la distanță sunt trimise și în clipboardul celorlalte sesiuni conectate."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Заблокировать холст"),
         ("Sync clipboard between sessions", "Синхронизировать буфер обмена между сеансами"),
         ("sync-clipboard-between-sessions-tip", "Текст или изображения, скопированные в одном удалённом сеансе, также отправляются в буфер обмена других подключённых сеансов."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Bloca sa tela"),
         ("Sync clipboard between sessions", "Sincroniza sa punta de billete intre is sessiones"),
         ("sync-clipboard-between-sessions-tip", "Su testu o is immàgines copiadas in una sessione remota sunt imbiadas fintzas a sa punta de billete de is àteras sessiones connètidas."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Uzamknúť zobrazenie"),
         ("Sync clipboard between sessions", "Synchronizovať schránku medzi reláciami"),
         ("sync-clipboard-between-sessions-tip", "Text alebo obrázky skopírované v jednej vzdialenej relácii sa odošlú aj do schránky ostatných pripojených relácií."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Zakleni platno"),
         ("Sync clipboard between sessions", "Sinhroniziraj odložišče med sejami"),
         ("sync-clipboard-between-sessions-tip", "Besedilo ali slike, kopirane v eni oddaljeni seji, se pošljejo tudi v odložišče vaših drugih povezanih sej."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Kyç canvas"),
         ("Sync clipboard between sessions", "Sinkronizo clipboard-in midis sesioneve"),
         ("sync-clipboard-between-sessions-tip", "Teksti ose imazhet e kopjuara në një sesion të largët dërgohen edhe në clipboard-in e sesioneve të tjera të lidhura."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Zaključaj pozadinu"),
         ("Sync clipboard between sessions", "Sinhronizuj klipbord između sesija"),
         ("sync-clipboard-between-sessions-tip", "Tekst ili slike kopirane u jednoj udaljenoj sesiji šalju se i u klipbord vaših ostalih povezanih sesija."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Lås canvas"),
         ("Sync clipboard between sessions", "Synkronisera urklipp mellan sessioner"),
         ("sync-clipboard-between-sessions-tip", "Text eller bilder som kopieras i en fjärrsession skickas även till urklipp i dina andra anslutna sessioner."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "கேன்வாஸைப் பூட்டு"),
         ("Sync clipboard between sessions", "அமர்வுகளுக்கு இடையே கிளிப்போர்டை ஒத்திசைக்கவும்"),
         ("sync-clipboard-between-sessions-tip", "ஒரு தொலை அமர்வில் நகலெடுக்கப்பட்ட உரை அல்லது படங்கள் உங்கள் பிற இணைக்கப்பட்ட அமர்வுகளின் கிளிப்போர்டுக்கும் அனுப்பப்படும்."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", ""),
         ("Sync clipboard between sessions", ""),
         ("sync-clipboard-between-sessions-tip", ""),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "ล็อคแคนวาส"),
         ("Sync clipboard between sessions", "ซิงค์คลิปบอร์ดระหว่างเซสชัน"),
         ("sync-clipboard-between-sessions-tip", "ข้อความหรือรูปภาพที่คัดลอกในเซสชันระยะไกลหนึ่งจะถูกส่งไปยังคลิปบอร์ดของเซสชันอื่นที่เชื่อมต่ออยู่ด้วย"),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Tuvali kilitle"),
         ("Sync clipboard between sessions", "Oturumlar arasında panoyu senkronize et"),
         ("sync-clipboard-between-sessions-tip", "Bir uzak oturumda kopyalanan metin veya görseller, bağlı diğer oturumlarınızın panosuna da gönderilir."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "鎖定畫布"),
         ("Sync clipboard between sessions", "在工作階段間同步剪貼簿"),
         ("sync-clipboard-between-sessions-tip", "在一個遠端工作階段中複製的文字或圖片也會傳送到其他已連線工作階段的剪貼簿。"),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Блокування полотна"),
         ("Sync clipboard between sessions", "Синхронізувати буфер обміну між сеансами"),
         ("sync-clipboard-between-sessions-tip", "Текст або зображення, скопійовані в одному віддаленому сеансі, також надсилаються до буфера обміну інших підключених сеансів."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ur.rs
+++ b/src/lang/ur.rs
@@ -745,6 +745,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Display Name", "display-name"),
         ("password-hidden-tip", ""),
         ("preset-password-in-use-tip", ""),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }
-

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -763,5 +763,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Lock canvas", "Khóa khung hình"),
         ("Sync clipboard between sessions", "Đồng bộ clipboard giữa các phiên"),
         ("sync-clipboard-between-sessions-tip", "Văn bản hoặc hình ảnh được sao chép trong một phiên từ xa cũng được gửi đến clipboard của các phiên đã kết nối khác."),
+        ("No devices responded. Make sure RustDesk is running on other devices and allowed to answer LAN discovery requests. A firewall or network isolation can prevent replies.", ""),
+        ("This device's firewall blocked LAN discovery. Some available devices may not appear in this list.", ""),
+        ("This device will not answer LAN discovery requests because \"Deny LAN discovery\" is enabled. It can still discover other devices.", ""),
     ].iter().cloned().collect();
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -46,6 +46,103 @@ struct ActiveUserLookupCache {
 
 const INVALID_TERM_VALUES: [&str; 3] = ["", "unknown", "dumb"];
 const SHELL_PROCESSES: [&str; 4] = ["bash", "zsh", "fish", "sh"];
+const LAN_DISCOVERY_FIREWALL_LOG_MAX_BYTES: usize = 1024 * 1024;
+
+fn has_ufw_blocked_lan_discovery_reply(data: &[u8], response_ports: &[u16]) -> bool {
+    String::from_utf8_lossy(data).lines().any(|line| {
+        if !line.contains("[UFW BLOCK]") {
+            return false;
+        }
+        let mut udp = false;
+        let mut source_port = None;
+        let mut destination_port = None;
+        for field in line.split_ascii_whitespace() {
+            if field == "PROTO=UDP" {
+                udp = true;
+            } else if let Some(value) = field.strip_prefix("SPT=") {
+                source_port = value.parse::<u16>().ok();
+            } else if let Some(value) = field.strip_prefix("DPT=") {
+                destination_port = value.parse::<u16>().ok();
+            }
+        }
+        udp && source_port == Some((hbb_common::config::RENDEZVOUS_PORT + 3) as u16)
+            && destination_port
+                .map(|port| response_ports.contains(&port))
+                .unwrap_or(false)
+    })
+}
+
+pub async fn lan_discovery_firewall_blocked(
+    scan_started: std::time::SystemTime,
+    response_ports: &[u16],
+) -> bool {
+    use hbb_common::tokio::{io::AsyncReadExt, process::Command, time::timeout};
+    use std::{process::Stdio, time::UNIX_EPOCH};
+
+    let Ok(started) = scan_started.duration_since(UNIX_EPOCH) else {
+        return false;
+    };
+    let since = format!("@{}", started.as_secs());
+    let mut child = match Command::new("journalctl")
+        .args(["--dmesg", "--since", &since, "--output=cat", "--no-pager"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(err) => {
+            log::debug!("Failed to inspect firewall logs: {err}");
+            return false;
+        }
+    };
+    let Some(stdout) = child.stdout.take() else {
+        return false;
+    };
+    let read = async {
+        let mut data = Vec::new();
+        stdout
+            .take((LAN_DISCOVERY_FIREWALL_LOG_MAX_BYTES + 1) as u64)
+            .read_to_end(&mut data)
+            .await?;
+        if data.len() > LAN_DISCOVERY_FIREWALL_LOG_MAX_BYTES {
+            child.kill().await.ok();
+            bail!("Firewall log output exceeds limit");
+        }
+        let status = child.wait().await?;
+        if !status.success() {
+            bail!("journalctl failed");
+        }
+        Ok::<Vec<u8>, hbb_common::anyhow::Error>(data)
+    };
+    match timeout(Duration::from_secs(1), read).await {
+        Ok(Ok(data)) => has_ufw_blocked_lan_discovery_reply(&data, response_ports),
+        Ok(Err(err)) => {
+            log::debug!("Failed to inspect firewall logs: {err}");
+            false
+        }
+        Err(_) => {
+            child.kill().await.ok();
+            log::debug!("Timed out while inspecting firewall logs");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod lan_discovery_firewall_tests {
+    use super::*;
+
+    #[test]
+    fn matches_only_blocked_replies_to_this_scan() {
+        let data = b"[UFW BLOCK] IN=wlan0 PROTO=UDP SPT=21119 DPT=33287 LEN=85\n\
+                     [UFW BLOCK] IN=wlan0 PROTO=UDP SPT=21119 DPT=40000 LEN=85\n\
+                     [UFW BLOCK] IN=wlan0 PROTO=TCP SPT=21119 DPT=33287 LEN=85";
+
+        assert!(has_ufw_blocked_lan_discovery_reply(data, &[33287]));
+        assert!(!has_ufw_blocked_lan_discovery_reply(data, &[50000]));
+    }
+}
 
 // Terminal type constants
 const TERM_XTERM_256COLOR: &str = "xterm-256color";

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -567,8 +567,9 @@ impl UI {
     }
 
     fn discover(&self) {
+        let id = self.get_id();
         std::thread::spawn(move || {
-            allow_err!(crate::lan::discover());
+            allow_err!(crate::lan::discover(id));
         });
     }
 

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -20,7 +20,10 @@ use serde_derive::Serialize;
 use std::process::Child;
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
 };
 
 use crate::common::SOFTWARE_UPDATE_URL;
@@ -30,6 +33,8 @@ use crate::hbbs_http::account;
 use crate::ipc;
 
 type Message = RendezvousMessage;
+
+static LAN_DISCOVERY_RUNNING: AtomicBool = AtomicBool::new(false);
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub type Children = Arc<Mutex<(bool, HashMap<(String, String), Child>)>>;
@@ -776,8 +781,24 @@ pub fn create_shortcut(_id: String) {
 #[cfg(any(target_os = "android", target_os = "ios", feature = "flutter"))]
 #[inline]
 pub fn discover() {
+    if LAN_DISCOVERY_RUNNING.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    #[cfg(feature = "flutter")]
+    crate::flutter_ffi::main_update_lan_discovery("scanning", false, false);
     std::thread::spawn(move || {
-        allow_err!(crate::lan::discover());
+        let result = crate::lan::discover(get_id());
+        #[cfg(feature = "flutter")]
+        match &result {
+            Ok(result) => crate::flutter_ffi::main_update_lan_discovery(
+                "completed",
+                result.found_peers,
+                result.firewall_blocked,
+            ),
+            Err(_) => crate::flutter_ffi::main_update_lan_discovery("failed", false, false),
+        }
+        LAN_DISCOVERY_RUNNING.store(false, Ordering::Release);
+        allow_err!(result);
     });
 }
 

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -787,6 +787,15 @@ pub fn discover() {
     #[cfg(feature = "flutter")]
     crate::flutter_ffi::main_update_lan_discovery("scanning", false, false);
     std::thread::spawn(move || {
+        struct LanDiscoveryRunningGuard;
+
+        impl Drop for LanDiscoveryRunningGuard {
+            fn drop(&mut self) {
+                LAN_DISCOVERY_RUNNING.store(false, Ordering::Release);
+            }
+        }
+
+        let _running_guard = LanDiscoveryRunningGuard;
         let result = crate::lan::discover(get_id());
         #[cfg(feature = "flutter")]
         match &result {
@@ -797,7 +806,6 @@ pub fn discover() {
             ),
             Err(_) => crate::flutter_ffi::main_update_lan_discovery("failed", false, false),
         }
-        LAN_DISCOVERY_RUNNING.store(false, Ordering::Release);
         allow_err!(result);
     });
 }


### PR DESCRIPTION
inayayousfi directed the work and made every decision.
GPT-5.6 Sol, running in OpenCode, carried inayayousfi's decisions out.

## Summary

LAN discovery currently relies on IPv4 broadcast, so peers connected through Tailscale do not appear. This keeps the existing broadcasts and also queries `tailscale status --json` for online IPv4 peers, then sends the existing UDP discovery packet directly to each address.

Discovery now retries the same probes with full-jitter exponential backoff under a shared 15-second deadline. Results are displayed as they arrive.

The response path rejects self-discovery using the RustDesk ID, local IP address, or a usable MAC address. It preserves cached peers when a scan receives no replies and prevents overlapping scans.

The Flutter view reports scanning, failure, no response, local firewall blocks, and disabled incoming LAN discovery without hiding available peers. Linux firewall reporting is best effort and appears only when current-scan UDP replies match readable UFW block records.

## Tests

- `CXXFLAGS='-include cstdint' cargo test --features flutter --lib lan` (19 passed on current upstream master)
- `flutter test --no-pub test/lan_discovery_empty_state_test.dart` (7 passed)
- Changed-file Flutter analysis found no new issues; 8 pre-existing informational notices remain in `model.dart`
- Live discovery from Linux to 2 Windows peers, one through LAN and one through Tailscale, including delayed replies and UFW block/allow behavior



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved LAN device discovery with more reliable scanning, self-device filtering, and broader desktop network coverage.
  * Added status indicators for scanning, completion, failures, firewall blocking, and disabled responses.
  * Added retry support and troubleshooting guidance when no devices respond.

* **Bug Fixes**
  * Prevented concurrent LAN discovery scans.
  * Improved detection of firewall-related discovery issues on Linux.

* **Localization**
  * Added LAN discovery status messages across supported languages; some translations remain pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extends LAN discovery to probe online Tailscale IPv4 peers while retaining broadcast discovery, and adds bounded retries, scan-state reporting, self-filtering, cache preservation, and overlap prevention.
- Queries Tailscale peer status and directly sends existing UDP discovery packets to eligible addresses.
- Uses a shared scan deadline with jittered retries and incremental peer updates.
- Adds Flutter discovery states, retry guidance, and Linux UFW diagnostics.
- Adds localized discovery messages and widget/unit coverage.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains in the eligible follow-up review scope.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lan.rs | Extends discovery with Tailscale targets, deadline-bound retries, response filtering, incremental persistence, and focused unit tests. |
| src/ui_interface.rs | Serializes discovery scans and publishes scanning, completion, and failure state to Flutter. |
| src/platform/linux.rs | Adds bounded best-effort inspection of UFW logs for blocked replies associated with the current scan. |
| flutter/lib/common/widgets/peers_view.dart | Adds lifecycle-triggered discovery and status, warning, retry, and empty-state presentation without hiding cached peers. |
| flutter/lib/models/peer_model.dart | Adds discovery state fields and event handling to the LAN peers model. |
| flutter/test/lan_discovery_empty_state_test.dart | Covers scanning, completion, failure, retry, cached-peer, firewall, disabled-discovery, and narrow-layout states. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Flutter LAN view
    participant Core as Discovery coordinator
    participant TS as Tailscale CLI
    participant Net as LAN/Tailnet peers
    participant Cache as LAN peer cache

    UI->>Core: Start discovery
    Core-->>UI: scanning
    Core->>TS: tailscale status --json
    TS-->>Core: Online peer IPv4 addresses
    loop Until shared deadline
        Core->>Net: UDP ping via broadcast and unicast
        Net-->>Core: UDP pong
        Core->>Cache: Merge and persist peer
        Core-->>UI: Refresh visible peers
    end
    Core-->>UI: completed or failed
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(lan): release discovery slot while u..."](https://github.com/rustdesk/rustdesk/commit/0cf4e8fbc00b60752bfbbc46f0da18681216582d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59920891)</sub>

<!-- /greptile_comment -->