### PR TITLE
fix(screenshot): keep cached image when saving fails

### DIFF
--- a/src/client/screenshot.rs
+++ b/src/client/screenshot.rs
@@ -59,11 +59,14 @@ impl Screenshot {
     }
 
     fn handle_screenshot(&mut self, action: String) -> String {
-        let Some(data) = self.data.take() else {
+        let Some(data) = self.data.as_ref().cloned() else {
             return "No cached screenshot".to_owned();
         };
         match Self::handle_screenshot_(data, action) {
-            Ok(()) => "".to_owned(),
+            Ok(()) => {
+                self.data = None;
+                "".to_owned()
+            }
             Err(e) => e.to_string(),
         }
     }
@@ -97,4 +100,38 @@ pub fn set_screenshot(data: bytes::Bytes) {
 
 pub fn handle_screenshot(action: String) -> String {
     SCREENSHOT.lock().unwrap().handle_screenshot(action)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Screenshot;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn preserves_cached_screenshot_when_save_fails() {
+        let data = bytes::Bytes::from_static(b"screenshot data");
+        let mut screenshot = Screenshot {
+            data: Some(data.clone()),
+        };
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let missing_parent = std::env::temp_dir()
+            .join(format!("rustdesk-screenshot-missing-parent-{unique}"))
+            .join("screenshot.png");
+        let valid_path = std::env::temp_dir().join(format!("rustdesk-screenshot-{unique}.png"));
+
+        let error = screenshot.handle_screenshot(format!("0:{}", missing_parent.display()));
+
+        assert!(!error.is_empty());
+        assert_eq!(screenshot.data.as_deref(), Some(data.as_ref()));
+        assert_eq!(
+            screenshot.handle_screenshot(format!("0:{}", valid_path.display())),
+            ""
+        );
+        assert!(screenshot.data.is_none());
+        assert_eq!(std::fs::read(&valid_path).unwrap(), data.as_ref());
+        std::fs::remove_file(valid_path).unwrap();
+    }
 }


### PR DESCRIPTION


`handle_screenshot()` called `self.data.take()` before attempting to save the screenshot.

If `std::fs::write()` failed, for example because the selected parent directory did not exist, the screenshot had already been removed from the cache. A subsequent save attempt therefore returned `No cached screenshot`.



Use a reference-counted clone of the cached `bytes::Bytes` while handling the action. Clear the cache only when the action completes successfully. Failed `SaveAs` operations now preserve the screenshot for retry.



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes screenshot-cache lifecycle management so screenshot bytes are borrowed through a reference-counted clone and removed only after the requested action succeeds.
- Failed `SaveAs` operations preserve the cached screenshot for a subsequent retry.
- Successful save, copy, and discard actions continue to consume the cached screenshot.
- A regression test covers failure preservation followed by a successful retry.
- Regression surface is limited to `src/client/screenshot.rs` and the screenshot action-handling path; the lifecycle change is necessary to avoid losing data after failed writes.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations were identified.

Failed filesystem writes now leave the reference-counted screenshot bytes cached, while successful actions preserve the previous consume-once behavior, and mutex serialization prevents the delayed clear from deleting a concurrently replaced screenshot.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/client/screenshot.rs | Correctly defers cache clearing until successful action completion and adds focused retry coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(screenshot): keep cached image when ..."](https://github.com/rustdesk/rustdesk/commit/35e0ff4a9033d533b8c6f11819ddeb6d321a6e3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61622311)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cached screenshots are now preserved when saving fails.
  * Cached screenshots are cleared after a successful save.

* **Tests**
  * Added coverage for successful and failed screenshot-saving scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->