### PR TITLE
AGENTS.md: require a regression-surface check before a change is done

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,19 @@
 * Accept a little duplication over a restructure. A new function that repeats a few lines of an existing one is a better diff than reshaping the original so both can share it.
 * Put new logic in self-contained functions in the module it belongs to (platform-specific logic in `src/platform/`, with `use` inside the function body to avoid churning shared import blocks). Call sites in shared files (`src/tray.rs`, `src/core_main.rs`, `src/server/connection.rs`, …) should be thin one-line hooks.
 
+### Mandatory regression-surface check
+
+Before considering any implementation complete, perform a minimization pass over the final diff.
+
+* Inspect every modified existing file and every modified existing code path. Each must be strictly necessary for the requested change. Revert changes that are merely cleanup, refactoring, consistency improvements, or fixes for pre-existing issues.
+* For new features, preserve the existing implementation path when the feature is disabled or unsupported whenever practical. `feature off` should run the old code, not a rewritten equivalent.
+* Do not route existing behavior through a new abstraction merely to share code with the new feature. Prefer a parallel new function or a small amount of duplication over changing a proven existing path.
+* Keep new implementation logic in new or feature-specific modules. Changes to shared/core files should normally be thin hooks, capability checks, or protocol plumbing.
+* Do not fix unrelated pre-existing bugs in the same PR. Put them in a separate change unless they directly block correctness or security of the requested work.
+* For submodule bumps, inspect the exact commit range and ensure unrelated changes are not being pulled into the parent PR.
+* Before finalizing, explicitly report the regression surface: list the existing files and existing runtime paths whose behavior changed, and explain why each change is unavoidable.
+* During review, treat an unnecessarily modified legacy path as a review finding even if tests pass and the rewritten behavior appears equivalent.
+
 ## Reviewing a PR
 
 * Review only what the diff introduces. Verify ownership with `gh pr diff` before reporting a finding — if the offending lines are untouched context, it is a pre-existing problem, not this PR's.


### PR DESCRIPTION
The minimal-invasiveness rules say what to prefer; nothing made an agent check the final diff against them, so a feature could still route the old path through its new code while every principle was "followed". This adds the gate: audit every modified existing path, keep feature-off on the old code, report the regression surface, and treat an unnecessarily rewritten legacy path as a review finding whatever the tests say.


Claude-Session: https://claude.ai/code/session_01EZ49AbZJYfm8NTp5yDPMab

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR strengthens the repository’s agent guidance by requiring a final minimization pass and explicit regression-surface reporting.
- Requires every modification to an existing path to be justified by the requested change.
- Preserves legacy behavior when new features are disabled or unsupported.
- Discourages unrelated fixes, unnecessary abstractions, and broad submodule updates.
- Changes agent workflow documentation only; no application runtime paths are affected.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The added guidance reinforces existing minimal-invasiveness rules without introducing contradictions, ambiguous applicability, or runtime changes.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds clear, internally consistent requirements for minimizing and reporting the regression surface of implementation changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["AGENTS.md: require a regression-surface ..."](https://github.com/rustdesk/rustdesk/commit/7bb8ce78b32bc745b704e1b18019fba53a553a4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60364534)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added mandatory guidance for minimizing regression risk during changes.
  * Added requirements to preserve disabled and unsupported behavior.
  * Added review practices for isolating new logic, limiting shared-file changes, inspecting submodule updates, and reporting potential regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->