### PR TITLE
Fit to client

### DIFF
--- a/.github/workflows/fit-client-build.yml
+++ b/.github/workflows/fit-client-build.yml
@@ -1,0 +1,224 @@
+# Build the two binaries this fork actually needs:
+#   * Linux x86_64 Flutter RPM (laptop host)
+#   * unsigned iOS IPA (iPhone client)
+#
+# Trigger: Actions → "Fit-client Linux host + iOS IPA" → Run workflow
+name: Fit-client Linux host + iOS IPA
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [fit-to-client]
+    paths:
+      - ".github/workflows/fit-client-build.yml"
+      - "src/**"
+      - "flutter/**"
+      - "libs/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "build.py"
+      - "vcpkg.json"
+
+concurrency:
+  group: fit-client-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  RUST_VERSION: "1.75"
+  FLUTTER_VERSION: "3.24.5"
+  VERSION: "1.5.0"
+  VCPKG_COMMIT_ID: "9e593bb18ea69cc5095e012465dcd675a822ed0d"
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
+jobs:
+  generate-bridge:
+    uses: ./.github/workflows/bridge.yml
+
+  linux-host-rpm:
+    name: Linux x86_64 Flutter RPM
+    needs: [generate-bridge]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Maximize build space
+        run: |
+          sudo rm -rf /opt/ghc /usr/local/lib/android /usr/share/dotnet
+          sudo apt-get update -y
+
+      - name: Checkout source code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: recursive
+
+      - name: Install native dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            clang cmake curl gcc git g++ nasm ninja-build pkg-config \
+            libayatana-appindicator3-dev libasound2-dev libclang-dev \
+            libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            libgtk-3-dev libpulse-dev libva-dev libxcb-randr0-dev \
+            libxcb-shape0-dev libxcb-xfixes0-dev libxdo-dev libxfixes-dev \
+            llvm-dev python3 rpm unzip wget xz-utils libssl-dev
+          sudo apt-get remove -y libopus-dev || true
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: x86_64-unknown-linux-gnu
+          components: rustfmt
+
+      - name: Disable extra rust crate types
+        run: sed -i 's/\["cdylib", "staticlib", "rlib"\]/["cdylib"]/g' Cargo.toml
+
+      - name: Restore bridge files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bridge-artifact
+          path: ./
+
+      - name: Setup vcpkg with Github Actions binary cache
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11
+        with:
+          vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
+          doNotCache: false
+
+      - name: Install vcpkg dependencies
+        run: |
+          if ! "$VCPKG_ROOT/vcpkg" install --triplet x64-linux --x-install-root="$VCPKG_ROOT/installed"; then
+            find "$VCPKG_ROOT" -name "*.log" | while read -r log; do
+              echo "===== $log ====="
+              tail -n 80 "$log" || true
+            done
+            exit 1
+          fi
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          channel: stable
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+
+      - name: Patch Flutter 3.24.5
+        run: |
+          cd "$(dirname "$(dirname "$(which flutter)")")"
+          git apply "${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff"
+
+      - name: Build rustdesk library
+        run: cargo build --locked --lib --features hwcodec,flutter,unix-file-copy-paste --release
+
+      - name: Build Flutter linux bundle and RPM
+        run: |
+          export CARGO_INCREMENTAL=0
+          python3 ./build.py --flutter --skip-cargo
+          HBB="$(pwd)" rpmbuild ./res/rpm-flutter.spec -bb
+          mkdir -p dist
+          cp -v "$HOME/rpmbuild/RPMS/x86_64"/rustdesk*.rpm dist/
+          ls -lh dist
+
+      - name: Upload Linux RPM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rustdesk-${{ env.VERSION }}-x86_64.rpm
+          path: dist/rustdesk*.rpm
+          if-no-files-found: error
+
+  ios-ipa:
+    name: iOS unsigned IPA
+    needs: [generate-bridge]
+    runs-on: macos-latest
+    steps:
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Install dependencies
+        run: brew install nasm yasm
+
+      - name: Checkout source code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: recursive
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          channel: stable
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+
+      - name: Patch Flutter 3.24.5
+        run: |
+          cd "$(dirname "$(dirname "$(which flutter)")")"
+          git apply "${{ github.workspace }}/.github/patches/flutter_3.24.4_dropdown_menu_enableFilter.diff"
+
+      - name: Setup vcpkg with Github Actions binary cache
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11
+        with:
+          vcpkgGitCommitId: ${{ env.VCPKG_COMMIT_ID }}
+          doNotCache: false
+
+      - name: Install vcpkg dependencies
+        run: |
+          if ! "$VCPKG_ROOT/vcpkg" install --triplet arm64-ios --x-install-root="$VCPKG_ROOT/installed"; then
+            find "$VCPKG_ROOT" -name "*.log" | while read -r log; do
+              echo "===== $log ====="
+              tail -n 80 "$log" || true
+            done
+            exit 1
+          fi
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: aarch64-apple-ios
+          components: rustfmt
+
+      - name: Restore bridge files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bridge-artifact
+          path: ./
+
+      - name: Build rustdesk iOS library
+        run: |
+          rustup target add aarch64-apple-ios
+          cargo build --locked --features flutter,hwcodec --release --target aarch64-apple-ios --lib
+
+      - name: Build unsigned IPA
+        working-directory: flutter
+        run: |
+          flutter build ipa --release --no-codesign
+          mkdir -p build/ios/ipa
+          ARCHIVE="build/ios/archive/Runner.xcarchive"
+          if [[ -d "$ARCHIVE/Products/Applications" ]]; then
+            pushd "$ARCHIVE/Products/Applications"
+            rm -rf Payload
+            mkdir Payload
+            cp -R *.app Payload/
+            zip -r ../../../../ipa/RustDesk-unsigned.ipa Payload
+            popd
+          fi
+          ls -lh build/ios/ipa || true
+          test -n "$(ls -A build/ios/ipa/*.ipa 2>/dev/null)"
+
+      - name: Upload iOS IPA
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rustdesk-${{ env.VERSION }}-ios-unsigned.ipa
+          path: flutter/build/ios/ipa/*.ipa
+          if-no-files-found: error

--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -62,6 +62,10 @@ final isWebOnWindows = isWebOnWindows_;
 final isWebOnLinux = isWebOnLinux_;
 final isWebOnMacOs = isWebOnMacOS_;
 var isMobile = isAndroid || isIOS;
+/// Phone clients only offer a remote-desktop session. Extra RustDesk
+/// session types stay in the protocol (the public server still works)
+/// but are hidden from the UI.
+bool get kPhoneRemoteOnly => isMobile;
 var version = '';
 int androidVersion = 0;
 

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -583,6 +583,17 @@ abstract class BasePeerCard extends StatelessWidget {
     );
   }
 
+  List<MenuEntryBase<String>> _extraSessionActions(BuildContext context) {
+    if (kPhoneRemoteOnly) {
+      return <MenuEntryBase<String>>[];
+    }
+    return <MenuEntryBase<String>>[
+      _transferFileAction(context),
+      _viewCameraAction(context),
+      _terminalAction(context),
+    ];
+  }
+
   @protected
   MenuEntryBase<String> _transferFileAction(BuildContext context) {
     return _connectCommonAction(
@@ -968,12 +979,10 @@ class RecentPeerCard extends BasePeerCard {
       BuildContext context) async {
     final List<MenuEntryBase<String>> menuItems = [
       _connectAction(context),
-      _transferFileAction(context),
-      _viewCameraAction(context),
-      _terminalAction(context),
+      ..._extraSessionActions(context),
     ];
 
-    if (peer.platform == kPeerPlatformWindows) {
+    if (!kPhoneRemoteOnly && peer.platform == kPeerPlatformWindows) {
       menuItems.add(_terminalRunAsAdminAction(context));
     }
 
@@ -1033,12 +1042,10 @@ class FavoritePeerCard extends BasePeerCard {
       BuildContext context) async {
     final List<MenuEntryBase<String>> menuItems = [
       _connectAction(context),
-      _transferFileAction(context),
-      _viewCameraAction(context),
-      _terminalAction(context),
+      ..._extraSessionActions(context),
     ];
 
-    if (peer.platform == kPeerPlatformWindows) {
+    if (!kPhoneRemoteOnly && peer.platform == kPeerPlatformWindows) {
       menuItems.add(_terminalRunAsAdminAction(context));
     }
 
@@ -1093,12 +1100,10 @@ class DiscoveredPeerCard extends BasePeerCard {
       BuildContext context) async {
     final List<MenuEntryBase<String>> menuItems = [
       _connectAction(context),
-      _transferFileAction(context),
-      _viewCameraAction(context),
-      _terminalAction(context),
+      ..._extraSessionActions(context),
     ];
 
-    if (peer.platform == kPeerPlatformWindows) {
+    if (!kPhoneRemoteOnly && peer.platform == kPeerPlatformWindows) {
       menuItems.add(_terminalRunAsAdminAction(context));
     }
 
@@ -1152,12 +1157,10 @@ class AddressBookPeerCard extends BasePeerCard {
       BuildContext context) async {
     final List<MenuEntryBase<String>> menuItems = [
       _connectAction(context),
-      _transferFileAction(context),
-      _viewCameraAction(context),
-      _terminalAction(context),
+      ..._extraSessionActions(context),
     ];
 
-    if (peer.platform == kPeerPlatformWindows) {
+    if (!kPhoneRemoteOnly && peer.platform == kPeerPlatformWindows) {
       menuItems.add(_terminalRunAsAdminAction(context));
     }
 
@@ -1309,12 +1312,10 @@ class MyGroupPeerCard extends BasePeerCard {
       BuildContext context) async {
     final List<MenuEntryBase<String>> menuItems = [
       _connectAction(context),
-      _transferFileAction(context),
-      _viewCameraAction(context),
-      _terminalAction(context),
+      ..._extraSessionActions(context),
     ];
 
-    if (peer.platform == kPeerPlatformWindows) {
+    if (!kPhoneRemoteOnly && peer.platform == kPeerPlatformWindows) {
       menuItems.add(_terminalRunAsAdminAction(context));
     }
 

--- a/flutter/lib/common/widgets/toolbar.dart
+++ b/flutter/lib/common/widgets/toolbar.dart
@@ -887,16 +887,41 @@ Future<List<TToggleMenu>> toolbarDisplayToggle(
   final sessionId = ffi.sessionId;
   final isDefaultConn = ffi.connType == ConnType.defaultConn;
 
+  if (isDefaultConn && ffiModel.keyboard) {
+    final fitOpt = await bind.sessionGetFlutterOption(
+        sessionId: sessionId, k: kOptionFitToClient);
+    final fitEnabled =
+        fitOpt == 'Y' || ((fitOpt == null || fitOpt.isEmpty) && isMobile);
+    v.add(TToggleMenu(
+        value: fitEnabled,
+        onChanged: (value) async {
+          if (value == null) return;
+          await bind.sessionSetFlutterOption(
+              sessionId: sessionId,
+              k: kOptionFitToClient,
+              v: value ? 'Y' : 'N');
+          if (value) {
+            await ffiModel.applyFitToClient();
+          } else {
+            await ffiModel.restoreFitToClient();
+          }
+        },
+        child: Text(translate('Fit to client'))));
+  }
+
   // show quality monitor
-  final option = 'show-quality-monitor';
-  v.add(TToggleMenu(
-      value: bind.sessionGetToggleOptionSync(sessionId: sessionId, arg: option),
-      onChanged: (value) async {
-        if (value == null) return;
-        await bind.sessionToggleOption(sessionId: sessionId, value: option);
-        ffi.qualityMonitorModel.checkShowQualityMonitor(sessionId);
-      },
-      child: Text(translate('Show quality monitor'))));
+  if (!kPhoneRemoteOnly) {
+    final option = 'show-quality-monitor';
+    v.add(TToggleMenu(
+        value:
+            bind.sessionGetToggleOptionSync(sessionId: sessionId, arg: option),
+        onChanged: (value) async {
+          if (value == null) return;
+          await bind.sessionToggleOption(sessionId: sessionId, value: option);
+          ffi.qualityMonitorModel.checkShowQualityMonitor(sessionId);
+        },
+        child: Text(translate('Show quality monitor'))));
+  }
   // mute
   if (isDefaultConn && perms['audio'] != false) {
     final option = 'disable-audio';

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -81,6 +81,9 @@ const String kWindowEventGetCachedSessionData = "get_cached_session_data";
 const String kWindowEventOpenMonitorSession = "open_monitor_session";
 
 const String kOptionViewStyle = "view_style";
+/// Persist whether this session should shrink the host desktop so it stays
+/// readable on a small client (phone). Stored as 'Y' / 'N'.
+const String kOptionFitToClient = "fit-to-client";
 const String kOptionScrollStyle = "scroll_style";
 const String kOptionEdgeScrollEdgeThickness = "edge-scroll-edge-thickness";
 const String kOptionImageQuality = "image_quality";

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -18,6 +18,7 @@ import 'package:window_size/window_size.dart' as window_size;
 
 import '../../common.dart';
 import '../../models/model.dart';
+import '../../models/fit_client.dart';
 import '../../models/platform_model.dart';
 import '../../common/shared_state.dart';
 import './popup_menu.dart';
@@ -2500,7 +2501,18 @@ class _ResolutionsMenuState extends State<_ResolutionsMenu> {
       }
     }
 
-    return null;
+    final picked = pickFitClientMode(
+      viewport: FitClientViewport(
+        logicalWidth: _localResolution!.width.toDouble(),
+        logicalHeight: _localResolution!.height.toDouble(),
+        devicePixelRatio: 1.0,
+      ),
+      hostModes: resolutions.map((r) => HostMode(r.width, r.height)).toList(),
+    );
+    if (picked == null) {
+      return null;
+    }
+    return Resolution(picked.width, picked.height);
   }
 
   bool _isRemoteResolutionFitLocal() {

--- a/flutter/lib/mobile/pages/remote_page.dart
+++ b/flutter/lib/mobile/pages/remote_page.dart
@@ -513,6 +513,7 @@ class _RemotePageState extends State<RemotePage> with WidgetsBindingObserver {
                                       .resetMobileActionsOverlay(ffi: gFFI);
                                   _currentOrientation = orientation;
                                   gFFI.canvasModel.updateViewStyle();
+                                  gFFI.ffiModel.scheduleFitToClient();
                                 });
                               }
                               return Container(

--- a/flutter/lib/models/fit_client.dart
+++ b/flutter/lib/models/fit_client.dart
@@ -1,0 +1,121 @@
+/// Host framebuffer size advertised in PeerInfo.resolutions.
+class HostMode {
+  final int width;
+  final int height;
+  const HostMode(this.width, this.height);
+
+  int get area => width * height;
+
+  @override
+  bool operator ==(Object other) =>
+      other is HostMode && other.width == width && other.height == height;
+
+  @override
+  int get hashCode => Object.hash(width, height);
+
+  @override
+  String toString() => '${width}x$height';
+}
+
+/// Client viewport used to pick a readable host mode.
+class FitClientViewport {
+  final double logicalWidth;
+  final double logicalHeight;
+  final double devicePixelRatio;
+
+  const FitClientViewport({
+    required this.logicalWidth,
+    required this.logicalHeight,
+    required this.devicePixelRatio,
+  });
+
+  double get physicalWidth => logicalWidth * devicePixelRatio;
+  double get physicalHeight => logicalHeight * devicePixelRatio;
+}
+
+/// Uniform adaptive scale that fits [hostW]x[hostH] into the client.
+double adaptiveFitScale({
+  required double clientW,
+  required double clientH,
+  required double hostW,
+  required double hostH,
+}) {
+  if (hostW <= 0 || hostH <= 0 || clientW <= 0 || clientH <= 0) {
+    return 0;
+  }
+  final s1 = clientW / hostW;
+  final s2 = clientH / hostH;
+  return s1 < s2 ? s1 : s2;
+}
+
+/// Pick a host mode that still fits on the phone after adaptive scaling.
+///
+/// A 2880×1800 laptop squeezed onto an iPhone becomes unreadably small.
+/// Choosing a smaller advertised mode (for example 1280×800) makes the
+/// whole desktop fit *and* leaves icons large enough to tap.
+///
+/// Portrait phones are treated as landscape: the laptop is not rotated
+/// into a 390×844 desktop, which breaks most apps.
+HostMode? pickFitClientMode({
+  required FitClientViewport viewport,
+  required List<HostMode> hostModes,
+  int minWidth = 1280,
+  int minHeight = 720,
+}) {
+  if (hostModes.isEmpty) {
+    return null;
+  }
+
+  var targetW = viewport.physicalWidth;
+  var targetH = viewport.physicalHeight;
+  if (targetH > targetW) {
+    final tmp = targetW;
+    targetW = targetH;
+    targetH = tmp;
+  }
+
+  final unique = <String, HostMode>{};
+  for (final mode in hostModes) {
+    if (mode.width > 0 && mode.height > 0) {
+      unique['${mode.width}x${mode.height}'] = mode;
+    }
+  }
+  final modes = unique.values.toList();
+  if (modes.isEmpty) {
+    return null;
+  }
+
+  bool usableDesktop(HostMode mode) {
+    final landscape = mode.width >= mode.height;
+    final w = landscape ? mode.width : mode.height;
+    final h = landscape ? mode.height : mode.width;
+    return w >= minWidth && h >= minHeight;
+  }
+
+  var candidates = modes.where(usableDesktop).toList();
+  if (candidates.isEmpty) {
+    modes.sort((a, b) => b.area.compareTo(a.area));
+    return modes.first;
+  }
+
+  double score(HostMode mode) {
+    final fit = adaptiveFitScale(
+      clientW: targetW,
+      clientH: targetH,
+      hostW: mode.width.toDouble(),
+      hostH: mode.height.toDouble(),
+    );
+    // Higher fit = larger on-phone UI. Cap so a tiny 800×600 does not
+    // always win over a still-readable 1280×800 desktop.
+    return fit.clamp(0.0, 1.75);
+  }
+
+  candidates.sort((a, b) {
+    final byScore = score(b).compareTo(score(a));
+    if (byScore != 0) {
+      return byScore;
+    }
+    return a.area.compareTo(b.area);
+  });
+  return candidates.first;
+}

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -43,6 +43,7 @@ import '../common/widgets/dialog.dart';
 import 'input_model.dart';
 import 'platform_model.dart';
 import 'package:flutter_hbb/utils/scale.dart';
+import 'package:flutter_hbb/models/fit_client.dart';
 
 import 'package:flutter_hbb/generated_bridge.dart'
     if (dart.library.html) 'package:flutter_hbb/web/bridge.dart';
@@ -137,6 +138,8 @@ class FfiModel with ChangeNotifier {
   bool isRefreshing = false;
 
   Timer? timerScreenshot;
+  Timer? _fitClientDebounce;
+  (int, int)? _lastFitClientApplied;
 
   Rect? get rect => _rect;
   bool get isOriginalResolutionSet =>
@@ -263,6 +266,9 @@ class FfiModel with ChangeNotifier {
     clearPermissions();
     waitForImageTimer?.cancel();
     timerScreenshot?.cancel();
+    _fitClientDebounce?.cancel();
+    _fitClientDebounce = null;
+    _lastFitClientApplied = null;
   }
 
   setConnectionType(
@@ -1497,7 +1503,110 @@ class FfiModel with ChangeNotifier {
 
     if (!isCache) {
       tryUseAllMyDisplaysForTheRemoteSession(peerId);
+      scheduleFitToClient();
     }
+  }
+
+  void scheduleFitToClient() {
+    if (parent.target?.connType != ConnType.defaultConn) {
+      return;
+    }
+    _fitClientDebounce?.cancel();
+    _fitClientDebounce = Timer(const Duration(milliseconds: 400), () {
+      applyFitToClient();
+    });
+  }
+
+  Future<bool> isFitToClientEnabled() async {
+    final opt = await bind.sessionGetFlutterOption(
+        sessionId: sessionId, k: kOptionFitToClient);
+    if (opt == null || opt.isEmpty) {
+      return isMobile;
+    }
+    return opt == 'Y';
+  }
+
+  Future<void> applyFitToClient() async {
+    final ffi = parent.target;
+    if (ffi == null || ffi.connType != ConnType.defaultConn) {
+      return;
+    }
+    if (!keyboard) {
+      return;
+    }
+    if (!await isFitToClientEnabled()) {
+      return;
+    }
+    if (_pi.resolutions.isEmpty) {
+      return;
+    }
+    final displayIndex = _pi.currentDisplay;
+    if (displayIndex == kAllDisplayValue) {
+      return;
+    }
+    final display = _pi.tryGetDisplayIfNotAllDisplay(display: displayIndex);
+    if (display == null) {
+      return;
+    }
+
+    await bind.sessionSetViewStyle(
+        sessionId: sessionId, value: kRemoteViewStyleAdaptive);
+    await ffi.canvasModel.updateViewStyle();
+
+    final views = ui.PlatformDispatcher.instance.views;
+    if (views.isEmpty) {
+      return;
+    }
+    final view = ui.PlatformDispatcher.instance.implicitView ?? views.first;
+    final dpr = view.devicePixelRatio;
+    final logical = view.physicalSize / dpr;
+    final picked = pickFitClientMode(
+      viewport: FitClientViewport(
+        logicalWidth: logical.width,
+        logicalHeight: logical.height,
+        devicePixelRatio: dpr,
+      ),
+      hostModes:
+          _pi.resolutions.map((r) => HostMode(r.width, r.height)).toList(),
+    );
+    if (picked == null) {
+      return;
+    }
+    if (display.width == picked.width && display.height == picked.height) {
+      _lastFitClientApplied = (picked.width, picked.height);
+      return;
+    }
+    if (_lastFitClientApplied != null &&
+        _lastFitClientApplied!.$1 == picked.width &&
+        _lastFitClientApplied!.$2 == picked.height) {
+      return;
+    }
+    _lastFitClientApplied = (picked.width, picked.height);
+    await bind.sessionChangeResolution(
+      sessionId: sessionId,
+      display: displayIndex,
+      width: picked.width,
+      height: picked.height,
+    );
+  }
+
+  Future<void> restoreFitToClient() async {
+    _fitClientDebounce?.cancel();
+    _lastFitClientApplied = null;
+    final displayIndex = _pi.currentDisplay;
+    final display = _pi.tryGetDisplayIfNotAllDisplay(display: displayIndex);
+    if (display == null || !display.isOriginalResolutionSet) {
+      return;
+    }
+    if (display.isOriginalResolution) {
+      return;
+    }
+    await bind.sessionChangeResolution(
+      sessionId: sessionId,
+      display: displayIndex,
+      width: display.originalWidth,
+      height: display.originalHeight,
+    );
   }
 
   checkDesktopKeyboardMode() async {

--- a/flutter/test/fit_client_test.dart
+++ b/flutter/test/fit_client_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_hbb/models/fit_client.dart';
+
+void main() {
+  const laptopModes = [
+    HostMode(2880, 1800),
+    HostMode(2560, 1600),
+    HostMode(1920, 1200),
+    HostMode(1920, 1080),
+    HostMode(1600, 900),
+    HostMode(1280, 800),
+    HostMode(1280, 720),
+    HostMode(1024, 768),
+  ];
+
+  const iphone = FitClientViewport(
+    logicalWidth: 393,
+    logicalHeight: 852,
+    devicePixelRatio: 3,
+  );
+
+  test('empty host mode list returns null', () {
+    expect(
+      pickFitClientMode(viewport: iphone, hostModes: const []),
+      isNull,
+    );
+  });
+
+  test('iPhone portrait picks a small landscape desktop, not 2880x1800', () {
+    final picked = pickFitClientMode(
+      viewport: iphone,
+      hostModes: laptopModes,
+    );
+    expect(picked, isNotNull);
+    expect(picked!.width, lessThanOrEqualTo(1280));
+    expect(picked.height, lessThanOrEqualTo(800));
+    expect(picked.width, greaterThanOrEqualTo(1280));
+    expect(picked.height, greaterThanOrEqualTo(720));
+  });
+
+  test('iPhone landscape picks the same readable desktop', () {
+    const landscape = FitClientViewport(
+      logicalWidth: 852,
+      logicalHeight: 393,
+      devicePixelRatio: 3,
+    );
+    final portrait = pickFitClientMode(
+      viewport: iphone,
+      hostModes: laptopModes,
+    );
+    final rotated = pickFitClientMode(
+      viewport: landscape,
+      hostModes: laptopModes,
+    );
+    expect(portrait, rotated);
+  });
+
+  test('chosen mode is more readable than native 2880x1800', () {
+    final picked = pickFitClientMode(
+      viewport: iphone,
+      hostModes: laptopModes,
+    )!;
+    // Physical iPhone landscape after the portrait→landscape remap.
+    const clientW = 852.0 * 3;
+    const clientH = 393.0 * 3;
+    final native = adaptiveFitScale(
+      clientW: clientW,
+      clientH: clientH,
+      hostW: 2880,
+      hostH: 1800,
+    );
+    final fitted = adaptiveFitScale(
+      clientW: clientW,
+      clientH: clientH,
+      hostW: picked.width.toDouble(),
+      hostH: picked.height.toDouble(),
+    );
+    expect(fitted, greaterThan(native));
+    expect(fitted, greaterThan(1.0));
+  });
+
+  test('does not invent a mode missing from the host list', () {
+    final picked = pickFitClientMode(
+      viewport: iphone,
+      hostModes: const [HostMode(1920, 1080), HostMode(1280, 720)],
+    );
+    expect(picked, anyOf(const HostMode(1920, 1080), const HostMode(1280, 720)));
+  });
+
+  test('falls back to the largest mode when none meet the desktop minimum', () {
+    final picked = pickFitClientMode(
+      viewport: iphone,
+      hostModes: const [HostMode(800, 600), HostMode(640, 480)],
+    );
+    expect(picked, const HostMode(800, 600));
+  });
+
+  test('deduplicates identical width x height entries', () {
+    final picked = pickFitClientMode(
+      viewport: iphone,
+      hostModes: const [
+        HostMode(1280, 800),
+        HostMode(1280, 800),
+        HostMode(2880, 1800),
+      ],
+    );
+    expect(picked, const HostMode(1280, 800));
+  });
+}

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -161,6 +161,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("no fingerprints", "No fingerprints"),
         ("resolution_original_tip", "Original resolution"),
         ("resolution_fit_local_tip", "Fit local resolution"),
+        ("Fit to client", "Fit to client"),
+        ("fit_to_client_tip", "Shrink the remote desktop so the whole screen stays readable on this device."),
         ("resolution_custom_tip", "Custom resolution"),
         ("Accept and Elevate", "Accept and elevate"),
         ("accept_and_elevate_btn_tooltip", "Accept the connection and elevate UAC permissions."),

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -1957,6 +1957,9 @@ pub fn current_resolution(name: &str) -> ResultType<Resolution> {
 }
 
 pub fn change_resolution_directly(name: &str, width: usize, height: usize) -> ResultType<()> {
+    if try_kscreen_change_mode(name, width, height) {
+        return Ok(());
+    }
     Command::new("xrandr")
         .args(vec![
             "--output",
@@ -1966,6 +1969,154 @@ pub fn change_resolution_directly(name: &str, width: usize, height: usize) -> Re
         ])
         .spawn()?;
     Ok(())
+}
+
+fn kscreen_doctor_output() -> ResultType<String> {
+    let output = Command::new("kscreen-doctor").arg("-o").output()?;
+    if !output.status.success() {
+        bail!(
+            "kscreen-doctor -o failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Highest-refresh `WxH@rate` token advertised for [name], if any.
+pub fn parse_kscreen_best_mode(output: &str, name: &str, width: usize, height: usize) -> Option<String> {
+    let mut current = None;
+    let mut best: Option<(f64, String)> = None;
+    let wanted = format!("{}x{}", width, height);
+    for line in output.lines() {
+        if let Some(rest) = line.strip_prefix("Output:") {
+            current = rest.split_whitespace().nth(1).map(|s| s.to_string());
+            continue;
+        }
+        if current.as_deref() != Some(name) {
+            continue;
+        }
+        let Some(modes_part) = line.split("Modes:").nth(1) else {
+            continue;
+        };
+        for token in modes_part.split_whitespace() {
+            // 15:1280x800@119.85*!  or  14:1280x800@59.81
+            let token = token.trim_end_matches(['*', '!']);
+            let Some((_, mode)) = token.split_once(':') else {
+                continue;
+            };
+            let Some((wh, rate_s)) = mode.split_once('@') else {
+                continue;
+            };
+            if wh != wanted {
+                continue;
+            }
+            let rate = rate_s.parse::<f64>().unwrap_or(0.0);
+            if best.as_ref().map(|(r, _)| rate > *r).unwrap_or(true) {
+                best = Some((rate, mode.to_string()));
+            }
+        }
+    }
+    best.map(|(_, mode)| mode)
+}
+
+pub fn parse_kscreen_scale(output: &str, name: &str) -> Option<f64> {
+    let mut current = None;
+    for line in output.lines() {
+        if let Some(rest) = line.strip_prefix("Output:") {
+            current = rest.split_whitespace().nth(1).map(|s| s.to_string());
+            continue;
+        }
+        if current.as_deref() != Some(name) {
+            continue;
+        }
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("Scale:") {
+            return rest.trim().parse().ok();
+        }
+    }
+    None
+}
+
+fn try_kscreen_change_mode(name: &str, width: usize, height: usize) -> bool {
+    let Ok(info) = kscreen_doctor_output() else {
+        return false;
+    };
+    let Some(mode) = parse_kscreen_best_mode(&info, name, width, height) else {
+        return false;
+    };
+    Command::new("kscreen-doctor")
+        .arg(format!("output.{}.mode.{}", name, mode))
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+pub fn get_display_scale(name: &str) -> Option<f64> {
+    let info = kscreen_doctor_output().ok()?;
+    parse_kscreen_scale(&info, name)
+}
+
+pub fn set_display_scale(name: &str, scale: f64) -> ResultType<()> {
+    let status = Command::new("kscreen-doctor")
+        .arg(format!("output.{}.scale.{}", name, scale))
+        .status()?;
+    if !status.success() {
+        bail!("kscreen-doctor scale {} on {} failed", scale, name);
+    }
+    Ok(())
+}
+
+/// When the host shrinks for a phone-sized client, raise OS scale so
+/// icons and text actually render larger instead of just being fewer pixels.
+pub fn suggested_fit_client_scale(new_width: i32, current_scale: f64) -> f64 {
+    if new_width <= 0 {
+        return current_scale;
+    }
+    let target = if new_width <= 1280 {
+        2.0
+    } else if new_width <= 1600 {
+        1.5
+    } else {
+        current_scale
+    };
+    current_scale.max(target).min(3.0)
+}
+
+#[cfg(test)]
+mod fit_client_kscreen_tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"Output: 1 eDP-1 59758141-7cd8-4e1f-86ad-ce2184261ba8
+enabled
+connected
+Modes:  1:2880x1800@120.00*!  14:1280x800@59.81  15:1280x800@119.85  21:1920x1080@119.93
+Geometry: 0,0 1920x1200
+Scale: 1.5
+Output: 2 HDMI-1 abc
+Scale: 1
+"#;
+
+    #[test]
+    fn picks_highest_refresh_for_mode() {
+        assert_eq!(
+            parse_kscreen_best_mode(SAMPLE, "eDP-1", 1280, 800).as_deref(),
+            Some("1280x800@119.85")
+        );
+    }
+
+    #[test]
+    fn reads_scale_for_named_output() {
+        assert_eq!(parse_kscreen_scale(SAMPLE, "eDP-1"), Some(1.5));
+        assert_eq!(parse_kscreen_scale(SAMPLE, "HDMI-1"), Some(1.0));
+        assert_eq!(parse_kscreen_scale(SAMPLE, "DP-1"), None);
+    }
+
+    #[test]
+    fn raises_scale_on_phone_sized_modes() {
+        assert_eq!(suggested_fit_client_scale(1280, 1.5), 2.0);
+        assert_eq!(suggested_fit_client_scale(1920, 1.5), 1.5);
+        assert_eq!(suggested_fit_client_scale(2880, 1.5), 1.5);
+    }
 }
 
 /// Scoped to `uid`, the user of the session being refreshed: the compositor starts Xwayland as

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -4653,6 +4653,29 @@ impl Connection {
                             e
                         );
                     }
+                    #[cfg(target_os = "linux")]
+                    {
+                        if let Some(cur_scale) = crate::platform::linux::get_display_scale(&name) {
+                            let new_scale = crate::platform::linux::suggested_fit_client_scale(
+                                r.width, cur_scale,
+                            );
+                            if (new_scale - cur_scale).abs() > 0.05 {
+                                display_service::set_last_changed_scale(
+                                    &name, cur_scale, new_scale,
+                                );
+                                if let Err(e) =
+                                    crate::platform::linux::set_display_scale(&name, new_scale)
+                                {
+                                    log::error!(
+                                        "Failed to set scale of '{}' to {}: {:?}",
+                                        &name,
+                                        new_scale,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/server/display_service.rs
+++ b/src/server/display_service.rs
@@ -6,8 +6,11 @@ use crate::platform::linux::is_x11;
 use crate::virtual_display_manager;
 #[cfg(windows)]
 use hbb_common::get_version_number;
+use hbb_common::config::Config;
 use hbb_common::protobuf::MessageField;
 use scrap::Display;
+use serde_json::json;
+use std::fs;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 // https://github.com/rustdesk/rustdesk/discussions/6042, avoiding dbus call
@@ -20,6 +23,8 @@ const DUMMY_DISPLAY_SIDE_MAX_SIZE: usize = 1024;
 struct ChangedResolution {
     original: (i32, i32),
     changed: (i32, i32),
+    original_scale: Option<f64>,
+    changed_scale: Option<f64>,
 }
 
 lazy_static::lazy_static! {
@@ -385,21 +390,117 @@ pub(super) fn check_display_changed(
 
 #[inline]
 pub fn set_last_changed_resolution(display_name: &str, original: (i32, i32), changed: (i32, i32)) {
-    let mut lock = CHANGED_RESOLUTIONS.write().unwrap();
-    match lock.get_mut(display_name) {
-        Some(res) => res.changed = changed,
-        None => {
-            lock.insert(
-                display_name.to_owned(),
-                ChangedResolution { original, changed },
-            );
+    {
+        let mut lock = CHANGED_RESOLUTIONS.write().unwrap();
+        match lock.get_mut(display_name) {
+            Some(res) => res.changed = changed,
+            None => {
+                lock.insert(
+                    display_name.to_owned(),
+                    ChangedResolution {
+                        original,
+                        changed,
+                        original_scale: None,
+                        changed_scale: None,
+                    },
+                );
+            }
         }
+    }
+    persist_changed_resolutions();
+}
+
+#[inline]
+pub fn set_last_changed_scale(display_name: &str, original: f64, changed: f64) {
+    let mut lock = CHANGED_RESOLUTIONS.write().unwrap();
+    if let Some(res) = lock.get_mut(display_name) {
+        if res.original_scale.is_none() {
+            res.original_scale = Some(original);
+        }
+        res.changed_scale = Some(changed);
+    }
+    drop(lock);
+    persist_changed_resolutions();
+}
+
+fn changed_resolutions_path() -> std::path::PathBuf {
+    Config::path("fit-to-client-restore.json")
+}
+
+fn persist_changed_resolutions() {
+    let lock = CHANGED_RESOLUTIONS.read().unwrap();
+    let path = changed_resolutions_path();
+    if lock.is_empty() {
+        let _ = fs::remove_file(&path);
+        return;
+    }
+    let items: Vec<serde_json::Value> = lock
+        .iter()
+        .map(|(name, res)| {
+            json!({
+                "name": name,
+                "original_width": res.original.0,
+                "original_height": res.original.1,
+                "changed_width": res.changed.0,
+                "changed_height": res.changed.1,
+                "original_scale": res.original_scale,
+                "changed_scale": res.changed_scale,
+            })
+        })
+        .collect();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(path, serde_json::to_vec(&items).unwrap_or_default());
+}
+
+fn load_changed_resolutions_from_disk() {
+    let path = changed_resolutions_path();
+    let Ok(bytes) = fs::read(&path) else {
+        return;
+    };
+    let Ok(items) = serde_json::from_slice::<Vec<serde_json::Value>>(&bytes) else {
+        let _ = fs::remove_file(&path);
+        return;
+    };
+    let mut lock = CHANGED_RESOLUTIONS.write().unwrap();
+    if !lock.is_empty() {
+        return;
+    }
+    for item in items {
+        let Some(name) = item.get("name").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(ow) = item.get("original_width").and_then(|v| v.as_i64()) else {
+            continue;
+        };
+        let Some(oh) = item.get("original_height").and_then(|v| v.as_i64()) else {
+            continue;
+        };
+        let cw = item
+            .get("changed_width")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(ow);
+        let ch = item
+            .get("changed_height")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(oh);
+        lock.insert(
+            name.to_owned(),
+            ChangedResolution {
+                original: (ow as i32, oh as i32),
+                changed: (cw as i32, ch as i32),
+                original_scale: item.get("original_scale").and_then(|v| v.as_f64()),
+                changed_scale: item.get("changed_scale").and_then(|v| v.as_f64()),
+            },
+        );
     }
 }
 
 #[inline]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub fn restore_resolutions() {
+    load_changed_resolutions_from_disk();
     for (name, res) in CHANGED_RESOLUTIONS.read().unwrap().iter() {
         let (w, h) = res.original;
         log::info!("Restore resolution of display '{}' to ({}, {})", name, w, h);
@@ -412,9 +513,21 @@ pub fn restore_resolutions() {
                 e
             );
         }
+        #[cfg(target_os = "linux")]
+        if let Some(scale) = res.original_scale {
+            if let Err(e) = crate::platform::linux::set_display_scale(name, scale) {
+                log::error!(
+                    "Failed to restore scale of display '{}' to {}: {}",
+                    name,
+                    scale,
+                    e
+                );
+            }
+        }
     }
     // Can be cleared because restore resolutions is called when there is no client connected.
     CHANGED_RESOLUTIONS.write().unwrap().clear();
+    persist_changed_resolutions();
 }
 
 #[inline]
@@ -438,6 +551,8 @@ pub fn is_privacy_mode_mag_supported() -> bool {
 }
 
 pub fn new() -> GenericService {
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    restore_resolutions();
     let svc = EmptyExtraFieldService::new(NAME.to_owned(), true);
     GenericService::run(&svc.clone(), run);
     svc.sp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Fit to client” to automatically scale remote desktops for smaller screens, with support for orientation changes.
  - Added controls to enable or disable fit-to-client behavior.
  - Phone clients now focus on remote desktop sessions and hide unsupported session actions.
  - Linux display scaling and resolution changes are adjusted to improve fit-to-client viewing and restored afterward.
  - Added automated publishing of Linux RPM and unsigned iOS IPA builds.

- **Bug Fixes**
  - Improved selection of compatible remote display resolutions across client orientations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a phone-oriented “Fit to client” mode that selects a smaller advertised host resolution, switches the session to adaptive scaling, adjusts Linux/KDE display scaling, and persists host display state for restoration. It also hides non-remote session actions on phones and adds a fork-specific Linux/iOS build workflow.

- Adds viewport-based host-mode selection and mobile orientation reapplication.
- Adds Linux `kscreen-doctor` mode and scale handling.
- Persists original display settings so they can be restored after a session or restart.
- Adds the setting to the remote toolbar and restricts several phone UI actions.
- Includes Dart and Rust tests for mode selection and KDE output parsing.
</details>


<details><summary><h3>Confidence Score: 1/5</h3></summary>

The PR is not safe to merge until generic Linux resolution changes stop altering host scaling, fit state is correctly restored and scoped per display, and failed host-setting restoration remains retryable.

Four blocking behavioral failures remain: unrelated resolution requests alter system scaling, the fit cache can suppress changes on another monitor, disabling the feature leaves adaptive view style enabled, and transient restore failures permanently discard recovery state. Explicit repository requirements around legacy-path isolation, localization, and error handling also need to be satisfied.

**Files Needing Attention:** src/server/connection.rs, src/server/display_service.rs, flutter/lib/models/model.dart, flutter/lib/desktop/widgets/remote_toolbar.dart, src/lang/en.rs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| flutter/lib/models/model.dart | Implements fitting, debouncing, caching, and restoration, but the cache is not display-specific and disabling the feature leaves adaptive view style active. |
| flutter/lib/models/fit_client.dart | Adds a self-contained, tested algorithm for choosing a readable mode from the host-advertised resolutions. |
| src/server/connection.rs | Hooks Linux scaling into the generic resolution handler without distinguishing fit-to-client requests from existing manual resolution operations. |
| src/server/display_service.rs | Adds persistent resolution and scale recovery, but forgets failed restorations and silently ignores persistence failures. |
| src/platform/linux.rs | Adds KDE mode parsing and scaling helpers; its monotonic scale policy becomes problematic because the generic caller does not feature-gate it. |
| flutter/lib/desktop/widgets/remote_toolbar.dart | Reuses the phone mode picker in an existing desktop Fit-local path, changing established no-match behavior. |
| src/lang/en.rs | Adds display strings without following the repository’s localization-key registration requirements. |
| .github/workflows/fit-client-build.yml | Adds manually dispatchable Linux RPM and unsigned iOS IPA builds using the existing reusable bridge workflow. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Flutter as Flutter client
    participant Host as Host connection
    participant Display as Linux display
    participant Recovery as Restore state

    User->>Flutter: Enable Fit to client
    Flutter->>Flutter: Select advertised host mode
    Flutter->>Flutter: Set adaptive view style
    Flutter->>Host: Change display resolution
    Host->>Recovery: Persist original resolution and scale
    Host->>Display: Apply resolution
    Host->>Display: Raise KDE display scale
    User->>Flutter: Disable or disconnect
    Flutter->>Host: Request original resolution
    Host->>Display: Restore saved display state
    Host->>Recovery: Clear restored state
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2316097%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=16097&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fserver%2Fconnection.rs%3A4656-4678%0A**Scaling%20affects%20every%20resolution**%0A%0AEvery%20keyboard-enabled%20Linux%20resolution%20request%20reaches%20this%20block%2C%20including%20ordinary%20manual%20resolution%20changes%20and%20monitor%20switches.%20For%20widths%20at%20or%20below%201600%2C%20it%20raises%20the%20host's%20system-wide%20display%20scale%20without%20checking%20whether%20%E2%80%9CFit%20to%20client%E2%80%9D%20initiated%20the%20request.%20Selecting%20a%20larger%20resolution%20does%20not%20lower%20the%20scale%2C%20so%20the%20host%20remains%20unexpectedly%20scaled%20until%20the%20last%20remote%20connection%20closes.%0A%0A%23%23%23%20Issue%202%0Aflutter%2Flib%2Fmodels%2Fmodel.dart%3A1579-1583%0A**Fit%20cache%20ignores%20display**%0A%0A%60_lastFitClientApplied%60%20records%20only%20the%20selected%20dimensions%2C%20not%20the%20display%20they%20were%20applied%20to.%20After%20switching%20from%20display%20A%20to%20display%20B%2C%20an%20orientation%20change%20or%20another%20fit%20operation%20can%20select%20the%20same%20dimensions%20and%20return%20here%20even%20though%20display%20B%20is%20still%20at%20a%20different%20resolution.%20%E2%80%9CFit%20to%20client%E2%80%9D%20then%20remains%20unapplied%20on%20the%20current%20monitor.%0A%0A%23%23%23%20Issue%203%0Aflutter%2Flib%2Fmodels%2Fmodel.dart%3A1593-1609%0A**View%20style%20stays%20adaptive**%0A%0AEnabling%20%E2%80%9CFit%20to%20client%E2%80%9D%20unconditionally%20changes%20the%20session%20view%20style%20to%20adaptive%2C%20but%20disabling%20it%20restores%20only%20the%20remote%20resolution.%20A%20user%20whose%20previous%20style%20was%20original-size%20or%20scroll%20therefore%20remains%20in%20adaptive%20mode%20after%20turning%20the%20feature%20off%2C%20so%20the%20toggle%20does%20not%20restore%20all%20session%20state%20that%20it%20changed.%0A%0A%23%23%23%20Issue%204%0Asrc%2Fserver%2Fdisplay_service.rs%3A528-530%0A**Failed%20restores%20are%20forgotten**%0A%0AResolution%20and%20scale%20restoration%20failures%20are%20only%20logged%2C%20but%20this%20code%20then%20clears%20the%20entire%20restore%20map%20and%20removes%20the%20persisted%20recovery%20state.%20If%20a%20display%20is%20temporarily%20unavailable%20or%20restoration%20otherwise%20fails%20during%20startup%20or%20disconnect%2C%20RustDesk%20cannot%20retry%20and%20the%20host%20can%20remain%20at%20the%20modified%20resolution%20or%20scale.%0A%0A%23%23%23%20Issue%205%0Aflutter%2Flib%2Fdesktop%2Fwidgets%2Fremote_toolbar.dart%3A2504-2515%0A**Desktop%20fit%20behavior%20changes**%0A%0AThis%20phone-oriented%20fallback%20also%20changes%20the%20existing%20desktop%20%E2%80%9CFit%20local%20resolution%E2%80%9D%20path.%20When%20the%20local%20resolution%20is%20not%20advertised%20by%20the%20host%2C%20the%20old%20path%20offered%20no%20action%3B%20the%20new%20algorithm%20can%20expose%20the%20button%20and%20select%20an%20unrelated%20smaller%20mode%20such%20as%201280%C3%97800.%20The%20repository%20requires%20existing%20behavior%20to%20remain%20unchanged%20when%20a%20new%20feature%20is%20disabled%20or%20unsupported%2C%20so%20this%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A%23%23%23%20Issue%206%0Asrc%2Flang%2Fen.rs%3A164-165%0A**Localization%20keys%20are%20incomplete**%0A%0AThese%20two%20keys%20were%20added%20only%20to%20%60en.rs%60%2C%20but%20the%20repository%20requires%20every%20new%20key%20to%20be%20appended%20to%20%60template.rs%60%20and%20every%20locale%20map.%20Non-English%20locales%20therefore%20cannot%20provide%20translations%20and%20always%20fall%20back%20to%20English.%20The%20identical%20%60%28%22Fit%20to%20client%22%2C%20%22Fit%20to%20client%22%29%60%20entry%20also%20violates%20the%20directive%20that%20%60en.rs%60%20contain%20only%20display%20text%20that%20differs%20from%20its%20key.%20These%20localization%20requirements%20must%20be%20satisfied%20before%20merging.%0A%0A%23%23%23%20Issue%207%0Asrc%2Fserver%2Fdisplay_service.rs%3A451-454%0A**Persistence%20errors%20are%20hidden**%0A%0ADirectory%20creation%20and%20file-write%20failures%20are%20silently%20discarded%2C%20while%20a%20serialization%20failure%20is%20converted%20into%20an%20empty%20byte%20sequence.%20This%20can%20disable%20crash%20recovery%20or%20replace%20valid%20recovery%20state%20with%20invalid%20data%20without%20leaving%20any%20diagnostic.%20The%20repository%20explicitly%20requires%20production%20Rust%20code%20not%20to%20ignore%20errors%20silently%2C%20so%20this%20error%20handling%20must%20be%20corrected%20before%20merging.%20The%20same%20silent-discard%20pattern%20also%20appears%20when%20the%20recovery%20file%20is%20removed.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16097&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fit-to-client%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fit-to-client%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fserver%2Fconnection.rs%3A4656-4678%0A**Scaling%20affects%20every%20resolution**%0A%0AEvery%20keyboard-enabled%20Linux%20resolution%20request%20reaches%20this%20block%2C%20including%20ordinary%20manual%20resolution%20changes%20and%20monitor%20switches.%20For%20widths%20at%20or%20below%201600%2C%20it%20raises%20the%20host's%20system-wide%20display%20scale%20without%20checking%20whether%20%E2%80%9CFit%20to%20client%E2%80%9D%20initiated%20the%20request.%20Selecting%20a%20larger%20resolution%20does%20not%20lower%20the%20scale%2C%20so%20the%20host%20remains%20unexpectedly%20scaled%20until%20the%20last%20remote%20connection%20closes.%0A%0A%23%23%23%20Issue%202%0Aflutter%2Flib%2Fmodels%2Fmodel.dart%3A1579-1583%0A**Fit%20cache%20ignores%20display**%0A%0A%60_lastFitClientApplied%60%20records%20only%20the%20selected%20dimensions%2C%20not%20the%20display%20they%20were%20applied%20to.%20After%20switching%20from%20display%20A%20to%20display%20B%2C%20an%20orientation%20change%20or%20another%20fit%20operation%20can%20select%20the%20same%20dimensions%20and%20return%20here%20even%20though%20display%20B%20is%20still%20at%20a%20different%20resolution.%20%E2%80%9CFit%20to%20client%E2%80%9D%20then%20remains%20unapplied%20on%20the%20current%20monitor.%0A%0A%23%23%23%20Issue%203%0Aflutter%2Flib%2Fmodels%2Fmodel.dart%3A1593-1609%0A**View%20style%20stays%20adaptive**%0A%0AEnabling%20%E2%80%9CFit%20to%20client%E2%80%9D%20unconditionally%20changes%20the%20session%20view%20style%20to%20adaptive%2C%20but%20disabling%20it%20restores%20only%20the%20remote%20resolution.%20A%20user%20whose%20previous%20style%20was%20original-size%20or%20scroll%20therefore%20remains%20in%20adaptive%20mode%20after%20turning%20the%20feature%20off%2C%20so%20the%20toggle%20does%20not%20restore%20all%20session%20state%20that%20it%20changed.%0A%0A%23%23%23%20Issue%204%0Asrc%2Fserver%2Fdisplay_service.rs%3A528-530%0A**Failed%20restores%20are%20forgotten**%0A%0AResolution%20and%20scale%20restoration%20failures%20are%20only%20logged%2C%20but%20this%20code%20then%20clears%20the%20entire%20restore%20map%20and%20removes%20the%20persisted%20recovery%20state.%20If%20a%20display%20is%20temporarily%20unavailable%20or%20restoration%20otherwise%20fails%20during%20startup%20or%20disconnect%2C%20RustDesk%20cannot%20retry%20and%20the%20host%20can%20remain%20at%20the%20modified%20resolution%20or%20scale.%0A%0A%23%23%23%20Issue%205%0Aflutter%2Flib%2Fdesktop%2Fwidgets%2Fremote_toolbar.dart%3A2504-2515%0A**Desktop%20fit%20behavior%20changes**%0A%0AThis%20phone-oriented%20fallback%20also%20changes%20the%20existing%20desktop%20%E2%80%9CFit%20local%20resolution%E2%80%9D%20path.%20When%20the%20local%20resolution%20is%20not%20advertised%20by%20the%20host%2C%20the%20old%20path%20offered%20no%20action%3B%20the%20new%20algorithm%20can%20expose%20the%20button%20and%20select%20an%20unrelated%20smaller%20mode%20such%20as%201280%C3%97800.%20The%20repository%20requires%20existing%20behavior%20to%20remain%20unchanged%20when%20a%20new%20feature%20is%20disabled%20or%20unsupported%2C%20so%20this%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A%23%23%23%20Issue%206%0Asrc%2Flang%2Fen.rs%3A164-165%0A**Localization%20keys%20are%20incomplete**%0A%0AThese%20two%20keys%20were%20added%20only%20to%20%60en.rs%60%2C%20but%20the%20repository%20requires%20every%20new%20key%20to%20be%20appended%20to%20%60template.rs%60%20and%20every%20locale%20map.%20Non-English%20locales%20therefore%20cannot%20provide%20translations%20and%20always%20fall%20back%20to%20English.%20The%20identical%20%60%28%22Fit%20to%20client%22%2C%20%22Fit%20to%20client%22%29%60%20entry%20also%20violates%20the%20directive%20that%20%60en.rs%60%20contain%20only%20display%20text%20that%20differs%20from%20its%20key.%20These%20localization%20requirements%20must%20be%20satisfied%20before%20merging.%0A%0A%23%23%23%20Issue%207%0Asrc%2Fserver%2Fdisplay_service.rs%3A451-454%0A**Persistence%20errors%20are%20hidden**%0A%0ADirectory%20creation%20and%20file-write%20failures%20are%20silently%20discarded%2C%20while%20a%20serialization%20failure%20is%20converted%20into%20an%20empty%20byte%20sequence.%20This%20can%20disable%20crash%20recovery%20or%20replace%20valid%20recovery%20state%20with%20invalid%20data%20without%20leaving%20any%20diagnostic.%20The%20repository%20explicitly%20requires%20production%20Rust%20code%20not%20to%20ignore%20errors%20silently%2C%20so%20this%20error%20handling%20must%20be%20corrected%20before%20merging.%20The%20same%20silent-discard%20pattern%20also%20appears%20when%20the%20recovery%20file%20is%20removed.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16097&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/server/connection.rs:4656-4678
**Scaling affects every resolution**

Every keyboard-enabled Linux resolution request reaches this block, including ordinary manual resolution changes and monitor switches. For widths at or below 1600, it raises the host's system-wide display scale without checking whether “Fit to client” initiated the request. Selecting a larger resolution does not lower the scale, so the host remains unexpectedly scaled until the last remote connection closes.

### Issue 2
flutter/lib/models/model.dart:1579-1583
**Fit cache ignores display**

`_lastFitClientApplied` records only the selected dimensions, not the display they were applied to. After switching from display A to display B, an orientation change or another fit operation can select the same dimensions and return here even though display B is still at a different resolution. “Fit to client” then remains unapplied on the current monitor.

### Issue 3
flutter/lib/models/model.dart:1593-1609
**View style stays adaptive**

Enabling “Fit to client” unconditionally changes the session view style to adaptive, but disabling it restores only the remote resolution. A user whose previous style was original-size or scroll therefore remains in adaptive mode after turning the feature off, so the toggle does not restore all session state that it changed.

### Issue 4
src/server/display_service.rs:528-530
**Failed restores are forgotten**

Resolution and scale restoration failures are only logged, but this code then clears the entire restore map and removes the persisted recovery state. If a display is temporarily unavailable or restoration otherwise fails during startup or disconnect, RustDesk cannot retry and the host can remain at the modified resolution or scale.

### Issue 5
flutter/lib/desktop/widgets/remote_toolbar.dart:2504-2515
**Desktop fit behavior changes**

This phone-oriented fallback also changes the existing desktop “Fit local resolution” path. When the local resolution is not advertised by the host, the old path offered no action; the new algorithm can expose the button and select an unrelated smaller mode such as 1280×800. The repository requires existing behavior to remain unchanged when a new feature is disabled or unsupported, so this requirement must be satisfied before merging.

### Issue 6
src/lang/en.rs:164-165
**Localization keys are incomplete**

These two keys were added only to `en.rs`, but the repository requires every new key to be appended to `template.rs` and every locale map. Non-English locales therefore cannot provide translations and always fall back to English. The identical `("Fit to client", "Fit to client")` entry also violates the directive that `en.rs` contain only display text that differs from its key. These localization requirements must be satisfied before merging.

### Issue 7
src/server/display_service.rs:451-454
**Persistence errors are hidden**

Directory creation and file-write failures are silently discarded, while a serialization failure is converted into an empty byte sequence. This can disable crash recovery or replace valid recovery state with invalid data without leaving any diagnostic. The repository explicitly requires production Rust code not to ignore errors silently, so this error handling must be corrected before merging. The same silent-discard pattern also appears when the recovery file is removed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add GitHub Actions workflow for Linux ho..."](https://github.com/rustdesk/rustdesk/commit/01ce492b5ccb9fa054ecd601dd361521f80353b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60952912)</sub>

> Greptile also left **7 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/rustdesk/rustdesk/blob/master/AGENTS.md))

<!-- /greptile_comment -->