### PR TITLE
fix(audio): update CPAL for WASAPI thread priority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.15.3"
-source = "git+https://github.com/rustdesk-org/cpal?branch=osx-screencapturekit#6b374bcaed076750ca8fce6da518ab39b882e14a"
+source = "git+https://github.com/fufesou/cpal?rev=c2657388dc255fe99ad7a1f5cdfde0f0091f1dc4#c2657388dc255fe99ad7a1f5cdfde0f0091f1dc4"
 dependencies = [
  "alsa",
  "cidre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.15.3"
-source = "git+https://github.com/fufesou/cpal?rev=c2657388dc255fe99ad7a1f5cdfde0f0091f1dc4#c2657388dc255fe99ad7a1f5cdfde0f0091f1dc4"
+source = "git+https://github.com/rustdesk-org/cpal?branch=osx-screencapturekit#41c8a2a75903ffe9cd44cf176ce6b69e5d916d47"
 dependencies = [
  "alsa",
  "cidre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,7 @@ reqwest = { version = "0.12", features = ["blocking", "socks", "json", "native-t
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 # https://github.com/rustdesk/rustdesk/discussions/10197, not use cpal on linux
-# Temporary fork until https://github.com/rustdesk-org/cpal/pull/4 is merged.
-cpal = { git = "https://github.com/fufesou/cpal", rev = "c2657388dc255fe99ad7a1f5cdfde0f0091f1dc4" }
+cpal = { git = "https://github.com/rustdesk-org/cpal", branch = "osx-screencapturekit" }
 ringbuf = "0.3"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,8 @@ reqwest = { version = "0.12", features = ["blocking", "socks", "json", "native-t
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 # https://github.com/rustdesk/rustdesk/discussions/10197, not use cpal on linux
-cpal = { git = "https://github.com/rustdesk-org/cpal", branch = "osx-screencapturekit" }
+# Temporary fork until https://github.com/rustdesk-org/cpal/pull/4 is merged.
+cpal = { git = "https://github.com/fufesou/cpal", rev = "c2657388dc255fe99ad7a1f5cdfde0f0091f1dc4" }
 ringbuf = "0.3"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]


### PR DESCRIPTION
Update CPAL for the WASAPI thread-priority fix in [rustdesk-org/cpal#4](https://github.com/rustdesk-org/cpal/pull/4).

The old backend passes a thread ID, cast to a handle, to `SetThreadPriority`.

On the test machine, this fails with Windows error 6 and leaves both capture and playback threads at normal priority. The corrected call uses `GetCurrentThread()`.
It keeps the existing Time Critical request and reports failures through the stream error callback without stopping an otherwise usable stream.

## Tests

- [x] video/input responsiveness, CPU contention, and physical audio devices.
