### PR TITLE
fix(android): default to entire screen for capture

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/PermissionRequestTransparentActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/carriez/flutter_hbb/PermissionRequestTransparentActivity.kt
@@ -2,6 +2,7 @@ package com.carriez.flutter_hbb
 
 import android.app.Activity
 import android.content.Intent
+import android.media.projection.MediaProjectionConfig
 import android.media.projection.MediaProjectionManager
 import android.os.Build
 import android.os.Bundle
@@ -19,7 +20,13 @@ class PermissionRequestTransparentActivity: Activity() {
             ACT_REQUEST_MEDIA_PROJECTION -> {
                 val mediaProjectionManager =
                     getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
-                val intent = mediaProjectionManager.createScreenCaptureIntent()
+                val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    mediaProjectionManager.createScreenCaptureIntent(
+                        MediaProjectionConfig.createConfigForDefaultDisplay()
+                    )
+                } else {
+                    mediaProjectionManager.createScreenCaptureIntent()
+                }
                 startActivityForResult(intent, REQ_REQUEST_MEDIA_PROJECTION)
             }
             else -> finish()


### PR DESCRIPTION
## Summary

On Android 14+, request capture of the default display so the user does not have to choose between sharing one app and the entire screen before every remote-support session.

The controlled-device workflow needs the whole display because the remote operator navigates between apps and system settings. The per-session Android consent prompt remains unchanged.

Older Android versions continue using the existing no-argument API.

## Test

I tested the bytecode-equivalent change with RustDesk 1.4.9 on a physical Pixel 10a running GrapheneOS Android 17 / API 37:

- The system consent dialog opened with **Share entire screen** selected, without requiring the app-versus-screen choice.
- One tap on **Share screen** started RustDesk's foreground media-projection service successfully.
- The unmodified build was tested immediately beforehand and required choosing **Share entire screen** manually.

API reference: https://developer.android.com/reference/android/media/projection/MediaProjectionConfig#createConfigForDefaultDisplay()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen capture permission handling on Android 14 and newer.
  * Continued support for screen capture on older Android versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63076983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because the new API is compile-time available, runtime guarded, and compatible with the existing projection-result flow.

<details><summary><h3>Summary</h3></summary>

- Uses `MediaProjectionConfig.createConfigForDefaultDisplay()` behind an API 34 runtime guard.
- Preserves the no-argument capture-intent API below Android 14.
- Leaves the existing consent-result and foreground-service startup flow unchanged.
- Regression surface is limited to the media-projection intent created by `PermissionRequestTransparentActivity`.
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(android): default to entire screen f..."](https://github.com/rustdesk/rustdesk/commit/dfaa55c31526054a788d872ea729f87063bc333e)</sub>

<!-- /greptile_comment -->