### PR TITLE
Fix/ci

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -499,7 +499,9 @@ jobs:
           # Since rustup 1.29.1, i686 toolchains on x64 Windows require --force-non-host
           # for both installation and default selection, even though WOW64 can run them.
           # See https://github.com/rust-lang/rustup/pull/4935.
-          # Adding an i686 target alone would still use a 64-bit compiler and build scripts.
+          # Alternatively, an x64 compiler could use cargo build --target i686-pc-windows-msvc.
+          # This requires 64-bit LLVM for host build scripts and updated packaging paths,
+          # and has not been manually verified for RustDesk.
           rustup toolchain install nightly-2023-10-13-${{ matrix.job.target }} \
             --target ${{ matrix.job.target }} --component rustfmt \
             --profile minimal --no-self-update --force-non-host

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -494,7 +494,12 @@ jobs:
       - name: Install Rust toolchain
         shell: bash
         run: |
-          # Use a native 32-bit nightly for Sciter's abi_thiscall feature.
+          # Sciter's abi_thiscall feature requires nightly Rust.
+          # Use an i686 host toolchain so build scripts can load the 32-bit LLVM installed above.
+          # Since rustup 1.29.1, i686 toolchains on x64 Windows require --force-non-host
+          # for both installation and default selection, even though WOW64 can run them.
+          # See https://github.com/rust-lang/rustup/pull/4935.
+          # Adding an i686 target alone would still use a 64-bit compiler and build scripts.
           rustup toolchain install nightly-2023-10-13-${{ matrix.job.target }} \
             --target ${{ matrix.job.target }} --component rustfmt \
             --profile minimal --no-self-update --force-non-host

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -492,11 +492,13 @@ jobs:
           version: ${{ env.LLVM_VERSION }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: nightly-2023-10-13-${{ matrix.job.target }} # must use nightly here, because of abi_thiscall feature required
-          targets: ${{ matrix.job.target }}
-          components: "rustfmt"
+        shell: bash
+        run: |
+          # Use a native 32-bit nightly for Sciter's abi_thiscall feature.
+          rustup toolchain install nightly-2023-10-13-${{ matrix.job.target }} \
+            --target ${{ matrix.job.target }} --component rustfmt \
+            --profile minimal --no-self-update --force-non-host
+          rustup default nightly-2023-10-13-${{ matrix.job.target }} --force-non-host
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:


### PR DESCRIPTION
https://github.com/rustdesk/rustdesk/pull/16166 is closed and can't be reopened because I accidentally deleted the branch.

Fix https://github.com/rustdesk/rustdesk/actions/runs/34546367057/job/103099760684

https://github.com/fufesou/rustdesk/actions/runs/34659911996/job/103460074117

Extra parameter is not supported in `dtolnay/rust-toolchain` https://github.com/dtolnay/rust-toolchain

https://github.com/dtolnay/rust-toolchain/blob/d1031067263f94b142dd6c0ce24c5eb9d02d52a0/action.yml#L91

https://github.com/dtolnay/rust-toolchain/blob/d1031067263f94b142dd6c0ce24c5eb9d02d52a0/action.yml#L97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows build process to install and configure the required Rust toolchain directly, improving compatibility with current Rust tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63352046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable regression was identified in the Windows Sciter toolchain setup.

<details><summary><h3>Summary</h3></summary>

- Preserves the pinned nightly version, i686 target, and rustfmt component.
- Documents why this build needs a 32-bit host compiler alongside 32-bit LLVM.
- Regression surface: only `.github/workflows/flutter-build.yml` and the Windows Sciter toolchain-setup path change; explicit commands are needed to pass the unsupported action parameter. Other build paths remain unchanged.
- No actionable issues were identified.
</details>

<sub>Reviews (1) · Last reviewed commit: ["docs(ci): explain the unverified x64 cro..."](https://github.com/rustdesk/rustdesk/commit/d050772928d2df31e4c47d93ee296369afb8544c)</sub>

<!-- /greptile_comment -->