### PR TITLE
Dead peer recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4280,7 +4280,7 @@ dependencies = [
 [[package]]
 name = "kcp-sys"
 version = "0.1.0"
-source = "git+https://github.com/rustdesk-org/kcp-sys?branch=rustdesk-patches#023a0065398968989f2ddfcf5cc72bb886d02675"
+source = "git+https://github.com/rustdesk-org/kcp-sys?branch=rustdesk-patches#938eda3e5e9757a612385503af7a6cb1189b2cdd"
 dependencies = [
  "anyhow",
  "auto_impl",

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -896,9 +896,13 @@ class FfiModel with ChangeNotifier {
     final text = evt['text'];
     final link = evt['link'];
 
+    // The peer-gone detector reconnects under `restarting-show` rather than an error title, so
+    // it needs naming here too. By its own title, not the type: an explicitly restarted remote
+    // device reaches the same type from a path this change does not touch.
     if (isAndroid &&
         _androidDocumentPickerActive &&
-        title == 'Connection Error') {
+        (title == 'Connection Error' ||
+            (type == 'restarting-show' && title == 'Connecting...'))) {
       _androidDocumentPickerInterruptedConnection = true;
       return;
     }

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -355,7 +355,13 @@ impl<T: InvokeUiSession> Remote<T> {
                                     .map_or(false, |silent| silent >= KCP_PEER_SILENCE_LIMIT);
                             if peer_gone {
                                 log::info!("Peer stopped answering, reconnecting");
+                                #[cfg(feature = "flutter")]
                                 self.handler.msgbox("restarting-show", "Connecting...", "Connection in progress. Please wait.", "");
+                                // Sciter knows no `restarting-show` and would show a dialog that
+                                // waits for a click, where the timeout this arrives ahead of is
+                                // retryable and reconnects on its own. Keep that message for it.
+                                #[cfg(not(feature = "flutter"))]
+                                self.handler.msgbox("error", "Connection Error", "Timeout", "");
                                 break;
                             }
                             let elapsed = fps_instant.elapsed().as_millis();

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -15,24 +15,19 @@ use crate::{
 // Restart msgbox text is kept as a legacy UI fallback; Flutter handles the type as a control event.
 const RESTART_REMOTE_DEVICE_NO_DATA_TIMEOUT: Duration = Duration::from_secs(5);
 const KCP_CLOSE_REASON_FLUSH_DELAY: Duration = Duration::from_millis(30);
-const KCP_CLOSE_REASON_GONE_TIMEOUT: u64 = 500;
-// A peer that is killed, logged out or rebooted sends nothing at all over UDP, so the session
-// sees silence and only a timeout ends it. These bound that wait for the two transports that
-// have a liveness signal of their own; TCP and WebSocket are left exactly as they were, and the
-// 30s timeout below still backs all of them.
-//
-// Neither is a hard upper bound on how soon this notices: sends are awaited inline in this same
-// loop, so one in progress keeps the tick below from running. WebRTC caps that at its existing
-// send timeout; KCP sets none, so a large message can delay the check by however long it takes
-// to drain. Removing that needs the framing work that would stop one message owning the link.
-//
+// Deadline for the parting close-reason send once the peer is presumed gone; KCP waits for send
+// capacity with no deadline of its own.
+const KCP_CLOSE_REASON_GONE_DEADLINE: Duration = Duration::from_millis(500);
 // Grace after ICE reports Disconnected, which it does ~5s after it stops hearing from the peer,
 // for ~8s in total. Disconnected is transient by design, so this waits out a Wi-Fi roam or a
 // sleep/wake rather than acting on the first hint.
 const WEBRTC_SUSPECT_GRACE: Duration = Duration::from_secs(3);
-// KCP has no equivalent hint, only how long since a packet last arrived; its endpoint pings an
-// idle peer about every 2s, so this is several missed pings.
+// KCP gets no such hint, only how long since a packet arrived; its endpoint pings an idle peer
+// about every 2s, so this is several missed pings, and matches the 8s WebRTC arrives at.
 const KCP_PEER_SILENCE_LIMIT: Duration = Duration::from_secs(8);
+// Neither is a hard upper bound: sends are awaited inline in this loop, so one in progress keeps
+// the tick that checks them from running, capped only by the transport's own send timeout.
+// Removing that needs the framing work that would stop one message owning the link.
 #[cfg(feature = "unix-file-copy-paste")]
 use crate::{clipboard::try_empty_clipboard_files, clipboard_file::unix_file_clip};
 use base::{
@@ -317,8 +312,7 @@ impl<T: InvokeUiSession> Remote<T> {
                             // Not `last_recv_time` alone: a message larger than the transport's
                             // fragment size yields nothing until its last fragment, so a peer
                             // sending one steadily - a clipboard image is the case that occurs -
-                            // would otherwise be timed out mid-transfer. Transports that report no
-                            // progress leave this at its starting value and are unaffected.
+                            // would otherwise be timed out mid-transfer.
                             if last_recv_time.max(last_rx_progress_at).elapsed() >= SEC30 {
                                 self.handler.msgbox("error", "Connection Error", "Timeout", "");
                                 break;
@@ -340,10 +334,10 @@ impl<T: InvokeUiSession> Remote<T> {
                                 self.handler.msgbox("restarting-show", "Restarting remote device", "Connection in progress. Please wait.", "");
                                 break;
                             }
-                            // Bytes seen by the transport, so a message too large to have arrived
-                            // whole still counts, and it clears a suspicion ICE raised late.
                             let rx_progress = peer.rx_progress();
-                            let progressed = rx_progress.is_some() && rx_progress != last_rx_progress;
+                            // `None` for transports that report none, and it never changes for a
+                            // given one, so they are inert here.
+                            let progressed = rx_progress != last_rx_progress;
                             last_rx_progress = rx_progress;
                             if progressed {
                                 last_rx_progress_at = Instant::now();
@@ -409,14 +403,10 @@ impl<T: InvokeUiSession> Remote<T> {
                     s.send(()).ok();
                 }
                 if kcp.is_some() {
-                    // Bounded once the peer has been declared gone: KCP waits for send capacity
-                    // with no deadline of its own, and a queue that a dead peer will never drain
-                    // would hold this thread until the endpoint reaps the connection. Still
-                    // attempted rather than skipped - if the loss was one-way the peer does get
-                    // it, and drops its side of the session instead of waiting out its own
-                    // timeout.
+                    // Attempted rather than skipped even here: if the loss was one-way the peer
+                    // does get it, and drops its side instead of waiting out its own timeout.
                     if peer_gone {
-                        peer.set_send_timeout(KCP_CLOSE_REASON_GONE_TIMEOUT);
+                        peer.set_send_timeout(KCP_CLOSE_REASON_GONE_DEADLINE.as_millis() as u64);
                     }
                     // Send the close reason if it hasn't been sent yet, as KCP cannot detect the socket close event.
                     self.send_close_reason(&mut peer, "kcp").await;

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -15,6 +15,19 @@ use crate::{
 // Restart msgbox text is kept as a legacy UI fallback; Flutter handles the type as a control event.
 const RESTART_REMOTE_DEVICE_NO_DATA_TIMEOUT: Duration = Duration::from_secs(5);
 const KCP_CLOSE_REASON_FLUSH_DELAY: Duration = Duration::from_millis(30);
+// A peer that is killed, logged out or rebooted sends nothing at all over UDP, so the session
+// sees silence and only a timeout ends it. This bounds that wait for WebRTC, which has a liveness
+// signal of its own; TCP and WebSocket are left exactly as they were, and the 30s timeout below
+// still backs all of them.
+//
+// Not a hard upper bound on how soon this notices: sends are awaited inline in this same loop, so
+// one in progress keeps the tick below from running, capped by the transport's own send timeout.
+// Removing that needs the framing work that would stop one message owning the link.
+//
+// Grace after ICE reports Disconnected, which it does ~5s after it stops hearing from the peer,
+// for ~8s in total. Disconnected is transient by design, so this waits out a Wi-Fi roam or a
+// sleep/wake rather than acting on the first hint.
+const WEBRTC_SUSPECT_GRACE: Duration = Duration::from_secs(3);
 #[cfg(feature = "unix-file-copy-paste")]
 use crate::{clipboard::try_empty_clipboard_files, clipboard_file::unix_file_clip};
 use base::{
@@ -247,6 +260,8 @@ impl<T: InvokeUiSession> Remote<T> {
 
                 let _keep_it = client::hc_connection(feedback, rendezvous_server, token).await;
                 let mut last_recv_time = Instant::now();
+                let mut webrtc_suspect_since: Option<Instant> = None;
+                let mut last_rx_progress = peer.rx_progress();
 
                 loop {
                     tokio::select! {
@@ -311,6 +326,23 @@ impl<T: InvokeUiSession> Remote<T> {
                                 && last_recv_time.elapsed() >= RESTART_REMOTE_DEVICE_NO_DATA_TIMEOUT
                             {
                                 self.handler.msgbox("restarting-show", "Restarting remote device", "Connection in progress. Please wait.", "");
+                                break;
+                            }
+                            // Bytes seen by the transport, so a message too large to have arrived
+                            // whole still counts, and it clears a suspicion ICE raised late.
+                            let rx_progress = peer.rx_progress();
+                            let progressed = rx_progress.is_some() && rx_progress != last_rx_progress;
+                            last_rx_progress = rx_progress;
+                            if peer.webrtc_disconnected() && !progressed {
+                                webrtc_suspect_since.get_or_insert_with(Instant::now);
+                            } else {
+                                webrtc_suspect_since = None;
+                            }
+                            let peer_gone = webrtc_suspect_since
+                                .map_or(false, |since| since.elapsed() >= WEBRTC_SUSPECT_GRACE);
+                            if peer_gone {
+                                log::info!("Peer stopped answering, reconnecting");
+                                self.handler.msgbox("restarting-show", "Connecting...", "Connection in progress. Please wait.", "");
                                 break;
                             }
                             let elapsed = fps_instant.elapsed().as_millis();

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -15,6 +15,7 @@ use crate::{
 // Restart msgbox text is kept as a legacy UI fallback; Flutter handles the type as a control event.
 const RESTART_REMOTE_DEVICE_NO_DATA_TIMEOUT: Duration = Duration::from_secs(5);
 const KCP_CLOSE_REASON_FLUSH_DELAY: Duration = Duration::from_millis(30);
+const KCP_CLOSE_REASON_GONE_TIMEOUT: u64 = 500;
 // A peer that is killed, logged out or rebooted sends nothing at all over UDP, so the session
 // sees silence and only a timeout ends it. These bound that wait for the two transports that
 // have a liveness signal of their own; TCP and WebSocket are left exactly as they were, and the
@@ -266,6 +267,8 @@ impl<T: InvokeUiSession> Remote<T> {
                 let mut last_recv_time = Instant::now();
                 let mut webrtc_suspect_since: Option<Instant> = None;
                 let mut last_rx_progress = peer.rx_progress();
+                let mut last_rx_progress_at = last_recv_time;
+                let mut peer_gone = false;
 
                 loop {
                     tokio::select! {
@@ -311,7 +314,12 @@ impl<T: InvokeUiSession> Remote<T> {
                             self.handle_local_clipboard_msg(&mut peer, _msg).await;
                         }
                         _ = self.timer.tick() => {
-                            if last_recv_time.elapsed() >= SEC30 {
+                            // Not `last_recv_time` alone: a message larger than the transport's
+                            // fragment size yields nothing until its last fragment, so a peer
+                            // sending one steadily - a clipboard image is the case that occurs -
+                            // would otherwise be timed out mid-transfer. Transports that report no
+                            // progress leave this at its starting value and are unaffected.
+                            if last_recv_time.max(last_rx_progress_at).elapsed() >= SEC30 {
                                 self.handler.msgbox("error", "Connection Error", "Timeout", "");
                                 break;
                             }
@@ -337,12 +345,15 @@ impl<T: InvokeUiSession> Remote<T> {
                             let rx_progress = peer.rx_progress();
                             let progressed = rx_progress.is_some() && rx_progress != last_rx_progress;
                             last_rx_progress = rx_progress;
+                            if progressed {
+                                last_rx_progress_at = Instant::now();
+                            }
                             if peer.webrtc_disconnected() && !progressed {
                                 webrtc_suspect_since.get_or_insert_with(Instant::now);
                             } else {
                                 webrtc_suspect_since = None;
                             }
-                            let peer_gone = webrtc_suspect_since
+                            peer_gone = webrtc_suspect_since
                                 .map_or(false, |since| since.elapsed() >= WEBRTC_SUSPECT_GRACE)
                                 || kcp
                                     .as_ref()
@@ -398,6 +409,15 @@ impl<T: InvokeUiSession> Remote<T> {
                     s.send(()).ok();
                 }
                 if kcp.is_some() {
+                    // Bounded once the peer has been declared gone: KCP waits for send capacity
+                    // with no deadline of its own, and a queue that a dead peer will never drain
+                    // would hold this thread until the endpoint reaps the connection. Still
+                    // attempted rather than skipped - if the loss was one-way the peer does get
+                    // it, and drops its side of the session instead of waiting out its own
+                    // timeout.
+                    if peer_gone {
+                        peer.set_send_timeout(KCP_CLOSE_REASON_GONE_TIMEOUT);
+                    }
                     // Send the close reason if it hasn't been sent yet, as KCP cannot detect the socket close event.
                     self.send_close_reason(&mut peer, "kcp").await;
                     // KCP does not send messages immediately, so wait to ensure the last message is sent.

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -25,9 +25,6 @@ const WEBRTC_SUSPECT_GRACE: Duration = Duration::from_secs(3);
 // KCP gets no such hint, only how long since a packet arrived; its endpoint pings an idle peer
 // about every 2s, so this is several missed pings, and matches the 8s WebRTC arrives at.
 const KCP_PEER_SILENCE_LIMIT: Duration = Duration::from_secs(8);
-// Neither is a hard upper bound: sends are awaited inline in this loop, so one in progress keeps
-// the tick that checks them from running, capped only by the transport's own send timeout.
-// Removing that needs the framing work that would stop one message owning the link.
 #[cfg(feature = "unix-file-copy-paste")]
 use crate::{clipboard::try_empty_clipboard_files, clipboard_file::unix_file_clip};
 use base::{
@@ -262,7 +259,6 @@ impl<T: InvokeUiSession> Remote<T> {
                 let mut last_recv_time = Instant::now();
                 let mut webrtc_suspect_since: Option<Instant> = None;
                 let mut last_rx_progress = peer.rx_progress();
-                let mut last_rx_progress_at = last_recv_time;
                 let mut peer_gone = false;
 
                 loop {
@@ -309,11 +305,7 @@ impl<T: InvokeUiSession> Remote<T> {
                             self.handle_local_clipboard_msg(&mut peer, _msg).await;
                         }
                         _ = self.timer.tick() => {
-                            // Not `last_recv_time` alone: a message larger than the transport's
-                            // fragment size yields nothing until its last fragment, so a peer
-                            // sending one steadily - a clipboard image is the case that occurs -
-                            // would otherwise be timed out mid-transfer.
-                            if last_recv_time.max(last_rx_progress_at).elapsed() >= SEC30 {
+                            if last_recv_time.elapsed() >= SEC30 {
                                 self.handler.msgbox("error", "Connection Error", "Timeout", "");
                                 break;
                             }
@@ -339,14 +331,15 @@ impl<T: InvokeUiSession> Remote<T> {
                             // given one, so they are inert here.
                             let progressed = rx_progress != last_rx_progress;
                             last_rx_progress = rx_progress;
-                            if progressed {
-                                last_rx_progress_at = Instant::now();
-                            }
                             if peer.webrtc_disconnected() && !progressed {
                                 webrtc_suspect_since.get_or_insert_with(Instant::now);
                             } else {
                                 webrtc_suspect_since = None;
                             }
+                            // Neither limit is a hard upper bound. A send is awaited inline in
+                            // this loop, so one in progress delays this tick - bounded on WebRTC
+                            // by the timeout the stream was built with, not bounded at all on
+                            // KCP. The 30s watchdog above shares the loop and the same delay.
                             peer_gone = webrtc_suspect_since
                                 .map_or(false, |since| since.elapsed() >= WEBRTC_SUSPECT_GRACE)
                                 || kcp

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -16,18 +16,22 @@ use crate::{
 const RESTART_REMOTE_DEVICE_NO_DATA_TIMEOUT: Duration = Duration::from_secs(5);
 const KCP_CLOSE_REASON_FLUSH_DELAY: Duration = Duration::from_millis(30);
 // A peer that is killed, logged out or rebooted sends nothing at all over UDP, so the session
-// sees silence and only a timeout ends it. This bounds that wait for WebRTC, which has a liveness
-// signal of its own; TCP and WebSocket are left exactly as they were, and the 30s timeout below
-// still backs all of them.
+// sees silence and only a timeout ends it. These bound that wait for the two transports that
+// have a liveness signal of their own; TCP and WebSocket are left exactly as they were, and the
+// 30s timeout below still backs all of them.
 //
-// Not a hard upper bound on how soon this notices: sends are awaited inline in this same loop, so
-// one in progress keeps the tick below from running, capped by the transport's own send timeout.
-// Removing that needs the framing work that would stop one message owning the link.
+// Neither is a hard upper bound on how soon this notices: sends are awaited inline in this same
+// loop, so one in progress keeps the tick below from running. WebRTC caps that at its existing
+// send timeout; KCP sets none, so a large message can delay the check by however long it takes
+// to drain. Removing that needs the framing work that would stop one message owning the link.
 //
 // Grace after ICE reports Disconnected, which it does ~5s after it stops hearing from the peer,
 // for ~8s in total. Disconnected is transient by design, so this waits out a Wi-Fi roam or a
 // sleep/wake rather than acting on the first hint.
 const WEBRTC_SUSPECT_GRACE: Duration = Duration::from_secs(3);
+// KCP has no equivalent hint, only how long since a packet last arrived; its endpoint pings an
+// idle peer about every 2s, so this is several missed pings.
+const KCP_PEER_SILENCE_LIMIT: Duration = Duration::from_secs(8);
 #[cfg(feature = "unix-file-copy-paste")]
 use crate::{clipboard::try_empty_clipboard_files, clipboard_file::unix_file_clip};
 use base::{
@@ -339,7 +343,11 @@ impl<T: InvokeUiSession> Remote<T> {
                                 webrtc_suspect_since = None;
                             }
                             let peer_gone = webrtc_suspect_since
-                                .map_or(false, |since| since.elapsed() >= WEBRTC_SUSPECT_GRACE);
+                                .map_or(false, |since| since.elapsed() >= WEBRTC_SUSPECT_GRACE)
+                                || kcp
+                                    .as_ref()
+                                    .and_then(|k| k.peer_silent_for())
+                                    .map_or(false, |silent| silent >= KCP_PEER_SILENCE_LIMIT);
                             if peer_gone {
                                 log::info!("Peer stopped answering, reconnecting");
                                 self.handler.msgbox("restarting-show", "Connecting...", "Connection in progress. Please wait.", "");

--- a/src/kcp_stream.rs
+++ b/src/kcp_stream.rs
@@ -8,14 +8,15 @@ use hbb_common::{
     tokio_util, ResultType, Stream,
 };
 use kcp_sys::{
-    endpoint::KcpEndpoint,
+    endpoint::{ConnId, KcpEndpoint},
     packet_def::{KcpPacket, KcpPacketHeader},
     stream,
 };
 use std::{net::SocketAddr, sync::Arc};
 
 pub struct KcpStream {
-    _endpoint: KcpEndpoint,
+    endpoint: KcpEndpoint,
+    conn_id: ConnId,
     stop_sender: Option<oneshot::Sender<()>>,
 }
 
@@ -39,6 +40,14 @@ impl KcpStream {
                 config
             }));
         }
+    }
+
+    /// How long since a valid packet was last received from the peer, or `None` once the
+    /// connection is gone. Answered by the KCP endpoint's own tasks, not by the session's read
+    /// loop, so it stays meaningful while that loop is busy sending a large message; and the
+    /// endpoint pings an idle peer often enough that silence here means the peer, not quiet.
+    pub fn peer_silent_for(&self) -> Option<std::time::Duration> {
+        self.endpoint.peer_silent_for(&self.conn_id)
     }
 
     fn create_framed(stream: stream::KcpStream, local_addr: Option<SocketAddr>) -> Stream {
@@ -77,7 +86,8 @@ impl KcpStream {
         if let Some(stream) = stream::KcpStream::new(&endpoint, conn_id) {
             Ok((
                 Self {
-                    _endpoint: endpoint,
+                    endpoint,
+                    conn_id,
                     stop_sender: Some(stop_sender),
                 },
                 Self::create_framed(stream, udp_socket.local_addr().ok()),
@@ -108,7 +118,8 @@ impl KcpStream {
         if let Some(stream) = stream::KcpStream::new(&endpoint, conn_id) {
             Ok((
                 Self {
-                    _endpoint: endpoint,
+                    endpoint,
+                    conn_id,
                     stop_sender: Some(stop_sender),
                 },
                 Self::create_framed(stream, udp_socket.local_addr().ok()),


### PR DESCRIPTION
A controlling peer whose link dies without a close currently waits out the 30s
application-message inactivity timeout before it reconnects. Both UDP transports know
sooner than that, and neither says so: WebRTC has ICE's own liveness check, and KCP's
endpoint knows how long it has been since a valid packet arrived. This reads both and
reconnects in about eight seconds.

Nothing changes for TCP or WebSocket. `Stream::rx_progress()` answers `None` for them,
`webrtc_disconnected()` is false, and there is no KCP endpoint to ask, so every term of the
new condition is inert. The Android guard below is keyed on this path's own title for the
same reason, so those sessions are untouched on the UI side as well.

### How each transport is judged

**WebRTC.** ICE reports `Disconnected` about five seconds after it stops hearing from the
peer. That state is transient by design — a Wi-Fi roam or a sleep/wake raises it and then
clears — so it is not acted on directly. The detector waits `WEBRTC_SUSPECT_GRACE` (3s)
with the hint still raised *and* no receive progress in that time, which puts recovery at
roughly eight seconds and keeps a link that comes back on its own from being torn down.

Receive progress is what separates "the transport has gone quiet" from "a large message is
still arriving". `WebRTCStream::send` serialises fragments under a one-permit gate, so a
peer sending something big yields nothing from `next()` for the whole transfer while the
byte counter keeps moving. It is used for that distinction only.

**KCP.** No hint exists, only how long since a valid inbound packet, which the endpoint's
own tasks track rather than the session's read loop — so it stays meaningful while that
loop is busy sending. `KCP_PEER_SILENCE_LIMIT` is 8s, matching where WebRTC lands. The
kcp-sys bump below adds the accessor and tightens the idle-ping cadence so the value is
fresh enough for that budget.

### What is deliberately unchanged

- **The 30s application-message inactivity timeout.** Receive progress does not extend it.
  A single logical message that takes longer than 30s can still hit it, as it can on
  master; fixing that safely belongs with bounded framing, not here. An earlier revision of
  this branch did time the watchdog off progress, and that removed its upper bound — a peer
  sending one `FRAG_MORE` every twenty seconds and never a `FRAG_END` refreshed the
  deadline indefinitely while the reassembly buffer grew toward `MAX_FRAME_LENGTH`.
  Reverted.

- **Reconnect pacing.** `restarting-show` reconnects without the exponential backoff its
  `restarting` sibling uses. A cooldown there would also delay the recovery this exists for
  when a peer really does come back, and the loading it shows is cancellable
  (`showLoading(..., onCancel: closeConnection)`).

- **The KCP branch takes one sample.** `peer_silent_for()` is already accumulated silence,
  not a transient hint, so it needs no confirming tick the way the WebRTC grace does; a
  second sample would only move 8s to 9s.

- **Neither limit is a hard upper bound.** A send is awaited inline in the session loop, so
  one in progress delays the tick that checks them — bounded on WebRTC by the timeout the
  stream was built with, not bounded at all on KCP. The 30s watchdog shares the loop and
  the same delay, so this is not a property the change introduces.

### UI

`model.dart` is the only UI-side change. The Android document-picker guard defers this
path's `restarting-show` alongside a `Connection Error`, so a peer-gone reconnect behind an
open system picker is held and resumed after the picker closes, like any other
interruption. It is matched by title rather than by type: an explicitly restarted remote
device sends the same type from a path this change does not touch, on every transport, and
deferring that one too would change sessions this has no business touching.

Sciter keeps the `Connection Error` / `Timeout` message: it knows no `restarting-show` and
would otherwise show a dialog that waits for a click, where the timeout this arrives ahead
of is retryable (`check_if_retry`) and reconnects on its own through `msgbox_retry`.

### Teardown

Once the peer is presumed gone, the parting close-reason send gets a 500ms deadline on KCP,
which otherwise waits for send capacity with no deadline of its own. It is attempted rather
than skipped because a one-way loss still lets the peer receive it and drop its side
instead of waiting out its own timeout.

### Dependencies

**`libs/hbb_common`** `55395c6..29cf7cb` — https://github.com/rustdesk/hbb_common/pull/599
(merged)

- `c50c1fe` report receive progress and ICE's disconnected hint
- `166bb3d` do not hand out a cached session ICE has lost the peer on
- `6db01ec` name the state in the health-hint assert (edition 2018 does not capture
  `{terminal}` from a bare literal)

**`kcp-sys`** `023a006..938eda3` on the fork's `rustdesk-patches` branch — one commit,
`src/endpoint.rs` only, +101/-15.

- Adds `KcpEndpoint::peer_silent_for(&ConnId) -> Option<Duration>`, the accessor this PR
  polls.
- Shortens the idle-ping cadence from ~10s to ~2s (`PING_SLOTS` 10 → 2) so several pings
  fall inside an eight-second window. This is the one behaviour change in the range, and it
  is process-wide — see Follow-up.
- Everything else is naming: `last_pong` → `last_rx`, `notify_pong` → `note_rx`,
  `is_pong_timeout` → `is_rx_timeout`. The field was already refreshed by every valid
  inbound packet, not only pongs — `handle_packet` and the packet-input path both did so —
  so the 60s reaper's criterion is unchanged.
- Two new tests: `test_peer_silent_for_stays_fresh_while_idle` (no application traffic for
  five seconds, worst observed silence on either endpoint must stay under 4s, which the old
  10s cadence could not meet) and `test_peer_silent_for_grows_once_the_peer_is_gone` (peer
  and its packet-carrying tasks dropped; silence must exceed 2.5s after three seconds).

### Diff

```
Cargo.lock                    |  2 +-
flutter/lib/models/model.dart |  6 +++++-
libs/hbb_common               |  2 +-
src/client/io_loop.rs         | 49 +++++++++++++++++++++++++++++++++++++++++++
src/kcp_stream.rs             | 19 +++++++++++++----
5 files changed, 71 insertions(+), 7 deletions(-)
```

### Testing

`cargo check --lib` on the parent and `cargo check --features webrtc --all-targets` in
`hbb_common` both pass.

Still to check on real machines: peer reboot, peer process kill, user switch, a link cut
that recovers within the grace, and an eight-second stall with the Android document picker
open.

### Follow-up, not in this PR

- The kcp-sys ping cadence is a process-wide constant, so a controlled device pays it too
  even though only the controlling side reads `peer_silent_for`. Making it per-endpoint is
  a small change in the fork plus one call site here.
- `test_webrtc_rx_progress_moves_before_a_large_message_completes` is timing-dependent:
  `next()` reassembles in its own loop and returns only on `FRAG_END`, so a runner fast
  enough to finish 4 MiB inside one `next_timeout(20)` never reaches the branch that sets
  `moved_early`. A deterministic version sends a well-formed `FRAG_MORE` and withholds the
  `FRAG_END`, which makes the timeout certain and the progress certain with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aokqJuhjvB3kijXtAg5Ns