### PR TITLE
feat: add Nix flake support for installable package

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -29,6 +29,7 @@ on:
       - ".github/workflows/nix.yml"
       - "Cargo.lock"
       - "Cargo.toml"
+      - "libs/hbb_common"
 
 permissions:
   contents: read
@@ -64,6 +65,24 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@6221693898146dc97e38ad0e013488a16477a4c4 # v9
         with:
           use-flakehub: false
+
+      - name: Verify hbb_common submodule pin matches flake input
+        # The flake builds against the hbb_common commit pinned in
+        # flake.lock, not the gitlink in libs/hbb_common. If the two
+        # diverge, the flake builds against a stale hbb_common. This
+        # step compares the gitlink SHA against the flake input rev and
+        # fails if they don't match.
+        run: |
+          gitlink_sha=$(git submodule status libs/hbb_common | awk '{print $1}' | tr -d '+-')
+          flake_rev=$(jq -r '.nodes.hbb_common.locked.rev' flake.lock)
+          echo "submodule gitlink: $gitlink_sha"
+          echo "flake.lock pin:    $flake_rev"
+          if [ "$gitlink_sha" != "$flake_rev" ]; then
+            echo "ERROR: hbb_common submodule pin ($gitlink_sha) does not match flake.lock ($flake_rev)."
+            echo "Update the hbb_common flake input in flake.nix to match the submodule, then run 'nix flake update hbb_common'."
+            exit 1
+          fi
+          echo "OK: pins match"
 
       - name: nix flake check --all-systems
         # --no-build: evaluate every system's outputs (including darwin on

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,90 @@
+name: Nix flake
+
+# Validates the flake (flake.nix). The full RustDesk build takes 30+ minutes,
+# so this workflow runs only on manual dispatch, on published releases, or
+# when flake-related files change on a PR — not on every push.
+#
+# Steps, in order of what they catch:
+#   1. nix flake check --all-systems  — every system's outputs evaluate
+#      (including darwin on an ubuntu runner).
+#   2. nix build .#default            — the from-source build realises for
+#      the runner's system.
+#   3. nix run .#default -- --version — the built binary actually execs.
+#      This is the only step that catches the class of bug where evaluation
+#      passes but the wrapper/binary fails at runtime. Do NOT drop it.
+#   4. nix build .#source (if exists) — exercises the from-source build
+#      path. In this flake #source is the same as #default, but the step
+#      is kept for consistency with the nixify template.
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches: [master]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "nix/**"
+      - ".github/workflows/nix.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: nix flake check (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-26-intel, macos-26]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Enable Nix binary cache
+        uses: DeterminateSystems/magic-nix-cache-action@6221693898146dc97e38ad0e013488a16477a4c4 # v9
+        with:
+          use-flakehub: false
+
+      - name: nix flake check --all-systems
+        # --no-build: evaluate every system's outputs (including darwin on
+        # ubuntu) without realising them. Without --no-build, `nix flake
+        # check` builds every derivation in `checks`, which fails for
+        # non-native systems (darwin stdenv can't run on linux). The
+        # build/run steps below handle realisation for the runner's system.
+        run: nix flake check --all-systems --no-build
+
+      - name: nix build .#default
+        run: nix build .#default --print-build-logs
+
+      - name: nix run .#default -- --version
+        # SECURITY: Gate behind non-PR events. `nix run` executes the built
+        # binary outside the Nix sandbox on the runner, where it can reach
+        # GitHub's OIDC endpoint and the GITHUB_TOKEN. On a PR, that binary
+        # is PR-controlled code. `nix build` above is safe (realises inside
+        # the sandbox, no network).
+        if: github.event_name != 'pull_request'
+        run: nix run .#default -- --version
+
+      - name: nix build .#source (if exists)
+        # Exercises the from-source build path. Skip if the flake does not
+        # expose a #source output (source-build-only flakes use #default).
+        run: |
+          if nix flake show --json 2>/dev/null | jq -e 'any(.packages[]?; has("source"))' >/dev/null 2>&1; then
+            nix build .#source --print-build-logs
+          else
+            echo "No #source output — skipping"
+          fi

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,6 +18,8 @@ name: Nix flake
 
 on:
   workflow_dispatch: {}
+  release:
+    types: [published]
   pull_request:
     branches: [master]
     paths:
@@ -55,6 +57,10 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Enable Nix binary cache
+        # Skip on release events to avoid cache-poisoning risk: release
+        # builds should not write to the cache. PR and manual runs
+        # populate the cache; release runs only read.
+        if: github.event_name != 'release'
         uses: DeterminateSystems/magic-nix-cache-action@6221693898146dc97e38ad0e013488a16477a4c4 # v9
         with:
           use-flakehub: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  cache-poisoning:
+    ignore:
+      # The magic-nix-cache-action is guarded by `if: github.event_name != 'release'`
+      # so it never runs on release events. Cache poisoning requires the cache
+      # action to execute on a release-triggered workflow; skipping it entirely
+      # on releases eliminates the poisoning vector. zizmor's static analysis
+      # does not follow step-level `if:` conditionals.
+      - nix.yml:64

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ libsciter.dylib
 flutter/web/
 # libdrmtap is cloned at build time by build.py (not a submodule)
 /third_party/libdrmtap/
+# Nix
+/result
+/result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "hbb_common": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1788837886,
+        "narHash": "sha256-cGpfKKZnKmbpCZv06pcdMF9rfNCU4077I4fkh7vlWOA=",
+        "owner": "rustdesk",
+        "repo": "hbb_common",
+        "rev": "55395c6fcbcb8dd4bc8d4e7ab4d7d7c8d1789b43",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustdesk",
+        "repo": "hbb_common",
+        "rev": "55395c6fcbcb8dd4bc8d4e7ab4d7d7c8d1789b43",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788775869,
+        "narHash": "sha256-JRf1lSypbvKj6AzUZHpUA6YC1DirVuitZWOnRwcm+Ww=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "58973d74f1893afe13f5902919803a0e99da0ca4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-darwin-legacy": {
+      "locked": {
+        "lastModified": 1788807765,
+        "narHash": "sha256-J9oC0bKnkXUrMegqRTXVkyDFJ0gn2U/Qpoo9HgGMQmA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "93108a538f079596c9a16c72cf03e9322782b6dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "hbb_common": "hbb_common",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin-legacy": "nixpkgs-darwin-legacy"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,40 @@
 
           patches = [ ./nix/make-build-reproducible.patch ];
 
+          desktopItems = lib.optionals pkgs.stdenv.isLinux [
+            (pkgs.makeDesktopItem {
+              name = "rustdesk";
+              desktopName = "RustDesk";
+              genericName = "Remote Desktop";
+              comment = "Remote Desktop";
+              exec = "rustdesk %u";
+              icon = "rustdesk";
+              terminal = false;
+              type = "Application";
+              startupNotify = true;
+              categories = [ "Network" "RemoteAccess" "GTK" ];
+              keywords = [ "internet" "linux" "dart" "rust" "remote-control" "p2p" "teamviewer" "rust-lang" "rdp" "remote-desktop" "vnc" ];
+              startupWMClass = "rustdesk";
+              actions.new-window = {
+                name = "Open a New Window";
+                exec = "rustdesk %u";
+              };
+            })
+            (pkgs.makeDesktopItem {
+              name = "rustdesk-link";
+              desktopName = "RustDesk";
+              noDisplay = true;
+              mimeTypes = [ "x-scheme-handler/rustdesk" ];
+              tryExec = "rustdesk";
+              exec = "rustdesk %u";
+              icon = "rustdesk";
+              terminal = false;
+              type = "Application";
+              startupNotify = false;
+              startupWMClass = "rustdesk";
+            })
+          ];
+
           nativeBuildInputs = [
             pkgs.pkg-config
             pkgs.perl
@@ -150,6 +184,9 @@
             libsciter-darwin
           ];
 
+          # Replace the hbb_common submodule with the flake input pin.
+          # The pin in flake.lock must be updated when the submodule gitlink
+          # changes; the flake input is the source of truth for reproducibility.
           prePatch = ''
             rm -rf libs/hbb_common
             cp -r ${hbb_common} libs/hbb_common
@@ -172,7 +209,9 @@
             cp -a $src/src/ui $out/share/src
             install -Dm0644 $src/res/logo.svg $out/share/icons/hicolor/scalable/apps/rustdesk.svg
           '' + lib.optionalString pkgs.stdenv.isDarwin ''
+            mkdir -p $out/share/src
             ln -s ${libsciter-darwin}/lib/libsciter.dylib $out/lib/rustdesk/libsciter.dylib
+            cp -a $src/src/ui $out/share/src
           '';
 
           postFixup = lib.optionalString pkgs.stdenv.isLinux ''
@@ -225,18 +264,67 @@
         };
 
         devShells.default = pkgs.mkShell {
-          nativeBuildInputs = [ pkgs.pkg-config ];
+          nativeBuildInputs = [
+            pkgs.pkg-config
+            pkgs.perl
+            pkgs.makeWrapper
+            pkgs.rustPlatform.bindgenHook
+          ] ++ lib.optionals pkgs.stdenv.isLinux [
+            pkgs.copyDesktopItems
+            pkgs.wrapGAppsHook3
+          ];
+
           buildInputs = [
             pkgs.rustc
             pkgs.cargo
+            pkgs.bzip2
+            pkgs.libgit2
+            pkgs.libsodium
+            pkgs.libvpx
+            pkgs.libyuv
+            pkgs.libopus
+            pkgs.libaom
             pkgs.openssl
+            pkgs.zlib
+            pkgs.zstd
           ] ++ lib.optionals pkgs.stdenv.isLinux [
+            pkgs.atk
+            pkgs.cairo
+            pkgs.dbus
+            pkgs.gdk-pixbuf
+            pkgs.glib
+            pkgs.gst_all_1.gst-plugins-base
+            pkgs.gst_all_1.gstreamer
             pkgs.gtk3
+            pkgs.libpulseaudio
+            pkgs.libxtst
+            pkgs.libxkbcommon
+            pkgs.pam
+            pkgs.pango
+            pkgs.alsa-lib
+            pkgs.xdotool
             pkgs.libsciter
+            pkgs.libayatana-appindicator
           ] ++ lib.optionals pkgs.stdenv.isDarwin [
             pkgs.libiconv
             pkgs.apple-sdk
+            vcpkgRoot
+            libsciter-darwin
           ];
+
+          RUSTDESK_BUILD_FEATURES = lib.optionalString pkgs.stdenv.isLinux "linux-pkg-config";
+
+          shellHook = ''
+            # Set up hbb_common so cargo build works from the source tree.
+            if [ ! -e libs/hbb_common/Cargo.toml ]; then
+              rm -rf libs/hbb_common
+              cp -r ${hbb_common} libs/hbb_common
+              chmod -R u+w libs/hbb_common
+            fi
+          '' + lib.optionalString pkgs.stdenv.isDarwin ''
+            export VCPKG_ROOT="${vcpkgRoot}"
+            export VCPKG_INSTALLED_ROOT="${vcpkgRoot}/installed"
+          '';
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -185,8 +185,9 @@
           ];
 
           # Replace the hbb_common submodule with the flake input pin.
-          # The pin in flake.lock must be updated when the submodule gitlink
-          # changes; the flake input is the source of truth for reproducibility.
+          # CI verifies the flake.lock pin matches the submodule gitlink
+          # on every run — see the "Verify hbb_common submodule pin" step
+          # in .github/workflows/nix.yml.
           prePatch = ''
             rm -rf libs/hbb_common
             cp -r ${hbb_common} libs/hbb_common

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,243 @@
+{
+  description = "RustDesk Remote Desktop — open source TeamViewer / Citrix alternative";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-darwin-legacy.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+    flake-utils.url = "github:numtide/flake-utils";
+    hbb_common = {
+      url = "github:rustdesk/hbb_common/55395c6fcbcb8dd4bc8d4e7ab4d7d7c8d1789b43";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-darwin-legacy, flake-utils, hbb_common, ... }:
+    {
+      overlays.default = final: prev: {
+        rustdesk = (self.packages.${final.system} or self.packages.${final.stdenv.system}).default or null;
+      };
+    } // flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs =
+          if system == "x86_64-darwin"
+          then import nixpkgs-darwin-legacy { inherit system; config.allowUnfree = true; }
+          else import nixpkgs { inherit system; config.allowUnfree = true; };
+
+        lib = pkgs.lib;
+
+        # Static libopus — nixpkgs only ships a shared build; magnum-opus's
+        # build.rs links `static=opus` via the vcpkg shim below.
+        libopusStatic = pkgs.libopus.overrideAttrs (old: {
+          mesonFlags = (old.mesonFlags or [ ]) ++ [
+            "-Ddefault_library=static"
+          ];
+          postInstall = (old.postInstall or "") + ''
+            # meson puts the .a in $out/lib when default_library=static
+          '';
+        });
+
+        # libaom without vmaf — the static .a references vmaf symbols that
+        # the scrap build.rs doesn't link; disabling vmaf avoids the
+        # unresolved symbols at link time.
+        libaomNoVmaf = pkgs.libaom.override { enableVmaf = false; };
+
+        # Sciter runtime for macOS — nixpkgs only ships libsciter for Linux.
+        # The same sciter-sdk GitHub commit used by nixpkgs has bin.osx/libsciter.dylib.
+        libsciter-darwin = pkgs.stdenv.mkDerivation {
+          pname = "libsciter-darwin";
+          version = "4.4.8.23-bis";
+          src = pkgs.fetchurl {
+            url = "https://github.com/c-smile/sciter-sdk/raw/524a90ef7eab16575df9496f7e4c374bbd5fb1fe/bin.osx/libsciter.dylib";
+            hash = "sha256-qNhEQ5tDy3DwKoYQxzX/3nikG6oeVRBYuGkURjAkCg0=";
+          };
+          dontUnpack = true;
+          installPhase = ''
+            runHook preInstall
+            install -m755 -D $src $out/lib/libsciter.dylib
+            runHook postInstall
+          '';
+          meta = {
+            homepage = "https://sciter.com";
+            description = "Embeddable HTML/CSS/JavaScript engine for modern UI development";
+            platforms = lib.platforms.darwin;
+            sourceProvenance = with lib.sourceTypes; [ lib.sourceTypes.binaryNativeCode ];
+            license = lib.licenses.unfree;
+          };
+        };
+
+        # Assemble a vcpkg-like installed tree from nixpkgs static libs so
+        # libs/scrap/build.rs and magnum-opus/build.rs (which require
+        # VCPKG_ROOT on macOS x86_64 and only fall back to homebrew on
+        # aarch64) can find libyuv/libvpx/aom/opus.
+        # Layout: $out/installed/<target>/lib/*.a, .../include/*
+        vcpkgRoot = pkgs.runCommand "rustdesk-vcpkg-root" { } (
+          let
+            target =
+              if pkgs.stdenv.hostPlatform.isAarch64 then "arm64-osx"
+              else if pkgs.stdenv.hostPlatform.isx86_64 then "x64-osx"
+              else throw "unsupported darwin arch for vcpkg shim";
+            mkLinks = name: pkg: ''
+              ln -s ${lib.getLib pkg}/lib/lib${name}.a $out/installed/${target}/lib/lib${name}.a
+              for h in ${lib.getDev pkg}/include/*; do
+                ln -s "$h" "$out/installed/${target}/include/$(basename "$h")"
+              done
+            '';
+          in
+          ''
+            mkdir -p $out/installed/${target}/lib $out/installed/${target}/include
+            ${mkLinks "yuv" pkgs.libyuv}
+            ${mkLinks "vpx" pkgs.libvpx}
+            ${mkLinks "aom" libaomNoVmaf.static}
+            ${mkLinks "opus" libopusStatic}
+          ''
+        );
+
+        rustdesk = pkgs.rustPlatform.buildRustPackage {
+          pname = "rustdesk";
+          version = "1.5.0";
+          src = ./.;
+          cargoHash = "sha256-GTFAfVwcWtEz5ViPWRbInTvZbOM8jS/aD9cAxVhKsfw=";
+
+          patches = [ ./nix/make-build-reproducible.patch ];
+
+          nativeBuildInputs = [
+            pkgs.pkg-config
+            pkgs.perl
+            pkgs.makeWrapper
+            pkgs.rustPlatform.bindgenHook
+          ] ++ lib.optionals pkgs.stdenv.isLinux [
+            pkgs.copyDesktopItems
+            pkgs.wrapGAppsHook3
+          ];
+
+          buildFeatures = lib.optionals pkgs.stdenv.isLinux [ "linux-pkg-config" ];
+
+          doCheck = false;
+
+          buildInputs = [
+            pkgs.bzip2
+            pkgs.libgit2
+            pkgs.libsodium
+            pkgs.libvpx
+            pkgs.libyuv
+            pkgs.libopus
+            pkgs.libaom
+            pkgs.openssl
+            pkgs.zlib
+            pkgs.zstd
+          ] ++ lib.optionals pkgs.stdenv.isLinux [
+            pkgs.atk
+            pkgs.cairo
+            pkgs.dbus
+            pkgs.gdk-pixbuf
+            pkgs.glib
+            pkgs.gst_all_1.gst-plugins-base
+            pkgs.gst_all_1.gstreamer
+            pkgs.gtk3
+            pkgs.libpulseaudio
+            pkgs.libxtst
+            pkgs.libxkbcommon
+            pkgs.pam
+            pkgs.pango
+            pkgs.alsa-lib
+            pkgs.xdotool
+            pkgs.libsciter
+            pkgs.libayatana-appindicator
+          ] ++ lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.libiconv
+            pkgs.apple-sdk
+            vcpkgRoot
+            libsciter-darwin
+          ];
+
+          prePatch = ''
+            rm -rf libs/hbb_common
+            cp -r ${hbb_common} libs/hbb_common
+            chmod -R u+w libs/hbb_common
+          '';
+
+          postPatch = ''
+            sed -e '1i #include <cstdint>' -i $cargoDepsCopy/*/webm-1.1.0/src/sys/libwebm/mkvparser/mkvparser.cc
+            sed -e '1i #include <cstdint>' -i $cargoDepsCopy/*/webm-sys-1.0.4/libwebm/mkvparser/mkvparser.cc
+          '';
+
+          postInstall = ''
+            mkdir -p $out/lib/rustdesk $out/share
+            mv $out/bin/rustdesk $out/lib/rustdesk
+            makeWrapper $out/lib/rustdesk/rustdesk $out/bin/rustdesk \
+              --chdir "$out/share"
+          '' + lib.optionalString pkgs.stdenv.isLinux ''
+            mkdir -p $out/share/src
+            ln -s ${pkgs.libsciter}/lib/libsciter-gtk.so $out/lib/rustdesk
+            cp -a $src/src/ui $out/share/src
+            install -Dm0644 $src/res/logo.svg $out/share/icons/hicolor/scalable/apps/rustdesk.svg
+          '' + lib.optionalString pkgs.stdenv.isDarwin ''
+            ln -s ${libsciter-darwin}/lib/libsciter.dylib $out/lib/rustdesk/libsciter.dylib
+          '';
+
+          postFixup = lib.optionalString pkgs.stdenv.isLinux ''
+            patchelf --add-rpath "${pkgs.libayatana-appindicator}/lib" "$out/lib/rustdesk/rustdesk"
+          '';
+
+          env = {
+            SODIUM_USE_PKG_CONFIG = true;
+            ZSTD_SYS_USE_PKG_CONFIG = true;
+          } // lib.optionalAttrs pkgs.stdenv.isDarwin {
+            VCPKG_ROOT = "${vcpkgRoot}";
+            VCPKG_INSTALLED_ROOT = "${vcpkgRoot}/installed";
+          };
+
+          meta = {
+            description = "Virtual / remote desktop infrastructure for everyone! Open source TeamViewer / Citrix alternative";
+            homepage = "https://github.com/rustdesk/rustdesk";
+            license = lib.licenses.agpl3Only;
+            mainProgram = "rustdesk";
+          };
+        };
+      in
+      {
+        packages = {
+          rustdesk = rustdesk;
+          default = rustdesk;
+          source = rustdesk;
+        } // lib.optionalAttrs pkgs.stdenv.isLinux {
+          nixpkgs = pkgs.rustdesk;
+        };
+
+        apps = {
+          rustdesk = {
+            type = "app";
+            program = "${rustdesk}/bin/rustdesk";
+          };
+          default = {
+            type = "app";
+            program = "${rustdesk}/bin/rustdesk";
+          };
+        } // lib.optionalAttrs pkgs.stdenv.isLinux {
+          nixpkgs = {
+            type = "app";
+            program = "${pkgs.rustdesk}/bin/rustdesk";
+          };
+        };
+
+        checks = {
+          build = rustdesk;
+        };
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = [
+            pkgs.rustc
+            pkgs.cargo
+            pkgs.openssl
+          ] ++ lib.optionals pkgs.stdenv.isLinux [
+            pkgs.gtk3
+            pkgs.libsciter
+          ] ++ lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.libiconv
+            pkgs.apple-sdk
+          ];
+        };
+      }
+    );
+}

--- a/nix/make-build-reproducible.patch
+++ b/nix/make-build-reproducible.patch
@@ -1,0 +1,13 @@
+diff --git a/libs/hbb_common/src/lib.rs b/libs/hbb_common/src/lib.rs
+index 15ef310..f3ac940 100644
+--- a/libs/hbb_common/src/lib.rs
++++ b/libs/hbb_common/src/lib.rs
+@@ -218,7 +218,7 @@ pub fn gen_version() {
+         }
+     }
+     // generate build date
+-    let build_date = format!("{}", chrono::Local::now().format("%Y-%m-%d %H:%M"));
++    let build_date = "1970-01-01 00:00";
+     file.write_all(
+         format!("#[allow(dead_code)]\npub const BUILD_DATE: &str = \"{build_date}\";\n").as_bytes(),
+     )


### PR DESCRIPTION
## What

Adds a `flake.nix` so RustDesk can be installed and run directly from GitHub:

```bash
nix run github:rustdesk/rustdesk
nix profile add github:rustdesk/rustdesk
nix run github:rustdesk/rustdesk/v1.5.0   # pin a specific release
```

## Why

Enables `nix run github:rustdesk/rustdesk` and `nix profile add github:rustdesk/rustdesk` for users who already have Nix installed. The flake builds from source with all inputs pinned in `flake.lock`.

## Relationship to nixpkgs

This project is already in nixpkgs as `nixpkgs#rustdesk` (currently `1.4.9` on unstable; latest release is `1.5.0`). This flake is complementary, not redundant:

- **Faster release cadence** — the flake tracks the project's own releases directly; nixpkgs follows its own staging schedule (days to weeks behind).
- **Tag-pinning that works** — source-build flakes exist at every git tag, so `nix run github:rustdesk/rustdesk/vX.Y.Z` serves that exact version. nixpkgs only exposes the version its channel currently ships — older versions are gone once the channel moves.
- **Reproducible dev environment** — `devShells.default` pins the project's own toolchain; nixpkgs does not provide a per-project dev shell.
- **`x86_64-darwin` at the latest version** — nixpkgs's `meta.platforms` does not declare `x86_64-darwin` (the nixpkgs package is marked broken on Darwin because `libsciter` is Linux-only); the flake's `nixpkgs-darwin-legacy` pin builds it at the latest release by fetching the Sciter macOS runtime directly.
- **Shorter supply chain** — builds directly from `rustdesk/rustdesk`'s source, one fewer packaging layer to audit.

`nix profile add nixpkgs#rustdesk` still works on Linux and this flake does not replace it.

## nixpkgs output

The flake also exposes a `#nixpkgs` output that wraps the nixpkgs-packaged version of RustDesk (Linux only, since the nixpkgs package is broken on Darwin):

```bash
nix run github:rustdesk/rustdesk#nixpkgs
nix profile install github:rustdesk/rustdesk#nixpkgs
```

The nixpkgs packaging includes distribution patches, postInstall hooks, and runtime dependency setup that a naive from-source flake would miss. The `#nixpkgs` output gives users access to this more complete packaging alongside the from-source `#source` output. Users who want the latest version from source use `#source` or `#default`; users who want the nixpkgs-packaged version with its patches and hooks use `#nixpkgs`.

## Changes

- `flake.nix`: Nix flake with `packages.default`, `packages.rustdesk`, `packages.source`, `packages.nixpkgs` (Linux only), `apps.default`, `apps.rustdesk`, `checks`, `devShells.default`, and `overlays.default`
- `nix/make-build-reproducible.patch`: Patch to pin `BUILD_DATE` for reproducible builds
- `.gitignore`: Added Nix build result symlinks (`/result`, `/result-*`)
- `.github/workflows/nix.yml`: GitHub Actions CI for Nix validation (matrix: `ubuntu-latest`, `macos-26-intel`, `macos-26`)

## Testing

Verified locally on `x86_64-darwin`:

```bash
nix flake check --all-systems --no-build   # passes on all 4 systems
nix build .#default                        # builds successfully (~28 min)
nix run .#default -- --version             # outputs "1.5.0"
```

Builds and runs successfully on `x86_64-darwin`. Linux and `aarch64-darwin` are evaluation-tested via `nix flake check --all-systems --no-build` but not yet build-tested on native hardware.

## Notes

- The flake uses `nixpkgs-unstable` for Linux and `aarch64-darwin`; `nixpkgs-26.05-darwin` for `x86_64-darwin` (Intel Mac support, since `nixpkgs-unstable` dropped `x86_64-darwin`).
- Darwin builds assemble a vcpkg-like directory from nixpkgs static libraries (libyuv, libvpx, libaom, opus) so `libs/scrap/build.rs` and `magnum-opus/build.rs` find them without VCPKG_ROOT or homebrew.
- The Sciter runtime (`libsciter.dylib`) is fetched from the sciter-sdk GitHub repo for macOS, since nixpkgs only ships it for Linux.
- The `libs/hbb_common` git submodule is materialized via a flake input pinned to the checked-out commit, since flake source snapshots do not include submodule content.
- No breaking changes to existing build paths.

## Scope

The PR scope is well-contained — additive only, no existing functionality affected.

## Related

Resolves #16131


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Nix-based packaging for RustDesk across supported Linux and macOS environments.
  - Added runnable applications, development shell support, and source-package outputs for Nix users.
  - Added platform-specific dependency handling, including multimedia and macOS runtime components.

- **Chores**
  - Added automated validation for Nix builds across Linux and macOS.
  - Added reproducible build support by using a consistent build timestamp.
  - Excluded Nix build output links from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62062236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/rustdesk/-/pull-requests/rustdesk/rustdesk/16132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 3/5</h2>

The PR is not safe to merge until the Darwin package includes its runtime UI assets and the advertised development shell can build the project.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aflake.nix%3A174-176%0AOn%20Darwin%2C%20the%20wrapper%20starts%20RustDesk%20with%20%60%24out%2Fshare%60%20as%20its%20working%20directory%2C%20but%20this%20branch%20does%20not%20copy%20%60src%2Fui%60%20there.%20Since%20default%20builds%20do%20not%20enable%20%60inline%60%2C%20RustDesk%20loads%20%60src%2Fui%2F%3Cpage%3E%60%20from%20the%20current%20directory.%20The%20macOS%20package%20therefore%20points%20Sciter%20at%20missing%20files%20and%20cannot%20render%20its%20UI.%0A%0A%23%23%23%20Issue%202%0Aflake.nix%3A227-240%0AThe%20development%20shell%20omits%20native%20libraries%2C%20bindgen%20tooling%2C%20platform%20dependencies%2C%20and%20VCPKG%20configuration%20used%20by%20the%20package%20derivation.%20On%20Linux%2C%20it%20also%20leaves%20%60linux-pkg-config%60%20disabled%20and%20%60VCPKG_ROOT%60%20unset%2C%20so%20a%20normal%20%60cargo%20build%60%20fails%20when%20%60libs%2Fscrap%2Fbuild.rs%60%20tries%20to%20locate%20libyuv.%0A%0A%23%23%23%20Issue%203%0Aflake.nix%3A153-156%0AThis%20replaces%20the%20checked-out%20%60hbb_common%60%20submodule%20with%20one%20fixed%20revision.%20If%20a%20future%20tag%20or%20commit%20updates%20the%20gitlink%2C%20the%20flake%20will%20still%20build%20against%20%6055395c6%E2%80%A6%60%2C%20which%20can%20cause%20incompatible%20API%20failures%20or%20produce%20a%20package%20that%20does%20not%20match%20the%20requested%20source%20revision.%20Keeping%20these%20revisions%20synchronized%20manually%20creates%20an%20avoidable%20maintenance%20risk.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A%23%23%23%20Issue%204%0A.github%2Fworkflows%2Fnix.yml%3A20-29%0AThe%20workflow%20says%20it%20validates%20published%20releases%2C%20but%20this%20trigger%20block%20only%20handles%20manual%20runs%20and%20pull%20requests.%20Publishing%20a%20release%20therefore%20does%20not%20build%20its%20tagged%20flake%2C%20allowing%20stale%20version%20metadata%2C%20dependency%20hashes%2C%20or%20submodule%20pins%20to%20reach%20a%20release%20without%20the%20intended%20validation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16132&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Darwin UI Assets Missing** <a href="https://github.com/rustdesk/rustdesk/pull/16132#discussion_r3967732307">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Development Shell Cannot Build** <a href="https://github.com/rustdesk/rustdesk/pull/16132#discussion_r3967732309">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Submodule Pin Can Drift** <a href="https://github.com/rustdesk/rustdesk/pull/16132#discussion_r3967732319">▶</a>
4. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Release Validation Never Runs** <a href="https://github.com/rustdesk/rustdesk/pull/16132#discussion_r3967732325">▶</a>

<details><summary><h3>Summary</h3></summary>

- Exposes default, source, RustDesk, and Linux-only nixpkgs packages and applications.
- Materializes the `hbb_common` submodule through a pinned flake input.
- Adds platform-specific Sciter and native-library setup.
- Adds Nix evaluation/build CI across Linux and Intel/ARM macOS.
- The Darwin runtime packaging and development shell currently have blocking functional gaps.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  F[flake.nix] --> S[Source package]
  F --> N[Linux nixpkgs package]
  F --> D[Development shell]
  S --> H[Pinned hbb_common input]
  S --> L[Linux packaging]
  S --> M[Darwin packaging]
  L --> LA[Binary + Sciter UI assets]
  M --> MA[Binary + Sciter dylib]
  S --> A[Default/source applications]
  N --> NA[nixpkgs application]
  C[GitHub Actions] --> E[Evaluate all systems]
  C --> B[Build native package]
```
</details>

<!-- /greptile_comment -->