### PR TITLE
Add Ctrl+Alt+Pause keyboard capture toggle and status feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
         targets: ${{ matrix.job.target }}
         components: ''
 
+    - name: Test keyboard capture shortcut
+      run: python3 -m unittest discover -s tests -p test_keyboard_grab.py -v
+
     - name: Show version information (Rust, cargo, GCC)
       shell: bash
       run: |

--- a/flutter/lib/desktop/widgets/remote_toolbar.dart
+++ b/flutter/lib/desktop/widgets/remote_toolbar.dart
@@ -2545,12 +2545,16 @@ class _KeyboardMenu extends StatelessWidget {
       return toggles;
     }
 
+    final status = ffiModel.keyboardGrabStatus;
+    final local = status != null && !ffiModel.keyboardGrabbed;
     return _IconSubmenuButton(
-        tooltip: 'Keyboard Settings',
+        tooltip: status ?? 'Keyboard Settings',
         svg: "assets/keyboard_mouse.svg",
         ffi: ffi,
-        color: _ToolbarTheme.blueColor,
-        hoverColor: _ToolbarTheme.hoverBlueColor,
+        color: local ? _ToolbarTheme.inactiveColor : _ToolbarTheme.blueColor,
+        hoverColor: local
+            ? _ToolbarTheme.hoverInactiveColor
+            : _ToolbarTheme.hoverBlueColor,
         menuChildrenGetter: (_) => [
               keyboardMode(),
               localKeyboardType(),
@@ -2692,6 +2696,7 @@ class _KeyboardMenu extends StatelessWidget {
             ? (v) async {
                 if (v != null) {
                   await stateGlobal.setInputSource(ffi.sessionId, v);
+                  ffi.ffiModel.refreshKeyboardGrabStatus();
                   // Release native input; see the macOS trade-offs in RemotePage.
                   if (isMacOS) ffi.inputModel.enterOrLeave(false);
                   await ffi.ffiModel.checkDesktopKeyboardMode();

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -128,6 +128,7 @@ class FfiModel with ChangeNotifier {
   bool _androidDocumentPickerInterruptedConnection = false;
   bool _viewOnly = false;
   bool _showMyCursor = false;
+  bool keyboardGrabbed = false;
   WeakReference<FFI> parent;
   late final SessionID sessionId;
 
@@ -247,6 +248,20 @@ class FfiModel with ChangeNotifier {
   }
 
   bool get keyboard => _permissions['keyboard'] != false;
+
+  String? get keyboardGrabStatus {
+    if (!isDesktop ||
+        isInputSourceFlutter ||
+        parent.target?.connType != ConnType.defaultConn ||
+        !_pi.isSet.isTrue ||
+        !keyboard ||
+        viewOnly) {
+      return null;
+    }
+    return keyboardGrabbed ? 'Keyboard: remote' : 'Keyboard: local';
+  }
+
+  void refreshKeyboardGrabStatus() => notifyListeners();
 
   clear() {
     _pi = PeerInfo();
@@ -478,6 +493,21 @@ class FfiModel with ChangeNotifier {
       } else if (name == 'exit_relative_mouse_mode') {
         // Handle exit shortcut from rdev grab loop (Ctrl+Alt on Win/Linux, Cmd+G on macOS)
         parent.target?.inputModel.exitRelativeMouseModeWithKeyRelease();
+      } else if (name == 'keyboard_grab') {
+        final grabbed = evt['grabbed'] == true;
+        if (keyboardGrabbed != grabbed) {
+          keyboardGrabbed = grabbed;
+          notifyListeners();
+          final status = keyboardGrabStatus;
+          if (isWindows && status != null) {
+            try {
+              await const MethodChannel('org.rustdesk.rustdesk/keyboard')
+                  .invokeMethod<void>('notifyStatus', translate(status));
+            } catch (e) {
+              debugPrint('Failed to notify keyboard status: $e');
+            }
+          }
+        }
       } else {
         debugPrint('Event is not handled in the fixed branch: $name');
       }
@@ -742,6 +772,7 @@ class FfiModel with ChangeNotifier {
       parent.target?.inputModel.updateKeyboardMode();
     } else if (k == 'input_source') {
       stateGlobal.getInputSource(force: true);
+      notifyListeners();
     }
   }
 

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -264,6 +264,7 @@ class FfiModel with ChangeNotifier {
   void refreshKeyboardGrabStatus() => notifyListeners();
 
   clear() {
+    keyboardGrabbed = false;
     _pi = PeerInfo();
     lastUserDisplay = null;
     _cancelPendingMonitorRestore();

--- a/flutter/test/keyboard_grab_status_test.dart
+++ b/flutter/test/keyboard_grab_status_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_hbb/models/model.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uuid/uuid.dart';
+
+class _FakeFFI implements FFI {
+  @override
+  final sessionId = UuidValue('00000000-0000-0000-0000-000000000000');
+
+  @override
+  late final FfiModel ffiModel = FfiModel(WeakReference(this));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  test('clearing a reused session resets keyboard capture status', () {
+    final ffi = _FakeFFI();
+    final model = ffi.ffiModel;
+    addTearDown(model.dispose);
+
+    expect(model.keyboardGrabbed, isFalse);
+    model.keyboardGrabbed = true;
+    model.clear();
+    expect(model.keyboardGrabbed, isFalse);
+  });
+}

--- a/flutter/windows/runner/CMakeLists.txt
+++ b/flutter/windows/runner/CMakeLists.txt
@@ -34,6 +34,7 @@ target_compile_definitions(${BINARY_NAME} PRIVATE "NOMINMAX")
 # Add dependency libraries and include directories. Add any application-specific
 # dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter flutter_wrapper_app)
+target_link_libraries(${BINARY_NAME} PRIVATE oleacc uiautomationcore)
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 
 # Run the Flutter tool portions of the build. This must not be removed.

--- a/flutter/windows/runner/flutter_window.cpp
+++ b/flutter/windows/runner/flutter_window.cpp
@@ -13,6 +13,9 @@
 #include <flutter/standard_method_codec.h>
 
 #include <windows.h>
+#include <oleacc.h>
+#include <UIAutomation.h>
+#include <wrl/client.h>
 
 #include <optional>
 #include <memory>
@@ -20,6 +23,83 @@
 #include "win32_desktop.h"
 
 namespace {
+
+HRESULT NotifyKeyboardStatus(HWND window, const std::string& status) {
+  // Resolve dynamically so older Windows versions can still start the app.
+  static const auto raise_notification =
+      reinterpret_cast<decltype(&UiaRaiseNotificationEvent)>(GetProcAddress(
+          GetModuleHandleW(L"UIAutomationCore.dll"), "UiaRaiseNotificationEvent"));
+  if (!raise_notification || !UiaClientsAreListening()) {
+    return S_FALSE;
+  }
+
+  // Query Flutter directly: AccessibleObjectFromWindow can return a cached
+  // system proxy without the provider interface.
+  LRESULT object = SendMessageW(window, WM_GETOBJECT, 0, OBJID_CLIENT);
+  if (!object) {
+    return S_FALSE;
+  }
+  Microsoft::WRL::ComPtr<IAccessible> accessible;
+  HRESULT hr = ObjectFromLresult(object, __uuidof(IAccessible), 0, &accessible);
+  if (FAILED(hr)) {
+    return hr;
+  }
+  Microsoft::WRL::ComPtr<IRawElementProviderSimple> provider;
+  hr = accessible.As(&provider);
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                   status.c_str(), -1, nullptr, 0);
+  if (!length) {
+    return HRESULT_FROM_WIN32(GetLastError());
+  }
+  BSTR text = SysAllocStringLen(nullptr, length - 1);
+  BSTR activity = SysAllocString(L"rustdesk.keyboard");
+  if (!text || !activity) {
+    hr = E_OUTOFMEMORY;
+  } else if (!MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                 status.c_str(), -1, text, length)) {
+    hr = HRESULT_FROM_WIN32(GetLastError());
+  } else {
+    hr = raise_notification(provider.Get(), NotificationKind_Other,
+                            NotificationProcessing_ImportantMostRecent,
+                            text, activity);
+  }
+  SysFreeString(text);
+  SysFreeString(activity);
+  return hr;
+}
+
+void RegisterKeyboardStatusNotifications(
+    flutter::FlutterViewController* controller) {
+  flutter::MethodChannel<> channel(
+      controller->engine()->messenger(), "org.rustdesk.rustdesk/keyboard",
+      &flutter::StandardMethodCodec::GetInstance());
+  channel.SetMethodCallHandler(
+      [window = controller->view()->GetNativeWindow()](
+          const flutter::MethodCall<>& call,
+          std::unique_ptr<flutter::MethodResult<>> result) {
+        if (call.method_name() != "notifyStatus") {
+          result->NotImplemented();
+          return;
+        }
+        const auto* status = call.arguments()
+            ? std::get_if<std::string>(call.arguments()) : nullptr;
+        if (!status || status->empty()) {
+          result->Error("invalid_arguments", "Keyboard status must be a string");
+          return;
+        }
+        HRESULT hr = NotifyKeyboardStatus(window, *status);
+        if (FAILED(hr)) {
+          result->Error("uia_notification", "Could not notify keyboard status",
+                        flutter::EncodableValue(static_cast<int32_t>(hr)));
+        } else {
+          result->Success();
+        }
+      });
+}
 
 // If the window is resized between the creation of the Flutter surface and the
 // present of the first frame - which is what the PowerToys FancyZones option
@@ -146,6 +226,7 @@ bool FlutterWindow::OnCreate() {
     auto *flutter_view_controller =
         reinterpret_cast<flutter::FlutterViewController *>(controller);
     auto *registry = flutter_view_controller->engine();
+    RegisterKeyboardStatusNotifications(flutter_view_controller);
     TextureRgbaRendererPluginCApiRegisterWithRegistrar(
         registry->GetRegistrarForPlugin("TextureRgbaRendererPlugin"));
     FlutterGpuTextureRendererPluginCApiRegisterWithRegistrar(

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -665,9 +665,12 @@ fn handle_keyboard_grab_shortcut(event: &Event) -> bool {
             return true;
         }
     }
-    if !IS_RDEV_ENABLED.load(Ordering::SeqCst) || flutter::get_cur_session().is_none() {
+    if !IS_RDEV_ENABLED.load(Ordering::SeqCst) {
         return false;
     }
+    let Some(session) = flutter::get_cur_session() else {
+        return false;
+    };
     // X11 stops delivering keys after ungrab, so this path can only release.
     #[cfg(target_os = "linux")]
     if !KEYBOARD_HOOKED.load(Ordering::SeqCst) {
@@ -689,12 +692,17 @@ fn handle_keyboard_grab_shortcut(event: &Event) -> bool {
         return false;
     }
     if matches!(event.event_type, EventType::KeyPress(_)) {
+        let enter = !KEYBOARD_HOOKED.load(Ordering::SeqCst);
+        if enter
+            && (!session.is_default()
+                || !*session.server_keyboard_enabled.read().unwrap()
+                || session.lc.read().unwrap().view_only.v)
+        {
+            return false;
+        }
         #[cfg(not(target_os = "linux"))]
         SHORTCUT_DOWN.store(true, Ordering::SeqCst);
-        crate::flutter_ffi::session_enter_or_leave(
-            flutter::get_cur_session_id(),
-            !KEYBOARD_HOOKED.load(Ordering::SeqCst),
-        );
+        crate::flutter_ffi::session_enter_or_leave(flutter::get_cur_session_id(), enter);
     }
     true
 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -154,6 +154,15 @@ pub mod client {
         *lock = true;
     }
 
+    #[cfg(feature = "flutter")]
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    fn notify_keyboard_grab(session_id: u128, grabbed: bool) {
+        let session_id = crate::flutter_ffi::SessionID::from_u128(session_id);
+        if let Some(session) = flutter::sessions::get_session_by_session_id(&session_id) {
+            session.push_event_to("keyboard_grab", &[("grabbed", grabbed)], &[&session_id]);
+        }
+    }
+
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     pub fn change_grab_status(state: GrabState, keyboard_mode: &str, session_id: u128) {
         #[cfg(feature = "flutter")]
@@ -186,6 +195,8 @@ pub mod client {
                         "[grab] Run(0x{:x}): already owner, refresh debounce",
                         session_id
                     );
+                    #[cfg(feature = "flutter")]
+                    notify_keyboard_grab(session_id, true);
                     return;
                 }
 
@@ -202,11 +213,20 @@ pub mod client {
 
                 #[cfg(target_os = "linux")]
                 let had_owner = gs.owner.is_some();
+                #[cfg(feature = "flutter")]
+                let previous_owner = gs.owner;
                 gs.owner = Some(session_id);
                 gs.last_grab = Some(std::time::Instant::now());
                 // Invalidate any in-flight deferred release from the previous
                 // owner so it cannot suppress a fresh timer for the new owner.
                 gs.deferred_pending = false;
+                #[cfg(feature = "flutter")]
+                {
+                    if let Some(previous_owner) = previous_owner {
+                        notify_keyboard_grab(previous_owner, false);
+                    }
+                    notify_keyboard_grab(session_id, true);
+                }
                 #[cfg(target_os = "linux")]
                 {
                     run_grab_after_unlock = Some(had_owner);
@@ -260,6 +280,8 @@ pub mod client {
                                         KEYBOARD_HOOKED.store(false, Ordering::SeqCst);
                                         gs.owner = None;
                                         gs.last_grab = None;
+                                        #[cfg(feature = "flutter")]
+                                        notify_keyboard_grab(session_id, false);
                                         Some(to_release)
                                     } else {
                                         log::debug!(
@@ -295,6 +317,8 @@ pub mod client {
                 gs.owner = None;
                 gs.last_grab = None;
                 gs.deferred_pending = false;
+                #[cfg(feature = "flutter")]
+                notify_keyboard_grab(session_id, false);
                 release_after_unlock = Some(take_remote_keys());
                 #[cfg(target_os = "linux")]
                 {
@@ -609,11 +633,82 @@ fn should_block_relative_mouse_shortcut(key: Key, is_press: bool) -> bool {
     false
 }
 
+#[cfg(feature = "flutter")]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn handle_keyboard_grab_shortcut(event: &Event) -> bool {
+    #[cfg(target_os = "windows")]
+    let is_pause = {
+        use winapi::um::winuser::{VK_CANCEL, VK_PAUSE};
+        // Ctrl+Pause may be VK_CANCEL and share NumLock's scan code.
+        matches!(event.platform_code as i32, VK_PAUSE | VK_CANCEL)
+    };
+    #[cfg(not(target_os = "windows"))]
+    let is_pause = match event.event_type {
+        EventType::KeyPress(key) | EventType::KeyRelease(key) => {
+            matches!(key, Key::Pause | Key::Cancel)
+                // rdev maps the macOS Pause position to F15.
+                || (cfg!(target_os = "macos") && key == Key::F15)
+        }
+        _ => false,
+    };
+    if !is_pause {
+        return false;
+    }
+    #[cfg(not(target_os = "linux"))]
+    static SHORTCUT_DOWN: AtomicBool = AtomicBool::new(false);
+    #[cfg(not(target_os = "linux"))]
+    {
+        if matches!(event.event_type, EventType::KeyRelease(_)) {
+            return SHORTCUT_DOWN.swap(false, Ordering::SeqCst);
+        }
+        if SHORTCUT_DOWN.load(Ordering::SeqCst) {
+            return true;
+        }
+    }
+    if !IS_RDEV_ENABLED.load(Ordering::SeqCst) || flutter::get_cur_session().is_none() {
+        return false;
+    }
+    // X11 stops delivering keys after ungrab, so this path can only release.
+    #[cfg(target_os = "linux")]
+    if !KEYBOARD_HOOKED.load(Ordering::SeqCst) {
+        return false;
+    }
+    #[cfg(target_os = "windows")]
+    let (ctrl, alt) = (
+        rdev::get_modifier(Key::ControlLeft) || rdev::get_modifier(Key::ControlRight),
+        rdev::get_modifier(Key::Alt) || rdev::get_modifier(Key::AltGr),
+    );
+    #[cfg(target_os = "macos")]
+    let (ctrl, alt) = (
+        get_key_state(enigo::Key::Control) || get_key_state(enigo::Key::RightControl),
+        get_key_state(enigo::Key::Alt) || get_key_state(enigo::Key::RightAlt),
+    );
+    #[cfg(target_os = "linux")]
+    let (alt, ctrl, _, _) = client::get_modifiers_state(false, false, false, false);
+    if !ctrl || !alt {
+        return false;
+    }
+    if matches!(event.event_type, EventType::KeyPress(_)) {
+        #[cfg(not(target_os = "linux"))]
+        SHORTCUT_DOWN.store(true, Ordering::SeqCst);
+        crate::flutter_ffi::session_enter_or_leave(
+            flutter::get_cur_session_id(),
+            !KEYBOARD_HOOKED.load(Ordering::SeqCst),
+        );
+    }
+    true
+}
+
 fn start_grab_loop() {
     std::env::set_var("KEYBOARD_ONLY", "y");
     #[cfg(any(target_os = "windows", target_os = "macos"))]
     std::thread::spawn(move || {
         let try_handle_keyboard = move |event: Event, key: Key, is_press: bool| -> Option<Event> {
+            #[cfg(feature = "flutter")]
+            if handle_keyboard_grab_shortcut(&event) {
+                return None;
+            }
+
             // fix #2211：CAPS LOCK don't work
             if key == Key::CapsLock || key == Key::NumLock {
                 return Some(event);
@@ -686,6 +781,10 @@ fn start_grab_loop() {
     #[cfg(target_os = "linux")]
     if let Err(err) = rdev::start_grab_listen(move |event: Event| match event.event_type {
         EventType::KeyPress(key) | EventType::KeyRelease(key) => {
+            #[cfg(feature = "flutter")]
+            if handle_keyboard_grab_shortcut(&event) {
+                return None;
+            }
             let is_press = matches!(event.event_type, EventType::KeyPress(_));
             if let Key::Unknown(keycode) = key {
                 log::error!("rdev get unknown key, keycode is {:?}", keycode);

--- a/src/lang/ar.rs
+++ b/src/lang/ar.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "تعذّر على RustDesk تحميل مكوّن GStreamer اللازم لالتقاط الشاشة ({})"),
         ("Relay fallback delay in seconds", "مهلة التراجع إلى الترحيل بالثواني"),
         ("relay-fallback-delay-tip", "المدة التي ينتظرها اتصال الترحيل القائم بالفعل الاتصالَ المباشر عبر WebRTC قبل أن يُستخدم بدلًا منه. زِدها لمنح الاتصال المباشر البطيء فرصة أكبر للفوز؛ وقلّلها للاستقرار على الترحيل أسرع في الشبكات التي يتعذر فيها الاتصال المباشر. اتركها فارغة للقيمة الافتراضية 2.5 ثانية."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/az.rs
+++ b/src/lang/az.rs
@@ -772,5 +772,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("Enable TCP hole punching", "TCP deşik açmanı aktivləşdir"),
         ("Relay fallback delay in seconds", "Ötürücüyə keçid gecikməsi, saniyə"),
         ("relay-fallback-delay-tip", "Artıq qurulmuş ötürücü bağlantı birbaşa WebRTC bağlantısını nə qədər gözləyir, sonra onun əvəzinə istifadə olunur. Yavaş birbaşa bağlantıya daha çox vaxt vermək üçün artırın; birbaşa bağlantının mümkün olmadığı şəbəkələrdə ötürücüyə daha tez keçmək üçün azaldın. Standart 2.5 saniyə üçün boş buraxın."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/be.rs
+++ b/src/lang/be.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не змог загрузіць кампанент GStreamer, патрэбны для захопу экрана ({})"),
         ("Relay fallback delay in seconds", "Затрымка пераходу на рэтранслятар у секундах"),
         ("relay-fallback-delay-tip", "Колькі часу ўжо ўсталяванае злучэнне праз рэтранслятар чакае прамога злучэння WebRTC, перш чым будзе выкарыстана замест яго. Павялічце, каб даць павольнаму прамому злучэнню больш часу; паменшыце, каб хутчэй пераходзіць на рэтранслятар у сетках, дзе прамое злучэнне немагчымае. Пакіньце пустым для значэння па змаўчанні 2.5 секунды."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/bg.rs
+++ b/src/lang/bg.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не можа да зареди компонент на GStreamer, необходим за заснемане на екрана ({})"),
         ("Relay fallback delay in seconds", "Забавяне преди преминаване към препредаване в секунди"),
         ("relay-fallback-delay-tip", "Колко време вече установената връзка чрез препредаване изчаква директната WebRTC връзка, преди да бъде използвана вместо нея. Увеличете, за да дадете повече време на бавна директна връзка; намалете, за да се премине по-бързо към препредаване в мрежи, където директна връзка е невъзможна. Оставете празно за стойността по подразбиране 2.5 секунди."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ca.rs
+++ b/src/lang/ca.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "El RustDesk no ha pogut carregar un component del GStreamer necessari per capturar la pantalla ({})"),
         ("Relay fallback delay in seconds", "Retard abans de recórrer al relé en segons"),
         ("relay-fallback-delay-tip", "Quant de temps espera una connexió de relé ja establerta la connexió directa WebRTC abans d'utilitzar-se en lloc seu. Augmenteu-lo per donar més temps a una connexió directa lenta; reduïu-lo per passar abans al relé en xarxes on no es pot fer una connexió directa. Deixeu-lo buit per al valor predeterminat de 2.5 segons."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/cn.rs
+++ b/src/lang/cn.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk 无法加载屏幕捕获所需的 GStreamer 组件 ({})"),
         ("Relay fallback delay in seconds", "回落到中继前的等待时间（秒）"),
         ("relay-fallback-delay-tip", "已经建立的中继连接会等待直连的 WebRTC 多久，超过这个时间就改用中继。调大可以让较慢的直连有更多机会胜出；调小则在无法直连的网络上更快回落到中继。留空表示使用默认值 2.5 秒。"),
+        ("Keyboard: local", "键盘：本机"),
+        ("Keyboard: remote", "键盘：远程"),
     ].iter().cloned().collect();
 }

--- a/src/lang/cs.rs
+++ b/src/lang/cs.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nemohl načíst komponentu GStreameru potřebnou k zachycení obrazovky ({})"),
         ("Relay fallback delay in seconds", "Prodleva před přepnutím na přenos v sekundách"),
         ("relay-fallback-delay-tip", "Jak dlouho již navázané spojení přes přenos čeká na přímé spojení WebRTC, než bude použito místo něj. Zvyšte, aby pomalé přímé spojení mělo více času uspět; snižte, aby se v sítích, kde přímé spojení není možné, dříve přešlo na přenos. Ponechte prázdné pro výchozí hodnotu 2.5 sekundy."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/da.rs
+++ b/src/lang/da.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kunne ikke indlæse en GStreamer-komponent, der kræves til skærmoptagelse ({})"),
         ("Relay fallback delay in seconds", "Forsinkelse før brug af relæ i sekunder"),
         ("relay-fallback-delay-tip", "Hvor længe en allerede oprettet relæforbindelse venter på den direkte WebRTC-forbindelse, før den bruges i stedet. Forøg for at give en langsom direkte forbindelse mere tid; sænk for hurtigere at falde tilbage til relæet på netværk, hvor en direkte forbindelse ikke kan oprettes. Lad feltet stå tomt for standardværdien 2.5 sekunder."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/de.rs
+++ b/src/lang/de.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk konnte eine für die Bildschirmaufnahme benötigte GStreamer-Komponente nicht laden ({})"),
         ("Relay fallback delay in seconds", "Verzögerung bis zum Relais in Sekunden"),
         ("relay-fallback-delay-tip", "Wie lange eine bereits aufgebaute Relaisverbindung auf die direkte WebRTC-Verbindung wartet, bevor sie stattdessen verwendet wird. Erhöhen Sie den Wert, um einer langsamen direkten Verbindung mehr Zeit zu geben; verringern Sie ihn, um in Netzwerken ohne mögliche Direktverbindung schneller auf das Relais zurückzufallen. Leer lassen für den Standardwert von 2.5 Sekunden."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/el.rs
+++ b/src/lang/el.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "Το RustDesk δεν μπόρεσε να φορτώσει ένα στοιχείο του GStreamer που απαιτείται για την καταγραφή οθόνης ({})"),
         ("Relay fallback delay in seconds", "Καθυστέρηση πριν από τη χρήση αναμεταδότη σε δευτερόλεπτα"),
         ("relay-fallback-delay-tip", "Πόσο χρόνο περιμένει μια ήδη ενεργή σύνδεση αναμεταδότη την απευθείας σύνδεση WebRTC πριν χρησιμοποιηθεί στη θέση της. Αυξήστε το για να δώσετε σε μια αργή απευθείας σύνδεση περισσότερο χρόνο. Μειώστε το για ταχύτερη επιστροφή στον αναμεταδότη σε δίκτυα όπου δεν είναι δυνατή η απευθείας σύνδεση. Αφήστε το κενό για την προεπιλογή των 2.5 δευτερολέπτων."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eo.rs
+++ b/src/lang/eo.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ne povis ŝargi komponanton de GStreamer necesan por ekrankapto ({})"),
         ("Relay fallback delay in seconds", "Prokrasto antaŭ retransmisio en sekundoj"),
         ("relay-fallback-delay-tip", "Kiom longe jam establita retransmisia konekto atendas la rektan WebRTC-konekton antaŭ ol esti uzata anstataŭe. Pligrandigu ĝin por doni al malrapida rekta konekto pli da tempo; malpligrandigu ĝin por pli frue uzi la retransmision en retoj kie rekta konekto ne eblas. Lasu malplena por la defaŭlta valoro de 2.5 sekundoj."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/es.rs
+++ b/src/lang/es.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk no ha podido cargar un componente de GStreamer necesario para capturar la pantalla ({})"),
         ("Relay fallback delay in seconds", "Retardo antes de usar el relé en segundos"),
         ("relay-fallback-delay-tip", "Cuánto tiempo espera una conexión de relé ya establecida a la conexión directa WebRTC antes de usarse en su lugar. Auméntelo para dar más tiempo a una conexión directa lenta; redúzcalo para recurrir antes al relé en redes donde no es posible una conexión directa. Déjelo vacío para el valor predeterminado de 2.5 segundos."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/et.rs
+++ b/src/lang/et.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ei suutnud laadida ekraani jäädvustamiseks vajalikku GStreameri komponenti ({})"),
         ("Relay fallback delay in seconds", "Viivitus enne relee kasutamist sekundites"),
         ("relay-fallback-delay-tip", "Kui kaua juba loodud releeühendus ootab otsest WebRTC-ühendust, enne kui seda selle asemel kasutatakse. Suurendage, et anda aeglasele otseühendusele rohkem aega; vähendage, et võrkudes, kus otseühendust luua ei saa, releele kiiremini üle minna. Jätke tühjaks vaikeväärtuse 2.5 sekundit kasutamiseks."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/eu.rs
+++ b/src/lang/eu.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk-ek ezin izan du pantaila kapturatzeko beharrezkoa den GStreamer osagai bat kargatu ({})"),
         ("Relay fallback delay in seconds", "Errelera itzultzeko atzerapena segundotan"),
         ("relay-fallback-delay-tip", "Dagoeneko ezarritako errele-konexio batek WebRTC konexio zuzenari zenbat denbora itxaroten dion, haren ordez erabili aurretik. Handitu konexio zuzen motel bati denbora gehiago emateko; txikitu konexio zuzena egin ezin den sareetan lehenago errelera itzultzeko. Utzi hutsik 2.5 segundoko balio lehenetsirako."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fa.rs
+++ b/src/lang/fa.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk نتوانست مؤلفه GStreamer موردنیاز برای ضبط صفحه را بارگذاری کند ({})"),
         ("Relay fallback delay in seconds", "تأخیر بازگشت به رله بر حسب ثانیه"),
         ("relay-fallback-delay-tip", "یک اتصال رله که از قبل برقرار شده چقدر منتظر اتصال مستقیم WebRTC می ماند پیش از آنکه به جای آن استفاده شود. آن را افزایش دهید تا به اتصال مستقیم کند فرصت بیشتری داده شود؛ کاهش دهید تا در شبکه هایی که اتصال مستقیم ممکن نیست، زودتر به رله بازگردد. برای مقدار پیش فرض 2.5 ثانیه خالی بگذارید."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fi.rs
+++ b/src/lang/fi.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ei voinut ladata näytön kaappaukseen tarvittavaa GStreamer-osaa ({})"),
         ("Relay fallback delay in seconds", "Viive ennen välitykseen siirtymistä sekunteina"),
         ("relay-fallback-delay-tip", "Kuinka kauan jo muodostettu välitysyhteys odottaa suoraa WebRTC-yhteyttä ennen kuin sitä käytetään sen sijaan. Kasvata arvoa antaaksesi hitaalle suoralle yhteydelle enemmän aikaa; pienennä sitä siirtyäksesi nopeammin välitykseen verkoissa, joissa suoraa yhteyttä ei voi muodostaa. Jätä tyhjäksi käyttääksesi oletusarvoa 2.5 sekuntia."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/fr.rs
+++ b/src/lang/fr.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk n'a pas pu charger un composant GStreamer nécessaire à la capture d'écran ({})"),
         ("Relay fallback delay in seconds", "Délai avant bascule vers le relais en secondes"),
         ("relay-fallback-delay-tip", "Durée pendant laquelle une connexion relais déjà établie attend la connexion directe WebRTC avant d'être utilisée à sa place. Augmentez-la pour laisser plus de temps à une connexion directe lente ; diminuez-la pour basculer plus tôt vers le relais sur les réseaux où une connexion directe est impossible. Laissez vide pour la valeur par défaut de 2.5 secondes."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ge.rs
+++ b/src/lang/ge.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk-მა ვერ ჩატვირთა ეკრანის ჩაწერისთვის საჭირო GStreamer-ის კომპონენტი ({})"),
         ("Relay fallback delay in seconds", "რელეზე გადასვლის დაყოვნება წამებში"),
         ("relay-fallback-delay-tip", "რამდენ ხანს ელოდება უკვე დამყარებული რელე-კავშირი პირდაპირ WebRTC კავშირს, სანამ მის ნაცვლად გამოიყენება. გაზარდეთ, რომ ნელ პირდაპირ კავშირს მეტი დრო მისცეთ; შეამცირეთ, რომ ქსელებში, სადაც პირდაპირი კავშირი შეუძლებელია, უფრო სწრაფად გადავიდეს რელეზე. დატოვეთ ცარიელი ნაგულისხმევი 2.5 წამისთვის."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gl.rs
+++ b/src/lang/gl.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk non puido cargar un compoñente de GStreamer necesario para capturar a pantalla ({})"),
         ("Relay fallback delay in seconds", "Atraso antes de usar o relé en segundos"),
         ("relay-fallback-delay-tip", "Canto tempo agarda unha conexión de relé xa establecida pola conexión directa WebRTC antes de usarse no seu lugar. Auménteo para darlle máis tempo a unha conexión directa lenta; redúzao para recorrer antes ao relé en redes onde non é posible unha conexión directa. Déixeo baleiro para o valor predeterminado de 2.5 segundos."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/gu.rs
+++ b/src/lang/gu.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk સ્ક્રીન કૅપ્ચર માટે જરૂરી GStreamer ઘટક લોડ કરી શક્યું નથી ({})"),
         ("Relay fallback delay in seconds", "રિલે પર પાછા ફરવામાં વિલંબ સેકન્ડમાં"),
         ("relay-fallback-delay-tip", "પહેલેથી સ્થાપિત રિલે કનેક્શન સીધા WebRTC કનેક્શનની કેટલો સમય રાહ જુએ છે, ત્યાર બાદ તેના બદલે વપરાય છે. ધીમા સીધા કનેક્શનને વધુ સમય આપવા માટે વધારો; જ્યાં સીધું કનેક્શન શક્ય નથી તેવા નેટવર્ક પર વહેલા રિલે પર જવા માટે ઘટાડો. મૂળભૂત 2.5 સેકન્ડ માટે ખાલી રાખો."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/he.rs
+++ b/src/lang/he.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk לא הצליח לטעון רכיב GStreamer הדרוש ללכידת מסך ({})"),
         ("Relay fallback delay in seconds", "השהיה לפני מעבר לממסר בשניות"),
         ("relay-fallback-delay-tip", "כמה זמן חיבור ממסר שכבר נוצר ממתין לחיבור WebRTC הישיר לפני שישמש במקומו. הגדל כדי לתת לחיבור ישיר איטי יותר זמן; הקטן כדי לעבור מהר יותר לממסר ברשתות שבהן לא ניתן ליצור חיבור ישיר. השאר ריק לערך ברירת המחדל של 2.5 שניות."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hi.rs
+++ b/src/lang/hi.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk स्क्रीन कैप्चर के लिए आवश्यक GStreamer घटक लोड नहीं कर सका ({})"),
         ("Relay fallback delay in seconds", "रिले पर लौटने में विलंब सेकंड में"),
         ("relay-fallback-delay-tip", "पहले से स्थापित रिले कनेक्शन सीधे WebRTC कनेक्शन की कितनी देर प्रतीक्षा करता है, उसके बाद उसके स्थान पर उपयोग किया जाता है। धीमे सीधे कनेक्शन को अधिक समय देने के लिए बढ़ाएँ; जिन नेटवर्क पर सीधा कनेक्शन संभव नहीं है वहाँ जल्दी रिले पर जाने के लिए घटाएँ। डिफ़ॉल्ट 2.5 सेकंड के लिए खाली छोड़ें।"),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hr.rs
+++ b/src/lang/hr.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nije mogao učitati GStreamer komponentu potrebnu za snimanje zaslona ({})"),
         ("Relay fallback delay in seconds", "Odgoda prije prelaska na relej u sekundama"),
         ("relay-fallback-delay-tip", "Koliko dugo već uspostavljena relejna veza čeka izravnu WebRTC vezu prije nego što se upotrijebi umjesto nje. Povećajte da sporoj izravnoj vezi date više vremena; smanjite da se na mrežama gdje izravna veza nije moguća brže prijeđe na relej. Ostavite prazno za zadanu vrijednost od 2.5 sekunde."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/hu.rs
+++ b/src/lang/hu.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "A RustDesk nem tudta betölteni a képernyőrögzítéshez szükséges GStreamer összetevőt ({})"),
         ("Relay fallback delay in seconds", "Késleltetés a továbbítóra váltás előtt másodpercben"),
         ("relay-fallback-delay-tip", "Mennyi ideig vár a már létrejött továbbító kapcsolat a közvetlen WebRTC kapcsolatra, mielőtt helyette használnák. Növelje, hogy a lassú közvetlen kapcsolatnak több ideje legyen; csökkentse, hogy olyan hálózatokon, ahol közvetlen kapcsolat nem hozható létre, hamarabb váltson továbbítóra. Hagyja üresen az alapértelmezett 2.5 másodperchez."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/id.rs
+++ b/src/lang/id.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk tidak dapat memuat komponen GStreamer yang diperlukan untuk merekam layar ({})"),
         ("Relay fallback delay in seconds", "Jeda sebelum beralih ke relai dalam detik"),
         ("relay-fallback-delay-tip", "Berapa lama koneksi relai yang sudah terbentuk menunggu koneksi langsung WebRTC sebelum digunakan sebagai gantinya. Perbesar untuk memberi koneksi langsung yang lambat lebih banyak waktu; perkecil agar lebih cepat beralih ke relai pada jaringan yang tidak memungkinkan koneksi langsung. Biarkan kosong untuk nilai bawaan 2.5 detik."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/it.rs
+++ b/src/lang/it.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk non è riuscito a caricare un componente GStreamer necessario per l'acquisizione dello schermo ({})"),
         ("Relay fallback delay in seconds", ""),
         ("relay-fallback-delay-tip", ""),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ja.rs
+++ b/src/lang/ja.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk は画面キャプチャに必要な GStreamer コンポーネントを読み込めませんでした ({})"),
         ("Relay fallback delay in seconds", "中継に切り替えるまでの待ち時間 (秒)"),
         ("relay-fallback-delay-tip", "すでに確立された中継接続が、直接の WebRTC 接続をどれだけ待ってから代わりに使用されるかを指定します。値を大きくすると遅い直接接続に時間を与えられ、小さくすると直接接続できないネットワークで早く中継に切り替わります。空欄にすると既定値の 2.5 秒になります。"),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ko.rs
+++ b/src/lang/ko.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk가 화면 캡처에 필요한 GStreamer 구성 요소를 불러오지 못했습니다 ({})"),
         ("Relay fallback delay in seconds", "중계로 전환하기까지의 대기 시간(초)"),
         ("relay-fallback-delay-tip", "이미 연결된 중계 연결이 직접 WebRTC 연결을 얼마나 기다린 후 대신 사용되는지입니다. 값을 늘리면 느린 직접 연결에 더 많은 시간을 주고, 줄이면 직접 연결이 불가능한 네트워크에서 더 빨리 중계로 전환합니다. 비워 두면 기본값 2.5초가 사용됩니다."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/kz.rs
+++ b/src/lang/kz.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk экранды түсіру үшін қажет GStreamer компонентін жүктей алмады ({})"),
         ("Relay fallback delay in seconds", "Релеге ауысу кідірісі, секундпен"),
         ("relay-fallback-delay-tip", "Бұрыннан орнатылған реле байланысы тікелей WebRTC байланысын қанша уақыт күтеді, содан кейін оның орнына қолданылады. Баяу тікелей байланысқа көбірек уақыт беру үшін үлкейтіңіз; тікелей байланыс мүмкін емес желілерде релеге тезірек ауысу үшін кішірейтіңіз. Әдепкі 2.5 секунд үшін бос қалдырыңыз."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lt.rs
+++ b/src/lang/lt.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nepavyko įkelti ekrano įrašymui reikalingo GStreamer komponento ({})"),
         ("Relay fallback delay in seconds", "Delsa prieš pereinant prie perdavimo sekundėmis"),
         ("relay-fallback-delay-tip", "Kiek laiko jau užmegztas perdavimo ryšys laukia tiesioginio WebRTC ryšio, kol bus panaudotas vietoj jo. Padidinkite, kad lėtam tiesioginiam ryšiui būtų skirta daugiau laiko; sumažinkite, kad tinkluose, kuriuose tiesioginis ryšys neįmanomas, greičiau būtų pereinama prie perdavimo. Palikite tuščią numatytajai 2.5 sekundės reikšmei."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/lv.rs
+++ b/src/lang/lv.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nevarēja ielādēt ekrāna tveršanai nepieciešamo GStreamer komponentu ({})"),
         ("Relay fallback delay in seconds", "Aizkave pirms pārslēgšanās uz retranslatoru sekundēs"),
         ("relay-fallback-delay-tip", "Cik ilgi jau izveidots retranslatora savienojums gaida tiešo WebRTC savienojumu, pirms tiek izmantots tā vietā. Palieliniet, lai lēnam tiešajam savienojumam dotu vairāk laika; samaziniet, lai tīklos, kur tiešais savienojums nav iespējams, ātrāk pārslēgtos uz retranslatoru. Atstājiet tukšu noklusējuma 2.5 sekunžu vērtībai."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ml.rs
+++ b/src/lang/ml.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "സ്ക്രീൻ പകർത്താൻ ആവശ്യമായ GStreamer ഘടകം RustDesk-ന് ലോഡ് ചെയ്യാനായില്ല ({})"),
         ("Relay fallback delay in seconds", "റിലേയിലേക്ക് മാറുന്നതിനുള്ള കാലതാമസം സെക്കൻഡിൽ"),
         ("relay-fallback-delay-tip", "ഇതിനകം സ്ഥാപിതമായ റിലേ കണക്ഷൻ നേരിട്ടുള്ള WebRTC കണക്ഷനായി എത്ര നേരം കാത്തിരിക്കുന്നു, അതിനുശേഷം അതിനുപകരം ഉപയോഗിക്കുന്നു. മന്ദഗതിയിലുള്ള നേരിട്ടുള്ള കണക്ഷന് കൂടുതൽ സമയം നൽകാൻ വർദ്ധിപ്പിക്കുക; നേരിട്ടുള്ള കണക്ഷൻ സാധ്യമല്ലാത്ത നെറ്റ്‌വർക്കുകളിൽ വേഗത്തിൽ റിലേയിലേക്ക് മാറാൻ കുറയ്ക്കുക. സ്ഥിരസ്ഥിതിയായ 2.5 സെക്കൻഡിനായി ശൂന്യമാക്കിയിടുക."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nb.rs
+++ b/src/lang/nb.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kunne ikke laste en GStreamer-komponent som kreves for skjermopptak ({})"),
         ("Relay fallback delay in seconds", "Forsinkelse før bruk av relé i sekunder"),
         ("relay-fallback-delay-tip", "Hvor lenge en allerede opprettet reléforbindelse venter på den direkte WebRTC-forbindelsen før den brukes i stedet. Øk verdien for å gi en treg direkteforbindelse mer tid; senk den for å gå raskere over til reléet på nettverk der direkte forbindelse ikke er mulig. La stå tom for standardverdien på 2.5 sekunder."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/nl.rs
+++ b/src/lang/nl.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kon een GStreamer-component die nodig is voor schermopname niet laden ({})"),
         ("Relay fallback delay in seconds", "Vertraging voordat relay wordt gebruikt in seconden"),
         ("relay-fallback-delay-tip", "Hoe lang een al tot stand gekomen relayverbinding wacht op de directe WebRTC-verbinding voordat deze in plaats daarvan wordt gebruikt. Verhoog de waarde om een trage directe verbinding meer tijd te geven; verlaag deze om op netwerken waar een directe verbinding niet mogelijk is sneller op de relay terug te vallen. Laat leeg voor de standaardwaarde van 2.5 seconden."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pl.rs
+++ b/src/lang/pl.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nie mógł załadować składnika GStreamer wymaganego do przechwytywania ekranu ({})"),
         ("Relay fallback delay in seconds", "Opóźnienie przed przejściem na przekaźnik w sekundach"),
         ("relay-fallback-delay-tip", "Jak długo nawiązane już połączenie przez przekaźnik czeka na bezpośrednie połączenie WebRTC, zanim zostanie użyte zamiast niego. Zwiększ, aby dać wolnemu połączeniu bezpośredniemu więcej czasu; zmniejsz, aby w sieciach, w których połączenie bezpośrednie jest niemożliwe, szybciej przechodzić na przekaźnik. Pozostaw puste, aby użyć wartości domyślnej 2.5 sekundy."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/pt_PT.rs
+++ b/src/lang/pt_PT.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "O RustDesk não conseguiu carregar um componente do GStreamer necessário para capturar o ecrã ({})"),
         ("Relay fallback delay in seconds", "Atraso antes de recorrer ao retransmissor em segundos"),
         ("relay-fallback-delay-tip", "Quanto tempo uma ligação de retransmissão já estabelecida aguarda pela ligação direta WebRTC antes de ser usada em vez dela. Aumente para dar mais tempo a uma ligação direta lenta; diminua para recorrer mais cedo ao retransmissor em redes onde não é possível uma ligação direta. Deixe vazio para o valor predefinido de 2.5 segundos."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ptbr.rs
+++ b/src/lang/ptbr.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "O RustDesk não conseguiu carregar um componente do GStreamer necessário para a captura de tela ({})."),
         ("Relay fallback delay in seconds", "Atraso antes de recorrer ao retransmissor em segundos"),
         ("relay-fallback-delay-tip", "Quanto tempo uma conexão de retransmissão já estabelecida espera pela conexão direta WebRTC antes de ser usada no lugar dela. Aumente para dar mais tempo a uma conexão direta lenta; diminua para recorrer mais cedo ao retransmissor em redes onde não é possível uma conexão direta. Deixe vazio para o valor padrão de 2.5 segundos."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ro.rs
+++ b/src/lang/ro.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nu a putut încărca o componentă GStreamer necesară pentru capturarea ecranului ({})"),
         ("Relay fallback delay in seconds", "Întârziere înainte de trecerea la releu în secunde"),
         ("relay-fallback-delay-tip", "Cât timp așteaptă o conexiune prin releu deja stabilită conexiunea directă WebRTC înainte de a fi folosită în locul ei. Măriți valoarea pentru a acorda mai mult timp unei conexiuni directe lente; micșorați-o pentru a trece mai repede la releu în rețelele în care o conexiune directă nu este posibilă. Lăsați gol pentru valoarea implicită de 2.5 secunde."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ru.rs
+++ b/src/lang/ru.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не удалось загрузить компонент GStreamer, необходимый для захвата экрана ({})"),
         ("Relay fallback delay in seconds", "Задержка перед переходом на ретранслятор в секундах"),
         ("relay-fallback-delay-tip", "Сколько времени уже установленное соединение через ретранслятор ждёт прямое соединение WebRTC, прежде чем будет использовано вместо него. Увеличьте, чтобы дать медленному прямому соединению больше времени; уменьшите, чтобы быстрее переходить на ретранслятор в сетях, где прямое соединение невозможно. Оставьте пустым для значения по умолчанию 2.5 секунды."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sc.rs
+++ b/src/lang/sc.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk no at pòdidu carrigare unu cumponente de GStreamer netzessàriu pro registrare sa schermada ({})"),
         ("Relay fallback delay in seconds", "Tardu prima de impreare su relè in segundos"),
         ("relay-fallback-delay-tip", "Cantu tempus una connessione de relè giai istabilida abetat sa connessione direta WebRTC prima de èssere impreada in su postu suo. Aumenta pro dare prus tempus a una connessione direta lenta; diminuì pro colare prima a su relè in sas retes in ue non si podet fàghere una connessione direta. Lassa bòidu pro su valore predefinidu de 2.5 segundos."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sk.rs
+++ b/src/lang/sk.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nedokázal načítať komponent GStreamera potrebný na zachytenie obrazovky ({})"),
         ("Relay fallback delay in seconds", "Oneskorenie pred prepnutím na prenos v sekundách"),
         ("relay-fallback-delay-tip", "Ako dlho už nadviazané spojenie cez prenos čaká na priame spojenie WebRTC, kým sa použije namiesto neho. Zvýšte, aby pomalé priame spojenie malo viac času; znížte, aby sa v sieťach, kde priame spojenie nie je možné, skôr prešlo na prenos. Nechajte prázdne pre predvolenú hodnotu 2.5 sekundy."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sl.rs
+++ b/src/lang/sl.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ni mogel naložiti komponente GStreamer, potrebne za zajem zaslona ({})"),
         ("Relay fallback delay in seconds", "Zakasnitev pred preklopom na posrednika v sekundah"),
         ("relay-fallback-delay-tip", "Kako dolgo že vzpostavljena posredniška povezava čaka na neposredno povezavo WebRTC, preden se uporabi namesto nje. Povečajte, da počasni neposredni povezavi date več časa; zmanjšajte, da v omrežjih, kjer neposredna povezava ni mogoča, hitreje preklopite na posrednika. Pustite prazno za privzeto vrednost 2.5 sekunde."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sq.rs
+++ b/src/lang/sq.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nuk mundi të ngarkojë një komponent të GStreamer të nevojshëm për regjistrimin e ekranit ({})"),
         ("Relay fallback delay in seconds", "Vonesa para kalimit te releja në sekonda"),
         ("relay-fallback-delay-tip", "Sa gjatë pret një lidhje releje tashmë e vendosur lidhjen e drejtpërdrejtë WebRTC përpara se të përdoret në vend të saj. Rriteni për t'i dhënë më shumë kohë një lidhjeje të drejtpërdrejtë të ngadaltë; uleni për të kaluar më shpejt te releja në rrjete ku lidhja e drejtpërdrejtë nuk është e mundur. Lëreni bosh për vlerën e parazgjedhur prej 2.5 sekondash."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sr.rs
+++ b/src/lang/sr.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk nije mogao da učita GStreamer komponentu potrebnu za snimanje ekrana ({})"),
         ("Relay fallback delay in seconds", "Кашњење пре преласка на релеј у секундама"),
         ("relay-fallback-delay-tip", "Колико дуго већ успостављена релејна веза чека на директну WebRTC везу пре него што се употреби уместо ње. Повећајте да бисте спорој директној вези дали више времена; смањите да бисте на мрежама где директна веза није могућа брже прешли на релеј. Оставите празно за подразумевану вредност од 2.5 секунде."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/sv.rs
+++ b/src/lang/sv.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk kunde inte läsa in en GStreamer-komponent som krävs för skärminspelning ({})"),
         ("Relay fallback delay in seconds", "Fördröjning innan relä används i sekunder"),
         ("relay-fallback-delay-tip", "Hur länge en redan upprättad reläanslutning väntar på den direkta WebRTC-anslutningen innan den används i stället. Öka värdet för att ge en långsam direktanslutning mer tid; sänk det för att snabbare falla tillbaka på reläet i nätverk där direktanslutning inte är möjlig. Lämna tomt för standardvärdet 2.5 sekunder."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ta.rs
+++ b/src/lang/ta.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "திரைப் பதிவுக்குத் தேவையான GStreamer கூறை RustDesk ஏற்ற முடியவில்லை ({})"),
         ("Relay fallback delay in seconds", "ரிலேக்கு மாறுவதற்கான தாமதம் வினாடிகளில்"),
         ("relay-fallback-delay-tip", "ஏற்கனவே நிறுவப்பட்ட ரிலே இணைப்பு நேரடி WebRTC இணைப்புக்காக எவ்வளவு நேரம் காத்திருக்கிறது, அதன் பிறகு அதற்குப் பதிலாகப் பயன்படுத்தப்படுகிறது. மெதுவான நேரடி இணைப்புக்கு அதிக நேரம் வழங்க அதிகரிக்கவும்; நேரடி இணைப்பு சாத்தியமில்லாத பிணையங்களில் விரைவாக ரிலேக்கு மாற குறைக்கவும். இயல்புநிலை 2.5 வினாடிகளுக்கு காலியாக விடவும்."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/template.rs
+++ b/src/lang/template.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", ""),
         ("Relay fallback delay in seconds", ""),
         ("relay-fallback-delay-tip", ""),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/th.rs
+++ b/src/lang/th.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ไม่สามารถโหลดส่วนประกอบ GStreamer ที่จำเป็นสำหรับการบันทึกหน้าจอได้ ({})"),
         ("Relay fallback delay in seconds", "เวลารอก่อนเปลี่ยนไปใช้รีเลย์ (วินาที)"),
         ("relay-fallback-delay-tip", "การเชื่อมต่อผ่านรีเลย์ที่สร้างไว้แล้วจะรอการเชื่อมต่อ WebRTC โดยตรงนานเท่าใดก่อนที่จะถูกใช้แทน เพิ่มค่าเพื่อให้การเชื่อมต่อโดยตรงที่ช้ามีเวลามากขึ้น ลดค่าเพื่อเปลี่ยนไปใช้รีเลย์เร็วขึ้นในเครือข่ายที่ไม่สามารถเชื่อมต่อโดยตรงได้ เว้นว่างไว้เพื่อใช้ค่าเริ่มต้น 2.5 วินาที"),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tr.rs
+++ b/src/lang/tr.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk ekran yakalama için gereken GStreamer bileşenini yükleyemedi ({})"),
         ("Relay fallback delay in seconds", "Aktarıcıya geçiş gecikmesi (saniye)"),
         ("relay-fallback-delay-tip", "Zaten kurulmuş bir aktarıcı bağlantısının, onun yerine kullanılmadan önce doğrudan WebRTC bağlantısını ne kadar beklediğidir. Yavaş bir doğrudan bağlantıya daha fazla süre tanımak için artırın; doğrudan bağlantının kurulamadığı ağlarda aktarıcıya daha erken geçmek için azaltın. Varsayılan 2.5 saniye için boş bırakın."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/tw.rs
+++ b/src/lang/tw.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk 無法載入螢幕擷取所需的 GStreamer 元件 ({})"),
         ("Relay fallback delay in seconds", "回退到中繼前的等待時間（秒）"),
         ("relay-fallback-delay-tip", "已經建立的中繼連線會等待直連的 WebRTC 多久，超過這個時間就改用中繼。調大可以讓較慢的直連有更多機會勝出；調小則在無法直連的網路上更快回退到中繼。留空表示使用預設值 2.5 秒。"),
+        ("Keyboard: local", "鍵盤：本機"),
+        ("Keyboard: remote", "鍵盤：遠端"),
     ].iter().cloned().collect();
 }

--- a/src/lang/uk.rs
+++ b/src/lang/uk.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk не вдалося завантажити компонент GStreamer, потрібний для захоплення екрана ({})"),
         ("Relay fallback delay in seconds", "Затримка перед переходом на ретранслятор у секундах"),
         ("relay-fallback-delay-tip", "Скільки часу вже встановлене з'єднання через ретранслятор чекає на пряме з'єднання WebRTC, перш ніж буде використане замість нього. Збільште, щоб дати повільному прямому з'єднанню більше часу; зменште, щоб швидше переходити на ретранслятор у мережах, де пряме з'єднання неможливе. Залиште порожнім для типового значення 2.5 секунди."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/src/lang/ur.rs
+++ b/src/lang/ur.rs
@@ -780,6 +780,8 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk اسکرین ریکارڈنگ کے لیے درکار GStreamer جزو لوڈ نہیں کر سکا ({})"),
         ("Relay fallback delay in seconds", "ریلے پر واپس جانے میں تاخیر سیکنڈ میں"),
         ("relay-fallback-delay-tip", "پہلے سے قائم ریلے کنکشن براہ راست WebRTC کنکشن کا کتنی دیر انتظار کرتا ہے، اس کے بعد اس کی جگہ استعمال ہوتا ہے۔ سست براہ راست کنکشن کو مزید وقت دینے کے لیے بڑھائیں؛ ان نیٹ ورکس پر جہاں براہ راست کنکشن ممکن نہیں، جلد ریلے پر جانے کے لیے کم کریں۔ پہلے سے طے شدہ 2.5 سیکنڈ کے لیے خالی چھوڑ دیں۔"),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }
 

--- a/src/lang/vi.rs
+++ b/src/lang/vi.rs
@@ -780,5 +780,7 @@ pub static ref T: std::collections::HashMap<&'static str, &'static str> =
         ("RustDesk could not load a GStreamer component needed for screen capture ({})", "RustDesk không thể tải một thành phần GStreamer cần cho việc ghi màn hình ({})"),
         ("Relay fallback delay in seconds", "Độ trễ trước khi chuyển sang trung chuyển (giây)"),
         ("relay-fallback-delay-tip", "Kết nối trung chuyển đã thiết lập sẽ chờ kết nối WebRTC trực tiếp trong bao lâu trước khi được dùng thay thế. Tăng giá trị để cho kết nối trực tiếp chậm thêm thời gian; giảm để chuyển sang trung chuyển sớm hơn trên các mạng không thể kết nối trực tiếp. Để trống để dùng giá trị mặc định 2.5 giây."),
+        ("Keyboard: local", ""),
+        ("Keyboard: remote", ""),
     ].iter().cloned().collect();
 }

--- a/tests/test_keyboard_grab.py
+++ b/tests/test_keyboard_grab.py
@@ -29,7 +29,7 @@ mod winapi { pub mod um { pub mod winuser {
 } } }
 mod rdev {
     #[derive(Clone, Copy, PartialEq)]
-    pub enum Key { Pause, Cancel, F15, ControlLeft, ControlRight, Alt, AltGr }
+    pub enum Key { Pause, Cancel, F15, NumLock, ControlLeft, ControlRight, Alt, AltGr }
     #[derive(Clone, Copy)]
     pub enum EventType { KeyPress(Key), KeyRelease(Key), Other }
     pub struct Event { pub event_type: EventType, pub platform_code: u32 }
@@ -78,6 +78,24 @@ mod flutter_ffi {
 
 CHECKS = r'''
 fn main() {
+    for (key, platform_code) in [
+        #[cfg(keyboard_test_windows)]
+        (Key::NumLock, 0x03),
+        #[cfg(not(keyboard_test_windows))]
+        (Key::Cancel, 0),
+        #[cfg(keyboard_test_macos)]
+        (Key::F15, 0),
+    ] {
+        for captured in [false, true] {
+            KEYBOARD_HOOKED.store(captured, Ordering::SeqCst);
+            let handled = captured || !cfg!(keyboard_test_linux);
+            let press = Event { event_type: EventType::KeyPress(key), platform_code };
+            let release = Event { event_type: EventType::KeyRelease(key), platform_code };
+            assert_eq!(handle_keyboard_grab_shortcut(&press), handled);
+            assert_eq!(KEYBOARD_HOOKED.load(Ordering::SeqCst), !captured && handled);
+            assert_eq!(handle_keyboard_grab_shortcut(&release), handled && !cfg!(keyboard_test_linux));
+        }
+    }
     let press = Event { event_type: EventType::KeyPress(Key::Pause), platform_code: 0x13 };
     let release = Event { event_type: EventType::KeyRelease(Key::Pause), platform_code: 0x13 };
     for (default_session, keyboard, view_only) in [

--- a/tests/test_keyboard_grab.py
+++ b/tests/test_keyboard_grab.py
@@ -1,0 +1,144 @@
+"""Run: python -m unittest discover -s tests -p test_keyboard_grab.py
+
+Compile the actual shortcut with session/OS doubles, without installing hooks.
+Requires rustc on PATH; no RustDesk native dependencies are needed.
+"""
+
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+STUBS = r'''
+#![allow(dead_code)]
+use std::sync::{atomic::{AtomicBool, AtomicUsize, Ordering}, RwLock};
+use rdev::{Event, EventType, Key};
+static KEYBOARD_HOOKED: AtomicBool = AtomicBool::new(false);
+static IS_RDEV_ENABLED: AtomicBool = AtomicBool::new(true);
+static HAS_SESSION: AtomicBool = AtomicBool::new(true);
+static DEFAULT_SESSION: AtomicBool = AtomicBool::new(true);
+static KEYBOARD_PERMISSION: AtomicBool = AtomicBool::new(true);
+static VIEW_ONLY: AtomicBool = AtomicBool::new(false);
+static CTRL: AtomicBool = AtomicBool::new(true);
+static ALT: AtomicBool = AtomicBool::new(true);
+static TRANSITIONS: AtomicUsize = AtomicUsize::new(0);
+mod winapi { pub mod um { pub mod winuser {
+    pub const VK_PAUSE: i32 = 0x13;
+    pub const VK_CANCEL: i32 = 0x03;
+} } }
+mod rdev {
+    #[derive(Clone, Copy, PartialEq)]
+    pub enum Key { Pause, Cancel, F15, ControlLeft, ControlRight, Alt, AltGr }
+    #[derive(Clone, Copy)]
+    pub enum EventType { KeyPress(Key), KeyRelease(Key), Other }
+    pub struct Event { pub event_type: EventType, pub platform_code: u32 }
+    pub fn get_modifier(key: Key) -> bool {
+        match key {
+            Key::ControlLeft | Key::ControlRight => crate::CTRL.load(crate::Ordering::SeqCst),
+            Key::Alt | Key::AltGr => crate::ALT.load(crate::Ordering::SeqCst),
+            _ => false,
+        }
+    }
+}
+mod enigo { pub enum Key { Control, RightControl, Alt, RightAlt } }
+fn get_key_state(key: enigo::Key) -> bool {
+    match key {
+        enigo::Key::Control | enigo::Key::RightControl => CTRL.load(Ordering::SeqCst),
+        enigo::Key::Alt | enigo::Key::RightAlt => ALT.load(Ordering::SeqCst),
+    }
+}
+mod client {
+    pub fn get_modifiers_state(_: bool, _: bool, _: bool, _: bool) -> (bool, bool, bool, bool) {
+        (crate::ALT.load(crate::Ordering::SeqCst), crate::CTRL.load(crate::Ordering::SeqCst), false, false)
+    }
+}
+struct ViewOnly { v: bool }
+struct LocalConfig { view_only: ViewOnly }
+struct Session { server_keyboard_enabled: RwLock<bool>, lc: RwLock<LocalConfig> }
+impl Session { fn is_default(&self) -> bool { DEFAULT_SESSION.load(Ordering::SeqCst) } }
+mod flutter {
+    use super::*;
+    pub fn get_cur_session_id() -> u128 { 42 }
+    pub fn get_cur_session() -> Option<Session> {
+        HAS_SESSION.load(Ordering::SeqCst).then(|| Session {
+            server_keyboard_enabled: RwLock::new(KEYBOARD_PERMISSION.load(Ordering::SeqCst)),
+            lc: RwLock::new(LocalConfig { view_only: ViewOnly { v: VIEW_ONLY.load(Ordering::SeqCst) } }),
+        })
+    }
+}
+mod flutter_ffi {
+    pub fn session_enter_or_leave(id: u128, enter: bool) {
+        assert_eq!(id, 42);
+        crate::KEYBOARD_HOOKED.store(enter, crate::Ordering::SeqCst);
+        crate::TRANSITIONS.fetch_add(1, crate::Ordering::SeqCst);
+    }
+}
+'''
+
+CHECKS = r'''
+fn main() {
+    let press = Event { event_type: EventType::KeyPress(Key::Pause), platform_code: 0x13 };
+    let release = Event { event_type: EventType::KeyRelease(Key::Pause), platform_code: 0x13 };
+    for (default_session, keyboard, view_only) in [
+        (true, true, false), (false, true, false), (true, false, false), (true, true, true),
+    ] {
+        DEFAULT_SESSION.store(default_session, Ordering::SeqCst);
+        KEYBOARD_PERMISSION.store(keyboard, Ordering::SeqCst);
+        VIEW_ONLY.store(view_only, Ordering::SeqCst);
+        for captured in [false, true] {
+            KEYBOARD_HOOKED.store(captured, Ordering::SeqCst);
+            TRANSITIONS.store(0, Ordering::SeqCst);
+            CTRL.store(true, Ordering::SeqCst); ALT.store(true, Ordering::SeqCst);
+            let can_acquire = !cfg!(keyboard_test_linux) && default_session && keyboard && !view_only;
+            let handled = captured || can_acquire;
+            assert_eq!(handle_keyboard_grab_shortcut(&press), handled,
+                "default={default_session}, keyboard={keyboard}, view_only={view_only}, captured={captured}");
+            assert_eq!(KEYBOARD_HOOKED.load(Ordering::SeqCst), !captured && can_acquire);
+            if !cfg!(keyboard_test_linux) {
+                assert_eq!(handle_keyboard_grab_shortcut(&press), handled, "Repeat must not toggle capture");
+            }
+            CTRL.store(false, Ordering::SeqCst); ALT.store(false, Ordering::SeqCst);
+            assert_eq!(handle_keyboard_grab_shortcut(&release), handled && !cfg!(keyboard_test_linux));
+            assert_eq!(TRANSITIONS.load(Ordering::SeqCst), handled as usize);
+        }
+    }
+    DEFAULT_SESSION.store(true, Ordering::SeqCst);
+    VIEW_ONLY.store(false, Ordering::SeqCst);
+    for (enabled, session, ctrl, alt) in [
+        (false, true, true, true), (true, false, true, true),
+        (true, true, false, true), (true, true, true, false),
+    ] {
+        IS_RDEV_ENABLED.store(enabled, Ordering::SeqCst); HAS_SESSION.store(session, Ordering::SeqCst);
+        CTRL.store(ctrl, Ordering::SeqCst); ALT.store(alt, Ordering::SeqCst);
+        KEYBOARD_HOOKED.store(true, Ordering::SeqCst);
+        assert!(!handle_keyboard_grab_shortcut(&press));
+        assert!(KEYBOARD_HOOKED.load(Ordering::SeqCst), "Unsupported paths must not change capture");
+    }
+}
+'''
+
+
+class KeyboardGrabShortcutTest(unittest.TestCase):
+    def test_capture_toggle_and_session_eligibility(self):
+        source = (Path(__file__).resolve().parents[1] / 'src/keyboard.rs').read_text(encoding='utf-8')
+        start = source.index('fn handle_keyboard_grab_shortcut(')
+        shortcut = source[start:source.index('\nfn start_grab_loop()', start)]
+        for platform in ('windows', 'macos', 'linux'):
+            shortcut = shortcut.replace(f'target_os = "{platform}"', f'keyboard_test_{platform}')
+        with tempfile.TemporaryDirectory(prefix='rustdesk-keyboard-test-') as directory:
+            source_file = Path(directory) / 'keyboard_grab.rs'
+            executable = Path(directory) / 'keyboard_grab.exe'
+            source_file.write_text(STUBS + shortcut + CHECKS, encoding='utf-8')
+            for platform in ('windows', 'macos', 'linux'):
+                with self.subTest(platform=platform):
+                    result = subprocess.run(
+                        ['rustc', '--edition=2021', '--cfg', f'keyboard_test_{platform}',
+                         str(source_file), '-o', str(executable)], capture_output=True, text=True)
+                    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                    result = subprocess.run([str(executable)], capture_output=True, text=True)
+                    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Keyboard-only users have no direct shortcut to return input to the local computer once a remote session captures the keyboard. On Windows, the workaround is to open the local security screen with Ctrl+Alt+Delete and dismiss it with Esc.

This change adds Ctrl+Alt+Pause/Break to release keyboard capture through the existing session enter/leave path. On Windows and macOS, pressing it again reacquires capture. The remote view stays visible and the window keeps its position and focus. The existing toolbar keyboard icon and tooltip indicate `Keyboard: local` or `Keyboard: remote`; Windows also raises a UIA notification when the state changes, without adding a visible element or a live region.

The shortcut is inspired by [Microsoft RDP's Ctrl+Alt+Pause/Break shortcut](https://learn.microsoft.com/en-us/windows/win32/termserv/terminal-services-shortcut-keys). RDP uses it to switch between full-screen and windowed mode; this implementation changes keyboard capture directly.

Fixes #16174. Related: #1098.

### Scope and regression surface

- `src/keyboard.rs`: handle the shortcut in the existing desktop native-input callbacks and publish capture changes to the corresponding session. Existing grab/release operations are reused, including releasing held remote keys. Acquiring capture requires a normal remote-control session with keyboard permission and view-only mode disabled; releasing capture remains available after permission changes. This shortcut does not require relative-mouse support. Windows Pause/Break key codes and macOS's F15 mapping are handled. On Linux/X11 the shortcut releases capture only, because the grab callback stops receiving keys after ungrab.
- `flutter/lib/models/model.dart`: receive capture state for the icon and Windows notification, suppress duplicate notifications, refresh the indication when the input source changes, and reset capture status when clearing the model so a reused session starts with local status. Unsupported input paths retain the existing toolbar presentation.
- `flutter/lib/desktop/widgets/remote_toolbar.dart`: reuse the existing icon, colors, tooltip and menu; its layout and actions are retained.
- `flutter/windows/runner/flutter_window.cpp` and `CMakeLists.txt`: register the notification channel for secondary windows, reuse Flutter's accessibility provider and call `UiaRaiseNotificationEvent`. The notification API is resolved dynamically for older Windows versions.
- `src/lang/*.rs`: add the two status labels according to the repository's localization rules. Each of the 53 affected language tables adds exactly two entries; untranslated entries remain empty. The 61 changed files consist of these 53 tables, five functional/build files, two test files, and one CI workflow.
- `.github/workflows/ci.yml`: run the native keyboard regression in the existing build job after Rust toolchain setup and before the build. This adds one test step and changes no application runtime path.
- `tests/test_keyboard_grab.py` and `flutter/test/keyboard_grab_status_test.dart`: regression tests for shortcut eligibility, release/reacquire, repeated keys, platform-specific Pause mappings and model clearing. The native test compiles the actual shortcut function with session/OS doubles; the Flutter test uses the real `FfiModel`. Adding these tests changes no production runtime path.

No third-party dependency is added. The remote page, `src/platform/windows.rs`, generated bridges and legacy Sciter UI are unchanged.

### Validation

- Windows Rust compilation check with the release configuration: `cargo check --locked --features flutter --lib --release`.
- Repository native regression: `python3 -m unittest discover -s tests -p test_keyboard_grab.py -v` from the repository root (requires `rustc` on PATH), now configured to run in the existing CI workflow. The workflow parses successfully and its test command passes locally with the local Python interpreter. Windows, macOS and Linux conditional branches pass in the isolated harness. Running the same test against the pre-fix source fails on the missing session eligibility check. Additional isolated negative checks confirm that the new cases fail if Windows VK_CANCEL, macOS F15 or non-Windows Cancel support is removed.
- Repository Flutter regression: `flutter test --no-pub test/keyboard_grab_status_test.dart` from `flutter/`.
- Dart analysis of the affected UI files: no errors or warnings.
- Local extracted-source checks (outside the repository) cover shortcut release/reacquire, repeated key events, local Alt+Tab/Win+M pass-through, session-specific state events, notification deduplication, and unchanged toolbar layout/menu behavior. The review regressions were reproduced before the fixes: ineligible sessions acquiring capture and model reuse retaining stale status. The updated checks confirm capture acquisition is rejected for non-control, keyboard-disabled and view-only sessions, release remains available after permission changes, and model clearing resets the status without suppressing the next session's capture notification.
- A native harness using the bundled Flutter engine and a real Windows UIA event subscriber received both localized status notifications while the test window remained hidden and foreground focus was unchanged.

Full Windows Rust/Flutter release builds and verification of all 91 portable-bundle files were completed before the review fixes. The latest source was validated with the checks above and has not been repackaged.

macOS/Linux behavior was checked with local source harnesses, not on physical machines. Actual screen-reader speech output has not been verified; Windows UIA event delivery has been verified.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Ctrl+Alt plus Pause/Cancel shortcut to switch between local and remote keyboard control.
  - The keyboard control menu now displays the current status and uses inactive styling when control is unavailable.
  - Keyboard status changes are communicated to supported Windows accessibility features.
  - Added local and remote keyboard labels, including Chinese and Traditional Chinese translations.

- **Bug Fixes**
  - Keyboard status now refreshes after changing the input source and resets correctly between sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63403403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; both previous findings are resolved and no actionable new defect remains.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atests%2Ftest_keyboard_grab.py%3A140-141%0AThis%20test%20is%20only%20documented%20for%20manual%20execution%2C%20while%20the%20repository%20workflow%20runs%20%60cargo%20test%60%20and%20does%20not%20execute%20these%20Python%20tests.%20As%20a%20result%2C%20regressions%20in%20shortcut%20eligibility%20or%20platform-specific%20capture%20toggling%20can%20merge%20without%20this%20test%20detecting%20them.%20Please%20wire%20it%20into%20CI%20so%20it%20provides%20automated%20regression%20protection.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Regression test skipped by CI** <a href="https://github.com/rustdesk/rustdesk/pull/16173#discussion_r3996020111">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
tests/test_keyboard_grab.py:140-141
This test is only documented for manual execution, while the repository workflow runs `cargo test` and does not execute these Python tests. As a result, regressions in shortcut eligibility or platform-specific capture toggling can merge without this test detecting them. Please wire it into CI so it provides automated regression protection.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Publishes session-specific keyboard capture state from the native grab path to Flutter.
- Displays localized local/remote keyboard status through the existing toolbar control.
- Registers a Windows UI Automation notification channel for capture-state changes.
- Adds native and Flutter regressions and wires the native regression into CI.
- Adds the two status keys across the localization tables.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Ctrl+Alt+Pause/Break] --> B{Capture state}
  B -->|Remote| C[Release keyboard grab]
  B -->|Local and eligible| D[Acquire keyboard grab]
  C --> E[Publish keyboard_grab event]
  D --> E
  E --> F[Update FfiModel]
  F --> G[Refresh toolbar status]
  F --> H[Raise Windows UIA notification]
```
</details>

<sub>Reviews (5) · Last reviewed commit: ["test: cover platform Pause key mappings"](https://github.com/rustdesk/rustdesk/commit/5d3d20ec6eca4f8779211d5841ca659e9ca927e2)</sub>

<!-- /greptile_comment -->