### PR TITLE
fastlane: add es-ES Android metadata

### DIFF
--- a/fastlane/metadata/android/es-ES/full_description.txt
+++ b/fastlane/metadata/android/es-ES/full_description.txt
@@ -1,0 +1,11 @@
+Aplicación de escritorio remoto de código abierto, la alternativa open source a TeamViewer.
+Código fuente: https://github.com/rustdesk/rustdesk
+Documentación: https://rustdesk.com/docs/en/manual/mobile/
+
+Para que un dispositivo remoto controle tu Android mediante el ratón o el tacto, debes permitir que RustDesk utilice el servicio de "Accesibilidad". RustDesk utiliza la API AccessibilityService para implementar el control remoto en Android.
+
+Además del control remoto, también puedes transferir archivos fácilmente entre dispositivos Android y ordenadores mediante RustDesk.
+
+Tienes control total de tus datos, sin preocupaciones de seguridad. Puedes utilizar nuestro servidor rendezvous/relay, optar por el autoalojamiento o escribir tu propio servidor rendezvous/relay. El servidor autoalojado es gratuito y de código abierto: https://github.com/rustdesk/rustdesk-server
+
+Descarga e instala la versión de escritorio desde: https://rustdesk.com — entonces podrás acceder y controlar tu ordenador desde tu teléfono, o controlar tu teléfono desde tu ordenador.

--- a/fastlane/metadata/android/es-ES/short_description.txt
+++ b/fastlane/metadata/android/es-ES/short_description.txt
@@ -1,0 +1,1 @@
+Aplicación de acceso remoto de código abierto, alternativa a TeamViewer.


### PR DESCRIPTION
Adds es-ES (Spanish) metadata for Android Fastlane.

Currently, the Android Fastlane metadata includes several languages but is missing Spanish. This PR adds the Spanish translation for the short and full descriptions, following the existing metadata structure.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Spanish app store metadata for RustDesk.
  - Added a Spanish short description highlighting the app as an open-source remote access alternative.
  - Added a Spanish full description covering remote control, file transfer, data control options, and desktop downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds Spanish (Spain) Android store metadata under the existing Fastlane metadata structure.
- Adds localized short and full descriptions.
- Preserves the canonical description’s product claims, technical terminology, and URLs.
- Changes no existing files or runtime paths.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge as a narrowly scoped, additive metadata change with no identified issues.

Both files follow existing locale conventions, preserve the source listing’s meaning, and introduce no changes to existing runtime behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| fastlane/metadata/android/es-ES/full_description.txt | Adds a complete Spanish translation of the Android full description with canonical structure and link parity. |
| fastlane/metadata/android/es-ES/short_description.txt | Adds a Spanish short description that conforms to the existing metadata pattern and length constraint. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fastlane: add es-ES Android metadata"](https://github.com/rustdesk/rustdesk/commit/271386684c668f88f1d5b07515f62ef9e1ee6aa0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62256730)</sub>

<!-- /greptile_comment -->