### PR TITLE
fix: clipboard, preserve uncompressed special format data

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -698,7 +698,7 @@ mod proto {
         let content = if compress {
             compressed
         } else {
-            s.bytes().collect::<Vec<u8>>()
+            d
         };
         Clipboard {
             compress,
@@ -793,6 +793,29 @@ mod proto {
                 msg.set_clipboard(c.clone());
                 msg
             })
+    }
+
+    #[cfg(all(test, not(target_os = "android")))]
+    mod tests {
+        use super::{from_clipboard, special_to_proto};
+        use arboard::ClipboardData;
+
+        #[test]
+        fn preserves_uncompressed_special_clipboard_data() {
+            let data = vec![0x01, 0x02, 0x03];
+            let name = "custom-format".to_owned();
+
+            let clipboard = special_to_proto(data.clone(), name.clone());
+
+            assert!(!clipboard.compress);
+            assert_eq!(clipboard.content.as_ref(), data.as_slice());
+            assert_eq!(clipboard.special_name, name);
+            assert!(matches!(
+                from_clipboard(clipboard),
+                Some(ClipboardData::Special((restored_name, restored_data)))
+                    if restored_name == name && restored_data == data
+            ));
+        }
     }
 }
 


### PR DESCRIPTION


`special_to_proto()` used the special format name as `Clipboard.content` when compression did not reduce the payload size.

The decoder treats `Clipboard.content` as the special format payload, so short or otherwise incompressible payloads were replaced by the format name during serialization.


Preserve the original payload when special clipboard data is not compressed and  add a regression test covering the uncompressed fields and the Special clipboard round trip.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where special clipboard content could lose or alter its original binary payload when transferred.
  - Uncompressed special clipboard data now preserves both its name and payload when copied and restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects special-format clipboard serialization so an uncompressed message retains its original payload rather than substituting the format name.
- Stores the original `Vec<u8>` in `Clipboard.content` when compression is not beneficial.
- Adds assertions for the uncompressed fields and a complete Special clipboard encode/decode round trip.
- Regression surface is limited to uncompressed special-format clipboard serialization in `src/clipboard.rs`; compressed and non-special clipboard paths are unchanged.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the focused change restores the serializer/decoder contract and is covered by an appropriate regression test.

No actionable failures remain: ownership is valid, the payload and format name are serialized into their intended fields, and the new test covers both raw fields and round-trip behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/clipboard.rs | Correctly preserves uncompressed special-format payload bytes and adds focused regression coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: clipboard, preserve uncompressed sp..."](https://github.com/rustdesk/rustdesk/commit/446a1b51a37b948752859c201a5af82d5f20d451) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60970738)</sub>

<!-- /greptile_comment -->