### PR TITLE
connection: apply the non-video send timeout once the type is known

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -391,7 +391,9 @@ const SEC30: Duration = Duration::from_secs(30);
 const H1: Duration = Duration::from_secs(3600);
 const MILLI1: Duration = Duration::from_millis(1);
 const SEND_TIMEOUT_VIDEO: u64 = 12_000;
-const SEND_TIMEOUT_OTHER: u64 = SEND_TIMEOUT_VIDEO * 10;
+// The same horizon as the 30 s read timeout: a peer that has not drained a
+// single message for that long is the same dead peer that check would catch.
+const SEND_TIMEOUT_OTHER: u64 = 30_000;
 const SESSION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Whether the DRM backend can serve a Wayland login screen here.
@@ -585,13 +587,9 @@ impl Connection {
             crate::rustdesk_interval(time::interval_at(Instant::now(), TEST_DELAY_TIMEOUT));
         let mut last_recv_time = Instant::now();
 
-        conn.stream.set_send_timeout(
-            if conn.file_transfer.is_some() || conn.port_forward_socket.is_some() || conn.terminal {
-                SEND_TIMEOUT_OTHER
-            } else {
-                SEND_TIMEOUT_VIDEO
-            },
-        );
+        // The connection type is not known until the login request arrives;
+        // `on_message` picks the type-specific timeout then.
+        conn.stream.set_send_timeout(SEND_TIMEOUT_VIDEO);
 
         #[cfg(not(any(target_os = "android", target_os = "ios")))]
         std::thread::spawn(move || Self::handle_input(_rx_input, tx_cloned));
@@ -2765,6 +2763,17 @@ impl Connection {
                     }
                 }
             }
+
+            self.stream.set_send_timeout(
+                if self.file_transfer.is_some()
+                    || self.terminal
+                    || matches!(self.lr.union, Some(login_request::Union::PortForward(_)))
+                {
+                    SEND_TIMEOUT_OTHER
+                } else {
+                    SEND_TIMEOUT_VIDEO
+                },
+            );
 
             if !crate::common::is_direct_ip_access(&lr.username) && lr.username != Config::get_id()
             {

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -391,13 +391,7 @@ const SEC30: Duration = Duration::from_secs(30);
 const H1: Duration = Duration::from_secs(3600);
 const MILLI1: Duration = Duration::from_millis(1);
 const SEND_TIMEOUT_VIDEO: u64 = 12_000;
-// The same horizon as the 30 s read timeout: a peer that has not drained a
-// single message for that long is the same dead peer that check would catch.
-const SEND_TIMEOUT_OTHER: u64 = 30_000;
-// The raw port-forward loop's write to the local target: that loop idles for
-// an hour before giving up, and a target that stops draining is not a dead
-// peer, so this keeps the value the write always had.
-const PORT_FORWARD_LOCAL_SEND_TIMEOUT: u64 = 120_000;
+const SEND_TIMEOUT_OTHER: u64 = SEND_TIMEOUT_VIDEO * 10;
 const SESSION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Whether the DRM backend can serve a Wayland login screen here.
@@ -1240,7 +1234,7 @@ impl Connection {
                     res = self.stream.next() => {
                         if let Some(res) = res {
                             last_recv_time = Instant::now();
-                            timeout(PORT_FORWARD_LOCAL_SEND_TIMEOUT, forward.send(res?)).await??;
+                            timeout(SEND_TIMEOUT_OTHER, forward.send(res?)).await??;
                         } else {
                             bail!("Stream reset by the peer");
                         }

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -394,6 +394,10 @@ const SEND_TIMEOUT_VIDEO: u64 = 12_000;
 // The same horizon as the 30 s read timeout: a peer that has not drained a
 // single message for that long is the same dead peer that check would catch.
 const SEND_TIMEOUT_OTHER: u64 = 30_000;
+// The raw port-forward loop's write to the local target: that loop idles for
+// an hour before giving up, and a target that stops draining is not a dead
+// peer, so this keeps the value the write always had.
+const PORT_FORWARD_LOCAL_SEND_TIMEOUT: u64 = 120_000;
 const SESSION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Whether the DRM backend can serve a Wayland login screen here.
@@ -1236,7 +1240,7 @@ impl Connection {
                     res = self.stream.next() => {
                         if let Some(res) = res {
                             last_recv_time = Instant::now();
-                            timeout(SEND_TIMEOUT_OTHER, forward.send(res?)).await??;
+                            timeout(PORT_FORWARD_LOCAL_SEND_TIMEOUT, forward.send(res?)).await??;
                         } else {
                             bail!("Stream reset by the peer");
                         }


### PR DESCRIPTION
`Connection::start` set the send timeout before the login request had arrived, when `file_transfer`, `port_forward_socket` and `terminal` were all still unset, so every connection got `SEND_TIMEOUT_VIDEO` (12 s) and the `SEND_TIMEOUT_OTHER` branch never ran. A file transfer, terminal or port forward whose peer stopped draining for 12 s — a Wi-Fi roam, a VPN reconnect — was dropped.

The type-specific timeout is now set in `on_message` right after the login request's union has been matched; `start` keeps the video figure for the login phase.

`SEND_TIMEOUT_OTHER` also drops from 120 s to 30 s, the same horizon as the 30 s read timeout: the timeout wraps a single `send`, so it only fires when the peer makes no progress at all for that long, and beyond 30 s the read check would declare the same peer dead anyway. The raw port-forward pipe's write to its local target keeps its existing 120 s timeout via a separate constant, because its liveness policy is independent of the peer-facing 30 s timeout.


Claude-Session: https://claude.ai/code/session_01EZ49AbZJYfm8NTp5yDPMab



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved send-timeout handling by selecting the appropriate timeout after the connection type is identified.
  * File transfers and terminal sessions now use a 30-second send timeout.
  * Port forwarding retains an extended 120-second timeout when sending data to the local target, while other port-forward communication uses the shorter timeout.
  * Other connection types continue using the standard video send timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR keeps the video send timeout during login, then selects the connection-specific timeout after matching the login request.
- Applies the non-video timeout to file-transfer, terminal, and port-forward connections.
- Leaves video and other connection types on the video timeout.
- The latest revision restores the shared non-video timeout and its use for local port-forward writes.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge based on the current review state, with no accepted new findings.

No new non-duplicate issue remains; the previous local port-forward timeout thread was manually resolved without explanation and therefore does not remain outstanding.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/server/connection.rs | Defers type-specific send-timeout selection until the login request identifies the connection type. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Connection starts] --> B[Apply video send timeout]
    B --> C[Receive and match login request]
    C -->|File transfer, terminal, or port forward| D[Apply non-video send timeout]
    C -->|Other connection| E[Keep video send timeout]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["connection: keep the non-video send time..."](https://github.com/rustdesk/rustdesk/commit/ba65c30df18326b048699eca049dffa7b4d73d9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60320071)</sub>

<!-- /greptile_comment -->