### PR TITLE
Ci/native arm64 msbuild

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -374,6 +374,10 @@ jobs:
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
+        with:
+          # Native ARM64 MSBuild avoids the x86-hosted compiler's intermittent
+          # PCH allocation failures (C3859/C1076).
+          msbuild-architecture: ${{ matrix.job.arch == 'aarch64' && 'arm64' || 'x86' }}
 
       - name: Build msi
         # Builds the MSI for the matrix arch. res/msi (WiX v4 + native CustomActions) carries

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -375,8 +375,10 @@ jobs:
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
         with:
-          # Native ARM64 MSBuild avoids the x86-hosted compiler's intermittent
-          # PCH allocation failures (C3859/C1076).
+          # Select the MSBuild process architecture; -p:Platform sets the MSI target.
+          # Native ARM64 tools give the compiler more address space for PCH files
+          # (C3859/C1076 were reported by HostX86\arm64\CL.exe).
+          # Keep the action's default x86 MSBuild for the existing x64 MSI job.
           msbuild-architecture: ${{ matrix.job.arch == 'aarch64' && 'arm64' || 'x86' }}
 
       - name: Build msi


### PR DESCRIPTION
Try to fix MSI failures sometimes https://github.com/fufesou/rustdesk/actions/runs/34669012959/job/103487635238

`msbuild-architecture` is `x86` by default.

https://github.com/microsoft/setup-msbuild/blob/6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce/action.yml#L17

This is a rerun job
https://github.com/fufesou/rustdesk/actions/runs/34673271177/job/103505048390





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows ARM64 and x64 Flutter build reliability by using the appropriate native MSBuild tooling for each architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63374255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because the architecture expression matches the workflow matrix and the selected MSBuild host is supported by the ARM64 runner and MSI configuration.

<details><summary><h3>Summary</h3></summary>

- Uses the existing matrix architecture value to select the MSBuild host architecture.
- Leaves the MSI target-platform selection unchanged.
- Limits the behavioral change to the ARM64 MSI build path.
</details>

<sub>Reviews (1) · Last reviewed commit: ["ci: clarify MSBuild host and MSI target ..."](https://github.com/rustdesk/rustdesk/commit/872fe36194793ccde8cdf449dec2793731e3f980)</sub>

<!-- /greptile_comment -->