### PR TITLE
update base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:trixie-slim
 
 WORKDIR /
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Debian Bullseye has reached end‑of‑life and is no longer supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying runtime environment to a newer Debian release.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63416113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The change is likely safe to merge, but adding a non-blocking Docker smoke build would prevent base-image compatibility failures from reaching users.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0ADockerfile%3A1%0AThis%20upgrade%20spans%20two%20Debian%20releases%20and%20changes%20the%20compiler%2C%20libc%2C%20and%20package%20ecosystem%20used%20by%20every%20later%20build%20step.%20The%20Dockerfile%20is%20not%20built%20by%20CI%2C%20so%20compatibility%20failures%20in%20the%20pinned%202023%20vcpkg%20ports%2C%20source-built%20CMake%2C%20or%20downloaded%20native%20Sciter%20library%20would%20reach%20users%20running%20the%20documented%20Docker%20build%20manually.%20Adding%20a%20smoke%20build%20for%20this%20image%20would%20detect%20those%20failures%20earlier.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=rustdesk%2Frustdesk&pr=16176&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Docker Upgrade Lacks Coverage** <a href="https://github.com/rustdesk/rustdesk/pull/16176#discussion_r3996205977">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
Dockerfile:1
This upgrade spans two Debian releases and changes the compiler, libc, and package ecosystem used by every later build step. The Dockerfile is not built by CI, so compatibility failures in the pinned 2023 vcpkg ports, source-built CMake, or downloaded native Sciter library would reach users running the documented Docker build manually. Adding a smoke build for this image would detect those failures earlier.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Removes reliance on the end-of-life Bullseye base image.
- Changes the toolchain and system libraries used by all subsequent native build steps.
- The updated image currently lacks an automated smoke build.
</details>

<sub>Reviews (1) · Last reviewed commit: ["update base image in Dockerfile"](https://github.com/rustdesk/rustdesk/commit/2872c3b9531cc8bae1742bffc79864772e97dc83)</sub>

<!-- /greptile_comment -->