### PR TITLE
connection page: the Connect menu offers TCP tunneling, as the peer c…

### DIFF
--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -330,12 +330,14 @@ class _ConnectionPageState extends State<ConnectionPage>
   void onConnect(
       {bool isFileTransfer = false,
       bool isViewCamera = false,
-      bool isTerminal = false}) {
+      bool isTerminal = false,
+      bool isTcpTunneling = false}) {
     var id = _idController.id;
     connect(context, id,
         isFileTransfer: isFileTransfer,
         isViewCamera: isViewCamera,
-        isTerminal: isTerminal);
+        isTerminal: isTerminal,
+        isTcpTunneling: isTcpTunneling);
   }
 
   /// UI for the remote ID TextField.
@@ -568,6 +570,14 @@ class _ConnectionPageState extends State<ConnectionPage>
                                       '${translate('Terminal')} (beta)',
                                       () => onConnect(isTerminal: true)
                                     ),
+                                    // `connect` routes this through the
+                                    // desktop path only; the peer card gates
+                                    // it the same way.
+                                    if (isDesktop)
+                                      (
+                                        'TCP tunneling',
+                                        () => onConnect(isTcpTunneling: true)
+                                      ),
                                   ]
                                       .map((e) => MenuEntryButton<String>(
                                             childBuilder: (TextStyle? style) =>


### PR DESCRIPTION
…ard does

The dropdown beside Connect listed file transfer, camera and terminal but not port forwarding, so reaching it meant having a card for the peer. `connect` already takes `isTcpTunneling`; only the menu entry and the parameter that carries it were missing.

Shown on desktop only. The peer card gates the same entry on `isDesktop` because `connect` routes a tunnel through the desktop path alone; on web it would have opened a plain remote session instead.


Claude-Session: https://claude.ai/code/session_01EZ49AbZJYfm8NTp5yDPMab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a desktop-only TCP tunneling option to the remote connection menu.
  * Users can now initiate connections with TCP tunneling enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds TCP tunneling to the connection page’s Connect dropdown and forwards the selected mode through the existing desktop connection path.
- Extends `onConnect` with the existing `isTcpTunneling` option.
- Adds a localized, desktop-only TCP tunneling menu entry.
- Regression surface is limited to the connection-page helper and dropdown; existing connection modes retain their prior default values and routing.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new action following the established desktop TCP-tunneling route without changing existing connection behavior.

No actionable failures were identified; the flag is forwarded through an existing supported API, the platform gate excludes web, and the label uses the repository’s existing localization key.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| flutter/lib/desktop/pages/connection_page.dart | Adds a desktop-only TCP tunneling action and correctly forwards it through the existing connection API. |

</details>

<sub>Reviews (1): Last reviewed commit: ["connection page: the Connect menu offers..."](https://github.com/rustdesk/rustdesk/commit/e3434152db502b3dcc623c4ce2b23f9f95407b6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60494836)</sub>

<!-- /greptile_comment -->