### PR TITLE
Lower QoS sample logging to trace

### DIFF
--- a/src/server/video_qos.rs
+++ b/src/server/video_qos.rs
@@ -571,7 +571,7 @@ impl VideoQoS {
             adjust_ratio = user.delay.fps.is_none();
             user.delay.fps = Some(fps);
             let base = user.delay.rtt_calculator.get_rtt().unwrap_or_default();
-            log::debug!(
+            log::trace!(
                 "qos_trace t={} id={id} delay={delay} base={base} excess={} avg={avg_delay} bad={} good={} braked={braked} fps={fps} ratio={:.3} reduce_bitrate={reduce_bitrate}",
                 hbb_common::get_time(),
                 delay.saturating_sub(base),


### PR DESCRIPTION
Change the per-sample QoS diagnostic log from `debug` to `trace` to reduce log volume under the default release logging configuration. Enable it
  with `RUST_LOG=trace` when needed.

  Only the log level in `src/server/video_qos.rs` changes; QoS adjustment behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted network-delay QoS logging to a more detailed trace level without changing message content or processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63021191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because it only changes the visibility threshold of an optional diagnostic log.

<details><summary><h3>Summary</h3></summary>

- QoS calculations and adjustment behavior are unchanged.
- Detailed samples remain available with `RUST_LOG=trace`.
- Regression surface is limited to the log visibility of the existing per-sample path in `src/server/video_qos.rs`.
</details>

<sub>Reviews (1) · Last reviewed commit: ["Lower QoS sample logging to trace"](https://github.com/rustdesk/rustdesk/commit/9cf5f900e977dbc8e51f4723b1aab7924b4d1713)</sub>

<!-- /greptile_comment -->