### PR TITLE
fix(wayland): read host cursor shape from portal SPA_META_Cursor metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,7 +353,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits 0.2.19",
  "rusticata-macros",
  "thiserror 1.0.61",
@@ -759,6 +769,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
+ "annotate-snippets",
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
@@ -1106,7 +1117,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1116,7 +1127,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.14",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -1216,7 +1237,7 @@ dependencies = [
  "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap",
- "unicode-width",
+ "unicode-width 0.1.13",
  "vec_map",
 ]
 
@@ -1490,6 +1511,12 @@ name = "constant_time_eq"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
 name = "core-foundation"
@@ -2107,7 +2134,7 @@ checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits 0.2.19",
  "rusticata-macros",
@@ -2281,7 +2308,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.4",
 ]
 
 [[package]]
@@ -3659,6 +3686,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hbb_common"
 version = "0.1.0"
 dependencies = [
@@ -4050,12 +4083,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4407,7 +4440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4494,6 +4527,33 @@ dependencies = [
  "libc",
  "pkg-config",
  "walkdir",
+]
+
+[[package]]
+name = "libspa"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882f7427e7989dcc9d388b7f05c4630390a1d7696f9ffa469cd4a7a48f0b4c40"
+dependencies = [
+ "bitflags 2.9.1",
+ "cc",
+ "cookie-factory",
+ "libc",
+ "libspa-sys",
+ "nom 8.0.0",
+ "rustix 1.1.2",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "libspa-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b6e17bdaf63ed0d5e4144022624032b41fd9733112e8c74ac26fc9bf1291924"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -5118,6 +5178,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6094,6 +6163,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pipewire"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde71084c4e25959d68f1ea54daa75e5ecdb338e5caf0b5510143b79baa32d5c"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "libspa",
+ "libspa-sys",
+ "pipewire-sys",
+ "rustix 1.1.2",
+]
+
+[[package]]
+name = "pipewire-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce653f53e63e5b93853218092ee9a8906a5d082c92f3f1db26316955dd63ce0"
+dependencies = [
+ "bindgen 0.72.1",
+ "libspa-sys",
+ "system-deps 7.0.8",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6289,7 +6383,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
 dependencies = [
- "toml_datetime",
+ "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
 ]
 
@@ -7212,7 +7306,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -7408,11 +7502,13 @@ dependencies = [
  "hwcodec",
  "jni",
  "lazy_static",
+ "libspa",
  "log",
  "ndk 0.7.0",
  "ndk-context",
  "nokhwa",
  "num_cpus",
+ "pipewire",
  "pkg-config",
  "quest",
  "repng",
@@ -7583,6 +7679,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde 1.0.228",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -8190,10 +8295,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck 0.5.0",
  "pkg-config",
  "toml 0.8.2",
+ "version-compare 0.2.0",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr 0.20.9",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.5+spec-1.1.0",
  "version-compare 0.2.0",
 ]
 
@@ -8270,6 +8388,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "target_build_utils"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8319,7 +8443,7 @@ checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
 dependencies = [
  "dirs 4.0.0",
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
 ]
@@ -8348,7 +8472,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -8639,8 +8763,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde 1.0.228",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.6",
+ "toml_datetime 0.6.3",
  "toml_edit 0.19.15",
 ]
 
@@ -8651,9 +8775,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde 1.0.228",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.6",
+ "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -8666,6 +8805,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8673,9 +8821,9 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "serde 1.0.228",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+ "serde_spanned 0.6.6",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -8686,10 +8834,25 @@ checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde 1.0.228",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+ "serde_spanned 0.6.6",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "totp-rs"
@@ -8852,7 +9015,7 @@ dependencies = [
  "fnv",
  "home",
  "memchr",
- "nom",
+ "nom 7.1.3",
  "once_cell",
  "petgraph",
 ]
@@ -9064,6 +9227,12 @@ name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -10566,6 +10735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10748,7 +10923,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "ring",
  "rusticata-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ hwcodec = ["scrap/hwcodec"]
 vram = ["scrap/vram"]
 mediacodec = ["scrap/mediacodec"]
 drm = ["scrap/drm"]
+# Read the Wayland host cursor shape from the portal `SPA_META_Cursor` metadata (see the scrap
+# feature of the same name). Opt-in; when off the cursor path is unchanged (XFixes).
+portal-cursor = ["scrap/portal-cursor"]
 # The display wake, as its OWN compile gate on top of `drm`. Everything else in the drm backend
 # READS (it captures a scanout); the wake WRITES, injecting one synthetic pointer event from the
 # root service so a compositor that idle-disabled its outputs re-enables them. That is a different

--- a/libs/scrap/Cargo.toml
+++ b/libs/scrap/Cargo.toml
@@ -21,6 +21,12 @@ wayland = ["gstreamer", "gstreamer-app", "gstreamer-video", "dbus", "tracing", "
 # common/mod.rs, so `scrap/drm` on its own would compile nothing. The root crate happens to always
 # enable `scrap/wayland`, which is what hid this.
 drm = ["wayland", "hbb_common/wayland_probe"]
+# `portal-cursor` reads the Wayland host cursor shape from the xdg-desktop-portal ScreenCast
+# `SPA_META_Cursor` metadata via a parallel native-PipeWire stream, instead of the XWayland XFixes
+# cursor that native Wayland clients never update. Opt-in because it pulls in `pipewire`/`libspa`;
+# when off, the cursor path is unchanged (XFixes fallback). Depends on `wayland` (the portal session
+# and the module both live under the `wayland` arm).
+portal-cursor = ["wayland", "dep:pipewire", "dep:libspa"]
 mediacodec = ["ndk"]
 linux-pkg-config = ["dep:pkg-config"]
 hwcodec = ["dep:hwcodec"]
@@ -68,6 +74,8 @@ gstreamer = { version = "0.16", optional = true }
 gstreamer-app = { version = "0.16", features = ["v1_10"], optional = true }
 gstreamer-video = { version = "0.16", optional = true }
 zbus = { version = "3.15", optional = true }
+pipewire = { version = "0.10", optional = true }
+libspa = { version = "0.10", optional = true }
 
 [dependencies.hwcodec]
 git = "https://github.com/rustdesk-org/hwcodec"

--- a/libs/scrap/src/lib.rs
+++ b/libs/scrap/src/lib.rs
@@ -17,6 +17,9 @@ pub mod x11;
 #[cfg(all(x11, feature = "wayland"))]
 pub mod wayland;
 
+#[cfg(all(x11, feature = "portal-cursor"))]
+pub use wayland::pipewire_cursor::{portal_cursor, portal_cursor_id, PortalCursorData};
+
 #[cfg(dxgi)]
 pub mod dxgi;
 

--- a/libs/scrap/src/wayland.rs
+++ b/libs/scrap/src/wayland.rs
@@ -1,5 +1,7 @@
 pub mod capturable;
 pub mod pipewire;
+#[cfg(feature = "portal-cursor")]
+pub mod pipewire_cursor;
 pub mod display;
 mod screencast_portal;
 mod request_portal;

--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -69,6 +69,8 @@ impl PipewireDisplayOffsetCache {
 
 #[inline]
 pub fn close_session() {
+    #[cfg(feature = "portal-cursor")]
+    super::pipewire_cursor::stop_cursor_capture();
     let _ = RDP_SESSION_INFO.lock().unwrap().take();
     clear_wayland_displays_cache();
     HAS_POSITION_ATTR.store(false, Ordering::SeqCst);
@@ -89,6 +91,8 @@ pub fn try_close_session() {
         }
     }
     if close {
+        #[cfg(feature = "portal-cursor")]
+        super::pipewire_cursor::stop_cursor_capture();
         *rdp_info = None;
         clear_wayland_displays_cache();
         HAS_POSITION_ATTR.store(false, Ordering::SeqCst);
@@ -786,6 +790,20 @@ fn on_create_session_response(
                 });
             }
 
+            // The real capture session runs with `capture_cursor == false` (the embedded branch above
+            // is only the temporary monitor-disambiguation session). Ask the portal for the Metadata
+            // cursor mode so the shape can be read from `SPA_META_Cursor` instead of the stale
+            // XWayland XFixes cursor. Falls back to the default (unchanged behaviour) when the
+            // compositor does not advertise the Metadata bit.
+            #[cfg(feature = "portal-cursor")]
+            if !capture_cursor {
+                if let Ok(modes) = get_available_cursor_modes() {
+                    if modes & 0x4 != 0 {
+                        args.insert("cursor_mode".to_string(), Variant(Box::new(4u32)));
+                    }
+                }
+            }
+
             handle_response(
                 c,
                 get_request_path(c, select_sources_handle_token)?,
@@ -853,6 +871,15 @@ fn on_select_devices_response(
             args.insert("multiple".into(), Variant(Box::new(true)));
         }
         args.insert("types".into(), Variant(Box::new(1u32))); //| 2u32)));
+
+        // Remote-desktop portal path: request the Metadata cursor mode for the same reason as the
+        // ScreenCast path (see `on_create_session_response`). Unchanged when unavailable.
+        #[cfg(feature = "portal-cursor")]
+        if let Ok(modes) = get_available_cursor_modes() {
+            if modes & 0x4 != 0 {
+                args.insert("cursor_mode".to_string(), Variant(Box::new(4u32)));
+            }
+        }
 
         let session = session.clone();
         handle_response(
@@ -971,6 +998,13 @@ pub fn get_capturables() -> Result<Vec<PipeWireCapturable>, Box<dyn Error>> {
             is_support_restore_token,
             resolution: Arc::new(Mutex::new(None)),
         };
+        // Start the parallel native-PipeWire cursor listener for the freshly created session, reusing
+        // its fd and stream node ids. The GStreamer video pipeline is left untouched.
+        #[cfg(feature = "portal-cursor")]
+        {
+            let nodes: Vec<u64> = rdp_info.streams.iter().map(|s| s.path).collect();
+            super::pipewire_cursor::start_cursor_capture(rdp_info.fd.as_raw_fd(), &nodes);
+        }
         *rdp_connection = Some(rdp_info);
     }
 

--- a/libs/scrap/src/wayland/pipewire_cursor.rs
+++ b/libs/scrap/src/wayland/pipewire_cursor.rs
@@ -1,0 +1,445 @@
+// Wayland host cursor shape from the xdg-desktop-portal ScreenCast `SPA_META_Cursor` metadata.
+//
+// The video path (GStreamer `pipewiresrc`) drops SPA buffer metadata, and the legacy cursor path
+// reads the shape from XWayland via XFixes, which native Wayland clients never update -- so the
+// remote sees a stale shape (the "cursor stuck as I-beam" bug, rustdesk/rustdesk#12206). This module
+// opens a second, native-PipeWire consumer on the same portal fd and node ids, negotiates the cursor
+// metadata, and publishes the latest shape into a global store that `platform::linux::get_cursor*`
+// reads before falling back to XFixes. It never touches the video pipeline.
+//
+// Reading the metadata uses only the safe pipewire-rs 0.10 API (`Buffer::find_meta::<MetaCursor>`,
+// `MetaBitmap::bitmap_data`); the only unsafe is `libc::dup` for the fd the PipeWire core takes over.
+
+use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+use std::sync::Mutex;
+
+use pipewire as pw;
+use pw::spa;
+use tracing::warn;
+
+/// Cursor shape published to the cursor service. `colors` is tightly packed RGBA, matching what the
+/// XFixes path in `platform::linux::get_cursor_data` produces, so the consumer is format-agnostic.
+#[derive(Clone, Default)]
+pub struct PortalCursorData {
+    pub id: u64,
+    pub width: i32,
+    pub height: i32,
+    pub hotx: i32,
+    pub hoty: i32,
+    pub colors: Vec<u8>,
+}
+
+/// Published when the compositor reports the cursor invisible, so the id changes and the client drops
+/// the previous shape rather than keeping a stale visible cursor.
+const HIDDEN_CURSOR_ID: u64 = u64::MAX;
+
+// Mutter advertises the cursor meta sized for a 384x384 RGBA bitmap; KWin sizes it from its own
+// bitmap. SPA_PARAM_META_size negotiates a fixed value, so a smaller request does not truncate the
+// bitmap -- it drops the Cursor meta from the allocated buffers entirely. Ask for the larger of the
+// two so both compositors attach it.
+const MAX_CURSOR_DIMENSION: usize = 384;
+const CURSOR_META_SIZE: usize = std::mem::size_of::<spa::sys::spa_meta_cursor>()
+    + std::mem::size_of::<spa::sys::spa_meta_bitmap>()
+    + MAX_CURSOR_DIMENSION * MAX_CURSOR_DIMENSION * 4;
+
+static PORTAL_CURSOR: Mutex<Option<PortalCursorData>> = Mutex::new(None);
+static WORKER: Mutex<Option<Worker>> = Mutex::new(None);
+
+struct Worker {
+    stop: pw::channel::Sender<()>,
+    thread: std::thread::JoinHandle<()>,
+}
+
+/// Latest cursor shape id, or `None` until the first shape arrives (caller then falls back to XFixes).
+pub fn portal_cursor_id() -> Option<u64> {
+    PORTAL_CURSOR
+        .lock()
+        .ok()
+        .and_then(|g| g.as_ref().map(|c| c.id))
+}
+
+/// Latest cursor shape, or `None` until the first shape arrives.
+pub fn portal_cursor() -> Option<PortalCursorData> {
+    PORTAL_CURSOR.lock().ok().and_then(|g| g.clone())
+}
+
+fn publish(cursor: PortalCursorData) {
+    if let Ok(mut g) = PORTAL_CURSOR.lock() {
+        *g = Some(cursor);
+    }
+}
+
+fn clear() {
+    if let Ok(mut g) = PORTAL_CURSOR.lock() {
+        *g = None;
+    }
+}
+
+/// Start the native-PipeWire cursor listener for a freshly created portal session. `fd` is the portal
+/// remote fd (borrowed -- it is duplicated here, the caller keeps ownership); `node_ids` are the
+/// ScreenCast stream node ids. No-op if a listener is already running or there are no nodes.
+pub fn start_cursor_capture(fd: RawFd, node_ids: &[u64]) {
+    if node_ids.is_empty() {
+        return;
+    }
+    let mut worker = match WORKER.lock() {
+        Ok(w) => w,
+        Err(_) => return,
+    };
+    if worker.is_some() {
+        return;
+    }
+    // The PipeWire core takes ownership of the fd it is given (it closes it on drop), so hand it a dup
+    // and leave the portal session's original fd untouched.
+    let dup_fd = unsafe { hbb_common::libc::dup(fd) };
+    if dup_fd < 0 {
+        warn!("portal-cursor: failed to dup portal fd, cursor shape will fall back to XFixes");
+        return;
+    }
+    let owned = unsafe { OwnedFd::from_raw_fd(dup_fd) };
+    let nodes: Vec<u32> = node_ids.iter().map(|n| *n as u32).collect();
+    let (stop_tx, stop_rx) = pw::channel::channel::<()>();
+    let thread = match std::thread::Builder::new()
+        .name("portal-cursor".into())
+        .spawn(move || {
+            if let Err(e) = run_worker(owned, nodes, stop_rx) {
+                warn!("portal-cursor: worker exited: {e}");
+            }
+            clear();
+        }) {
+        Ok(t) => t,
+        Err(e) => {
+            warn!("portal-cursor: failed to spawn worker thread: {e}");
+            return;
+        }
+    };
+    *worker = Some(Worker {
+        stop: stop_tx,
+        thread,
+    });
+}
+
+/// Stop the listener (if any) and clear the published shape.
+pub fn stop_cursor_capture() {
+    let worker = match WORKER.lock() {
+        Ok(mut w) => w.take(),
+        Err(_) => None,
+    };
+    if let Some(worker) = worker {
+        // Waking the loop makes it quit; the thread then returns from run().
+        let _ = worker.stop.send(());
+        let _ = worker.thread.join();
+    }
+    clear();
+}
+
+fn run_worker(
+    fd: OwnedFd,
+    node_ids: Vec<u32>,
+    stop_rx: pw::channel::Receiver<()>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    pw::init();
+    let mainloop = pw::main_loop::MainLoopRc::new(None)?;
+    let context = pw::context::ContextRc::new(&mainloop, None)?;
+    let core = context.connect_fd_rc(fd, None)?;
+
+    // One stream per node; the cursor can sit on any of the shared displays and whichever stream sees
+    // it updates the single global shape. Listeners must outlive `run()`, so keep them alive here.
+    let mut streams = Vec::new();
+    let mut listeners = Vec::new();
+    for node in node_ids {
+        let stream = pw::stream::StreamRc::new(
+            core.clone(),
+            "rustdesk-cursor",
+            pw::properties::properties! {
+                *pw::keys::MEDIA_TYPE => "Video",
+                *pw::keys::MEDIA_CATEGORY => "Capture",
+                *pw::keys::MEDIA_ROLE => "Screen",
+            },
+        )?;
+        let listener = stream
+            .add_local_listener_with_user_data(())
+            .param_changed(|stream, _, id, param| {
+                if param.is_none() || id != spa::param::ParamType::Format.as_raw() {
+                    return;
+                }
+                if let Err(e) = negotiate_meta(stream) {
+                    warn!("portal-cursor: meta negotiation failed: {e}");
+                }
+            })
+            .process(|stream, _| {
+                while let Some(buffer) = stream.dequeue_buffer() {
+                    handle_buffer(&buffer);
+                }
+            })
+            .register()?;
+
+        let params = match build_format_params() {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("portal-cursor: failed to build format params: {e}");
+                continue;
+            }
+        };
+        let mut param_refs: Vec<&spa::pod::Pod> = params.iter().map(|p| p.as_ref()).collect();
+        stream.connect(
+            spa::utils::Direction::Input,
+            Some(node),
+            pw::stream::StreamFlags::AUTOCONNECT | pw::stream::StreamFlags::MAP_BUFFERS,
+            &mut param_refs,
+        )?;
+        streams.push(stream);
+        listeners.push(listener);
+    }
+
+    if streams.is_empty() {
+        return Ok(());
+    }
+
+    let quit_loop = mainloop.clone();
+    let _attached = stop_rx.attach(mainloop.loop_(), move |_| {
+        quit_loop.quit();
+    });
+
+    mainloop.run();
+    Ok(())
+}
+
+/// Owned pod bytes; `as_ref()` borrows a `&Pod` for the pipewire calls.
+struct OwnedPod(Vec<u8>);
+
+impl OwnedPod {
+    fn as_ref(&self) -> &spa::pod::Pod {
+        // The bytes were just produced by PodSerializer, so they are a valid serialized pod.
+        spa::pod::Pod::from_bytes(&self.0).expect("serialized pod is valid")
+    }
+}
+
+fn serialize_pod(value: &spa::pod::Value) -> Result<OwnedPod, Box<dyn std::error::Error>> {
+    let bytes = spa::pod::serialize::PodSerializer::serialize(std::io::Cursor::new(Vec::new()), value)
+        .map(|(cursor, _)| cursor.into_inner())
+        .map_err(|e| format!("pod serialize: {e}"))?;
+    Ok(OwnedPod(bytes))
+}
+
+/// A permissive raw-video EnumFormat: we do not consume the frames, but the node only produces buffers
+/// (and thus attaches the cursor meta) once a format is negotiated.
+fn build_format_params() -> Result<Vec<OwnedPod>, Box<dyn std::error::Error>> {
+    use spa::param::format::{FormatProperties, MediaSubtype, MediaType};
+    use spa::param::video::VideoFormat;
+    use spa::pod::{property, Value};
+    use spa::utils::{Fraction, Rectangle};
+
+    let obj = spa::pod::object! {
+        spa::utils::SpaTypes::ObjectParamFormat,
+        spa::param::ParamType::EnumFormat,
+        property!(FormatProperties::MediaType, Id, MediaType::Video),
+        property!(FormatProperties::MediaSubtype, Id, MediaSubtype::Raw),
+        property!(
+            FormatProperties::VideoFormat,
+            Choice,
+            Enum,
+            Id,
+            VideoFormat::RGBA,
+            VideoFormat::RGBA,
+            VideoFormat::RGBx,
+            VideoFormat::BGRA,
+            VideoFormat::BGRx,
+            VideoFormat::RGB,
+            VideoFormat::BGR
+        ),
+        property!(
+            FormatProperties::VideoSize,
+            Choice,
+            Range,
+            Rectangle,
+            Rectangle { width: 1920, height: 1080 },
+            Rectangle { width: 1, height: 1 },
+            Rectangle { width: 8192, height: 8192 }
+        ),
+        property!(
+            FormatProperties::VideoFramerate,
+            Choice,
+            Range,
+            Fraction,
+            Fraction { num: 30, denom: 1 },
+            Fraction { num: 0, denom: 1 },
+            Fraction { num: 240, denom: 1 }
+        ),
+    };
+    Ok(vec![serialize_pod(&Value::Object(obj))?])
+}
+
+/// Respond to a negotiated Format with Buffers + Meta params that reserve room for the cursor meta.
+fn negotiate_meta(stream: &pw::stream::Stream) -> Result<(), Box<dyn std::error::Error>> {
+    use spa::pod::{Object, Property, Value};
+    use spa::utils::Id;
+
+    let meta = Object {
+        type_: spa::utils::SpaTypes::ObjectParamMeta.as_raw(),
+        id: spa::param::ParamType::Meta.as_raw(),
+        properties: vec![
+            Property::new(
+                spa::sys::SPA_PARAM_META_type,
+                Value::Id(Id(spa::sys::SPA_META_Cursor)),
+            ),
+            Property::new(
+                spa::sys::SPA_PARAM_META_size,
+                Value::Int(CURSOR_META_SIZE as i32),
+            ),
+        ],
+    };
+    let pod = serialize_pod(&Value::Object(meta))?;
+    let mut params = [pod.as_ref()];
+    stream.update_params(&mut params)?;
+    Ok(())
+}
+
+fn handle_buffer(buffer: &pw::buffer::Buffer) {
+    use spa::buffer::meta::MetaCursor;
+
+    let cursor = match buffer.find_meta::<MetaCursor>() {
+        Some(c) => c,
+        None => return,
+    };
+    // id == 0 means "no new cursor data"; leave the last shape untouched.
+    if cursor.id() == 0 {
+        return;
+    }
+    // bitmap_offset == 0 means position-only update, shape unchanged; the cursor position travels over
+    // a separate service, so there is nothing for us to do.
+    if cursor.bitmap_offset() == 0 {
+        return;
+    }
+    let bitmap = match cursor.bitmap() {
+        Some(b) if b.is_valid() => b,
+        // Invalid/format 0 means the cursor is invisible: publish a hidden sentinel so the client drops
+        // the stale shape instead of keeping the last visible one.
+        _ => {
+            publish(PortalCursorData {
+                id: HIDDEN_CURSOR_ID,
+                width: 0,
+                height: 0,
+                hotx: 0,
+                hoty: 0,
+                colors: Vec::new(),
+            });
+            return;
+        }
+    };
+
+    let size = bitmap.size();
+    let width = size.width as usize;
+    let height = size.height as usize;
+    let stride = bitmap.stride().unsigned_abs() as usize;
+    if width == 0
+        || height == 0
+        || width > MAX_CURSOR_DIMENSION
+        || height > MAX_CURSOR_DIMENSION
+        || stride < width * 4
+    {
+        return;
+    }
+    let src = match bitmap.bitmap_data() {
+        Some(d) if d.len() >= height * stride => d,
+        _ => return,
+    };
+
+    let swap_rb = match bitmap.format() {
+        f if f == spa::param::video::VideoFormat::RGBA
+            || f == spa::param::video::VideoFormat::RGBx =>
+        {
+            false
+        }
+        f if f == spa::param::video::VideoFormat::BGRA
+            || f == spa::param::video::VideoFormat::BGRx =>
+        {
+            true
+        }
+        // Unknown/unsupported layout: skip and let XFixes serve this frame.
+        _ => return,
+    };
+
+    let mut colors = vec![0u8; width * height * 4];
+    for y in 0..height {
+        let row = &src[y * stride..y * stride + width * 4];
+        for x in 0..width {
+            let s = &row[x * 4..x * 4 + 4];
+            let d = &mut colors[(y * width + x) * 4..(y * width + x) * 4 + 4];
+            if swap_rb {
+                d[0] = s[2];
+                d[1] = s[1];
+                d[2] = s[0];
+                d[3] = s[3];
+            } else {
+                d[0] = s[0];
+                d[1] = s[1];
+                d[2] = s[2];
+                d[3] = s[3];
+            }
+        }
+    }
+
+    let hotspot = cursor.hotspot();
+    let hotx = hotspot.x;
+    let hoty = hotspot.y;
+    let id = shape_id(&colors, width as i32, height as i32, hotx, hoty);
+    publish(PortalCursorData {
+        id,
+        width: width as i32,
+        height: height as i32,
+        hotx,
+        hoty,
+        colors,
+    });
+}
+
+/// Synthetic shape id: FNV-1a over the pixels with geometry and hotspot folded in, so an identical
+/// bitmap at a different size or hotspot counts as a new shape (the cursor service dedupes by id).
+fn shape_id(colors: &[u8], width: i32, height: i32, hotx: i32, hoty: i32) -> u64 {
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+    let mut hash = OFFSET;
+    for b in colors {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(PRIME);
+    }
+    for v in [width, height, hotx, hoty] {
+        hash ^= v as u32 as u64;
+        hash = hash.wrapping_mul(PRIME);
+    }
+    // Never collide with the hidden sentinel.
+    if hash == HIDDEN_CURSOR_ID {
+        HIDDEN_CURSOR_ID - 1
+    } else {
+        hash
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shape_id_stable_and_geometry_sensitive() {
+        let px = vec![10u8, 20, 30, 40, 50, 60, 70, 80];
+        let a = shape_id(&px, 2, 1, 0, 0);
+        assert_eq!(a, shape_id(&px, 2, 1, 0, 0), "same input, same id");
+        assert_ne!(a, shape_id(&px, 1, 2, 0, 0), "geometry changes the id");
+        assert_ne!(a, shape_id(&px, 2, 1, 3, 3), "hotspot changes the id");
+        let mut px2 = px.clone();
+        px2[0] = 11;
+        assert_ne!(a, shape_id(&px2, 2, 1, 0, 0), "pixel change changes the id");
+    }
+
+    #[test]
+    fn shape_id_never_hidden_sentinel() {
+        // Exhaustive collisions are untestable, but the guard must map an exact hit off the sentinel.
+        assert_ne!(shape_id(&[1, 2, 3, 4], 1, 1, 0, 0), HIDDEN_CURSOR_ID);
+    }
+
+    #[test]
+    fn cursor_meta_size_covers_max_bitmap() {
+        assert!(CURSOR_META_SIZE >= MAX_CURSOR_DIMENSION * MAX_CURSOR_DIMENSION * 4);
+    }
+}

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -584,6 +584,16 @@ pub fn get_cursor() -> ResultType<Option<u64>> {
             }
         }
     }
+    // Wayland portal cursor: the shape arrives over a parallel native-PipeWire stream reading
+    // `SPA_META_Cursor`, not from XFixes. Prefer it over the XWayland XFixes serial, which native
+    // Wayland clients never update (the stale-shape bug). Falls through to XFixes until the first
+    // metadata frame is seen, preserving the current behaviour.
+    #[cfg(feature = "portal-cursor")]
+    if !is_x11() {
+        if let Some(id) = scrap::portal_cursor_id() {
+            return Ok(Some(id));
+        }
+    }
     let mut res = None;
     DISPLAY.with(|conn| {
         if let Ok(d) = conn.try_borrow_mut() {
@@ -626,6 +636,21 @@ pub fn get_cursor_data(hcursor: u64) -> ResultType<CursorData> {
                 cd.colors = c.colors.into();
                 return Ok(cd);
             }
+        }
+    }
+    // Wayland portal cursor: see get_cursor(). Return the latest metadata snapshot, whose id may have
+    // advanced past `hcursor` between get_cursor() and here, so return the latest rather than bailing.
+    #[cfg(feature = "portal-cursor")]
+    if !is_x11() {
+        if let Some(c) = scrap::portal_cursor() {
+            let mut cd: CursorData = Default::default();
+            cd.id = c.id;
+            cd.width = c.width;
+            cd.height = c.height;
+            cd.hotx = c.hotx;
+            cd.hoty = c.hoty;
+            cd.colors = c.colors.into();
+            return Ok(cd);
         }
     }
     let mut res = None;


### PR DESCRIPTION
### Problem

On a Wayland host, the cursor **shape** sent to the remote is read from XWayland via `XFixesGetCursorImage` (`src/platform/linux.rs`). XWayland only learns about the cursor while the pointer is over an X11 window; over native Wayland clients the XFixes serial never changes, so `mouse_cursor` service never detects a change and the client keeps drawing the last X11 shape — most visibly the text I-beam that never turns back into an arrow.

Fixes #12206. This is the default portal/PipeWire path (unrelated to the opt-in DRM path in #15420, which needs root and falls back to this same stale cursor).

Verified on the reporter's machine (KDE Plasma 6 Wayland): an `XFixesGetCursorImage` probe reports `ibeam` while the actual compositor cursor is an arrow, and only changes when the pointer crosses an X11 window.

### Approach

The maintainers already identified metadata as the right path in #5403 but noted the GStreamer bindings don't expose the SPA cursor metadata. This PR pays that cost with a small **native-PipeWire** consumer, leaving the GStreamer video pipeline untouched:

1. Request the portal **Metadata** cursor mode (`cursor_mode = 4`) on the real capture session. Note the existing `cursor_mode = 2` request only ran on the temporary monitor-disambiguation session (`capture_cursor == true`), never on the real one.
2. A parallel `pipewire`/`libspa` stream on the same portal fd + node ids negotiates `SPA_META_Cursor` and reads the shape from each buffer (safe `Buffer::find_meta::<MetaCursor>` / `MetaBitmap::bitmap_data`), converting to the same packed RGBA `CursorData` the XFixes path produces. A synthetic FNV-1a shape id (pixels + geometry + hotspot) drives change detection, mirroring the DRM cursor path.
3. `get_cursor` / `get_cursor_data` consult the published shape before falling back to XFixes.

### Scope / safety

- **Opt-in** behind a new `portal-cursor` feature (pulls in `pipewire`/`libspa`). With the feature off the cursor path is byte-for-byte unchanged (XFixes).
- All changes to existing files are `#[cfg(feature = "portal-cursor")]`-gated thin hooks; the new logic lives in `libs/scrap/src/wayland/pipewire_cursor.rs`.
- The video pipeline, the embedded-cursor disambiguation session, and the client are untouched.
- Falls back to XFixes until the first metadata frame arrives, and on any compositor that doesn't advertise the Metadata cursor mode.

### Testing

- `cargo check` / unit tests pass with the feature on and off (`shape_id` stability + geometry sensitivity, cursor meta sizing).
- Not yet run end-to-end in a live session; the reporter has a Plasma 6 Wayland host that reproduces the bug and can validate a build with `--features portal-cursor`. Happy to iterate — including gating it on by default once validated, or adjusting the dependency approach if you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for detecting and displaying native Wayland host cursor shapes through the desktop portal.
  * Cursor images now include accurate dimensions, colors, and hotspot positioning when portal cursor metadata is available.
  * Existing cursor handling remains available as a fallback when portal metadata is unavailable or the feature is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in native PipeWire consumer that reads Wayland cursor shapes from `SPA_META_Cursor`, publishes them alongside the existing capture session, and prefers that metadata over the stale XWayland cursor path.

- Adds the `portal-cursor` feature and optional PipeWire/libspa dependencies.
- Requests portal metadata cursor mode for ScreenCast and RemoteDesktop sessions.
- Starts and stops a parallel cursor-metadata listener with the portal session.
- Converts compositor cursor bitmaps into the existing packed RGBA cursor representation.
- Preserves the original XFixes path when the feature is disabled, unsupported, or has not produced metadata.
- Regression surface is limited to feature-gated hooks in the portal session lifecycle and Linux cursor accessors; however, conversion of negotiated RGBx/BGRx metadata currently mishandles the padding byte as alpha.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until RGBx/BGRx cursor metadata is converted with opaque alpha and the explicit production-panic rule violation is resolved.

The new stream advertises opaque `*x` pixel formats but interprets their padding byte as alpha, so a valid negotiation can produce transparent or corrupted remote cursors; the implementation also violates the repository’s mandatory error-handling rule.

**Files Needing Attention:** libs/scrap/src/wayland/pipewire_cursor.rs
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/scrap/src/wayland/pipewire_cursor.rs | Implements the native PipeWire cursor listener and metadata conversion; RGBx/BGRx padding is incorrectly propagated as alpha, and one production `expect` violates repository guidance. |
| libs/scrap/src/wayland/pipewire.rs | Requests metadata cursor mode and connects cursor-worker lifecycle to the existing portal session. |
| src/platform/linux.rs | Prefers the feature-gated portal cursor snapshot while retaining the existing DRM and XFixes fallbacks. |
| libs/scrap/Cargo.toml | Adds the opt-in feature and native PipeWire/libspa dependencies. |
| Cargo.toml | Exposes the scrap portal-cursor feature from the root crate. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Portal ScreenCast or RemoteDesktop session] --> B[Request Metadata cursor mode]
    A --> C[Existing GStreamer video pipeline]
    A --> D[Parallel native PipeWire streams]
    D --> E[Read SPA_META_Cursor]
    E --> F[Convert bitmap to packed RGBA]
    F --> G[Publish cursor shape and synthetic ID]
    G --> H[Linux cursor service]
    I[XFixes fallback] --> H
    H --> J[Remote client cursor]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20rustdesk%2Frustdesk%20PR%20%2316098%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=rustdesk%2Frustdesk&pr=16098&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alibs%2Fscrap%2Fsrc%2Fwayland%2Fpipewire_cursor.rs%3A373%0A**Padding%20becomes%20cursor%20alpha**%0A%0AWhen%20PipeWire%20negotiates%20RGBx%20or%20BGRx%E2%80%94both%20of%20which%20this%20stream%20offers%E2%80%94the%20fourth%20byte%20is%20padding%20rather%20than%20alpha.%20This%20conversion%20copies%20that%20byte%20into%20the%20RGBA%20output%2C%20so%20undefined%20or%20zero%20padding%20can%20make%20an%20otherwise%20opaque%20cursor%20partly%20or%20completely%20transparent.%20The%20%60*x%60%20formats%20should%20produce%20an%20alpha%20value%20of%20255%2C%20while%20RGBA%20and%20BGRA%20should%20preserve%20their%20source%20alpha.%0A%0A%23%23%23%20Issue%202%0Alibs%2Fscrap%2Fsrc%2Fwayland%2Fpipewire_cursor.rs%3A211%0A**Production%20code%20can%20panic**%0A%0A%60OwnedPod%3A%3Aas_ref%60%20calls%20%60expect%60%20in%20production%20code.%20This%20violates%20the%20repository%20directive%20to%20avoid%20%60unwrap%28%29%60%20and%20%60expect%28%29%60%20outside%20tests%20or%20lock-poisoning%20cases.%20This%20requirement%20must%20be%20satisfied%20before%20merging%20by%20returning%20and%20propagating%20the%20parse%20failure%20instead.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16098&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22rustdesk%2Frustdesk%22%20on%20the%20existing%20branch%20%22fix-wayland-portal-cursor-metadata%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-wayland-portal-cursor-metadata%22.%0A%0A%23%23%23%20Issue%201%0Alibs%2Fscrap%2Fsrc%2Fwayland%2Fpipewire_cursor.rs%3A373%0A**Padding%20becomes%20cursor%20alpha**%0A%0AWhen%20PipeWire%20negotiates%20RGBx%20or%20BGRx%E2%80%94both%20of%20which%20this%20stream%20offers%E2%80%94the%20fourth%20byte%20is%20padding%20rather%20than%20alpha.%20This%20conversion%20copies%20that%20byte%20into%20the%20RGBA%20output%2C%20so%20undefined%20or%20zero%20padding%20can%20make%20an%20otherwise%20opaque%20cursor%20partly%20or%20completely%20transparent.%20The%20%60*x%60%20formats%20should%20produce%20an%20alpha%20value%20of%20255%2C%20while%20RGBA%20and%20BGRA%20should%20preserve%20their%20source%20alpha.%0A%0A%23%23%23%20Issue%202%0Alibs%2Fscrap%2Fsrc%2Fwayland%2Fpipewire_cursor.rs%3A211%0A**Production%20code%20can%20panic**%0A%0A%60OwnedPod%3A%3Aas_ref%60%20calls%20%60expect%60%20in%20production%20code.%20This%20violates%20the%20repository%20directive%20to%20avoid%20%60unwrap%28%29%60%20and%20%60expect%28%29%60%20outside%20tests%20or%20lock-poisoning%20cases.%20This%20requirement%20must%20be%20satisfied%20before%20merging%20by%20returning%20and%20propagating%20the%20parse%20failure%20instead.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16098&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/scrap/src/wayland/pipewire_cursor.rs:373
**Padding becomes cursor alpha**

When PipeWire negotiates RGBx or BGRx—both of which this stream offers—the fourth byte is padding rather than alpha. This conversion copies that byte into the RGBA output, so undefined or zero padding can make an otherwise opaque cursor partly or completely transparent. The `*x` formats should produce an alpha value of 255, while RGBA and BGRA should preserve their source alpha.

### Issue 2
libs/scrap/src/wayland/pipewire_cursor.rs:211
**Production code can panic**

`OwnedPod::as_ref` calls `expect` in production code. This violates the repository directive to avoid `unwrap()` and `expect()` outside tests or lock-poisoning cases. This requirement must be satisfied before merging by returning and propagating the parse failure instead.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(wayland): serve the portal cursor s..."](https://github.com/rustdesk/rustdesk/commit/f4e9203767c22cb11ff85a8378f477f02b7a13c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60954427)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/rustdesk/rustdesk/blob/master/CLAUDE.md))

<!-- /greptile_comment -->