### PR TITLE
fix(ci): ubuntu-22.04-arm, oom

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -1537,7 +1537,6 @@ jobs:
           submodules: recursive
 
       - name: Set Swap Space
-        if: ${{ matrix.job.arch == 'x86_64' }}
         uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c # v1.0
         with:
           swap-size-gb: 12
@@ -2150,6 +2149,12 @@ jobs:
           sed -i 's/"baseline": ".*"/"baseline": "${{ env.ARMV7_VCPKG_COMMIT_ID }}"/' vcpkg.json
           echo "Modified vcpkg.json for armv7 build:"
           grep -A 2 -B 2 '"baseline"' vcpkg.json
+
+      - name: Set Swap Space
+        if: matrix.job.arch == 'armv7'
+        uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c # v1.0
+        with:
+          swap-size-gb: 12
 
       - name: Free Space
         run: |


### PR DESCRIPTION
fix https://github.com/rustdesk/rustdesk/actions/runs/33756773778/job/100653017737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved Linux build reliability by allocating additional swap space across supported runner architectures, including ARM-based builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR expands swap provisioning to the Ubuntu ARM builds to address out-of-memory CI failures.
- Runs the existing 12 GB swap setup for both x86_64 and aarch64 in the main Linux build job.
- Adds armv7-only swap setup to the Sciter Linux build job.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking issue identified.

The newly covered targets are Linux ARM runners, the swap action is architecture-independent and pinned, and the armv7 path has no duplicate swap setup or established resource conflict.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/flutter-build.yml | Extends the pinned swap-space action to the aarch64 and armv7 CI paths; no actionable defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): ubuntu-22.04-arm, oom"](https://github.com/rustdesk/rustdesk/commit/4bd2ab85e7b10d557532a33f0e234bcb57606790) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60219154)</sub>

<!-- /greptile_comment -->