### PR TITLE
Fix formatting and punctuation in full_description.txt pt-BR

### DIFF
--- a/fastlane/metadata/android/pt-BR/full_description.txt
+++ b/fastlane/metadata/android/pt-BR/full_description.txt
@@ -6,6 +6,6 @@ Para que um dispositivo remoto controle seu Android via mouse ou toque, você pr
 
 Além do controle remoto, você também pode transferir arquivos entre dispositivos Android e PCs com facilidade usando o RustDesk.
 
-Você tem controle total dos seus dados, sem preocupações com segurança. Você pode usar nosso servidor rendezvous/relay, optar pela auto-hospedagem, ou escrever seu próprio servidor rendezvous/relay. O servidor auto-hospedado é gratuito e open source: https://github.com/rustdesk/rustdesk-server
+Você tem controle total dos seus dados, sem preocupações com segurança. Você pode usar nosso servidor rendezvous/relay, optar pela auto-hospedagem ou criar seu próprio servidor de rendezvous/relay. O servidor auto-hospedado é gratuito e open source: https://github.com/rustdesk/rustdesk-server
 
 Baixe e instale a versão desktop em: https://rustdesk.com — então você pode acessar e controlar seu desktop pelo celular, ou controlar seu celular pelo desktop.


### PR DESCRIPTION
Fix formatting and punctuation in full_description.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Portuguese (Brazil) app description to clarify that users can create their own rendezvous/relay server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62424326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only wording change appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Removes an unnecessary comma before “ou”.
- Rephrases the custom-server option and adds the appropriate “de” preposition.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Fix formatting and punctuation in full\_d..."](https://github.com/rustdesk/rustdesk/commit/73b94e60dfeaf96f04293c5c640215c9310fafe1)</sub>

<!-- /greptile_comment -->