### PR TITLE
fix(linux): resolve Wayland reconnect failure with "Failed to get capturer display info"

### DIFF
--- a/libs/scrap/src/wayland/pipewire.rs
+++ b/libs/scrap/src/wayland/pipewire.rs
@@ -84,8 +84,9 @@ pub fn try_close_session() {
     let mut rdp_info = RDP_SESSION_INFO.lock().unwrap();
     let mut close = false;
     if let Some(rdp_info) = &*rdp_info {
-        // If is server running and restore token is supported, there's no need to keep the session.
-        if is_server_running() && rdp_info.is_support_restore_token {
+        // If restore token is supported, there's no need to keep the session.
+        // In non-server mode, the session does not survive disconnect, so it must also be closed.
+        if !is_server_running() || rdp_info.is_support_restore_token {
             close = true;
         }
     }

--- a/src/server/wayland.rs
+++ b/src/server/wayland.rs
@@ -524,7 +524,6 @@ pub(super) async fn check_init() -> ResultType<()> {
                 }
                 log::debug!("Attempting to fix logical size with try_fix_logical_size()");
                 try_fix_logical_size(&mut all);
-                *PIPEWIRE_INITIALIZED.write().unwrap() = true;
                 let num = all.len();
                 let primary = super::display_service::get_primary_2(&all);
                 let mut displays = super::display_service::update_sync_displays(&all);
@@ -550,8 +549,23 @@ pub(super) async fn check_init() -> ResultType<()> {
                 for (idx, display) in all.into_iter().enumerate() {
                     // No `with_context` here: the peer is shown `format!("{}", err)`, which
                     // renders only the outermost layer, and the mapped reason is the inner one.
-                    let capturer = Box::into_raw(Box::new(Capturer::new(display)?));
-                    let capturer = CapturerPtr(capturer);
+                    let capturer = match Capturer::new(display) {
+                        Ok(c) => CapturerPtr(Box::into_raw(Box::new(c))),
+                        Err(e) => {
+                            for (_, addr) in lock.iter() {
+                                let cap_display_info: *mut CapDisplayInfo = *addr as _;
+                                unsafe {
+                                    let _box_capturer =
+                                        Box::from_raw((*cap_display_info).capturer.0);
+                                    let _box_cap_display_info = Box::from_raw(cap_display_info);
+                                }
+                            }
+                            lock.clear();
+                            *PIPEWIRE_INITIALIZED.write().unwrap() = false;
+                            scrap::wayland::pipewire::close_session();
+                            return Err(e.into());
+                        }
+                    };
 
                     let cap_display_info = Box::into_raw(Box::new(CapDisplayInfo {
                         rects: rects.clone(),
@@ -564,6 +578,8 @@ pub(super) async fn check_init() -> ResultType<()> {
 
                     lock.insert(idx, cap_display_info as u64);
                 }
+
+                *PIPEWIRE_INITIALIZED.write().unwrap() = true;
             }
         }
     }
@@ -602,6 +618,8 @@ pub(super) async fn get_displays_and_primary() -> ResultType<(Vec<DisplayInfo>, 
             Ok((cap_display_info.displays.clone(), cap_display_info.primary))
         }
     } else {
+        drop(cap_map);
+        *PIPEWIRE_INITIALIZED.write().unwrap() = false;
         bail!("Failed to get capturer display info");
     }
 }
@@ -635,6 +653,7 @@ pub fn clear() {
 
     // Reset PipeWire initialization flag to allow recreation on next init
     *PIPEWIRE_INITIALIZED.write().unwrap() = false;
+    scrap::wayland::pipewire::close_session();
 }
 
 /// Initialize the PipeWire/portal capture path from the plain (sync) video thread, so a DRM display


### PR DESCRIPTION
### Description

Fixes an issue on Linux Wayland where connecting once and disconnecting causes subsequent connections to fail with:
`Failed to get capturer display info`

This occurs primarily when running RustDesk in non-server / standalone desktop mode.

### Steps to Reproduce
1. Launch RustDesk on Linux Wayland (without system `--server` background service, i.e., standalone client mode).
2. Connect to the machine from another client. The connection succeeds and screen capture works.
3. Disconnect the session.
4. Attempt to connect to the machine again from the client.
5. Connection fails with error: `Failed to get capturer display info`.

### Root Cause Analysis
1. **Stale Session Reuse in Non-Server Mode**: In `libs/scrap/src/wayland/pipewire.rs`, `try_close_session()` previously only closed the session if `is_server_running() && rdp_info.is_support_restore_token`. In non-server / standalone mode (`!is_server_running()`), `*RDP_SESSION_INFO` was never cleared on disconnect. Consequently, subsequent connections reused the stale portal/pipewire session handle, which had already become invalid after disconnection.
2. **Premature `PIPEWIRE_INITIALIZED` Flag**: In `src/server/wayland.rs`, `check_init()` set `*PIPEWIRE_INITIALIZED = true` before the loop initializing display capturers (`Capturer::new(display)?`). When capturer initialization failed (due to the stale session handle), the function returned early with an error, leaving `CAP_DISPLAY_INFO` empty while `PIPEWIRE_INITIALIZED` remained latched to `true`. On subsequent attempts, `check_init()` saw `*PIPEWIRE_INITIALIZED == true`, returned `Ok(())` prematurely without initializing any capturers, and caused `get_displays_and_primary()` to bail with `"Failed to get capturer display info"`.
3. **Missing Penetration Cleanup on Disconnect**: `wayland::clear()` cleared `CAP_DISPLAY_INFO` and reset `PIPEWIRE_INITIALIZED = false`, but did not penetrate to clean up the underlying PipeWire portal session (`scrap::wayland::pipewire::close_session()`).

### Solution
1. **Allow Session Teardown in Non-Server Mode**: Updated `try_close_session()` in `libs/scrap/src/wayland/pipewire.rs` to close the session if `!is_server_running() || rdp_info.is_support_restore_token`.
2. **Deferred Initialization Flag & Error Cleanup**: In `src/server/wayland.rs`, only set `*PIPEWIRE_INITIALIZED = true` after all capturers are successfully initialized. If capturer creation fails in the loop, cleanly destroy already-allocated raw pointers, reset `*PIPEWIRE_INITIALIZED = false`, and call `scrap::wayland::pipewire::close_session()`. Additionally, reset `*PIPEWIRE_INITIALIZED = false` if `CAP_DISPLAY_INFO` is empty in `get_displays_and_primary()`.
3. **Penetrate Underlying Session Teardown**: In `src/server/wayland.rs`, call `scrap::wayland::pipewire::close_session()` inside `wayland::clear()` so that whenever wayland capturers are cleared on disconnect/teardown, the underlying PipeWire portal session is also cleanly closed.

### Verification & Testing
- Verified with `rustfmt --edition 2021` ensuring consistent code style.
- Verified minimal diff footprint adhering to RustDesk's codebase conventions.
- Tested repeated connect-disconnect-reconnect lifecycle on Wayland desktop sessions. Reconnection now successfully initializes a fresh PipeWire capture session without getting stuck on stale session handles or empty display maps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Wayland/PipeWire session cleanup when the server is unavailable or a connection is interrupted.
  - Fixed initialization handling so partially created display capture sessions are cleaned up when setup fails.
  - Prevented failed or empty display discovery from leaving sessions marked as active.
  - Improved resource cleanup when clearing a PipeWire session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63430348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the changed Wayland initialization and teardown paths consistently discard stale state without an established regression.

<details><summary><h3>Summary</h3></summary>

- Broadens session cleanup after the last standalone remote connection disconnects.
- Marks PipeWire initialized only after every display capturer has been created.
- Frees partially initialized capturers and closes the portal session after initialization failure.
- Resets inconsistent empty-map state so later initialization attempts can retry.
- Extends the existing last-display and server teardown paths to clear the underlying PipeWire session.
- Regression surface: `libs/scrap/src/wayland/pipewire.rs` changes only the session-retention decision at final remote disconnect; `src/server/wayland.rs` changes Wayland capture initialization failure and teardown paths, both necessary to prevent stale-session reuse.
</details>

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Remote connection requests Wayland displays] --> B[check_init]
  B --> C{Capture map already populated?}
  C -->|Yes| G[Return display information]
  C -->|No| D[Create capturer for each display]
  D -->|All succeed| E[Set PIPEWIRE_INITIALIZED true]
  E --> G
  D -->|Any fails| F[Free created capturers<br/>clear map and flag<br/>close portal session]
  F --> H[Return initialization error]
  G --> I[Connection disconnects]
  I --> J{Last active display?}
  J -->|No| K[Keep shared capture state]
  J -->|Yes| L[Clear capturers and flag<br/>close portal session]
  L --> M[Next connection creates fresh session]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(linux): cleanup Wayland PipeWire ses..."](https://github.com/rustdesk/rustdesk/commit/984a2a5c006d635e80b31539889efe9b65f9f49a)</sub>

<!-- /greptile_comment -->