### PR TITLE
Wayland portal staged errors

### DIFF
--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -24,7 +24,7 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
 use base::platform::linux::CMD_SH;
-use hbb_common::{bail, config, serde_json, tokio, ResultType};
+use hbb_common::{anyhow::anyhow, bail, config, serde_json, tokio, ResultType};
 
 use super::capturable::PixelProvider;
 use super::capturable::{Capturable, Recorder};
@@ -264,11 +264,21 @@ pub struct PipeWireRecorder {
     saved_raw_data: Vec<u8>, // for faster compare and copy
 }
 
+// Element creation fails the same way for a plugin that is not installed as for one that is
+// broken, so the tag does not claim which. Only the name travels to the peer -- it is what
+// says which package to look at -- and the factory's own error stays here in the log.
+fn gst_element(name: &str) -> ResultType<gst::Element> {
+    gst::ElementFactory::make(name, None).map_err(|e| {
+        error!("Failed to create GStreamer element {}: {}", name, e);
+        anyhow!(stage_err("gst-plugin", "unavailable", name))
+    })
+}
+
 impl PipeWireRecorder {
     pub fn new(capturable: PipeWireCapturable) -> ResultType<Self> {
         let pipeline = gst::Pipeline::new(None);
 
-        let src = gst::ElementFactory::make("pipewiresrc", None)?;
+        let src = gst_element("pipewiresrc")?;
         src.set_property("fd", &capturable.fd.as_raw_fd())?;
         src.set_property("path", &format!("{}", capturable.path))?;
         src.set_property("keepalive_time", &1_000.as_raw_fd())?;
@@ -283,9 +293,9 @@ impl PipeWireRecorder {
         // "no more output formats" / not-negotiated (-4). videoconvert accepts any
         // system-memory video/x-raw format, widening negotiation so the portal can
         // settle on a format it can deliver via its SHM path.
-        let convert = gst::ElementFactory::make("videoconvert", None)?;
+        let convert = gst_element("videoconvert")?;
 
-        let sink = gst::ElementFactory::make("appsink", None)?;
+        let sink = gst_element("appsink")?;
         sink.set_property("drop", &true)?;
         sink.set_property("max-buffers", &1u32)?;
 
@@ -464,11 +474,125 @@ impl Drop for PipeWireRecorder {
     }
 }
 
+// The portal handshake is four sequential requests whose outcomes arrive as asynchronous
+// `Response` signals, so where and why it failed is known only inside the signal handler.
+// Recording it here, instead of collapsing every outcome into one `failed` flag, is what lets
+// the app side name the real cause rather than guess it from the error text.
+#[derive(Clone, Copy)]
+enum PortalStage {
+    CreateSession = 1,
+    SelectDevices = 2,
+    SelectSources = 3,
+    Start = 4,
+    OpenPipeWireRemote = 5,
+}
+
+impl PortalStage {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::CreateSession => "create-session",
+            Self::SelectDevices => "select-devices",
+            Self::SelectSources => "select-sources",
+            Self::Start => "start",
+            Self::OpenPipeWireRemote => "open-pipewire-remote",
+        }
+    }
+
+    fn from_u8(v: u8) -> Self {
+        match v {
+            2 => Self::SelectDevices,
+            3 => Self::SelectSources,
+            4 => Self::Start,
+            5 => Self::OpenPipeWireRemote,
+            _ => Self::CreateSession,
+        }
+    }
+}
+
+// `wl-stage:<stage>:<kind>:<detail>`, parsed by `map_err_scrap` on the app side. The detail
+// reaches the user through a `{}` placeholder in a translated string, so it must not bring
+// braces, control characters or unbounded length of its own.
+const STAGE_TAG: &str = "wl-stage:";
+
+fn stage_err(stage: &str, kind: &str, detail: &str) -> String {
+    let detail: String = detail
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .filter(|c| *c != '{' && *c != '}')
+        .take(200)
+        .collect();
+    format!("{}{}:{}:{}", STAGE_TAG, stage, kind, detail.trim())
+}
+
+// The name alone is usually the generic `org.freedesktop.DBus.Error.Failed`; the message is
+// where a backend says what it objected to. This ends up in the log, so carry both.
+fn dbus_stage_err(stage: &str, err: &dbus::Error) -> String {
+    let detail = match (err.name(), err.message()) {
+        (Some(name), Some(message)) if !name.is_empty() && !message.is_empty() => {
+            format!("{}: {}", name, message)
+        }
+        (Some(name), _) if !name.is_empty() => name.to_owned(),
+        (_, message) => message.unwrap_or_default().to_owned(),
+    };
+    let kind = match err.name().unwrap_or_default() {
+        "org.freedesktop.DBus.Error.UnknownMethod"
+        | "org.freedesktop.DBus.Error.UnknownInterface" => "unsupported",
+        _ => "dbus",
+    };
+    stage_err(stage, kind, &detail)
+}
+
+#[derive(Clone)]
+struct PortalTrace {
+    failed: Arc<AtomicBool>,
+    reason: Arc<Mutex<Option<String>>>,
+    // The stage whose `Response` we are still waiting for, so the polling loop can tell a
+    // non-interactive step apart from the one that waits for a human.
+    waiting_for: Arc<AtomicU8>,
+}
+
+impl PortalTrace {
+    fn new() -> Self {
+        Self {
+            failed: Arc::new(AtomicBool::new(false)),
+            reason: Arc::new(Mutex::new(None)),
+            waiting_for: Arc::new(AtomicU8::new(PortalStage::CreateSession as u8)),
+        }
+    }
+
+    fn fail(&self, stage: PortalStage, kind: &str, detail: &str) {
+        self.record(stage_err(stage.as_str(), kind, detail));
+        self.failed.store(true, Ordering::SeqCst);
+    }
+
+    // The first failure is the cause; whatever follows it is a consequence.
+    fn record(&self, tag: String) {
+        if let Ok(mut reason) = self.reason.lock() {
+            if reason.is_none() {
+                *reason = Some(tag);
+            }
+        }
+    }
+
+    fn waiting(&self, stage: PortalStage) {
+        self.waiting_for.store(stage as u8, Ordering::SeqCst);
+    }
+
+    fn waiting_stage(&self) -> PortalStage {
+        PortalStage::from_u8(self.waiting_for.load(Ordering::SeqCst))
+    }
+
+    fn take_reason(&self) -> Option<String> {
+        self.reason.lock().ok().and_then(|mut r| r.take())
+    }
+}
+
 fn handle_response<F>(
     conn: &SyncConnection,
     path: dbus::Path<'static>,
     mut f: F,
-    failure_out: Arc<AtomicBool>,
+    trace: PortalTrace,
+    stage: PortalStage,
 ) -> Result<dbus::channel::Token, dbus::Error>
 where
     F: FnMut(
@@ -491,18 +615,29 @@ where
             0 => {}
             1 => {
                 warn!("DBus response: User cancelled interaction.");
-                failure_out.store(true, Ordering::SeqCst);
+                trace.fail(stage, "declined", "");
+                return true;
+            }
+            2 => {
+                warn!("DBus response: User interaction ended in some other way.");
+                trace.fail(stage, "ended", "");
                 return true;
             }
             c => {
                 warn!("DBus response: Unknown error, code: {}.", c);
-                failure_out.store(true, Ordering::SeqCst);
+                trace.fail(stage, "portal-error", &c.to_string());
                 return true;
             }
         }
         if let Err(err) = f(r, c, m) {
-            warn!("Error requesting screen capture via dbus: {}", err);
-            failure_out.store(true, Ordering::SeqCst);
+            let text = err.to_string();
+            warn!("Error requesting screen capture via dbus: {}", text);
+            if text.starts_with(STAGE_TAG) {
+                trace.record(text);
+                trace.failed.store(true, Ordering::SeqCst);
+            } else {
+                trace.fail(trace.waiting_stage(), "internal", &text);
+            }
         }
         true
     })
@@ -638,15 +773,16 @@ pub fn request_remote_desktop(
             INIT = true;
         }
     }
-    let conn = SyncConnection::new_session()?;
+    let conn =
+        SyncConnection::new_session().map_err(|e| anyhow!(dbus_stage_err("session-bus", &e)))?;
     let portal = get_portal(&conn);
     let mut args: PropMap = HashMap::new();
     let fd: Arc<Mutex<Option<OwnedFd>>> = Arc::new(Mutex::new(None));
     let fd_res = fd.clone();
     let streams: Arc<Mutex<Vec<PwStreamInfo>>> = Arc::new(Mutex::new(Vec::new()));
     let streams_res = streams.clone();
-    let failure = Arc::new(AtomicBool::new(false));
-    let failure_res = failure.clone();
+    let trace = PortalTrace::new();
+    let trace_res = trace.clone();
     let session: Arc<Mutex<Option<dbus::Path>>> = Arc::new(Mutex::new(None));
     let session_res = session.clone();
     let create_session_handle_token = "u1";
@@ -674,38 +810,45 @@ pub fn request_remote_desktop(
     // the caller to subscribe to the signal before making the method call.
     handle_response(
         &conn,
-        get_request_path(&conn, create_session_handle_token)?,
+        get_request_path(&conn, create_session_handle_token)
+            .map_err(|e| anyhow!(dbus_stage_err("create-session", &e)))?,
         on_create_session_response(
             fd.clone(),
             streams.clone(),
             session.clone(),
-            failure.clone(),
+            trace.clone(),
             is_support_restore_token,
             capture_cursor,
         ),
-        failure_res.clone(),
-    )?;
+        trace.clone(),
+        PortalStage::CreateSession,
+    )
+    .map_err(|e| anyhow!(dbus_stage_err("create-session", &e)))?;
     if is_server_running() {
-        let _ = screencast_portal::create_session(&portal, args)?;
+        let _ = screencast_portal::create_session(&portal, args)
+            .map_err(|e| anyhow!(dbus_stage_err("create-session", &e)))?;
     } else {
-        let _ = remote_desktop_portal::create_session(&portal, args)?;
+        let _ = remote_desktop_portal::create_session(&portal, args)
+            .map_err(|e| anyhow!(dbus_stage_err("create-session", &e)))?;
     }
 
     // wait 3 minutes for user interaction
     for _ in 0..1800 {
-        conn.process(Duration::from_millis(100))?;
+        conn.process(Duration::from_millis(100))
+            .map_err(|e| anyhow!(dbus_stage_err(trace_res.waiting_stage().as_str(), &e)))?;
         // Once we got a file descriptor we are done!
         if fd_res.lock().unwrap().is_some() {
             break;
         }
 
-        if failure_res.load(Ordering::SeqCst) {
+        if trace_res.failed.load(Ordering::SeqCst) {
             break;
         }
     }
     let fd_res = fd_res.lock().unwrap();
     let streams_res = streams_res.lock().unwrap();
     let session_res = session_res.lock().unwrap();
+    let have_fd = fd_res.is_some();
 
     if let Some(fd_res) = fd_res.clone() {
         if let Some(session) = session_res.clone() {
@@ -720,14 +863,20 @@ pub fn request_remote_desktop(
             }
         }
     }
-    bail!("Failed to obtain screen capture. You may need to upgrade the PipeWire library for better compatibility. Please check https://github.com/rustdesk/rustdesk/issues/8600#issuecomment-2254720954 for more details.")
+    bail!(trace_res.take_reason().unwrap_or_else(|| {
+        if have_fd {
+            stage_err("streams", "empty", "")
+        } else {
+            stage_err(trace_res.waiting_stage().as_str(), "no-response", "")
+        }
+    }))
 }
 
 fn on_create_session_response(
     fd: Arc<Mutex<Option<OwnedFd>>>,
     streams: Arc<Mutex<Vec<PwStreamInfo>>>,
     session: Arc<Mutex<Option<dbus::Path<'static>>>>,
-    failure: Arc<AtomicBool>,
+    trace: PortalTrace,
     is_support_restore_token: bool,
     capture_cursor: bool,
 ) -> impl Fn(
@@ -787,19 +936,23 @@ fn on_create_session_response(
                 });
             }
 
+            trace.waiting(PortalStage::SelectSources);
             handle_response(
                 c,
                 get_request_path(c, select_sources_handle_token)?,
                 on_select_sources_response(
                     fd.clone(),
                     streams.clone(),
-                    failure.clone(),
+                    trace.clone(),
                     ses.clone(),
                     is_support_restore_token,
                 ),
-                failure.clone(),
+                trace.clone(),
+                PortalStage::SelectSources,
             )?;
-            let _ = portal.select_sources(ses.clone(), args)?;
+            let _ = portal
+                .select_sources(ses.clone(), args)
+                .map_err(|e| DBusError(dbus_stage_err("select-sources", &e)))?;
         } else {
             // TODO: support persist_mode for remote_desktop_portal
             // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.RemoteDesktop.html
@@ -811,19 +964,23 @@ fn on_create_session_response(
             );
             args.insert("types".to_string(), Variant(Box::new(7u32)));
 
+            trace.waiting(PortalStage::SelectDevices);
             handle_response(
                 c,
                 get_request_path(c, select_devices_handle_token)?,
                 on_select_devices_response(
                     fd.clone(),
                     streams.clone(),
-                    failure.clone(),
+                    trace.clone(),
                     ses.clone(),
                     is_support_restore_token,
                 ),
-                failure.clone(),
+                trace.clone(),
+                PortalStage::SelectDevices,
             )?;
-            let _ = portal.select_devices(ses.clone(), args)?;
+            let _ = portal
+                .select_devices(ses.clone(), args)
+                .map_err(|e| DBusError(dbus_stage_err("select-devices", &e)))?;
         }
 
         Ok(())
@@ -833,7 +990,7 @@ fn on_create_session_response(
 fn on_select_devices_response(
     fd: Arc<Mutex<Option<OwnedFd>>>,
     streams: Arc<Mutex<Vec<PwStreamInfo>>>,
-    failure: Arc<AtomicBool>,
+    trace: PortalTrace,
     session: dbus::Path<'static>,
     is_support_restore_token: bool,
 ) -> impl Fn(
@@ -856,19 +1013,23 @@ fn on_select_devices_response(
         args.insert("types".into(), Variant(Box::new(1u32))); //| 2u32)));
 
         let session = session.clone();
+        trace.waiting(PortalStage::SelectSources);
         handle_response(
             c,
             get_request_path(c, select_sources_handle_token)?,
             on_select_sources_response(
                 fd.clone(),
                 streams.clone(),
-                failure.clone(),
+                trace.clone(),
                 session.clone(),
                 is_support_restore_token,
             ),
-            failure.clone(),
+            trace.clone(),
+            PortalStage::SelectSources,
         )?;
-        let _ = portal.select_sources(session.clone(), args)?;
+        let _ = portal
+            .select_sources(session.clone(), args)
+            .map_err(|e| DBusError(dbus_stage_err("select-sources", &e)))?;
 
         Ok(())
     }
@@ -877,7 +1038,7 @@ fn on_select_devices_response(
 fn on_select_sources_response(
     fd: Arc<Mutex<Option<OwnedFd>>>,
     streams: Arc<Mutex<Vec<PwStreamInfo>>>,
-    failure: Arc<AtomicBool>,
+    trace: PortalTrace,
     session: dbus::Path<'static>,
     is_support_restore_token: bool,
 ) -> impl Fn(
@@ -893,6 +1054,7 @@ fn on_select_sources_response(
             "handle_token".to_string(),
             Variant(Box::new(start_handle_token.to_string())),
         );
+        trace.waiting(PortalStage::Start);
         handle_response(
             c,
             get_request_path(c, start_handle_token)?,
@@ -900,14 +1062,18 @@ fn on_select_sources_response(
                 fd.clone(),
                 streams.clone(),
                 session.clone(),
+                trace.clone(),
                 is_support_restore_token,
             ),
-            failure.clone(),
+            trace.clone(),
+            PortalStage::Start,
         )?;
         if is_server_running() {
-            let _ = screencast_portal::start(&portal, session.clone(), "", args)?;
+            let _ = screencast_portal::start(&portal, session.clone(), "", args)
+                .map_err(|e| DBusError(dbus_stage_err("start", &e)))?;
         } else {
-            let _ = remote_desktop_portal::start(&portal, session.clone(), "", args)?;
+            let _ = remote_desktop_portal::start(&portal, session.clone(), "", args)
+                .map_err(|e| DBusError(dbus_stage_err("start", &e)))?;
         }
 
         Ok(())
@@ -918,6 +1084,7 @@ fn on_start_response(
     fd: Arc<Mutex<Option<OwnedFd>>>,
     streams: Arc<Mutex<Vec<PwStreamInfo>>>,
     session: dbus::Path<'static>,
+    trace: PortalTrace,
     is_support_restore_token: bool,
 ) -> impl Fn(
     OrgFreedesktopPortalRequestResponse,
@@ -945,10 +1112,14 @@ fn on_start_response(
             .lock()
             .unwrap()
             .append(&mut streams_from_response(r));
-        fd.clone()
-            .lock()
-            .unwrap()
-            .replace(portal.open_pipe_wire_remote(session.clone(), HashMap::new())?);
+        // Past this point the user has granted the request; anything that fails now is the
+        // hand-over of the PipeWire fd, which is a different thing to go looking at.
+        trace.waiting(PortalStage::OpenPipeWireRemote);
+        fd.clone().lock().unwrap().replace(
+            portal
+                .open_pipe_wire_remote(session.clone(), HashMap::new())
+                .map_err(|e| DBusError(dbus_stage_err("open-pipewire-remote", &e)))?,
+        );
 
         Ok(())
     }
@@ -1554,4 +1725,30 @@ fn sort_streams(
     }
     *streams = sorted_streams;
     *shared_displays = sorted_shared_displays;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stage_err;
+
+    #[test]
+    fn stage_err_keeps_the_detail_safe_for_a_placeholder() {
+        assert_eq!(
+            stage_err("start", "declined", ""),
+            "wl-stage:start:declined:"
+        );
+        // Braces of its own would break the placeholder lookup on the peer.
+        assert_eq!(
+            stage_err("create-session", "dbus", "org.freedesktop.{Error}"),
+            "wl-stage:create-session:dbus:org.freedesktop.Error"
+        );
+        assert_eq!(
+            stage_err("select-sources", "internal", "one\ntwo"),
+            "wl-stage:select-sources:internal:one two"
+        );
+        assert_eq!(
+            stage_err("start", "internal", &"x".repeat(300)),
+            format!("wl-stage:start:internal:{}", "x".repeat(200))
+        );
+    }
 }

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "تمرير جميع اتصالات إعادة توجيه المنافذ عبر اتصال واحد بالجهاز الآخر، بدلاً من الاتصال وتسجيل الدخول من جديد لكل اتصال."),
         ("Enable WebRTC P2P connection", "تمكين اتصال نظير إلى نظير عبر WebRTC"),
         ("Enable TCP hole punching", "تمكين تقنية حفر الثغرات عبر TCP"),
+        ("The screen sharing request was declined on the remote device", "تم رفض طلب مشاركة الشاشة على الجهاز البعيد"),
+        ("The screen sharing request timed out on the remote device", "انتهت مهلة طلب مشاركة الشاشة على الجهاز البعيد"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "يتعذّر على RustDesk الوصول إلى جلسة سطح المكتب على الجهاز البعيد، تأكد من أن جلسة سطح المكتب تعمل وأن RustDesk يمكنه استخدامها"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "بوابة سطح المكتب على الجهاز البعيد تفتقر إلى إمكانية لازمة لمشاركة الشاشة أو التحكم عن بُعد، قد لا تكون واجهتها الخلفية مثبتة"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "تمت الموافقة على مشاركة الشاشة على الجهاز البعيد، لكن تعذّر فتح اتصال PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "انتهى طلب مشاركة الشاشة على الجهاز البعيد دون أن يكتمل"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "تعذّر على RustDesk الحصول على شاشة قابلة للاستخدام من XDG Desktop Portal، قد تكون مكتبة PipeWire قديمة جدًا"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "تعذّر على RustDesk تحميل مكوّن GStreamer اللازم لالتقاط الشاشة ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Перадаваць усе злучэнні аднаго перанакіравання партоў праз адно злучэнне з аддаленай прыладай замест паўторнага падлучэння і ўваходу для кожнага з іх."),
         ("Enable WebRTC P2P connection", "Выкарыстоўваць падключэнне WebRTC P2P"),
         ("Enable TCP hole punching", "Выкарыстоўваць TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Запыт на абагульванне экрана быў адхілены на аддаленай прыладзе"),
+        ("The screen sharing request timed out on the remote device", "Час чакання запыту на абагульванне экрана на аддаленай прыладзе выйшаў"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk не можа атрымаць доступ да сеанса працоўнага стала на аддаленай прыладзе, праверце, ці запушчаны сеанс і ці даступны ён для RustDesk"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Партал працоўнага стала на аддаленай прыладзе не мае магчымасці, патрэбнай для абагульвання экрана або аддаленага кіравання, магчыма не ўсталяваны яго бэкенд"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Абагульванне экрана было дазволена на аддаленай прыладзе, але не ўдалося адкрыць злучэнне PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "Запыт на абагульванне экрана на аддаленай прыладзе завяршыўся, не будучы выкананым"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk не змог атрымаць прыдатны экран ад XDG Desktop Portal, магчыма бібліятэка PipeWire занадта старая"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не змог загрузіць кампанент GStreamer, патрэбны для захопу экрана ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Всички връзки на едно пренасочване на портове минават през една връзка към отсрещния компютър, вместо да се свързвате и влизате отново за всяка от тях."),
         ("Enable WebRTC P2P connection", "Позволяване на WebRTC P2P връзка"),
         ("Enable TCP hole punching", "Позволяване на TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Заявката за споделяне на екрана беше отхвърлена на отдалеченото устройство"),
+        ("The screen sharing request timed out on the remote device", "Заявката за споделяне на екрана на отдалеченото устройство изтече"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk не може да достигне сесията на работния плот на отдалеченото устройство, проверете дали сесията работи и дали RustDesk може да я използва"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Порталът на работния плот на отдалеченото устройство няма възможност, необходима за споделяне на екрана или отдалечено управление, може да липсва неговата реализация"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Споделянето на екрана беше одобрено на отдалеченото устройство, но връзката с PipeWire не можа да бъде отворена"),
+        ("The screen sharing request ended without completing on the remote device", "Заявката за споделяне на екрана на отдалеченото устройство приключи, без да бъде изпълнена"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk не можа да получи използваем екран от XDG Desktop Portal, библиотеката PipeWire може да е твърде стара"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не можа да зареди компонент на GStreamer, необходим за заснемане на екрана ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Fa passar totes les connexions d'una redirecció de ports per una única connexió amb l'altre equip, en lloc de connectar i iniciar la sessió de nou per a cadascuna."),
         ("Enable WebRTC P2P connection", "Habilita la connexió WebRTC P2P"),
         ("Enable TCP hole punching", "Activa la perforació TCP"),
+        ("The screen sharing request was declined on the remote device", "La sol·licitud de compartició de pantalla s'ha rebutjat al dispositiu remot"),
+        ("The screen sharing request timed out on the remote device", "La sol·licitud de compartició de pantalla ha esgotat el temps al dispositiu remot"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "El RustDesk no pot accedir a la sessió d'escriptori del dispositiu remot; comproveu que hi ha una sessió en marxa i que el RustDesk hi pot accedir"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Al portal d'escriptori del dispositiu remot li falta una funcionalitat necessària per compartir la pantalla o per al control remot; potser no té cap implementació instal·lada"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "S'ha aprovat la compartició de pantalla al dispositiu remot, però no s'ha pogut obrir la connexió PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "La sol·licitud de compartició de pantalla al dispositiu remot ha acabat sense completar-se"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "El RustDesk no ha pogut obtenir cap pantalla utilitzable de l'XDG Desktop Portal; la biblioteca PipeWire pot ser massa antiga"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "El RustDesk no ha pogut carregar un component del GStreamer necessari per capturar la pantalla ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "同一条端口转发规则上的所有连接共用一条到对方的连接，而不是每条连接都重新连接并登录一次。"),
         ("Enable WebRTC P2P connection", "启用 WebRTC P2P 连接"),
         ("Enable TCP hole punching", "启用 TCP 打洞"),
+        ("The screen sharing request was declined on the remote device", "远程设备上的用户拒绝了屏幕共享请求"),
+        ("The screen sharing request timed out on the remote device", "远程设备上的屏幕共享请求超时了"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk 无法访问远程设备的桌面会话，请确认桌面会话已启动并且 RustDesk 可以使用它"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "远程设备上的桌面门户缺少屏幕共享或远程控制所需的功能，可能没有安装它的后端"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "远程设备上已批准屏幕共享，但无法打开 PipeWire 连接"),
+        ("The screen sharing request ended without completing on the remote device", "远程设备上的屏幕共享请求已结束，但未完成"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk 无法从 XDG Desktop Portal 获取可用的屏幕，PipeWire 库可能过旧"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk 无法加载屏幕捕获所需的 GStreamer 组件 ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Vede všechna připojení jednoho přesměrování portů přes jediné připojení k protějšku místo opakovaného připojování a přihlašování pro každé z nich."),
         ("Enable WebRTC P2P connection", "Povolit připojení WebRTC P2P"),
         ("Enable TCP hole punching", "Povolit TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Žádost o sdílení obrazovky byla na vzdáleném zařízení odmítnuta"),
+        ("The screen sharing request timed out on the remote device", "Vypršel časový limit žádosti o sdílení obrazovky na vzdáleném zařízení"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk nemůže získat přístup k relaci plochy na vzdáleném zařízení, ověřte, že relace běží a že ji RustDesk může použít"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Portálu plochy na vzdáleném zařízení chybí funkce potřebná pro sdílení obrazovky nebo vzdálené ovládání, jeho implementace možná není nainstalována"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Sdílení obrazovky bylo na vzdáleném zařízení schváleno, ale připojení PipeWire se nepodařilo otevřít"),
+        ("The screen sharing request ended without completing on the remote device", "Žádost o sdílení obrazovky na vzdáleném zařízení skončila, aniž by byla dokončena"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nezískal z XDG Desktop Portal použitelnou obrazovku, knihovna PipeWire může být příliš stará"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nemohl načíst komponentu GStreameru potřebnou k zachycení obrazovky ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Fører alle forbindelser i en portvideresendelse gennem én enkelt forbindelse til modparten i stedet for at forbinde og logge ind igen for hver enkelt."),
         ("Enable WebRTC P2P connection", "Aktivér WebRTC P2P-forbindelse"),
         ("Enable TCP hole punching", "Aktivér TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Anmodningen om skærmdeling blev afvist på fjernenheden"),
+        ("The screen sharing request timed out on the remote device", "Anmodningen om skærmdeling fik timeout på fjernenheden"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk kan ikke nå skrivebordssessionen på fjernenheden, kontrollér at en session kører, og at RustDesk kan bruge den"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Skrivebordsportalen på fjernenheden mangler en funktion, der kræves til skærmdeling eller fjernstyring, dens backend er måske ikke installeret"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Skærmdeling blev godkendt på fjernenheden, men PipeWire-forbindelsen kunne ikke åbnes"),
+        ("The screen sharing request ended without completing on the remote device", "Anmodningen om skærmdeling på fjernenheden sluttede uden at blive gennemført"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk kunne ikke få en brugbar skærm fra XDG Desktop Portal, PipeWire-biblioteket er måske for gammelt"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kunne ikke indlæse en GStreamer-komponent, der kræves til skærmoptagelse ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Alle Verbindungen einer Portweiterleitung über eine einzige Verbindung zur Gegenstelle führen, statt sich für jede einzelne neu zu verbinden und anzumelden."),
         ("Enable WebRTC P2P connection", "WebRTC-P2P-Verbindung aktivieren"),
         ("Enable TCP hole punching", "TCP-Hole-Punching aktivieren"),
+        ("The screen sharing request was declined on the remote device", "Die Anfrage zur Bildschirmfreigabe wurde auf dem entfernten Gerät abgelehnt"),
+        ("The screen sharing request timed out on the remote device", "Bei der Anfrage zur Bildschirmfreigabe auf dem entfernten Gerät ist eine Zeitüberschreitung aufgetreten"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk kann die Desktop-Sitzung auf dem entfernten Gerät nicht erreichen. Prüfen Sie, ob eine Sitzung läuft und ob RustDesk sie nutzen kann"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Dem Desktop-Portal auf dem entfernten Gerät fehlt eine für Bildschirmfreigabe oder Fernsteuerung benötigte Fähigkeit, sein Backend ist möglicherweise nicht installiert"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Die Bildschirmfreigabe wurde auf dem entfernten Gerät genehmigt, aber die PipeWire-Verbindung konnte nicht geöffnet werden"),
+        ("The screen sharing request ended without completing on the remote device", "Die Anfrage zur Bildschirmfreigabe auf dem entfernten Gerät endete, ohne abgeschlossen zu werden"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk konnte vom XDG Desktop Portal keinen nutzbaren Bildschirm erhalten, die PipeWire-Bibliothek ist möglicherweise zu alt"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk konnte eine für die Bildschirmaufnahme benötigte GStreamer-Komponente nicht laden ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Όλες οι συνδέσεις μιας προώθησης θυρών περνούν από μία μόνο σύνδεση προς τον απομακρυσμένο υπολογιστή, αντί να πραγματοποιείται νέα σύνδεση και ταυτοποίηση για κάθε μία."),
         ("Enable WebRTC P2P connection", "Ενεργοποίηση σύνδεσης WebRTC P2P"),
         ("Enable TCP hole punching", "Ενεργοποίηση διάτρησης οπών TCP"),
+        ("The screen sharing request was declined on the remote device", "Το αίτημα κοινής χρήσης οθόνης απορρίφθηκε στην απομακρυσμένη συσκευή"),
+        ("The screen sharing request timed out on the remote device", "Το αίτημα κοινής χρήσης οθόνης έληξε στην απομακρυσμένη συσκευή"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "Το RustDesk δεν μπορεί να προσεγγίσει τη συνεδρία επιφάνειας εργασίας στην απομακρυσμένη συσκευή, ελέγξτε ότι μια συνεδρία εκτελείται και ότι το RustDesk μπορεί να τη χρησιμοποιήσει"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Στην πύλη επιφάνειας εργασίας της απομακρυσμένης συσκευής λείπει μια δυνατότητα που απαιτείται για κοινή χρήση οθόνης ή απομακρυσμένο έλεγχο, ίσως δεν είναι εγκατεστημένο το υποσύστημά της"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Η κοινή χρήση οθόνης εγκρίθηκε στην απομακρυσμένη συσκευή, αλλά δεν ήταν δυνατό το άνοιγμα της σύνδεσης PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "Το αίτημα κοινής χρήσης οθόνης στην απομακρυσμένη συσκευή έληξε χωρίς να ολοκληρωθεί"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "Το RustDesk δεν μπόρεσε να λάβει αξιοποιήσιμη οθόνη από το XDG Desktop Portal, η βιβλιοθήκη PipeWire ίσως είναι πολύ παλιά"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "Το RustDesk δεν μπόρεσε να φορτώσει ένα στοιχείο του GStreamer που απαιτείται για την καταγραφή οθόνης ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Ĉiuj konektoj de unu pordo-plusendado iras tra unu sola konekto al la alia komputilo, anstataŭ konekti kaj ensaluti denove por ĉiu el ili."),
         ("Enable WebRTC P2P connection", "Ebligi WebRTC P2P-konekton"),
         ("Enable TCP hole punching", "Ebligi TCP-trapikadon"),
+        ("The screen sharing request was declined on the remote device", "La peto pri ekrandividado estis rifuzita sur la fora aparato"),
+        ("The screen sharing request timed out on the remote device", "La peto pri ekrandividado eltempiĝis sur la fora aparato"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk ne povas atingi la labortablan seancon sur la fora aparato, kontrolu ke seanco funkcias kaj ke RustDesk povas uzi ĝin"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Al la labortabla portalo sur la fora aparato mankas kapablo necesa por ekrandividado aŭ fora regado, ĝia realigo eble ne estas instalita"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Ekrandividado estis aprobita sur la fora aparato, sed la konekto PipeWire ne malfermiĝis"),
+        ("The screen sharing request ended without completing on the remote device", "La peto pri ekrandividado sur la fora aparato finiĝis sen kompletiĝi"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk ne povis akiri uzeblan ekranon de XDG Desktop Portal, la biblioteko PipeWire eble estas tro malnova"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ne povis ŝargi komponanton de GStreamer necesan por ekrankapto ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Llevar todas las conexiones de una redirección de puertos por una única conexión con el otro equipo, en lugar de conectar e iniciar sesión de nuevo para cada una."),
         ("Enable WebRTC P2P connection", "Habilitar conexión WebRTC P2P"),
         ("Enable TCP hole punching", "Habilitar perforación de agujero TCP"),
+        ("The screen sharing request was declined on the remote device", "La solicitud de compartir pantalla fue rechazada en el dispositivo remoto"),
+        ("The screen sharing request timed out on the remote device", "La solicitud de compartir pantalla ha agotado el tiempo de espera en el dispositivo remoto"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk no puede acceder a la sesión de escritorio del dispositivo remoto; compruebe que hay una sesión en marcha y que RustDesk puede usarla"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Al portal de escritorio del dispositivo remoto le falta una función necesaria para compartir la pantalla o para el control remoto; puede que no tenga instalada su implementación"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Se aprobó compartir la pantalla en el dispositivo remoto, pero no se pudo abrir la conexión PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "La solicitud de compartir pantalla en el dispositivo remoto terminó sin completarse"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk no ha podido obtener una pantalla utilizable del XDG Desktop Portal; la biblioteca PipeWire puede ser demasiado antigua"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk no ha podido cargar un componente de GStreamer necesario para capturar la pantalla ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Juhib ühe pordisuunamise kõik ühendused ühe teise arvutiga loodud ühenduse kaudu, selle asemel et iga ühenduse jaoks uuesti ühenduda ja sisse logida."),
         ("Enable WebRTC P2P connection", "Luba WebRTC P2P-ühendus"),
         ("Enable TCP hole punching", "Luba TCP-augustamine"),
+        ("The screen sharing request was declined on the remote device", "Ekraani jagamise taotlus lükati kaugseadmes tagasi"),
+        ("The screen sharing request timed out on the remote device", "Ekraani jagamise taotlus aegus kaugseadmes"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk ei pääse kaugseadmes töölauaseansini, kontrollige, kas seanss töötab ja kas RustDesk saab seda kasutada"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Kaugseadme töölauaportaalil puudub ekraani jagamiseks või kaugjuhtimiseks vajalik võimalus, selle taustarakendus ei pruugi olla paigaldatud"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Ekraani jagamine kiideti kaugseadmes heaks, kuid PipeWire'i ühendust ei õnnestunud avada"),
+        ("The screen sharing request ended without completing on the remote device", "Ekraani jagamise taotlus kaugseadmes lõppes ilma lõpule jõudmata"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk ei saanud XDG Desktop Portalilt kasutatavat ekraani, PipeWire'i teek võib olla liiga vana"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ei suutnud laadida ekraani jäädvustamiseks vajalikku GStreameri komponenti ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Portu-birbideratze baten konexio guztiak beste ordenagailurako konexio bakar batetik eramaten ditu, bakoitzerako berriro konektatu eta saioa hasi beharrean."),
         ("Enable WebRTC P2P connection", "Gaitu WebRTC P2P konexioa"),
         ("Enable TCP hole punching", "Gaitu TCP zulo-egitea"),
+        ("The screen sharing request was declined on the remote device", "Pantaila partekatzeko eskaera baztertu egin da urruneko gailuan"),
+        ("The screen sharing request timed out on the remote device", "Pantaila partekatzeko eskaerak denbora-muga gainditu du urruneko gailuan"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk-ek ezin du urruneko gailuko mahaigaineko saioa atzitu, egiaztatu saio bat martxan dagoela eta RustDesk-ek erabil dezakeela"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Urruneko gailuko mahaigaineko atariari pantaila partekatzeko edo urrunetik kontrolatzeko behar den gaitasun bat falta zaio, agian ez dago haren backend-a instalatuta"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Pantaila partekatzea onartu da urruneko gailuan, baina ezin izan da PipeWire konexioa ireki"),
+        ("The screen sharing request ended without completing on the remote device", "Urruneko gailuko pantaila partekatzeko eskaera osatu gabe amaitu da"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk-ek ezin izan du pantaila erabilgarririk lortu XDG Desktop Portal-etik, PipeWire liburutegia zaharregia izan daiteke"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk-ek ezin izan du pantaila kapturatzeko beharrezkoa den GStreamer osagai bat kargatu ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "همه اتصال‌های یک هدایت پورت از یک اتصال واحد به دستگاه مقابل عبور می‌کنند، به‌جای اتصال و ورود دوباره برای هر کدام."),
         ("Enable WebRTC P2P connection", "فعال‌سازی اتصال همتا‌به‌همتای WebRTC"),
         ("Enable TCP hole punching", "فعال‌سازی تکنیک TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "درخواست اشتراک‌گذاری صفحه در دستگاه راه دور رد شد"),
+        ("The screen sharing request timed out on the remote device", "مهلت درخواست اشتراک‌گذاری صفحه در دستگاه راه دور به پایان رسید"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk نمی‌تواند به نشست میزکار دستگاه راه دور دسترسی پیدا کند، بررسی کنید که نشست میزکار در حال اجرا باشد و RustDesk بتواند از آن استفاده کند"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "درگاه میزکار در دستگاه راه دور قابلیت لازم برای اشتراک‌گذاری صفحه یا کنترل از راه دور را ندارد، شاید پیاده‌سازی آن نصب نشده باشد"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "اشتراک‌گذاری صفحه در دستگاه راه دور تأیید شد، اما اتصال PipeWire باز نشد"),
+        ("The screen sharing request ended without completing on the remote device", "درخواست اشتراک‌گذاری صفحه در دستگاه راه دور بدون تکمیل شدن پایان یافت"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk نتوانست صفحه‌ای قابل استفاده از XDG Desktop Portal دریافت کند، ممکن است کتابخانه PipeWire خیلی قدیمی باشد"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk نتوانست مؤلفه GStreamer موردنیاز برای ضبط صفحه را بارگذاری کند ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Välittää kaikki yhden portin edelleenohjauksen yhteydet yhden vastapuoleen avatun yhteyden kautta sen sijaan, että jokaista varten muodostettaisiin yhteys ja kirjauduttaisiin uudelleen."),
         ("Enable WebRTC P2P connection", "Ota WebRTC P2P yhteys käyttöön"),
         ("Enable TCP hole punching", "Ota käyttöön TCP hole punching  tekniikka"),
+        ("The screen sharing request was declined on the remote device", "Näytön jakamispyyntö hylättiin etälaitteessa"),
+        ("The screen sharing request timed out on the remote device", "Näytön jakamispyyntö aikakatkaistiin etälaitteessa"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk ei tavoita etälaitteen työpöytäistuntoa, tarkista että istunto on käynnissä ja että RustDesk voi käyttää sitä"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Etälaitteen työpöytäportaalista puuttuu näytön jakamiseen tai etäohjaukseen tarvittava ominaisuus, sen taustaosaa ei ehkä ole asennettu"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Näytön jakaminen hyväksyttiin etälaitteessa, mutta PipeWire-yhteyttä ei voitu avata"),
+        ("The screen sharing request ended without completing on the remote device", "Näytön jakamispyyntö etälaitteessa päättyi ilman että se saatiin valmiiksi"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk ei saanut XDG Desktop Portalilta käyttökelpoista näyttöä, PipeWire-kirjasto voi olla liian vanha"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ei voinut ladata näytön kaappaukseen tarvittavaa GStreamer-osaa ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Faire passer toutes les connexions d'une redirection de ports par une seule connexion vers le pair, au lieu de se connecter et de s'authentifier à nouveau pour chacune."),
         ("Enable WebRTC P2P connection", "Activer la connexion P2P WebRTC"),
         ("Enable TCP hole punching", "Activer le « hole punching » TCP"),
+        ("The screen sharing request was declined on the remote device", "La demande de partage d'écran a été refusée sur l'appareil distant"),
+        ("The screen sharing request timed out on the remote device", "La demande de partage d'écran a expiré sur l'appareil distant"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk ne peut pas accéder à la session de bureau de l'appareil distant, vérifiez qu'une session est ouverte et que RustDesk peut l'utiliser"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Il manque au portail de bureau de l'appareil distant une fonctionnalité nécessaire au partage d'écran ou au contrôle à distance, son backend n'est peut-être pas installé"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Le partage d'écran a été approuvé sur l'appareil distant, mais la connexion PipeWire n'a pas pu être ouverte"),
+        ("The screen sharing request ended without completing on the remote device", "La demande de partage d'écran sur l'appareil distant s'est terminée sans aboutir"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk n'a pas pu obtenir d'écran exploitable auprès du XDG Desktop Portal, la bibliothèque PipeWire est peut-être trop ancienne"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk n'a pas pu charger un composant GStreamer nécessaire à la capture d'écran ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "ერთი პორტის გადამისამართების ყველა კავშირი გადის მეორე კომპიუტერთან დამყარებული ერთი კავშირით, ნაცვლად იმისა, რომ თითოეულისთვის თავიდან დაუკავშირდეს და შევიდეს სისტემაში."),
         ("Enable WebRTC P2P connection", "WebRTC P2P კავშირის ჩართვა"),
         ("Enable TCP hole punching", "TCP hole punching-ის ჩართვა"),
+        ("The screen sharing request was declined on the remote device", "ეკრანის გაზიარების მოთხოვნა უარყოფილია დისტანციურ მოწყობილობაზე"),
+        ("The screen sharing request timed out on the remote device", "ეკრანის გაზიარების მოთხოვნას ვადა გაუვიდა დისტანციურ მოწყობილობაზე"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk-ს არ შეუძლია დისტანციური მოწყობილობის სამუშაო მაგიდის სესიასთან წვდომა, შეამოწმეთ, რომ სესია გაშვებულია და RustDesk-ს შეუძლია მისი გამოყენება"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "დისტანციური მოწყობილობის სამუშაო მაგიდის პორტალს აკლია ეკრანის გაზიარებისთვის ან დისტანციური მართვისთვის საჭირო შესაძლებლობა, შესაძლოა მისი ბექენდი დაინსტალირებული არ არის"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "ეკრანის გაზიარება დამტკიცდა დისტანციურ მოწყობილობაზე, მაგრამ PipeWire-ის კავშირის გახსნა ვერ მოხერხდა"),
+        ("The screen sharing request ended without completing on the remote device", "ეკრანის გაზიარების მოთხოვნა დისტანციურ მოწყობილობაზე დასრულდა შეუსრულებლად"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk-მა ვერ მიიღო გამოსადეგი ეკრანი XDG Desktop Portal-იდან, PipeWire-ის ბიბლიოთეკა შესაძლოა ძალიან ძველია"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk-მა ვერ ჩატვირთა ეკრანის ჩაწერისთვის საჭირო GStreamer-ის კომპონენტი ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/gl.rs
+++ b/src/lang/gl.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Canalizar todas as conexións dun mapeo de reenvío de portos a través dunha única conexión co par, en lugar de conectar e iniciar sesión de novo para cada unha."),
         ("Enable WebRTC P2P connection", "Activar conexión P2P por WebRTC"),
         ("Enable TCP hole punching", "Activar perforación de portos TCP"),
+        ("The screen sharing request was declined on the remote device", "A solicitude de compartir pantalla foi rexeitada no dispositivo remoto"),
+        ("The screen sharing request timed out on the remote device", "A solicitude de compartir pantalla esgotou o tempo no dispositivo remoto"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk non pode acceder á sesión de escritorio do dispositivo remoto, comprobe que hai unha sesión en marcha e que RustDesk pode usala"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Ao portal de escritorio do dispositivo remoto fáltalle unha funcionalidade necesaria para compartir a pantalla ou para o control remoto, pode que non teña instalada a súa implementación"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Aprobouse compartir a pantalla no dispositivo remoto, pero non se puido abrir a conexión PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "A solicitude de compartir pantalla no dispositivo remoto rematou sen completarse"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk non puido obter unha pantalla utilizable do XDG Desktop Portal, a biblioteca PipeWire pode ser demasiado antiga"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk non puido cargar un compoñente de GStreamer necesario para capturar a pantalla ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "એક પોર્ટ ફોરવર્ડિંગનાં બધાં કનેક્શન સામેના કમ્પ્યુટર સાથેના એક જ કનેક્શન મારફતે જાય છે, દરેક માટે ફરીથી કનેક્ટ અને લોગિન કરવાને બદલે."),
         ("Enable WebRTC P2P connection", "WebRTC P2P કનેક્શન સક્ષમ કરો"),
         ("Enable TCP hole punching", "TCP હોલ પંચિંગ સક્ષમ કરો"),
+        ("The screen sharing request was declined on the remote device", "રિમોટ ઉપકરણ પર સ્ક્રીન શેરિંગ વિનંતી નકારવામાં આવી"),
+        ("The screen sharing request timed out on the remote device", "રિમોટ ઉપકરણ પર સ્ક્રીન શેરિંગ વિનંતીનો સમય સમાપ્ત થયો"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk રિમોટ ઉપકરણના ડેસ્કટોપ સત્ર સુધી પહોંચી શકતું નથી, ખાતરી કરો કે ડેસ્કટોપ સત્ર ચાલુ છે અને RustDesk તેનો ઉપયોગ કરી શકે છે"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "રિમોટ ઉપકરણ પરના ડેસ્કટોપ પોર્ટલમાં સ્ક્રીન શેરિંગ અથવા રિમોટ કંટ્રોલ માટે જરૂરી ક્ષમતા નથી, તેનું બેકએન્ડ કદાચ ઇન્સ્ટોલ કરેલું નથી"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "રિમોટ ઉપકરણ પર સ્ક્રીન શેરિંગ મંજૂર થયું, પરંતુ PipeWire કનેક્શન ખોલી શકાયું નહીં"),
+        ("The screen sharing request ended without completing on the remote device", "રિમોટ ઉપકરણ પર સ્ક્રીન શેરિંગ વિનંતી પૂર્ણ થયા વિના સમાપ્ત થઈ"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk XDG Desktop Portal પાસેથી ઉપયોગી સ્ક્રીન મેળવી શક્યું નથી, PipeWire લાઇબ્રેરી કદાચ ઘણી જૂની છે"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk સ્ક્રીન કૅપ્ચર માટે જરૂરી GStreamer ઘટક લોડ કરી શક્યું નથી ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "כל החיבורים של העברת פורטים אחת עוברים דרך חיבור יחיד למחשב המרוחק, במקום ליצור חיבור חדש ולהיכנס מחדש עבור כל אחד מהם."),
         ("Enable WebRTC P2P connection", "אפשר חיבור WebRTC P2P"),
         ("Enable TCP hole punching", "אפשר TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "בקשת שיתוף המסך נדחתה במכשיר המרוחק"),
+        ("The screen sharing request timed out on the remote device", "תם הזמן המוקצב לבקשת שיתוף המסך במכשיר המרוחק"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk אינו יכול לגשת להפעלת שולחן העבודה במכשיר המרוחק, ודאו שההפעלה פועלת ושRustDesk יכול להשתמש בה"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "לפורטל שולחן העבודה במכשיר המרוחק חסרה יכולת הדרושה לשיתוף מסך או לשליטה מרחוק, ייתכן שהמימוש שלו אינו מותקן"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "שיתוף המסך אושר במכשיר המרוחק, אך לא ניתן היה לפתוח את חיבור PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "בקשת שיתוף המסך במכשיר המרוחק הסתיימה מבלי להתבצע"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk לא הצליח לקבל מסך שמיש מ-XDG Desktop Portal, ייתכן שספריית PipeWire ישנה מדי"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk לא הצליח לטעון רכיב GStreamer הדרוש ללכידת מסך ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "एक पोर्ट फ़ॉरवर्डिंग के सभी कनेक्शन दूसरे कंप्यूटर से बने एक ही कनेक्शन से होकर जाते हैं, हर एक के लिए दोबारा कनेक्ट और लॉगिन करने के बजाय।"),
         ("Enable WebRTC P2P connection", "WebRTC P2P कनेक्शन सक्षम करें"),
         ("Enable TCP hole punching", "TCP होल पंचिंग सक्षम करें"),
+        ("The screen sharing request was declined on the remote device", "रिमोट डिवाइस पर स्क्रीन शेयरिंग अनुरोध अस्वीकार कर दिया गया"),
+        ("The screen sharing request timed out on the remote device", "रिमोट डिवाइस पर स्क्रीन शेयरिंग अनुरोध का समय समाप्त हो गया"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk रिमोट डिवाइस के डेस्कटॉप सत्र तक नहीं पहुँच सकता, जाँचें कि डेस्कटॉप सत्र चल रहा है और RustDesk उसका उपयोग कर सकता है"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "रिमोट डिवाइस के डेस्कटॉप पोर्टल में स्क्रीन शेयरिंग या रिमोट कंट्रोल के लिए आवश्यक क्षमता नहीं है, शायद उसका बैकएंड इंस्टॉल नहीं है"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "रिमोट डिवाइस पर स्क्रीन शेयरिंग स्वीकृत हुई, लेकिन PipeWire कनेक्शन नहीं खोला जा सका"),
+        ("The screen sharing request ended without completing on the remote device", "रिमोट डिवाइस पर स्क्रीन शेयरिंग अनुरोध पूरा हुए बिना समाप्त हो गया"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk XDG Desktop Portal से उपयोग योग्य स्क्रीन प्राप्त नहीं कर सका, PipeWire लाइब्रेरी बहुत पुरानी हो सकती है"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk स्क्रीन कैप्चर के लिए आवश्यक GStreamer घटक लोड नहीं कर सका ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Sve veze jednog prosljeđivanja portova idu kroz jednu vezu prema drugoj strani, umjesto ponovnog povezivanja i prijave za svaku od njih."),
         ("Enable WebRTC P2P connection", "Omogući WebRTC P2P vezu"),
         ("Enable TCP hole punching", "Omogući TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Zahtjev za dijeljenje zaslona odbijen je na udaljenom uređaju"),
+        ("The screen sharing request timed out on the remote device", "Zahtjev za dijeljenje zaslona istekao je na udaljenom uređaju"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk ne može pristupiti sesiji radne površine na udaljenom uređaju, provjerite radi li sesija i može li je RustDesk koristiti"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Portalu radne površine na udaljenom uređaju nedostaje mogućnost potrebna za dijeljenje zaslona ili daljinsko upravljanje, njegov pozadinski dio možda nije instaliran"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Dijeljenje zaslona odobreno je na udaljenom uređaju, ali PipeWire vezu nije bilo moguće otvoriti"),
+        ("The screen sharing request ended without completing on the remote device", "Zahtjev za dijeljenje zaslona na udaljenom uređaju završio je bez dovršetka"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nije mogao dobiti upotrebljiv zaslon od XDG Desktop Portala, PipeWire biblioteka je možda prestara"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nije mogao učitati GStreamer komponentu potrebnu za snimanje zaslona ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Egy portátirányítás összes kapcsolatát egyetlen, a másik géppel létesített kapcsolaton vezeti át, ahelyett hogy mindegyikhez újra csatlakozna és bejelentkezne."),
         ("Enable WebRTC P2P connection", "WebRTC P2P kapcsolat engedélyezése"),
         ("Enable TCP hole punching", "TCP résszűrés engedélyezése"),
+        ("The screen sharing request was declined on the remote device", "A képernyőmegosztási kérést elutasították a távoli eszközön"),
+        ("The screen sharing request timed out on the remote device", "A képernyőmegosztási kérés időtúllépést okozott a távoli eszközön"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "A RustDesk nem éri el az asztali munkamenetet a távoli eszközön, ellenőrizze, hogy fut-e munkamenet és hogy a RustDesk használhatja-e"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "A távoli eszköz asztali portáljából hiányzik a képernyőmegosztáshoz vagy távvezérléshez szükséges képesség, a háttérrendszere talán nincs telepítve"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "A képernyőmegosztást jóváhagyták a távoli eszközön, de a PipeWire-kapcsolatot nem sikerült megnyitni"),
+        ("The screen sharing request ended without completing on the remote device", "A képernyőmegosztási kérés a távoli eszközön befejeződött anélkül, hogy teljesült volna"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "A RustDesk nem kapott használható képernyőt az XDG Desktop Portaltól, a PipeWire programkönyvtár túl régi lehet"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "A RustDesk nem tudta betölteni a képernyőrögzítéshez szükséges GStreamer összetevőt ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Menyalurkan semua koneksi dari satu penerusan port melalui satu koneksi ke perangkat lain, alih-alih menyambung dan masuk lagi untuk setiap koneksi."),
         ("Enable WebRTC P2P connection", "Aktifkan koneksi P2P WebRTC"),
         ("Enable TCP hole punching", "Aktifkan TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Permintaan berbagi layar ditolak di perangkat jarak jauh"),
+        ("The screen sharing request timed out on the remote device", "Permintaan berbagi layar kehabisan waktu di perangkat jarak jauh"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk tidak dapat mengakses sesi desktop di perangkat jarak jauh, pastikan sesi desktop berjalan dan dapat digunakan oleh RustDesk"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Portal desktop di perangkat jarak jauh tidak memiliki kemampuan yang diperlukan untuk berbagi layar atau kendali jarak jauh, backend-nya mungkin belum terpasang"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Berbagi layar disetujui di perangkat jarak jauh, tetapi koneksi PipeWire tidak dapat dibuka"),
+        ("The screen sharing request ended without completing on the remote device", "Permintaan berbagi layar di perangkat jarak jauh berakhir tanpa diselesaikan"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk tidak mendapatkan layar yang dapat digunakan dari XDG Desktop Portal, pustaka PipeWire mungkin terlalu lama"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk tidak dapat memuat komponen GStreamer yang diperlukan untuk merekam layar ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Fa passare tutte le connessioni di un inoltro porte in un'unica connessione verso il dispositivo remoto, invece di connettersi e autenticarsi di nuovo per ognuna."),
         ("Enable WebRTC P2P connection", "Abilita connessione P2P WebRTC"),
         ("Enable TCP hole punching", "Abilita  hole punching TCP"),
+        ("The screen sharing request was declined on the remote device", ""),
+        ("The screen sharing request timed out on the remote device", ""),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", ""),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", ""),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", ""),
+        ("The screen sharing request ended without completing on the remote device", ""),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", ""),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "1 つのポート転送のすべての接続を、相手への 1 本の接続にまとめます。接続ごとに接続とログインをやり直しません。"),
         ("Enable WebRTC P2P connection", "WebRTC P2P 接続を有効化する"),
         ("Enable TCP hole punching", "TCP ホールパンチを有効化する"),
+        ("The screen sharing request was declined on the remote device", "リモート端末で画面共有の要求が拒否されました"),
+        ("The screen sharing request timed out on the remote device", "リモート端末で画面共有の要求がタイムアウトしました"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk はリモート端末のデスクトップセッションにアクセスできません。セッションが動作していて RustDesk から利用できることを確認してください"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "リモート端末のデスクトップポータルに画面共有または遠隔操作に必要な機能がありません。バックエンドが未インストールの可能性があります"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "リモート端末で画面共有は許可されましたが、PipeWire 接続を開けませんでした"),
+        ("The screen sharing request ended without completing on the remote device", "リモート端末での画面共有の要求は完了しないまま終了しました"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk は XDG Desktop Portal から使用可能な画面を取得できませんでした。PipeWire ライブラリが古すぎる可能性があります"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk は画面キャプチャに必要な GStreamer コンポーネントを読み込めませんでした ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "포트 포워딩 하나의 모든 연결을 상대방과의 단일 연결로 전달합니다. 연결마다 다시 접속하고 로그인하지 않습니다."),
         ("Enable WebRTC P2P connection", "WebRTC P2P 연결 사용"),
         ("Enable TCP hole punching", "TCP 홀 펀칭 사용"),
+        ("The screen sharing request was declined on the remote device", "원격 장치에서 화면 공유 요청이 거부되었습니다"),
+        ("The screen sharing request timed out on the remote device", "원격 장치에서 화면 공유 요청이 시간 초과되었습니다"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk가 원격 장치의 데스크톱 세션에 접근할 수 없습니다. 세션이 실행 중이고 RustDesk가 사용할 수 있는지 확인하세요"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "원격 장치의 데스크톱 포털에 화면 공유 또는 원격 제어에 필요한 기능이 없습니다. 백엔드가 설치되지 않았을 수 있습니다"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "원격 장치에서 화면 공유가 승인되었지만 PipeWire 연결을 열 수 없습니다"),
+        ("The screen sharing request ended without completing on the remote device", "원격 장치의 화면 공유 요청이 완료되지 않은 채 종료되었습니다"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk가 XDG Desktop Portal에서 사용 가능한 화면을 가져오지 못했습니다. PipeWire 라이브러리가 너무 오래되었을 수 있습니다"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk가 화면 캡처에 필요한 GStreamer 구성 요소를 불러오지 못했습니다 ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Бір порт бағыттаудың барлық қосылымдары әрқайсысы үшін қайта қосылып кірудің орнына қарсы құрылғымен орнатылған бір қосылым арқылы өтеді."),
         ("Enable WebRTC P2P connection", "WebRTC P2P қосылымын іске қосу"),
         ("Enable TCP hole punching", "TCP hole punching'ті іске қосу"),
+        ("The screen sharing request was declined on the remote device", "Қашықтағы құрылғыда экранды бөлісу сұрауы қабылданбады"),
+        ("The screen sharing request timed out on the remote device", "Қашықтағы құрылғыда экранды бөлісу сұрауының уақыты бітті"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk қашықтағы құрылғының жұмыс үстелі сеансына қол жеткізе алмайды, сеанстың іске қосылғанын және RustDesk оны пайдалана алатынын тексеріңіз"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Қашықтағы құрылғының жұмыс үстелі порталында экранды бөлісуге немесе қашықтан басқаруға қажет мүмкіндік жоқ, оның бэкенді орнатылмаған болуы мүмкін"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Қашықтағы құрылғыда экранды бөлісуге рұқсат берілді, бірақ PipeWire байланысын ашу мүмкін болмады"),
+        ("The screen sharing request ended without completing on the remote device", "Қашықтағы құрылғыдағы экранды бөлісу сұрауы аяқталмай тоқтады"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk XDG Desktop Portal-дан жарамды экран ала алмады, PipeWire кітапханасы тым ескі болуы мүмкін"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk экранды түсіру үшін қажет GStreamer компонентін жүктей алмады ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Visi vieno prievadų peradresavimo ryšiai eina per vieną ryšį su kitu kompiuteriu, užuot kiekvienam iš jų jungiantis ir prisijungiant iš naujo."),
         ("Enable WebRTC P2P connection", "Įgalinti WebRTC P2P ryšį"),
         ("Enable TCP hole punching", "Įgalinti TCP gręžimą (hole punching)"),
+        ("The screen sharing request was declined on the remote device", "Ekrano bendrinimo užklausa buvo atmesta nuotoliniame įrenginyje"),
+        ("The screen sharing request timed out on the remote device", "Baigėsi ekrano bendrinimo užklausos laikas nuotoliniame įrenginyje"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk negali pasiekti nuotolinio įrenginio darbalaukio seanso, patikrinkite, ar seansas veikia ir ar RustDesk gali jį naudoti"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Nuotolinio įrenginio darbalaukio portalui trūksta ekrano bendrinimui ar nuotoliniam valdymui reikalingos galimybės, gali būti neįdiegta jo posistemė"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Ekrano bendrinimas nuotoliniame įrenginyje buvo patvirtintas, bet nepavyko atverti PipeWire ryšio"),
+        ("The screen sharing request ended without completing on the remote device", "Ekrano bendrinimo užklausa nuotoliniame įrenginyje baigėsi jos neužbaigus"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk negavo tinkamo ekrano iš XDG Desktop Portal, PipeWire biblioteka gali būti per sena"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nepavyko įkelti ekrano įrašymui reikalingo GStreamer komponento ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Visi viena portu pārsūtījuma savienojumi tiek novadīti pa vienu savienojumu ar otru datoru, nevis katram no tiem izveidojot jaunu savienojumu un pieteikšanos."),
         ("Enable WebRTC P2P connection", "Iespējot WebRTC P2P savienojumu"),
         ("Enable TCP hole punching", "Iespējot TCP caurumu veidošanu"),
+        ("The screen sharing request was declined on the remote device", "Ekrāna koplietošanas pieprasījums attālinātajā ierīcē tika noraidīts"),
+        ("The screen sharing request timed out on the remote device", "Ekrāna koplietošanas pieprasījumam attālinātajā ierīcē iestājās noildze"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk nevar piekļūt attālinātās ierīces darbvirsmas sesijai, pārbaudiet, vai sesija darbojas un vai RustDesk to var izmantot"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Attālinātās ierīces darbvirsmas portālam trūkst ekrāna koplietošanai vai attālinātai vadībai nepieciešamās iespējas, tā aizmugursistēma varētu nebūt instalēta"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Ekrāna koplietošana attālinātajā ierīcē tika apstiprināta, bet PipeWire savienojumu neizdevās atvērt"),
+        ("The screen sharing request ended without completing on the remote device", "Ekrāna koplietošanas pieprasījums attālinātajā ierīcē beidzās, netiekot pabeigts"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk neieguva izmantojamu ekrānu no XDG Desktop Portal, PipeWire bibliotēka var būt pārāk veca"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nevarēja ielādēt ekrāna tveršanai nepieciešamo GStreamer komponentu ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "ഒരു പോർട്ട് ഫോർവേഡിംഗിന്റെ എല്ലാ കണക്ഷനുകളും മറ്റേ കമ്പ്യൂട്ടറിലേക്കുള്ള ഒരൊറ്റ കണക്ഷനിലൂടെ കടന്നുപോകുന്നു, ഓരോന്നിനും വീണ്ടും കണക്റ്റ് ചെയ്ത് ലോഗിൻ ചെയ്യുന്നതിനു പകരം."),
         ("Enable WebRTC P2P connection", "WebRTC P2P കണക്ഷൻ അനുവദിക്കുക"),
         ("Enable TCP hole punching", "TCP ഹോൾ പഞ്ചിംഗ് അനുവദിക്കുക"),
+        ("The screen sharing request was declined on the remote device", "വിദൂര ഉപകരണത്തിൽ സ്ക്രീൻ പങ്കിടൽ അഭ്യർത്ഥന നിരസിച്ചു"),
+        ("The screen sharing request timed out on the remote device", "വിദൂര ഉപകരണത്തിൽ സ്ക്രീൻ പങ്കിടൽ അഭ്യർത്ഥനയുടെ സമയം കഴിഞ്ഞു"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk-ന് വിദൂര ഉപകരണത്തിലെ ഡെസ്ക്ടോപ്പ് സെഷനിലേക്ക് എത്താൻ കഴിയുന്നില്ല, സെഷൻ പ്രവർത്തിക്കുന്നുണ്ടെന്നും RustDesk-ന് അത് ഉപയോഗിക്കാമെന്നും ഉറപ്പാക്കുക"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "വിദൂര ഉപകരണത്തിലെ ഡെസ്ക്ടോപ്പ് പോർട്ടലിന് സ്ക്രീൻ പങ്കിടലിനോ വിദൂര നിയന്ത്രണത്തിനോ ആവശ്യമായ ശേഷിയില്ല, അതിന്റെ ബാക്കെൻഡ് ഇൻസ്റ്റാൾ ചെയ്തിട്ടില്ലായിരിക്കാം"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "വിദൂര ഉപകരണത്തിൽ സ്ക്രീൻ പങ്കിടൽ അനുവദിച്ചു, പക്ഷേ PipeWire കണക്ഷൻ തുറക്കാനായില്ല"),
+        ("The screen sharing request ended without completing on the remote device", "വിദൂര ഉപകരണത്തിലെ സ്ക്രീൻ പങ്കിടൽ അഭ്യർത്ഥന പൂർത്തിയാകാതെ അവസാനിച്ചു"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "XDG Desktop Portal-ൽ നിന്ന് ഉപയോഗയോഗ്യമായ സ്ക്രീൻ RustDesk-ന് ലഭിച്ചില്ല, PipeWire ലൈബ്രറി വളരെ പഴയതാകാം"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "സ്ക്രീൻ പകർത്താൻ ആവശ്യമായ GStreamer ഘടകം RustDesk-ന് ലോഡ് ചെയ്യാനായില്ല ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Fører alle tilkoblinger i en portvideresending gjennom én enkelt tilkobling til motparten i stedet for å koble til og logge inn på nytt for hver enkelt."),
         ("Enable WebRTC P2P connection", "Aktiver WebRTC P2P-tilkobling"),
         ("Enable TCP hole punching", "Aktiver TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Forespørselen om skjermdeling ble avvist på den eksterne enheten"),
+        ("The screen sharing request timed out on the remote device", "Forespørselen om skjermdeling fikk tidsavbrudd på den eksterne enheten"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk får ikke tilgang til skrivebordsøkten på den eksterne enheten, kontroller at en økt kjører og at RustDesk kan bruke den"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Skrivebordsportalen på den eksterne enheten mangler en funksjon som kreves for skjermdeling eller fjernstyring, bakstykket er kanskje ikke installert"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Skjermdeling ble godkjent på den eksterne enheten, men PipeWire-tilkoblingen kunne ikke åpnes"),
+        ("The screen sharing request ended without completing on the remote device", "Forespørselen om skjermdeling på den eksterne enheten ble avsluttet uten å bli fullført"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk fikk ingen brukbar skjerm fra XDG Desktop Portal, PipeWire-biblioteket kan være for gammelt"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kunne ikke laste en GStreamer-komponent som kreves for skjermopptak ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Alle verbindingen van een poortdoorschakeling via één enkele verbinding met de andere computer laten lopen, in plaats van voor elke verbinding opnieuw verbinding te maken en in te loggen."),
         ("Enable WebRTC P2P connection", "WebRTC P2P-verbinding inschakelen"),
         ("Enable TCP hole punching", "TCP-hole punching inschakelen"),
+        ("The screen sharing request was declined on the remote device", "Het verzoek om schermdeling is geweigerd op het externe apparaat"),
+        ("The screen sharing request timed out on the remote device", "Het verzoek om schermdeling is verlopen op het externe apparaat"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk heeft geen toegang tot de bureaubladsessie op het externe apparaat, controleer of er een sessie actief is en of RustDesk die kan gebruiken"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "De bureaubladportal op het externe apparaat mist een functie die nodig is voor schermdeling of besturing op afstand, de backend is mogelijk niet geïnstalleerd"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Schermdeling is goedgekeurd op het externe apparaat, maar de PipeWire-verbinding kon niet worden geopend"),
+        ("The screen sharing request ended without completing on the remote device", "Het verzoek om schermdeling op het externe apparaat is geëindigd zonder te zijn voltooid"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk kon geen bruikbaar scherm verkrijgen van de XDG Desktop Portal, de PipeWire-bibliotheek is mogelijk te oud"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kon een GStreamer-component die nodig is voor schermopname niet laden ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Przekazuj wszystkie połączenia jednego przekierowania portów przez jedno połączenie ze zdalnym komputerem, zamiast łączyć się i logować od nowa dla każdego z nich."),
         ("Enable WebRTC P2P connection", "Włącz połączenie P2P WebRTC"),
         ("Enable TCP hole punching", "Włącz tworzenie tunelu TCP"),
+        ("The screen sharing request was declined on the remote device", "Żądanie udostępnienia ekranu zostało odrzucone na urządzeniu zdalnym"),
+        ("The screen sharing request timed out on the remote device", "Upłynął limit czasu żądania udostępnienia ekranu na urządzeniu zdalnym"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk nie może uzyskać dostępu do sesji pulpitu na urządzeniu zdalnym, sprawdź, czy sesja działa i czy RustDesk może z niej korzystać"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Portalowi pulpitu na urządzeniu zdalnym brakuje funkcji wymaganej do udostępniania ekranu lub zdalnego sterowania, jego zaplecze może nie być zainstalowane"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Udostępnianie ekranu zostało zatwierdzone na urządzeniu zdalnym, ale nie udało się otworzyć połączenia PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "Żądanie udostępnienia ekranu na urządzeniu zdalnym zakończyło się bez ukończenia"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nie uzyskał użytecznego ekranu z XDG Desktop Portal, biblioteka PipeWire może być zbyt stara"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nie mógł załadować składnika GStreamer wymaganego do przechwytywania ekranu ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Encaminhar todas as ligações de um reencaminhamento de portas por uma única ligação ao outro computador, em vez de ligar e iniciar sessão novamente para cada uma."),
         ("Enable WebRTC P2P connection", "Ativar ligação P2P por WebRTC"),
         ("Enable TCP hole punching", "Ativar TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "O pedido de partilha de ecrã foi recusado no dispositivo remoto"),
+        ("The screen sharing request timed out on the remote device", "O pedido de partilha de ecrã expirou no dispositivo remoto"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "O RustDesk não consegue aceder à sessão de ambiente de trabalho no dispositivo remoto, verifique se existe uma sessão ativa e se o RustDesk a pode usar"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Falta ao portal de ambiente de trabalho do dispositivo remoto uma capacidade necessária para partilha de ecrã ou controlo remoto, o seu backend pode não estar instalado"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "A partilha de ecrã foi aprovada no dispositivo remoto, mas não foi possível abrir a ligação PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "O pedido de partilha de ecrã no dispositivo remoto terminou sem ser concluído"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "O RustDesk não conseguiu obter um ecrã utilizável do XDG Desktop Portal, a biblioteca PipeWire pode ser demasiado antiga"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "O RustDesk não conseguiu carregar um componente do GStreamer necessário para capturar o ecrã ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Levar todas as conexões de um encaminhamento de portas por uma única conexão com o outro computador, em vez de conectar e fazer login novamente para cada uma."),
         ("Enable WebRTC P2P connection", "Habilitar conexão WebRTC P2P"),
         ("Enable TCP hole punching", "Habilitar TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "A solicitação de compartilhamento de tela foi recusada no dispositivo remoto"),
+        ("The screen sharing request timed out on the remote device", "A solicitação de compartilhamento de tela expirou no dispositivo remoto"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "O RustDesk não consegue acessar a sessão de área de trabalho no dispositivo remoto, verifique se há uma sessão em execução e se o RustDesk pode usá-la"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Falta ao portal de área de trabalho do dispositivo remoto um recurso necessário para compartilhamento de tela ou controle remoto, seu backend pode não estar instalado"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "O compartilhamento de tela foi aprovado no dispositivo remoto, mas não foi possível abrir a conexão PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "A solicitação de compartilhamento de tela no dispositivo remoto terminou sem ser concluída"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "O RustDesk não conseguiu obter uma tela utilizável do XDG Desktop Portal, a biblioteca PipeWire pode ser muito antiga"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "O RustDesk não conseguiu carregar um componente do GStreamer necessário para capturar a tela ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Trece toate conexiunile unei redirecționări de porturi printr-o singură conexiune către celălalt calculator, în loc să se conecteze și să se autentifice din nou pentru fiecare."),
         ("Enable WebRTC P2P connection", "Activează conexiunea P2P prin WebRTC"),
         ("Enable TCP hole punching", "Activează traversarea TCP (hole punching)"),
+        ("The screen sharing request was declined on the remote device", "Cererea de partajare a ecranului a fost refuzată pe dispozitivul de la distanță"),
+        ("The screen sharing request timed out on the remote device", "Cererea de partajare a ecranului a expirat pe dispozitivul de la distanță"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk nu poate accesa sesiunea de desktop de pe dispozitivul de la distanță, verificați dacă o sesiune rulează și dacă RustDesk o poate folosi"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Portalului de desktop de pe dispozitivul de la distanță îi lipsește o funcționalitate necesară pentru partajarea ecranului sau controlul de la distanță, componenta sa de bază poate lipsi"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Partajarea ecranului a fost aprobată pe dispozitivul de la distanță, dar conexiunea PipeWire nu a putut fi deschisă"),
+        ("The screen sharing request ended without completing on the remote device", "Cererea de partajare a ecranului pe dispozitivul de la distanță s-a încheiat fără a fi finalizată"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nu a putut obține un ecran utilizabil de la XDG Desktop Portal, biblioteca PipeWire poate fi prea veche"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nu a putut încărca o componentă GStreamer necesară pentru capturarea ecranului ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Передавать все соединения одного перенаправления портов через одно подключение к удалённому устройству вместо повторного подключения и входа для каждого из них."),
         ("Enable WebRTC P2P connection", "Использовать подключение WebRTC P2P"),
         ("Enable TCP hole punching", "Использовать TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Запрос на демонстрацию экрана отклонён на удалённом устройстве"),
+        ("The screen sharing request timed out on the remote device", "Истекло время ожидания запроса на демонстрацию экрана на удалённом устройстве"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk не может получить доступ к сеансу рабочего стола на удалённом устройстве, проверьте, что сеанс запущен и доступен RustDesk"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Порталу рабочего стола на удалённом устройстве не хватает возможности, необходимой для демонстрации экрана или удалённого управления, его реализация может быть не установлена"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Демонстрация экрана была разрешена на удалённом устройстве, но не удалось открыть соединение PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "Запрос на демонстрацию экрана на удалённом устройстве завершился, не будучи выполненным"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk не смог получить пригодный экран от XDG Desktop Portal, библиотека PipeWire может быть слишком старой"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не удалось загрузить компонент GStreamer, необходимый для захвата экрана ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Totu is connessiones de un'imbiu de portas passant in una connessione ebbia a s'àteru computadore, in logu de si connètere e intrare torra pro dontzi una."),
         ("Enable WebRTC P2P connection", "Abìlita connessione P2P WebRTC"),
         ("Enable TCP hole punching", "Abìlita s'istampadura TCP"),
+        ("The screen sharing request was declined on the remote device", "Sa rechesta de cumpartzidura de sa schermada est istada refudada in su dispositivu remotu"),
+        ("The screen sharing request timed out on the remote device", "Sa rechesta de cumpartzidura de sa schermada at superadu su tempus in su dispositivu remotu"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk no podet acèdere a sa sessione de iscrivania in su dispositivu remotu, controlla chi una sessione siat ativa e chi RustDesk la potzat impreare"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "A su portale de iscrivania in su dispositivu remotu li mancat una funtzionalidade netzessària pro sa cumpartzidura de sa schermada o pro su controllu remotu, su backend suo podet non èssere installadu"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Sa cumpartzidura de sa schermada est istada aprovada in su dispositivu remotu, ma no si est pòdidu abèrrere sa connessione PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "Sa rechesta de cumpartzidura de sa schermada in su dispositivu remotu est acabada chene si cumpletare"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk no at pòdidu otènnere una schermada impreabile dae XDG Desktop Portal, sa libreria PipeWire podet èssere tropu betza"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk no at pòdidu carrigare unu cumponente de GStreamer netzessàriu pro registrare sa schermada ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Vedie všetky pripojenia jedného presmerovania portov cez jediné pripojenie k druhej strane namiesto opakovaného pripájania a prihlasovania pre každé z nich."),
         ("Enable WebRTC P2P connection", "Povoliť pripojenie WebRTC P2P"),
         ("Enable TCP hole punching", "Povoliť TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Žiadosť o zdieľanie obrazovky bola na vzdialenom zariadení odmietnutá"),
+        ("The screen sharing request timed out on the remote device", "Vypršal časový limit žiadosti o zdieľanie obrazovky na vzdialenom zariadení"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk nemá prístup k relácii plochy na vzdialenom zariadení, overte, či relácia beží a či ju RustDesk môže použiť"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Portálu plochy na vzdialenom zariadení chýba funkcia potrebná na zdieľanie obrazovky alebo vzdialené ovládanie, jeho implementácia možno nie je nainštalovaná"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Zdieľanie obrazovky bolo na vzdialenom zariadení schválené, ale pripojenie PipeWire sa nepodarilo otvoriť"),
+        ("The screen sharing request ended without completing on the remote device", "Žiadosť o zdieľanie obrazovky na vzdialenom zariadení sa skončila bez dokončenia"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nezískal z XDG Desktop Portal použiteľnú obrazovku, knižnica PipeWire môže byť príliš stará"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nedokázal načítať komponent GStreamera potrebný na zachytenie obrazovky ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Vse povezave enega posredovanja vrat potekajo prek ene same povezave do druge strani, namesto ponovnega povezovanja in prijave za vsako od njih."),
         ("Enable WebRTC P2P connection", "Omogoči povezavo WebRTC P2P"),
         ("Enable TCP hole punching", "Omogoči preboj lukenj TCP"),
+        ("The screen sharing request was declined on the remote device", "Zahteva za skupno rabo zaslona je bila na oddaljeni napravi zavrnjena"),
+        ("The screen sharing request timed out on the remote device", "Zahteva za skupno rabo zaslona je na oddaljeni napravi potekla"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk ne more dostopati do namizne seje na oddaljeni napravi, preverite, ali seja teče in ali jo RustDesk lahko uporablja"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Namiznemu portalu na oddaljeni napravi manjka zmožnost, potrebna za skupno rabo zaslona ali oddaljeno upravljanje, njegovo zaledje morda ni nameščeno"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Skupna raba zaslona je bila na oddaljeni napravi odobrena, vendar povezave PipeWire ni bilo mogoče odpreti"),
+        ("The screen sharing request ended without completing on the remote device", "Zahteva za skupno rabo zaslona na oddaljeni napravi se je končala, ne da bi bila dokončana"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk od XDG Desktop Portala ni dobil uporabnega zaslona, knjižnica PipeWire je morda prestara"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ni mogel naložiti komponente GStreamer, potrebne za zajem zaslona ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Të gjitha lidhjet e një përcjelljeje portesh kalojnë përmes një lidhjeje të vetme me kompjuterin tjetër, në vend që të lidhet dhe të hyjë sërish për secilën prej tyre."),
         ("Enable WebRTC P2P connection", "Aktivizo lidhjen WebRTC P2P"),
         ("Enable TCP hole punching", "Aktivizo TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Kërkesa për ndarjen e ekranit u refuzua në pajisjen e largët"),
+        ("The screen sharing request timed out on the remote device", "Kërkesa për ndarjen e ekranit skadoi në pajisjen e largët"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk nuk mund të arrijë sesionin e desktopit në pajisjen e largët, kontrolloni që një sesion desktopi po funksionon dhe që RustDesk mund ta përdorë"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Portalit të desktopit në pajisjen e largët i mungon një aftësi e nevojshme për ndarjen e ekranit ose kontrollin në distancë, backend-i i tij mund të mos jetë i instaluar"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Ndarja e ekranit u miratua në pajisjen e largët, por lidhja PipeWire nuk mund të hapej"),
+        ("The screen sharing request ended without completing on the remote device", "Kërkesa për ndarjen e ekranit në pajisjen e largët përfundoi pa u kryer"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nuk mori një ekran të përdorshëm nga XDG Desktop Portal, biblioteka PipeWire mund të jetë shumë e vjetër"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nuk mundi të ngarkojë një komponent të GStreamer të nevojshëm për regjistrimin e ekranit ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Sve veze jednog prosleđivanja portova idu kroz jednu vezu ka drugoj strani, umesto povezivanja i prijavljivanja iznova za svaku od njih."),
         ("Enable WebRTC P2P connection", "Omogući WebRTC P2P konekciju"),
         ("Enable TCP hole punching", "Omogući TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Zahtev za deljenje ekrana je odbijen na udaljenom uređaju"),
+        ("The screen sharing request timed out on the remote device", "Zahtev za deljenje ekrana je istekao na udaljenom uređaju"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk ne može da pristupi sesiji radne površine na udaljenom uređaju, proverite da li sesija radi i da li RustDesk može da je koristi"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Portalu radne površine na udaljenom uređaju nedostaje mogućnost potrebna za deljenje ekrana ili daljinsko upravljanje, njegov pozadinski deo možda nije instaliran"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Deljenje ekrana je odobreno na udaljenom uređaju, ali PipeWire vezu nije bilo moguće otvoriti"),
+        ("The screen sharing request ended without completing on the remote device", "Zahtev za deljenje ekrana na udaljenom uređaju završio se bez dovršetka"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nije mogao da dobije upotrebljiv ekran od XDG Desktop Portala, PipeWire biblioteka je možda prestara"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nije mogao da učita GStreamer komponentu potrebnu za snimanje ekrana ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Låt alla anslutningar i en portvidarebefordran gå via en enda anslutning till motparten, i stället för att ansluta och logga in på nytt för varje anslutning."),
         ("Enable WebRTC P2P connection", "Aktivera WebRTC P2P anslutning"),
         ("Enable TCP hole punching", "Aktivera TCP hålslagning"),
+        ("The screen sharing request was declined on the remote device", "Begäran om skärmdelning avvisades på fjärrenheten"),
+        ("The screen sharing request timed out on the remote device", "Begäran om skärmdelning nådde tidsgränsen på fjärrenheten"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk kan inte nå skrivbordssessionen på fjärrenheten, kontrollera att en session körs och att RustDesk kan använda den"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Skrivbordsportalen på fjärrenheten saknar en funktion som krävs för skärmdelning eller fjärrstyrning, dess bakände är kanske inte installerad"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Skärmdelning godkändes på fjärrenheten, men PipeWire-anslutningen kunde inte öppnas"),
+        ("The screen sharing request ended without completing on the remote device", "Begäran om skärmdelning på fjärrenheten avslutades utan att slutföras"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk fick ingen användbar skärm från XDG Desktop Portal, PipeWire-biblioteket kan vara för gammalt"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kunde inte läsa in en GStreamer-komponent som krävs för skärminspelning ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "ஒரு போர்ட் ஃபார்வேர்டிங்கின் அனைத்து இணைப்புகளும் மறுமுனைக்கான ஒரே இணைப்பின் வழியாகச் செல்லும், ஒவ்வொன்றுக்கும் மீண்டும் இணைந்து உள்நுழைவதற்குப் பதிலாக."),
         ("Enable WebRTC P2P connection", "WebRTC P2P இணைப்பு இயக்கு"),
         ("Enable TCP hole punching", "TCP hole punching இயக்கு"),
+        ("The screen sharing request was declined on the remote device", "தொலைநிலை சாதனத்தில் திரை பகிர்வு கோரிக்கை நிராகரிக்கப்பட்டது"),
+        ("The screen sharing request timed out on the remote device", "தொலைநிலை சாதனத்தில் திரை பகிர்வு கோரிக்கையின் நேரம் முடிந்தது"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk தொலைநிலை சாதனத்தின் டெஸ்க்டாப் அமர்வை அணுக முடியவில்லை, ஒரு அமர்வு இயங்குகிறதா என்பதையும் RustDesk அதைப் பயன்படுத்த முடியுமா என்பதையும் சரிபார்க்கவும்"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "தொலைநிலை சாதனத்தின் டெஸ்க்டாப் போர்ட்டலில் திரை பகிர்வுக்கோ தொலை கட்டுப்பாட்டுக்கோ தேவையான திறன் இல்லை, அதன் பின்தளம் நிறுவப்படாமல் இருக்கலாம்"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "தொலைநிலை சாதனத்தில் திரை பகிர்வு அனுமதிக்கப்பட்டது, ஆனால் PipeWire இணைப்பைத் திறக்க முடியவில்லை"),
+        ("The screen sharing request ended without completing on the remote device", "தொலைநிலை சாதனத்தில் திரை பகிர்வு கோரிக்கை நிறைவடையாமல் முடிந்தது"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "XDG Desktop Portal-லிருந்து பயன்படுத்தக்கூடிய திரையை RustDesk பெற முடியவில்லை, PipeWire நூலகம் மிகவும் பழையதாக இருக்கலாம்"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "திரைப் பதிவுக்குத் தேவையான GStreamer கூறை RustDesk ஏற்ற முடியவில்லை ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", ""),
         ("Enable WebRTC P2P connection", ""),
         ("Enable TCP hole punching", ""),
+        ("The screen sharing request was declined on the remote device", ""),
+        ("The screen sharing request timed out on the remote device", ""),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", ""),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", ""),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", ""),
+        ("The screen sharing request ended without completing on the remote device", ""),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", ""),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "ส่งการเชื่อมต่อทั้งหมดของการส่งต่อพอร์ตหนึ่งรายการผ่านการเชื่อมต่อเดียวไปยังอีกฝ่าย แทนการเชื่อมต่อและเข้าสู่ระบบใหม่ทุกครั้ง"),
         ("Enable WebRTC P2P connection", "เปิดใช้งานการเชื่อมต่อ P2P แบบ WebRTC"),
         ("Enable TCP hole punching", "เปิดใช้งาน TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "คำขอแชร์หน้าจอถูกปฏิเสธบนอุปกรณ์ระยะไกล"),
+        ("The screen sharing request timed out on the remote device", "คำขอแชร์หน้าจอบนอุปกรณ์ระยะไกลหมดเวลา"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk ไม่สามารถเข้าถึงเซสชันเดสก์ท็อปบนอุปกรณ์ระยะไกล ตรวจสอบว่าเซสชันเดสก์ท็อปกำลังทำงานและ RustDesk ใช้งานได้"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "พอร์ทัลเดสก์ท็อปบนอุปกรณ์ระยะไกลขาดความสามารถที่จำเป็นสำหรับการแชร์หน้าจอหรือการควบคุมระยะไกล แบ็กเอนด์ของมันอาจยังไม่ได้ติดตั้ง"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "การแชร์หน้าจอได้รับอนุญาตบนอุปกรณ์ระยะไกลแล้ว แต่ไม่สามารถเปิดการเชื่อมต่อ PipeWire ได้"),
+        ("The screen sharing request ended without completing on the remote device", "คำขอแชร์หน้าจอบนอุปกรณ์ระยะไกลสิ้นสุดลงโดยไม่เสร็จสมบูรณ์"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk ไม่สามารถรับหน้าจอที่ใช้งานได้จาก XDG Desktop Portal ไลบรารี PipeWire อาจเก่าเกินไป"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ไม่สามารถโหลดส่วนประกอบ GStreamer ที่จำเป็นสำหรับการบันทึกหน้าจอได้ ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Bir port yönlendirmesindeki tüm bağlantıları, her biri için yeniden bağlanıp oturum açmak yerine karşı tarafa açılan tek bir bağlantı üzerinden taşır."),
         ("Enable WebRTC P2P connection", "WebRTC P2P bağlantısını etkinleştir"),
         ("Enable TCP hole punching", "TCP delik açmayı etkinleştir"),
+        ("The screen sharing request was declined on the remote device", "Ekran paylaşımı isteği uzak cihazda reddedildi"),
+        ("The screen sharing request timed out on the remote device", "Uzak cihazdaki ekran paylaşımı isteği zaman aşımına uğradı"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk uzak cihazdaki masaüstü oturumuna erişemiyor, bir masaüstü oturumunun çalıştığını ve RustDesk tarafından kullanılabildiğini doğrulayın"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Uzak cihazdaki masaüstü portalında ekran paylaşımı veya uzaktan denetim için gereken bir yetenek yok, arka ucu kurulu olmayabilir"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Ekran paylaşımı uzak cihazda onaylandı, ancak PipeWire bağlantısı açılamadı"),
+        ("The screen sharing request ended without completing on the remote device", "Uzak cihazdaki ekran paylaşımı isteği tamamlanmadan sona erdi"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk, XDG Desktop Portal'dan kullanılabilir bir ekran alamadı, PipeWire kitaplığı çok eski olabilir"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ekran yakalama için gereken GStreamer bileşenini yükleyemedi ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "同一條連接埠轉送規則上的所有連線共用一條到對方的連線，而不是每條連線都重新連線並登入一次。"),
         ("Enable WebRTC P2P connection", "啟用 WebRTC P2P 連線"),
         ("Enable TCP hole punching", "啟用 TCP 打洞"),
+        ("The screen sharing request was declined on the remote device", "遠端裝置上的使用者拒絕了螢幕分享要求"),
+        ("The screen sharing request timed out on the remote device", "遠端裝置上的螢幕分享要求逾時了"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk 無法存取遠端裝置的桌面工作階段，請確認工作階段已啟動且 RustDesk 可以使用它"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "遠端裝置上的桌面入口缺少螢幕分享或遠端控制所需的功能，可能沒有安裝它的後端"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "遠端裝置上已核准螢幕分享，但無法開啟 PipeWire 連線"),
+        ("The screen sharing request ended without completing on the remote device", "遠端裝置上的螢幕分享要求已結束，但未完成"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk 無法從 XDG Desktop Portal 取得可用的螢幕，PipeWire 函式庫可能過舊"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk 無法載入螢幕擷取所需的 GStreamer 元件 ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Передавати всі з'єднання одного перенаправлення портів через одне з'єднання з віддаленим пристроєм замість повторного під'єднання та входу для кожного з них."),
         ("Enable WebRTC P2P connection", "Увімкнути P2P-підключення через WebRTC"),
         ("Enable TCP hole punching", "Увімкнути TCP hole punching"),
+        ("The screen sharing request was declined on the remote device", "Запит на демонстрацію екрана відхилено на віддаленому пристрої"),
+        ("The screen sharing request timed out on the remote device", "Час очікування запиту на демонстрацію екрана на віддаленому пристрої вичерпано"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk не може отримати доступ до сеансу стільниці на віддаленому пристрої, перевірте, чи запущено сеанс і чи може RustDesk його використовувати"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Порталу стільниці на віддаленому пристрої бракує можливості, потрібної для демонстрації екрана або віддаленого керування, його реалізацію може бути не встановлено"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Демонстрацію екрана було схвалено на віддаленому пристрої, але не вдалося відкрити з'єднання PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "Запит на демонстрацію екрана на віддаленому пристрої завершився, не будучи виконаним"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk не зміг отримати придатний екран від XDG Desktop Portal, бібліотека PipeWire може бути застарою"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не вдалося завантажити компонент GStreamer, потрібний для захоплення екрана ({})"),
     ].iter().cloned().collect();
 }

--- a/src/lang/ur.rs
+++ b/src/lang/ur.rs
@@ -770,6 +770,14 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "ایک پورٹ فارورڈنگ کے تمام کنکشن دوسرے کمپیوٹر کے ساتھ بنے ایک ہی کنکشن سے گزرتے ہیں، ہر ایک کے لیے دوبارہ منسلک ہو کر لاگ اِن کرنے کے بجائے۔"),
         ("Enable WebRTC P2P connection", "WebRTC P2P کنکشن کو فعال کریں"),
         ("Enable TCP hole punching", "TCP ہول پنچنگ کو فعال کریں"),
+        ("The screen sharing request was declined on the remote device", "ریموٹ ڈیوائس پر اسکرین شیئرنگ کی درخواست مسترد کر دی گئی"),
+        ("The screen sharing request timed out on the remote device", "ریموٹ ڈیوائس پر اسکرین شیئرنگ کی درخواست کا وقت ختم ہو گیا"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk ریموٹ ڈیوائس کے ڈیسک ٹاپ سیشن تک رسائی حاصل نہیں کر سکتا، تصدیق کریں کہ ڈیسک ٹاپ سیشن چل رہا ہے اور RustDesk اسے استعمال کر سکتا ہے"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "ریموٹ ڈیوائس کے ڈیسک ٹاپ پورٹل میں اسکرین شیئرنگ یا ریموٹ کنٹرول کے لیے درکار صلاحیت موجود نہیں، شاید اس کا بیک اینڈ نصب نہیں ہے"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "ریموٹ ڈیوائس پر اسکرین شیئرنگ کی منظوری مل گئی، لیکن PipeWire کنکشن نہیں کھولا جا سکا"),
+        ("The screen sharing request ended without completing on the remote device", "ریموٹ ڈیوائس پر اسکرین شیئرنگ کی درخواست مکمل ہوئے بغیر ختم ہو گئی"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk کو XDG Desktop Portal سے قابلِ استعمال اسکرین نہیں مل سکی، PipeWire لائبریری شاید بہت پرانی ہے"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk اسکرین ریکارڈنگ کے لیے درکار GStreamer جزو لوڈ نہیں کر سکا ({})"),
     ].iter().cloned().collect();
 }
 

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -770,5 +770,13 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Chuyển toàn bộ kết nối của một quy tắc chuyển tiếp cổng qua một kết nối duy nhất tới máy đối phương, thay vì kết nối và đăng nhập lại cho từng kết nối."),
         ("Enable WebRTC P2P connection", "Cho phép kết nối WebRTC P2P"),
         ("Enable TCP hole punching", "Bật TCP Hole Punching"),
+        ("The screen sharing request was declined on the remote device", "Yêu cầu chia sẻ màn hình đã bị từ chối trên thiết bị từ xa"),
+        ("The screen sharing request timed out on the remote device", "Yêu cầu chia sẻ màn hình đã hết thời gian chờ trên thiết bị từ xa"),
+        ("RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it", "RustDesk không thể truy cập phiên màn hình nền trên thiết bị từ xa, hãy kiểm tra rằng một phiên đang chạy và RustDesk có thể dùng nó"),
+        ("The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed", "Cổng màn hình nền trên thiết bị từ xa thiếu một khả năng cần cho chia sẻ màn hình hoặc điều khiển từ xa, phần nền của nó có thể chưa được cài đặt"),
+        ("Screen sharing was approved on the remote device, but the PipeWire connection could not be opened", "Chia sẻ màn hình đã được chấp thuận trên thiết bị từ xa, nhưng không thể mở kết nối PipeWire"),
+        ("The screen sharing request ended without completing on the remote device", "Yêu cầu chia sẻ màn hình trên thiết bị từ xa đã kết thúc mà chưa hoàn tất"),
+        ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk không lấy được màn hình dùng được từ XDG Desktop Portal, thư viện PipeWire có thể quá cũ"),
+        ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk không thể tải một thành phần GStreamer cần cho việc ghi màn hình ({})"),
     ].iter().cloned().collect();
 }

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -21,6 +21,7 @@ lazy_static::lazy_static! {
     static ref CAP_DISPLAY_INFO: RwLock<HashMap<usize, u64>> = RwLock::new(HashMap::new());
     static ref PIPEWIRE_INITIALIZED: RwLock<bool> = RwLock::new(false);
     static ref LOG_SCRAP_COUNT: Mutex<u32> = Mutex::new(0);
+    static ref LAST_STAGE_ERR: Mutex<Option<(String, std::time::Instant)>> = Mutex::new(None);
     static ref ACTIVE_DISPLAY_COUNT: RwLock<usize> = RwLock::new(0);
 }
 
@@ -44,9 +45,21 @@ pub(super) fn decrement_active_display_count() -> usize {
 
 fn map_err_scrap(err: String) -> io::Error {
     // to-do: Handle error better, do not restart server
+    // Reached by the capture loop, which is what this crude self-heal was for. A no-reply
+    // during the portal handshake is tagged below and is reported instead of exiting: at
+    // login there is someone waiting to be told, and a portal that is slow to activate is
+    // not a reason to take the service down.
     if err.starts_with("Did not receive a reply") {
         log::error!("Fatal pipewire error, {}", &err);
         std::process::exit(-1);
+    }
+
+    if let Some(tag) = err.strip_prefix(WAYLAND_STAGE_TAG) {
+        log_staged_once(&err);
+        return io::Error::new(
+            io::ErrorKind::Other,
+            staged_message(tag, is_ubuntu_before_21()),
+        );
     }
 
     if DISTRO.name.to_uppercase() == "Ubuntu".to_uppercase() {
@@ -74,6 +87,38 @@ fn map_err_scrap(err: String) -> io::Error {
     }
 }
 
+/// `Display::all` and `Capturer::new` reach the peer through `map_err_scrap`, but
+/// `fill_displays` opens a portal session of its own and returns its error straight up, so a
+/// tag has to be resolved here or it lands in the login dialog verbatim.
+fn map_staged_err(err: anyhow::Error) -> anyhow::Error {
+    let text = err.to_string();
+    match text.strip_prefix(WAYLAND_STAGE_TAG) {
+        Some(tag) => {
+            log_staged_once(&text);
+            anyhow::anyhow!(staged_message(tag, is_ubuntu_before_21()))
+        }
+        None => err,
+    }
+}
+
+// The video service retries about once a second, so a wedged portal would otherwise write a
+// line a second forever. Repeat the message only when the cause changes, or after long
+// enough that a reader would want to see the fault is still there.
+const STAGE_ERR_REPEAT: std::time::Duration = std::time::Duration::from_secs(600);
+
+fn log_staged_once(err: &str) {
+    let now = std::time::Instant::now();
+    let mut last = LAST_STAGE_ERR.lock().unwrap();
+    let repeat = match last.as_ref() {
+        Some((seen, at)) => seen != err || now.duration_since(*at) >= STAGE_ERR_REPEAT,
+        None => true,
+    };
+    if repeat {
+        log::error!("Wayland portal handshake failed: {}", err);
+        *last = Some((err.to_owned(), now));
+    }
+}
+
 fn try_log(err: &String) {
     let mut lock_count = LOG_SCRAP_COUNT.lock().unwrap();
     if *lock_count >= 1000000 {
@@ -83,6 +128,168 @@ fn try_log(err: &String) {
         log::error!("Failed scrap {}", err);
     }
     *lock_count += 1;
+}
+
+// Translation keys, so the key itself is the English text: an older peer that has never heard
+// of them falls back to displaying the key and still reads as a sentence.
+const WAYLAND_DECLINED: &str = "The screen sharing request was declined on the remote device";
+const WAYLAND_TIMED_OUT: &str = "The screen sharing request timed out on the remote device";
+const WAYLAND_NO_SESSION: &str = "RustDesk cannot reach the desktop session on the remote device, check that a desktop session is running and that RustDesk can use it";
+const WAYLAND_UNSUPPORTED: &str = "The desktop portal on the remote device is missing a capability needed for screen sharing or remote control, its backend may not be installed";
+const WAYLAND_PIPEWIRE_HANDOVER: &str = "Screen sharing was approved on the remote device, but the PipeWire connection could not be opened";
+const WAYLAND_ENDED: &str =
+    "The screen sharing request ended without completing on the remote device";
+// The remedy the message it replaces used to carry, minus the link: this is the outcome
+// rustdesk/rustdesk#8600 is about.
+const WAYLAND_NO_USABLE_SCREEN: &str = "RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old";
+const WAYLAND_GST_UNAVAILABLE: &str =
+    "RustDesk could not load a GStreamer component needed for screen capture ({})";
+
+const WAYLAND_STAGE_TAG: &str = "wl-stage:";
+
+// `translate()` on the peer strips the braces itself, so what goes on the wire is the key
+// with the detail still *inside* the placeholder.
+fn with_detail(key: &str, detail: &str) -> String {
+    key.replace("{}", &format!("{{{}}}", detail))
+}
+
+fn is_ubuntu_before_21() -> bool {
+    DISTRO.name.to_uppercase() == "Ubuntu".to_uppercase() && DISTRO.version_id < "21".to_owned()
+}
+
+/// Maps a `<stage>:<kind>:<detail>` tag from the portal handshake, see
+/// `scrap::wayland::pipewire`, onto what to tell the peer. Everything the capture loop reports
+/// carries no tag and keeps the legacy substring heuristics above.
+fn staged_message(tag: &str, ubuntu_before_21: bool) -> String {
+    let mut parts = tag.splitn(3, ':');
+    let stage = parts.next().unwrap_or_default();
+    let kind = parts.next().unwrap_or_default();
+    let detail = parts.next().unwrap_or_default().trim();
+
+    // An outcome that says something about the machine is what the Ubuntu branch was written
+    // for, so that branch keeps it. An outcome that says what a person did is a fact no distro
+    // check can improve on.
+    let of_the_machine = |msg: &str| {
+        if ubuntu_before_21 {
+            SCRAP_UBUNTU_HIGHER_REQUIRED.to_owned()
+        } else {
+            msg.to_owned()
+        }
+    };
+
+    match (stage, kind) {
+        (_, "declined") => WAYLAND_DECLINED.to_owned(),
+        (_, "ended") => WAYLAND_ENDED.to_owned(),
+        (_, "no-response") => WAYLAND_TIMED_OUT.to_owned(),
+        ("streams", _) => of_the_machine(WAYLAND_NO_USABLE_SCREEN),
+        ("gst-plugin", _) => of_the_machine(&with_detail(WAYLAND_GST_UNAVAILABLE, detail)),
+        // The bus the portal lives on was never reached, so the portal has not been asked
+        // anything yet and telling anyone to restart it would be a guess.
+        ("session-bus", _) => of_the_machine(WAYLAND_NO_SESSION),
+        // The portal answered `Start`, so the request was granted and the only thing left
+        // was handing over the PipeWire connection. Whatever went wrong, it is not the
+        // portal being unavailable -- it had just answered.
+        ("open-pipewire-remote", _) => of_the_machine(WAYLAND_PIPEWIRE_HANDOVER),
+        // The portal is there and answering; it just does not implement what was called,
+        // which restarting it cannot fix.
+        (_, "unsupported") => of_the_machine(WAYLAND_UNSUPPORTED),
+        // Everything else is the portal not delivering, which is what this key already says --
+        // and unlike a message of our own it carries the `systemctl --user restart` remedy.
+        _ => of_the_machine(SCRAP_XDP_PORTAL_UNAVAILABLE),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn staged_message_names_the_outcome() {
+        let m = |tag| staged_message(tag, false);
+        assert_eq!(m("start:declined:"), WAYLAND_DECLINED);
+        assert_eq!(m("start:ended:"), WAYLAND_ENDED);
+        assert_eq!(m("start:no-response:"), WAYLAND_TIMED_OUT);
+        // A restored session shows no picker at all, so a timeout anywhere is a timeout and
+        // never a claim about someone not answering.
+        assert_eq!(m("create-session:no-response:"), WAYLAND_TIMED_OUT);
+        assert_eq!(m("streams:empty:"), WAYLAND_NO_USABLE_SCREEN);
+    }
+
+    #[test]
+    fn only_a_portal_that_may_be_dead_is_told_to_restart() {
+        let m = |tag| staged_message(tag, false);
+        // Not reached the bus at all: the portal has not been asked anything yet.
+        assert_eq!(
+            m("session-bus:dbus:org.freedesktop.DBus.Error.NotSupported"),
+            WAYLAND_NO_SESSION
+        );
+        // Answering, but without an implementation behind the interface that was called --
+        // at any stage, not just the first one.
+        assert_eq!(
+            m("create-session:unsupported:org.freedesktop.DBus.Error.UnknownMethod"),
+            WAYLAND_UNSUPPORTED
+        );
+        assert_eq!(
+            m("select-sources:unsupported:org.freedesktop.DBus.Error.UnknownMethod"),
+            WAYLAND_UNSUPPORTED
+        );
+        // Absent or silent, which is what the existing key's remedy is for.
+        assert_eq!(
+            m("create-session:dbus:org.freedesktop.DBus.Error.ServiceUnknown"),
+            SCRAP_XDP_PORTAL_UNAVAILABLE
+        );
+        // Not this one: `Start` had already been answered, so the portal was alive and the
+        // request granted. Saying it may have crashed would walk the diagnosis backwards.
+        assert_eq!(
+            m("open-pipewire-remote:dbus:org.freedesktop.DBus.Error.Failed"),
+            WAYLAND_PIPEWIRE_HANDOVER
+        );
+        // A tag this build does not know must never fall back to a guess.
+        assert_eq!(
+            m("some-new-stage:some-new-kind:x"),
+            SCRAP_XDP_PORTAL_UNAVAILABLE
+        );
+        assert_eq!(m(""), SCRAP_XDP_PORTAL_UNAVAILABLE);
+    }
+
+    // The peer resolves a message by replacing its first `{...}` with `{}` and looking that
+    // up, so a detail-carrying message has to reduce back to its key exactly.
+    #[test]
+    fn a_detail_carrying_message_reduces_back_to_its_key() {
+        let gst = staged_message("gst-plugin:unavailable:pipewiresrc", false);
+        assert_eq!(
+            gst,
+            "RustDesk could not load a GStreamer component needed for screen capture ({pipewiresrc})"
+        );
+        let open = gst.find('{').expect("no placeholder");
+        let close = gst[open..].find('}').expect("unclosed placeholder") + open;
+        assert_eq!(
+            format!("{}{{}}{}", &gst[..open], &gst[close + 1..]),
+            WAYLAND_GST_UNAVAILABLE
+        );
+    }
+
+    #[test]
+    fn legacy_ubuntu_keeps_its_message_for_machine_faults_only() {
+        let m = |tag| staged_message(tag, true);
+        assert_eq!(
+            m("create-session:dbus:org.freedesktop.DBus.Error.ServiceUnknown"),
+            SCRAP_UBUNTU_HIGHER_REQUIRED
+        );
+        assert_eq!(
+            m("create-session:unsupported:org.freedesktop.DBus.Error.UnknownMethod"),
+            SCRAP_UBUNTU_HIGHER_REQUIRED
+        );
+        assert_eq!(
+            m("gst-plugin:unavailable:pipewiresrc"),
+            SCRAP_UBUNTU_HIGHER_REQUIRED
+        );
+        assert_eq!(m("streams:empty:"), SCRAP_UBUNTU_HIGHER_REQUIRED);
+        assert_eq!(m("session-bus:dbus:"), SCRAP_UBUNTU_HIGHER_REQUIRED);
+        assert_eq!(m("start:declined:"), WAYLAND_DECLINED);
+        assert_eq!(m("start:ended:"), WAYLAND_ENDED);
+        assert_eq!(m("start:no-response:"), WAYLAND_TIMED_OUT);
+    }
 }
 
 struct CapturerPtr(*mut Capturer);
@@ -312,7 +519,8 @@ pub(super) async fn check_init() -> ResultType<()> {
                 {
                     let temp_mouse_move_handle = input_service::TemporaryMouseMoveHandle::new();
                     let move_mouse_to = |x, y| temp_mouse_move_handle.move_mouse_to(x, y);
-                    fill_displays(move_mouse_to, crate::get_cursor_pos, &mut all)?;
+                    fill_displays(move_mouse_to, crate::get_cursor_pos, &mut all)
+                        .map_err(map_staged_err)?;
                 }
                 log::debug!("Attempting to fix logical size with try_fix_logical_size()");
                 try_fix_logical_size(&mut all);
@@ -340,10 +548,9 @@ pub(super) async fn check_init() -> ResultType<()> {
 
                 // Create individual CapDisplayInfo for each display with its own capturer
                 for (idx, display) in all.into_iter().enumerate() {
-                    let capturer =
-                        Box::into_raw(Box::new(Capturer::new(display).with_context(|| {
-                            format!("Failed to create capturer for display {}", idx)
-                        })?));
+                    // No `with_context` here: the peer is shown `format!("{}", err)`, which
+                    // renders only the outermost layer, and the mapped reason is the inner one.
+                    let capturer = Box::into_raw(Box::new(Capturer::new(display)?));
                     let capturer = CapturerPtr(capturer);
 
                     let cap_display_info = Box::into_raw(Box::new(CapDisplayInfo {


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/discussions/12897
https://github.com/rustdesk/rustdesk-server-pro/issues/832

On Wayland, every way the XDG portal handshake can fail leaves
`request_remote_desktop` through one `bail!` carrying one string, and
`map_err_scrap` then guesses a cause by looking for "dbus" or "pipewire" in
that string. There is nothing left to guess from, so the guess is usually
wrong.

That string always mentions "PipeWire library", so it matches the "pipewire"
test. The two most common outcomes in the field both come out the same way:

| what happened | what the user is told today |
|---|---|
| the person at the remote machine clicked Cancel | *Wayland requires higher version of linux distro. Please try X11 desktop or change your OS.* |
| nobody was there to click anything for three minutes | the same |
| `pipewiresrc` is not installed | *x11 expected*, with a link to the X11 docs |

On Ubuntu 21+ (`src/server/wayland.rs`) the mapping passes the text through
untouched, so on the most common Wayland distro those cases show raw English
plus a link to an unrelated issue.

## What this changes

The response code and the D-Bus error are in hand at the moment of failure and
are thrown away: `handle_response` collapses all of it into one `AtomicBool`.
This records them instead, tagged with the stage that produced them
(`wl-stage:<stage>:<kind>:<detail>`), and lets the app side look the tag up.

`map_err_scrap` gains one leading branch. **Anything untagged — which is every
error the capture loop reports — takes the existing path unchanged.**

## What the peer is told, and why only that

The rule throughout is that a message may state what the tag proves and nothing
more.

| outcome | message |
|---|---|
| response 1 (spec: the user cancelled) | the request was declined on the remote device |
| response 2 (spec: ended some other way) | the request ended without completing |
| the wait ran out | the request timed out |
| the session bus could not be opened | RustDesk cannot reach the desktop session; check one is running and usable |
| `UnknownMethod` / `UnknownInterface` | the portal is missing a capability needed for screen sharing or remote control |
| `Start` answered, then the fd handover failed | screen sharing was approved, but the PipeWire connection could not be opened |
| the portal returned no streams | no screen to capture, the PipeWire library may be too old |
| a GStreamer element could not be created | that plugin is missing, named |
| the portal absent, silent, or failing mid-handshake | the existing `xdp-portal-unavailable` |

Several of these are deliberately weaker than they could be:

- A timeout does not say nobody answered. RustDesk passes a saved
  `restore_token` with `persist_mode` 2, and a restored session is exactly the
  case where the portal shows no picker, so there may have been no dialog for
  anyone to answer.
- Response 2 does not say who ended it. The Request spec guarantees only that
  the interaction ended some other way, and libportal treats 2 as a plain
  failure.
- Failing to open the session bus does not say nobody is logged in. A stale
  `DBUS_SESSION_BUS_ADDRESS`, or a service that did not inherit the session
  environment, looks identical with a live desktop.
- `UnknownMethod` on RemoteDesktop does not say the portal cannot capture a
  screen — ScreenCast may well be there. Which interface was called is in the
  D-Bus message that goes to the log; the message to the peer does not claim
  one.
- Only the portal being absent, silent, or failing mid-handshake keeps the
  `systemctl --user restart xdg-desktop-portal` remedy. Once `Start` has been
  answered, calling the portal unavailable would walk the diagnosis backwards.

The five new keys are sentence-case English, so a peer that has never heard of
them falls back to displaying the key and still reads as a sentence, instead of
showing a slug the way `x11 expected` does today. The D-Bus error name and
message, and the portal response code, stay in the log; only the GStreamer
element name also reaches the peer, because it is the one detail that says
which package to look at.

## Two existing paths change

**`check_init` no longer wraps `Capturer::new` in `with_context`.** The peer is
shown `format!("{}", err)` (`connection.rs`), which renders only the outermost
layer, so that context was replacing the mapped code with "Failed to create
capturer for display 0" — every `SCRAP_*` code produced on that path was lost.

**The `std::process::exit(-1)` on libdbus' no-reply text is now reached only by
the capture loop**, which is what that self-heal was written for. Every D-Bus
call in the handshake — the session bus, `get_request_path`, the `add_match`
inside `handle_response`, `create_session`, `select_sources`, `select_devices`,
`start`, `open_pipe_wire_remote`, and `conn.process` in the wait loop — carries
a tag, so a no-reply there is reported rather than fatal. Worth stating plainly
what that branch did before: the portal proxy has a one-second timeout, so a
portal that was slow to activate could take the whole service down.

`fill_displays` needs the tag resolved at its own call site: it opens a second
portal session for cursor-based display disambiguation, and its error returns
straight up `check_init` without passing through `map_err_scrap`, so a tag
would otherwise reach the peer verbatim.

## Deliberately not in this PR

- **`check_init` blocks a Tokio worker for up to three minutes** while holding
  a `std` write lock (`#[tokio::main]` is multi-threaded, so on a two-core box
  a second connection taking the read lock stalls the runtime). Real, and
  squarely against AGENTS.md's Tokio rules, but it changes the path every Linux
  user is on and the lock ordering with it.
- **Shortening the three-minute wait.** An earlier draft gave the
  non-interactive steps a budget of their own. Dropped: naming the stalled
  stage does not depend on it — the loop's own exhaustion already reports it —
  so all it bought was failing sooner, at the cost of possibly cutting off a
  portal that was about to answer.
- **`gstreamer::init()`** is still untagged. It is a GLib error and cannot
  carry the no-reply text, so it does not affect the conclusion above, but it
  means not every Wayland initialisation error is classified yet.
- **`is_server_running()`'s `ps aux | grep`** and the `process::exit` itself.

## Verified

- Linux (Debian 12): `cargo check --all-targets` for the root crate and for
  `scrap --features wayland`, 0 errors; `cargo test --lib server::wayland` 4/4;
  `cargo test -p scrap --features wayland` all green.
- macOS: `cargo check --all-targets`, 0 errors (the lang files are
  cross-platform).
- `rustfmt`: `pipewire.rs` was clean before and still is; `src/server/wayland.rs`
  has exactly the four spots that were already unformatted on master, untouched.
- The eight constants were diffed against all 52 lang files: every one present,
  no key text drift. The message naming RustDesk was checked to keep the literal
  token in all 51 translations, so the custom-app-name replacement in
  `translate()` still applies.

Wayland cannot be exercised in CI, so the part most likely to rot — parsing the
tag and choosing the message — is a pure function with unit tests, including one
that pins the rule that only a portal which may actually be dead is told to
restart. Those tests caught a real defect during development: the detail has to
travel *inside* the braces, because `lang.rs`'s `extract_placeholder` resolves a
key by replacing the first `{...}` with `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZ49AbZJYfm8NTp5yDPMab

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61530503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/rustdesk/-/pull-requests/rustdesk/rustdesk/16118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable new defect or outstanding previous finding remains.

<details><summary><h3>Summary</h3></summary>

- Preserves response codes, D-Bus failures, timeout stages, stream availability, and GStreamer element failures instead of inferring causes from flattened error text.
- Keeps untagged capture-loop errors on the existing mapping path.
- Distinguishes declined, incomplete, timed-out, unavailable-session, unsupported-portal, PipeWire handover, empty-stream, and GStreamer component failures.
- Adds corresponding translations and unit coverage for tag parsing and message selection.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Begin Wayland portal handshake] --> B[Create session]
    B --> C[Select devices or sources]
    C --> D[Start screen sharing]
    D --> E[Open PipeWire remote]
    E --> F[Create GStreamer pipeline]
    B -. failure .-> G[Record stage and failure kind]
    C -. failure .-> G
    D -. failure .-> G
    E -. failure .-> G
    F -. failure .-> G
    G --> H[Map structured tag to localized peer message]
```
</details>

<!-- /greptile_comment -->