### PR TITLE
fastlane: add it-IT Android metadata

### DIFF
--- a/fastlane/metadata/android/it-IT/full_description.txt
+++ b/fastlane/metadata/android/it-IT/full_description.txt
@@ -1,0 +1,11 @@
+Applicazione open source per desktop remoto, l'alternativa open source a TeamViewer.
+Codice sorgente: https://github.com/rustdesk/rustdesk
+Documentazione: https://rustdesk.com/docs/it/client/android/
+
+Per consentire a un dispositivo remoto di controllare il tuo Android tramite mouse o tocco, devi permettere a RustDesk di utilizzare il servizio "Accessibilità". RustDesk utilizza l'API AccessibilityService per implementare il controllo remoto su Android.
+
+Oltre al controllo remoto, puoi anche trasferire facilmente file tra dispositivi Android e PC con RustDesk.
+
+Hai il controllo totale dei tuoi dati, senza preoccupazioni per la sicurezza. Puoi usare il nostro server rendezvous/relay, optare per l'hosting autonomo, o scrivere il tuo server rendezvous/relay. Il server auto-ospitato è gratuito e open source: https://github.com/rustdesk/rustdesk-server
+
+Scarica e installa la versione per desktop da: https://rustdesk.com — potrai quindi accedere e controllare il tuo computer dal cellulare, o controllare il tuo cellulare dal computer.

--- a/fastlane/metadata/android/it-IT/short_description.txt
+++ b/fastlane/metadata/android/it-IT/short_description.txt
@@ -1,0 +1,1 @@
+App open source per desktop remoto, alternativa a TeamViewer.


### PR DESCRIPTION
Adds it-IT (Italian) metadata for Android Fastlane.
Includes short_description.txt and full_description.txt with verified Italian translations.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63070075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The metadata-only change appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Provides localized short and full descriptions.
- Preserves the source listing’s product capabilities and project links.
- Directs Italian users to the corresponding Italian Android documentation.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fastlane: add it-IT Android metadata"](https://github.com/rustdesk/rustdesk/commit/c2279cf7f9cf5b6d2e29183d8833854d63b5cf97)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Italian Google Play Store metadata for the Android app.
  - Added a localized short description highlighting the app as an open-source remote desktop alternative.
  - Added a localized full description covering remote control, file transfer, server options, and desktop downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->