### PR TITLE
fix(audio): restart capture when the device is unavailable

### DIFF
--- a/src/server/audio_capture_error.rs
+++ b/src/server/audio_capture_error.rs
@@ -11,7 +11,10 @@ pub(super) struct CaptureErrorHandler {
 
 impl CaptureErrorHandler {
     pub(super) fn handle(&self, error: cpal::StreamError) {
-        if matches!(error, cpal::StreamError::StreamInterrupted { .. }) {
+        if matches!(
+            error,
+            cpal::StreamError::StreamInterrupted { .. } | cpal::StreamError::DeviceNotAvailable
+        ) {
             // ScreenCaptureKit can stop capture while the remote session stays open.
             // The observed -3821 error does not identify its underlying trigger.
             // https://developer.apple.com/documentation/screencapturekit/scstreamdelegate/stream(_:didstopwitherror:)
@@ -48,6 +51,19 @@ mod tests {
         assert!(!errors.needs_restart());
         callback.handle(system_interruption());
         assert!(errors.needs_restart());
+    }
+
+    #[test]
+    fn device_removal_requests_recreation_of_its_stream() {
+        let errors = CaptureErrorHandler::default();
+        let callback = errors.clone();
+        let replacement = CaptureErrorHandler::default();
+        assert!(!errors.needs_restart());
+
+        callback.handle(StreamError::DeviceNotAvailable);
+
+        assert!(errors.needs_restart());
+        assert!(!replacement.needs_restart());
     }
 
     #[test]

--- a/src/server/audio_capture_error.rs
+++ b/src/server/audio_capture_error.rs
@@ -54,19 +54,6 @@ mod tests {
     }
 
     #[test]
-    fn device_removal_requests_recreation_of_its_stream() {
-        let errors = CaptureErrorHandler::default();
-        let callback = errors.clone();
-        let replacement = CaptureErrorHandler::default();
-        assert!(!errors.needs_restart());
-
-        callback.handle(StreamError::DeviceNotAvailable);
-
-        assert!(errors.needs_restart());
-        assert!(!replacement.needs_restart());
-    }
-
-    #[test]
     fn late_error_from_an_old_stream_does_not_restart_its_replacement() {
         let old_callback = CaptureErrorHandler::default();
         let replacement = CaptureErrorHandler::default();


### PR DESCRIPTION
When a CPAL capture stream reports `DeviceNotAvailable`, the error is only traced and the service keeps the failed stream. Request recreation through the existing per-stream flag, as already done for `StreamInterrupted`.

The service thread handles teardown and stream creation through the existing restart path. Other backend errors keep their current handling.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio capture now correctly detects device-unavailable errors as interruptions, improving recovery when an audio device disconnects or becomes unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62479903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The implementation appears safe to merge, with a non-blocking regression-test coverage gap for the newly handled error variant.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fserver%2Faudio_capture_error.rs%3A16%0AThe%20new%20%60DeviceNotAvailable%60%20restart%20branch%20has%20no%20regression%20test%20in%20this%20changeset%3A%20the%20existing%20tests%20exercise%20only%20%60StreamInterrupted%60%20and%20backend-specific%20errors.%20Add%20a%20test%20that%20sends%20%60DeviceNotAvailable%60%2C%20verifies%20that%20recreation%20is%20requested%2C%20and%20confirms%20that%20a%20replacement%20stream%20retains%20independent%20error%20state.%20Without%20this%20coverage%2C%20this%20recovery%20behavior%20could%20regress%20unnoticed.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16142&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Device error lacks coverage** <a href="https://github.com/rustdesk/rustdesk/pull/16142#discussion_r3976292831">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/server/audio_capture_error.rs:16
The new `DeviceNotAvailable` restart branch has no regression test in this changeset: the existing tests exercise only `StreamInterrupted` and backend-specific errors. Add a test that sends `DeviceNotAvailable`, verifies that recreation is requested, and confirms that a replacement stream retains independent error state. Without this coverage, this recovery behavior could regress unnoticed.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Preserves current handling for other backend errors.
- Reuses per-stream state so late errors from an obsolete stream cannot affect its replacement.
- The new error variant is not covered by a committed regression test.
</details>

<sub>Reviews (1) · Last reviewed commit: ["refact: remove low-value test"](https://github.com/rustdesk/rustdesk/commit/663cc44ed6b301ec6a1db56f7b21ccab59b67361)</sub>

<!-- /greptile_comment -->