### PR TITLE
chore(deps): bump quinn-proto, bytes, crossbeam-epoch for RUSTSEC-2026 fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,9 +985,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde 1.0.228",
 ]
@@ -1791,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -6496,9 +6496,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",


### PR DESCRIPTION
Cargo.lock-only security bumps, all within existing version requirements:

- **quinn-proto 0.11.13 → 0.11.15** — closes two advisories in the QUIC transport layer (quinn reaches rustdesk through reqwest's HTTP/3 support):
  - RUSTSEC-2026-0037 / CVE-2026-31812 / GHSA-6xvm-j4wr-6v98 — denial of service in Quinn endpoints
  - RUSTSEC-2026-0185 / CVE-2026-25800 / GHSA-4w2j-m93h-cj5j — remote memory exhaustion via unbounded out-of-order stream reassembly
- **bytes 1.10.1 → 1.11.1** — RUSTSEC-2026-0007 / CVE-2026-25541 / GHSA-434x-w66g-qw3r (memory-corruption)
- **crossbeam-epoch 0.9.18 → 0.9.20** — RUSTSEC-2026-0204 (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`)

Deliberately left out (flagging for awareness):

- `time 0.3.36` is in RUSTSEC-2026-0009 range, but the fix (0.3.47) pulls a wider companion cascade (time-core 0.1.8, time-macros 0.2.27, deranged 0.5.x) — better done by your own `cargo update -p time`.
- `git2 0.16.1` (RUSTSEC-2026-0008, patched ≥ 0.20.4) has no patched release in its line; fixing it needs a version-requirement bump of the depending crate, not a lock edit.

Cargo.lock-only. Each new version's dependency list was verified identical to the pinned version against crates.io metadata, so every entry is a pure version+checksum swap; all bumps stay within existing version requirements (no manifest changes). Dep references in parent entries were updated for multi-version crates. Lock structure validated (TOML parse + full reference integrity across all package entries).
