### PR TITLE
fix(macos): recover system-stopped audio capture streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.15.3"
-source = "git+https://github.com/rustdesk-org/cpal?rev=eaee235cf4e93a47e8ce9372c25597e41fa593be#eaee235cf4e93a47e8ce9372c25597e41fa593be"
+source = "git+https://github.com/rustdesk-org/cpal?branch=osx-screencapturekit#69ad2578adc9200093fc81cdfbdad63dbc4274f9"
 dependencies = [
  "alsa",
  "cidre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.15.3"
-source = "git+https://github.com/rustdesk-org/cpal?branch=osx-screencapturekit#41c8a2a75903ffe9cd44cf176ce6b69e5d916d47"
+source = "git+https://github.com/rustdesk-org/cpal?rev=eaee235cf4e93a47e8ce9372c25597e41fa593be#eaee235cf4e93a47e8ce9372c25597e41fa593be"
 dependencies = [
  "alsa",
  "cidre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,8 @@ reqwest = { version = "0.12", features = ["blocking", "socks", "json", "native-t
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 # https://github.com/rustdesk/rustdesk/discussions/10197, not use cpal on linux
-cpal = { git = "https://github.com/rustdesk-org/cpal", branch = "osx-screencapturekit" }
+# ScreenCaptureKit stop notifications: https://github.com/rustdesk-org/cpal/pull/5
+cpal = { git = "https://github.com/rustdesk-org/cpal", rev = "eaee235cf4e93a47e8ce9372c25597e41fa593be" }
 ringbuf = "0.3"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,8 +89,7 @@ reqwest = { version = "0.12", features = ["blocking", "socks", "json", "native-t
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 # https://github.com/rustdesk/rustdesk/discussions/10197, not use cpal on linux
-# ScreenCaptureKit stop notifications: https://github.com/rustdesk-org/cpal/pull/5
-cpal = { git = "https://github.com/rustdesk-org/cpal", rev = "eaee235cf4e93a47e8ce9372c25597e41fa593be" }
+cpal = { git = "https://github.com/rustdesk-org/cpal", branch = "osx-screencapturekit" }
 ringbuf = "0.3"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src/server/audio_capture_error.rs
+++ b/src/server/audio_capture_error.rs
@@ -1,0 +1,72 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+// Each stream owns its flag so a late callback cannot restart a replacement.
+#[derive(Clone, Default)]
+pub(super) struct CaptureErrorHandler {
+    interrupted: Arc<AtomicBool>,
+}
+
+impl CaptureErrorHandler {
+    pub(super) fn handle(&self, error: cpal::StreamError) {
+        if matches!(error, cpal::StreamError::StreamInterrupted { .. }) {
+            // ScreenCaptureKit can stop capture while the remote session stays open.
+            // The observed -3821 error does not identify its underlying trigger.
+            // https://developer.apple.com/documentation/screencapturekit/scstreamdelegate/stream(_:didstopwitherror:)
+            hbb_common::log::error!("Audio capture stream interrupted: {error}");
+            self.interrupted.store(true, Ordering::Relaxed);
+        } else {
+            // Keep frequent sample-buffer errors at the existing trace level.
+            hbb_common::log::trace!("an error occurred on stream: {error}");
+        }
+    }
+
+    pub(super) fn needs_restart(&self) -> bool {
+        self.interrupted.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cpal::{BackendSpecificError, StreamError};
+
+    fn system_interruption() -> StreamError {
+        StreamError::StreamInterrupted {
+            err: BackendSpecificError {
+                description: "ScreenCaptureKit system-stopped capture (-3821)".to_owned(),
+            },
+        }
+    }
+
+    #[test]
+    fn system_interruption_requests_recreation_of_the_active_stream() {
+        let errors = CaptureErrorHandler::default();
+        let callback = errors.clone();
+        assert!(!errors.needs_restart());
+        callback.handle(system_interruption());
+        assert!(errors.needs_restart());
+    }
+
+    #[test]
+    fn late_error_from_an_old_stream_does_not_restart_its_replacement() {
+        let old_callback = CaptureErrorHandler::default();
+        let replacement = CaptureErrorHandler::default();
+        old_callback.handle(system_interruption());
+        assert!(old_callback.needs_restart());
+        assert!(!replacement.needs_restart());
+    }
+
+    #[test]
+    fn other_backend_errors_do_not_request_recreation() {
+        let errors = CaptureErrorHandler::default();
+        errors.handle(StreamError::BackendSpecific {
+            err: BackendSpecificError {
+                description: "A sample buffer could not be read".to_owned(),
+            },
+        });
+        assert!(!errors.needs_restart());
+    }
+}

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -172,8 +172,13 @@ pub fn is_screen_capture_kit_available() -> bool {
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[path = "audio_capture_error.rs"]
+mod audio_capture_error;
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 mod cpal_impl {
     use self::service::{Reset, ServiceSwap};
+    use super::audio_capture_error::CaptureErrorHandler;
     use super::*;
     use cpal::{
         traits::{DeviceTrait, HostTrait, StreamTrait},
@@ -192,7 +197,7 @@ mod cpal_impl {
 
     #[derive(Default)]
     pub struct State {
-        stream: Option<(Box<dyn StreamTrait>, Arc<Message>)>,
+        stream: Option<(Box<dyn StreamTrait>, Arc<Message>, CaptureErrorHandler)>,
     }
 
     impl super::service::Reset for State {
@@ -210,7 +215,7 @@ mod cpal_impl {
             }
             _ => {}
         }
-        if let Some((_, format)) = &state.stream {
+        if let Some((_, format, _)) = &state.stream {
             sp.send_shared(format.clone());
         }
         RESTARTING.store(false, Ordering::SeqCst);
@@ -225,7 +230,7 @@ mod cpal_impl {
                 }
                 _ => {}
             }
-            if let Some((_, format)) = &state.stream {
+            if let Some((_, format, _)) = &state.stream {
                 sps.send_shared(format.clone());
             }
             Ok(())
@@ -234,6 +239,13 @@ mod cpal_impl {
     }
 
     pub fn run(sp: EmptyExtraFieldService, state: &mut State) -> ResultType<()> {
+        if let Some((_, _, errors)) = &state.stream {
+            if errors.needs_restart() {
+                // Recreate on the service thread, outside the backend's error callback.
+                log::warn!("Recreating interrupted audio capture stream");
+                super::restart();
+            }
+        }
         if !RESTARTING.load(Ordering::SeqCst) {
             run_serv_snapshot(sp, state)
         } else {
@@ -353,7 +365,9 @@ mod cpal_impl {
         Ok((device, format))
     }
 
-    fn play(sp: &GenericService) -> ResultType<(Box<dyn StreamTrait>, Arc<Message>)> {
+    fn play(
+        sp: &GenericService,
+    ) -> ResultType<(Box<dyn StreamTrait>, Arc<Message>, CaptureErrorHandler)> {
         use cpal::SampleFormat::*;
         let (device, config) = get_device()?;
         let sp = sp.clone();
@@ -371,7 +385,7 @@ mod cpal_impl {
             48000
         };
         let ch = if config.channels() > 1 { Stereo } else { Mono };
-        let stream = match config.sample_format() {
+        let (stream, errors) = match config.sample_format() {
             I8 => build_input_stream::<i8>(device, &config, sp, sample_rate, ch)?,
             I16 => build_input_stream::<i16>(device, &config, sp, sample_rate, ch)?,
             I32 => build_input_stream::<i32>(device, &config, sp, sample_rate, ch)?,
@@ -388,6 +402,7 @@ mod cpal_impl {
         Ok((
             Box::new(stream),
             Arc::new(create_format_msg(sample_rate, ch as _)),
+            errors,
         ))
     }
 
@@ -397,14 +412,13 @@ mod cpal_impl {
         sp: GenericService,
         sample_rate: u32,
         encode_channel: magnum_opus::Channels,
-    ) -> ResultType<cpal::Stream>
+    ) -> ResultType<(cpal::Stream, CaptureErrorHandler)>
     where
         T: cpal::SizedSample + dasp::sample::ToSample<f32>,
     {
-        let err_fn = move |err| {
-            // too many UnknownErrno, will improve later
-            log::trace!("an error occurred on stream: {}", err);
-        };
+        let errors = CaptureErrorHandler::default();
+        let callback_errors = errors.clone();
+        let err_fn = move |err| callback_errors.handle(err);
         let sample_rate_0 = config.sample_rate().0;
         log::debug!("Audio sample rate : {}", sample_rate);
         unsafe {
@@ -449,7 +463,7 @@ mod cpal_impl {
             err_fn,
             timeout,
         )?;
-        Ok(stream)
+        Ok((stream, errors))
     }
 }
 

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -217,6 +217,8 @@ mod cpal_impl {
         }
         if let Some((_, format, _)) = &state.stream {
             sp.send_shared(format.clone());
+            #[cfg(target_os = "macos")]
+            log::info!("Audio capture stream recreated; replacement format sent");
         }
         RESTARTING.store(false, Ordering::SeqCst);
         Ok(())
@@ -399,6 +401,8 @@ mod cpal_impl {
             f => bail!("unsupported audio format: {:?}", f),
         };
         stream.play()?;
+        #[cfg(target_os = "macos")]
+        log::info!("Audio capture start call succeeded");
         Ok((
             Box::new(stream),
             Arc::new(create_format_msg(sample_rate, ch as _)),
@@ -419,6 +423,8 @@ mod cpal_impl {
         let errors = CaptureErrorHandler::default();
         let callback_errors = errors.clone();
         let err_fn = move |err| callback_errors.handle(err);
+        #[cfg(target_os = "macos")]
+        let (mut received_samples, mut received_signal) = (false, false);
         let sample_rate_0 = config.sample_rate().0;
         log::debug!("Audio sample rate : {}", sample_rate);
         unsafe {
@@ -445,6 +451,25 @@ mod cpal_impl {
             &stream_config,
             move |data: &[T], _: &InputCallbackInfo| {
                 let buffer: Vec<f32> = data.iter().map(|s| T::to_sample(*s)).collect();
+                #[cfg(target_os = "macos")]
+                {
+                    // Starting capture does not guarantee sample delivery or audible data.
+                    if !received_samples && !buffer.is_empty() {
+                        received_samples = true;
+                        log::info!(
+                            "Audio capture received first PCM block: {} samples",
+                            buffer.len()
+                        );
+                    }
+                    if !received_signal
+                        && buffer
+                            .iter()
+                            .any(|sample| sample.is_finite() && *sample != 0.0)
+                    {
+                        received_signal = true;
+                        log::info!("Audio capture received first nonzero PCM");
+                    }
+                }
                 let mut lock = INPUT_BUFFER.lock().unwrap();
                 lock.extend(buffer);
                 while lock.len() >= rechannel_len {


### PR DESCRIPTION
When ScreenCaptureKit stops macOS audio capture with `systemStoppedStream` (-3821), the remote desktop session can remain connected while audio never resumes. This change consumes CPAL's stop notification, recreates the capture stream on the service thread, and sends its replacement audio format. It also logs capture startup and first sample delivery so a successful start call is distinguishable from actual captured audio.

## Observed failure and reproduction limits

1. In a connection, the audio may initially work; the last capture diagnostic was at 22:11:27, and ScreenCaptureKit reported `com.apple.ScreenCaptureKit.SCStreamErrorDomain`, code -3821, at 22:11:28.420. The connection remained open until 22:16:57 without capture resuming. Stream-creation logs showed `delegate=(null)` in the original CPAL backend. The timeline and investigation are also recorded in the linked CPAL PR.

**The natural OS failure is difficult to reproduce, and no deterministic ordinary user action or automated trigger is known.** Repeated connections and short generated audio files usually work. This was an audio capture stop after initial success, not an application crash or evidence explaining silence from the beginning of a connection. Neither the OS error nor the available logs establishes that fetching a sample buffer, changing file amplitude, an audio file, or a driver caused the stop.

The controlled regression below stops a real stream and explicitly supplies a marked -3821 notification. It validates the recovery path, but does not reproduce or explain the natural OS trigger. No inference about natural failure probability is made from these tests.

## Changes and affected paths

- `src/server/audio_capture_error.rs`: retain an interruption flag per capture stream, preserving the full error domain/code/description. An old callback cannot request a restart of its replacement. Only the typed system interruption requests recreation; intentional user stops (-3817) and other backend errors remain distinct.
- `src/server/audio_service.rs`: use the existing service restart path, outside the backend callback, and resend the audio format. Add macOS-only info logs for a successful start call, a recreated stream/format, the first nonempty PCM block, and the first finite nonzero PCM. The two first-data messages occur once per stream; there are no periodic sample counters or PCM dumps.

The nonzero scan stops after the first signal and does not change samples, encoding, silence gating or restart decisions. The Linux capture/IPC path is unchanged. If recreation fails, the error still propagates to the existing service error/retry logging; a successful start call alone is not reported as recovered audible output.

## Logs

System interruptions are error-level logs. Other backend errors keep their existing trace level, so the module filter above includes their details without enabling global trace logging. Example expected recovery messages (callback delivery can race with the start-call return):

```text
Audio capture stream interrupted: ... domain=com.apple.ScreenCaptureKit.SCStreamErrorDomain, code=-3821, ...
Recreating interrupted audio capture stream
Audio capture start call succeeded
Audio capture stream recreated; replacement format sent
Audio capture received first PCM block: 1920 samples
Audio capture received first nonzero PCM
```

The nonzero message appears only after the source actually plays a signal. It proves source activity, not receiver playback or acoustic speaker output. Verify receiver audio separately. For system-side evidence, collect a targeted unified log while testing, substituting the capture process PID:

```sh
/usr/bin/log stream --style compact --level debug \
  --predicate 'processID == MAC_PID && (senderImagePath CONTAINS "ScreenCaptureKit" OR eventMessage CONTAINS "Capture controlled test")' \
  > /tmp/rustdesk-screencapturekit.log
```

## References

- CPAL stop notification change and natural-event evidence: https://github.com/rustdesk-org/cpal/pull/5
- Apple [SCStream initializer/delegate](https://developer.apple.com/documentation/screencapturekit/scstream/init%28filter%3Aconfiguration%3Adelegate%3A%29)
- Apple [stream(_:didStopWithError:)](https://developer.apple.com/documentation/screencapturekit/scstreamdelegate/stream%28_%3Adidstopwitherror%3A%29)
- Apple [systemStoppedStream](https://developer.apple.com/documentation/screencapturekit/scstreamerror/systemstoppedstream)
- Apple [userStopped](https://developer.apple.com/documentation/screencapturekit/scstreamerror/code/userstopped)
- Apple [stopCapture(completionHandler:)](https://developer.apple.com/documentation/screencapturekit/scstream/stopcapture%28completionhandler%3A%29)


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62099437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/rustdesk/-/pull-requests/rustdesk/rustdesk/16123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The implementation appears safe to merge, with non-blocking follow-up needed for end-to-end recovery coverage and accurate CPAL revision provenance.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fserver%2Faudio_service.rs%3A244-249%0AThe%20new%20tests%20only%20exercise%20%60CaptureErrorHandler%60%20in%20isolation.%20They%20do%20not%20verify%20that%20the%20service%20observes%20the%20flag%2C%20replaces%20the%20stream%2C%20clears%20the%20restart%20state%2C%20and%20resends%20the%20audio%20format.%20A%20future%20lifecycle%20change%20could%20therefore%20break%20macOS%20audio%20recovery%20while%20these%20tests%20continue%20to%20pass.%20Please%20add%20a%20service-level%20test%20using%20an%20injectable%20or%20mock%20stream%20that%20drives%20an%20interruption%20through%20%60run%28%29%60%20and%20verifies%20replacement%20and%20format%20delivery.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A%23%23%23%20Issue%202%0ACargo.lock%3A1720%0AThe%20lockfile%20selects%20CPAL%20commit%20%6069ad2578adc9200093fc81cdfbdad63dbc4274f9%60%2C%20while%20the%20PR%20states%20that%20the%20dependency%20is%20pinned%20to%20reviewed%20commit%20%60eaee235cf4e93a47e8ce9372c25597e41fa593be%60.%20Align%20the%20selected%20revision%20with%20the%20declared%20dependency%20or%20document%20and%20review%20the%20additional%20commit%20range.%20Otherwise%2C%20reviewers%20and%20future%20debugging%20will%20rely%20on%20incorrect%20dependency%20provenance%20for%20the%20new%20%60StreamInterrupted%60%20contract.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16123&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Recovery Lifecycle Untested** <a href="https://github.com/rustdesk/rustdesk/pull/16123#discussion_r3968796924">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**CPAL Revision Mismatch** <a href="https://github.com/rustdesk/rustdesk/pull/16123#discussion_r3968796939">▶</a>

<details><summary><h3>Summary</h3></summary>

- Polls backend stop notifications from the audio service thread and recreates the capture stream through the existing restart path.
- Associates restart state with each stream so late callbacks cannot restart its replacement.
- Resends the audio format after successful recreation.
- Adds macOS diagnostics distinguishing successful startup, first PCM delivery, and first nonzero signal.
- Updates the resolved CPAL fork revision, although it differs from the revision named in the PR description.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SCK as ScreenCaptureKit
    participant CPAL as CPAL error callback
    participant H as CaptureErrorHandler
    participant Service as Audio service thread
    participant Client as Audio subscriber

    SCK->>CPAL: systemStoppedStream (-3821)
    CPAL->>H: StreamInterrupted
    H->>H: Set per-stream interrupted flag
    Service->>H: needs_restart()
    H-->>Service: true
    Service->>Service: Request existing restart path
    Service->>Service: Drop old stream
    Service->>CPAL: Build and start replacement stream
    CPAL-->>Service: Replacement stream and format
    Service->>Client: Send replacement audio format
    CPAL->>Client: Send newly encoded audio frames
```
</details>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio capture now detects interrupted streams and automatically recreates them, helping recording continue without manual intervention.
  * Other audio backend errors continue to be handled without triggering unnecessary stream restarts.
  * Improved macOS audio diagnostics provide clearer visibility into capture startup, stream recreation, and incoming audio data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->