### PR TITLE
fix(audio): throttled debug logs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2250,7 +2250,9 @@ impl AudioBuffer {
         let occupied = lock.occupied_len();
         drop(lock);
         if let Some((discarded, generation)) = discard {
-            log::debug!(
+            hbb_common::throttled_log!(
+                audio_playback::AUDIO_PLAYBACK_LOG_INTERVAL,
+                debug,
                 "Audio buffer capacity discard: samples={discarded}, generation={generation}"
             );
         }
@@ -2441,7 +2443,7 @@ impl AudioHandler {
         }
         #[cfg(target_os = "linux")]
         if self.simple.is_none() {
-            log::debug!("PulseAudio simple binding does not exists");
+            log::trace!("PulseAudio simple binding does not exists");
             return;
         }
         self.audio_decoder.as_mut().map(|(d, buffer)| {

--- a/src/client/audio_playback.rs
+++ b/src/client/audio_playback.rs
@@ -6,6 +6,8 @@ use std::sync::{
 };
 
 pub(super) const UNDERRUN_DECLICK_MS: usize = 5;
+pub(super) const AUDIO_PLAYBACK_LOG_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(5);
 const MILLISECONDS_PER_SECOND: usize = 1_000;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -47,7 +49,11 @@ impl AudioPlaybackStatus {
     pub(super) fn report_errors(&self) {
         let contentions = self.contentions.swap(0, Ordering::Relaxed);
         if contentions != 0 {
-            log::debug!("Audio playback PCM buffer contention: callbacks={contentions}");
+            hbb_common::throttled_log!(
+                AUDIO_PLAYBACK_LOG_INTERVAL,
+                debug,
+                "Audio playback PCM buffer contention: callbacks={contentions}"
+            );
         }
         if self.buffer_poisoned.swap(false, Ordering::Relaxed) {
             log::error!("Audio playback stopped reading a poisoned PCM buffer");

--- a/src/server/audio_service/audio_capture_encoder.rs
+++ b/src/server/audio_service/audio_capture_encoder.rs
@@ -87,7 +87,7 @@ impl CaptureStatsReporter {
             return;
         }
         let stats = std::mem::take(&mut self.pending);
-        log::debug!(
+        log::trace!(
             "Audio capture PCM handoff stats: observed_max_queued_packets={}, approx_queued_audio_ms={}, capacity_packets={}",
             stats.max_queued_packets,
             stats.max_queued_packets.saturating_mul(CAPTURE_PACKET_MS),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repetitive audio playback diagnostics by limiting repeated buffer-contention messages to once every five seconds.
  * Audio contention information now remains available while accumulating between reports, improving diagnostic accuracy.
  * Lowered routine audio capture and Linux audio availability messages to less prominent diagnostic levels, keeping logs clearer while preserving detailed troubleshooting information.
  * Audio playback diagnostic reporting is now tracked independently for separate playback sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63388128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no outstanding actionable findings.

<details><summary><h3>Summary</h3></summary>

- Throttles audio buffer-discard diagnostics to once every five seconds.
- Uses a per-playback throttle so contention counts accumulate until emitted and remain isolated between playback instances.
- Lowers routine PulseAudio and capture-stat diagnostics from debug to trace.
- Adds regression coverage for accumulated contention counts and independent playback throttles.
- Regression surface is limited to diagnostic logging in the existing audio playback and capture paths; audio decoding, buffering, and capture behavior are unchanged.
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix(audio): preserve contention counts a..."](https://github.com/rustdesk/rustdesk/commit/26712cb05dee9f806b0f31f5e6e335152ae8d14d)</sub>

<!-- /greptile_comment -->