### PR TITLE
Agents regression surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,12 @@
 * Accept a little duplication over a restructure. A new function that repeats a few lines of an existing one is a better diff than reshaping the original so both can share it.
 * Put new logic in self-contained functions in the module it belongs to (platform-specific logic in `src/platform/`, with `use` inside the function body to avoid churning shared import blocks). Call sites in shared files (`src/tray.rs`, `src/core_main.rs`, `src/server/connection.rs`, …) should be thin one-line hooks.
 
+### Scope check before touching shared code
+
+* Before changing a shared trait, a shared struct, or the signature of a widely used function, check whether the bug or feature is specific to one path. If it is, keep the change inside that path unless that is impossible, and say in the PR why it was.
+* If an unrelated caller needs `Default::default()`, `None`, or another placeholder solely to satisfy a signature you changed, the diff is too broad: stop and redesign.
+* The expected shape of a fix is a new function in the feature's own module, plus at most a new field or a thin hook in the shared code it needs. Feature-specific state belongs beside the feature's existing state, not in a new abstraction every caller has to learn.
+
 ### Mandatory regression-surface check
 
 Before considering any implementation complete, perform a minimization pass over the final diff.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,19 @@
 * Accept a little duplication over a restructure. A new function that repeats a few lines of an existing one is a better diff than reshaping the original so both can share it.
 * Put new logic in self-contained functions in the module it belongs to (platform-specific logic in `src/platform/`, with `use` inside the function body to avoid churning shared import blocks). Call sites in shared files (`src/tray.rs`, `src/core_main.rs`, `src/server/connection.rs`, …) should be thin one-line hooks.
 
+### Mandatory regression-surface check
+
+Before considering any implementation complete, perform a minimization pass over the final diff.
+
+* Inspect every modified existing file and every modified existing code path. Each must be strictly necessary for the requested change. Revert changes that are merely cleanup, refactoring, consistency improvements, or fixes for pre-existing issues.
+* For new features, preserve the existing implementation path when the feature is disabled or unsupported whenever practical. `feature off` should run the old code, not a rewritten equivalent.
+* Do not route existing behavior through a new abstraction merely to share code with the new feature. Prefer a parallel new function or a small amount of duplication over changing a proven existing path.
+* Keep new implementation logic in new or feature-specific modules. Changes to shared/core files should normally be thin hooks, capability checks, or protocol plumbing.
+* Do not fix unrelated pre-existing bugs in the same PR. Put them in a separate change unless they directly block correctness or security of the requested work.
+* For submodule bumps, inspect the exact commit range and ensure unrelated changes are not being pulled into the parent PR.
+* Before finalizing, explicitly report the regression surface: list the existing files and existing runtime paths whose behavior changed, and explain why each change is unavoidable.
+* During review, treat an unnecessarily modified legacy path as a review finding even if tests pass and the rewritten behavior appears equivalent.
+
 ## Reviewing a PR
 
 * Review only what the diff introduces. Verify ownership with `gh pr diff` before reporting a finding — if the offending lines are untouched context, it is a pre-existing problem, not this PR's.


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR expands the contributor guidance in `AGENTS.md` to reduce regression risk when changing shared interfaces and state.
- Requires checking whether a change can remain path-specific before modifying shared code.
- Identifies placeholder arguments at unrelated call sites as evidence of an overly broad interface change.
- Recommends feature-local implementation with only minimal shared hooks or state.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The added guidance is consistent with the surrounding minimal-diff and regression-surface rules, and no contradictory, misleading, or behavior-breaking requirement was identified.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds clear, consistent guidance for minimizing the regression surface of changes to shared code. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;master&#39; into agents-regres..."](https://github.com/rustdesk/rustdesk/commit/91294ca3f42a5fd42a5b14c155fdf2403fe4a3ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60381798)</sub>

<!-- /greptile_comment -->