### PR TITLE
Bound pending video frames per connection

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -42,7 +42,7 @@ use hbb_common::{
     sleep, timeout,
     tokio::{
         net::TcpStream,
-        sync::mpsc,
+        sync::{mpsc, Notify},
         time::{self, Duration, Instant},
     },
     tokio_util::codec::{BytesCodec, Framed},
@@ -55,7 +55,7 @@ use serde_json::{json, value::Value};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use std::sync::atomic::Ordering;
 use std::{
-    collections::HashSet,
+    collections::{HashSet, VecDeque},
     net::Ipv6Addr,
     num::NonZeroI64,
     path::PathBuf,
@@ -70,6 +70,111 @@ use windows::Win32::Foundation::{CloseHandle, HANDLE};
 #[cfg(windows)]
 use crate::virtual_display_manager;
 pub type Sender = mpsc::UnboundedSender<(Instant, Arc<Message>)>;
+
+type VideoMessage = (Instant, Arc<Message>);
+const MAX_PENDING_VIDEO_MESSAGES: usize = 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum VideoMessageKind {
+    Frame,
+    SwitchDisplay,
+}
+
+struct PendingVideoMessage {
+    value: VideoMessage,
+    kind: VideoMessageKind,
+}
+
+struct VideoChannelState {
+    pending: Mutex<VecDeque<PendingVideoMessage>>,
+    notify: Notify,
+    receiver_closed: std::sync::atomic::AtomicBool,
+}
+
+#[derive(Clone)]
+pub struct VideoSender {
+    state: Arc<VideoChannelState>,
+}
+
+struct VideoReceiver {
+    state: Arc<VideoChannelState>,
+}
+
+fn video_channel() -> (VideoSender, VideoReceiver) {
+    let state = Arc::new(VideoChannelState {
+        pending: Mutex::new(VecDeque::with_capacity(MAX_PENDING_VIDEO_MESSAGES)),
+        notify: Notify::new(),
+        receiver_closed: std::sync::atomic::AtomicBool::new(false),
+    });
+    (
+        VideoSender {
+            state: state.clone(),
+        },
+        VideoReceiver { state },
+    )
+}
+
+impl VideoSender {
+    fn send(&self, value: VideoMessage, kind: VideoMessageKind) -> Result<(), &'static str> {
+        if self
+            .state
+            .receiver_closed
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return Err("video receiver closed");
+        }
+
+        let mut pending = self.state.pending.lock().unwrap();
+        match kind {
+            VideoMessageKind::Frame => {
+                if let Some(index) = pending
+                    .iter()
+                    .rposition(|queued| queued.kind == VideoMessageKind::Frame)
+                {
+                    pending[index] = PendingVideoMessage { value, kind };
+                } else {
+                    if pending.len() >= MAX_PENDING_VIDEO_MESSAGES {
+                        pending.pop_front();
+                    }
+                    pending.push_back(PendingVideoMessage { value, kind });
+                }
+            }
+            VideoMessageKind::SwitchDisplay => {
+                // Frames and older display switches are stale after a new display switch.
+                pending.clear();
+                pending.push_back(PendingVideoMessage { value, kind });
+            }
+        }
+        drop(pending);
+        self.state.notify.notify_one();
+        Ok(())
+    }
+}
+
+impl VideoReceiver {
+    async fn recv(&mut self) -> Option<VideoMessage> {
+        loop {
+            // Register before checking the queue so a send between the check and
+            // await cannot be missed.
+            let notified = self.state.notify.notified();
+            let queued = { self.state.pending.lock().unwrap().pop_front() };
+            if let Some(queued) = queued {
+                return Some(queued.value);
+            }
+            notified.await;
+        }
+    }
+}
+
+impl Drop for VideoReceiver {
+    fn drop(&mut self) {
+        self.state
+            .receiver_closed
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.state.pending.lock().unwrap().clear();
+        self.state.notify.notify_waiters();
+    }
+}
 
 const FAILURE_IDX_ID_WHITELIST: usize = 2;
 // How long a rejection counts, so also how long a blocked address stays blocked. Longer
@@ -132,7 +237,7 @@ pub static MOUSE_MOVE_TIME: AtomicI64 = AtomicI64::new(0);
 pub struct ConnInner {
     id: i32,
     tx: Option<Sender>,
-    tx_video: Option<Sender>,
+    tx_video: Option<VideoSender>,
 }
 
 struct InputMouse {
@@ -353,7 +458,7 @@ pub struct Connection {
 }
 
 impl ConnInner {
-    pub fn new(id: i32, tx: Option<Sender>, tx_video: Option<Sender>) -> Self {
+    pub fn new(id: i32, tx: Option<Sender>, tx_video: Option<VideoSender>) -> Self {
         Self { id, tx, tx_video }
     }
 }
@@ -367,22 +472,23 @@ impl Subscriber for ConnInner {
     #[inline]
     fn send(&mut self, msg: Arc<Message>) {
         // Send SwitchDisplay on the same channel as VideoFrame to avoid send order problems.
-        let tx_by_video = match &msg.union {
-            Some(message::Union::VideoFrame(_)) => true,
+        let video_kind = match &msg.union {
+            Some(message::Union::VideoFrame(_)) => Some(VideoMessageKind::Frame),
             Some(message::Union::Misc(misc)) => match &misc.union {
-                Some(misc::Union::SwitchDisplay(_)) => true,
-                _ => false,
+                Some(misc::Union::SwitchDisplay(_)) => Some(VideoMessageKind::SwitchDisplay),
+                _ => None,
             },
-            _ => false,
+            _ => None,
         };
-        let tx = if tx_by_video {
-            self.tx_video.as_mut()
+        if let Some(kind) = video_kind {
+            if let Some(tx) = self.tx_video.as_mut() {
+                allow_err!(tx.send((Instant::now(), msg), kind));
+            }
         } else {
-            self.tx.as_mut()
-        };
-        tx.map(|tx| {
-            allow_err!(tx.send((Instant::now(), msg)));
-        });
+            self.tx.as_mut().map(|tx| {
+                allow_err!(tx.send((Instant::now(), msg)));
+            });
+        }
     }
 }
 
@@ -437,7 +543,7 @@ impl Connection {
         let tx_from_cm = tx_from_cm_holder.clone();
         let (tx_to_cm, rx_to_cm) = mpsc::unbounded_channel::<ipc::Data>();
         let (tx, mut rx) = mpsc::unbounded_channel::<(Instant, Arc<Message>)>();
-        let (tx_video, mut rx_video) = mpsc::unbounded_channel::<(Instant, Arc<Message>)>();
+        let (tx_video, mut rx_video) = video_channel();
         let (tx_input, _rx_input) = std_mpsc::channel();
         let (tx_from_authed, mut rx_from_authed) = mpsc::unbounded_channel::<ipc::Data>();
         let mut hbbs_rx = crate::hbbs_http::sync::signal_receiver();
@@ -6888,6 +6994,98 @@ fn wildcard_match(pattern: &str, text: &str) -> bool {
 mod test {
     #[allow(unused)]
     use super::*;
+
+    #[test]
+    fn video_channel_keeps_only_latest_pending_frame() {
+        let (sender, _receiver) = video_channel();
+        let first = Arc::new(Message::new());
+        let latest = Arc::new(Message::new());
+
+        sender
+            .send((Instant::now(), first), VideoMessageKind::Frame)
+            .unwrap();
+        sender
+            .send((Instant::now(), latest.clone()), VideoMessageKind::Frame)
+            .unwrap();
+
+        let pending = sender.state.pending.lock().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert!(Arc::ptr_eq(&pending[0].value.1, &latest));
+    }
+
+    #[test]
+    fn video_channel_preserves_switch_before_latest_frame() {
+        let (sender, _receiver) = video_channel();
+        let display_switch = Arc::new(Message::new());
+        let old_frame = Arc::new(Message::new());
+        let latest_frame = Arc::new(Message::new());
+
+        sender
+            .send(
+                (Instant::now(), display_switch.clone()),
+                VideoMessageKind::SwitchDisplay,
+            )
+            .unwrap();
+        sender
+            .send((Instant::now(), old_frame), VideoMessageKind::Frame)
+            .unwrap();
+        sender
+            .send(
+                (Instant::now(), latest_frame.clone()),
+                VideoMessageKind::Frame,
+            )
+            .unwrap();
+
+        let pending = sender.state.pending.lock().unwrap();
+        assert_eq!(pending.len(), MAX_PENDING_VIDEO_MESSAGES);
+        assert_eq!(pending[0].kind, VideoMessageKind::SwitchDisplay);
+        assert!(Arc::ptr_eq(&pending[0].value.1, &display_switch));
+        assert_eq!(pending[1].kind, VideoMessageKind::Frame);
+        assert!(Arc::ptr_eq(&pending[1].value.1, &latest_frame));
+    }
+
+    #[test]
+    fn video_channel_new_switch_discards_stale_messages() {
+        let (sender, _receiver) = video_channel();
+        let stale_switch = Arc::new(Message::new());
+        let stale_frame = Arc::new(Message::new());
+        let latest_switch = Arc::new(Message::new());
+
+        sender
+            .send(
+                (Instant::now(), stale_switch),
+                VideoMessageKind::SwitchDisplay,
+            )
+            .unwrap();
+        sender
+            .send((Instant::now(), stale_frame), VideoMessageKind::Frame)
+            .unwrap();
+        sender
+            .send(
+                (Instant::now(), latest_switch.clone()),
+                VideoMessageKind::SwitchDisplay,
+            )
+            .unwrap();
+
+        let pending = sender.state.pending.lock().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].kind, VideoMessageKind::SwitchDisplay);
+        assert!(Arc::ptr_eq(&pending[0].value.1, &latest_switch));
+    }
+
+    #[test]
+    fn video_channel_rejects_messages_after_receiver_closes() {
+        let (sender, receiver) = video_channel();
+        drop(receiver);
+
+        assert!(sender
+            .send(
+                (Instant::now(), Arc::new(Message::new())),
+                VideoMessageKind::Frame,
+            )
+            .is_err());
+        assert!(sender.state.pending.lock().unwrap().is_empty());
+    }
 
     #[cfg(feature = "flutter")]
     #[cfg(not(any(target_os = "android", target_os = "ios")))]


### PR DESCRIPTION
## Summary

- replace the unbounded per-connection video channel with a queue capped at two pending video messages
- coalesce queued video frames so slow viewers receive the newest frame instead of retaining stale frames
- preserve display-switch ordering while discarding obsolete video data
- clear pending frames when the receiver closes
- add unit tests for frame coalescing, display switching, and receiver shutdown

## Problem

Each authenticated viewer had its own unbounded channel for outgoing video messages. When a viewer consumed frames more slowly than the host produced them, stale `Arc<Message>` video frames accumulated in the host process. With multiple simultaneous viewers this caused rapidly increasing private/committed memory and page-file pressure on Windows.

## Fix

The specialized video queue keeps at most a display-switch message and the newest frame. A newer frame replaces an older pending frame. A display switch clears obsolete video data before the next frame. Non-video messages and all authentication, input, clipboard, audio, file-transfer, and networking behavior remain unchanged.

## Verification

- `rustfmt --edition 2021 --check src/server/connection.rs`
- four focused unit tests are included
- the same queue implementation built successfully as a Windows x64 client
- a short runtime stress test with five simultaneous viewers stayed near 459 MB total private memory across the RustDesk processes instead of showing the previously observed runaway growth

This commit is based on the current upstream `master` and contains only the implementation and tests in `src/server/connection.rs`.

Signed-off-by: Sebastian J. H. <kamohy@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved video delivery by prioritizing the latest pending frame, reducing stale frames and unnecessary backlog.
  * Switching displays now discards outdated queued video messages to keep playback current.

* **Reliability**
  * Video messages are rejected cleanly after the receiving connection closes.
  * Improved notification handling helps prevent missed video updates while waiting for new frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces each connection's unbounded video channel with a bounded queue that coalesces frames and discards stale messages around display switches.
- Adds a custom `VideoSender`/`VideoReceiver` backed by a two-entry `VecDeque`.
- Routes video frames and display-switch messages through the bounded channel.
- Adds unit coverage for frame coalescing, display-switch replacement, and receiver closure.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until frame coalescing preserves the post-switch keyframe needed to restart client decoding.

Under network backpressure, a delta frame can replace the only queued keyframe after SwitchDisplay resets the client decoder, causing video to remain frozen without a periodic recovery keyframe.

**Files Needing Attention:** src/server/connection.rs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/connection.rs | Introduces bounded frame coalescing, but replacement can discard the only post-switch keyframe while the network writer is backpressured. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    S[Display switch] --> Q[Queue SwitchDisplay]
    Q --> K[Queue fresh keyframe]
    K --> B{Network send backpressured?}
    B -- Yes --> D[Later delta replaces keyframe]
    D --> R[Client receives SwitchDisplay and resets decoder]
    R --> F[Delta cannot initialize decoder]
    F --> O[Video freezes until another keyframe]
    B -- No --> C[Keyframe reaches client]
    C --> P[Playback resumes]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2316051%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=16051&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fserver%2Fconnection.rs%3A130-134%0A**Coalescing%20Drops%20Required%20Keyframes**%0A%0AIf%20the%20network%20send%20is%20backpressured%20after%20a%20display%20switch%2C%20a%20subsequent%20delta%20frame%20replaces%20the%20queued%20post-switch%20keyframe.%20The%20client%20then%20resets%20its%20decoder%20but%20receives%20only%20an%20undecodable%20delta%20frame%2C%20leaving%20video%20frozen%20or%20black%20until%20another%20display%20switch%20produces%20a%20new%20keyframe.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16051&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22codex%2Fbounded-video-queue-upstream%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fbounded-video-queue-upstream%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fserver%2Fconnection.rs%3A130-134%0A**Coalescing%20Drops%20Required%20Keyframes**%0A%0AIf%20the%20network%20send%20is%20backpressured%20after%20a%20display%20switch%2C%20a%20subsequent%20delta%20frame%20replaces%20the%20queued%20post-switch%20keyframe.%20The%20client%20then%20resets%20its%20decoder%20but%20receives%20only%20an%20undecodable%20delta%20frame%2C%20leaving%20video%20frozen%20or%20black%20until%20another%20display%20switch%20produces%20a%20new%20keyframe.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16051&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/connection.rs:130-134
**Coalescing Drops Required Keyframes**

If the network send is backpressured after a display switch, a subsequent delta frame replaces the queued post-switch keyframe. The client then resets its decoder but receives only an undecodable delta frame, leaving video frozen or black until another display switch produces a new keyframe.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bound pending video frames per conn..."](https://github.com/rustdesk/rustdesk/commit/9ef315708605119be9bd863a4ca45b823b7e7a27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60034900)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->