### PR TITLE
fix(linux): don't reject IPC peers when /proc/<pid>/exe is unreadable (#16073)

### DIFF
--- a/src/ipc/auth.rs
+++ b/src/ipc/auth.rs
@@ -479,16 +479,27 @@ fn peer_exe_read_permission_denied(err: &anyhow::Error) -> bool {
         .is_some_and(|io_err| io_err.kind() == std::io::ErrorKind::PermissionDenied)
 }
 
-// A root IPC server can always read a same-user-namespace peer's /proc/<pid>/exe, so a permission
-// error there is genuinely anomalous (e.g. a cross-namespace peer) and must stay fail-closed. Only a
-// NON-root server (the non-systemd case where the service could not register as root and runs as the
-// active user) cannot introspect a peer; there the executable check has no information to act on, so
-// deferring to the uid gate is both the best achievable and the pre-1.4.7 behavior — and it keeps the
-// hardened root-service path untouched.
+// The degrade is confined to a NON-root server. In a standard install the IPC server is the root
+// service, which normally can read a same-user-namespace peer's /proc/<pid>/exe; a root server that
+// nonetheless fails the read (e.g. dropped CAP_SYS_PTRACE, or a cross-namespace peer) is anomalous
+// and stays fail-closed. Only when the server itself is unprivileged (the non-systemd case where the
+// service could not register as root and runs as the active user) can it not introspect ANY peer;
+// there the executable check has no information to act on, so deferring to the uid gate is both the
+// best achievable and the pre-1.4.7 behavior, while the hardened root-service path is untouched.
 #[cfg(target_os = "linux")]
 #[inline]
 fn ipc_server_is_unprivileged() -> bool {
     unsafe { libc::geteuid() != 0 }
+}
+
+// The privilege-dependent authorization decision, pure so both branches are unit-testable: defer to
+// the uid gate only when an unprivileged server hit a permission error introspecting the peer. A root
+// server (`server_is_unprivileged == false`) always stays fail-closed, and a non-permission error
+// (e.g. the peer vanished) never degrades.
+#[cfg(target_os = "linux")]
+#[inline]
+fn should_defer_exe_check_to_uid_gate(err: &anyhow::Error, server_is_unprivileged: bool) -> bool {
+    server_is_unprivileged && peer_exe_read_permission_denied(err)
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -498,7 +509,7 @@ fn ensure_peer_executable_matches_current_by_pid(peer_pid: u32, postfix: &str) -
         Ok(peer_exe) => peer_exe,
         Err(err) => {
             #[cfg(target_os = "linux")]
-            if peer_exe_read_permission_denied(&err) && ipc_server_is_unprivileged() {
+            if should_defer_exe_check_to_uid_gate(&err, ipc_server_is_unprivileged()) {
                 log::warn!(
                     "Peer executable link not introspectable on ipc channel '{}' by an unprivileged server (peer_pid={}): {}; identity unavailable, deferring to the uid gate",
                     postfix,
@@ -1078,8 +1089,7 @@ mod tests {
     #[test]
     fn test_peer_exe_read_permission_denied_classification() {
         // EACCES/EPERM reading /proc/<pid>/exe (both map to `PermissionDenied`) means the peer is
-        // not introspectable and must be classified as such even after `context()` is attached, so
-        // the caller degrades to the uid gate instead of rejecting a legitimate peer.
+        // not introspectable and must be classified as such even after `context()` is attached.
         for errno in [hbb_common::libc::EACCES, hbb_common::libc::EPERM] {
             let err = hbb_common::anyhow::Error::new(std::io::Error::from_raw_os_error(errno))
                 .context("Failed to read peer executable link '/proc/1/exe'");
@@ -1088,13 +1098,41 @@ mod tests {
                 "errno {errno} must classify as permission denied"
             );
         }
-        // A vanished peer (NotFound) or a non-io error must NOT degrade to allow.
+        // A vanished peer (NotFound) or a non-io error must NOT classify as permission denied.
         let not_found =
             hbb_common::anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::NotFound))
                 .context("Failed to read peer executable link '/proc/1/exe'");
         assert!(!super::peer_exe_read_permission_denied(&not_found));
         assert!(!super::peer_exe_read_permission_denied(
             &hbb_common::anyhow::anyhow!("canonicalize failure text")
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_should_defer_exe_check_to_uid_gate_matrix() {
+        let eacces = || {
+            hbb_common::anyhow::Error::new(std::io::Error::from_raw_os_error(
+                hbb_common::libc::EACCES,
+            ))
+            .context("Failed to read peer executable link '/proc/1/exe'")
+        };
+        let not_found = || {
+            hbb_common::anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::NotFound))
+                .context("Failed to read peer executable link '/proc/1/exe'")
+        };
+        // Only an unprivileged server that hit a permission error defers to the uid gate.
+        assert!(super::should_defer_exe_check_to_uid_gate(&eacces(), true));
+        // A root server stays fail-closed even on a permission error.
+        assert!(!super::should_defer_exe_check_to_uid_gate(&eacces(), false));
+        // A non-permission error never degrades, regardless of privilege.
+        assert!(!super::should_defer_exe_check_to_uid_gate(
+            &not_found(),
+            true
+        ));
+        assert!(!super::should_defer_exe_check_to_uid_gate(
+            &not_found(),
+            false
         ));
     }
 }

--- a/src/ipc/auth.rs
+++ b/src/ipc/auth.rs
@@ -306,11 +306,14 @@ fn current_exe_canonical_path() -> ResultType<PathBuf> {
 fn peer_exe_canonical_path_by_pid(peer_pid: u32) -> ResultType<PathBuf> {
     let proc_exe = PathBuf::from(format!("/proc/{peer_pid}/exe"));
     let peer_exe = fs::read_link(&proc_exe).map_err(|err| {
-        anyhow::anyhow!(
+        // Keep the io::Error as the source (not just its text) so the read's error kind survives for
+        // `peer_exe_read_permission_denied`, while the context preserves the same logged message.
+        let msg = format!(
             "Failed to read peer executable link '{}': {}",
             proc_exe.display(),
             err
-        )
+        );
+        anyhow::Error::new(err).context(msg)
     })?;
     fs::canonicalize(&peer_exe).map_err(|err| {
         anyhow::anyhow!(
@@ -467,10 +470,46 @@ fn portable_service_helper_is_trusted(
     peer_hash == current_hash
 }
 
+// EACCES/EPERM from reading /proc/<pid>/exe (both map to `PermissionDenied`) means the peer could
+// not be introspected, which is distinct from a successfully read but mismatched executable path.
+#[cfg(target_os = "linux")]
+#[inline]
+fn peer_exe_read_permission_denied(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<std::io::Error>()
+        .is_some_and(|io_err| io_err.kind() == std::io::ErrorKind::PermissionDenied)
+}
+
+// A root IPC server can always read a same-user-namespace peer's /proc/<pid>/exe, so a permission
+// error there is genuinely anomalous (e.g. a cross-namespace peer) and must stay fail-closed. Only a
+// NON-root server (the non-systemd case where the service could not register as root and runs as the
+// active user) cannot introspect a peer; there the executable check has no information to act on, so
+// deferring to the uid gate is both the best achievable and the pre-1.4.7 behavior — and it keeps the
+// hardened root-service path untouched.
+#[cfg(target_os = "linux")]
+#[inline]
+fn ipc_server_is_unprivileged() -> bool {
+    unsafe { libc::geteuid() != 0 }
+}
+
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 #[inline]
 fn ensure_peer_executable_matches_current_by_pid(peer_pid: u32, postfix: &str) -> ResultType<()> {
-    let peer_exe = peer_exe_canonical_path_by_pid(peer_pid)?;
+    let peer_exe = match peer_exe_canonical_path_by_pid(peer_pid) {
+        Ok(peer_exe) => peer_exe,
+        Err(err) => {
+            #[cfg(target_os = "linux")]
+            if peer_exe_read_permission_denied(&err) && ipc_server_is_unprivileged() {
+                log::warn!(
+                    "Peer executable link not introspectable on ipc channel '{}' by an unprivileged server (peer_pid={}): {}; identity unavailable, deferring to the uid gate",
+                    postfix,
+                    peer_pid,
+                    err
+                );
+                return Ok(());
+            }
+            return Err(err);
+        }
+    };
     let current_exe = current_exe_canonical_path()?;
     if executable_paths_match(&peer_exe, &current_exe) {
         return Ok(());
@@ -1033,5 +1072,29 @@ mod tests {
             .parse()
             .unwrap_or_else(|_| panic!("failed to parse get_active_userid() output: '{raw_uid}'"));
         assert_eq!(parsed_uid, console_uid);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_peer_exe_read_permission_denied_classification() {
+        // EACCES/EPERM reading /proc/<pid>/exe (both map to `PermissionDenied`) means the peer is
+        // not introspectable and must be classified as such even after `context()` is attached, so
+        // the caller degrades to the uid gate instead of rejecting a legitimate peer.
+        for errno in [hbb_common::libc::EACCES, hbb_common::libc::EPERM] {
+            let err = hbb_common::anyhow::Error::new(std::io::Error::from_raw_os_error(errno))
+                .context("Failed to read peer executable link '/proc/1/exe'");
+            assert!(
+                super::peer_exe_read_permission_denied(&err),
+                "errno {errno} must classify as permission denied"
+            );
+        }
+        // A vanished peer (NotFound) or a non-io error must NOT degrade to allow.
+        let not_found =
+            hbb_common::anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::NotFound))
+                .context("Failed to read peer executable link '/proc/1/exe'");
+        assert!(!super::peer_exe_read_permission_denied(&not_found));
+        assert!(!super::peer_exe_read_permission_denied(
+            &hbb_common::anyhow::anyhow!("canonicalize failure text")
+        ));
     }
 }

--- a/src/ipc/auth.rs
+++ b/src/ipc/auth.rs
@@ -1135,4 +1135,46 @@ mod tests {
             false
         ));
     }
+
+    // The matrix test above pins the pure decision; this one pins the WIRING, so rerouting the
+    // authorization path (e.g. degrading without consulting the server's privilege) cannot pass CI.
+    // PID 1 is a real peer whose executable differs from the test binary: an unprivileged server
+    // cannot read its /proc/<pid>/exe and must defer to the uid gate, while a server that can read
+    // it must still reject the mismatch.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_ensure_peer_executable_honors_server_privilege() {
+        let peer_exe_link = std::fs::read_link("/proc/1/exe");
+        let result = super::ensure_peer_executable_matches_current_by_pid(1, "_uinput_mouse");
+        match peer_exe_link {
+            Ok(peer_exe) => {
+                let peer = std::fs::canonicalize(&peer_exe).ok();
+                let current = std::env::current_exe()
+                    .ok()
+                    .and_then(|exe| std::fs::canonicalize(exe).ok());
+                // Only assert when the peer really is a different binary than this test.
+                if peer.is_some() && peer != current {
+                    assert!(
+                        result.is_err(),
+                        "a readable but mismatched peer executable must be rejected"
+                    );
+                }
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+                if super::ipc_server_is_unprivileged() {
+                    assert!(
+                        result.is_ok(),
+                        "an unprivileged server must defer to the uid gate when the peer executable is unreadable"
+                    );
+                } else {
+                    assert!(
+                        result.is_err(),
+                        "a root server must stay fail-closed when the peer executable is unreadable"
+                    );
+                }
+            }
+            // No /proc, or PID 1 not inspectable for another reason: nothing to pin here.
+            Err(_) => {}
+        }
+    }
 }


### PR DESCRIPTION
## Problem

On non-systemd Linux (Artix/OpenRC, and Void/runit per a second reporter), a remote session shows the screen but remote **keyboard and mouse do nothing**. The controlled side logs:

```
Failed to read peer executable link '/proc/<pid>/exe': Permission denied (os error 13)
Rejected unauthorized connection on protected service-scoped IPC channel due to executable mismatch
Rejected connection on protected uinput ipc channel due to executable mismatch: _uinput_control/_uinput_keyboard/_uinput_mouse
```

Fixes #16073.

## Root cause

The service-scoped `_service` channel and the three `_uinput_*` input channels are guarded by an executable-identity check added in the 1.4.7 IPC hardening (present in 1.4.7–1.4.9, absent in 1.4.6). In `src/ipc/auth.rs`, `ensure_peer_executable_matches_current_by_pid` confirms the peer is the same RustDesk binary by reading the peer's `/proc/<pid>/exe` symlink and comparing it to our own.

That read was **fail-closed on any error**: an `EACCES` from being unable to read the link was treated identically to "the peer is a different binary", and the peer was rejected. With every uinput channel rejected, remote input dies while screen capture keeps working — exactly the report.

Reading the `/proc/<pid>/exe` magic symlink requires `ptrace_may_access(PTRACE_MODE_READ_FSCREDS)`. That succeeds only when the reader has `CAP_SYS_PTRACE` (i.e. is root, in the same user namespace) or shares the peer's credentials **and** the peer is dumpable; otherwise it returns `EACCES`. I verified this on a live host: a root reader (minus `CAP_SYS_PTRACE`), a same-uid but non-dumpable peer, and a cross-namespace peer all reproduce the exact `Permission denied` error.

**Why only non-systemd distros hit it:** in a correct install the reader is the **root** systemd service, and root can always read the link, so this never fires. Without systemd, `rustdesk --install-service` fails (`no systemctl`), so there is no root service and the IPC-server side ends up running as the unprivileged user. An unprivileged reader cannot introspect the peer, so the gate rejects it. The check thus turns "no root service" into "remote input silently rejected" — a regression from 1.4.6.

The exe check is not redundant: the service/uinput sockets are mode `0666` inside a world-traversable `0711` parent dir, so the only real access gates are the UID check (`peer_uid == 0 || == active_uid`) and this exe check. So the check cannot simply be removed.

## The fix

Distinguish **"could not read the peer's exe"** (a permission/introspection failure) from **"read it and it is a different binary"**, and only relax the former:

1. `peer_exe_canonical_path_by_pid` (Linux) now preserves the underlying `io::Error` as the error source (same logged message), so its kind survives to the classifier.
2. On `EACCES`/`EPERM` (both map to `ErrorKind::PermissionDenied`), and **only when the IPC server is itself unprivileged** (`geteuid() != 0`), treat peer identity as unavailable, log a warning, and defer to the UID gate the callers already enforce. This mirrors the existing Windows portable-service "identity unavailable → defer to other boundaries" path in the same file.
3. A **readable but mismatched** binary is still rejected. macOS and Windows behavior is byte-for-byte unchanged (the new logic is `#[cfg(target_os = "linux")]`).

Both reported channels are fixed through the single shared function; neither call site changes.

## Why this is a *safe* degrade

The relaxation is deliberately confined so the hardened path is untouched:

- **Standard systemd + root service (the case that must stay strict): fully unchanged.** A root server can always read a same-user-namespace peer's `/proc/<pid>/exe`, so it never legitimately hits `EACCES`. If a root server *did* see `EACCES` (e.g. a cross-namespace peer), that is genuinely anomalous and stays **fail-closed** — the `geteuid() != 0` guard prevents the degrade from ever applying to a root server.
- **Non-standard, non-root server (the broken non-systemd case): degrade is the only option.** An unprivileged reader cannot introspect *any* peer, legitimate or malicious, so the exe check has no information to act on. Deferring to the UID gate there is both the best achievable and exactly the pre-1.4.7 posture that shipped for years.

### Residual risk (stated honestly)

When the server is already unprivileged (non-systemd), a same-uid process could still bypass the exe check by making itself non-dumpable to force `EACCES`. This is unavoidable in that environment — the reader fundamentally cannot tell a legitimate un-introspectable peer from a malicious one — and it does not affect the standard root-service deployment at all. Closing it entirely would require abandoning `/proc` introspection in favor of a spawn-time token handshake between the service and `--server`, which is a much larger protocol change and out of scope here.

## Alternatives considered

- **`prctl(PR_SET_DUMPABLE, 1)` on RustDesk processes** so a same-uid reader can introspect the peer, keeping the exe check strict. Rejected as primary: it only fixes the non-dumpable-peer trigger (not cross-namespace / genuinely unprivileged readers) and makes the server's memory introspectable by same-uid processes.
- **Unconditional allow on read failure.** Rejected: it would also relax the root-service path on a cross-namespace `EACCES`, which we want to keep fail-closed.

## Testing

- Verified on a live Linux host that `EACCES` on `/proc/<pid>/exe` reproduces for a non-dumpable same-uid peer, a root peer read by a non-root reader, a reader lacking `CAP_SYS_PTRACE`, and a cross-user-namespace peer.
- Added a Linux unit test (`test_peer_exe_read_permission_denied_classification`) asserting `EACCES`/`EPERM` classify as permission-denied (degrade) while `NotFound` and non-io errors do not (still reject).
- The changed logic type-checks against the pinned `anyhow` (downcast survives `.context()`); the file is rustfmt-clean.

## Regression surface

Only `src/ipc/auth.rs` changes. The two touched existing functions are Linux-only or reduce to identical behavior on macOS/Windows; the rest is new, `#[cfg(target_os = "linux")]`-gated code and one test. No shared traits, signatures, or dependencies change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lq6xFoeEmjcuKwRx1GfdQ2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Linux IPC authentication when executable information cannot be read due to permission restrictions.
  - Preserved permission-denied details so valid identity-based checks can proceed safely.
  - Continued rejecting unrelated executable-verification errors.
  - Ensured privileged IPC servers remain fail-closed when verification is unavailable.
  - Added coverage for permission handling and security decisions across supported Linux scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes Linux IPC executable authentication to distinguish an unreadable peer executable from a confirmed mismatch.
- Preserves the underlying I/O error when reading `/proc/<pid>/exe`.
- Allows an unprivileged IPC server to defer permission-denied cases to the existing UID gate.
- Keeps root servers and readable executable mismatches fail-closed.
- Adds decision-matrix and end-to-end wiring tests; the latter remains dependent on the host’s `/proc/1` behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The implementation appears safe to merge; the remaining feedback is a non-blocking concern about environment-dependent regression coverage.

The authorization change preserves strict rejection for root servers, non-permission failures, and readable executable mismatches. The only new finding is that the added wiring test can pass without exercising an authorization branch when the host does not expose `/proc/1/exe` as expected.

**Files Needing Attention:** src/ipc/auth.rs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/ipc/auth.rs | Adds the Linux-only permission-denied fallback and comprehensive pure decision tests, but the new wiring test can silently skip assertions depending on `/proc/1`. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Read peer /proc/pid/exe] -->|Readable| B{Matches current executable?}
    B -->|Yes| C[Accept executable check]
    B -->|No| D[Reject peer]
    A -->|Permission denied| E{IPC server unprivileged?}
    E -->|Yes| F[Defer to existing UID gate]
    E -->|No| D
    A -->|Other error| D
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2316088%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=16088&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fipc%2Fauth.rs%3A1177%0A**Wiring%20test%20can%20skip**%0A%0AIf%20%60%2Fproc%2F1%2Fexe%60%20is%20unavailable%20for%20any%20reason%20other%20than%20%60PermissionDenied%60%2C%20this%20branch%20makes%20no%20assertion%2C%20so%20the%20test%20passes%20without%20checking%20either%20authorization%20outcome.%20Canonicalization%20failure%20can%20similarly%20suppress%20the%20mismatch%20assertion.%20This%20makes%20the%20regression%20coverage%20depend%20on%20the%20host's%20live%20%60%2Fproc%60%20setup%3B%20use%20a%20controlled%20peer%20or%20injectable%20lookup%20result%20so%20the%20expected%20branch%20is%20always%20exercised.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16088&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix%2F16073-ipc-exe-check-eacces%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F16073-ipc-exe-check-eacces%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fipc%2Fauth.rs%3A1177%0A**Wiring%20test%20can%20skip**%0A%0AIf%20%60%2Fproc%2F1%2Fexe%60%20is%20unavailable%20for%20any%20reason%20other%20than%20%60PermissionDenied%60%2C%20this%20branch%20makes%20no%20assertion%2C%20so%20the%20test%20passes%20without%20checking%20either%20authorization%20outcome.%20Canonicalization%20failure%20can%20similarly%20suppress%20the%20mismatch%20assertion.%20This%20makes%20the%20regression%20coverage%20depend%20on%20the%20host's%20live%20%60%2Fproc%60%20setup%3B%20use%20a%20controlled%20peer%20or%20injectable%20lookup%20result%20so%20the%20expected%20branch%20is%20always%20exercised.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16088&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/ipc/auth.rs:1177
**Wiring test can skip**

If `/proc/1/exe` is unavailable for any reason other than `PermissionDenied`, this branch makes no assertion, so the test passes without checking either authorization outcome. Canonicalization failure can similarly suppress the mismatch assertion. This makes the regression coverage depend on the host's live `/proc` setup; use a controlled peer or injectable lookup result so the expected branch is always exercised.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["test(linux): pin the exe-check wiring, n..."](https://github.com/rustdesk/rustdesk/commit/9dd427d49fb903c7a664ad412267d8cb495cd939) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60861392)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->