### PR TITLE
server: end a connection a newer one from the same session has replaced

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -355,6 +355,10 @@ pub enum Data {
     MouseMoveTime(i64),
     Authorize,
     Close,
+    // A newer authorized connection has taken this one's place. Ends the superseded connection
+    // like `Close`, but sends the peer nothing: the peer has already moved on, and the link it
+    // would be sent over is the very one that stopped working.
+    Displaced,
     #[cfg(windows)]
     SAS,
     UserSid(Option<u32>),

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1018,6 +1018,15 @@ impl Connection {
                 },
                 Some(data) = rx_from_authed.recv() => {
                     match data {
+                        // A newer connection from this session has taken over. Nothing is sent
+                        // to the peer and the screen is not locked: the session continues, on
+                        // the connection that replaced this one.
+                        ipc::Data::Displaced => {
+                            conn.chat_unanswered = false; // seen
+                            conn.file_transferred = false; //seen
+                            conn.on_close("displaced by a newer connection", false).await;
+                            break;
+                        }
                         #[cfg(all(target_os = "windows", feature = "flutter"))]
                         ipc::Data::PrinterData(data) => {
                             if Self::permission(keys::OPTION_ENABLE_REMOTE_PRINTER, &conn.control_permissions) {
@@ -2065,6 +2074,7 @@ impl Connection {
         } else if sub_service {
             if !wait_session_id_confirm {
                 self.try_sub_monitor_services();
+                raii::AuthedConnID::displace_others(self.inner.id(), &self.session_key());
             }
         }
         true
@@ -3850,6 +3860,10 @@ impl Connection {
                                 self.try_sub_camera_displays();
                             } else if !self.terminal {
                                 self.try_sub_monitor_services();
+                                raii::AuthedConnID::displace_others(
+                                    self.inner.id(),
+                                    &self.session_key(),
+                                );
                             }
                         }
                     }
@@ -6658,6 +6672,43 @@ mod raii {
     pub struct AuthedConnID(i32, AuthConnType);
 
     impl AuthedConnID {
+        // Remote control only. It is where the cost is - a stale one stays a video subscriber
+        // the capture loop waits on and a viewer the rate control averages in - and the only
+        // kind that can lock the screen, `keyboard` being cleared for every other one. It is
+        // also the only kind where two under one session id cannot be legitimate: `connToken`
+        // hands a session's id to a transfer, a camera view, a terminal or a tunnel opened from
+        // its toolbar, never to a second remote control, and a port forward window gives every
+        // local socket it accepts its own login on that one id by design.
+        //
+        // Older, not merely other: ids come from a counter, so of any two that raced to
+        // register the higher always wins and neither can end the other.
+        pub(super) fn is_displaced(c: &AuthedConn, conn_id: i32, session_key: &SessionKey) -> bool {
+            c.conn_id < conn_id
+                && c.conn_type == AuthConnType::Remote
+                && &c.session_key == session_key
+        }
+
+        /// Ends the connections this one has replaced. Called where it has taken over, not where
+        /// it registered: until the services are subscribed, ending the old one would unsubscribe
+        /// a capturer nothing has resubscribed, and a login that failed on the way here would
+        /// have cost a session that was still working.
+        pub fn displace_others(conn_id: i32, session_key: &SessionKey) {
+            let displaced: Vec<_> = AUTHED_CONNS
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|c| Self::is_displaced(c, conn_id, session_key))
+                .map(|c| (c.conn_id, c.sender.clone()))
+                .collect();
+            for (displaced_id, sender) in displaced {
+                log::info!("#{displaced_id} displaced by #{conn_id}");
+                if let Err(err) = sender.send(Data::Displaced) {
+                    // Its loop has already ended, which is the outcome this wanted anyway.
+                    log::debug!("#{displaced_id} was already gone: {err}");
+                }
+            }
+        }
+
         pub fn new(
             conn_id: i32,
             conn_type: AuthConnType,
@@ -7546,5 +7597,61 @@ mod test {
             scoped.terminal_persistent.enum_value(),
             Ok(BoolOption::NotSet)
         );
+    }
+
+    // Too wide and it ends a connection that should keep running; too narrow and the stale one
+    // lingers, still subscribed to video and still counted by the rate control.
+    #[test]
+    fn only_an_older_remote_control_in_the_same_session_is_displaced() {
+        use super::raii::AuthedConnID;
+
+        let key = |session_id: u64, peer: &str| SessionKey {
+            peer_id: peer.to_owned(),
+            name: "".to_owned(),
+            session_id,
+        };
+        let conn = |conn_id: i32, conn_type: AuthConnType, session_key: SessionKey| AuthedConn {
+            conn_id,
+            conn_type,
+            session_key,
+            sender: mpsc::unbounded_channel().0,
+            printer: false,
+        };
+        let mine = key(7, "peer");
+        let remote = AuthConnType::Remote;
+
+        assert!(AuthedConnID::is_displaced(
+            &conn(1, remote, mine.clone()),
+            2,
+            &mine
+        ));
+        // Itself, and anything that registered after it: of two that raced, the higher id wins.
+        for id in [2, 3] {
+            assert!(!AuthedConnID::is_displaced(
+                &conn(id, remote, mine.clone()),
+                2,
+                &mine
+            ));
+        }
+
+        // No other kind, whether beside this one or of its own kind: a window's port forward
+        // mappings log in concurrently on one session id, and ending a terminal connection
+        // destroys the service its replacement attached to.
+        for other in [
+            AuthConnType::FileTransfer,
+            AuthConnType::PortForward,
+            AuthConnType::ViewCamera,
+            AuthConnType::Terminal,
+        ] {
+            assert!(
+                !AuthedConnID::is_displaced(&conn(1, other, mine.clone()), 2, &mine),
+                "{other:?} must not be displaced"
+            );
+        }
+
+        // Another session, and another peer entirely.
+        for foreign in [key(8, "peer"), key(7, "other")] {
+            assert!(!AuthedConnID::is_displaced(&conn(1, remote, foreign), 2, &mine));
+        }
     }
 }


### PR DESCRIPTION
When a controller's link dies without a close reaching the peer - the only case that matters, since anything graceful already closes cleanly - the connection it abandoned keeps running here until the inactivity timeout. If the controller reconnects in the meantime, and it does, two authorized connections for one session overlap, and everything the stale one costs is charged to the session that replaced it.

The cost is not only cosmetic. It stays a video subscriber, and the capture loop waits for every subscriber to fetch the current frame before capturing the next, for up to three seconds; a connection whose own send is blocked never fetches, so frames for the live session arrive at that rate. It stays a viewer the rate control averages in, holding the shared target down. And the connection manager lists it: its own same-peer dedup only drops entries already marked disconnected, which this one is not.

So end it when the replacement authorizes. Nothing is sent to the peer - the link it would go over is the one that just failed, and the peer that owned this connection has already moved on - and the screen is not locked, because the session is continuing rather than ending. A connection alongside it that is not remote control is untouched: a file transfer or port forward sharing the session is expected.


Claude-Session: https://claude.ai/code/session_019aokqJuhjvB3kijXtAg5Ns



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Connection displacement now occurs after login completes, preventing interruptions during authentication.
  - Existing connections close quietly without sending an unnecessary response.
  - Reconnecting through a newer connection no longer interrupts the active session or unnecessarily locks the screen.
  - Concurrent reconnects are handled consistently.
  - Port-forward connections are no longer displaced by newer connections.

- **Documentation**
  - Clarified connection displacement behavior in the IPC documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61530555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/rustdesk/-/pull-requests/rustdesk/rustdesk/16119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because concurrent authorization can still leave two remote-control connections active for one session.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fserver%2Fconnection.rs%3A6686%0AWhen%20an%20older%20connection%20is%20delayed%20before%20registration%2C%20a%20later-created%20connection%20can%20register%2C%20subscribe%2C%20and%20scan%20%60AUTHED_CONNS%60%20before%20the%20older%20connection%20appears.%20The%20delayed%20connection%20then%20registers%20and%20subscribes%2C%20but%20this%20comparison%20prevents%20it%20from%20displacing%20the%20active%20higher-ID%20connection.%20Because%20IDs%20are%20assigned%20when%20connections%20are%20accepted%20rather%20than%20when%20takeover%20completes%2C%20both%20remote-control%20connections%20remain%20active%20and%20preserve%20the%20duplicate%20subscriber%20and%20rate-control%20problem.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16119&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Authorization order leaves duplicates** <a href="https://github.com/rustdesk/rustdesk/pull/16119#discussion_r3964703492">▶</a>

<details><summary><h3>Summary</h3></summary>

- Restricts displacement to older remote-control connections with the same session key.
- Leaves file-transfer, port-forward, camera, and terminal connections untouched.
- Handles displacement in the authenticated-connection channel and logs failed sends.
- Regression surface: `src/ipc.rs` adds the internal signal, while the remote authorization and Windows delayed-session paths in `src/server/connection.rs` invoke displacement after subscription; these paths are necessary to avoid interrupting a working session before takeover completes.
- A remaining authorization-order race can still leave duplicate remote-control connections active.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant A as Older-created connection A
    participant B as Later-created connection B
    participant L as AUTHED_CONNS
    A->>A: Authentication delayed
    B->>L: Register higher connection ID
    B->>B: Subscribe services
    B->>L: Scan for lower registered IDs
    Note over B,L: A is not registered yet
    A->>L: Register lower connection ID
    A->>A: Subscribe services
    A->>L: Scan for IDs lower than A
    Note over A,B: B has a higher ID, so neither is ended
```
</details>

<!-- /greptile_comment -->