### PR TITLE
Update it.rs

### DIFF
--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -761,12 +761,12 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Continue", "Continua"),
         ("Browser didn't open? Use the url below to sign in.", "Il browser non si è aperto? Usa l'URL qui sotto per accedere."),
         ("Lock canvas", "Blocca tela"),
-        ("Sync clipboard between sessions", "Sincronizza gli appunti tra le sessioni"),
+        ("Sync clipboard between sessions", "Sincronizza appunti tra le sessioni"),
         ("sync-clipboard-between-sessions-tip", "Il testo o le immagini copiati in una sessione remota vengono inviati anche agli appunti delle altre sessioni connesse."),
-        ("terminal-clipboard-write-tip", ""),
-        ("Allow terminal apps to copy to clipboard", ""),
+        ("terminal-clipboard-write-tip", "Un'app nel terminale vuole copiare il testo negli appunti di questo dispositivo. Se concessa, questa autorizzazione si applica alle app terminali in tutte le connessioni finché non la disattivi in Impostazioni. Le operazioni di copia e incolla manuali non sono interessate."),
+        ("Allow terminal apps to copy to clipboard", "Consenti alle app terminali di copiare negli appunti"),
         ("Enable", "Abilita"),
-        ("Reuse one connection for port forwarding", "Riutilizza una sola connessione per l'inoltro delle porte"),
-        ("port-forward-mux-tip", "Fa passare tutte le connessioni di un inoltro di porte su un'unica connessione verso il dispositivo remoto, invece di connettersi e autenticarsi di nuovo per ognuna."),
+        ("Reuse one connection for port forwarding", "Per l'inoltro delle porte riusa una sola connessione "),
+        ("port-forward-mux-tip", "Fa passare tutte le connessioni di un inoltro porte in un'unica connessione verso il dispositivo remoto, invece di connettersi e autenticarsi di nuovo per ognuna."),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -660,7 +660,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("screenshot-action-tip", "Seleziona come continuare con la schermata."),
         ("Save as", "Salva come"),
         ("Export", "Esporta"),
-        ("Export Logs", "Esporta i log"),
+        ("Export Logs", "Esporta registri"),
         ("Import Folder", "Importa cartella"),
         ("Copy to clipboard", "Copia negli appunti"),
         ("Enable remote printer", "Abilita stampante remota"),


### PR DESCRIPTION
@rustdesk 

Please merge.

Note: the strings

        ("Export", "Esporta"),
        ("Export Logs", "Esporta i log"),
        ("Import Folder", "Importa cartella"),

where there the string that I change before 

        ("Export Logs", "Esporta registri"),

and you didn't accept are new strings (vs previous translation) then the system automatically translated them.

These strings are not availabel in previous translation revision then the rule that is not possible to change strings already translated cannot apply to these strings because these strings are availabel for translator revision only now for the first ti,e.

Thanks.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Localization**
  - Updated Italian translations for exporting logs, clipboard synchronization, terminal clipboard permissions, and port-forwarding settings.
  - Added Italian text for enabling WebRTC peer-to-peer connections and TCP hole punching.
  - Refined wording and added guidance to make connection, clipboard, and synchronization options clearer for Italian-speaking users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates Italian localization entries.
- Adds translations for two previously empty terminal-clipboard strings.
- Revises several existing clipboard, port-forwarding, and log-export translations.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not ready to merge because the unresolved localization requirement still requires restoring three existing non-empty translations.

The previous finding remains outstanding: `Sync clipboard between sessions`, `Reuse one connection for port forwarding`, and `port-forward-mux-tip` still modify existing non-empty translations, contrary to the repository directive to only fill empty values. The separate `Export Logs` thread was manually resolved after bovirus disputed the finding, so it does not affect merge confidence.

**Files Needing Attention:** src/lang/it.rs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lang/it.rs | Adds two permitted translations, while previously reported edits to existing non-empty translations remain in the file. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;master&#39; into master"](https://github.com/rustdesk/rustdesk/commit/dc220141f27f3a678789ac8fde09eec64bf0b6e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60759650)</sub>

<!-- /greptile_comment -->