### PR TITLE
temporary password: rotate when a peer is let in, not when it leaves

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1087,9 +1087,6 @@ impl Connection {
             }
         }
         video_service::notify_video_frame_fetched_by_conn_id(id, None);
-        if conn.authorized {
-            password::update_temporary_password();
-        }
         if let Err(err) = conn.try_port_forward_loop(&mut rx_from_cm).await {
             conn.on_close(&err.to_string(), false).await;
             raii::AuthedConnID::check_remove_session(conn.inner.id(), conn.session_key());
@@ -1747,6 +1744,10 @@ impl Connection {
             return false;
         }
         self.authorized = true;
+        // One-time means gone once it has let a peer in, not once that peer
+        // leaves. This session's later logins come in on the password the
+        // session remembers, so they are not affected.
+        password::update_temporary_password();
         // Releases the budget `check_id_whitelist` charges against this address: only a peer
         // that got this far proved more than a self-reported id.
         self.clear_id_whitelist_failures();


### PR DESCRIPTION
## Why

The temporary (one-time) password is regenerated in `Connection::start` after the message loop exits, that is when the connection closes. Until then it stays valid: a remote desktop session keeps it usable for hours, and a port-forward mapping on the multiplexed tunnel of #16062 for as long as the mapping lives. Only the raw port-forward path rotated at authorization, and only because its loop breaks out before that line.

Raised during review of #16062; split out because it changes every connection type.

## What changes

`password::update_temporary_password()` moves from the end of the connection loop to the point where `authorized` is set in `send_logon_response_and_keep_alive`, the only place it is set. Every connection type rotates once, at authorization. Nothing else moves.

## What does not change

Later logins of the same session are accepted on the password the session remembers (`is_recent_session`): keyed by peer id, name and session id, alive for 30 seconds past the session's last activity, refreshed by live traffic, and kept across closes that allow a retry.

- Reconnect within 30 s of a drop: accepted, no prompt. After 30 s: a prompt for the new password, as before, since the old code rotated at the drop anyway.
- File transfer or TCP tunneling opened from a live session's toolbar: same session id, accepted.
- Several port-forward mappings in one window: same session id, all accepted.
- Raw port forward: already rotated at this moment.
- Rotation after ten wrong attempts, and the manual refresh button: untouched.

What users notice: the password on the main window changes as soon as a peer is in rather than when it leaves, and a second window to the same peer opened independently (not from the session's toolbar) needs the new password while the first session is still up.

## Test cases

- [x] One-time password, remote desktop: the main window's password changes immediately on connect. A second independent connection with the old password is refused; with the new one it succeeds.
- [x] From the live session's toolbar, open file transfer and TCP tunneling: no password prompt.
- [x] Pull the network for under 30 s: the session reconnects without a prompt. Over 30 s: a prompt for the new password.
- [x] Click-to-approve: the password rotates on Accept, not when the request arrives. A rejected request leaves it unchanged.
- [x] 2FA: rotation happens after the code is accepted. A wrong code leaves it unchanged.
- [x] Permanent password login: works, and the one-time password still rotates once.
- [x] Port forward window with several mappings on a one-time password: all mappings log in on one password entry.
- [x] Ten wrong attempts still rotate; the refresh button still rotates.
- [x] Android controlled side: same as 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ49AbZJYfm8NTp5yDPMab


Claude-Session: https://claude.ai/code/session_01EZ49AbZJYfm8NTp5yDPMab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Temporary passwords now rotate immediately after successful authorization, before the login response is sent.
- Prevents password rotation from being delayed until after the connection closes.
- Improves the timing and consistency of temporary-password updates during the login process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=60696777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because concurrent authentication attempts can still consume the same one-time password successfully.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fserver%2Fconnection.rs%3Aundefined-1879%0AConcurrent%20connection%20tasks%20can%20both%20validate%20the%20same%20current%20temporary%20password%20before%20either%20reaches%20this%20rotation.%20Both%20peers%20may%20therefore%20become%20authorized%20with%20a%20credential%20intended%20for%20one-time%20use.%20The%20password%20must%20be%20consumed%20atomically%20as%20part%20of%20successful%20validation%20rather%20than%20rotated%20later%20in%20the%20authorization%20flow.%0A%0A**How%20this%20was%20verified%3A**%20Each%20connection%20authenticates%20independently%2C%20and%20the%20shared%20temporary%20password%20is%20accepted%20before%20the%20later%20rotation%20without%20a%20lock%20spanning%20both%20operations.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16080&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=7"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Password consumption is not atomic** <a href="https://github.com/rustdesk/rustdesk/pull/16080#discussion_r3939712779">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/server/connection.rs:undefined-1879
Concurrent connection tasks can both validate the same current temporary password before either reaches this rotation. Both peers may therefore become authorized with a credential intended for one-time use. The password must be consumed atomically as part of successful validation rather than rotated later in the authorization flow.

**How this was verified:** Each connection authenticates independently, and the shared temporary password is accepted before the later rotation without a lock spanning both operations.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary>Summary</summary>

The PR changes temporary-password rotation from connection teardown to successful authorization.
- Removes rotation after the connection loop exits.
- Rotates the temporary password immediately after a peer becomes authorized.
- Preserves the existing session-reuse behavior for subsequent logins belonging to the same session.
- Regression surface is limited to `src/server/connection.rs` and the timing of temporary-password rotation across authorization paths.
</details>

<details open><summary>Diagram</summary>

```mermaid
sequenceDiagram
    participant Peer
    participant Connection
    participant PasswordStore

    Peer->>Connection: Submit login credentials
    Connection->>PasswordStore: Validate temporary password
    PasswordStore-->>Connection: Accepted
    Connection->>Connection: Mark connection authorized
    Connection->>PasswordStore: Rotate temporary password
    Connection-->>Peer: Send successful login response
    Note over Connection,PasswordStore: Validation and rotation remain separate operations
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["temporary password: rotate when a peer i..."](https://github.com/rustdesk/rustdesk/commit/40da387b16e18272b8168faa03445c632c7ad3cd)</sub>

<!-- /greptile_comment -->