### PR TITLE
Update link for pt and Revise full description for Android app pt-BR

### DIFF
--- a/fastlane/metadata/android/pt-BR/full_description.txt
+++ b/fastlane/metadata/android/pt-BR/full_description.txt
@@ -1,11 +1,11 @@
 Aplicativo de desktop remoto de código aberto, a alternativa open source ao TeamViewer.
 Código-fonte: https://github.com/rustdesk/rustdesk
-Documentação: https://rustdesk.com/docs/en/manual/mobile/
+Documentação: https://rustdesk.com/docs/pt/client/android/
 
 Para que um dispositivo remoto controle seu Android via mouse ou toque, você precisa permitir que o RustDesk utilize o serviço de "Acessibilidade". O RustDesk usa a API AccessibilityService para implementar o controle remoto no Android.
 
 Além do controle remoto, você também pode transferir arquivos entre dispositivos Android e PCs com facilidade usando o RustDesk.
 
-Você tem controle total dos seus dados, sem preocupações com segurança. Você pode usar nosso servidor rendezvous/relay, optar pela auto-hospedagem ou criar seu próprio servidor de rendezvous/relay. O servidor auto-hospedado é gratuito e open source: https://github.com/rustdesk/rustdesk-server
+Você tem controle total dos seus dados, sem preocupações com a segurança. Você pode usar nosso servidor rendezvous/relay, optar pela auto-hospedagem ou criar seu próprio servidor de rendezvous/relay. O servidor auto-hospedado é gratuito e open source: https://github.com/rustdesk/rustdesk-server
 
-Baixe e instale a versão desktop em: https://rustdesk.com — então você pode acessar e controlar seu desktop pelo celular, ou controlar seu celular pelo desktop.
+Baixe e instale a versão para desktop em: https://rustdesk.com — então você poderá acessar e controlar seu computador pelo celular ou controlar seu celular pelo computador.


### PR DESCRIPTION
Update link for pt and Revise full description for Android app pt-BR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Brazilian Portuguese Android app description with a localized documentation link.
  * Corrected grammar and refined wording for clarity and natural phrasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62425603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The metadata-only localization update appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Replaces the English mobile documentation link with the Portuguese Android guide.
- Improves Portuguese wording and consistency in the security and desktop-access descriptions.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Revise full description for Android app ..."](https://github.com/rustdesk/rustdesk/commit/ff58d7b626d45dbbf445d9c772c14facfe470121)</sub>

<!-- /greptile_comment -->