### PR TITLE
fix(downloader): keep delayed cleanup alive after download

### DIFF
--- a/src/hbbs_http/downloader.rs
+++ b/src/hbbs_http/downloader.rs
@@ -18,6 +18,14 @@ lazy_static! {
     static ref DOWNLOADERS: Mutex<HashMap<String, Downloader>> = Default::default();
 }
 
+fn schedule_auto_delete(id: String, dur: Duration) {
+    // Keep the cleanup alive after do_download's temporary Tokio runtime is dropped.
+    std::thread::spawn(move || {
+        std::thread::sleep(dur);
+        DOWNLOADERS.lock().unwrap().remove(&id);
+    });
+}
+
 /// This struct is used to return the download data to the caller.
 /// The caller should check if the file is downloaded successfully and remove the job from the map.
 /// If the file is not downloaded successfully, the `data` field will be empty.
@@ -260,12 +268,8 @@ async fn do_download(
         downloader.finished = true;
     }
     if is_all_downloaded {
-        let id_del = id.to_string();
         if let Some(dur) = auto_del_dur {
-            tokio::spawn(async move {
-                tokio::time::sleep(dur).await;
-                DOWNLOADERS.lock().unwrap().remove(&id_del);
-            });
+            schedule_auto_delete(id.to_string(), dur);
         }
     }
     Ok(is_all_downloaded)
@@ -306,4 +310,50 @@ pub fn cancel(id: &str) {
 
 pub fn remove(id: &str) {
     let _ = DOWNLOADERS.lock().unwrap().remove(id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{schedule_auto_delete, Downloader, DOWNLOADERS};
+    use hbb_common::tokio::{runtime::Builder, sync::mpsc::unbounded_channel};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn auto_delete_outlives_download_runtime() {
+        let id = format!(
+            "auto-delete-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let (tx_cancel, _) = unbounded_channel();
+        DOWNLOADERS.lock().unwrap().insert(
+            id.clone(),
+            Downloader {
+                data: Vec::new(),
+                path: None,
+                total_size: Some(0),
+                downloaded_size: 0,
+                error: None,
+                finished: true,
+                tx_cancel,
+            },
+        );
+
+        Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap()
+            .block_on(async {
+                schedule_auto_delete(id.clone(), Duration::from_millis(10));
+            });
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while DOWNLOADERS.lock().unwrap().contains_key(&id) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(!DOWNLOADERS.lock().unwrap().contains_key(&id));
+    }
 }


### PR DESCRIPTION


`do_download()` is annotated with:

```rust
#[tokio::main(flavor = "current_thread")]
```

After a successful download, the code scheduled delayed cleanup with `tokio::spawn`. However, the Tokio runtime created by `#[tokio::main]` is dropped as soon as `do_download()` returns, so the spawned cleanup task can be cancelled before `auto_del_dur` elapses.

As a result, completed downloader entries may remain in `DOWNLOADERS`, and subsequent requests for the same URL can incorrectly reuse the stale entry.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary files from successful downloads are now reliably cleaned up, even after the download process finishes.
  * Added coverage to verify delayed cleanup continues as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62573354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until delayed cleanup is prevented from deleting a newer downloader that reused the same URL.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fhbbs_http%2Fdownloader.rs%3A25%0AThe%20delayed%20cleanup%20removes%20whichever%20downloader%20currently%20uses%20this%20URL.%20The%20UI%20can%20remove%20a%20completed%20entry%20and%20start%20another%20download%20for%20the%20same%20URL%20before%20the%20three-second%20delay%20expires.%20The%20old%20cleanup%20then%20removes%20the%20active%20replacement%2C%20causing%20progress%20polling%20to%20report%20that%20the%20downloader%20was%20not%20found.%20Associate%20cleanup%20with%20the%20specific%20downloader%20instance%20or%20generation%20that%20scheduled%20it%2C%20and%20add%20a%20regression%20test%20for%20removal%20and%20reinsertion%20before%20expiry.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Stale cleanup deletes replacement** <a href="https://github.com/rustdesk/rustdesk/pull/16151#discussion_r3979015841">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/hbbs_http/downloader.rs:25
The delayed cleanup removes whichever downloader currently uses this URL. The UI can remove a completed entry and start another download for the same URL before the three-second delay expires. The old cleanup then removes the active replacement, causing progress polling to report that the downloader was not found. Associate cleanup with the specific downloader instance or generation that scheduled it, and add a regression test for removal and reinsertion before expiry.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Changes the existing successful updater-download path by making its delayed removal effective after runtime shutdown.
- Adds a regression test confirming that cleanup outlives a current-thread Tokio runtime.
- The effective timer can race with removal and reinsertion of another download under the same URL.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(downloader): keep delayed cleanup al..."](https://github.com/rustdesk/rustdesk/commit/acd664772710a6ae12407d6c2ea9fd62931de749)</sub>

<!-- /greptile_comment -->