### PR TITLE
fix(macOS): preserve release entitlements when signing

### DIFF
--- a/.github/scripts/sign-macos-app.sh
+++ b/.github/scripts/sign-macos-app.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+app_path=$1
+identity=$2
+entitlements=$3
+
+sign_args=(--force --options runtime --sign "$identity")
+if [[ "$identity" != "-" ]]; then
+  sign_args+=(--timestamp)
+fi
+
+frameworks_path="$app_path/Contents/Frameworks"
+if [[ -d "$frameworks_path" ]]; then
+  while IFS= read -r -d '' code; do
+    if file -b "$code" | grep -q 'Mach-O'; then
+      codesign "${sign_args[@]}" "$code"
+    fi
+  done < <(find "$frameworks_path" -type f -print0)
+
+  while IFS= read -r -d '' framework; do
+    codesign "${sign_args[@]}" "$framework"
+  done < <(find "$frameworks_path" -depth -type d -name '*.framework' -print0)
+fi
+
+service_path="$app_path/Contents/MacOS/service"
+if [[ -f "$service_path" ]]; then
+  codesign "${sign_args[@]}" "$service_path"
+fi
+
+codesign "${sign_args[@]}" --generate-entitlement-der \
+  --entitlements "$entitlements" "$app_path"
+codesign --verify --deep --strict --verbose=2 "$app_path"
+
+actual_entitlements=$(codesign -d --entitlements :- "$app_path" 2>/dev/null)
+audio_input=$(plutil -extract 'com\.apple\.security\.device\.audio-input' raw - \
+  <<<"$actual_entitlements")
+if [[ "$audio_input" != "true" ]]; then
+  echo "Missing com.apple.security.device.audio-input entitlement" >&2
+  exit 1
+fi

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -916,6 +916,8 @@ jobs:
 
       - name: Codesign app and create signed dmg
         if: env.MACOS_P12_BASE64 != null && env.UPLOAD_ARTIFACT == 'true'
+        env:
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
         run: |
           # Patch create-dmg to give more attempts to unmount image
           CREATE_DMG="$(command -v create-dmg)"
@@ -926,7 +928,10 @@ jobs:
           security unlock-keychain -p ${{ secrets.MACOS_P12_PASSWORD }} rustdesk.keychain
           # start sign the rustdesk.app and dmg
           rm -rf *.dmg || true
-          codesign --force --options runtime -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep --strict ./flutter/build/macos/Build/Products/Release/RustDesk.app -vvv
+          bash ./.github/scripts/sign-macos-app.sh \
+            ./flutter/build/macos/Build/Products/Release/RustDesk.app \
+            "$MACOS_CODESIGN_IDENTITY" \
+            ./flutter/macos/Runner/Release.entitlements
           create-dmg --icon "RustDesk.app" 200 190 --hide-extension "RustDesk.app" --window-size 800 400 --app-drop-link 600 185 rustdesk-${{ env.VERSION }}.dmg ./flutter/build/macos/Build/Products/Release/RustDesk.app
           codesign --force --options runtime -s ${{ secrets.MACOS_CODESIGN_IDENTITY }} --deep --strict rustdesk-${{ env.VERSION }}.dmg -vvv
           # notarize the rustdesk-${{ env.VERSION }}.dmg


### PR DESCRIPTION
The final macOS `codesign` command re-signed `RustDesk.app` without `Release.entitlements`. Release artifacts therefore lacked `com.apple.security.device.audio-input`, and TCC denied microphone access before showing a consent prompt.

This change:
- signs nested Mach-O code and framework bundles first, without app entitlements;
- signs the outer app last with `Release.entitlements`;
- verifies the bundle and required microphone entitlement before packaging.

Hardened Runtime and normal library validation remain enabled. `--deep` is used only for verification.

Tested against a copy of the official 1.4.9 x86_64 app: strict recursive verification passed, only the outer app received the microphone entitlement, and the affected Mac regained the consent prompt and two-way audio.

Refs #14281, #13088. Discussion: https://github.com/rustdesk/rustdesk/discussions/14282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Release**
  * Improved macOS application signing during release builds.
  * Added verification that signed applications include required microphone access permissions.
  * Added runtime hardening and signature validation for macOS app bundles and embedded components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61971096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/rustdesk/-/pull-requests/rustdesk/rustdesk/16125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no concrete correctness, security, or repository-rule violations identified.

<details><summary><h3>Summary</h3></summary>

- Signs nested Mach-O files, framework bundles, and the RustDesk service before the outer application.
- Signs the outer application with `Release.entitlements`.
- Verifies the complete bundle and confirms the microphone entitlement before DMG creation.
- Regression surface is limited to the signed macOS release workflow and its signing behavior.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Locate RustDesk.app] --> B[Sign Mach-O files in Frameworks]
    B --> C[Sign framework bundles depth-first]
    C --> D[Sign Contents/MacOS/service]
    D --> E[Sign outer app with Release.entitlements]
    E --> F[Strict recursive signature verification]
    F --> G[Verify microphone entitlement]
    G --> H[Create and sign DMG]
```
</details>

<!-- /greptile_comment -->