### PR TITLE
feat(input): prioritize physical mouse input on Windows

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -99,6 +99,7 @@ use winreg::{enums::*, RegKey};
 mod acl;
 mod installer_handoff;
 mod installer_shell;
+pub(crate) mod local_input;
 mod msi_registry;
 pub(crate) use acl::current_process_user_sid_string;
 pub use acl::{

--- a/src/platform/windows/local_input.rs
+++ b/src/platform/windows/local_input.rs
@@ -1,0 +1,392 @@
+use hbb_common::{anyhow::anyhow, ResultType};
+use std::{
+    io::Error,
+    mem::size_of,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering},
+        mpsc, OnceLock,
+    },
+    thread::{self, JoinHandle},
+    time::Instant,
+};
+use winapi::{
+    ctypes::c_int,
+    shared::{
+        minwindef::{FALSE, HMODULE, LPARAM, LRESULT, WPARAM},
+        ntdef::NULL,
+    },
+    um::{
+        libloaderapi::{
+            GetModuleHandleExA, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        },
+        winuser::{
+            CallNextHookEx, GetMessageA, PostThreadMessageA, SendInput, SetWindowsHookExA,
+            UnhookWindowsHookEx, HC_ACTION, INPUT, INPUT_MOUSE, LLMHF_INJECTED, MOUSEEVENTF_LEFTUP,
+            MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_XUP, MOUSEINPUT, MSG,
+            MSLLHOOKSTRUCT, WH_MOUSE_LL, WM_QUIT, XBUTTON1, XBUTTON2,
+        },
+    },
+};
+
+use crate::input::{
+    MOUSE_BUTTON_BACK, MOUSE_BUTTON_FORWARD, MOUSE_BUTTON_LEFT, MOUSE_BUTTON_RIGHT,
+    MOUSE_BUTTON_WHEEL, MOUSE_TYPE_DOWN, MOUSE_TYPE_UP,
+};
+
+const LOCAL_MOUSE_PRIORITY_TIMEOUT_MS: u64 = 600;
+
+static LAST_LOCAL_MOUSE_ACTIVITY: AtomicU64 = AtomicU64::new(0);
+static REMOTE_BUTTONS_DOWN: AtomicU8 = AtomicU8::new(0);
+static OBSERVER_RUNNING: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum RemoteMouseAction {
+    Allow,
+    Suppress,
+}
+
+pub(crate) struct LocalMouseObserver {
+    thread_id: u32,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Drop for LocalMouseObserver {
+    fn drop(&mut self) {
+        let posted = unsafe { PostThreadMessageA(self.thread_id, WM_QUIT, 0, 0) };
+        if posted == FALSE {
+            log::error!(
+                "Failed to stop local mouse observer, error: {}",
+                Error::last_os_error()
+            );
+            return;
+        }
+        if let Some(thread) = self.thread.take() {
+            if let Err(err) = thread.join() {
+                log::error!("Failed to join local mouse observer: {:?}", err);
+            }
+        }
+    }
+}
+
+pub(crate) fn start_local_mouse_observer() -> ResultType<LocalMouseObserver> {
+    if OBSERVER_RUNNING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return Err(anyhow!("local mouse observer is already running"));
+    }
+
+    let (tx, rx) = mpsc::sync_channel(1);
+    let thread = match thread::Builder::new()
+        .name("local-mouse-observer".to_owned())
+        .spawn(move || run_observer(tx))
+    {
+        Ok(thread) => thread,
+        Err(err) => {
+            OBSERVER_RUNNING.store(false, Ordering::Release);
+            return Err(err.into());
+        }
+    };
+
+    match rx.recv() {
+        Ok(Ok(thread_id)) => Ok(LocalMouseObserver {
+            thread_id,
+            thread: Some(thread),
+        }),
+        Ok(Err(err)) => {
+            thread.join().ok();
+            Err(anyhow!(err))
+        }
+        Err(err) => {
+            thread.join().ok();
+            Err(err.into())
+        }
+    }
+}
+
+fn run_observer(tx: mpsc::SyncSender<Result<u32, String>>) {
+    let mut module = std::ptr::null_mut() as HMODULE;
+    let got_module = unsafe {
+        GetModuleHandleExA(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            local_mouse_hook as _,
+            &mut module,
+        )
+    };
+    if got_module == FALSE {
+        OBSERVER_RUNNING.store(false, Ordering::Release);
+        tx.send(Err(format!(
+            "GetModuleHandleExA failed for local mouse observer: {}",
+            Error::last_os_error()
+        )))
+        .ok();
+        return;
+    }
+
+    let hook = unsafe { SetWindowsHookExA(WH_MOUSE_LL, Some(local_mouse_hook), module, 0) };
+    if hook.is_null() {
+        OBSERVER_RUNNING.store(false, Ordering::Release);
+        tx.send(Err(format!(
+            "SetWindowsHookExA(WH_MOUSE_LL) failed: {}",
+            Error::last_os_error()
+        )))
+        .ok();
+        return;
+    }
+
+    let thread_id = unsafe { winapi::um::processthreadsapi::GetCurrentThreadId() };
+    if tx.send(Ok(thread_id)).is_err() {
+        unsafe {
+            UnhookWindowsHookEx(hook);
+        }
+        OBSERVER_RUNNING.store(false, Ordering::Release);
+        return;
+    }
+
+    let mut msg = unsafe { std::mem::zeroed::<MSG>() };
+    unsafe {
+        while GetMessageA(&mut msg, NULL as _, 0, 0) > 0 {}
+        if UnhookWindowsHookEx(hook) == FALSE {
+            log::error!(
+                "Failed to unhook local mouse observer, error: {}",
+                Error::last_os_error()
+            );
+        }
+    }
+    OBSERVER_RUNNING.store(false, Ordering::Release);
+}
+
+extern "system" fn local_mouse_hook(code: c_int, w_param: WPARAM, l_param: LPARAM) -> LRESULT {
+    if code == HC_ACTION {
+        let event = unsafe { &*(l_param as *const MSLLHOOKSTRUCT) };
+        if is_local_physical_mouse_event(event.flags, event.dwExtraInfo) {
+            note_local_mouse_activity();
+        }
+    }
+    unsafe { CallNextHookEx(std::ptr::null_mut(), code, w_param, l_param) }
+}
+
+#[inline]
+fn monotonic_millis() -> u64 {
+    static START: OnceLock<Instant> = OnceLock::new();
+    START
+        .get_or_init(Instant::now)
+        .elapsed()
+        .as_millis()
+        .saturating_add(1) as u64
+}
+
+#[inline]
+fn is_local_physical_mouse_event(flags: u32, extra_info: usize) -> bool {
+    // LLMHF_INJECTED also covers lower-integrity injected input. Keep RustDesk's marker as a
+    // second guard so its own SendInput events can never refresh the priority window.
+    flags & LLMHF_INJECTED == 0 && extra_info != enigo::ENIGO_INPUT_EXTRA_VALUE
+}
+
+#[inline]
+fn local_mouse_has_priority_at(last_activity: u64, now: u64, timeout_ms: u64) -> bool {
+    last_activity != 0 && now.wrapping_sub(last_activity) < timeout_ms
+}
+
+fn note_local_mouse_activity() {
+    let buttons_to_release = note_local_mouse_activity_at(
+        monotonic_millis(),
+        &LAST_LOCAL_MOUSE_ACTIVITY,
+        &REMOTE_BUTTONS_DOWN,
+    );
+    if buttons_to_release != 0 {
+        // Release before the physical event leaves the hook so local movement cannot continue a
+        // drag that a remote peer started.
+        release_remote_buttons(buttons_to_release);
+    }
+}
+
+fn note_local_mouse_activity_at(
+    now: u64,
+    last_activity: &AtomicU64,
+    remote_buttons_down: &AtomicU8,
+) -> u8 {
+    last_activity.store(now, Ordering::Relaxed);
+    remote_buttons_down.swap(0, Ordering::AcqRel)
+}
+
+fn release_remote_buttons(buttons: u8) {
+    unsafe {
+        if buttons & MOUSE_BUTTON_LEFT as u8 != 0 {
+            send_mouse_button_up(MOUSEEVENTF_LEFTUP, 0);
+        }
+        if buttons & MOUSE_BUTTON_RIGHT as u8 != 0 {
+            send_mouse_button_up(MOUSEEVENTF_RIGHTUP, 0);
+        }
+        if buttons & MOUSE_BUTTON_WHEEL as u8 != 0 {
+            send_mouse_button_up(MOUSEEVENTF_MIDDLEUP, 0);
+        }
+        if buttons & MOUSE_BUTTON_BACK as u8 != 0 {
+            send_mouse_button_up(MOUSEEVENTF_XUP, XBUTTON1 as u32);
+        }
+        if buttons & MOUSE_BUTTON_FORWARD as u8 != 0 {
+            send_mouse_button_up(MOUSEEVENTF_XUP, XBUTTON2 as u32);
+        }
+    }
+}
+
+unsafe fn send_mouse_button_up(flags: u32, data: u32) {
+    let mut input = std::mem::zeroed::<INPUT>();
+    input.type_ = INPUT_MOUSE;
+    *input.u.mi_mut() = MOUSEINPUT {
+        dx: 0,
+        dy: 0,
+        mouseData: data,
+        dwFlags: flags,
+        time: 0,
+        dwExtraInfo: enigo::ENIGO_INPUT_EXTRA_VALUE,
+    };
+    if SendInput(1, &mut input, size_of::<INPUT>() as c_int) == 0 {
+        log::error!(
+            "Failed to release remote mouse button during local takeover, error: {}",
+            Error::last_os_error()
+        );
+    }
+}
+
+#[inline]
+pub(crate) fn arbitrate_remote_mouse() -> RemoteMouseAction {
+    arbitrate_remote_mouse_at(local_mouse_has_priority())
+}
+
+fn local_mouse_has_priority() -> bool {
+    local_mouse_has_priority_at(
+        LAST_LOCAL_MOUSE_ACTIVITY.load(Ordering::Relaxed),
+        monotonic_millis(),
+        LOCAL_MOUSE_PRIORITY_TIMEOUT_MS,
+    )
+}
+
+pub(crate) fn record_remote_mouse_injected(evt_type: i32, buttons: i32) {
+    let buttons_to_release = record_remote_mouse_injected_with(
+        evt_type,
+        buttons,
+        local_mouse_has_priority,
+        &REMOTE_BUTTONS_DOWN,
+    );
+    if buttons_to_release != 0 {
+        release_remote_buttons(buttons_to_release);
+    }
+}
+
+fn record_remote_mouse_injected_with<F: FnOnce() -> bool>(
+    evt_type: i32,
+    buttons: i32,
+    local_has_priority: F,
+    remote_buttons_down: &AtomicU8,
+) -> u8 {
+    let buttons = buttons as u8;
+    if evt_type == MOUSE_TYPE_DOWN {
+        remote_buttons_down.fetch_or(buttons, Ordering::AcqRel);
+        if local_has_priority() {
+            return remote_buttons_down.swap(0, Ordering::AcqRel);
+        }
+    } else if evt_type == MOUSE_TYPE_UP {
+        remote_buttons_down.fetch_and(!buttons, Ordering::AcqRel);
+    }
+    0
+}
+
+fn arbitrate_remote_mouse_at(local_has_priority: bool) -> RemoteMouseAction {
+    if local_has_priority {
+        RemoteMouseAction::Suppress
+    } else {
+        RemoteMouseAction::Allow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::{MOUSE_BUTTON_LEFT, MOUSE_BUTTON_RIGHT};
+
+    #[test]
+    fn local_priority_window_and_refresh_are_deterministic() {
+        assert!(!local_mouse_has_priority_at(0, 100, 600));
+        assert!(local_mouse_has_priority_at(100, 699, 600));
+        assert!(!local_mouse_has_priority_at(100, 700, 600));
+        assert!(local_mouse_has_priority_at(500, 1_099, 600));
+        assert!(!local_mouse_has_priority_at(500, 1_100, 600));
+    }
+
+    #[test]
+    fn only_hardware_events_count_as_local_activity() {
+        assert!(is_local_physical_mouse_event(0, 0));
+        assert!(!is_local_physical_mouse_event(
+            LLMHF_INJECTED,
+            enigo::ENIGO_INPUT_EXTRA_VALUE
+        ));
+        assert!(!is_local_physical_mouse_event(LLMHF_INJECTED, 0));
+    }
+
+    #[test]
+    fn remote_input_is_allowed_without_local_activity() {
+        assert_eq!(arbitrate_remote_mouse_at(false), RemoteMouseAction::Allow);
+    }
+
+    #[test]
+    fn local_takeover_suppresses_motion_wheel_and_new_down() {
+        assert_eq!(arbitrate_remote_mouse_at(true), RemoteMouseAction::Suppress);
+    }
+
+    #[test]
+    fn local_takeover_releases_all_remote_buttons() {
+        let buttons = AtomicU8::new(0);
+        assert_eq!(
+            record_remote_mouse_injected_with(
+                MOUSE_TYPE_DOWN,
+                MOUSE_BUTTON_LEFT,
+                || false,
+                &buttons,
+            ),
+            0
+        );
+        assert_eq!(
+            record_remote_mouse_injected_with(
+                MOUSE_TYPE_DOWN,
+                MOUSE_BUTTON_RIGHT,
+                || false,
+                &buttons,
+            ),
+            0
+        );
+        let last_activity = AtomicU64::new(0);
+        assert_eq!(
+            note_local_mouse_activity_at(100, &last_activity, &buttons),
+            (MOUSE_BUTTON_LEFT | MOUSE_BUTTON_RIGHT) as u8
+        );
+        assert_eq!(last_activity.load(Ordering::Relaxed), 100);
+        assert_eq!(buttons.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            record_remote_mouse_injected_with(MOUSE_TYPE_UP, MOUSE_BUTTON_LEFT, || true, &buttons),
+            0
+        );
+    }
+
+    #[test]
+    fn down_racing_with_local_takeover_is_immediately_released() {
+        let buttons = AtomicU8::new(0);
+        assert_eq!(
+            record_remote_mouse_injected_with(
+                MOUSE_TYPE_DOWN,
+                MOUSE_BUTTON_LEFT,
+                || true,
+                &buttons,
+            ),
+            MOUSE_BUTTON_LEFT as u8
+        );
+        assert_eq!(buttons.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn priority_is_global_across_remote_peers() {
+        assert_eq!(arbitrate_remote_mouse_at(true), RemoteMouseAction::Suppress);
+        assert_eq!(arbitrate_remote_mouse_at(true), RemoteMouseAction::Suppress);
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -601,6 +601,15 @@ pub async fn start_server(is_server: bool, no_server: bool) {
     });
 
     if is_server {
+        #[cfg(windows)]
+        let _local_mouse_observer =
+            match crate::platform::windows::local_input::start_local_mouse_observer() {
+                Ok(observer) => Some(observer),
+                Err(err) => {
+                    log::warn!("Local mouse priority is unavailable: {}", err);
+                    None
+                }
+            };
         crate::common::set_server_running(true);
         std::thread::spawn(move || {
             if let Err(err) = crate::ipc::start("") {

--- a/src/server/input_service.rs
+++ b/src/server/input_service.rs
@@ -1115,6 +1115,14 @@ pub fn handle_mouse_simulation_(evt: &MouseEvent, conn: i32) {
     }
 
     #[cfg(windows)]
+    match crate::platform::windows::local_input::arbitrate_remote_mouse() {
+        crate::platform::windows::local_input::RemoteMouseAction::Allow => {}
+        crate::platform::windows::local_input::RemoteMouseAction::Suppress => {
+            return;
+        }
+    }
+
+    #[cfg(windows)]
     crate::platform::windows::try_change_desktop();
     let buttons = evt.mask >> 3;
     let evt_type = evt.mask & MOUSE_TYPE_MASK;
@@ -1281,6 +1289,8 @@ pub fn handle_mouse_simulation_(evt: &MouseEvent, conn: i32) {
         }
         _ => {}
     }
+    #[cfg(windows)]
+    crate::platform::windows::local_input::record_remote_mouse_injected(evt_type, buttons);
     #[cfg(not(target_os = "macos"))]
     for key in to_release {
         en.key_up(key.clone());

--- a/src/server/portable_service.rs
+++ b/src/server/portable_service.rs
@@ -447,6 +447,14 @@ pub mod server {
     }
 
     pub fn run_portable_service() {
+        let _local_mouse_observer =
+            match crate::platform::windows::local_input::start_local_mouse_observer() {
+                Ok(observer) => Some(observer),
+                Err(err) => {
+                    log::warn!("Local mouse priority is unavailable: {}", err);
+                    None
+                }
+            };
         let shmem_name = match portable_service_shmem_name_from_args() {
             Some(name) => name,
             None => {


### PR DESCRIPTION
Closes #40.

## Problem

When a remote peer continues moving the controlled Windows computer's mouse, physical movement at that computer can fight with the injected movement. The person physically present should temporarily own mouse control.

## Implementation

Add a Windows-only, event-driven `WH_MOUSE_LL` observer in the process that performs input injection. This covers both direct injection and the portable-service process.

Physical activity records a monotonic atomic timestamp. Remote mouse events are suppressed for 600 ms after the latest physical event, with expiry evaluated lazily on incoming remote events.

The old cursor-position comparison was not restored because it relied on polling, mutexes, and sleeps in the mouse input path and was unreliable for fast movement and on macOS.

Events are considered physical only when `LLMHF_INJECTED` is clear and `dwExtraInfo` does not contain `ENIGO_INPUT_EXTRA_VALUE`. RustDesk's own `SendInput` events therefore cannot recursively activate local priority.

## Button safety

Accepted remote button-down state is tracked for left, right, middle, back, and forward buttons. Physical takeover atomically clears and releases held remote buttons. A post-injection check also handles a down event racing with takeover, preventing stuck buttons and continuing remote drags.

## Properties

- No cursor polling
- No sleeps in the remote input path
- O(1) atomic arbitration
- No protocol changes
- All remote peers share the same physical-priority state
- Observer initialization failure fails open
- Keyboard, permissions, clipboard, and Privacy Mode behavior are unchanged

## Tests

Automated tests cover timeout boundaries, refresh, normal input, injected-event filtering, takeover suppression, held-button release, the injection/takeover race, and process-global multi-peer arbitration.

## Scope and limitations

Windows only. macOS, Linux, and the separate pointer/touch scale path are unchanged. Input marked by Windows as injected by third-party software is not treated as physical input.

Manual two-machine, installed-service, elevated-desktop, multi-monitor, Privacy Mode, and repeated-takeover testing remains to be completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows local mouse activity detection for remote-control sessions.
  * Remote mouse movement, scrolling, and new button presses are temporarily suppressed while local activity is detected.
  * Held remote mouse buttons are released when local input takes priority.
  * Local input monitoring starts automatically for server and portable service sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62514492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because physical-priority arbitration stops working when remote injection moves to a different Windows input desktop.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fplatform%2Fwindows%2Flocal_input.rs%3A127%0AWhen%20Windows%20switches%20to%20another%20input%20desktop%2C%20such%20as%20an%20elevated%20or%20secure%20desktop%2C%20this%20process-lifetime%20hook%20remains%20on%20its%20initial%20desktop%20while%20the%20remote-input%20thread%20switches%20to%20the%20current%20one.%20Physical%20mouse%20events%20on%20the%20new%20desktop%20are%20therefore%20not%20recorded%2C%20so%20remote%20input%20is%20not%20suppressed%20and%20can%20continue%20fighting%20the%20local%20user.%0A%0A%23%23%23%20Issue%202%0Asrc%2Fplatform%2Fwindows%2Flocal_input.rs%3A285-288%0AThis%20records%20every%20button%20bit%20in%20a%20down%20event%2C%20but%20the%20injection%20path%20accepts%20only%20one%20recognized%20button%20at%20a%20time.%20A%20combined%20or%20unsupported%20mask%20records%20buttons%20that%20were%20never%20injected%3B%20the%20next%20physical%20takeover%20then%20sends%20synthetic%20button-up%20events%20for%20them%2C%20which%20can%20release%20a%20button%20the%20local%20user%20is%20holding.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16147&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Hook stays on old desktop** <a href="https://github.com/rustdesk/rustdesk/pull/16147#discussion_r3977367015">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Bookkeeping records uninjected buttons** <a href="https://github.com/rustdesk/rustdesk/pull/16147#discussion_r3977367025">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/platform/windows/local_input.rs:127
When Windows switches to another input desktop, such as an elevated or secure desktop, this process-lifetime hook remains on its initial desktop while the remote-input thread switches to the current one. Physical mouse events on the new desktop are therefore not recorded, so remote input is not suppressed and can continue fighting the local user.

### Issue 2
src/platform/windows/local_input.rs:285-288
This records every button bit in a down event, but the injection path accepts only one recognized button at a time. A combined or unsupported mask records buttons that were never injected; the next physical takeover then sends synthetic button-up events for them, which can release a button the local user is holding.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Introduces a `WH_MOUSE_LL` observer and a 600 ms local-priority window.
- Suppresses remote mouse events while physical input has priority.
- Tracks and releases remotely held mouse buttons during takeover.
- Starts the observer in both the normal server and portable-service processes.
- Changes the existing Windows input path through thin arbitration and post-injection bookkeeping hooks.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Local as Physical mouse
    participant Hook as WH_MOUSE_LL observer<br/>startup desktop
    participant Input as Remote input thread<br/>current input desktop
    participant OS as Windows input

    Local->>Hook: Physical mouse event
    Hook->>Hook: Record activity and clear held buttons
    Hook->>OS: Release tracked remote buttons
    Input->>Input: Check local-priority timestamp
    alt Local priority active
        Input-->>Input: Suppress remote event
    else Priority inactive
        Input->>Input: Switch to current input desktop
        Input->>OS: Inject remote event
        Input->>Input: Record injected button state
    end
    Note over Hook,Input: The hook is not recreated when the input desktop changes
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat(input): prioritize physical mouse i..."](https://github.com/rustdesk/rustdesk/commit/6fe705f1f66d2e5d4af37bf470c7311d5ce3938b)</sub>

<!-- /greptile_comment -->