### PR TITLE
fix(custom client): preserve executable name casing during update

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1496,8 +1496,8 @@ pub fn rename_exe_cmd(src_exe: &str, path: &str) -> ResultType<String> {
         .ok_or(anyhow!("Can't get file name of {src_exe}"))?
         .to_string_lossy()
         .to_string();
-    let app_name = crate::get_app_name().to_lowercase();
-    if src_exe_filename.to_lowercase() == format!("{app_name}.exe") {
+    let app_name = crate::get_app_name();
+    if src_exe_filename == format!("{app_name}.exe") {
         Ok("".to_owned())
     } else {
         Ok(format!(


### PR DESCRIPTION
Custom-client EXE updates renamed the installed executable using a lowercase application name.

Older MSI packages compare process names case-sensitively during upgrades.

https://github.com/rustdesk/rustdesk/blob/6c578292e8ebbbec708b76986ba8c4bc7c509747/res/msi/CustomActions/CustomActions.cpp#L303

It will not affect startup or upgrades. However, after uninstallation, there will be residual processes with lowercase names.

After an EXE auto-update, this casing difference could prevent the MSI custom action from terminating the running client process.

This change:

  - Preserves the configured application name casing when renaming the updated executable.
  - Uses an exact filename comparison so case-only differences are not skipped.
  - Keeps upgrades compatible with legacy MSI custom actions using case-sensitive process matching.

## Tests

  - [x] public EXE -> new EXE. The original public EXE is also lowercase.
  - [x] custom client  MSI -> old EXE -> new EXE.
  - [x] custom client MSI -> new EXE.
  - [x] custom client  EXE -> old EXE -> new EXE.
  - [x] custom client EXE -> new EXE.



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves configured application-name casing when Windows updates rename an executable, maintaining compatibility with legacy MSI process-name matching.
- Stops lowercasing the configured application name.
- Uses an exact filename comparison so case-only differences reach the existing rename path.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the focused change matching the documented update behavior.

The changed comparison intentionally sends case-only filename differences through the existing rename path, and no reachable build, runtime, data, or security failure was identified.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/platform/windows.rs | The focused comparison change correctly preserves configured executable casing, with no actionable defect identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(custom client): msi update, preserve..."](https://github.com/rustdesk/rustdesk/commit/2dc11816a77544f54cae86ef2a1c56c9b3eef362) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60232423)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Windows executable renaming now distinguishes filenames with different capitalization, ensuring only an exact filename match skips the move operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->