### PR TITLE
Upgrade FFmpeg to 7.1.1 to fix HEVC WPP deadlocks

### DIFF
--- a/res/vcpkg/ffmpeg/portfile.cmake
+++ b/res/vcpkg/ffmpeg/portfile.cmake
@@ -1,8 +1,10 @@
+# FFmpeg 7.1.1 includes the HEVC WPP slice-thread deadlock fix:
+# https://github.com/FFmpeg/FFmpeg/commit/79c47dfd25f101b6842bbec8c6ffef8d5077c3ae
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ffmpeg/ffmpeg
     REF "n${VERSION}"
-    SHA512 3b273769ef1a1b63aed0691eef317a760f8c83b1d0e1c232b67bbee26db60b4864aafbc88df0e86d6bebf07185bbd057f33e2d5258fde6d97763b9994cd48b6f
+    SHA512 6b9a5ee501be41d6abc7579a106263b31f787321cbc45dedee97abf992bf8236cdb2394571dd256a74154f4a20018d429ae7e7f0409611ddc4d6f529d924d175
     HEAD_REF master
     PATCHES
     0001-create-lib-libraries.patch

--- a/res/vcpkg/ffmpeg/vcpkg.json
+++ b/res/vcpkg/ffmpeg/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "ffmpeg",
-  "version": "7.1",
-  "port-version": 1,
+  "version": "7.1.1",
   "description": [
     "a library to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.",
     "FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created. It supports the most obscure ancient formats up to the cutting edge. No matter if they were designed by some standards committee, the community or a corporation. It is also highly portable: FFmpeg compiles, runs, and passes our testing infrastructure FATE across Linux, Mac OS X, Microsoft Windows, the BSDs, Solaris, etc. under a wide variety of build environments, machine architectures, and configurations."


### PR DESCRIPTION
FFmpeg 7.1 can deadlock during software HEVC decoding with WPP slice threading, as reproduced on Linux, macOS, and Windows. FFmpeg 7.1.1 includes the [upstream progress2 fix](https://github.com/FFmpeg/FFmpeg/commit/79c47dfd25f101b6842bbec8c6ffef8d5077c3ae), allowing decoding to retain its existing thread-count policy.

This PR updates the FFmpeg overlay version and source archive checksum, resets the port revision, and documents the fix. The existing patches and build options are unchanged. The diff is limited to `res/vcpkg/ffmpeg/vcpkg.json` and `portfile.cmake`; it does not change RustDesk application logic or force single-thread decoding.

## Manual testing

Manual testing with FFmpeg 7.1.1 passed for the following hardware codec paths:

- [x] Windows: H.264/HEVC NVENC, AMF and QSV encoding with RAM and VRAM input; D3D11VA decoding to RAM and VRAM.
- [x] macOS: HEVC VideoToolbox encoding; H.264/HEVC VideoToolbox decoding.
- [x] Linux: H.264/HEVC NVENC and AMF encoding, H.264 VAAPI encoding, and H.264/HEVC CUDA/NVDEC and VAAPI decoding.
- [x] Android: H.264/HEVC MediaCodec encoding.

## Automated validation

Validation on macOS arm64 and Linux x64:

- Built the macOS overlay successfully with all 23 existing patches. Verified the source archive checksum and `git diff --check`.
- Downloaded the actual [macOS arm64](https://github.com/21pages/rustdesk/releases/download/vcpkg_ffmpeg711/arm64-osx.zip) and [Linux x64](https://github.com/21pages/rustdesk/releases/download/vcpkg_ffmpeg711/x64-linux.zip) CI packages, verified their SHA-256 hashes, and confirmed FFmpeg 7.1.1 / libavcodec 61.19.101 at runtime.
- On each platform, the original HEVC/WPP reproducer passed 1,000 rounds / 71,000 frames with four slice threads; the single-thread control passed 21,300 frames. Resolution-switch replay passed 6,816 frames and four-thread H.264 replay passed 4,100 frames. All completed without a stall or decode error, with matching decoded-image checksums. Linux also passed 21,300 frames with eight slice threads.
- macOS VideoToolbox H.264/HEVC encoding with software and hardware decoding: all six cases across 640×360, 1280×720 and 1920×1080 matched the FFmpeg 7.1 baseline, including bitrate changes.

Additional Linux Intel validation on the Core i5-12400, Ubuntu 22.04 (kernel 6.5.0-26), using the Linux x64 FFmpeg 7.1.1 CI package above:

- Generated a 1280×720, 71-frame HEVC stream with WPP enabled and 22 entry-point offsets per frame. The replay harness matched the RustDesk software-decoder setup: `AV_CODEC_FLAG_LOW_DELAY`, four active slice threads, and decoder recreation for every round.
- FFmpeg 7.1 / libavcodec 61.19.100 stalled after reporting round 400 / 28,400 frames and was terminated by the 180-second watchdog. The same harness linked against FFmpeg 7.1.1 / libavcodec 61.19.101 completed 1,000 rounds / 71,000 frames in about 60 seconds without a stall or decode error; every round matched the reference frame count and sampled-image checksum.

Branch integration validation used RustDesk `re-encode-static-image` at `b4106f642486`, its locked hwcodec revision `8dd76fdf0e62`, and the CI packages above. This integration branch is test coverage, not additional code included in this PR:

- RustDesk Rust-library builds and all six static-refresh module tests passed on both macOS and Linux. Rebuilt native dependencies and checked the linked libraries for the fixed thread-progress implementation.
- On macOS, the branch's actual static-refresh module and codecs passed dynamic → static → dynamic tests: HEVC, VP8 and VP9 stopped after 100 static attempts, respected the 100 ms / 5 fps / 1 fps limits, and resumed on new frames; AV1 correctly skipped static re-encoding.
- The 1080p VideoToolbox HEVC test produced 171 packets, all decoded successfully by both four-thread software and hardware decoders. Eight encoder recreations/resolution changes produced another 232 packets, also fully decoded with correct dimensions and no timestamp errors.
- Test application version checks and GUI startup passed on both platforms.

Additional Linux AMD hardware validation on the Ryzen 7 5800H / Cezanne integrated GPU, Ubuntu 22.04.5, using the same FFmpeg 7.1.1 CI package:

- Installed the compatible AMD 23.30 userspace encoding/Vulkan packages (AMF 1.4.32, AMD repository 5.7.3), retaining the distribution kernel driver and firmware. Mesa 23.2.1 provides VAAPI decoding.
- H.264/HEVC AMF hardware encoding passed all six cases at 640×360, 1280×720 and 1920×1080, including dynamic → static → dynamic input and bitrate changes. All 540 encoded packets decoded successfully through both VAAPI hardware decoding and four-thread software decoding, with the expected dimensions. Verified actual hardware frames and successful frame downloads; no software fallback in the VAAPI results.
- The rebuilt `re-encode-static-image` RustDesk application detected and passed its codec probes for `h264_amf`, `hevc_amf`, and H.264/HEVC VAAPI decoders in the normal installed environment. Desktop login and application startup also passed. This is AMF **encoding** plus VAAPI **decoding**; FFmpeg 7.1.1 does not provide an AMF decoder.

Validation on Windows x64 with NVIDIA / Intel GPUs (RustDesk `re-encode-static-image` at `b4106f642486`, with its locked hwcodec revision `8dd76fdf0e62`, using the [7.1.1 vcpkg package](https://github.com/21pages/rustdesk/releases/download/vcpkg_ffmpeg711/x64-windows-static.zip)):

- FFmpeg 7.1 reproduced the HEVC WPP deadlock in all four 720p/1080p, 4/8-thread replay cases. The same cases with 7.1.1 completed 4,000 rounds / 284,000 frames without a stall or decode error, retaining slice threading and the original thread counts.
- NVIDIA GTX 1650 and Intel UHD 730: H.264/HEVC RAM and VRAM encoding passed with software decoding and cross-adapter VRAM hardware decoding; RAM D3D11VA decoding passed with decoder recreation on resolution changes.
- VP8, VP9 and AV1 software encoding/decoding passed, including VP9/AV1 I444. All 15 matrix cases passed at 640×360, 1280×720 and 1920×1080: 5,400 encoded frames, 19,800 decoded frames and 1,620 repeated VRAM input frames, including quality changes and encoder recreation.
- All six hwcodec library tests and four scrap common-module tests passed, including the branch's GPU re-encoding and failed-input recovery tests.

Additional Windows AMD validation on the Ryzen 7 5800H / Radeon Graphics (driver `31.0.12044.47003`), using the same integration commits and Windows 7.1.1 package:

- All 11 codec cases / 33 resolution combinations passed at 640×360, 1280×720 and 1920×1080: VP8, VP9 and AV1 software codecs (including VP9/AV1 I444), plus H.264/HEVC AMF encoding with RAM and VRAM input. This covered 3,960 encoded frames, 10,440 decoded outputs and 1,080 repeated VRAM input frames, including quality changes and encoder recreation. Software, RAM D3D11VA and VRAM decoding passed; VRAM decoding covered both AMD logical adapters and verified output texture devices, dimensions and sampled pixels. RAM D3D11VA decoders were recreated on resolution changes.
- A same-code AMF continuous-encoding comparison against this machine's backed-up FFmpeg 7.1 passed twice per version. Each run covered 16 adapter/codec/resolution combinations and 1,920 frames, including bitrate changes and repeated input, with zero encoding failures.
- HEVC WPP software replay with 7.1.1 completed 1,000 rounds each at 720p with four and eight slice threads. Both 1080p runs reached at least 800 completed rounds before the 600-second overall limit while still making progress; each then completed a separate 200-round supplement. The initial 1080p results remain timeouts. Across the initial and supplemental runs, at least 284,000 decoded frames were confirmed, with zero decode errors and no stall-watchdog trigger.
- **The existing encoding stress/recovery tests were intermittent on both FFmpeg versions.** Initial 7.1.1 runs had encoding failures returning `-1`. A subsequent serial comparison in the same desktop session, in 7.1 → 7.1.1 → 7.1.1 → 7.1 order, passed 6/6, 6/6, 6/6 and 3/6 hwcodec tests respectively. Thus both versions had fully passing runs, and the encoding failure also occurred with 7.1; its root cause remains unresolved. This is separate from the HEVC software-decoder deadlock. The desktop scrap common-module rerun passed 4/4 tests.

Additional baseline check: reusing a RAM D3D11VA decoder across 640×360 → 1280×720 retained the old output dimensions for both H.264 and HEVC on **both 7.1 and 7.1.1**. Recreating the decoder passed on both versions. This pre-existing issue is separate from the HEVC deadlock and is not changed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled FFmpeg version to 7.1.1, including a fix for an HEVC WPP slice-thread deadlock.
* **Chores**
  * Updated the FFmpeg package metadata to match the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63361318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no new actionable issues identified.

<details><summary><h3>Summary</h3></summary>

- Updates the source archive checksum for FFmpeg 7.1.1.
- Resets the vcpkg port revision by removing the prior `port-version`.
- Documents the relevant upstream FFmpeg fix.
- Leaves existing patches and build options unchanged.
</details>

<sub>Reviews (2) · Last reviewed commit: ["Upgrade FFmpeg to 7.1.1 to fix HEVC WPP ..."](https://github.com/rustdesk/rustdesk/commit/b752023ea2ae3d62b073e72c8713d1d5e629a193)</sub>

<!-- /greptile_comment -->