### PR TITLE
feat: add opt-in ASIO audio host on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "asio-sys"
+version = "0.2.2"
+source = "git+https://github.com/rustdesk-org/cpal?branch=osx-screencapturekit#69ad2578adc9200093fc81cdfbdad63dbc4274f9"
+dependencies = [
+ "bindgen 0.69.4",
+ "cc",
+ "num-derive 0.4.2",
+ "num-traits 0.2.19",
+ "parse_cfg",
+ "walkdir",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,12 +782,15 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
+ "log",
+ "prettyplease",
  "proc-macro2 1.0.93",
  "quote 1.0.36",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.98",
+ "which",
 ]
 
 [[package]]
@@ -1720,6 +1736,7 @@ version = "0.15.3"
 source = "git+https://github.com/rustdesk-org/cpal?branch=osx-screencapturekit#69ad2578adc9200093fc81cdfbdad63dbc4274f9"
 dependencies = [
  "alsa",
+ "asio-sys",
  "cidre",
  "core-foundation-sys 0.8.7",
  "coreaudio-rs",
@@ -1730,6 +1747,7 @@ dependencies = [
  "mach2",
  "ndk 0.8.0",
  "ndk-context",
+ "num-traits 0.2.19",
  "oboe",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5921,6 +5939,15 @@ dependencies = [
  "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "parse_cfg"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905787a434a2c721408e7c9a252e85f3d93ca0f118a5283022636c0e05a7ea49"
+dependencies = [
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ unix-file-copy-paste = [
     "clipboard/unix-file-copy-paste",
 ]
 screencapturekit = ["cpal/screencapturekit"]
+# Enables CPAL's ASIO backend on Windows. It is opt-in because ASIO requires
+# the Steinberg SDK and a compatible driver at build/runtime.
+asio = ["cpal/asio"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ Please download Sciter dynamic library yourself.
 
 ## [Build](https://rustdesk.com/docs/en/dev/build/)
 
+### ASIO audio on Windows
+
+Windows builds can opt into CPAL's ASIO host with `--asio`:
+
+```sh
+python3 build.py --flutter --asio
+```
+
+The resulting build keeps WASAPI as the default. On a machine with an ASIO
+driver installed, select `ASIO` under the desktop audio settings; the audio
+service and remote playback will then use the selected host. The ASIO SDK and
+LLVM/Clang build prerequisites are documented in the CPAL README.
+
 ## How to Build on Linux
 
 ### Ubuntu 18 (Debian 10)
@@ -179,4 +192,3 @@ Please ensure that you run these commands from the root of the RustDesk reposito
 ![File Transfer](https://github.com/rustdesk/rustdesk/assets/28412477/39511ad3-aa9a-4f8c-8947-1cce286a46ad)
 
 ![TCP Tunneling](https://github.com/rustdesk/rustdesk/assets/28412477/78e8708f-e87e-4570-8373-1360033ea6c5)
-

--- a/build.py
+++ b/build.py
@@ -139,6 +139,12 @@ def make_parser():
         action='store_true',
         help='Build with unix file copy paste feature'
     )
+    if windows:
+        parser.add_argument(
+            '--asio',
+            action='store_true',
+            help='Enable ASIO audio host support (Windows only)',
+        )
     parser.add_argument(
         '--drm',
         action='store_true',
@@ -322,6 +328,8 @@ def get_features(args):
         features.append('flutter')
     if args.unix_file_copy_paste:
         features.append('unix-file-copy-paste')
+    if windows and args.asio:
+        features.append('asio')
     if args.drm:
         # Say so rather than quietly handing back a stock build: the backend is Linux-only, so on
         # any other host the flag cannot be honoured and the resulting binary would look like a

--- a/flutter/lib/common/widgets/audio_input.dart
+++ b/flutter/lib/common/widgets/audio_input.dart
@@ -21,7 +21,17 @@ class AudioInput extends StatelessWidget {
       : super(key: key);
 
   static String getDefault() {
-    if (bind.mainAudioSupportLoopback()) return translate(_kSystemSound);
+    if (bind.mainAudioSupportLoopback()) {
+      return translate(_kSystemSound);
+    }
+    return '';
+  }
+
+  static Future<String> getDefaultForHost() async {
+    final audioHost = await bind.mainGetOption(key: 'audio-host');
+    if (bind.mainAudioSupportLoopback() && audioHost.isEmpty) {
+      return getDefault();
+    }
     return '';
   }
 
@@ -38,13 +48,18 @@ class AudioInput extends StatelessWidget {
     if (device.isNotEmpty) {
       return device;
     } else {
-      return getDefault();
+      return getDefaultForHost();
     }
   }
 
   static Future<void> setDevice(
       String device, bool isCm, bool isVoiceCall) async {
-    if (device == getDefault()) device = '';
+    if (device == await getDefaultForHost()) {
+      device = '';
+      if (!isVoiceCall) {
+        await bind.mainSetOption(key: 'audio-host', value: '');
+      }
+    }
     if (isVoiceCall) {
       await bind.setVoiceCallInputDevice(isCm: isCm, device: device);
     } else {
@@ -55,7 +70,8 @@ class AudioInput extends StatelessWidget {
   static Future<Map<String, Object>> getDevicesInfo(
       bool isCm, bool isVoiceCall) async {
     List<String> devices = (await bind.mainGetSoundInputs()).toList();
-    if (bind.mainAudioSupportLoopback()) {
+    final audioHost = await bind.mainGetOption(key: 'audio-host');
+    if (bind.mainAudioSupportLoopback() && audioHost.isEmpty) {
       devices.insert(0, translate(_kSystemSound));
     }
     String current = await getValue(isCm, isVoiceCall);
@@ -75,6 +91,38 @@ class AudioInput extends StatelessWidget {
         return builder(devices, currentDevice, (devices) {
           setDevice(devices, isCm, isVoiceCall);
         });
+      },
+    );
+  }
+}
+
+class AudioHost extends StatelessWidget {
+  final Widget Function(List<String> hosts, String currentHost,
+      Future<void> Function(String) setHost) builder;
+
+  const AudioHost({Key? key, required this.builder}) : super(key: key);
+
+  static Future<Map<String, Object>> getHostsInfo() async {
+    final hosts = (await bind.mainGetAudioHosts()).toList();
+    final configured = await bind.mainGetOption(key: 'audio-host');
+    final current = configured.isEmpty ? 'wasapi' : configured;
+    return {'hosts': hosts, 'current': current};
+  }
+
+  static Future<void> setAudioHost(String host) async {
+    await bind.mainSetOption(
+        key: 'audio-host', value: host == 'wasapi' ? '' : host);
+    await bind.mainSetOption(key: 'audio-input', value: '');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return futureBuilder(
+      future: getHostsInfo(),
+      hasData: (data) {
+        final hosts = data['hosts'] as List<String>;
+        if (hosts.length < 2) return const Offstage();
+        return builder(hosts, data['current'] as String, setAudioHost);
       },
     );
   }

--- a/flutter/lib/common/widgets/audio_input.dart
+++ b/flutter/lib/common/widgets/audio_input.dart
@@ -28,11 +28,17 @@ class AudioInput extends StatelessWidget {
   }
 
   static Future<String> getDefaultForHost() async {
-    final audioHost = await bind.mainGetOption(key: 'audio-host');
+    final audioHost = await getEffectiveHost();
     if (bind.mainAudioSupportLoopback() && audioHost.isEmpty) {
       return getDefault();
     }
     return '';
+  }
+
+  static Future<String> getEffectiveHost() async {
+    final configured = await bind.mainGetOption(key: 'audio-host');
+    final hosts = (await bind.mainGetAudioHosts()).toList();
+    return configured.isNotEmpty && hosts.contains(configured) ? configured : '';
   }
 
   static Future<String> getAudioInput(bool isCm, bool isVoiceCall) {
@@ -70,7 +76,7 @@ class AudioInput extends StatelessWidget {
   static Future<Map<String, Object>> getDevicesInfo(
       bool isCm, bool isVoiceCall) async {
     List<String> devices = (await bind.mainGetSoundInputs()).toList();
-    final audioHost = await bind.mainGetOption(key: 'audio-host');
+    final audioHost = await getEffectiveHost();
     if (bind.mainAudioSupportLoopback() && audioHost.isEmpty) {
       devices.insert(0, translate(_kSystemSound));
     }
@@ -105,7 +111,7 @@ class AudioHost extends StatelessWidget {
   static Future<Map<String, Object>> getHostsInfo() async {
     final hosts = (await bind.mainGetAudioHosts()).toList();
     final configured = await bind.mainGetOption(key: 'audio-host');
-    final current = configured.isEmpty ? 'wasapi' : configured;
+    final current = hosts.contains(configured) ? configured : 'wasapi';
     return {'hosts': hosts, 'current': current};
   }
 

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -416,6 +416,7 @@ class _GeneralState extends State<_General> {
         theme(),
         _Card(title: 'Language', children: [language()]),
         if (!isWeb) hwcodec(),
+        if (!isWeb) audioHost(context),
         if (!isWeb) audio(context),
         if (!isWeb) record(context),
         if (!isWeb) WaylandCard(),
@@ -757,6 +758,23 @@ class _GeneralState extends State<_General> {
     }
 
     return AudioInput(builder: builder, isCm: false, isVoiceCall: false);
+  }
+
+  Widget audioHost(BuildContext context) {
+    builder(hosts, currentHost, setHost) {
+      final child = ComboBox(
+        keys: hosts,
+        values: hosts.map((host) => host.toUpperCase()).toList(),
+        initialKey: currentHost,
+        onChanged: (key) async {
+          await setHost(key);
+          setState(() {});
+        },
+      ).marginOnly(left: _kContentHMargin);
+      return _Card(title: 'Audio Host', children: [child]);
+    }
+
+    return AudioHost(builder: builder);
   }
 
   Widget record(BuildContext context) {

--- a/flutter/lib/desktop/pages/desktop_setting_page.dart
+++ b/flutter/lib/desktop/pages/desktop_setting_page.dart
@@ -771,7 +771,7 @@ class _GeneralState extends State<_General> {
           setState(() {});
         },
       ).marginOnly(left: _kContentHMargin);
-      return _Card(title: 'Audio Host', children: [child]);
+      return _Card(title: translate('Audio host'), children: [child]);
     }
 
     return AudioHost(builder: builder);

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use clipboard_master::CallbackResult;
 #[cfg(not(target_os = "linux"))]
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    Device, Host, StreamConfig,
+    Device, StreamConfig,
 };
 use crossbeam_queue::ArrayQueue;
 use magnum_opus::{Channels::*, Decoder as AudioDecoder};
@@ -149,11 +149,6 @@ struct ClipboardState {
     #[cfg(all(feature = "flutter", feature = "unix-file-copy-paste"))]
     is_file_required: bool,
     running: bool,
-}
-
-#[cfg(not(target_os = "linux"))]
-lazy_static::lazy_static! {
-    static ref AUDIO_HOST: Host = cpal::default_host();
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -2218,7 +2213,8 @@ impl AudioHandler {
     /// Start the audio playback.
     #[cfg(not(target_os = "linux"))]
     fn start_audio(&mut self, format0: AudioFormat) -> ResultType<()> {
-        let device = AUDIO_HOST
+        let host = crate::audio_service::get_audio_host();
+        let device = host
             .default_output_device()
             .with_context(|| "Failed to get default output device")?;
         log::info!(

--- a/src/common.rs
+++ b/src/common.rs
@@ -322,7 +322,7 @@ pub fn get_default_sound_input() -> Option<String> {
     #[cfg(not(target_os = "linux"))]
     {
         use cpal::traits::{DeviceTrait, HostTrait};
-        let host = cpal::default_host();
+        let host = crate::audio_service::get_audio_host();
         let dev = host.default_input_device();
         return if let Some(dev) = dev {
             match dev.name() {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -938,6 +938,10 @@ pub fn main_get_sound_inputs() -> Vec<String> {
     vec![String::from("")]
 }
 
+pub fn main_get_audio_hosts() -> Vec<String> {
+    crate::audio_service::get_audio_hosts()
+}
+
 pub fn main_get_login_device_info() -> SyncReturn<String> {
     SyncReturn(get_login_device_info_json())
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -738,6 +738,7 @@ pub struct CheckIfRestart {
     stop_service: String,
     rendezvous_servers: Vec<String>,
     audio_input: String,
+    audio_host: String,
     voice_call_input: String,
     ws: String,
     disable_udp: String,
@@ -751,6 +752,7 @@ impl CheckIfRestart {
             stop_service: Config::get_option("stop-service"),
             rendezvous_servers: Config::get_rendezvous_servers(),
             audio_input: Config::get_option("audio-input"),
+            audio_host: Config::get_option("audio-host"),
             voice_call_input: Config::get_option("voice-call-input"),
             ws: Config::get_option(OPTION_ALLOW_WEBSOCKET),
             disable_udp: Config::get_option(keys::OPTION_DISABLE_UDP),
@@ -780,7 +782,9 @@ impl Drop for CheckIfRestart {
             }
             RendezvousMediator::restart();
         }
-        if self.audio_input != Config::get_option("audio-input") {
+        if self.audio_input != Config::get_option("audio-input")
+            || self.audio_host != Config::get_option("audio-host")
+        {
             crate::audio_service::restart();
         }
         if self.voice_call_input != Config::get_option("voice-call-input") {

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "انتهى طلب مشاركة الشاشة على الجهاز البعيد دون أن يكتمل"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "تعذّر على RustDesk الحصول على شاشة قابلة للاستخدام من XDG Desktop Portal، قد تكون مكتبة PipeWire قديمة جدًا"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "تعذّر على RustDesk تحميل مكوّن GStreamer اللازم لالتقاط الشاشة ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/az.rs
+++ b/src/lang/az.rs
@@ -770,5 +770,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("port-forward-mux-tip", "Port yönləndirmə xəritələnməsinin hər əlaqəsini qarşı tərəfə açılan tək əlaqə üzərindən daşıyır, hər biri üçün yenidən qoşulub giriş etmək əvəzinə."),
         ("Enable WebRTC P2P connection", "WebRTC P2P əlaqəsini aktivləşdir"),
         ("Enable TCP hole punching", "TCP deşik açmanı aktivləşdir"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Запыт на абагульванне экрана на аддаленай прыладзе завяршыўся, не будучы выкананым"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk не змог атрымаць прыдатны экран ад XDG Desktop Portal, магчыма бібліятэка PipeWire занадта старая"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не змог загрузіць кампанент GStreamer, патрэбны для захопу экрана ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Заявката за споделяне на екрана на отдалеченото устройство приключи, без да бъде изпълнена"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk не можа да получи използваем екран от XDG Desktop Portal, библиотеката PipeWire може да е твърде стара"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не можа да зареди компонент на GStreamer, необходим за заснемане на екрана ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "La sol·licitud de compartició de pantalla al dispositiu remot ha acabat sense completar-se"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "El RustDesk no ha pogut obtenir cap pantalla utilitzable de l'XDG Desktop Portal; la biblioteca PipeWire pot ser massa antiga"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "El RustDesk no ha pogut carregar un component del GStreamer necessari per capturar la pantalla ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "远程设备上的屏幕共享请求已结束，但未完成"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk 无法从 XDG Desktop Portal 获取可用的屏幕，PipeWire 库可能过旧"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk 无法加载屏幕捕获所需的 GStreamer 组件 ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Žádost o sdílení obrazovky na vzdáleném zařízení skončila, aniž by byla dokončena"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nezískal z XDG Desktop Portal použitelnou obrazovku, knihovna PipeWire může být příliš stará"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nemohl načíst komponentu GStreameru potřebnou k zachycení obrazovky ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Anmodningen om skærmdeling på fjernenheden sluttede uden at blive gennemført"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk kunne ikke få en brugbar skærm fra XDG Desktop Portal, PipeWire-biblioteket er måske for gammelt"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kunne ikke indlæse en GStreamer-komponent, der kræves til skærmoptagelse ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Die Anfrage zur Bildschirmfreigabe auf dem entfernten Gerät endete, ohne abgeschlossen zu werden"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk konnte vom XDG Desktop Portal keinen nutzbaren Bildschirm erhalten, die PipeWire-Bibliothek ist möglicherweise zu alt"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk konnte eine für die Bildschirmaufnahme benötigte GStreamer-Komponente nicht laden ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Το αίτημα κοινής χρήσης οθόνης στην απομακρυσμένη συσκευή έληξε χωρίς να ολοκληρωθεί"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "Το RustDesk δεν μπόρεσε να λάβει αξιοποιήσιμη οθόνη από το XDG Desktop Portal, η βιβλιοθήκη PipeWire ίσως είναι πολύ παλιά"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "Το RustDesk δεν μπόρεσε να φορτώσει ένα στοιχείο του GStreamer που απαιτείται για την καταγραφή οθόνης ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/en.rs
+++ b/src/lang/en.rs
@@ -278,5 +278,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("sync-clipboard-between-sessions-tip", "Text or images copied in one remote session are also sent to the clipboard of your other connected sessions."),
         ("terminal-clipboard-write-tip", "An app in the terminal wants to copy text to this device's clipboard. If granted, this permission applies to terminal apps in all connections until you turn it off in Settings. Manual copy and paste are unaffected."),
         ("port-forward-mux-tip", "Carry every connection of a port-forward mapping over a single connection to the peer, instead of connecting and logging in again for each one."),
+        ("Audio host", "Audio host"),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "La peto pri ekrandividado sur la fora aparato finiĝis sen kompletiĝi"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk ne povis akiri uzeblan ekranon de XDG Desktop Portal, la biblioteko PipeWire eble estas tro malnova"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ne povis ŝargi komponanton de GStreamer necesan por ekrankapto ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "La solicitud de compartir pantalla en el dispositivo remoto terminó sin completarse"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk no ha podido obtener una pantalla utilizable del XDG Desktop Portal; la biblioteca PipeWire puede ser demasiado antigua"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk no ha podido cargar un componente de GStreamer necesario para capturar la pantalla ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Ekraani jagamise taotlus kaugseadmes lõppes ilma lõpule jõudmata"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk ei saanud XDG Desktop Portalilt kasutatavat ekraani, PipeWire'i teek võib olla liiga vana"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ei suutnud laadida ekraani jäädvustamiseks vajalikku GStreameri komponenti ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Urruneko gailuko pantaila partekatzeko eskaera osatu gabe amaitu da"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk-ek ezin izan du pantaila erabilgarririk lortu XDG Desktop Portal-etik, PipeWire liburutegia zaharregia izan daiteke"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk-ek ezin izan du pantaila kapturatzeko beharrezkoa den GStreamer osagai bat kargatu ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "درخواست اشتراک‌گذاری صفحه در دستگاه راه دور بدون تکمیل شدن پایان یافت"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk نتوانست صفحه‌ای قابل استفاده از XDG Desktop Portal دریافت کند، ممکن است کتابخانه PipeWire خیلی قدیمی باشد"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk نتوانست مؤلفه GStreamer موردنیاز برای ضبط صفحه را بارگذاری کند ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Näytön jakamispyyntö etälaitteessa päättyi ilman että se saatiin valmiiksi"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk ei saanut XDG Desktop Portalilta käyttökelpoista näyttöä, PipeWire-kirjasto voi olla liian vanha"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ei voinut ladata näytön kaappaukseen tarvittavaa GStreamer-osaa ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "La demande de partage d'écran sur l'appareil distant s'est terminée sans aboutir"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk n'a pas pu obtenir d'écran exploitable auprès du XDG Desktop Portal, la bibliothèque PipeWire est peut-être trop ancienne"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk n'a pas pu charger un composant GStreamer nécessaire à la capture d'écran ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "ეკრანის გაზიარების მოთხოვნა დისტანციურ მოწყობილობაზე დასრულდა შეუსრულებლად"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk-მა ვერ მიიღო გამოსადეგი ეკრანი XDG Desktop Portal-იდან, PipeWire-ის ბიბლიოთეკა შესაძლოა ძალიან ძველია"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk-მა ვერ ჩატვირთა ეკრანის ჩაწერისთვის საჭირო GStreamer-ის კომპონენტი ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gl.rs
+++ b/src/lang/gl.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "A solicitude de compartir pantalla no dispositivo remoto rematou sen completarse"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk non puido obter unha pantalla utilizable do XDG Desktop Portal, a biblioteca PipeWire pode ser demasiado antiga"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk non puido cargar un compoñente de GStreamer necesario para capturar a pantalla ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "રિમોટ ઉપકરણ પર સ્ક્રીન શેરિંગ વિનંતી પૂર્ણ થયા વિના સમાપ્ત થઈ"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk XDG Desktop Portal પાસેથી ઉપયોગી સ્ક્રીન મેળવી શક્યું નથી, PipeWire લાઇબ્રેરી કદાચ ઘણી જૂની છે"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk સ્ક્રીન કૅપ્ચર માટે જરૂરી GStreamer ઘટક લોડ કરી શક્યું નથી ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "בקשת שיתוף המסך במכשיר המרוחק הסתיימה מבלי להתבצע"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk לא הצליח לקבל מסך שמיש מ-XDG Desktop Portal, ייתכן שספריית PipeWire ישנה מדי"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk לא הצליח לטעון רכיב GStreamer הדרוש ללכידת מסך ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "रिमोट डिवाइस पर स्क्रीन शेयरिंग अनुरोध पूरा हुए बिना समाप्त हो गया"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk XDG Desktop Portal से उपयोग योग्य स्क्रीन प्राप्त नहीं कर सका, PipeWire लाइब्रेरी बहुत पुरानी हो सकती है"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk स्क्रीन कैप्चर के लिए आवश्यक GStreamer घटक लोड नहीं कर सका ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Zahtjev za dijeljenje zaslona na udaljenom uređaju završio je bez dovršetka"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nije mogao dobiti upotrebljiv zaslon od XDG Desktop Portala, PipeWire biblioteka je možda prestara"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nije mogao učitati GStreamer komponentu potrebnu za snimanje zaslona ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "A képernyőmegosztási kérés a távoli eszközön befejeződött anélkül, hogy teljesült volna"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "A RustDesk nem kapott használható képernyőt az XDG Desktop Portaltól, a PipeWire programkönyvtár túl régi lehet"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "A RustDesk nem tudta betölteni a képernyőrögzítéshez szükséges GStreamer összetevőt ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Permintaan berbagi layar di perangkat jarak jauh berakhir tanpa diselesaikan"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk tidak mendapatkan layar yang dapat digunakan dari XDG Desktop Portal, pustaka PipeWire mungkin terlalu lama"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk tidak dapat memuat komponen GStreamer yang diperlukan untuk merekam layar ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", ""),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", ""),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", ""),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "リモート端末での画面共有の要求は完了しないまま終了しました"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk は XDG Desktop Portal から使用可能な画面を取得できませんでした。PipeWire ライブラリが古すぎる可能性があります"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk は画面キャプチャに必要な GStreamer コンポーネントを読み込めませんでした ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "원격 장치의 화면 공유 요청이 완료되지 않은 채 종료되었습니다"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk가 XDG Desktop Portal에서 사용 가능한 화면을 가져오지 못했습니다. PipeWire 라이브러리가 너무 오래되었을 수 있습니다"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk가 화면 캡처에 필요한 GStreamer 구성 요소를 불러오지 못했습니다 ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Қашықтағы құрылғыдағы экранды бөлісу сұрауы аяқталмай тоқтады"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk XDG Desktop Portal-дан жарамды экран ала алмады, PipeWire кітапханасы тым ескі болуы мүмкін"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk экранды түсіру үшін қажет GStreamer компонентін жүктей алмады ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Ekrano bendrinimo užklausa nuotoliniame įrenginyje baigėsi jos neužbaigus"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk negavo tinkamo ekrano iš XDG Desktop Portal, PipeWire biblioteka gali būti per sena"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nepavyko įkelti ekrano įrašymui reikalingo GStreamer komponento ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Ekrāna koplietošanas pieprasījums attālinātajā ierīcē beidzās, netiekot pabeigts"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk neieguva izmantojamu ekrānu no XDG Desktop Portal, PipeWire bibliotēka var būt pārāk veca"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nevarēja ielādēt ekrāna tveršanai nepieciešamo GStreamer komponentu ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "വിദൂര ഉപകരണത്തിലെ സ്ക്രീൻ പങ്കിടൽ അഭ്യർത്ഥന പൂർത്തിയാകാതെ അവസാനിച്ചു"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "XDG Desktop Portal-ൽ നിന്ന് ഉപയോഗയോഗ്യമായ സ്ക്രീൻ RustDesk-ന് ലഭിച്ചില്ല, PipeWire ലൈബ്രറി വളരെ പഴയതാകാം"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "സ്ക്രീൻ പകർത്താൻ ആവശ്യമായ GStreamer ഘടകം RustDesk-ന് ലോഡ് ചെയ്യാനായില്ല ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Forespørselen om skjermdeling på den eksterne enheten ble avsluttet uten å bli fullført"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk fikk ingen brukbar skjerm fra XDG Desktop Portal, PipeWire-biblioteket kan være for gammelt"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kunne ikke laste en GStreamer-komponent som kreves for skjermopptak ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Het verzoek om schermdeling op het externe apparaat is geëindigd zonder te zijn voltooid"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk kon geen bruikbaar scherm verkrijgen van de XDG Desktop Portal, de PipeWire-bibliotheek is mogelijk te oud"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kon een GStreamer-component die nodig is voor schermopname niet laden ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Żądanie udostępnienia ekranu na urządzeniu zdalnym zakończyło się bez ukończenia"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nie uzyskał użytecznego ekranu z XDG Desktop Portal, biblioteka PipeWire może być zbyt stara"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nie mógł załadować składnika GStreamer wymaganego do przechwytywania ekranu ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "O pedido de partilha de ecrã no dispositivo remoto terminou sem ser concluído"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "O RustDesk não conseguiu obter um ecrã utilizável do XDG Desktop Portal, a biblioteca PipeWire pode ser demasiado antiga"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "O RustDesk não conseguiu carregar um componente do GStreamer necessário para capturar o ecrã ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "A solicitação de compartilhamento de tela no dispositivo remoto terminou sem ser concluída"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "O RustDesk não conseguiu obter uma tela utilizável do XDG Desktop Portal, a biblioteca PipeWire pode ser muito antiga"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "O RustDesk não conseguiu carregar um componente do GStreamer necessário para capturar a tela ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Cererea de partajare a ecranului pe dispozitivul de la distanță s-a încheiat fără a fi finalizată"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nu a putut obține un ecran utilizabil de la XDG Desktop Portal, biblioteca PipeWire poate fi prea veche"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nu a putut încărca o componentă GStreamer necesară pentru capturarea ecranului ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Запрос на демонстрацию экрана на удалённом устройстве завершился, не будучи выполненным"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk не смог получить пригодный экран от XDG Desktop Portal, библиотека PipeWire может быть слишком старой"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не удалось загрузить компонент GStreamer, необходимый для захвата экрана ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Sa rechesta de cumpartzidura de sa schermada in su dispositivu remotu est acabada chene si cumpletare"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk no at pòdidu otènnere una schermada impreabile dae XDG Desktop Portal, sa libreria PipeWire podet èssere tropu betza"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk no at pòdidu carrigare unu cumponente de GStreamer netzessàriu pro registrare sa schermada ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Žiadosť o zdieľanie obrazovky na vzdialenom zariadení sa skončila bez dokončenia"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nezískal z XDG Desktop Portal použiteľnú obrazovku, knižnica PipeWire môže byť príliš stará"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nedokázal načítať komponent GStreamera potrebný na zachytenie obrazovky ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Zahteva za skupno rabo zaslona na oddaljeni napravi se je končala, ne da bi bila dokončana"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk od XDG Desktop Portala ni dobil uporabnega zaslona, knjižnica PipeWire je morda prestara"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ni mogel naložiti komponente GStreamer, potrebne za zajem zaslona ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Kërkesa për ndarjen e ekranit në pajisjen e largët përfundoi pa u kryer"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nuk mori një ekran të përdorshëm nga XDG Desktop Portal, biblioteka PipeWire mund të jetë shumë e vjetër"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nuk mundi të ngarkojë një komponent të GStreamer të nevojshëm për regjistrimin e ekranit ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Zahtev za deljenje ekrana na udaljenom uređaju završio se bez dovršetka"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk nije mogao da dobije upotrebljiv ekran od XDG Desktop Portala, PipeWire biblioteka je možda prestara"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nije mogao da učita GStreamer komponentu potrebnu za snimanje ekrana ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Begäran om skärmdelning på fjärrenheten avslutades utan att slutföras"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk fick ingen användbar skärm från XDG Desktop Portal, PipeWire-biblioteket kan vara för gammalt"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kunde inte läsa in en GStreamer-komponent som krävs för skärminspelning ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "தொலைநிலை சாதனத்தில் திரை பகிர்வு கோரிக்கை நிறைவடையாமல் முடிந்தது"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "XDG Desktop Portal-லிருந்து பயன்படுத்தக்கூடிய திரையை RustDesk பெற முடியவில்லை, PipeWire நூலகம் மிகவும் பழையதாக இருக்கலாம்"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "திரைப் பதிவுக்குத் தேவையான GStreamer கூறை RustDesk ஏற்ற முடியவில்லை ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", ""),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", ""),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", ""),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "คำขอแชร์หน้าจอบนอุปกรณ์ระยะไกลสิ้นสุดลงโดยไม่เสร็จสมบูรณ์"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk ไม่สามารถรับหน้าจอที่ใช้งานได้จาก XDG Desktop Portal ไลบรารี PipeWire อาจเก่าเกินไป"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ไม่สามารถโหลดส่วนประกอบ GStreamer ที่จำเป็นสำหรับการบันทึกหน้าจอได้ ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Uzak cihazdaki ekran paylaşımı isteği tamamlanmadan sona erdi"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk, XDG Desktop Portal'dan kullanılabilir bir ekran alamadı, PipeWire kitaplığı çok eski olabilir"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ekran yakalama için gereken GStreamer bileşenini yükleyemedi ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "遠端裝置上的螢幕分享要求已結束，但未完成"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk 無法從 XDG Desktop Portal 取得可用的螢幕，PipeWire 函式庫可能過舊"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk 無法載入螢幕擷取所需的 GStreamer 元件 ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Запит на демонстрацію екрана на віддаленому пристрої завершився, не будучи виконаним"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk не зміг отримати придатний екран від XDG Desktop Portal, бібліотека PipeWire може бути застарою"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не вдалося завантажити компонент GStreamer, потрібний для захоплення екрана ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ur.rs
+++ b/src/lang/ur.rs
@@ -778,6 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "ریموٹ ڈیوائس پر اسکرین شیئرنگ کی درخواست مکمل ہوئے بغیر ختم ہو گئی"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk کو XDG Desktop Portal سے قابلِ استعمال اسکرین نہیں مل سکی، PipeWire لائبریری شاید بہت پرانی ہے"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk اسکرین ریکارڈنگ کے لیے درکار GStreamer جزو لوڈ نہیں کر سکا ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }
-

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -778,5 +778,6 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("The screen sharing request ended without completing on the remote device", "Yêu cầu chia sẻ màn hình trên thiết bị từ xa đã kết thúc mà chưa hoàn tất"),
         ("RustDesk could not obtain a usable screen from the XDG Desktop Portal, the PipeWire library may be too old", "RustDesk không lấy được màn hình dùng được từ XDG Desktop Portal, thư viện PipeWire có thể quá cũ"),
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk không thể tải một thành phần GStreamer cần cho việc ghi màn hình ({})"),
+        ("Audio host", ""),
     ].iter().cloned().collect();
 }

--- a/src/server/audio_service.rs
+++ b/src/server/audio_service.rs
@@ -26,6 +26,41 @@ lazy_static::lazy_static! {
     static ref VOICE_CALL_INPUT_DEVICE: Arc::<Mutex::<Option<String>>> = Default::default();
 }
 
+/// Return the configured audio host. WASAPI remains the default on Windows;
+/// ASIO is used only when RustDesk was built with the `asio` feature and the
+/// user explicitly selected it.
+#[cfg(not(target_os = "linux"))]
+pub fn get_audio_host() -> cpal::Host {
+    #[cfg(all(target_os = "windows", feature = "asio"))]
+    if Config::get_option("audio-host").eq_ignore_ascii_case("asio") {
+        match cpal::host_from_id(cpal::HostId::Asio) {
+            Ok(host) => {
+                log::info!("Using ASIO audio host");
+                return host;
+            }
+            Err(err) => {
+                log::warn!("Failed to initialise ASIO audio host, falling back to WASAPI: {err}");
+            }
+        }
+    }
+    cpal::default_host()
+}
+
+/// Hosts that can be selected by the desktop audio settings.
+pub fn get_audio_hosts() -> Vec<String> {
+    #[cfg(target_os = "windows")]
+    {
+        let mut hosts = vec!["wasapi".to_owned()];
+        #[cfg(feature = "asio")]
+        if cpal::available_hosts().contains(&cpal::HostId::Asio) {
+            hosts.push("asio".to_owned());
+        }
+        return hosts;
+    }
+    #[cfg(not(target_os = "windows"))]
+    Vec::new()
+}
+
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn new() -> GenericService {
     let svc = EmptyExtraFieldService::new(NAME.to_owned(), true);
@@ -186,7 +221,6 @@ mod cpal_impl {
     };
 
     lazy_static::lazy_static! {
-        static ref HOST: Host = cpal::default_host();
         static ref INPUT_BUFFER: Arc<Mutex<std::collections::VecDeque<f32>>> = Default::default();
     }
 
@@ -282,12 +316,13 @@ mod cpal_impl {
 
     #[cfg(feature = "screencapturekit")]
     fn get_device() -> ResultType<(Device, SupportedStreamConfig)> {
+        let host = super::get_audio_host();
         let audio_input = super::get_audio_input();
         if !audio_input.is_empty() {
-            return get_audio_input(&audio_input);
+            return get_audio_input(&host, &audio_input);
         }
         if !is_screen_capture_kit_available() {
-            return get_audio_input("");
+            return get_audio_input(&host, "");
         }
         let device = HOST_SCREEN_CAPTURE_KIT
             .as_ref()?
@@ -303,11 +338,12 @@ mod cpal_impl {
 
     #[cfg(windows)]
     fn get_device() -> ResultType<(Device, SupportedStreamConfig)> {
+        let host = super::get_audio_host();
         let audio_input = super::get_audio_input();
         if !audio_input.is_empty() {
-            return get_audio_input(&audio_input);
+            return get_audio_input(&host, &audio_input);
         }
-        let device = HOST
+        let device = host
             .default_output_device()
             .with_context(|| "Failed to get default output device for loopback")?;
         log::info!(
@@ -324,11 +360,15 @@ mod cpal_impl {
 
     #[cfg(not(any(windows, feature = "screencapturekit")))]
     fn get_device() -> ResultType<(Device, SupportedStreamConfig)> {
+        let host = super::get_audio_host();
         let audio_input = super::get_audio_input();
-        get_audio_input(&audio_input)
+        get_audio_input(&host, &audio_input)
     }
 
-    fn get_audio_input(audio_input: &str) -> ResultType<(Device, SupportedStreamConfig)> {
+    fn get_audio_input(
+        host: &Host,
+        audio_input: &str,
+    ) -> ResultType<(Device, SupportedStreamConfig)> {
         let mut device = None;
         #[cfg(feature = "screencapturekit")]
         if !audio_input.is_empty() && is_screen_capture_kit_available() {
@@ -344,7 +384,7 @@ mod cpal_impl {
             }
         }
         if device.is_none() && !audio_input.is_empty() {
-            for d in HOST
+            for d in host
                 .devices()
                 .with_context(|| "Failed to get audio devices")?
             {
@@ -355,7 +395,7 @@ mod cpal_impl {
             }
         }
         let device = device.unwrap_or(
-            HOST.default_input_device()
+            host.default_input_device()
                 .with_context(|| "Failed to get default input device for loopback")?,
         );
         log::info!("Input device: {}", device.name().unwrap_or("".to_owned()));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -334,6 +334,10 @@ impl UI {
         Value::from_iter(get_sound_inputs())
     }
 
+    fn get_audio_hosts(&self) -> Value {
+        Value::from_iter(crate::audio_service::get_audio_hosts())
+    }
+
     fn set_options(&self, v: Value) {
         let mut m = HashMap::new();
         for (k, v) in v.items() {
@@ -785,6 +789,7 @@ impl sciter::EventHandler for UI {
         fn get_license();
         fn test_if_valid_server(String, bool);
         fn get_sound_inputs();
+        fn get_audio_hosts();
         fn set_options(Value);
         fn set_option(String, String);
         fn get_software_update_url();
@@ -835,7 +840,7 @@ impl sciter::host::HostHandler for UIHostHandler {
 fn get_sound_inputs() -> Vec<String> {
     let mut out = Vec::new();
     use cpal::traits::{DeviceTrait, HostTrait};
-    let host = cpal::default_host();
+    let host = crate::audio_service::get_audio_host();
     if let Ok(devices) = host.devices() {
         for device in devices {
             if device.default_input_config().is_err() {

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -152,6 +152,11 @@ var myIdMenu;
 var audioInputMenu;
 var audioHostMenu;
 
+function audio_host_is_asio() {
+    var hosts = handler.get_audio_hosts();
+    return hosts.length > 1 && handler.get_option("audio-host") == "asio";
+}
+
 class AudioHosts: Reactor.Component {
     function this() {
         audioHostMenu = this;
@@ -162,7 +167,7 @@ class AudioHosts: Reactor.Component {
         if (hosts.length < 2) return <li style="display:hidden" />;
         var me = this;
         self.timer(1ms, function() { me.toggleMenuState() });
-        return <li>{translate('Audio Host')}
+        return <li>{translate('Audio host')}
             <menu #audio-host key={hosts.length}>
                 {hosts.map(function(name) {
                 var label = name == "asio" ? "ASIO" : "WASAPI";
@@ -200,7 +205,7 @@ class AudioInputs: Reactor.Component {
     function render() {
         if (!this.show) return <li />;
         var inputs = handler.get_sound_inputs();
-        if (is_win && handler.get_option("audio-host") != "asio") {
+        if (is_win && !audio_host_is_asio()) {
             inputs = ["System Sound"].concat(inputs);
         }
         if (!inputs.length) return <li style="display:hidden" />;
@@ -218,7 +223,7 @@ class AudioInputs: Reactor.Component {
     }
 
     function get_default() {
-        if (is_win && handler.get_option("audio-host") != "asio") return "System Sound";
+        if (is_win && !audio_host_is_asio()) return "System Sound";
         return "";
     }
 

--- a/src/ui/index.tis
+++ b/src/ui/index.tis
@@ -150,6 +150,48 @@ class DirectServer: Reactor.Component {
 
 var myIdMenu;
 var audioInputMenu;
+var audioHostMenu;
+
+class AudioHosts: Reactor.Component {
+    function this() {
+        audioHostMenu = this;
+    }
+
+    function render() {
+        var hosts = handler.get_audio_hosts();
+        if (hosts.length < 2) return <li style="display:hidden" />;
+        var me = this;
+        self.timer(1ms, function() { me.toggleMenuState() });
+        return <li>{translate('Audio Host')}
+            <menu #audio-host key={hosts.length}>
+                {hosts.map(function(name) {
+                var label = name == "asio" ? "ASIO" : "WASAPI";
+                return <li id={name}><span>{svg_checkmark}</span>{label}</li>;
+                })}
+            </menu>
+        </li>;
+    }
+
+    function get_value() {
+        return handler.get_option("audio-host") || "wasapi";
+    }
+
+    function toggleMenuState() {
+        var v = this.get_value();
+        for (var el in this.$$(menu#audio-host>li)) {
+            el.attributes.toggleClass("selected", el.id == v);
+        }
+    }
+
+    event click $(menu#audio-host>li) (_, me) {
+        if (me.id == this.get_value()) return;
+        handler.set_option("audio-host", me.id == "wasapi" ? "" : me.id);
+        handler.set_option("audio-input", "");
+        this.toggleMenuState();
+        if (audioInputMenu) audioInputMenu.update({ show: true });
+    }
+};
+
 class AudioInputs: Reactor.Component {
     function this() {
         audioInputMenu = this;
@@ -158,7 +200,9 @@ class AudioInputs: Reactor.Component {
     function render() {
         if (!this.show) return <li />;
         var inputs = handler.get_sound_inputs();
-        if (is_win) inputs = ["System Sound"].concat(inputs);
+        if (is_win && handler.get_option("audio-host") != "asio") {
+            inputs = ["System Sound"].concat(inputs);
+        }
         if (!inputs.length) return <li style="display:hidden" />;
         var me = this;
         self.timer(1ms, function() { me.toggleMenuState() });
@@ -174,7 +218,7 @@ class AudioInputs: Reactor.Component {
     }
 
     function get_default() {
-        if (is_win) return "System Sound";
+        if (is_win && handler.get_option("audio-host") != "asio") return "System Sound";
         return "";
     }
 
@@ -205,7 +249,10 @@ class AudioInputs: Reactor.Component {
             handler.set_option(v, handler.get_option(v) != 'N' ? 'N' : default_option_yes);
         } else {
           if (v == this.get_value()) return;
-          if (v == this.get_default()) v = "";
+          if (v == this.get_default()) {
+            handler.set_option("audio-host", "");
+            v = "";
+          }
           handler.set_option("audio-input", v);
         }
         this.toggleMenuState();
@@ -523,6 +570,7 @@ class MyIdMenu: Reactor.Component {
                 {!disable_settings && is_win ? <li #enable-block-input><span>{svg_checkmark}</span>{translate('Enable blocking user input')}</li> : ""}
                 {!disable_settings && (handler.get_supported_privacy_mode_impls() != '[]') && <li #enable-privacy-mode><span>{svg_checkmark}</span>{translate('Enable privacy mode')}</li>}
                 {!disable_settings && <li #enable-lan-discovery><span>{svg_checkmark}</span>{translate('Enable LAN discovery')}</li>}
+                <AudioHosts />
                 <AudioInputs />
                 <Enhancements />
                 {!disable_settings && <li #allow-remote-config-modification><span>{svg_checkmark}</span>{translate('Enable remote configuration modification')}</li>}
@@ -557,6 +605,7 @@ class MyIdMenu: Reactor.Component {
     }
 
     function showSettingMenu() {
+        if (audioHostMenu) audioHostMenu.update({ show: true });
         audioInputMenu.update({ show: true });
         this.toggleMenuState();
         if (direct_server) direct_server.update();
@@ -1408,6 +1457,7 @@ function showSettings() {
     // show immediately at button, then update menu state asynchronously
     anchor.popup(menu);
     self.timer(1ms, function() {
+        if (audioHostMenu) audioHostMenu.update({ show: true });
         audioInputMenu.update({ show: true });
         myIdMenu.toggleMenuState();
         if (direct_server) direct_server.update();

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -370,7 +370,7 @@ pub fn get_sound_inputs() -> Vec<String> {
             use cpal::traits::{DeviceTrait, HostTrait};
             // Do not use `cpal::host_from_id(cpal::HostId::ScreenCaptureKit)` for feature = "screencapturekit"
             // Because we explicitly handle the "System Sound" device.
-            let host = cpal::default_host();
+            let host = crate::audio_service::get_audio_host();
             if let Ok(devices) = host.devices() {
                 for device in devices {
                     if device.default_input_config().is_err() {
@@ -409,6 +409,11 @@ pub fn get_sound_inputs() -> Vec<String> {
 }
 
 #[inline]
+pub fn get_audio_hosts() -> Vec<String> {
+    crate::audio_service::get_audio_hosts()
+}
+
+#[inline]
 pub fn set_options(m: HashMap<String, String>) {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     {
@@ -444,7 +449,7 @@ pub fn set_option(key: String, value: String) {
                 return;
             }
         }
-    } else if &key == "audio-input" {
+    } else if &key == "audio-input" || &key == "audio-host" {
         #[cfg(not(target_os = "ios"))]
         crate::audio_service::restart();
     }


### PR DESCRIPTION
## Summary

Addresses #3762 by adding opt-in ASIO host support to RustDesk on Windows.

- Adds a root `asio` feature wired to the existing RustDesk CPAL fork.
- Adds `python3 build.py --flutter --asio` for Windows builds.
- Keeps WASAPI as the default when ASIO is not selected.
- Adds an Audio Host selector to the Flutter desktop settings and Sciter settings.
- Uses the selected host for capture, playback, device enumeration, and audio-service restart.
- Keeps System Sound/WASAPI loopback behavior unchanged by default.
- Documents the ASIO SDK and LLVM/Clang prerequisites.

## Validation

- `git diff --check` passed.
- `python3 -m py_compile build.py` passed.
- `cargo metadata --locked --format-version 1 --features asio` passed.
- CPAL helper crate: `cargo check --locked --features asio` passed on macOS.
- RustDesk `cargo check --locked --lib --features asio` reached the changed CPAL/audio code, then stopped because this macOS environment lacks pre-existing native libraries `libyuv` and `opus`.
- A Windows cross-check reached the ASIO C++ build but could not finish because this environment lacks the MinGW C++ compiler and ASIO SDK setup.

The change is deliberately opt-in so existing Windows builds and users remain on WASAPI unless they explicitly build with ASIO and select it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows audio host selection with WASAPI and optional ASIO support.
  * Added an Audio Host setting to desktop audio preferences.
  * Added an opt-in ASIO build option for Windows.
  * Audio service now refreshes automatically when the audio host or input device changes.
  * Invalid or unavailable audio host selections now fall back to WASAPI.

* **Documentation**
  * Added Windows ASIO setup, build, and prerequisite information to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62535785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because capture fails for ASIO devices exposing more than eight channels, and the explicit repository requirements also need to be satisfied.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Flang%2Fen.rs%3A281%0AThis%20adds%20an%20English%20mapping%20whose%20value%20is%20identical%20to%20its%20sentence-case%20key.%20The%20localization%20directive%20says%20these%20keys%20should%20rely%20on%20the%20normal%20key%20fallback%20and%20must%20be%20added%20to%20%60en.rs%60%20only%20when%20the%20displayed%20English%20text%20differs.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A%23%23%23%20Issue%202%0AREADME.md%3A194%0AThis%20removes%20only%20the%20trailing%20blank%20line%20from%20%60README.md%60.%20The%20repository%20directive%20prohibits%20formatting-only%20edits%20and%20requires%20the%20diff%20to%20remain%20limited%20to%20changes%20needed%20for%20the%20feature.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A%23%23%23%20Issue%203%0Asrc%2Fui%2Findex.tis%3Aundefined-165%0AThe%20new%20user-facing%20key%20%60Audio%20Host%60%20violates%20the%20repository%20localization%20directive%3A%20new%20English-text%20keys%20must%20use%20sentence%20case%20%28%60Audio%20host%60%29%20and%20be%20appended%20to%20every%20%60src%2Flang%2F*.rs%60%20file.%20The%20same%20unregistered%20Title%20Case%20text%20is%20used%20by%20the%20Flutter%20settings%2C%20leaving%20the%20label%20untranslated%20and%20making%20future%20localization%20inconsistent.%20This%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16149&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Redundant English mapping** <a href="https://github.com/rustdesk/rustdesk/pull/16149#discussion_r3978292716">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Unrelated formatting change** <a href="https://github.com/rustdesk/rustdesk/pull/16149#discussion_r3978292734">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Audio Host bypasses localization** <a href="https://github.com/rustdesk/rustdesk/pull/16149#discussion_r3977961948">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/lang/en.rs:281
This adds an English mapping whose value is identical to its sentence-case key. The localization directive says these keys should rely on the normal key fallback and must be added to `en.rs` only when the displayed English text differs. This repository requirement must be satisfied before merging.

```suggestion

```

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 2
README.md:194
This removes only the trailing blank line from `README.md`. The repository directive prohibits formatting-only edits and requires the diff to remain limited to changes needed for the feature. This repository requirement must be satisfied before merging.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 3
src/ui/index.tis:undefined-165
The new user-facing key `Audio Host` violates the repository localization directive: new English-text keys must use sentence case (`Audio host`) and be appended to every `src/lang/*.rs` file. The same unregistered Title Case text is used by the Flutter settings, leaving the label untranslated and making future localization inconsistent. This repository requirement must be satisfied before merging.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds the ASIO Cargo/build feature and Windows audio-host selection.
- Routes capture, playback, and device enumeration through the selected host.
- Adds fixed-frame resampling and asynchronous capture encoding.
- Corrects stale persisted-host fallback and registers the sentence-case localization key.
- One capture defect remains for devices exposing more than eight channels, along with two repository-rule violations.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  S[Audio host setting] --> H[CPAL host selection]
  H --> D[Capture device and format]
  D --> F[Fixed-frame capture]
  F --> R[Resample]
  R --> C[Rechannel to mono or stereo]
  C --> Q[PCM queue]
  Q --> E[Opus encoder]
  E --> P[Remote audio packets]
  P --> O[Remote host output stream]
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/rustdesk/rustdesk/commit/14b1462769c9a7e6cca7c56c9c15d055d745ba09)</sub>

<!-- /greptile_comment -->